### PR TITLE
files: Local#writeStream should use it's own file_put_contents

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -439,9 +439,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 	public function file_put_contents($path, $data) {
 		$handle = $this->fopen($path, 'w+');
-		fwrite($handle, $data);
+		$result = fwrite($handle, $data);
 		fclose($handle);
-		return true;
+		return $result;
 	}
 
 	public function writeStream(string $path, $stream, int $size = null): int {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -486,8 +486,8 @@ class DAV extends Common {
 
 	/**
 	 * @param string $path
-	 * @param string $data
-	 * @return int
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		$path = $this->cleanPath($path);

--- a/lib/private/Files/Storage/Flysystem.php
+++ b/lib/private/Files/Storage/Flysystem.php
@@ -73,7 +73,11 @@ abstract class Flysystem extends Common {
 	 * {@inheritdoc}
 	 */
 	public function file_put_contents($path, $data) {
-		return $this->flysystem->put($this->buildPath($path), $data);
+		$result = $this->flysystem->put($this->buildPath($path), $data);
+		if ($result === true) {
+			return strlen($data);
+		}
+		return $result;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -556,7 +556,7 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function writeStream(string $path, $stream, int $size = null): int {
-		$result = file_put_contents($this->getSourcePath($path), $stream);
+		$result = $this->file_put_contents($path, $stream);
 		if ($result === false) {
 			throw new GenericFileException("Failed write steam to $path");
 		} else {

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -309,8 +309,8 @@ class Encoding extends Wrapper {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		return $this->storage->file_put_contents($this->findPathToUse($path), $data);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -234,8 +234,8 @@ class Encryption extends Wrapper {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		// file put content will always be translated to a stream write

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -259,8 +259,8 @@ class Jail extends Wrapper {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		return $this->getWrapperStorage()->file_put_contents($this->getUnjailedPath($path), $data);

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -121,8 +121,8 @@ class Quota extends Wrapper {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		$free = $this->free_space($path);

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -250,8 +250,8 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 */
 	public function file_put_contents($path, $data) {
 		return $this->getWrapperStorage()->file_put_contents($path, $data);

--- a/lib/public/Files/Storage.php
+++ b/lib/public/Files/Storage.php
@@ -230,8 +230,8 @@ interface Storage extends IStorage {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 * @since 6.0.0
 	 */
 	public function file_put_contents($path, $data);

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -226,8 +226,8 @@ interface IStorage {
 	 * see http://php.net/manual/en/function.file_put_contents.php
 	 *
 	 * @param string $path
-	 * @param string $data
-	 * @return bool
+	 * @param mixed $data
+	 * @return int|false
 	 * @since 9.0.0
 	 */
 	public function file_put_contents($path, $data);


### PR DESCRIPTION
The OC\Files\Storage\Local#writeStream use system provided file_put_contents.
However, it overrides file_put_contents, thus expects that the default behaviour
can be different.

Use Local#file_put_contents in writeStream to benefit from class specific functionality.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>