### PR TITLE
Revert "Do not read certificate bundle from data dir by default"

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -98,18 +98,18 @@ class Client implements IClient {
 	}
 
 	private function getCertBundle(): string {
+		if ($this->certificateManager->listCertificates() !== []) {
+			return $this->certificateManager->getAbsoluteBundlePath();
+		}
+
 		// If the instance is not yet setup we need to use the static path as
 		// $this->certificateManager->getAbsoluteBundlePath() tries to instantiate
 		// a view
-		if ($this->config->getSystemValue('installed', false) === false) {
-			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+		if ($this->config->getSystemValue('installed', false)) {
+			return $this->certificateManager->getAbsoluteBundlePath(null);
 		}
 
-		if ($this->certificateManager->listCertificates() === []) {
-			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
-		}
-
-		return $this->certificateManager->getAbsoluteBundlePath();
+		return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 	}
 
 	/**

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -461,8 +461,9 @@ class ClientTest extends \Test\TestCase {
 			->with('installed', false)
 			->willReturn(false);
 		$this->certificateManager
-			->expects($this->never())
-			->method('listCertificates');
+			->expects($this->once())
+			->method('listCertificates')
+			->willReturn([]);
 
 		$this->assertEquals([
 			'verify' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',


### PR DESCRIPTION
This reverts commit 18b0d753f2d76da10fefbf9a34e22dfdcbdc93b0 from #21090 


Problem:

* custom SSL certs are not properly used

Test

* start `mitmproxy` (https://mitmproxy.org)
* add `'proxy' => '127.0.0.1:8080',` to your `config.php`
* import the self signed certificate: `php occ security:certificates:import ~/.mitmproxy/mitmproxy-ca-cert.pem`
* open the admin settings with the setup checks
* before: "no internet connection" warning and `cURL error 60: SSL certificate problem: self signed certificate in certificate chain` in the logs
* after: no setup warnings and no logs (also clean HTTPS connections in the mitmproxy interface)

