### PR TITLE
LDAP: fix inGroup for memberUid type of group memberships

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -55,7 +55,7 @@ use OCP\ILogger;
 class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend {
 	protected $enabled = false;
 
-	/** @var string[] $cachedGroupMembers array of users with gid as key */
+	/** @var string[][] $cachedGroupMembers array of users with gid as key */
 	protected $cachedGroupMembers;
 	/** @var string[] $cachedGroupsByMember array of groups with uid as key */
 	protected $cachedGroupsByMember;
@@ -168,23 +168,21 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 						$users = array_merge($users, $search);
 					}
 				}
-				
+
 				if (count($filterParts) > 0) {
 					// if there are filterParts left we need to add their result
 					$filter = $this->access->combineFilterWithOr($filterParts);
 					$search = $this->access->fetchListOfUsers($filter, $requestAttributes, count($filterParts));
 					$users = array_merge($users, $search);
 				}
-				
+
 				// now we cleanup the users array to get only dns
-				$dns = array_reduce($users, function (array $carry, array $record) {
-					if (!in_array($carry, $record['dn'][0])) {
-						$carry[$record['dn'][0]] = 1;
-					}
-					return $carry;
-				}, []);
+				$dns = [];
+				foreach ($users as $record) {
+					$dns[$record['dn'][0]] = 1;
+				}
 				$members = array_keys($dns);
-				
+
 				break;
 		}
 

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -136,10 +136,6 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 
 		//usually, LDAP attributes are said to be case insensitive. But there are exceptions of course.
 		$members = $this->_groupMembers($groupDN);
-		if (!is_array($members) || count($members) === 0) {
-			$this->access->connection->writeToCache($cacheKey, false);
-			return false;
-		}
 
 		//extra work if we don't get back user DNs
 		switch ($this->ldapGroupMemberAssocAttr) {
@@ -184,6 +180,11 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 				$members = array_keys($dns);
 
 				break;
+		}
+
+		if (count($members) === 0) {
+			$this->access->connection->writeToCache($cacheKey, false);
+			return false;
 		}
 
 		$isInGroup = in_array($userDN, $members);

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -170,9 +170,14 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 				if (count($filterParts) > 0) {
 					$filter = $this->access->combineFilterWithOr($filterParts);
 					$users = $this->access->fetchListOfUsers($filter, $requestAttributes, count($filterParts));
-					$dns = array_merge($dns, $users);
+					$dns = array_reduce($users, function (array $carry, array $record) {
+						if (!in_array($carry, $record['dn'][0])) {
+							$carry[$record['dn'][0]] = 1;
+						}
+						return $carry;
+					}, $dns);
 				}
-				$members = $dns;
+				$members = array_keys($dns);
 				break;
 		}
 

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -503,6 +503,179 @@ class Group_LDAPTest extends TestCase {
 		$groupBackend->inGroup($uid, $gid);
 	}
 
+	public function  groupWithMembersProvider() {
+		return [
+			[
+				'someGroup',
+				'cn=someGroup,ou=allTheGroups,ou=someDepartment,dc=someDomain,dc=someTld',
+				[
+					'uid=oneUser,ou=someTeam,ou=someDepartment,dc=someDomain,dc=someTld',
+					'uid=someUser,ou=someTeam,ou=someDepartment,dc=someDomain,dc=someTld',
+					'uid=anotherUser,ou=someTeam,ou=someDepartment,dc=someDomain,dc=someTld',
+					'uid=differentUser,ou=someTeam,ou=someDepartment,dc=someDomain,dc=someTld',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider groupWithMembersProvider
+	 */
+	public function testInGroupMember(string $gid, string $groupDn, array $memberDNs) {
+		$access = $this->getAccessMock();
+		$pluginManager = $this->getPluginManagerMock();
+
+		$access->connection = $this->createMock(Connection::class);
+
+		$uid = 'someUser';
+		$userDn = $memberDNs[0];
+
+		$access->connection->expects($this->any())
+			->method('__get')
+			->willReturnCallback(function ($name) {
+				switch ($name) {
+					case 'ldapGroupMemberAssocAttr':
+						return 'member';
+					case 'ldapDynamicGroupMemberURL':
+						return '';
+					case 'hasPrimaryGroups':
+					case 'ldapNestedGroups';
+						return 0;
+					default:
+						return 1;
+				}
+			});
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->willReturn(null);
+
+		$access->expects($this->once())
+			->method('username2dn')
+			->with($uid)
+			->willReturn($userDn);
+		$access->expects($this->once())
+			->method('groupname2dn')
+			->willReturn($groupDn);
+		$access->expects($this->any())
+			->method('readAttribute')
+			->willReturn($memberDNs);
+
+		$groupBackend = new GroupLDAP($access, $pluginManager);
+		$this->assertTrue($groupBackend->inGroup($uid, $gid));
+	}
+
+	/**
+	 * @dataProvider groupWithMembersProvider
+	 */
+	public function testInGroupMemberNot(string $gid, string $groupDn, array $memberDNs) {
+		$access = $this->getAccessMock();
+		$pluginManager = $this->getPluginManagerMock();
+
+		$access->connection = $this->createMock(Connection::class);
+
+		$uid = 'unelatedUser';
+		$userDn = 'uid=unrelatedUser,ou=unrelatedTeam,ou=unrelatedDepartment,dc=someDomain,dc=someTld';
+
+		$access->connection->expects($this->any())
+			->method('__get')
+			->willReturnCallback(function ($name) {
+				switch ($name) {
+					case 'ldapGroupMemberAssocAttr':
+						return 'member';
+					case 'ldapDynamicGroupMemberURL':
+						return '';
+					case 'hasPrimaryGroups':
+					case 'ldapNestedGroups';
+						return 0;
+					default:
+						return 1;
+				}
+			});
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->willReturn(null);
+
+		$access->expects($this->once())
+			->method('username2dn')
+			->with($uid)
+			->willReturn($userDn);
+		$access->expects($this->once())
+			->method('groupname2dn')
+			->willReturn($groupDn);
+		$access->expects($this->any())
+			->method('readAttribute')
+			->willReturn($memberDNs);
+
+		$groupBackend = new GroupLDAP($access, $pluginManager);
+		$this->assertFalse($groupBackend->inGroup($uid, $gid));
+	}
+
+	/**
+	 * @dataProvider groupWithMembersProvider
+	 */
+	public function testInGroupMemberUid(string $gid, string $groupDn, array $memberDNs) {
+		$access = $this->getAccessMock();
+		$pluginManager = $this->getPluginManagerMock();
+
+		$memberUids = [];
+		$userRecords = [];
+		foreach ($memberDNs as $dn) {
+			$memberUids[] = ldap_explode_dn($dn, false)[0];
+			$userRecords[] = ['dn' => [$dn]];
+		}
+
+
+		$access->connection = $this->createMock(Connection::class);
+
+		$uid = 'someUser';
+		$userDn = $memberDNs[0];
+
+		$access->connection->expects($this->any())
+			->method('__get')
+			->willReturnCallback(function ($name) {
+				switch ($name) {
+					case 'ldapGroupMemberAssocAttr':
+						return 'memberUid';
+					case 'ldapDynamicGroupMemberURL':
+						return '';
+					case 'ldapLoginFilter':
+						return 'uid=%uid';
+					case 'hasPrimaryGroups':
+					case 'ldapNestedGroups';
+						return 0;
+					default:
+						return 1;
+				}
+			});
+		$access->connection->expects($this->any())
+			->method('getFromCache')
+			->willReturn(null);
+
+		$access->userManager->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['uid', 'mail', 'displayname']);
+
+		$access->expects($this->once())
+			->method('username2dn')
+			->with($uid)
+			->willReturn($userDn);
+		$access->expects($this->once())
+			->method('groupname2dn')
+			->willReturn($groupDn);
+		$access->expects($this->any())
+			->method('readAttribute')
+			->willReturn($memberUids);
+		$access->expects($this->any())
+			->method('fetchListOfUsers')
+			->willReturn($userRecords);
+		$access->expects($this->any())
+			->method('combineFilterWithOr')
+			->willReturn('(|(pseudo=filter)(filter=pseudo))');
+
+		$groupBackend = new GroupLDAP($access, $pluginManager);
+		$this->assertTrue($groupBackend->inGroup($uid, $gid));
+	}
+
 	public function testGetGroupsWithOffset() {
 		$access = $this->getAccessMock();
 		$pluginManager = $this->getPluginManagerMock();


### PR DESCRIPTION
fixes #24252

basically, the code that resolves the rdns to full DNs returned the whole records, as @Hexasoft observed, but the following code requires a flat list of DNs. 

@Hexasoft @steffen-moser can you confirm it fixes the issue for you?

@tofuSCHNITZEL you are informed because it is relevant for _zimbramailforwardingaddress_ types, I would be surprised if it breaks anything though.

It set the label to "developing", because i want to check one, two things tomorrow.