### PR TITLE
Make sure we add new line between vcf groups exports

### DIFF
--- a/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
+++ b/apps/dav/lib/CardDAV/MultiGetExportPlugin.php
@@ -74,7 +74,7 @@ class MultiGetExportPlugin extends DAV\ServerPlugin {
 
 		// Reduce the vcards into one string
 		$output = array_reduce($responseXml->getResponses(), function ($vcf, $card) {
-			$vcf .= $card->getResponseProperties()[200]['{urn:ietf:params:xml:ns:carddav}address-data'];
+			$vcf .= $card->getResponseProperties()[200]['{urn:ietf:params:xml:ns:carddav}address-data'] . PHP_EOL;
 			return $vcf;
 		}, '');
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/23250

Sometimes vcards in the db doesn't have the extra new line at the end.
This ensure enough space is added to split them apart.