### PR TITLE
Fix DataResponse typehints

### DIFF
--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -41,13 +41,13 @@ class DataResponse extends Response {
 
 	/**
 	 * response data
-	 * @var array|object
+	 * @var array|int|float|string|bool|object
 	 */
 	protected $data;
 
 
 	/**
-	 * @param array|object $data the object or array that should be transformed
+	 * @param array|int|float|string|bool|object $data the object or array that should be transformed
 	 * @param int $statusCode the Http status code, defaults to 200
 	 * @param array $headers additional key value based headers
 	 * @since 8.0.0
@@ -64,7 +64,7 @@ class DataResponse extends Response {
 
 	/**
 	 * Sets values in the data json array
-	 * @param array|object $data an array or object which will be transformed
+	 * @param array|int|float|string|object $data an array or object which will be transformed
 	 * @return DataResponse Reference to this object
 	 * @since 8.0.0
 	 */
@@ -77,7 +77,7 @@ class DataResponse extends Response {
 
 	/**
 	 * Used to get the set parameters
-	 * @return array the data
+	 * @return array|int|float|string|bool|object the data
 	 * @since 8.0.0
 	 */
 	public function getData() {


### PR DESCRIPTION
We use this already in several places where we just pass strings or
numbers.
This all works because we just convert it to a json response in the end.
So better to have the typehints reflect this.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>