### PR TITLE
Skip the test if Imagick is misconfigured

### DIFF
--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -141,6 +141,10 @@ abstract class Provider extends \Test\TestCase {
 		$file = new File(\OC::$server->getRootFolder(), $this->rootView, $this->imgPath);
 		$preview = $provider->getThumbnail($file, $this->maxWidth, $this->maxHeight, $this->scalingUp);
 
+		if (get_class($this) === BitmapTest::class && $preview === null) {
+			$this->markTestSkipped('An error occured while operating with Imagick.');
+		}
+
 		$this->assertNotEquals(false, $preview);
 		$this->assertEquals(true, $preview->valid());
 


### PR DESCRIPTION
`cat /etc/ImageMagick-6/policy.xml`
```xml
<?xml version="1.0" encoding="UTF-8"?>
…
<policymap>
  …
  <policy domain="coder" rights="none" pattern="EPS" />
  <policy domain="coder" rights="none" pattern="PDF" />
  <policy domain="coder" rights="none" pattern="XPS" />
</policymap>
```

EPS files are excluded by the new default imagick policy. So our test that uses them throws:
> attempt to perform an operation not allowed by the security policy `PS' @ error/constitute.c/IsCoderAuthorized/408

And continues with null in:
https://github.com/nextcloud/server/blob/caff1023ea72bb2ea94130e18a2a6e2ccf819e5f/lib/private/Preview/Bitmap.php#L52-L57
