### PR TITLE
18.0.13 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = array(18, 0, 12, 2);
+$OC_Version = array(18, 0, 13, 0);
 
 // The human readable string
-$OC_VersionString = '18.0.12';
+$OC_VersionString = '18.0.13 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24651 Bump ini from 1.3.5 to 1.3.7
* #24761 Enables the file name check also to match name of mountpoints
* #24800 Actually set the TTL on redis set
* #24857 Fix total upload size overwritten by next upload
* #24881 Make share results distinguishable if there are more than one with the exact same display name
* #24902 Bump pear/archive_tar from 1.4.8 to 1.4.11
* #24974 Don't throw a 500 when importing a broken ics reminder file
* #24992 Update root.crl due to revocation of transmission.crt
* [3rdparty#534](https://github.com/nextcloud/3rdparty/pull/534) Bump pear/archive_tar from 1.4.8 to 1.4.11
* [text#1194](https://github.com/nextcloud/text/pull/1194) Bump stylelint from 13.7.2 to 13.8.0
* [text#1209](https://github.com/nextcloud/text/pull/1209) Bump babel-loader from 8.2.1 to 8.2.2
* [text#1226](https://github.com/nextcloud/text/pull/1226) Bump @babel/plugin-transform-runtime from 7.12.1 to 7.12.10
* [text#1227](https://github.com/nextcloud/text/pull/1227) Bump core-js from 3.7.0 to 3.8.1
* [text#1228](https://github.com/nextcloud/text/pull/1228) Bump prosemirror-view from 1.16.1 to 1.16.5
* [text#1229](https://github.com/nextcloud/text/pull/1229) Bump @babel/core from 7.12.3 to 7.12.10
* [text#1237](https://github.com/nextcloud/text/pull/1237) Bump vue-loader from 15.9.5 to 15.9.6
* [text#1238](https://github.com/nextcloud/text/pull/1238) Bump @babel/preset-env from 7.12.1 to 7.12.11
* [text#1240](https://github.com/nextcloud/text/pull/1240) Bump @vue/test-utils from 1.1.1 to 1.1.2
* [text#1284](https://github.com/nextcloud/text/pull/1284) Bump prosemirror-model from 1.12.0 to 1.13.1
* [text#1291](https://github.com/nextcloud/text/pull/1291) Fix cypress
* [text#1292](https://github.com/nextcloud/text/pull/1292) Handle 403 errors the same as not found
* [text#1293](https://github.com/nextcloud/text/pull/1293) Fix: use OC.Files API to get file info
* [text#1301](https://github.com/nextcloud/text/pull/1301) Bump cypress from 5.1.0 to 5.6.0
