### PR TITLE
fixes sharing to group ids with characters that are being url encoded

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -345,9 +345,6 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
 		$principals = array_merge($principals, $this->principalBackend->getCircleMembership($principalUriOriginal));
 
-		$principals = array_map(function ($principal) {
-			return urldecode($principal);
-		}, $principals);
 		$principals[] = $principalUri;
 
 		$fields = array_values($this->propertyMap);

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -191,9 +191,6 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$principals = $this->principalBackend->getGroupMembership($principalUriOriginal, true);
 		$principals = array_merge($principals, $this->principalBackend->getCircleMembership($principalUriOriginal));
 
-		$principals = array_map(function ($principal) {
-			return urldecode($principal);
-		}, $principals);
 		$principals[] = $principalUri;
 
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -231,7 +231,7 @@ class GroupPrincipalBackend implements BackendInterface {
 							}
 						}
 
-						$carry[] = self::PRINCIPAL_PREFIX . '/' . $gid;
+						$carry[] = self::PRINCIPAL_PREFIX . '/' . urlencode($gid);
 						return $carry;
 					}, []);
 					break;

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -107,6 +107,7 @@ class Backend {
 			return;
 		}
 
+		$principal[2] = urldecode($principal[2]);
 		if (($principal[1] === 'users' && !$this->userManager->userExists($principal[2])) ||
 			($principal[1] === 'groups' && !$this->groupManager->groupExists($principal[2]))) {
 			// User or group does not exist


### PR DESCRIPTION
When you try to share a calendar to (local) group "Route#44" it will fail, because internally the group name was not decoded.

What also was and still is not the case that on failed sharing a proper error was being reported. I.e. at the moment you do not see that it was failing,  only with a reload (or  a complaint by one of the members :)). That might be a follow up PR.