### PR TITLE
[stable20] dont use system composer for autoload checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ clover.xml
 # Tests - dependencies
 tests/acceptance/composer.lock
 tests/acceptance/vendor/
+
+composer.phar

--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -42,6 +42,8 @@ do
     fi
 done
 
+rm composer.phar
+
 echo
 if [ $composerfile = true ]
 then

--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -1,26 +1,18 @@
 #!/usr/bin/env bash
 
-COMPOSER_COMMAND=$(which "composer")
-if [ "$COMPOSER_COMMAND" = '' ]
-then
-	#No global composer found, try local or download it
-	if [ -e "composer.phar" ]
-	then
-		echo "Composer found: checking for update"
-	else
-		echo "Composer not found: fetching"
-		php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-		php composer-setup.php
-		php -r "unlink('composer-setup.php');"
-	fi
+COMPOSER_COMMAND="php composer.phar"
 
-	COMPOSER_COMMAND="php composer.phar"
+if [ -e "composer.phar" ]
+then
+  echo "Composer found: checking for update"
+  $COMPOSER_COMMAND self-update
 else
-	echo "Global composer found: checking for update"
+  echo "Composer not found: fetching"
+  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+  php composer-setup.php
+  php -r "unlink('composer-setup.php');"
 fi
 
-#Make sure we are on the latest composer
-$COMPOSER_COMMAND self-update
 
 REPODIR=`git rev-parse --show-toplevel`
 

--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -9,7 +9,7 @@ then
 else
   echo "Composer not found: fetching"
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-  php composer-setup.php
+  php composer-setup.php --1
   php -r "unlink('composer-setup.php');"
 fi
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/24396 and https://github.com/nextcloud/server/pull/24545 for stable20 to always use composer 1.