### PR TITLE
21 beta5

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 11];
+$OC_Version = [21, 0, 0, 12];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta4';
+$OC_VersionString = '21.0.0 beta5';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #22992 Allow authenticating using urlencoded passwords
* #23261 Expose session based authentication through mount point type
* #24317 App password command
* #24829 Add migration for oc_share_external columns
* #24864 Also include external share results in recommendations
* #24886 Bump guzzlehttp/guzzle from 6.5.2 to 6.5.5
* #24890 Bump pear/archive_tar from 1.4.9 to 1.4.11
* #24892 Use the Symfony dispatcher correctly
* #24900 Fix updating user settings
* #24907 Update license headers
* #24911 Tasks search: make sure we have existing indexes before using them
* #24916 Bump psr/log and psr/http-client
* #24917 Update all the things for Guzzle 7 (php8 compat)
* #24934 Remove useless ini_set calls
* #24936 Bump webpack-cli from 4.3.0 to 4.3.1
* #24941 Bump 3rdparty from `225c515` to `e8bad7c`
* #24946 Bump pimple/pimple from 3.2.3 to 3.3.1
* #24948 Bump doctrine/dbal from 2.12.0 to 3.0.0
* #24955 Allow using any ldap property as login name when using login credentials
* #24961 Fix unreliable ViewTest
* #24964 Don't throw a 500 when importing a broken ics reminder file
* #24967 Bump @nextcloud/axios from 1.5.0 to 1.6.0
* #24969 Bump core-js from 3.8.1 to 3.8.2
* #24970 Fix dashboard greetings that show 'good morning' after noon
* #24979 [Automated] Update psalm-baseline.xml
* #24986 Update root.crl due to revocation of transmission.crt
* #24988 Set the JSCombiner cache if needed
* #24989 Ignore files that have no read permissions during scanning
* #24993 No need to run mysql5 tests anymore
* #24994 Update postgres version tests
* #24999 Set the user language when adding the footer
* #25000 Hide client link in welcome mail if an empty customclient_desktop config is set
* #25001 Fix column name to check prior to deleting
* #25003 Fix return types for Archive::getStream
* #25004 Fix warning in PHP 8 about optional parameter before mandatory one
* #25010 Revert "allow using any ldap property as login name when using login credentials"
* #25011 Catch throwable instead of exception
* #25015 Replace patchwork/utf8 with symfony-polyfill-*
* #25017 Fix clearing the label of a share
* #25018 Fix name of avatar integration tests in Drone
* #25020 (LDAP) respect DB limits of arguments in an IN statement
* #25021 Print an exception trace for setup exceptions
* #25025 [Automated] Update psalm-baseline.xml
* #25029 Change defaultapp in config.sample.php to dashboard to improve docs and align it to source code
* #25031 Revert "(LDAP) respect DB limits of arguments in an IN statement"
* [3rdparty#526](https://github.com/nextcloud/3rdparty/pull/526) Bump psr/log and psr/http-client
* [3rdparty#535](https://github.com/nextcloud/3rdparty/pull/535) Bump pear/archive_tar from 1.4.9 to 1.4.11
* [3rdparty#575](https://github.com/nextcloud/3rdparty/pull/575) Update all the things for Guzzle 7
* [3rdparty#576](https://github.com/nextcloud/3rdparty/pull/576) Bump doctrine/event-manager from 1.1.0 to 1.1.1
* [3rdparty#577](https://github.com/nextcloud/3rdparty/pull/577) Invite the sabre family to the php8 party
* [3rdparty#581](https://github.com/nextcloud/3rdparty/pull/581) Bump doctrine/dbal from 2.12.0 to 3.0.0
* [3rdparty#584](https://github.com/nextcloud/3rdparty/pull/584) Bump pimple/pimple from 3.2.3 to 3.3.1
* [3rdparty#587](https://github.com/nextcloud/3rdparty/pull/587) Replace patchwork/utf8 with symfony-polyfill-*
* [activity#541](https://github.com/nextcloud/activity/pull/541) Correctly set the user for activity parsing when preparing a notifica…
* [activity#543](https://github.com/nextcloud/activity/pull/543) Fix dbal type constants
* [notifications#822](https://github.com/nextcloud/notifications/pull/822) Bump @nextcloud/vue from 3.3.1 to 3.3.2
* [notifications#823](https://github.com/nextcloud/notifications/pull/823) Add pslam
* [notifications#826](https://github.com/nextcloud/notifications/pull/826) Bump axios from 0.21.0 to 0.21.1
* [notifications#827](https://github.com/nextcloud/notifications/pull/827) Fix usage of DBAL types
* [password_policy#109](https://github.com/nextcloud/password_policy/pull/109) L10n: Improve spelling stylistics
* [photos#612](https://github.com/nextcloud/photos/pull/612) Add Psalm
* [photos#614](https://github.com/nextcloud/photos/pull/614) Bump eslint-plugin-vue from 7.3.0 to 7.4.0
* [text#1310](https://github.com/nextcloud/text/pull/1310) Bump webpack-cli from 4.3.0 to 4.3.1
* [text#1312](https://github.com/nextcloud/text/pull/1312) Bump axios from 0.21.0 to 0.21.1


Pending PRs:

* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #24661 Dont offer to edit external config settings if we can't edit them @icewind1991
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #25016 Add setup check to verify that the used DB version is still supported… @MorrisJobke
* [ ] #25036 Respect DB restrictions on number of arguments in statements and queries @blizzz
