### PR TITLE
Fix total upload size overwritten by next upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -586,7 +586,10 @@ OC.Uploader.prototype = _.extend({
 		_.each(uploads, function(upload) {
 			self._uploads[upload.data.uploadId] = upload;
 		});
-		self.totalToUpload = _.reduce(uploads, function(memo, upload) { return memo+upload.getFile().size; }, 0);
+		if (!self._uploading) {
+			self.totalToUpload = 0;
+		}
+		self.totalToUpload += _.reduce(uploads, function(memo, upload) { return memo+upload.getFile().size; }, 0);
 		var semaphore = new OCA.Files.Semaphore(5);
 		var promises = _.map(uploads, function(upload) {
 			return semaphore.acquire().then(function(){


### PR DESCRIPTION
This fixes a regression introduced in 7c4c5fe6ae91

The upload progress [is based on the `totalToUpload` variable](https://github.com/nextcloud/server/blob/f9536b08096ed1c80391af36d33a18198be1fced/apps/files/js/file-upload.js#L1173-L1176). However, as the variable is set when an upload is submitted, if another upload is submitted before the previous one finished the upload progress only took into account the size of the new upload (although the upload itself worked fine; the files of the new submitted upload are added to the active one). Now `totalToUpload` is either increased or set depending on whether an upload is active or not.

Note that although `data.total` holds the total size of the files being uploaded `totalToUpload` needs to be used in `fileuploadprogressall` instead; `totalToUpload` is calculated when the upload is submitted, but since 7c4c5fe6ae91 the actual upload of the files, and thus updating the value of `data.total`, may be deferred until the parent folders were created.

## How to test

- Open the Files app
- Open the network tab in the developer console of the browser and throttle the connection to 3G or something similar (so you have time to do the checks)
- Upload a 5 MiB file (you can generate it with `dd if=/dev/urandom of=test-file-5mib bs=1K count=5K`)
- Before the upload finishes, upload a 100 KiB file (you can generate it with `dd if=/dev/urandom of=test-file-100kib bs=1K count=100`)
- Hover on the upload progress

### Result with this pull request

The upload progress is based on the size of both files

### Result without this pull request

The upload progress is based only on the size of the last file
