### PR TITLE
Replace patchwork/utf8 with symfony-polyfill-*

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -629,8 +629,7 @@ class OC {
 		self::handleAuthHeaders();
 		self::registerAutoloaderCache();
 
-		// initialize intl fallback is necessary
-		\Patchwork\Utf8\Bootup::initIntl();
+		// initialize intl fallback if necessary
 		OC_Util::isSetLocaleWorking();
 
 		if (!defined('PHPUNIT_RUN')) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1293,7 +1293,13 @@ class OC_Util {
 	 * @return bool
 	 */
 	public static function isSetLocaleWorking() {
-		\Patchwork\Utf8\Bootup::initLocale();
+		if ('' === basename('§')) {
+			// Borrowed from \Patchwork\Utf8\Bootup::initLocale
+			setlocale(LC_ALL, 'C.UTF-8', 'C');
+			setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
+		}
+
+		// Check again
 		if ('' === basename('§')) {
 			return false;
 		}


### PR DESCRIPTION
- [x] https://github.com/nextcloud/3rdparty/pull/587
- [x] Rebase

To test
* Disable `ìntl` extension
* Run `occ`

On master: :boom:  because the polyfill redeclares a function
Here: inner piece

Full disclaimer: I don't fully know if everything is working as before as it's hard to tell where the polyfill is active or not and if they behave the exact same way. But at least we use a more widely used package instead of the old, pratically unmaintained one.