### PR TITLE
First attempt to check against core routes before loading all app routes

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -234,32 +234,29 @@ class Router implements IRouter {
 	 * @throws \Exception
 	 * @return array
 	 */
-	public function findMatchingRoute(string $url): array {
-		if (substr($url, 0, 6) === '/apps/') {
+	public function findMatchingRoute(string $url, bool $loadAll = false): array {
+		if (strpos($url, '/apps/') === 0) {
 			// empty string / 'apps' / $app / rest of the route
 			[, , $app,] = explode('/', $url, 4);
 
 			$app = \OC_App::cleanAppId($app);
 			\OC::$REQUESTEDAPP = $app;
 			$this->loadRoutes($app);
-		} elseif (substr($url, 0, 13) === '/ocsapp/apps/') {
+		} elseif (strpos($url, '/ocsapp/apps/') === 0) {
 			// empty string / 'ocsapp' / 'apps' / $app / rest of the route
 			[, , , $app,] = explode('/', $url, 5);
 
 			$app = \OC_App::cleanAppId($app);
 			\OC::$REQUESTEDAPP = $app;
 			$this->loadRoutes($app);
-		} elseif (substr($url, 0, 10) === '/settings/') {
+		} elseif (strpos($url, '/settings/') === 0) {
 			$this->loadRoutes('settings');
-		} elseif (substr($url, 0, 6) === '/core/') {
-			\OC::$REQUESTEDAPP = $url;
-			if (!\OC::$server->getConfig()->getSystemValueBool('maintenance') && !Util::needUpgrade()) {
-				\OC_App::loadApps();
-			}
-			$this->loadRoutes('core');
-		} else {
-			$this->loadRoutes();
 		}
+		\OC::$REQUESTEDAPP = $url;
+		if (!\OC::$server->getConfig()->getSystemValueBool('maintenance') && !Util::needUpgrade()) {
+			\OC_App::loadApps();
+		}
+		$this->loadRoutes('core');
 
 		$matcher = new UrlMatcher($this->root, $this->context);
 		try {
@@ -272,6 +269,11 @@ class Router implements IRouter {
 				try {
 					$parameters = $matcher->match($url . '/');
 				} catch (ResourceNotFoundException $newException) {
+					// Attempt to fallback to load all routes if none of the above route patterns matches and the route is not in core
+					if (!$loadAll) {
+						$this->loadRoutes();
+						return $this->findMatchingRoute($url, true);
+					}
 					// If we still didn't match a route, we throw the original exception
 					throw $e;
 				}


### PR DESCRIPTION
Most of the time we will find a matching route in either the loaded ones
matched on the URL or in the core ones. Therfore we can attempt to try
those first and only load all app routes if no match was found by the
Symfony URLMatcher.

This improves the loading times of all routes that do not match the checks to load only required routes `/apps/`, `/ocsapp/apps/`, `/settings/` or `/core/`, mostly the core routes that do not start with core like unified search, svg, css, login to mention some of them.

https://blackfire.io/profiles/compare/4c47d56e-5311-4acc-883a-176b8f7c374f/graph
https://blackfire.io/profiles/compare/6df20296-dc75-43a6-8629-22d530805fb7/graph