### PR TITLE
Wrap display_name similarly to email to allow changes via occ

### DIFF
--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -178,10 +178,24 @@ class Setting extends Base {
 					return 1;
 				}
 
-				if ($app === 'settings' && $key === 'email') {
+				if ($app === 'settings' && in_array($key , ['email', 'display_name'])) {
 					$user = $this->userManager->get($uid);
 					if ($user instanceof IUser) {
-						$user->setEMailAddress($input->getArgument('value'));
+						if ($key === 'email') {
+							$user->setEMailAddress($input->getArgument('value'));
+						} elseif ($key === 'display_name') {
+							if (!$user->setDisplayName($input->getArgument('value'))) {
+								if ($user->getDisplayName() === $input->getArgument('value')) {
+									$output->writeln('<error>New and old display name are the same</error>');
+								} elseif ($input->getArgument('value') === '') {
+									$output->writeln('<error>New display name can\'t be empty</error>');
+								} else {
+									$output->writeln('<error>Could not set display name</error>');
+								}
+								return 1;
+							}
+						}
+						// setEmailAddress and setDisplayName both internally set the value
 						return 0;
 					}
 				}
@@ -194,11 +208,17 @@ class Setting extends Base {
 					return 1;
 				}
 
-				if ($app === 'settings' && $key === 'email') {
+				if ($app === 'settings' && in_array($key , ['email', 'display_name'])) {
 					$user = $this->userManager->get($uid);
 					if ($user instanceof IUser) {
-						$user->setEMailAddress('');
-						return 0;
+						if ($key === 'email') {
+							$user->setEMailAddress('');
+							// setEmailAddress already deletes the value
+							return 0;
+						} elseif ($key === 'display_name') {
+							$output->writeln('<error>Display name can\'t be deleted.</error>');
+							return 1;
+						}
 					}
 				}
 
@@ -207,14 +227,17 @@ class Setting extends Base {
 			} elseif ($value !== null) {
 				$output->writeln($value);
 				return 0;
+			} elseif ($input->hasParameterOption('--default-value')) {
+				$output->writeln($input->getOption('default-value'));
+				return 0;
 			} else {
-				if ($input->hasParameterOption('--default-value')) {
-					$output->writeln($input->getOption('default-value'));
+				if ($app === 'settings' && $key === 'display_name') {
+					$user = $this->userManager->get($uid);
+					$output->writeln($user->getDisplayName());
 					return 0;
-				} else {
-					$output->writeln('<error>The setting does not exist for user "' . $uid . '".</error>');
-					return 1;
 				}
+				$output->writeln('<error>The setting does not exist for user "' . $uid . '".</error>');
+				return 1;
 			}
 		} else {
 			$settings = $this->getUserSettings($uid, $app);
@@ -238,6 +261,10 @@ class Setting extends Base {
 		while ($row = $result->fetch()) {
 			$settings[$row['appid']][$row['configkey']] = $row['configvalue'];
 		}
+
+		$user = $this->userManager->get($uid);
+		$settings['settings']['display_name'] = $user->getDisplayName();
+
 		$result->closeCursor();
 
 		return $settings;


### PR DESCRIPTION
This patch allows setting and getting the display name via `occ user:setting <user> settings display_name`.

## Limitations

- as far as I can tell a new user won't necessarily have a display name set, so the property can't be read from this tool
- the `--delete` option won't work as the display name can't be set to an empty string, I've decided to just return an error