### PR TITLE
Update comment to reflect current CSP policy

### DIFF
--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -36,7 +36,7 @@ namespace OCP\AppFramework\Http;
  * notice that Nextcloud ships already with sensible defaults and those policies
  * should require no modification at all for most use-cases.
  *
- * This class allows unsafe-eval of javascript and unsafe-inline of CSS.
+ * This class allows unsafe-inline of CSS.
  *
  * @since 8.1.0
  */


### PR DESCRIPTION
People actually read comments :D

JS unsafe-eval was removed a long time ago in https://github.com/nextcloud/server/pull/11028