### PR TITLE
enables the file name check also to match name of mountpoints

### DIFF
--- a/apps/workflowengine/lib/Check/FileName.php
+++ b/apps/workflowengine/lib/Check/FileName.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\WorkflowEngine\Check;
 
 use OCA\WorkflowEngine\Entity\File;
+use OCP\Files\Mount\IMountManager;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\WorkflowEngine\IFileCheck;
@@ -33,21 +34,38 @@ class FileName extends AbstractStringCheck implements IFileCheck {
 
 	/** @var IRequest */
 	protected $request;
+	/** @var IMountManager */
+	private $mountManager;
 
 	/**
 	 * @param IL10N $l
 	 * @param IRequest $request
 	 */
-	public function __construct(IL10N $l, IRequest $request) {
+	public function __construct(IL10N $l, IRequest $request, IMountManager $mountManager) {
 		parent::__construct($l);
 		$this->request = $request;
+		$this->mountManager = $mountManager;
 	}
 
 	/**
 	 * @return string
 	 */
 	protected function getActualValue(): string {
-		return $this->path === null ? '' : basename($this->path);
+		$fileName = $this->path === null ? '' : basename($this->path);
+		if ($fileName === '' && !$this->storage->isLocal()) {
+			// Return the mountpoint name of external storages that are not mounted as user home
+			$mountPoints = $this->mountManager->findByStorageId($this->storage->getId());
+			if (empty($mountPoints) || $mountPoints[0]->getMountType() !== 'external') {
+				return $fileName;
+			}
+			$mountPointPath = rtrim($mountPoints[0]->getMountPoint(), '/');
+			$mountPointPieces = explode('/', $mountPointPath);
+			$mountPointName = array_pop($mountPointPieces);
+			if (!empty($mountPointName) && $mountPointName !== 'files' && count($mountPointPieces) !== 2) {
+				return $mountPointName;
+			}
+		}
+		return $fileName;
 	}
 
 	/**

--- a/apps/workflowengine/lib/Check/FileName.php
+++ b/apps/workflowengine/lib/Check/FileName.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\WorkflowEngine\Check;
 
+use OC\Files\Storage\Local;
 use OCA\WorkflowEngine\Entity\File;
 use OCP\Files\Mount\IMountManager;
 use OCP\IL10N;
@@ -52,7 +53,7 @@ class FileName extends AbstractStringCheck implements IFileCheck {
 	 */
 	protected function getActualValue(): string {
 		$fileName = $this->path === null ? '' : basename($this->path);
-		if ($fileName === '' && !$this->storage->isLocal()) {
+		if ($fileName === '' && (!$this->storage->isLocal() || $this->storage->instanceOfStorage(Local::class))) {
 			// Return the mountpoint name of external storages that are not mounted as user home
 			$mountPoints = $this->mountManager->findByStorageId($this->storage->getId());
 			if (empty($mountPoints) || $mountPoints[0]->getMountType() !== 'external') {


### PR DESCRIPTION
When you have an external storage configured, you can assign tags to it as well. The file name checker of the workflow engine could not do so, because the filename is technically empty, instead we have a mountpoint name. 

Thus, if we receive an empty file and identify an external storage, we return the name of the mountpoint, unless it is mounted as user home (`/`).

