### PR TITLE
Mark cleanAppId as sanitizer for include

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -81,6 +81,7 @@ class OC_App {
 	 * clean the appId
 	 *
 	 * @psalm-taint-escape file
+	 * @psalm-taint-escape include
 	 *
 	 * @param string $app AppId that needs to be cleaned
 	 * @return string


### PR DESCRIPTION
Should remove a bunch of false positive code scanning results.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>