### PR TITLE
Reenable skipped federated sharing integration test steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -789,7 +789,7 @@ steps:
   commands:
     - git submodule update --init
 - name: integration-federation_features
-  image: ghcr.io/nextcloud/continuous-integration-integration-php7.3:latest
+  image: ghcr.io/nextcloud/continuous-integration-integration-php7.4:latest
   commands:
     - bash tests/drone-run-integration-tests.sh || exit 0
     - ./occ maintenance:install --admin-pass=admin

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -231,7 +231,7 @@ class FederatedShareProvider implements IShareProvider {
 				$ownerCloudId = $this->cloudIdManager->getCloudId($remoteShare['owner'], $remoteShare['remote']);
 				$shareId = $this->addShareToDB($itemSource, $itemType, $shareWith, $sharedBy, $ownerCloudId->getId(), $permissions, 'tmp_token_' . time(), $shareType, $expirationDate);
 				$share->setId($shareId);
-				[$token, $remoteId] = $this->askOwnerToReShare($shareWith, $share, $shareId);
+				[$token, $remoteId] = $this->askOwnerToReShare($shareWith, $share, $shareId, $shareType);
 				// remote share was create successfully if we get a valid token as return
 				$send = is_string($token) && $token !== '';
 			} catch (\Exception $e) {
@@ -328,7 +328,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * @return array
 	 * @throws \Exception
 	 */
-	protected function askOwnerToReShare($shareWith, IShare $share, $shareId) {
+	protected function askOwnerToReShare($shareWith, IShare $share, $shareId, $shareType) {
 		$remoteShare = $this->getShareFromExternalShareTable($share);
 		$token = $remoteShare['share_token'];
 		$remoteId = $remoteShare['remote_id'];
@@ -341,7 +341,8 @@ class FederatedShareProvider implements IShareProvider {
 			$remote,
 			$shareWith,
 			$share->getPermissions(),
-			$share->getNode()->getName()
+			$share->getNode()->getName(),
+			$shareType
 		);
 
 		return [$token, $remoteId];

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -229,7 +229,7 @@ class FederatedShareProvider implements IShareProvider {
 		if ($remoteShare) {
 			try {
 				$ownerCloudId = $this->cloudIdManager->getCloudId($remoteShare['owner'], $remoteShare['remote']);
-				$shareId = $this->addShareToDB($itemSource, $itemType, $shareWith, $sharedBy, $ownerCloudId->getId(), $permissions, 'tmp_token_' . time(), $shareType, $expirationDate);
+				$shareId = $this->addShareToDB($itemSource, $itemType, $cloudId->getId(), $sharedBy, $ownerCloudId->getId(), $permissions, 'tmp_token_' . time(), $shareType, $expirationDate);
 				$share->setId($shareId);
 				[$token, $remoteId] = $this->askOwnerToReShare($shareWith, $share, $shareId, $shareType);
 				// remote share was create successfully if we get a valid token as return

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -159,7 +159,7 @@ class Notifications {
 	 * @throws \OCP\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission, $filename) {
+	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission, $filename, $shareType) {
 		$fields = [
 			'shareWith' => $shareWith,
 			'token' => $token,
@@ -171,6 +171,7 @@ class Notifications {
 		$ocmFields['remoteId'] = (string)$id;
 		$ocmFields['localId'] = $shareId;
 		$ocmFields['name'] = $filename;
+		$ocmFields['shareType'] = $shareType;
 
 		$ocmResult = $this->tryOCMEndPoint($remote, $ocmFields, 'reshare');
 		if (is_array($ocmResult) && isset($ocmResult['token']) && isset($ocmResult['providerId'])) {

--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -79,7 +79,7 @@ trait BasicStructure {
 		$this->adminUser = $admin;
 		$this->regularUser = $regular_user_password;
 		$this->localBaseUrl = $this->baseUrl;
-		$this->remoteBaseUrl = $this->baseUrl;
+		$this->remoteBaseUrl = str_replace('8080', '8180', $this->baseUrl);
 		$this->currentServer = 'LOCAL';
 		$this->cookieJar = new CookieJar();
 

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -190,29 +190,30 @@ Feature: federated
 		And User "user1" from server "REMOTE" accepts last pending share
 		And Using server "REMOTE"
 		And As an "user1"
+    # FIXME this step causes issues in case there is already another incoming share with the (2) suffix
 		When creating a share with
 			| path | /textfile0 (2).txt |
 			| shareType | 0 |
 			| shareWith | user2 |
 			| permissions | 19 |
-		#Then the OCS status code should be "100"
-		#And the HTTP status code should be "200"
-		#And Share fields of last share match with
-		#	| id | A_NUMBER |
-		#	| item_type | file |
-		#	| item_source | A_NUMBER |
-		#	| share_type | 0 |
-		#	| file_source | A_NUMBER |
-		#	| path | /textfile0 (2).txt |
-		#	| permissions | 19 |
-		#	| stime | A_NUMBER |
-		#	| storage | A_NUMBER |
-		#	| mail_send | 1 |
-		#	| uid_owner | user1 |
-		#	| file_parent | A_NUMBER |
-		#	| displayname_owner | user1 |
-		#	| share_with | user2 |
-		#	| share_with_displayname | user2 |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And Share fields of last share match with
+			| id | A_NUMBER |
+			| item_type | file |
+			| item_source | A_NUMBER |
+			| share_type | 0 |
+			| file_source | A_NUMBER |
+			| path | /textfile0 (2).txt |
+			| permissions | 19 |
+			| stime | A_NUMBER |
+			| storage | A_NUMBER |
+			| mail_send | 1 |
+			| uid_owner | user1 |
+			| file_parent | A_NUMBER |
+			| displayname_owner | user1 |
+			| share_with | user2 |
+			| share_with_displayname | user2 |
 
 	Scenario: Overwrite a federated shared file as recipient
 		Given Using server "REMOTE"
@@ -240,9 +241,9 @@ Feature: federated
 		And Using server "REMOTE"
 		And As an "user1"
 		And User "user1" modifies text of "/textfile0.txt" with text "BLABLABLA"
-		#When User "user1" uploads file "../../data/user1/files/textfile0.txt" to "/PARENT (2)/textfile0.txt"
-		#And Downloading file "/PARENT (2)/textfile0.txt" with range "bytes=0-8"
-		#Then Downloaded content should be "BLABLABLA"
+		When User "user1" uploads file "../../data/user1/files/textfile0.txt" to "/PARENT (2)/textfile0.txt"
+		And Downloading file "/PARENT (2)/textfile0.txt" with range "bytes=0-8"
+		Then Downloaded content should be "BLABLABLA"
 
 	Scenario: Overwrite a federated shared file as recipient using old chunking
 		Given Using server "REMOTE"
@@ -254,11 +255,11 @@ Feature: federated
 		And User "user1" from server "REMOTE" accepts last pending share
 		And Using server "REMOTE"
 		And As an "user1"
-		#And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt"
-		#And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt"
-		#And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt"
-		#When Downloading file "/textfile0 (2).txt" with range "bytes=0-4"
-		#Then Downloaded content should be "AAAAA"
+		And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt"
+		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt"
+		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt"
+		When Downloading file "/textfile0 (2).txt" with range "bytes=0-4"
+		Then Downloaded content should be "AAAAA"
 
 	Scenario: Overwrite a federated shared folder as recipient using old chunking
 		Given Using server "REMOTE"
@@ -270,11 +271,11 @@ Feature: federated
 		And User "user1" from server "REMOTE" accepts last pending share
 		And Using server "REMOTE"
 		And As an "user1"
-		#And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt"
-		#And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt"
-		#And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt"
-		#When Downloading file "/PARENT (2)/textfile0.txt" with range "bytes=3-13"
-		#Then Downloaded content should be "AABBBBBCCCC"
+		And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt"
+		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt"
+		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt"
+		When Downloading file "/PARENT (2)/textfile0.txt" with range "bytes=3-13"
+		Then Downloaded content should be "AABBBBBCCCC"
 
 
 

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -34,13 +34,13 @@ if [ -z "$EXECUTOR_NUMBER" ]; then
 fi
 PORT=$((8080 + $EXECUTOR_NUMBER))
 echo $PORT
-php -S localhost:$PORT -t ../.. &
+PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT -t ../.. &
 PHPPID=$!
 echo $PHPPID
 
 PORT_FED=$((8180 + $EXECUTOR_NUMBER))
 echo $PORT_FED
-php -S localhost:$PORT_FED -t ../.. &
+PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT_FED -t ../.. &
 PHPPID_FED=$!
 echo $PHPPID_FED
 
@@ -66,6 +66,7 @@ RESULT=$?
 
 kill $PHPPID
 kill $PHPPID_FED
+pkill -9 php
 
 if [ "$INSTALLED" == "true" ]; then
 

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -34,13 +34,13 @@ if [ -z "$EXECUTOR_NUMBER" ]; then
 fi
 PORT=$((8080 + $EXECUTOR_NUMBER))
 echo $PORT
-PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT -t ../.. &>/tmp/nc-access-$PORT &
+PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT -t ../.. &>/tmp/nc-access-$PORT
 PHPPID=$!
 echo $PHPPID
 
 PORT_FED=$((8180 + $EXECUTOR_NUMBER))
 echo $PORT_FED
-PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT_FED -t ../.. &>/tmp/nc-access-$PORT_FED &
+PHP_CLI_SERVER_WORKERS=10 php -S 0.0.0.0:$PORT_FED -t ../.. &>/tmp/nc-access-$PORT_FED
 PHPPID_FED=$!
 echo $PHPPID_FED
 


### PR DESCRIPTION
- They currently run fine locally except for one that only succeedes on the first run (see FIXME)
- Enabling APCu locally brings a huge speed boost, might make sense in general for the integration tests