### PR TITLE
Add focus-visible outline for checkboxes and radio buttons

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -290,6 +290,9 @@ table th#headerName {
 	height: 50px;
 }
 
+table th#headerSelection {
+	padding-top: 2px;
+}
 table th#headerSize, table td.filesize {
 	text-align: right;
 }
@@ -481,6 +484,10 @@ table td.selection {
 #fileList tr td.selection>.selectCheckBox + label,
 .select-all + label {
 	padding: 16px;
+}
+#fileList tr td.selection>.selectCheckBox:focus-visible + label,
+.select-all:focus-visible + label {
+	outline-offset: 0px;
 }
 
 #fileList tr td.filename {

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -366,6 +366,12 @@ input {
 			&:focus + label:before {
 				border-color: var(--color-primary-element);
 			}
+			&:focus-visible + label {
+				outline-style: solid;
+				outline-color: var(--color-primary-element);
+				outline-width: 1px;
+				outline-offset: 2px;
+			}
 			&:checked + label:before,
 			&.checkbox:indeterminate + label:before {
 			/* ^ :indeterminate have a strange behavior on radio,

--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -368,7 +368,7 @@ input {
 			}
 			&:focus-visible + label {
 				outline-style: solid;
-				outline-color: var(--color-primary-element);
+				outline-color: var(--color-main-text);
 				outline-width: 1px;
 				outline-offset: 2px;
 			}


### PR DESCRIPTION
To make keyboard navigation visible in forms.
When clicking with the mouse it doesn't appear (it's the magic of :focus-visible instead of :focus)

Ref https://www.w3.org/WAI/WCAG21/quickref/#focus-visible

This is how it looks like in this PR using the outline style and tabbing with the keyboard:

<img width="238" alt="image" src="https://user-images.githubusercontent.com/277525/99822086-12a4c400-2b53-11eb-8bed-d52552bcbc30.png">

<img width="153" alt="image" src="https://user-images.githubusercontent.com/277525/99822381-70d1a700-2b53-11eb-8778-b00ddf1628b5.png">

Without this it is almost impossible to find out what checkbox or radio button is currently focussed.

Tested with the settings pages and in the talk app.

@nextcloud/designers 