### PR TITLE
Resolves #24699, Support ES2 and ECS instance providers for S3 buckets

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -105,7 +105,7 @@ trait S3ConnectionTrait {
 			CredentialProvider::chain(
 				$this->paramCredentialProvider(),
 				CredentialProvider::env(),
-				CredentialProvider::assumeRoleWithWebIdentityCredentialProvider()
+				CredentialProvider::assumeRoleWithWebIdentityCredentialProvider(),
 				!empty(getenv(EcsCredentialProvider::ENV_URI))
 					? CredentialProvider::ecsCredentials()
 					: CredentialProvider::instanceProfile()

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -105,21 +105,12 @@ trait S3ConnectionTrait {
 			CredentialProvider::chain(
 				$this->paramCredentialProvider(),
 				CredentialProvider::env(),
-				CredentialProvider::instanceProfile()
+				CredentialProvider::assumeRoleWithWebIdentityCredentialProvider()
+				!empty(getenv(EcsCredentialProvider::ENV_URI))
+					? CredentialProvider::ecsCredentials()
+					: CredentialProvider::instanceProfile()
 			)
 		);
-
-		// If running in an ECS environment, then also include the ECS task role in the chain
-		if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
-			$provider = CredentialProvider::memoize(
-				CredentialProvider::chain(
-					$this->paramCredentialProvider(),
-					CredentialProvider::env(),
-					CredentialProvider::ecsCredentials(),
-					CredentialProvider::instanceProfile()
-				)
-			);
-		}
 
 		$options = [
 			'version' => isset($this->params['version']) ? $this->params['version'] : 'latest',

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -103,8 +103,7 @@ trait S3ConnectionTrait {
 		$provider = CredentialProvider::memoize(
 			CredentialProvider::chain(
 				$this->paramCredentialProvider(),
-				CredentialProvider::env(),
-				CredentialProvider::instanceProfile()
+				CredentialProvider::defaultProvider()
 			)
 		);
 


### PR DESCRIPTION
Switch out specifically called out env and instanceProvider CredentialProvider for the defaultProvider, this adds support for running nextcloud in ECS instances and using the task role to provide permissions for S3 access.

New order for fallback is defined in [the AWS docs](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#defaultprovider-provider)

> It first attempts to load credentials from environment variables, then from an .ini file (an .aws/credentials file first, followed by an .aws/config file), and then from an instance profile (EcsCredentials first, followed by Ec2 metadata). 