### PR TITLE
Catch throwable instead of exception

### DIFF
--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -301,7 +301,7 @@ class Storage implements IStorage {
 						$fallback = false;
 						try {
 							$clearData = $this->crypto->decrypt($data);
-						} catch (\Exception $e) {
+						} catch (\Throwable $e) {
 							$fallback = true;
 						}
 


### PR DESCRIPTION
The error that gets thrown can also be a type error etc. So we should
properly catch the Throwable.

Should help with #23197 

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>