### PR TITLE
Fix loading order for OCS endpoints

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -51,12 +51,15 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 try {
 	OC_App::loadApps(['session']);
 	OC_App::loadApps(['authentication']);
+
+	// load all apps to get all api routes properly setup
+	// FIXME: this should ideally appear after handleLogin but will cause
+	// side effects in existing apps
+	OC_App::loadApps();
+
 	if (!\OC::$server->getUserSession()->isLoggedIn()) {
 		OC::handleLogin(\OC::$server->getRequest());
 	}
-
-	// load all apps to get all api routes properly setup
-	OC_App::loadApps();
 
 	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
 } catch (ResourceNotFoundException $e) {


### PR DESCRIPTION
The loading order can have side effects in the way how apps register
plugins, listeners, etc.

Recently the order had been changed as part of cleaning up old code, but
caused apps to break.

This brings back the old app loading order to guarantee that apps won't
break, even though it might not semantically make sense.

Fixes https://github.com/nextcloud/spreed/issues/4736
