### PR TITLE
Only execute plain mimetype check for directories and do the fallback…

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -102,8 +102,12 @@ class FileMimeType extends AbstractStringCheck implements IFileCheck {
 	 */
 	public function executeCheck($operator, $value) {
 		$actualValue = $this->getActualValue();
-		return $this->executeStringCheck($operator, $value, $actualValue) ||
-			$this->executeStringCheck($operator, $value, $this->mimeTypeDetector->detectPath($this->path));
+		$plainMimetypeResult = $this->executeStringCheck($operator, $value, $actualValue);
+		if ($actualValue === 'httpd/unix-directory') {
+			return $plainMimetypeResult;
+		}
+		$detectMimetypeBasedOnFilenameResult = $this->executeStringCheck($operator, $value, $this->mimeTypeDetector->detectPath($this->path));
+		return $plainMimetypeResult || $detectMimetypeBasedOnFilenameResult;
 	}
 
 	/**


### PR DESCRIPTION
… only for non-directories

Introduced with #23096

Fixes https://github.com/nextcloud/files_accesscontrol/issues/182

@juliushaertl I'm open for other approaches, but this seems to be useful here.