### PR TITLE
Make oc_files_trash.auto_id a bigint

### DIFF
--- a/apps/files_trashbin/lib/Migration/Version1010Date20200630192639.php
+++ b/apps/files_trashbin/lib/Migration/Version1010Date20200630192639.php
@@ -45,10 +45,9 @@ class Version1010Date20200630192639 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('files_trash')) {
 			$table = $schema->createTable('files_trash');
-			$table->addColumn('auto_id', Types::INTEGER, [
+			$table->addColumn('auto_id', Types::BIGINT, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$table->addColumn('id', Types::STRING, [
 				'notnull' => true,

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -69,6 +69,7 @@ class ConvertFilecacheBigInt extends Command {
 			'federated_reshares' => ['share_id'],
 			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
 			'filecache_extended' => ['fileid'],
+			'files_trash' => ['auto_id'],
 			'file_locks' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],


### PR DESCRIPTION
Adjusted migration.
Added to occ command to update existing tables.

Part of https://github.com/nextcloud/server/issues/24813#issuecomment-750374841