### PR TITLE
Limit getIncomplete query to one row

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -997,7 +997,8 @@ class Cache implements ICache {
 			->from('filecache')
 			->whereStorageId()
 			->andWhere($query->expr()->lt('size', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
-			->orderBy('fileid', 'DESC');
+			->orderBy('fileid', 'DESC')
+			->setMaxResults(1);
 
 		$result = $query->execute();
 		$path = $result->fetchColumn();


### PR DESCRIPTION
Found this while debugging https://github.com/nextcloud/server/issues/24401. 

How to test:

- Go to oc_filecache and set size to -1 for some or all files (to simulate a situation with many unscanned files)
- Attach xdebug and set a breakpoint in `getIncomplete` 
- See (for example by evaluating `$result->rowCount()`) that the query returns x rows but only the first row is consumed

This pull request limits the number of results to 1. 

Limit to one was already set for < Nextcloud 18 and got lost in a bigger refactoring: https://github.com/nextcloud/server/commit/d3b6dbc0bc1aa2c81ca5e526d597ddbfca762cdf#diff-f36621cc749f37af880e8d2d5ea4b70870a0a13de93ce1461cc99be75e1abf47L833-L834 (the second argument for prepare is limit). 