### PR TITLE
20.0.3 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 3, 0];
+$OC_Version = [20, 0, 3, 1];
 
 // The human readable string
-$OC_VersionString = '20.0.3 RC1';
+$OC_VersionString = '20.0.3 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24181 Check quota of subdirectories when uploading to them
* #24196 CircleId too short in some request
* #24212 Missing level in ScopedPsrLogger
* #24228 Fix nextcloud logo in email notifications misalignment
* #24230 Allow selecting multiple columns with SELECT DISTINCT
* #24231 Use file name instead of path in 'not allowed to share' message
* #24232 Fix setting images through occ for theming
* #24239 Use regex when searching on single file shares
* #24249 Harden EncryptionLegacyCipher a bit
* #24258 Update ScanLegacyFormat.php
* #24259 Simple typo in comments
* #24263 Use correct year for generated birthdays events
* #24297 Delete files that exceed trashbin size immediately
* #24311 Update sabre/xml to fix XML parsing errors
* #24325 Only check path for being accessible when the storage is a object home
* #24333 Avoid empty null default with value that will be inserted anyways
* #24342 Fix contacts menu position and show uid as a tooltip
* #24346 Fix the config key on the sharing expire checkbox
* #24353 Set the display name of federated sharees from addressbook
* #24367 Catch storage not available in versions expire command
* #24377 Use proper bundles for files client and fileinfo
* #24387 Properly encode path when fetching inherited shares
* #24391 Formatting remote sharer should take protocol, path into account
* #24443 Make sure we add new line between vcf groups exports
* #24446 Fix public calendars shared to circles
* #24453 Store scss variables under a different prefix for each theming config version
* #24455 External storages: save group ids not display names in configuration
* #24462 Use correct l10n source in files_sharing JS code
* #24477 Set frame-ancestors to none if none are filled
* #24478 Move the password fiels of chaging passwords to post
* #24479 Move the global password for files external to post
* #24483 Only attempt to move to trash if a file is not in appdata
* #24491 Fix loading mtime of new file in conflict dialog in firefox
* #24502 Harden setup check for TLS version if host is not reachable
* #24509 Fix file size computation on 32bit platforms
* #24511 Allow subscription to indicate that a userlimit is reached
* #24513 Set mountid for personal external storage mounts
* #24517 Only execute plain mimetype check for directories and do the fallback…
* #24527 Fix vsprint parameter
* #24530 Replace abandoned log normalizer with our fork
* #24531 Add icon to user limit notification
* #24532 Also run repair steps when encryption is disabled but a legacy key is present
* #24534 [3rdparty][security] Archive TAR to 1.4.11
* #24553 Generate a new session id if the decrypting the session data fails
* #24556 Revert "Do not read certificate bundle from data dir by default"
* #24557 Dont use system composer for autoload checker
* #24563 Remember me is not an app_password
* #24582 Do not load nonexisting setup.js
* [3rdparty#529](https://github.com/nextcloud/3rdparty/pull/529) Update sabre/xml to fix XML parsing errors
* [3rdparty#532](https://github.com/nextcloud/3rdparty/pull/532) Use composer v1 on CI
* [3rdparty#536](https://github.com/nextcloud/3rdparty/pull/536) Bump pear/archive_tar from 1.4.9 to 1.4.11
* [3rdparty#543](https://github.com/nextcloud/3rdparty/pull/543) Replace abandoned log normalizer with our fork
* [activity#535](https://github.com/nextcloud/activity/pull/535) Allow nullable values as subject params
* [notifications#803](https://github.com/nextcloud/notifications/pull/803) Don't log when unknown array is null
* [photos#550](https://github.com/nextcloud/photos/pull/550) Feat/virtual grid
* [recommendations#336](https://github.com/nextcloud/recommendations/pull/336) Always get recommendations for dashboard if enabled
* [serverinfo#258](https://github.com/nextcloud/serverinfo/pull/258) Properly fetch oracle database information
* [text#1181](https://github.com/nextcloud/text/pull/1181) Also register to urlChanged event to update RichWorkspace
* [text#1214](https://github.com/nextcloud/text/pull/1214) Move away from GET
