### PR TITLE
Also run repair steps when encryption is disabled but a legacy key is present

### DIFF
--- a/lib/private/Repair/NC20/EncryptionLegacyCipher.php
+++ b/lib/private/Repair/NC20/EncryptionLegacyCipher.php
@@ -58,7 +58,8 @@ class EncryptionLegacyCipher implements IRepairStep {
 			return;
 		}
 
-		if ($this->manager->isEnabled()) {
+		$masterKeyId = $this->config->getAppValue('encryption', 'masterKeyId');
+		if ($this->manager->isEnabled() || !empty($masterKeyId)) {
 			if ($this->config->getSystemValue('encryption.legacy_format_support', '') === '') {
 				$this->config->setSystemValue('encryption.legacy_format_support', true);
 			}

--- a/lib/private/Repair/NC20/EncryptionMigration.php
+++ b/lib/private/Repair/NC20/EncryptionMigration.php
@@ -58,7 +58,8 @@ class EncryptionMigration implements IRepairStep {
 			return;
 		}
 
-		if ($this->manager->isEnabled()) {
+		$masterKeyId = $this->config->getAppValue('encryption', 'masterKeyId');
+		if ($this->manager->isEnabled() || !empty($masterKeyId)) {
 			if ($this->config->getSystemValue('encryption.key_storage_migrated', '') === '') {
 				$this->config->setSystemValue('encryption.key_storage_migrated', false);
 			}


### PR DESCRIPTION
The repair steps should also run when there is a legacy master key present in the system but encryption is currently enabled as the encryption would still be needed with the legacy key format then to decrypt files that would still be encrypted.