### PR TITLE
Make integration tests work with both PHP 7.3 and 7.4

### DIFF
--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -47,7 +47,6 @@ trait BasicStructure {
 	use Avatar;
 	use Download;
 	use Mail;
-	use Trashbin;
 
 	/** @var string */
 	private $currentUser = '';

--- a/build/integration/features/bootstrap/FeatureContext.php
+++ b/build/integration/features/bootstrap/FeatureContext.php
@@ -35,4 +35,5 @@ require __DIR__ . '/../../vendor/autoload.php';
 class FeatureContext implements Context, SnippetAcceptingContext {
 	use Search;
 	use WebDav;
+	use Trashbin;
 }

--- a/build/integration/features/bootstrap/SharingContext.php
+++ b/build/integration/features/bootstrap/SharingContext.php
@@ -32,7 +32,8 @@ require __DIR__ . '/../../vendor/autoload.php';
  * Features context.
  */
 class SharingContext implements Context, SnippetAcceptingContext {
-	use Sharing;
+	use WebDav;
+	use Trashbin;
 	use AppConfiguration;
 	use CommandLine;
 

--- a/build/integration/features/bootstrap/Trashbin.php
+++ b/build/integration/features/bootstrap/Trashbin.php
@@ -30,7 +30,8 @@ require __DIR__ . '/../../vendor/autoload.php';
  * Trashbin functions
  */
 trait Trashbin {
-	use WebDav;
+
+	// WebDav trait is expected to be used in the class that uses this trait.
 
 	/**
 	 * @When User :user empties trashbin


### PR DESCRIPTION
Found by @juliushaertl in #24551

The `Trashbin` and `WebDav` traits were using each other in a circular dependency (`WebDav -> Sharing -> Provisioning -> BasicStructure -> Trashbin -> WebDav`). In PHP 7.3 this worked fine, but in PHP 7.4 the fatal error `Trait 'WebDav' not found in .../Trashbin.php` was thrown. To solve this now the `TrashBin` trait no longer explicitly uses `WebDav`.

However, due to this change, the class using `TrashBin` is now expected to also use `WebDav`. As the `Trashbin` trait was not needed by most contexts using the `BasicStructure` trait `Trashbin` was removed from it and added only to those contexts that actually need it.

~~I will keep this in `developing` state until CI has finished just in case there is some other context that needs to use the `Trashbin` trait too (it helps not to forget to commit the changes to check them... :facepalm:).~~

Unfortunately I do not know if the issue is in PHP 7.4 itself, Behat, its autoloader... But I have distilled the issue to the following test case:
[integration-tests-recursive-traits.patch.txt](https://github.com/nextcloud/server/files/5752441/integration-tests-recursive-traits.patch.txt)

After applying the patch,
- `./run-docker.sh --image nextcloudci/php7.3:php7.3-5 features/traittest.feature` :+1: works 
- `./run-docker.sh --image nextcloudci/php7.4:php7.4-3 features/traittest.feature` :boom: shows `PHP Fatal error:  Trait 'TraitTestA' not found in /nextcloud/build/integration/features/bootstrap/TraitTestB.php on line 5`

Therefore it seems that the problem is in the circular dependency between the traits.
