### PR TITLE
Indicate preview availability in recent file api responses

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -179,6 +179,7 @@ class ApiController extends Controller {
 			/** @var \OC\Files\Node\Node $shareTypes */
 			$shareTypes = $this->getShareTypes($node);
 			$file = \OCA\Files\Helper::formatFileInfo($node->getFileInfo());
+			$file['hasPreview'] = $this->previewManager->isAvailable($node);
 			$parts = explode('/', dirname($node->getPath()), 4);
 			if (isset($parts[3])) {
 				$file['path'] = '/' . $parts[3];


### PR DESCRIPTION
Ref #23350, #14849

The recent files list also has ugly borders when there is no preview available. I fixed this by adding the boolean `hasPreview` to responses from the recent files api.

## Before
![recent-before](https://user-images.githubusercontent.com/1479486/101785841-88ba9c00-3afd-11eb-8d4c-17ca91b32ad3.png)

## After
![recent-after](https://user-images.githubusercontent.com/1479486/101785838-88220580-3afd-11eb-97a2-e992080e4289.png)
