### PR TITLE
20.0.5 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 4, 0];
+$OC_Version = [20, 0, 5, 0];
 
 // The human readable string
-$OC_VersionString = '20.0.4';
+$OC_VersionString = '20.0.5 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24546 Don't log params of imagecreatefromstring
* #24590 Use storage copy implementation when doing dav copy
* #24592 Use in objectstore copy
* #24697 Add tel, note, org and title search
* #24698 Check php compatibility of app store app releases
* #24709 Fix #24682]: ensure federation cloud id is retruned if FN property not found
* #24714 Do not include non-required scripts on the upgrade page
* #24716 LDAP: fix inGroup for memberUid type of group memberships
* #24728 Cancel user search requests to avoid duplicate results being added
* #24751 Also unset the other possible unused paramters
* #24760 Enables the file name check also to match name of mountpoints
* #24763 Fixes sharing to group ids with characters that are being url encoded
* #24791 Limit getIncomplete query to one row
* #24792 Fix Argon2 descriptions
* #24798 Actually set the TTL on redis set
* #24806 Allow to force rename a conflicting calendar
* #24823 Fix IPv6 localhost regex
* #24826 Catch the error on heartbeat update
* #24853 Make oc_files_trash.auto_id a bigint
* #24854 Fix total upload size overwritten by next upload
* #24876 Avoid huge exception argument logging
* #24878 Make share results distinguishable if there are more than one with the exact same display name
* #24963 Add migration for oc_share_external columns
* #24972 Don't throw a 500 when importing a broken ics reminder file
* #24976 Fix unreliable ViewTest
* #24990 Update root.crl due to revocation of transmission.crt
* #24997 Set the JSCombiner cache if needed
* #25009 Fix column name to check prior to deleting
* #25013 Catch throwable instead of exception
* [activity#542](https://github.com/nextcloud/activity/pull/542) Correctly set the user for activity parsing when preparing a notifica…
* [photos#597](https://github.com/nextcloud/photos/pull/597) Bump vue-virtual-grid from 2.2.1 to 2.3.0
* [text#1221](https://github.com/nextcloud/text/pull/1221) Catch possible database exceptions when fetching document data
* [text#1234](https://github.com/nextcloud/text/pull/1234) Make sure we have the proper PHP version installed before running composer
* [text#1235](https://github.com/nextcloud/text/pull/1235) Revert removal of transformResponse
* [text#1255](https://github.com/nextcloud/text/pull/1255) Bump prosemirror-view from 1.16.1 to 1.16.5
* [text#1257](https://github.com/nextcloud/text/pull/1257) Bump @babel/preset-env from 7.12.1 to 7.12.11
* [text#1259](https://github.com/nextcloud/text/pull/1259) Bump babel-loader from 8.1.0 to 8.2.2
* [text#1261](https://github.com/nextcloud/text/pull/1261) Bump eslint-plugin-standard from 4.0.2 to 4.1.0
* [text#1263](https://github.com/nextcloud/text/pull/1263) Bump vue-loader from 15.9.5 to 15.9.6
* [text#1265](https://github.com/nextcloud/text/pull/1265) Bump prosemirror-model from 1.12.0 to 1.13.1
* [text#1266](https://github.com/nextcloud/text/pull/1266) Bump core-js from 3.7.0 to 3.8.1
* [text#1269](https://github.com/nextcloud/text/pull/1269) Bump stylelint from 13.7.2 to 13.8.0
* [text#1271](https://github.com/nextcloud/text/pull/1271) Bump @babel/plugin-transform-runtime from 7.12.1 to 7.12.10
* [text#1273](https://github.com/nextcloud/text/pull/1273) Bump sass-loader from 10.0.5 to 10.1.0
* [text#1274](https://github.com/nextcloud/text/pull/1274) Bump webpack-merge from 5.3.0 to 5.7.2
* [text#1277](https://github.com/nextcloud/text/pull/1277) Bump @babel/core from 7.12.3 to 7.12.10
* [text#1278](https://github.com/nextcloud/text/pull/1278) Bump cypress from 5.1.0 to 5.6.0
* [text#1279](https://github.com/nextcloud/text/pull/1279) Bump @vue/test-utils from 1.1.1 to 1.1.2
* [text#1303](https://github.com/nextcloud/text/pull/1303) Bump webpack-merge from 5.7.2 to 5.7.3


Pending PRs:

* [ ] #25019 Set the user language when adding the footer 
