### PR TITLE
Fix IPv6 localhost regex

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -75,7 +75,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	// Android Chrome user agent: https://developers.google.com/chrome/mobile/docs/user-agent
 	public const USER_AGENT_ANDROID_MOBILE_CHROME = '#Android.*Chrome/[.0-9]*#';
 	public const USER_AGENT_FREEBOX = '#^Mozilla/5\.0$#';
-	public const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost|::1)$/';
+	public const REGEX_LOCALHOST = '/^(127\.0\.0\.1|localhost|\[::1\])$/';
 
 	/**
 	 * @deprecated use \OCP\IRequest::USER_AGENT_CLIENT_IOS instead


### PR DESCRIPTION
STR:

1. run a local nextcloud instance
2. access on `127.0.0.1` => works
3. access on `[::1]` => access denied, address not in `trusted_domains` config

The example in the [docs](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/config_sample_php_parameters.html) is also using brackets.