### PR TITLE
Avoid huge exception argument logging

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -314,7 +314,7 @@ class Log implements ILogger, IDataLogger {
 		$app = $context['app'] ?? 'no app in context';
 		$level = $context['level'] ?? ILogger::ERROR;
 
-		$serializer = new ExceptionSerializer();
+		$serializer = new ExceptionSerializer($this->config);
 		$data = $serializer->serializeException($exception);
 		$data['CustomMessage'] = $context['message'] ?? '--';
 

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -33,6 +33,7 @@ use OC\Core\Controller\SetupController;
 use OC\HintException;
 use OC\Security\IdentityProof\Key;
 use OC\Setup;
+use OC\SystemConfig;
 
 class ExceptionSerializer {
 	public const methodsWithSensitiveParameters = [
@@ -91,6 +92,13 @@ class ExceptionSerializer {
 		// Preview providers, don't log big data strings
 		'imagecreatefromstring',
 	];
+
+	/** @var SystemConfig */
+	private $systemConfig;
+
+	public function __construct(SystemConfig $systemConfig) {
+		$this->systemConfig = $systemConfig;
+	}
 
 	public const methodsWithSensitiveParametersByClass = [
 		SetupController::class => [
@@ -163,11 +171,21 @@ class ExceptionSerializer {
 			$data = get_object_vars($arg);
 			$data['__class__'] = get_class($arg);
 			return array_map([$this, 'encodeArg'], $data);
-		} elseif (is_array($arg)) {
-			return array_map([$this, 'encodeArg'], $arg);
-		} else {
-			return $arg;
 		}
+
+		if (is_array($arg)) {
+			// Only log the first 5 elements of an array unless we are on debug
+			if ((int)$this->systemConfig->getValue('loglevel', 2) !== 0) {
+				$elemCount = count($arg);
+				if ($elemCount > 5) {
+					$arg = array_slice($arg, 0, 5);
+					$arg[] = 'And ' . ($elemCount - 5) . ' more entries, set log level to debug to see all entries';
+				}
+			}
+			return array_map([$this, 'encodeArg'], $arg);
+		}
+
+		return $arg;
 	}
 
 	public function serializeException(\Throwable $exception) {


### PR DESCRIPTION
In some cases it might happen that you have an argument that deep down
somewhere has an array with a lot of entries (think thousands). Now
before we would just happily print them all. Which would fill the log.

Now it will just print the first 5. And add a line that there are N
more.

If you are on debug level we will still print them all.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>