### PR TITLE
Allow unified search results to have attributes

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -110,13 +110,16 @@ class FilesSearchProvider implements IProvider {
 					? $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->id])
 					: '';
 
-				return new SearchResultEntry(
+				$searchResultEntry = new SearchResultEntry(
 					$thumbnailUrl,
 					$result->name,
 					$this->formatSubline($result),
 					$this->urlGenerator->getAbsoluteURL($result->link),
 					$result->type === 'folder' ? 'icon-folder' : $this->mimeTypeDetector->mimeTypeIcon($result->mime_type)
 				);
+				$searchResultEntry->addAttribute('fileId', (string)$result->id);
+				$searchResultEntry->addAttribute('path', $result->path);
+				return $searchResultEntry;
 			}, $this->fileSearch->search($query->getTerm()))
 		);
 	}

--- a/lib/public/Search/SearchResultEntry.php
+++ b/lib/public/Search/SearchResultEntry.php
@@ -83,6 +83,13 @@ class SearchResultEntry implements JsonSerializable {
 	protected $rounded;
 
 	/**
+	 * @var string[]
+	 * @psalm-var array<string, string>
+	 * @since 20.0.0
+	 */
+	protected $attributes = [];
+
+	/**
 	 * @param string $thumbnailUrl a relative or absolute URL to the thumbnail or icon of the entry
 	 * @param string $title a main title of the entry
 	 * @param string $subline the secondary line of the entry
@@ -107,6 +114,19 @@ class SearchResultEntry implements JsonSerializable {
 	}
 
 	/**
+	 * Add optional attributes to the result entry, e.g. an ID or some other
+	 * context information that can be read by the client application
+	 *
+	 * @param string $key
+	 * @param string $value
+	 *
+	 * @since 20.0.0
+	 */
+	public function addAttribute(string $key, string $value): void {
+		$this->attributes[$key] = $value;
+	}
+
+	/**
 	 * @return array
 	 *
 	 * @since 20.0.0
@@ -119,6 +139,7 @@ class SearchResultEntry implements JsonSerializable {
 			'resourceUrl' => $this->resourceUrl,
 			'icon' => $this->icon,
 			'rounded' => $this->rounded,
+			'attributes' => $this->attributes,
 		];
 	}
 }


### PR DESCRIPTION
This is the result of a bit of discussion about https://github.com/nextcloud/server/pull/24410 with @tobiasKaminsky and affectively an alternative solution. In the first PR we settled with an extension of the API so that each result entry can have a `type` and a `object ID` as that seemed generic enough. Now we discussed whether file search results should use the *file ID*, the *remote file ID* or the *remote path* for the ID. This lead me to the idea that we may want to be more flexible, as in allow each result to have any arbitrary number of *attributes*. Then we can put *type*, *IDs* and anything else there. The API is restrictive enough to only allow strings. Also if you use a composite key (Deck card on a specific board for example) you can now specify the key with two attributes and don't have to serialize it into the single field of the other PR.

@blizzz @MorrisJobke @nickvergessen @rullzer what do you think? Which solution would you prefer?

I'd summarize that https://github.com/nextcloud/server/pull/24410 is more restrictive and this one more adaptable for future changes and adding more than one way to identify an object – files could specify all three of the IDs mentioned above and the clients use whatever is most convenient for them.