### PR TITLE
avoid fread on directories and unencrypted files

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -943,7 +943,6 @@ class Encryption extends Wrapper {
 			// legacy file. If true, we add the default encryption module
 			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY] && (!empty($result) || $exists)) {
 				$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
-				}
 			}
 		}
 

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -941,11 +941,8 @@ class Encryption extends Wrapper {
 
 			// if the header doesn't contain a encryption module we check if it is a
 			// legacy file. If true, we add the default encryption module
-			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY])) {
-				if (!empty($result)) {
-					$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
-				} elseif ($exists) {
-					$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
+			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY] && (!empty($result) || $exists)) {
+				$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
 				}
 			}
 		}

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -941,7 +941,7 @@ class Encryption extends Wrapper {
 
 			// if the header doesn't contain a encryption module we check if it is a
 			// legacy file. If true, we add the default encryption module
-			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY] && (!empty($result) || $exists)) {
+			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY]) && (!empty($result) || $exists)) {
 				$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
 			}
 		}

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -929,19 +929,22 @@ class Encryption extends Wrapper {
 			$path = $realFile;
 		}
 
-		$firstBlock = $this->readFirstBlock($path);
-		$result = $this->parseRawHeader($firstBlock);
+		$result = [];
+		
+		// first check if it is an encrypted file at all
+		// We would do query to filecache only if we know that entry in filecache exists
+		
+		$info = $this->getCache()->get($path);
+		if (isset($info['encrypted']) && $info['encrypted'] === true) {
+			$firstBlock = $this->readFirstBlock($path);
+			$result = $this->parseRawHeader($firstBlock);
 
-		// if the header doesn't contain a encryption module we check if it is a
-		// legacy file. If true, we add the default encryption module
-		if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY])) {
-			if (!empty($result)) {
-				$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
-			} elseif ($exists) {
-				// if the header was empty we have to check first if it is a encrypted file at all
-				// We would do query to filecache only if we know that entry in filecache exists
-				$info = $this->getCache()->get($path);
-				if (isset($info['encrypted']) && $info['encrypted'] === true) {
+			// if the header doesn't contain a encryption module we check if it is a
+			// legacy file. If true, we add the default encryption module
+			if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY])) {
+				if (!empty($result)) {
+					$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
+				} elseif ($exists) {
 					$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
 				}
 			}

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -597,7 +597,7 @@ class EncryptionTest extends Storage {
 			->setMethods(['getCache','readFirstBlock', 'parseRawHeader'])
 			->getMock();
 		
-		$instance->expects($this->any())->method('getCache')->willReturn($cache);
+		$instance->expects($this->once())->method('getCache')->willReturn($cache);
 		
 		$instance->expects($this->once())->method(('parseRawHeader'))
 			->willReturn([Util::HEADER_ENCRYPTION_MODULE_KEY => 'OC_DEFAULT_MODULE']);
@@ -671,8 +671,8 @@ class EncryptionTest extends Storage {
 			->setMethods(['readFirstBlock', 'parseRawHeader', 'getCache'])
 			->getMock();
 
-		$instance->expects($this->once())->method(('parseRawHeader'))->willReturn($header);
-		$instance->expects($this->any())->method('getCache')->willReturn($cache);
+		$instance->expects($this->any())->method(('parseRawHeader'))->willReturn($header);
+		$instance->expects($this->once())->method('getCache')->willReturn($cache);
 
 		$result = $this->invokePrivate($instance, 'getHeader', ['test.txt']);
 		$this->assertSameSize($expected, $result);

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -560,6 +560,12 @@ class EncryptionTest extends Storage {
 	 * @param string $strippedPath
 	 */
 	public function testGetHeader($path, $strippedPathExists, $strippedPath) {
+		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+			->disableOriginalConstructor()->getMock();
+		$cache->expects($this->any())
+			->method('get')
+			->willReturn(['encrypted' => true]);
+		
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
 
@@ -586,7 +592,7 @@ class EncryptionTest extends Storage {
 					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
-			->setMethods(['readFirstBlock', 'parseRawHeader'])
+			->setMethods(['getCache','readFirstBlock', 'parseRawHeader'])
 			->getMock();
 
 		$instance->expects($this->once())->method(('parseRawHeader'))

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -560,12 +560,6 @@ class EncryptionTest extends Storage {
 	 * @param string $strippedPath
 	 */
 	public function testGetHeader($path, $strippedPathExists, $strippedPath) {
-		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
-			->disableOriginalConstructor()->getMock();
-		$cache->expects($this->any())
-			->method('get')
-			->willReturn(['encrypted' => true]);
-		
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
 
@@ -579,6 +573,14 @@ class EncryptionTest extends Storage {
 					$this->arrayCache
 				]
 			)->getMock();
+		
+		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+			->disableOriginalConstructor()->getMock();
+		$cache->expects($this->any())
+			->method('get')
+			->willReturnCallback(function ($path) {
+				return ['encrypted' => true, 'path' => $path];
+			});
 
 		$instance = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Encryption')
 			->setConstructorArgs(
@@ -594,7 +596,9 @@ class EncryptionTest extends Storage {
 			)
 			->setMethods(['getCache','readFirstBlock', 'parseRawHeader'])
 			->getMock();
-
+		
+		$instance->expects($this->any())->method('getCache')->willReturn($cache);
+		
 		$instance->expects($this->once())->method(('parseRawHeader'))
 			->willReturn([Util::HEADER_ENCRYPTION_MODULE_KEY => 'OC_DEFAULT_MODULE']);
 


### PR DESCRIPTION
Reworking the logic in order to first check the filecache and only then reading the fileheader.
This in order to solve #21578.
Signed-off-by: Jasper Knockaert jasper@knockaert.nl