### PR TITLE
Prevent login hook from being executed twice

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -172,6 +172,11 @@ class UserHooks implements IHook {
 	 * @return boolean|null
 	 */
 	public function login($params) {
+		// prevent session from being initialized twice
+		if ($this->session->isReady()) {
+			return true;
+		}
+
 		// ensure filesystem is loaded
 		if (!\OC\Files\Filesystem::$loaded) {
 			$this->setupFS($params['uid']);


### PR DESCRIPTION
Ignore login if the keystore is already successfully initialized.

This allow us to implement alternative means of providing a
user secret, for instance in an SSO situation.

(see nextcloud/user_saml#497)