### PR TITLE
Use proper bundles for files client and fileinfo

### DIFF
--- a/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
+++ b/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
@@ -41,8 +41,6 @@ class LoadAdditionalSettingsScriptsListener implements IEventListener {
 		}
 
 		script('core', [
-			'files/fileinfo',
-			'files/client',
 			'dist/systemtags',
 		]);
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/23542 as they were moved to bundles with https://github.com/nextcloud/server/commit/44d05bf356824329d7691e00e91aa7de891221b9