### PR TITLE
Allow SSO authentication to provide a user secret

### DIFF
--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -170,7 +170,9 @@ class OC_User {
 				$userSession = \OC::$server->getUserSession();
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();
-				$userSession->createSessionToken($request, $uid, $uid);
+				$secret = $backend->getCurrentUserSecret();
+				$userSession->createSessionToken($request, $uid, $uid, $secret);
+				$pw = $secret === null ? '' : $secret;
 				// setup the filesystem
 				OC_Util::setupFS($uid);
 				// first call the post_login hooks, the login-process needs to be
@@ -182,7 +184,7 @@ class OC_User {
 					'post_login',
 					[
 						'uid' => $uid,
-						'password' => '',
+						'password' => $pw,
 						'isTokenLogin' => false,
 					]
 				);

--- a/lib/public/Authentication/IApacheBackend.php
+++ b/lib/public/Authentication/IApacheBackend.php
@@ -62,4 +62,12 @@ interface IApacheBackend {
 	 * @since 6.0.0
 	 */
 	public function getCurrentUserId();
+
+	/**
+	 * Optionally returns a stable per-user secret. This secret is for
+	 * instance used to secure file encryption keys.
+	 * @return string|null
+	 * @since 21.0.0
+	 */
+	public function getCurrentUserSecret();
 }


### PR DESCRIPTION
Allow Authentication\IApacheBackend to return a per-user secret. This
secret is used in lieu of a passwort to initialize the session.
This allows an SSO backend to support per-user encrypted files.