### PR TITLE
user_ldap : fix exception when LDAP user is a numeric string like "1234"

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -294,6 +294,9 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		if (is_string($user)) {
 			$user = $this->access->userManager->get($user);
 		}
+		elseif (is_numeric($user)) {
+			$user = $this->access->userManager->get($user);
+		}
 		if (is_null($user)) {
 			return false;
 		}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -291,10 +291,7 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function userExistsOnLDAP($user) {
-		if (is_string($user)) {
-			$user = $this->access->userManager->get($user);
-		}
-		elseif (is_numeric($user)) {
+		if (!is_object($user)) {
 			$user = $this->access->userManager->get($user);
 		}
 		if (is_null($user)) {


### PR DESCRIPTION
user_ldap : fix the userExistsOnLDAP($user) function, because PHP crashes if the LDAP user name is a numeric string like "1234"

This issue has been detected after running occ fulltextsearch:live