### PR TITLE
[Fix #24682]: ensure federation cloud id is retruned if FN property not found

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -86,7 +86,13 @@ class CloudIdManager implements ICloudIdManager {
 			if (isset($entry['CLOUD'])) {
 				foreach ($entry['CLOUD'] as $cloudID) {
 					if ($cloudID === $cloudId) {
-						return $entry['FN'];
+						// Warning, if user decides to make his full name local only,
+						// no FN is found on federated servers
+						if (isset($entry['FN'])) {
+							return $entry['FN'];
+						} else {
+							return $cloudID;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This PR is fixing #24682

I have tested it on my migrated instance (19.0.6) and it is working fine.

Let me know if anything is missing or need to be reworked (I am not an expert)