### PR TITLE
Store scss variables under a different prefix for each theming config version

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -290,13 +290,14 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return array scss variables to overwrite
 	 */
 	public function getScssVariables() {
-		$cache = $this->cacheFactory->createDistributed('theming-' . $this->urlGenerator->getBaseUrl());
+		$cacheBuster = $this->config->getAppValue('theming', 'cachebuster', '0');
+		$cache = $this->cacheFactory->createDistributed('theming-' . $cacheBuster . '-' . $this->urlGenerator->getBaseUrl());
 		if ($value = $cache->get('getScssVariables')) {
 			return $value;
 		}
 
 		$variables = [
-			'theming-cachebuster' => "'" . $this->config->getAppValue('theming', 'cachebuster', '0') . "'",
+			'theming-cachebuster' => "'" . $cacheBuster . "'",
 			'theming-logo-mime' => "'" . $this->config->getAppValue('theming', 'logoMime') . "'",
 			'theming-background-mime' => "'" . $this->config->getAppValue('theming', 'backgroundMime') . "'",
 			'theming-logoheader-mime' => "'" . $this->config->getAppValue('theming', 'logoheaderMime') . "'",

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -634,9 +634,10 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testGetScssVariablesCached() {
+		$this->config->expects($this->any())->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('1');
 		$this->cacheFactory->expects($this->once())
 			->method('createDistributed')
-			->with('theming-')
+			->with('theming-1-')
 			->willReturn($this->cache);
 		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(['foo' => 'bar']);
 		$this->assertEquals(['foo' => 'bar'], $this->template->getScssVariables());
@@ -658,7 +659,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->util->expects($this->any())->method('elementColor')->with($this->defaults->getColorPrimary())->willReturn('#aaaaaa');
 		$this->cacheFactory->expects($this->once())
 			->method('createDistributed')
-			->with('theming-')
+			->with('theming-0-')
 			->willReturn($this->cache);
 		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(null);
 		$this->imageManager->expects($this->at(0))->method('getImageUrl')->with('logo')->willReturn('custom-logo?v=0');


### PR DESCRIPTION
The main issue with using the general theming- prefix is that with APCu caching
the cache is not shared between processes, so when trying to reset the cache
through the CLI, e.g. when updating the theming config the old cache is never
invalidated.

To reproduce:
- Configure APCu cache only
- Be not in debug mode
- Run `occ theming:config color '#ffffaa'`
- Reload the page and see that the color didn't update
- Running `occ maintenance:repair` also doesn't help