### PR TITLE
Always install composer v2

### DIFF
--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -9,7 +9,7 @@ then
 else
   echo "Composer not found: fetching"
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-  php composer-setup.php
+  php composer-setup.php --2
   php -r "unlink('composer-setup.php');"
 fi
 


### PR DESCRIPTION
It seems that the [stable channel of composer](https://getcomposer.org/versions) changed from v2 ~ 2 hours ago https://drone.nextcloud.com/nextcloud/server/174/2/3 to v1 https://drone.nextcloud.com/nextcloud/server/183/2/3

Therefore the installer now downloads composer v1 again, however since we use v2 we can fore install that one in the autoload checker.

Raised https://github.com/composer/getcomposer.org/issues/177 upstream for this