### PR TITLE
Use regex when searching on single file shares

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -177,4 +177,20 @@ class Cache extends CacheJail {
 	public function clear() {
 		// Not a valid action for Shared Cache
 	}
+
+	public function search($pattern) {
+		// Do the normal search on the whole storage for non files
+		if ($this->storage->getItemType() !== 'file') {
+			return parent::search($pattern);
+		}
+
+		$regex = '/' . str_replace('%', '.*', $pattern) . '/i';
+
+		$data = $this->get('');
+		if (preg_match($regex, $data->getName()) === 1) {
+			return [$data];
+		}
+
+		return [];
+	}
 }


### PR DESCRIPTION
There is no need to consult the database when we want to search and
there are a lot of incomming single file shares. We can then just do a
regex and be done with it.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>