### PR TITLE
Remove the deprecated update.php

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -185,7 +185,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 	/**
 	 * Updates old storage ids (v0.2.1 and older) that are based on key and secret to new ones based on the bucket name.
-	 * TODO Do this in an update.php. requires iterating over all users and loading the mount.json from their home
+	 * TODO Do this in a repair step. requires iterating over all users and loading the mount.json from their home
 	 *
 	 * @param array $params
 	 */

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -157,30 +157,12 @@ class CheckCode extends Command implements CompletionAwareInterface {
 			$errors = array_merge($errors, $schemaErrors['errors']);
 		}
 
-		$this->analyseUpdateFile($appId, $output);
-
 		if (empty($errors)) {
 			$output->writeln('<info>App is compliant - awesome job!</info>');
 			return 0;
 		} else {
 			$output->writeln('<error>App is not compliant</error>');
 			return 101;
-		}
-	}
-
-	/**
-	 * @param string $appId
-	 * @param $output
-	 */
-	private function analyseUpdateFile($appId, OutputInterface $output) {
-		$appPath = \OC_App::getAppPath($appId);
-		if ($appPath === false) {
-			throw new \RuntimeException("No app with given id <$appId> known.");
-		}
-
-		$updatePhp = $appPath . '/appinfo/update.php';
-		if (file_exists($updatePhp)) {
-			$output->writeln("<info>Deprecated file found: $updatePhp - please use repair steps</info>");
 		}
 	}
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -990,11 +990,6 @@ class OC_App {
 		\OC::$server->getAppManager()->clearAppsCache();
 		\OC::$server->getAppManager()->getAppVersion($appId, false);
 
-		// run upgrade code
-		if (file_exists($appPath . '/appinfo/update.php')) {
-			self::loadApp($appId);
-			include $appPath . '/appinfo/update.php';
-		}
 		self::setupBackgroundJobs($appData['background-jobs']);
 
 		//set remote/public handlers


### PR DESCRIPTION
* It was documented as deprecated.
* The app code checker warned about it
* It's been three years

Leftover usages: https://github.com/search?q=org%3Anextcloud+filename%3Aupdate.php+path%3Aappinfo&type=Code

* [x] Saml: https://github.com/nextcloud/user_saml/pull/490
* [x] System: https://github.com/nextcloud/system/issues/2
* [x] Survey server: https://github.com/nextcloud/survey_server/issues/28

Doc update at https://github.com/nextcloud/documentation/pull/5489.