### PR TITLE
Revert "allow using any ldap property as login name when using login credentials"

### DIFF
--- a/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
+++ b/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
@@ -30,7 +30,6 @@ use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Listener\StorePasswordListener;
-use OCA\User_LDAP\IUserLDAP;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore as CredentialsStore;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -82,7 +81,7 @@ class LoginCredentials extends AuthMechanism {
 
 				$credentials = [
 					'user' => $sessionCredentials->getLoginName(),
-					'password' => $sessionCredentials->getPassword(),
+					'password' => $sessionCredentials->getPassword()
 				];
 
 				$this->credentialsManager->store($user->getUID(), self::CREDENTIALS_IDENTIFIER, $credentials);
@@ -100,42 +99,7 @@ class LoginCredentials extends AuthMechanism {
 		}
 		$credentials = $this->getCredentials($user);
 
-		$loginKey = $storage->getBackendOption("login_ldap_attr");
-		if ($loginKey) {
-			$backend = $user->getBackend();
-			if ($backend instanceof IUserLDAP) {
-				$value = $this->getLdapPropertyForUser($backend, $user, $loginKey);
-				if ($value === null) {
-					throw new InsufficientDataForMeaningfulAnswerException('Custom ldap attribute not set for user ' . $user->getUID());
-				}
-				$storage->setBackendOption('user', $value);
-			} else {
-				throw new InsufficientDataForMeaningfulAnswerException('Custom ldap attribute configured but user ' . $user->getUID() . ' is not an ldap user');
-			}
-		} else {
-			$storage->setBackendOption('user', $credentials['user']);
-		}
+		$storage->setBackendOption('user', $credentials['user']);
 		$storage->setBackendOption('password', $credentials['password']);
-	}
-
-	private function getLdapPropertyForUser(IUserLDAP $ldap, IUser $user, string $property): ?string {
-		$access = $ldap->getLDAPAccess($user->getUID());
-		$connection = $access->getConnection();
-		$key = "external_login::" . $user->getUID() . "::" . $property;
-		$cached = $connection->getFromCache($key);
-
-		if ($cached !== null) {
-			return $cached;
-		}
-
-		$value = $access->readAttribute($access->username2dn($user->getUID()), $property);
-		if (count($value) > 0) {
-			$value = current($value);
-		} else {
-			return null;
-		}
-		$connection->writeToCache($key, $value);
-
-		return $value;
 	}
 }


### PR DESCRIPTION
Reverts nextcloud/server#24955

As far as I know there was no reason for merging it post feature freeze. Correct me if I am wrong.

But also, https://github.com/nextcloud/server/pull/24955#pullrequestreview-563465047