### PR TITLE
18.0.12 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 11, 2);
+$OC_Version = array(18, 0, 12, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.11';
+$OC_VersionString = '18.0.12 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24152 CircleId too short in some request
* #24261 Simple typo in comments
* #24332 Fix contacts menu position in sharing sidebar
* #24335 Avoid empty null default with value that will be inserted anyways
* #24344 Only check path for being accessible when the storage is a object home
* #24369 Catch storage not available in versions expire command
* #24371 Avoid substr() error when strpos returns false
* #24388 Properly encode path when fetching inherited shares
* #24437 Respect default share permissions
* #24445 Make sure we add new line between vcf groups exports
* #24458 External storages: save group ids not display names in configuration
* #24465 Use correct l10n source in files_sharing JS code
* #24481 Fix the config key on the sharing expire checkbox
* #24485 Only attempt to move to trash if a file is not in appdata
* #24504 Harden setup check for TLS version if host is not reachable