### PR TITLE
send expected format of cloud id

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -110,7 +110,8 @@ class CloudIdManager implements ICloudIdManager {
 			$host = $fixedRemote;
 		}
 		$id = $user . '@' . $remote;
-		return new CloudId($id, $user, $fixedRemote, $this->getDisplayNameFromContact($id));
+		$displayName = $this->getDisplayNameFromContact($user . '@' . $host);
+		return new CloudId($id, $user, $fixedRemote, $displayName);
 	}
 
 	/**


### PR DESCRIPTION
addendum to https://github.com/nextcloud/server/pull/24162 and actually fixing the bug (again)…

The first parameter must be for some reason the unsanitized id, because at least one of the many test cases that take these things into account relies on it. Initially I did so and only used $remote as returned by `fixRemoteURL`, but needed to revert this for the tests to work (I would rather not break them). It slipped that it breaks the `getDisplayNameFromContact` which requires an id with sanitized remote portion. 

My preference would be to smooth it and streamline it everywhere, but since it shall be backported and i wasted too much time on the whole topic, this shall it be for now.