### PR TITLE
Make debugging migration exceptions easier

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -27,6 +27,7 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Index;
@@ -421,7 +422,13 @@ class MigrationService {
 		// read known migrations
 		$toBeExecuted = $this->getMigrationsToExecute($to);
 		foreach ($toBeExecuted as $version) {
-			$this->executeStep($version, $schemaOnly);
+			try {
+				$this->executeStep($version, $schemaOnly);
+			} catch (DriverException $e) {
+				// The exception itself does not contain the name of the migration,
+				// so we wrap it here, to make debugging easier.
+				throw new \Exception('Database error when running migration ' . $to . ' for app ' . $this->getApp(), 0, $e);
+			}
 		}
 	}
 


### PR DESCRIPTION
The current exception stacktrace does nto give you any hint which app or migration is causing it. You might be able to guess it, but turns out I checked a wrong one until I figured out the correct one.

```
In AbstractOracleDriver.php line 57:
                                                                                                                             
  [Doctrine\DBAL\Exception\DriverException]                                                                                  
  An exception occurred while executing 'ALTER TABLE "oc_activity_mq" MODIFY ("amq_subjectparams" CLOB DEFAULT NULL NULL)':  
                                                                                                                             
  ORA-22859: invalid modification of columns                                                                                 
                                                                                                                             

Exception trace:
  at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php:57
 Doctrine\DBAL\Driver\AbstractOracleDriver->convertException() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:169
 Doctrine\DBAL\DBALException::wrapException() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:149
 Doctrine\DBAL\DBALException::driverExceptionDuringQuery() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1019
 Doctrine\DBAL\Connection->query() at /home/nickv/Nextcloud/20/server/lib/private/DB/Migrator.php:261
 OC\DB\Migrator->applySchema() at /home/nickv/Nextcloud/20/server/lib/private/DB/Migrator.php:85
 OC\DB\Migrator->migrate() at /home/nickv/Nextcloud/20/server/lib/private/DB/Connection.php:466
 OC\DB\Connection->migrateToSchema() at /home/nickv/Nextcloud/20/server/lib/private/DB/MigrationService.php:486
 OC\DB\MigrationService->executeStep() at /home/nickv/Nextcloud/20/server/lib/private/DB/MigrationService.php:414
 OC\DB\MigrationService->migrate() at /home/nickv/Nextcloud/20/server/lib/private/Installer.php:590
 OC\Installer::installShippedApp() at /home/nickv/Nextcloud/20/server/lib/private/Installer.php:553
 OC\Installer::installShippedApps() at /home/nickv/Nextcloud/20/server/lib/private/Setup.php:407
 OC\Setup->install() at /home/nickv/Nextcloud/20/server/core/Command/Maintenance/Install.php:106
 OC\Core\Command\Maintenance\Install->execute() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:1000
 Symfony\Component\Console\Application->doRunCommand() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:271
 Symfony\Component\Console\Application->doRun() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:147
 Symfony\Component\Console\Application->run() at /home/nickv/Nextcloud/20/server/lib/private/Console/Application.php:215
 OC\Console\Application->run() at /home/nickv/Nextcloud/20/server/console.php:100
 require_once() at /home/nickv/Nextcloud/20/server/occ:11

In OCI8Exception.php line 23:
                                              
  [Doctrine\DBAL\Driver\OCI8\OCI8Exception]   
  ORA-22859: invalid modification of columns  
                                              

Exception trace:
  at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Exception.php:23
 Doctrine\DBAL\Driver\OCI8\OCI8Exception::fromErrorInfo() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Statement.php:399
 Doctrine\DBAL\Driver\OCI8\OCI8Statement->execute() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Driver/OCI8/OCI8Connection.php:120
 Doctrine\DBAL\Driver\OCI8\OCI8Connection->query() at /home/nickv/Nextcloud/20/server/3rdparty/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1017
 Doctrine\DBAL\Connection->query() at /home/nickv/Nextcloud/20/server/lib/private/DB/Migrator.php:261
 OC\DB\Migrator->applySchema() at /home/nickv/Nextcloud/20/server/lib/private/DB/Migrator.php:85
 OC\DB\Migrator->migrate() at /home/nickv/Nextcloud/20/server/lib/private/DB/Connection.php:466
 OC\DB\Connection->migrateToSchema() at /home/nickv/Nextcloud/20/server/lib/private/DB/MigrationService.php:486
 OC\DB\MigrationService->executeStep() at /home/nickv/Nextcloud/20/server/lib/private/DB/MigrationService.php:414
 OC\DB\MigrationService->migrate() at /home/nickv/Nextcloud/20/server/lib/private/Installer.php:590
 OC\Installer::installShippedApp() at /home/nickv/Nextcloud/20/server/lib/private/Installer.php:553
 OC\Installer::installShippedApps() at /home/nickv/Nextcloud/20/server/lib/private/Setup.php:407
 OC\Setup->install() at /home/nickv/Nextcloud/20/server/core/Command/Maintenance/Install.php:106
 OC\Core\Command\Maintenance\Install->execute() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:1000
 Symfony\Component\Console\Application->doRunCommand() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:271
 Symfony\Component\Console\Application->doRun() at /home/nickv/Nextcloud/20/server/3rdparty/symfony/console/Application.php:147
 Symfony\Component\Console\Application->run() at /home/nickv/Nextcloud/20/server/lib/private/Console/Application.php:215
 OC\Console\Application->run() at /home/nickv/Nextcloud/20/server/console.php:100
 require_once() at /home/nickv/Nextcloud/20/server/occ:11
```