### PR TITLE
Cleanup bundle files before checking the rebuild

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,6 +24,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies & build
       run: |
+        make clean
         npm ci
         npm run build --if-present
     - name: Check webpack build changes


### PR DESCRIPTION
After a6d343b1822 we ended up with having lots of unused chunks in the settings app. We should in addition to the regular build clean up the previous chunks to make sure that those leftovers will be catched by CI as well.