### PR TITLE
Set the JSCombiner cache if needed

### DIFF
--- a/lib/private/Template/JSCombiner.php
+++ b/lib/private/Template/JSCombiner.php
@@ -121,7 +121,9 @@ class JSCombiner {
 		$fileName = $fileName . '.deps';
 		try {
 			$deps = $this->depsCache->get($folder->getName() . '-' . $fileName);
+			$fromCache = true;
 			if ($deps === null || $deps === '') {
+				$fromCache = false;
 				$depFile = $folder->getFile($fileName);
 				$deps = $depFile->getContent();
 			}
@@ -142,6 +144,10 @@ class JSCombiner {
 				if (!file_exists($file) || filemtime($file) > $mtime) {
 					return false;
 				}
+			}
+
+			if ($fromCache === false) {
+				$this->depsCache->set($folder->getName() . '-' . $fileName, json_encode($deps));
 			}
 
 			return true;


### PR DESCRIPTION
Found while debugging a customer setup. They had to flush their Redis.
Hence the info was no longer there. Since they also used S3 this meant
requesting the files over and over on template render. Which on S3 is
not cheap.

Now we just write it back if we can't get it from the cache in the first
place. So that the next run has it cached properly again.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>