### PR TITLE
20.0.4

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Oct 14 03:12:15 2020 GMT
+## Certificate data from Mozilla as of: Tue Dec  8 04:12:05 2020 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.28.
-## SHA256: a831d3bc63ba1f65478afe28038742b7150c0c2efd243ac342b64792a75d2038
+## SHA256: d820b8696d8ffe42064a1384a56a8981cdc7e7e198036bbb5fa04a6c282dd9a2
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 3, 2];
+$OC_Version = [20, 0, 4, 0];
 
 // The human readable string
-$OC_VersionString = '20.0.3';
+$OC_VersionString = '20.0.4';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24636 Avoid dashboard crash when accessibility app is not installed
* #24649 Bump ini from 1.3.5 to 1.3.7
* #24653 Handle owncloud migration to latest release
* #24654 Use string for storing a OCM remote id
* [serverinfo#262](https://github.com/nextcloud/serverinfo/pull/262) Fix MySQL database size calculation
