### PR TITLE
Remember me is not an app_password

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -832,8 +832,18 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		// Set the session variable so we know this is an app password
-		$this->session->set('app_password', $token);
+		try {
+			$dbToken = $this->tokenProvider->getToken($token);
+		} catch (InvalidTokenException $e) {
+			// Can't relaly happen but better save than sorry
+			return true;
+		}
+
+		// Remember me tokens are not app_passwords
+		if ($dbToken->getRemember() === IToken::DO_NOT_REMEMBER) {
+			// Set the session variable so we know this is an app password
+			$this->session->set('app_password', $token);
+		}
 
 		return true;
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -835,7 +835,7 @@ class Session implements IUserSession, Emitter {
 		try {
 			$dbToken = $this->tokenProvider->getToken($token);
 		} catch (InvalidTokenException $e) {
-			// Can't relaly happen but better save than sorry
+			// Can't really happen but better save than sorry
 			return true;
 		}
 


### PR DESCRIPTION
While technically they are stored the same. This session variable is
used to indicate that a user is using an app password to authenticate.
Like from a client. Or when having it generated automatically.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>