### PR TITLE
Error: Unknown named parameter $remote_id

### DIFF
--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -149,7 +149,7 @@ class ManagerTest extends TestCase {
 			'shareType' => IShare::TYPE_USER,
 			'accepted' => false,
 			'user' => $this->uid,
-			'remote_id' => '2342'
+			'remoteId' => '2342'
 		];
 		$shareData2 = $shareData1;
 		$shareData2['token'] = 'token2';


### PR DESCRIPTION
![Screenshot from 2020-12-10 10-19-06](https://user-images.githubusercontent.com/3902676/101752066-56934500-3ad1-11eb-9a8f-ba3673ed4727.png)

https://github.com/nextcloud/server/blob/aefe8262023f5f3daaa33a33e6b31c8e12e33112/apps/files_sharing/lib/External/Manager.php#L134

The parameter is called $remoteId however the test used `remote_id`. Test fails only on PHP 8 so no backport required.