### PR TITLE
Fix the config key on the sharing expire checkbox

### DIFF
--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -56,7 +56,7 @@
 		<input type="text" name='shareapi_internal_expire_after_n_days' id="shareapiInternalExpireAfterNDays" placeholder="<?php p('7')?>"
 			   value='<?php p($_['shareInternalExpireAfterNDays']) ?>' />
 		<?php p($l->t('days')); ?>
-		<input type="checkbox" name="shareapi_internal_enforce_expire_date" id="shareapiInternalEnforceExpireDate" class="checkbox"
+		<input type="checkbox" name="shareapi_enforce_internal_expire_date" id="shareapiInternalEnforceExpireDate" class="checkbox"
 			   value="1" <?php if ($_['shareInternalEnforceExpireDate'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -160,7 +160,7 @@ class JSConfigHelper {
 		$defaultInternalExpireDate = $defaultInternalExpireDateEnforced = null;
 		if ($defaultInternalExpireDateEnabled) {
 			$defaultInternalExpireDate = (int)$this->config->getAppValue('core', 'shareapi_internal_expire_after_n_days', '7');
-			$defaultInternalExpireDateEnforced = $this->config->getAppValue('core', 'shareapi_internal_enforce_expire_date', 'no') === 'yes';
+			$defaultInternalExpireDateEnforced = $this->config->getAppValue('core', 'shareapi_enforce_internal_expire_date', 'no') === 'yes';
 		}
 
 		$countOfDataLocation = 0;


### PR DESCRIPTION
We don't use `shareapi_internal_enforce_expire_date` anywhere.
`shareapi_enforce_internal_expire_date` is the one we want.

Regression of https://github.com/nextcloud/server/pull/17725.

On master you can't actually set/unset "Enforce expiration date". The js will update some config value, but it's the wrong one. Hence the expiration date was **always enforced**.