### PR TITLE
Set the user language when adding the footer

### DIFF
--- a/apps/settings/lib/Mailer/NewUserMailHelper.php
+++ b/apps/settings/lib/Mailer/NewUserMailHelper.php
@@ -159,7 +159,7 @@ class NewUserMailHelper {
 			);
 		}
 
-		$emailTemplate->addFooter();
+		$emailTemplate->addFooter('', $lang);
 
 		return $emailTemplate;
 	}

--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -139,7 +139,7 @@ class NewUserMailHelperTest extends TestCase {
 		$this->timeFactory
 			->expects($this->once())
 			->method('getTime')
-			->willReturn('12345');
+			->willReturn(12345);
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
@@ -370,6 +370,7 @@ Welcome aboard
 Welcome to your TestCloud account, you can add, protect, and share your data.
 
 Your username is: john
+
 
 Set your password: https://example.com/resetPassword/MySuperLongSecureRandomToken
 Install Client: https://nextcloud.com/install/#install-clients


### PR DESCRIPTION
- Create a new user and set the language to something different than the default
- See that the footer of the welcome email is not in the expected user language
