### PR TITLE
Make sure we properly ass well-known paths to index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -65,8 +65,8 @@
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
-  RewriteCond %{REQUEST_URI} !^/\.well-known/(acme-challenge|pki-validation)/.*
-  RewriteRule ^(?:\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
+  RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
+  RewriteRule ^(?:\.(?!well-known)|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 <IfModule mod_mime.c>
   AddType image/svg+xml svg svgz


### PR DESCRIPTION
This makes sure we pass .well-known paths to index.php if they are not acme-challenge|pki-validation. The fallback for random files starting with "." is still preserved. Otherwise the rewrite to a 404 status page will cause issues with the get parameters not being preserved when the 404 is handled by our own ErrorDocument handling in https://github.com/nextcloud/server/blob/d89a75be0b01f0423a7c1ad2d58aac73c3cc1f3a/lib/private/Setup.php#L523

Ref https://github.com/nextcloud/server/pull/24702