### PR TITLE
19.0.7 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 6, 2];
+$OC_Version = [19, 0, 7, 0];
 
 // The human readable string
-$OC_VersionString = '19.0.6';
+$OC_VersionString = '19.0.7 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24591 Use storage copy implementation when doing dav copy
* #24593 Use in objectstore copy
* #24762 Fixes sharing to group ids with characters that are being url encoded
* #24795 Fix Argon2 descriptions
* #24799 Actually set the TTL on redis set
* #24855 Fix total upload size overwritten by next upload
* #24875 Avoid huge exception argument logging
* #24880 Make share results distinguishable if there are more than one with the exact same display name
* #24901 Bump pear/archive_tar from 1.4.9 to 1.4.11
* #24962 Fix #24682]: ensure federation cloud id is retruned if FN property not found
* #24973 Don't throw a 500 when importing a broken ics reminder file
* #24991 Update root.crl due to revocation of transmission.crt
* [3rdparty#533](https://github.com/nextcloud/3rdparty/pull/533) Bump pear/archive_tar from 1.4.9 to 1.4.11
* [text#1222](https://github.com/nextcloud/text/pull/1222) Catch possible database exceptions when fetching document data
* [text#1256](https://github.com/nextcloud/text/pull/1256) Bump prosemirror-view from 1.16.1 to 1.16.5
* [text#1258](https://github.com/nextcloud/text/pull/1258) Bump @vue/test-utils from 1.1.1 to 1.1.2
* [text#1260](https://github.com/nextcloud/text/pull/1260) Bump eslint-plugin-standard from 4.0.2 to 4.1.0
* [text#1262](https://github.com/nextcloud/text/pull/1262) Bump @babel/preset-env from 7.12.1 to 7.12.11
* [text#1264](https://github.com/nextcloud/text/pull/1264) Bump @babel/plugin-transform-runtime from 7.12.1 to 7.12.10
* [text#1267](https://github.com/nextcloud/text/pull/1267) Bump babel-loader from 8.1.0 to 8.2.2
* [text#1268](https://github.com/nextcloud/text/pull/1268) Bump prosemirror-model from 1.12.0 to 1.13.1
* [text#1270](https://github.com/nextcloud/text/pull/1270) Bump vue-loader from 15.9.5 to 15.9.6
* [text#1272](https://github.com/nextcloud/text/pull/1272) Bump stylelint from 13.7.2 to 13.8.0
* [text#1275](https://github.com/nextcloud/text/pull/1275) Bump @babel/core from 7.12.3 to 7.12.10
* [text#1276](https://github.com/nextcloud/text/pull/1276) Bump core-js from 3.7.0 to 3.8.1
* [text#1290](https://github.com/nextcloud/text/pull/1290) Fix cypress tests
* [text#1294](https://github.com/nextcloud/text/pull/1294) Fix: use OC.Files API to get file info
* [text#1295](https://github.com/nextcloud/text/pull/1295) Fix link menu positioning
* [text#1302](https://github.com/nextcloud/text/pull/1302) Bump cypress from 5.1.0 to 5.6.0
