### PR TITLE
21 beta3

### DIFF
--- a/resources/config/ca-bundle.crt
+++ b/resources/config/ca-bundle.crt
@@ -1,7 +1,7 @@
 ##
 ## Bundle of CA Root Certificates
 ##
-## Certificate data from Mozilla as of: Wed Oct 14 03:12:15 2020 GMT
+## Certificate data from Mozilla as of: Tue Dec  8 04:12:05 2020 GMT
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
@@ -14,7 +14,7 @@
 ## Just configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.28.
-## SHA256: a831d3bc63ba1f65478afe28038742b7150c0c2efd243ac342b64792a75d2038
+## SHA256: d820b8696d8ffe42064a1384a56a8981cdc7e7e198036bbb5fa04a6c282dd9a2
 ##
 
 

--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 9];
+$OC_Version = [21, 0, 0, 10];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta2';
+$OC_VersionString = '21.0.0 beta3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22085 Adding social profile to search index
* #22222 Re-index contacts with social profiles
* #22916 Unify links to php.net
* #23319 Fix Argon2 descriptions
* #24515 Fixes sharing to group ids with characters that are being url encoded
* #24594 Files: Local#writeStream should use it's own file_put_contents
* #24604 Allow to force rename a conflicting calendar
* #24610 Adding a ShareDeletedEvent
* #24702 Add well known handlers API
* #24703 Enables the file name check also to match name of mountpoints
* #24715 Limit getIncomplete query to one row
* #24730 Fix IPv6 localhost regex
* #24732 Add another of my emails to mailmap
* #24770 Fix-dialog-buttons
* #24773 Bump webpack-merge from 5.6.1 to 5.7.2
* #24774 Bump @babel/preset-env from 7.12.10 to 7.12.11
* #24776 Bump vue-loader from 15.9.5 to 15.9.6
* #24796 Actually set the TTL on redis set
* #24812 Bump deepdiver/zipstreamer to 2.0.0
* #24816 Drop all dead packages
* #24819 Update the Psalm baseline
* #24824 Catch the error on heartbeat update
* [3rdparty#521](https://github.com/nextcloud/3rdparty/pull/521) Bump deepdiver/zipstreamer from 1.1.1 to 2.0.0
* [3rdparty#555](https://github.com/nextcloud/3rdparty/pull/555) Drop all dead packages
* [files_pdfviewer#277](https://github.com/nextcloud/files_pdfviewer/pull/277) Bump vue-loader from 15.9.5 to 15.9.6
* [files_pdfviewer#278](https://github.com/nextcloud/files_pdfviewer/pull/278) Bump @babel/preset-env from 7.12.10 to 7.12.11
* [firstrunwizard#459](https://github.com/nextcloud/firstrunwizard/pull/459) Bump @babel/preset-env from 7.12.10 to 7.12.11
* [firstrunwizard#460](https://github.com/nextcloud/firstrunwizard/pull/460) Bump vue-loader from 15.9.5 to 15.9.6
* [firstrunwizard#461](https://github.com/nextcloud/firstrunwizard/pull/461) Bump @nextcloud/vue from 3.3.1 to 3.3.2
* [notifications#820](https://github.com/nextcloud/notifications/pull/820) Bump vue-loader from 15.9.5 to 15.9.6
* [photos#600](https://github.com/nextcloud/photos/pull/600) Bump @babel/preset-env from 7.12.10 to 7.12.11
* [photos#601](https://github.com/nextcloud/photos/pull/601) Bump vue-loader from 15.9.5 to 15.9.6
* [photos#603](https://github.com/nextcloud/photos/pull/603) Bump eslint from 7.15.0 to 7.16.0
* [photos#604](https://github.com/nextcloud/photos/pull/604) Bump webpack-merge from 5.7.0 to 5.7.2
* [photos#605](https://github.com/nextcloud/photos/pull/605) Bump eslint-plugin-vue from 7.2.0 to 7.3.0
* [text#1217](https://github.com/nextcloud/text/pull/1217) Bump highlight.js from 9.18.3 to 10.4.1
* [text#1236](https://github.com/nextcloud/text/pull/1236) Bump @babel/core from 7.11.6 to 7.12.10
* [text#1239](https://github.com/nextcloud/text/pull/1239) Bump node-sass from 4.14.1 to 5.0.0
* [text#1241](https://github.com/nextcloud/text/pull/1241) Bump stylelint-webpack-plugin from 2.1.0 to 2.1.1
* [text#1242](https://github.com/nextcloud/text/pull/1242) Bump webpack-merge from 5.2.0 to 5.7.2
* [text#1243](https://github.com/nextcloud/text/pull/1243) Bump @nextcloud/initial-state from 1.1.2 to 1.2.0
* [text#1244](https://github.com/nextcloud/text/pull/1244) Bump vue-jest from 3.0.6 to 3.0.7
* [text#1245](https://github.com/nextcloud/text/pull/1245) Bump url-loader from 4.1.0 to 4.1.1
* [text#1246](https://github.com/nextcloud/text/pull/1246) Bump vue-loader from 15.9.3 to 15.9.6
* [text#1247](https://github.com/nextcloud/text/pull/1247) Bump @nextcloud/vue from 2.7.0 to 3.3.2
* [text#1248](https://github.com/nextcloud/text/pull/1248) Bump @babel/preset-env from 7.11.5 to 7.12.11
* [text#1249](https://github.com/nextcloud/text/pull/1249) Bump babel-jest from 26.3.0 to 26.6.3
* [text#1250](https://github.com/nextcloud/text/pull/1250) Bump cypress-image-snapshot from 3.1.1 to 4.0.0
* [text#1251](https://github.com/nextcloud/text/pull/1251) Bump acorn from 7.4.0 to 8.0.4
* [text#1252](https://github.com/nextcloud/text/pull/1252) Bump entities from 2.0.3 to 2.1.0
* [text#1253](https://github.com/nextcloud/text/pull/1253) Bump @babel/plugin-transform-classes from 7.10.4 to 7.12.1
* [text#1254](https://github.com/nextcloud/text/pull/1254) Bump @vue/test-utils from 1.1.1 to 1.1.2
* [text#1280](https://github.com/nextcloud/text/pull/1280) Bump cypress from 5.1.0 to 6.2.0
* [text#1281](https://github.com/nextcloud/text/pull/1281) Bump eslint-plugin-import from 2.22.0 to 2.22.1
* [text#1282](https://github.com/nextcloud/text/pull/1282) Bump prosemirror-view from 1.16.0 to 1.16.5
* [text#1283](https://github.com/nextcloud/text/pull/1283) Bump prosemirror-model from 1.13.0 to 1.13.1
* [text#1285](https://github.com/nextcloud/text/pull/1285) Bump jest from 24.9.0 to 26.6.3
* [text#1286](https://github.com/nextcloud/text/pull/1286) Bump webpack-cli from 3.3.12 to 4.2.0
* [text#1287](https://github.com/nextcloud/text/pull/1287) Bump markdown-it from 12.0.2 to 12.0.4
* [text#1288](https://github.com/nextcloud/text/pull/1288) Bump babel-loader from 8.1.0 to 8.2.2
* [text#1289](https://github.com/nextcloud/text/pull/1289) Bump eslint-plugin-standard from 4.0.1 to 4.1.0
* [viewer#726](https://github.com/nextcloud/viewer/pull/726) Bump eslint from 7.15.0 to 7.16.0
* [viewer#728](https://github.com/nextcloud/viewer/pull/728) Bump eslint-plugin-vue from 7.2.0 to 7.3.0
* [viewer#729](https://github.com/nextcloud/viewer/pull/729) Bump webpack-merge from 5.7.0 to 5.7.2
* [viewer#730](https://github.com/nextcloud/viewer/pull/730) Bump vue-loader from 15.9.5 to 15.9.6


Pending PRs:

* [ ] #16696 Fixed moving of master key encrypted and versioned files between shared folders @yahesh
* [ ] #18199 Add and remove tags from multiple files at once @rolandinus
* [ ] #19942 Add mindmap type file icon @ACTom
* [ ] #20667 Allow to tweak default scopes for accounts @tcitworld
* [ ] #21049 Add support for shared file IDs on SMB storage @ddean4040
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22530 Fix inGroup check for memberUid mapped groups in LDAP when accepting or rejecting shares @g1smo
* [ ] #22628 Coalesce RewriteCond lines in .htaccess @Sp1l
* [ ] #22921 Dont apply encryption wrapper for root mount @icewind1991
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #22992 Allow authenticating using urlencoded passwords @icewind1991
* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #23073 Move preview repair to query @rullzer
* [ ] #23125 Also load app autoloader when located in /vendor @icewind1991
* [ ] #23138 Sharing: define public groups (exceptions for when sharing is restricted on groups) @chrisfritsche
* [ ] #23261 Expose session based authentication through mount point type @juliushaertl
* [ ] #23273 Avoid reading ~/.aws/config when using S3 provider @FlorentCoppint
* [ ] #23333 Persist the config changes of usermanagement @sharidas
* [ ] #23489 External delete directly @dassio
* [ ] #23529 Settings: new user row replaced by a modal @Simounet
* [ ] #23914 If basic auth provided but invalid fail @rullzer
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #24255 Add focus-visible outline for checkboxes and radio buttons @PVince81
* [ ] #24317 App password command @SMillerDev
* [ ] #24364 Sharing link & mail parity @skjnldsv
* [ ] #24533 Bump icewind/streams from 0.7.1 to 0.7.2 @ChristophWurst
* [ ] #24611 Remove limit from axios call that retrieves groups @lephisto
* [ ] #24661 Dont offer to edit external config settings if we can't edit them @icewind1991
* [ ] #24694 Specify the boundary element of the Actions menu @nickvergessen
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #24727 Enhance signature algorithm for code signatures @rullzer
* [ ] #24772 Bump dompurify from 2.2.3 to 2.2.6 
* [ ] #24775 Bump marked from 1.2.6 to 1.2.7 
* [ ] #24829 Add migration for oc_share_external columns @PVince81
* [ ] #24830 Add README section for committing back-end code @PVince81
* [ ] #24832 Make oc_files_trash.auto_id a bigint @PVince81
* [ ] #24833 Fix total upload size overwritten by next upload @danxuliu
* [ ] [3rdparty#560](https://github.com/nextcloud/3rdparty/pull/560) Bump icewind/streams from 0.7.1 to 0.7.2 @ChristophWurst
* [ ] [text#901](https://github.com/nextcloud/text/pull/901) Add input rule for checkboxes @juliushaertl
