### PR TITLE
DB conversion: improve console output

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -246,6 +246,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		$schemaManager = new \OC\DB\MDB2SchemaManager($toDB);
 		$apps = $input->getOption('all-apps') ? \OC_App::getAllApps() : \OC_App::getEnabledApps();
 		foreach ($apps as $app) {
+			$output->writeln('<info> - '.$app.'</info>');
 			if (file_exists(\OC_App::getAppPath($app).'/appinfo/database.xml')) {
 				$schemaManager->createDbFromStructure(\OC_App::getAppPath($app).'/appinfo/database.xml');
 			} else {
@@ -327,6 +328,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		}
 
 		$progress = new ProgressBar($output, $count);
+		$progress->setFormat('very_verbose');
 		$progress->start();
 		$redraw = $count > $chunkSize ? 100 : ($count > 100 ? 5 : 1);
 		$progress->setRedrawFrequency($redraw);
@@ -382,6 +384,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 			$result->closeCursor();
 		}
 		$progress->finish();
+		$output->writeln('');
 	}
 
 	protected function getColumnType(Table $table, $columnName) {
@@ -414,7 +417,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		try {
 			// copy table rows
 			foreach ($tables as $table) {
-				$output->writeln($table);
+				$output->writeln('<info> - '.$table.'</info>');
 				$this->copyTable($fromDB, $toDB, $schema->getTable($table), $input, $output);
 			}
 			if ($input->getArgument('type') === 'pgsql') {


### PR DESCRIPTION
This trivial MR improves the console output of the DB conversion tool by

* Adding information during the schema discovery
* Increasing verbosity of progress bar to show ETA
* Adding newline after progress bar has finished
* Improving printout of table conversion by adding `<info>` style, similar to other elements printed

:slightly_smiling_face: 