### PR TITLE
add text/org mimetype

### DIFF
--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -192,6 +192,15 @@ class RepairMimeTypes implements IRepairStep {
 		return $this->updateMimetypes($updatedMimetypes);
 	}
 
+	private function introduceOrgModeType() {
+		$updatedMimetypes = [
+			'org' => 'text/org'
+		];
+
+		return $this->updateMimetypes($updatedMimetypes);
+	}
+
+
 	/**
 	 * Fix mime types
 	 */
@@ -231,6 +240,10 @@ class RepairMimeTypes implements IRepairStep {
 
 		if (version_compare($ocVersionFromBeforeUpdate, '20.0.0.5', '<') && $this->introduceOpenDocumentTemplates()) {
 			$out->info('Fixed OpenDocument template mime types');
+		}
+		
+		if (version_compare($ocVersionFromBeforeUpdate, '21.0.0.7', '<') && $this->introduceOrgModeType()) {
+			$out->info('Fixed orgmode mime types');
 		}
 	}
 }

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -133,6 +133,7 @@
 	"one": ["application/msonenote"],
 	"opus": ["audio/ogg"],
 	"orf": ["image/x-dcraw"],
+	"org": ["text/org", "text/plain"],
 	"otf": ["application/font-sfnt"],
 	"pages": ["application/x-iwork-pages-sffpages"],
 	"pdf": ["application/pdf"],


### PR DESCRIPTION
The text app (or any future editor) should be able to edit .org files when `text/org` and `text/plain` MIME types are set and the webserver is correctly configured (based on comments from nextcloud/text#1205 )