### PR TITLE
Run oci tests against phpunit9/php8

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: [ '8.0' ]
+        php-versions: [ '7.3', '7.4', '8.0' ]
         databases: [ 'oci' ]
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -15,7 +15,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: [ '7.4' ]
+        php-versions: [ '8.0' ]
         databases: [ 'oci' ]
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}
@@ -41,8 +41,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype,curl,dom,fileinfo,gd,iconv,intl,json,mbstring,oci8,openssl,pdo_sqlite,posix,sqlite,xml,zip
-          tools: phpunit:8.5.2
+          extensions: ctype,curl,dom,fileinfo,gd,iconv,imagick,intl,json,mbstring,oci8,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          tools: phpunit:9
           coverage: none
 
       - name: Set up Nextcloud

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -24,91 +24,10 @@ declare(strict_types=1);
 
 namespace Test\Security;
 
-use OC\Security\CredentialsManager;
-use OCP\DB\IResult;
-use OCP\DB\QueryBuilder\IExpressionBuilder;
-use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
-use OCP\Security\ICrypto;
-
 /**
  * @group DB
  */
 class CredentialsManagerTest extends \Test\TestCase {
-
-	/** @var ICrypto */
-	protected $crypto;
-
-	/** @var IDBConnection */
-	protected $dbConnection;
-
-	/** @var CredentialsManager */
-	protected $manager;
-
-	protected function setUp(): void {
-		parent::setUp();
-		$this->crypto = $this->createMock(ICrypto::class);
-		$this->dbConnection = $this->getMockBuilder(IDBConnection::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->manager = new CredentialsManager($this->crypto, $this->dbConnection);
-	}
-
-	private function getQueryResult($row) {
-		$result = $this->createMock(IResult::class);
-
-		$result->expects($this->any())
-			->method('fetch')
-			->willReturn($row);
-
-		return $result;
-	}
-
-	public function testStore() {
-		$userId = 'abc';
-		$identifier = 'foo';
-		$credentials = 'bar';
-
-		$this->crypto->expects($this->once())
-			->method('encrypt')
-			->with(json_encode($credentials))
-			->willReturn('baz');
-
-		$this->dbConnection->expects($this->once())
-			->method('setValues')
-			->with(CredentialsManager::DB_TABLE,
-				['user' => $userId, 'identifier' => $identifier],
-				['credentials' => 'baz']
-			);
-
-		$this->manager->store($userId, $identifier, $credentials);
-	}
-
-	public function testRetrieve() {
-		$userId = 'abc';
-		$identifier = 'foo';
-
-		$this->crypto->expects($this->once())
-			->method('decrypt')
-			->with('baz')
-			->willReturn(json_encode('bar'));
-
-		$eb = $this->createMock(IExpressionBuilder::class);
-		$qb = $this->createMock(IQueryBuilder::class);
-		$qb->method('select')->willReturnSelf();
-		$qb->method('from')->willReturnSelf();
-		$qb->method('where')->willReturnSelf();
-		$qb->method('expr')->willReturn($eb);
-		$qb->expects($this->once())
-			->method('execute')
-			->willReturn($this->getQueryResult(['credentials' => 'baz']));
-
-		$this->dbConnection->expects($this->once())
-			->method('getQueryBuilder')
-			->willReturn($qb);
-
-		$this->manager->retrieve($userId, $identifier);
-	}
 
 	/**
 	 * @dataProvider credentialsProvider

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -33,6 +33,7 @@ use OCP\Defaults;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
+use PHPUnit\Util\Test;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/** @var \OC\Command\QueueBus */

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -33,7 +33,6 @@ use OCP\Defaults;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
-use PHPUnit\Util\Test;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/** @var \OC\Command\QueueBus */


### PR DESCRIPTION
- Run OCI unit tests against PHP8 and PHPunit9
- Fix tests in tests/Core that have not been executed for a while due to the uppercase directory name
- Fix use of removed getAnnotations method