### PR TITLE
Update Version2000Date20190808074233.php

### DIFF
--- a/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
+++ b/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
@@ -116,7 +116,7 @@ class Version2000Date20190808074233 extends SimpleMigrationStep {
 			$table->addColumn('entity', Types::STRING, [
 				'notnull' => true,
 				'length' => 256,
-				'default' => '',
+				'default' => ' ',
 			]);
 		}
 		if (!$table->hasColumn('events')) {


### PR DESCRIPTION
Modify 'protected function ensureEntityColumns()' to set a default of ' '. Fixes the broken automatic update from 17.0.10 to 18.0.10. 

Specifically implements the solution commented here: https://github.com/nextcloud/server/issues/23174#issuecomment-714296723