### PR TITLE
Do not update incompatible apps

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -360,7 +360,7 @@ class Updater extends BasicEmitter {
 		$disabledApps = [];
 		$appManager = \OC::$server->getAppManager();
 		foreach ($apps as $app) {
-			// check if the app is compatible with this version of ownCloud
+			// check if the app is compatible with this version of Nextcloud
 			$info = OC_App::getAppInfo($app);
 			if ($info === null || !OC_App::isAppCompatible($version, $info)) {
 				if ($appManager->isShipped($app)) {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -974,6 +974,15 @@ class OC_App {
 		\OC::$server->getAppManager()->clearAppsCache();
 		$appData = self::getAppInfo($appId);
 
+		$ignoreMaxApps = \OC::$server->getConfig()->getSystemValue('app_install_overwrite', []);
+		$ignoreMax = in_array($appId, $ignoreMaxApps, true);
+		\OC_App::checkAppDependencies(
+			\OC::$server->getConfig(),
+			\OC::$server->getL10N('core'),
+			$appData,
+			$ignoreMax
+		);
+
 		self::registerAutoloading($appId, $appPath, true);
 		self::executeRepairSteps($appId, $appData['repair-steps']['pre-migration']);
 


### PR DESCRIPTION
Previously there was no (platform) dependency check for an app that was
installed before. So Nextcloud happily upgraded an app that now requires
a php version newer than the current one. Which means in the lucky case
you see a failing upgrade due to the language incompatibility, or in the
unlucky case you see unexpected errors later in production.

Todo
- [ ] Adjust app store update to only pull apps that are compatible https://github.com/nextcloud/server/pull/24416
- [x] ~~See if it's possible to just disable an app that was replaced manually and therefore can't be updated~~ I'd say if someone replaces manually and this logic is in place we stop before anything bad could happen. And the instance is in maintenance mode until the update anyway. So there isn't much we can do.

Fixes https://github.com/nextcloud/mail/issues/4063