### PR TITLE
Harden setup check for TLS version if host is not reachable

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -262,6 +262,9 @@ class CheckSetupController extends Controller {
 				if ($e->getResponse()->getStatusCode() === 400) {
 					return $this->l10n->t('cURL is using an outdated %1$s version (%2$s). Please update your operating system or features such as %3$s will not work reliably.', ['NSS', $versionString, $features]);
 				}
+			} catch (\Exception $e) {
+				$this->logger->logException($e, ['app' => 'settings', 'level' => \OCP\ILogger::WARN]);
+				return $this->l10n->t('Could not determine if TLS version of cURL is outdated or not because an error happened during the HTTPS request against https://nextcloud.com. Please check the nextcloud log file for more details.');
 			}
 		}
 


### PR DESCRIPTION
Found on an instance that has a proxy that filters out non-whitelisted HTTP requests.