### PR TITLE
Add Psalm Security Analysis

### DIFF
--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -1,0 +1,26 @@
+name: Psalm Security Analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron: '0 0 * * 0'
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Psalm
+        uses: docker://vimeo/psalm-github-actions
+        with:
+          security_analysis: true
+          report_file: results.sarif
+      - name: Upload Security Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif

--- a/build/psalm/AppFrameworkTainter.php
+++ b/build/psalm/AppFrameworkTainter.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright (c) 2020 Lukas Reschke <lukas@statuscode.ch>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+use Psalm\CodeLocation;
+use Psalm\Plugin\Hook\AfterFunctionLikeAnalysisInterface;
+use Psalm\Type\TaintKindGroup;
+
+class AppFrameworkTainter implements AfterFunctionLikeAnalysisInterface {
+	public static function afterStatementAnalysis(
+		PhpParser\Node\FunctionLike $stmt,
+		Psalm\Storage\FunctionLikeStorage $classlike_storage,
+		Psalm\StatementsSource $statements_source,
+		Psalm\Codebase $codebase,
+		array &$file_replacements = []
+	): ?bool {
+		if ($statements_source->getFQCLN() !== null) {
+			if ($codebase->classExtendsOrImplements($statements_source->getFQCLN(), \OCP\AppFramework\Controller::class)) {
+				if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod) {
+					if ($stmt->isPublic() && !$stmt->isMagic()) {
+						foreach ($stmt->params as $i => $param) {
+							$expr_type = new Psalm\Type\Union([new Psalm\Type\Atomic\TString()]);
+							$expr_identifier = (strtolower($statements_source->getFQCLN()) . '::' . strtolower($classlike_storage->cased_name) . '#' . ($i+1));
+
+							if ($expr_type) {
+								$codebase->addTaintSource(
+									$expr_type,
+									$expr_identifier,
+									TaintKindGroup::ALL_INPUT,
+									new CodeLocation($statements_source, $param)
+								);
+							}
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -80,6 +80,8 @@ class OC_App {
 	/**
 	 * clean the appId
 	 *
+	 * @psalm-taint-escape file
+	 *
 	 * @param string $app AppId that needs to be cleaned
 	 * @return string
 	 */

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,9 @@
 	xsi:schemaLocation="https://getpsalm.org/schema/config"
     errorBaseline="build/psalm-baseline.xml"
 >
+	<plugins>
+		<plugin filename="build/psalm/AppFrameworkTainter.php" />
+	</plugins>
 	<projectFiles>
 		<directory name="apps"/>
 		<directory name="core"/>


### PR DESCRIPTION
This adds the Psalm Security Analysis, as described at
https://psalm.dev/docs/security_analysis/

It also adds a plugin for adding input into AppFramework.

The results can be viewed in the GitHub Security tab at
https://github.com/nextcloud/server/security/code-scanning

**Q&A:**

Q: Why do you not use the shipped Psalm version?
A: I do a lot of changes to the Psalm Taint behaviour. Using released
versions is not gonna get us the results we want.

Q: How do I improve false positives?
A: https://psalm.dev/docs/security_analysis/avoiding_false_positives/

Q: How do I add custom sources?
A: https://psalm.dev/docs/security_analysis/custom_taint_sources/

Q: We should run this on apps!
A: Yes.

Q: What will change in Psalm?
A: Quite some of the PHP core functions are not yet marked to propagate
the taint. This leads to results where the taint flow is lost. That's
something that I am currently working on.

Q: Why is the plugin MIT licensed?
A: Because its the first of its kind (based on GitHub Code Search) and
I want other people to copy it if they want to. Security is for all :)