### PR TITLE
external storages: save group ids not display names in configuration

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -93,8 +93,8 @@ function addSelect2 ($elements, userListLimit) {
 					var userCount = 0; // users is an object
 
 					// add groups
-					$.each(data.groups, function(i, group) {
-						results.push({name:group+'(group)', displayname:group, type:'group' });
+					$.each(data.groups, function(gid, group) {
+						results.push({name:gid+'(group)', displayname:group, type:'group' });
 					});
 					// add users
 					$.each(data.users, function(id, user) {


### PR DESCRIPTION
The web ui of external storages would have sent group display name instead of group ids as "applicable groups". While looking nicely on the frontend, administrators where wondering why the group members did not find access to it.

The occ command was not affected.

By principle the controller should also check the input and deal with invalid users and groups that are coming in. Since it is not an OCS endpoint, I refrained from adjusting this, due to it's rat tail (communication with frontend, presentation in frontend). Perhaps that will go better hand in hand with vuefying the settings code.