### PR TITLE
Do not load nonexisting setup.js

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -104,7 +104,6 @@ class SetupController {
 		];
 		$parameters = array_merge($defaults, $post);
 
-		\OC_Util::addScript('setup');
 		\OC_Template::printGuestPage('', 'installation', $parameters);
 	}
 


### PR DESCRIPTION
We don't have a setup.js script anymore since https://github.com/nextcloud/server/pull/19892

Fixes the report by @danxuliu in https://github.com/nextcloud/server/pull/19892#issuecomment-598121155