### PR TITLE
Add sanitizers for JSON output

### DIFF
--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -43,6 +43,7 @@ class OC_API {
 	 * respond to a call
 	 * @param \OC\OCS\Result $result
 	 * @param string $format the format xml|json
+	 * @psalm-taint-escape html
 	 */
 	public static function respond($result, $format = 'xml') {
 		$request = \OC::$server->getRequest();

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -99,6 +99,7 @@ class OC_JSON {
 	 * Send json error msg
 	 * @deprecated Use a AppFramework JSONResponse instead
 	 * @suppress PhanDeprecatedFunction
+	 * @psalm-taint-escape html
 	 */
 	public static function error($data = []) {
 		$data['status'] = 'error';
@@ -110,6 +111,7 @@ class OC_JSON {
 	 * Send json success msg
 	 * @deprecated Use a AppFramework JSONResponse instead
 	 * @suppress PhanDeprecatedFunction
+	 * @psalm-taint-escape html
 	 */
 	public static function success($data = []) {
 		$data['status'] = 'success';


### PR DESCRIPTION
Those functions set proper content-types that prevent rendering of data. Therefore it's safe to mark them as sanitizers.