### PR TITLE
promoted bad memory_limit check from warning to error as it may break updater

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -453,7 +453,7 @@
 								'core',
 								'The PHP memory limit is below the recommended value of 512MB.'
 							),
-							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+							type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 						})
 					}
 

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -695,7 +695,7 @@ describe('OC.SetupChecks tests', function() {
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
 					msg: 'The PHP memory limit is below the recommended value of 512MB.',
-					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+					type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 				}]);
 				done();
 			});


### PR DESCRIPTION
cf. https://github.com/nextcloud/updater/issues/316

I might not sure why admins would ignore orange message, but not red messages… but maybe it helps :four_leaf_clover: 