### PR TITLE
21 beta2

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 8];
+$OC_Version = [21, 0, 0, 9];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta1';
+$OC_VersionString = '21.0.0 beta2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #23017 Make share results distinguishable if there are more than one with the same display name
* #24194 Add action to clear all weather favorites
* #24402 LDAP: fix inGroup for memberUid type of group memberships
* #24418 Bump vuex from 3.5.1 to 3.6.0
* #24488 Add text/org mimetype
* #24589 Add tel, note, org and title search
* #24629 Make $vars and $secureRandom required.
* #24631 Prevent * and other things in the same query for Oracle
* #24659 Dav principal search to honour sharing.maxAutocompleteResults setting
* #24663 Add sanitizers for JSON output
* #24666 Bump dompurify from 2.2.2 to 2.2.3
* #24667 Bump sinon from 9.2.1 to 9.2.2
* #24668 Bump marked from 1.2.5 to 1.2.6
* #24669 Bump webpack-merge from 5.4.0 to 5.6.1
* #24670 Bump @babel/preset-env from 7.12.7 to 7.12.10
* #24671 Bump @babel/core from 7.12.9 to 7.12.10
* #24672 Bump core-js from 3.8.0 to 3.8.1
* #24679 Update comment to reflect current CSP policy
* #24683 [Fix #24682]: ensure federation cloud id is retruned if FN property not found
* #24695 Add missing parent::__construct() calls to Jobs
* #24706 Log an error when setting a custom header on "Not Modified" responses
* #24713 Do not include non-required scripts on the upgrade page
* #24717 Promoted bad memory_limit check from warning to error as it may break updater
* #24718 [Automated] Update psalm-baseline.xml
* #24721 Cancel user search requests to avoid duplicate results being added
* #24725 Fix untranslated "User disabled" on login screen
* #24731 Update all license headers for Nextcloud 21
* #24737 Also unset the other possible unused paramters
* #24740 Improve hints for default_phone_region
* [files_pdfviewer#274](https://github.com/nextcloud/files_pdfviewer/pull/274) Bump @babel/core from 7.12.9 to 7.12.10
* [files_pdfviewer#275](https://github.com/nextcloud/files_pdfviewer/pull/275) Bump @babel/preset-env from 7.12.7 to 7.12.10
* [files_pdfviewer#276](https://github.com/nextcloud/files_pdfviewer/pull/276) Bump ini from 1.3.5 to 1.3.8
* [firstrunwizard#443](https://github.com/nextcloud/firstrunwizard/pull/443) Bump vue-loader from 15.9.4 to 15.9.5
* [firstrunwizard#457](https://github.com/nextcloud/firstrunwizard/pull/457) Bump @babel/core from 7.12.9 to 7.12.10
* [firstrunwizard#458](https://github.com/nextcloud/firstrunwizard/pull/458) Bump @babel/preset-env from 7.12.7 to 7.12.10
* [notifications#817](https://github.com/nextcloud/notifications/pull/817) Bump @babel/preset-env from 7.12.7 to 7.12.10
* [notifications#818](https://github.com/nextcloud/notifications/pull/818) Bump core-js from 3.8.0 to 3.8.1
* [notifications#819](https://github.com/nextcloud/notifications/pull/819) Bump @babel/core from 7.12.9 to 7.12.10
* [photos#577](https://github.com/nextcloud/photos/pull/577) Bump workbox-webpack-plugin from 5.1.4 to 6.0.2
* [photos#588](https://github.com/nextcloud/photos/pull/588) Bump @babel/preset-env from 7.12.7 to 7.12.10
* [photos#589](https://github.com/nextcloud/photos/pull/589) Bump webpack-merge from 5.4.0 to 5.6.1
* [photos#590](https://github.com/nextcloud/photos/pull/590) Bump core-js from 3.8.0 to 3.8.1
* [photos#591](https://github.com/nextcloud/photos/pull/591) Bump eslint from 7.14.0 to 7.15.0
* [photos#592](https://github.com/nextcloud/photos/pull/592) Bump @babel/core from 7.12.9 to 7.12.10
* [photos#593](https://github.com/nextcloud/photos/pull/593) Bump ini from 1.3.5 to 1.3.8
* [photos#594](https://github.com/nextcloud/photos/pull/594) Bump @vue/test-utils from 1.1.1 to 1.1.2
* [photos#595](https://github.com/nextcloud/photos/pull/595) Bump vue-virtual-grid from 2.2.1 to 2.3.0
* [photos#596](https://github.com/nextcloud/photos/pull/596) Bump webpack-merge from 5.6.1 to 5.7.0
* [serverinfo#261](https://github.com/nextcloud/serverinfo/pull/261) Fix MySQL database size calculation
* [text#1015](https://github.com/nextcloud/text/pull/1015) Use to correct cache to obtain version info
* [text#1188](https://github.com/nextcloud/text/pull/1188) Bump prosemirror-inputrules from 1.1.2 to 1.1.3
* [text#1197](https://github.com/nextcloud/text/pull/1197) Bump tiptap-extensions from 1.33.1 to 1.33.2
* [text#1200](https://github.com/nextcloud/text/pull/1200) Bump @nextcloud/eslint-plugin from 1.4.0 to 1.5.0
* [text#1205](https://github.com/nextcloud/text/pull/1205) Add text/org mimetype #394
* [text#1218](https://github.com/nextcloud/text/pull/1218) Bump @babel/plugin-proposal-class-properties from 7.10.4 to 7.12.1
* [text#1223](https://github.com/nextcloud/text/pull/1223) Revert removal of transformResponse
* [text#1230](https://github.com/nextcloud/text/pull/1230) Bump @babel/plugin-transform-runtime from 7.11.5 to 7.12.10
* [text#1231](https://github.com/nextcloud/text/pull/1231) Bump prosemirror-model from 1.11.0 to 1.13.0
* [text#1232](https://github.com/nextcloud/text/pull/1232) Bump core-js from 3.6.5 to 3.8.1
* [viewer#709](https://github.com/nextcloud/viewer/pull/709) Bump jest from 24.9.0 to 26.6.3
* [viewer#711](https://github.com/nextcloud/viewer/pull/711) Bump eslint-plugin-vue from 7.1.0 to 7.2.0
* [viewer#712](https://github.com/nextcloud/viewer/pull/712) Bump eslint-webpack-plugin from 2.4.0 to 2.4.1
* [viewer#713](https://github.com/nextcloud/viewer/pull/713) Bump @nextcloud/vue from 3.2.0 to 3.3.1
* [viewer#715](https://github.com/nextcloud/viewer/pull/715) Bump @babel/preset-env from 7.12.7 to 7.12.10
* [viewer#716](https://github.com/nextcloud/viewer/pull/716) Bump cypress from 6.0.0 to 6.1.0
* [viewer#717](https://github.com/nextcloud/viewer/pull/717) Bump eslint from 7.14.0 to 7.15.0
* [viewer#719](https://github.com/nextcloud/viewer/pull/719) Bump @babel/core from 7.12.9 to 7.12.10
* [viewer#720](https://github.com/nextcloud/viewer/pull/720) Bump core-js from 3.8.0 to 3.8.1
* [viewer#721](https://github.com/nextcloud/viewer/pull/721) Retry cypress on failure
* [viewer#724](https://github.com/nextcloud/viewer/pull/724) Bump webpack-merge from 5.4.0 to 5.7.0


Pending PRs:

* [ ] #16696 Fixed moving of master key encrypted and versioned files between shared folders @yahesh
* [ ] #16746 Properly throw errors on users management @skjnldsv
* [ ] #17218 Fix: SMB/CIFS/CEPH mounted drive caused large file upload errors @stereu
* [ ] #18199 Add and remove tags from multiple files at once @rolandinus
* [ ] #19807 Fix filepicker list not being keyboard tabbable, ref #16494 @jancborchardt
* [ ] #20214 Allow to have multiple links per public calendar @tcitworld
* [ ] #20667 Allow to tweak default scopes for accounts @tcitworld
* [ ] #21049 Add support for shared file IDs on SMB storage @ddean4040
* [ ] #22085 Adding social profile to search index @call-me-matt
* [ ] #22222 Re-index contacts with social profiles @call-me-matt
* [ ] #22274 Move contactsmenu to vue @dk1a
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22527 Add interface for setup checks @kesselb
* [ ] #22530 Fix inGroup check for memberUid mapped groups in LDAP when accepting or rejecting shares @g1smo
* [ ] #22628 Coalesce RewriteCond lines in .htaccess @Sp1l
* [ ] #22916 Unify links to php.net @J0WI
* [ ] #22921 Dont apply encryption wrapper for root mount @icewind1991
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #22981 Support /.well-known/change-password URL @beatbrot
* [ ] #22992 Allow authenticating using urlencoded passwords @icewind1991
* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #23073 Move preview repair to query @rullzer
* [ ] #23125 Also load app autoloader when located in /vendor @icewind1991
* [ ] #23138 Sharing: define public groups (exceptions for when sharing is restricted on groups) @chrisfritsche
* [ ] #23261 Expose session based authentication through mount point type @juliushaertl
* [ ] #23273 Avoid reading ~/.aws/config when using S3 provider @FlorentCoppint
* [ ] #23319 Fix Argon2 descriptions @MichaIng
* [ ] #23333 Persist the config changes of usermanagement @sharidas
* [ ] #23444 Add dry-run option to files_external:notify @icewind1991
* [ ] #23489 External delete directly @dassio
* [ ] #23529 Settings: new user row replaced by a modal @Simounet
* [ ] #23665 Add executeQuery and executeUpdate @rullzer
* [ ] #23695 Do not show shares of disabled users @rullzer
* [ ] #23718 Expand 'path is already shared' error message @icewind1991
* [ ] #23719 Disable hyperextensible and tapToClose on sidebar snap @icewind1991
* [ ] #23865 Only filter submounts for fileinfo on demand @icewind1991
* [ ] #23914 If basic auth provided but invalid fail @rullzer
* [ ] #24036 Move encryption from app.php to IBootstrap @MorrisJobke
* [ ] #24107 Bump jquery from 3.1 to 3.5 @ChristophWurst
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #24193 Add option to set weather forecast offset @eneiluj
* [ ] #24248 [3rdparty] psr/log and psr/http-client updates @rullzer
* [ ] #24255 Add focus-visible outline for checkboxes and radio buttons @PVince81
* [ ] #24295 First attempt to check against core routes before loading all app routes @juliushaertl
* [ ] #24318 Use proper methods for display name retrieval @MorrisJobke
* [ ] #24364 Sharing link & mail parity @skjnldsv
* [ ] #24515 Fixes sharing to group ids with characters that are being url encoded @blizzz
* [ ] #24533 Bump icewind/streams from 0.7.1 to 0.7.2 @ChristophWurst
* [ ] #24594 Files: Local#writeStream should use it's own file_put_contents @kofemann
* [ ] #24604 Allow to force rename a conflicting calendar @skjnldsv
* [ ] #24610 Adding a ShareDeletedEvent @daita
* [ ] #24611 Remove limit from axios call that retrieves groups @lephisto
* [ ] #24661 Dont offer to edit external config settings if we can't edit them @icewind1991
* [ ] #24694 Specify the boundary element of the Actions menu @nickvergessen
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #24703 Enables the file name check also to match name of mountpoints @blizzz
* [ ] #24715 Limit getIncomplete query to one row @kesselb
* [ ] #24727 Enhance signature algorithm for code signatures @rullzer
* [ ] [3rdparty#492](https://github.com/nextcloud/3rdparty/pull/492) Bump sabre family @skjnldsv
