### PR TITLE
Hide client link in welcome mail if an empty customclient_desktop config is set

### DIFF
--- a/apps/settings/lib/Mailer/NewUserMailHelper.php
+++ b/apps/settings/lib/Mailer/NewUserMailHelper.php
@@ -143,12 +143,22 @@ class NewUserMailHelper {
 		} else {
 			$leftButtonText = $l10n->t('Go to %s', [$this->themingDefaults->getName()]);
 		}
-		$emailTemplate->addBodyButtonGroup(
-			$leftButtonText,
-			$link,
-			$l10n->t('Install Client'),
-			$this->config->getSystemValue('customclient_desktop', 'https://nextcloud.com/install/#install-clients')
-		);
+
+		$clientDownload = $this->config->getSystemValue('customclient_desktop', 'https://nextcloud.com/install/#install-clients');
+		if ($clientDownload === '') {
+			$emailTemplate->addBodyButton(
+				$leftButtonText,
+				$link
+			);
+		} else {
+			$emailTemplate->addBodyButtonGroup(
+				$leftButtonText,
+				$link,
+				$l10n->t('Install Client'),
+				$clientDownload
+			);
+		}
+
 		$emailTemplate->addFooter();
 
 		return $emailTemplate;


### PR DESCRIPTION
This allows admins to basically hide the client install button if the url is manually configured to be empty.