### PR TITLE
Log an error when setting a custom header on "Not Modified" responses

### DIFF
--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -38,6 +38,8 @@ namespace OCP\AppFramework\Http;
 
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 
 /**
  * Base class for responses. Also used to just send headers.
@@ -202,6 +204,18 @@ class Response {
 		$name = trim($name);  // always remove leading and trailing whitespace
 		// to be able to reliably check for security
 		// headers
+
+		if ($this->status === Http::STATUS_NOT_MODIFIED
+			&& stripos($name, 'x-') === 0) {
+			/** @var IConfig $config */
+			$config = \OC::$server->get(IConfig::class);
+
+			if ($config->getSystemValueBool('debug', false)) {
+				\OC::$server->get(LoggerInterface::class)->error(
+					'Setting a custom header on a 204 or 304 is not supported'
+				);
+			}
+		}
 
 		if (is_null($value)) {
 			unset($this->headers[$name]);


### PR DESCRIPTION
https://stackoverflow.com/a/17822709

Quoting from [section 10.3.5 of RFC 2616](https://tools.ietf.org/html/rfc2616#section-10.3.5):
> If the conditional GET used a strong cache validator, the response SHOULD NOT include other entity-headers. Otherwise (i.e., the conditional GET used a weak validator), the response MUST NOT include other entity-headers; this prevents inconsistencies between cached entity-bodies and updated headers. 

Apache is stripping them out anyway, so logging them as error for developing instances.