### PR TITLE
Add group backend interface to hide members from collaboration search

### DIFF
--- a/lib/private/Collaboration/Collaborators/GroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/GroupPlugin.php
@@ -118,7 +118,7 @@ class GroupPlugin implements ISearchPlugin {
 			// On page one we try if the search result has a direct hit on the
 			// user id and if so, we add that to the exact match list
 			$group = $this->groupManager->get($search);
-			if ($group instanceof IGroup && (!$this->shareWithGroupOnly || in_array($group->getGID(), $userGroups))) {
+			if ($group instanceof IGroup && (!$this->shareWithGroupOnly || in_array($group->getGID(), $userGroups)) && !$group->hideFromCollaboration()) {
 				$result['exact'][] = [
 					'label' => $group->getDisplayName(),
 					'value' => [

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -111,7 +111,8 @@ class MailPlugin implements ISearchPlugin {
 							$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 							$found = false;
 							foreach ($userGroups as $userGroup) {
-								if ($this->groupManager->isInGroup($contact['UID'], $userGroup)) {
+								$groupObject = $this->groupManager->get($userGroup);
+								if ($this->groupManager->isInGroup($contact['UID'], $userGroup) && $groupObject && !$groupObject->hideMembersFromCollaboration()) {
 									$found = true;
 									break;
 								}

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -94,6 +94,10 @@ class UserPlugin implements ISearchPlugin {
 		if ($this->shareWithGroupOnly) {
 			// Search in all the groups this user is part of
 			foreach ($currentUserGroups as $userGroupId) {
+				$group = $this->groupManager->get($userGroupId);
+				if (!$group || $group->hideFromCollaboration()) {
+					continue;
+				}
 				$usersInGroup = $this->groupManager->displayNamesInGroup($userGroupId, $search, $limit, $offset);
 				foreach ($usersInGroup as $userId => $displayName) {
 					$userId = (string) $userId;
@@ -202,6 +206,10 @@ class UserPlugin implements ISearchPlugin {
 				if ($this->shareWithGroupOnly) {
 					// Only add, if we have a common group
 					$commonGroups = array_intersect($currentUserGroups, $this->groupManager->getUserGroupIds($user));
+					$commonGroups = array_filter($commonGroups, function ($gid) {
+						$group = $this->groupManager->get($gid);
+						return $group && !$group->hideMembersFromCollaboration();
+					});
 					$addUser = !empty($commonGroups);
 				}
 

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -36,6 +36,7 @@ use OC\Hooks\PublicEmitter;
 use OCP\Group\Backend\ICountDisabledInGroup;
 use OCP\Group\Backend\IGetDisplayNameBackend;
 use OCP\Group\Backend\IHideFromCollaborationBackend;
+use OCP\Group\Backend\IHideMembersFromCollaborationBackend;
 use OCP\Group\Backend\ISetDisplayNameBackend;
 use OCP\GroupInterface;
 use OCP\IGroup;
@@ -400,6 +401,16 @@ class Group implements IGroup {
 	public function hideFromCollaboration(): bool {
 		return array_reduce($this->backends, function (bool $hide, GroupInterface $backend) {
 			return $hide | ($backend instanceof IHideFromCollaborationBackend && $backend->hideGroup($this->gid));
+		}, false);
+	}
+
+	/**
+	 * @return bool
+	 * @since 21.0.0
+	 */
+	public function hideMembersFromCollaboration(): bool {
+		return array_reduce($this->backends, function (bool $hide, GroupInterface $backend) {
+			return $hide | ($backend instanceof IHideMembersFromCollaborationBackend && $backend->hideGroupMembers($this->gid));
 		}, false);
 	}
 }

--- a/lib/public/Group/Backend/IHideMembersFromCollaborationBackend.php
+++ b/lib/public/Group/Backend/IHideMembersFromCollaborationBackend.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Group\Backend;
+
+/**
+ * @since 21.0.0
+ *
+ * Allow the backend to mark groups members to be excluded from being shown in search dialogs
+ */
+interface IHideMembersFromCollaborationBackend {
+	/**
+	 * Check if a group members should be hidden from search dialogs
+	 *
+	 * @param string $groupId
+	 * @return bool
+	 * @since 16.0.0
+	 */
+	public function hideGroupMembers(string $groupId): bool;
+}

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -154,4 +154,10 @@ interface IGroup {
 	 * @since 16.0.0
 	 */
 	public function hideFromCollaboration(): bool;
+
+	/**
+	 * @return bool
+	 * @since 21.0.0
+	 */
+	public function hideMembersFromCollaboration(): bool;
 }


### PR DESCRIPTION
This allows group backends to have their members not show up in collaboration search e.g. when sharing. It is quite a common use case to have groups that are used for internal purposes (like flow or app limitations) but they shall not see each other when sharing is limited to within the same groups.

A very simple solution would be a small app (started at https://github.com/juliushaertl/systemgroups without member handling yet) that provides a custom local group backend where admins can then manage those groups that are not exposing users to others through sharing.