### PR TITLE
PoC: Allow using app root route without router setup

### DIFF
--- a/apps/dashboard/appinfo/info.xml
+++ b/apps/dashboard/appinfo/info.xml
@@ -22,7 +22,7 @@
 	<navigations>
 		<navigation>
 			<name>Dashboard</name>
-			<route>dashboard.dashboard.index</route>
+			<route>dashboard</route>
 			<icon>dashboard.svg</icon>
 			<order>-1</order>
 		</navigation>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -57,7 +57,7 @@
 	<navigations>
 		<navigation>
 			<name>Files</name>
-			<route>files.view.index</route>
+			<route>files</route>
 			<order>0</order>
 		</navigation>
 	</navigations>

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -279,7 +279,10 @@ class NavigationManager implements INavigationManager {
 				$id = $nav['id'] ?? $app . ($key === 0 ? '' : $key);
 				$order = isset($nav['order']) ? $nav['order'] : 100;
 				$type = isset($nav['type']) ? $nav['type'] : 'link';
-				$route = $nav['route'] !== '' ? $this->urlGenerator->linkToRoute($nav['route']) : '';
+				$frontControllerActive = ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true');
+				$route = strpos($nav['route'], '.') ?
+					$this->urlGenerator->linkToRoute($nav['route']) :
+					'/' . \OC::$WEBROOT . ($frontControllerActive ? '' : 'index.php/') . 'apps/' . $nav['route'] . '/';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';
 				foreach ([$icon, "$app.svg"] as $i) {
 					try {


### PR DESCRIPTION
This is basically a shortcut to avoid unnecessary setup of apps routes for building the navigation. Currently we setup the router for each app in the navigation entry which could be avoided with this PR by allowing apps to register a navigation entry to their root route `/index.php/apps/{appId}/`. 

Comparison with dashboard, files, activity, photos, mail, deck [changed to use the root](https://github.com/nextcloud/server/compare/enh/route-navigation-performance?expand=1#diff-5e1bbc6c87a4766e435eea0a1914b342af344399643227db72259ffbd52a71edR25):

![image](https://user-images.githubusercontent.com/3404133/99960105-81b92d00-2d8c-11eb-979d-d7314185a070.png)