### PR TITLE
Drop all dead packages

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -31,7 +31,6 @@ namespace OCA\Federation\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -191,14 +190,7 @@ class GetSharedSecret extends Job {
 				'level' => ILogger::INFO,
 				'app' => 'federation',
 			]);
-		} catch (RingException $e) {
-			$status = -1; // There is no status code if we could not connect
-			$this->logger->logException($e, [
-				'message' => 'Could not connect to ' . $target,
-				'level' => ILogger::INFO,
-				'app' => 'federation',
-			]);
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;
 			$this->logger->logException($e, ['app' => 'federation']);
 		}

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -30,7 +30,6 @@ namespace OCA\Federation\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -184,10 +183,7 @@ class RequestSharedSecret extends Job {
 		} catch (RequestException $e) {
 			$status = -1; // There is no status code if we could not connect
 			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
-		} catch (RingException $e) {
-			$status = -1; // There is no status code if we could not connect
-			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;
 			$this->logger->logException($e, ['app' => 'federation']);
 		}

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -28,7 +28,6 @@
 namespace OCA\Federation\Tests\BackgroundJob;
 
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\BackgroundJob\GetSharedSecret;
 use OCA\Federation\TrustedServers;
 use OCA\Files_Sharing\Tests\TestCase;
@@ -291,43 +290,6 @@ class GetSharedSecretTest extends TestCase {
 					'connect_timeout' => 3,
 				]
 			)->willThrowException($this->createMock(ConnectException::class));
-
-		$this->trustedServers->expects($this->never())->method('addSharedSecret');
-
-		$this->invokePrivate($this->getSharedSecret, 'run', [$argument]);
-
-		$this->assertTrue($this->invokePrivate($this->getSharedSecret, 'retainJob'));
-	}
-
-	public function testRunRingException() {
-		$target = 'targetURL';
-		$source = 'sourceURL';
-		$token = 'token';
-
-		$argument = ['url' => $target, 'token' => $token];
-
-		$this->timeFactory->method('getTime')
-			->willReturn(42);
-
-		$this->urlGenerator
-			->expects($this->once())
-			->method('getAbsoluteURL')
-			->with('/')
-			->willReturn($source);
-		$this->httpClient->expects($this->once())->method('get')
-			->with(
-				$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret',
-				[
-					'query' =>
-						[
-							'url' => $source,
-							'token' => $token,
-							'format' => 'json',
-						],
-					'timeout' => 3,
-					'connect_timeout' => 3,
-				]
-			)->willThrowException($this->createMock(RingException::class));
 
 		$this->trustedServers->expects($this->never())->method('addSharedSecret');
 

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -27,7 +27,6 @@
 namespace OCA\Federation\Tests\BackgroundJob;
 
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Ring\Exception\RingException;
 use OCA\Federation\BackgroundJob\RequestSharedSecret;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
@@ -275,42 +274,6 @@ class RequestSharedSecretTest extends TestCase {
 					'connect_timeout' => 3,
 				]
 			)->willThrowException($this->createMock(ConnectException::class));
-
-		$this->invokePrivate($this->requestSharedSecret, 'run', [$argument]);
-		$this->assertTrue($this->invokePrivate($this->requestSharedSecret, 'retainJob'));
-	}
-
-	public function testRunRingException() {
-		$target = 'targetURL';
-		$source = 'sourceURL';
-		$token = 'token';
-
-		$argument = ['url' => $target, 'token' => $token];
-
-		$this->timeFactory->method('getTime')->willReturn(42);
-
-		$this->urlGenerator
-			->expects($this->once())
-			->method('getAbsoluteURL')
-			->with('/')
-			->willReturn($source);
-
-		$this->httpClient
-			->expects($this->once())
-			->method('post')
-			->with(
-				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret',
-				[
-					'body' =>
-						[
-							'url' => $source,
-							'token' => $token,
-							'format' => 'json',
-						],
-					'timeout' => 3,
-					'connect_timeout' => 3,
-				]
-			)->willThrowException($this->createMock(RingException::class));
 
 		$this->invokePrivate($this->requestSharedSecret, 'run', [$argument]);
 		$this->assertTrue($this->invokePrivate($this->requestSharedSecret, 'retainJob'));


### PR DESCRIPTION
Apparently we have plenty of leftover of previous sub-dependencies.
Composer automatically dumps those with any future dependency update, so
I'm dropping them in an atomic step.

- [x] https://github.com/nextcloud/3rdparty/pull/555