### PR TITLE
[stable20] Fix psalm errors

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -760,10 +760,9 @@
     <InvalidReturnType occurrences="1">
       <code>string[]</code>
     </InvalidReturnType>
-    <NullableReturnStatement occurrences="9">
+    <NullableReturnStatement occurrences="8">
       <code>null</code>
       <code>$this-&gt;circleToPrincipal($name)</code>
-      <code>null</code>
       <code>null</code>
       <code>null</code>
       <code>null</code>
@@ -3400,9 +3399,6 @@
       <code>strtolower</code>
     </RedundantCondition>
   </file>
-  <file src="lib/private/AppFramework/ScopedPsrLogger.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
   <file src="lib/private/AppFramework/Services/AppConfig.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$default</code>
@@ -4793,14 +4789,6 @@
       <code>true</code>
     </InvalidReturnType>
   </file>
-  <file src="lib/private/Files/Stream/Encryption.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$position</code>
-    </InvalidScalarArgument>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>$cacheEntry</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
     <FalsableReturnStatement occurrences="3">
       <code>false</code>
@@ -5529,8 +5517,7 @@
       <code>'OCP\Share::postUnshareFromSelf'</code>
       <code>$data</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="3">
-      <code>$this-&gt;shareApiLinkDefaultExpireDays()</code>
+    <InvalidScalarArgument occurrences="2">
       <code>$this-&gt;shareApiLinkDefaultExpireDays()</code>
       <code>$id</code>
     </InvalidScalarArgument>

--- a/lib/private/Avatar/Avatar.php
+++ b/lib/private/Avatar/Avatar.php
@@ -156,8 +156,8 @@ abstract class Avatar implements IAvatar {
 			$avatar->readImageBlob($svg);
 			$avatar->setImageFormat('png');
 			$image = new OC_Image();
-			$image->loadFromData($avatar);
-			return $image->data();
+			$image->loadFromData((string)$avatar);
+			return $image->data() ?? false;
 		} catch (\Exception $e) {
 			return false;
 		}

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -106,7 +106,7 @@ class Client implements IClient {
 		// $this->certificateManager->getAbsoluteBundlePath() tries to instantiate
 		// a view
 		if ($this->config->getSystemValue('installed', false)) {
-			return $this->certificateManager->getAbsoluteBundlePath(null);
+			return $this->certificateManager->getAbsoluteBundlePath('');
 		}
 
 		return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';


### PR DESCRIPTION
> ERROR: NullArgument - lib/private/Http/Client/Client.php:109:60 - Argument 1 of OCP\ICertificateManager::getAbsoluteBundlePath cannot be null, null value provided to parameter with type string (see https://psalm.dev/057)
                        return $this->certificateManager->getAbsoluteBundlePath(null);


Caused by https://github.com/nextcloud/server/pull/24556

For the other ones I'm not sure where they are coming from:


> ERROR: InvalidNullableReturnType - lib/private/Avatar/Avatar.php:145:13 - The declared return type 'bool|string' for OC\Avatar\Avatar::generateAvatarFromSvg is not nullable, but 'false|null|string' contains null (see https://psalm.dev/144)
         * @return string|boolean


> ERROR: ImplicitToStringCast - lib/private/Avatar/Avatar.php:159:25 - Argument 1 of OC_Image::loadFromData expects string, Imagick provided with a __toString method (see https://psalm.dev/060)
                        $image->loadFromData($avatar);


> ERROR: NullableReturnStatement - lib/private/Avatar/Avatar.php:160:11 - The declared return type 'bool|string' for OC\Avatar\Avatar::generateAvatarFromSvg is not nullable, but the function returns 'null|string' (see https://psalm.dev/139)
                        return $image->data();
