### PR TITLE
(LDAP) respect DB limits of arguments in an IN statement

### DIFF
--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -190,18 +190,30 @@ abstract class AbstractMapping {
 	}
 
 	public function getListOfIdsByDn(array $fdns): array {
+		$fdnsSlice = count($fdns) > 1000 ? array_slice($fdns, 0, 1000) : $fdns;
 		$qb = $this->dbc->getQueryBuilder();
 		$qb->select('owncloud_name', 'ldap_dn')
 			->from($this->getTableName(false))
-			->where($qb->expr()->in('ldap_dn', $qb->createNamedParameter($fdns, QueryBuilder::PARAM_STR_ARRAY)));
-		$stmt = $qb->execute();
+			->where($qb->expr()->in('ldap_dn', $qb->createNamedParameter($fdnsSlice, QueryBuilder::PARAM_STR_ARRAY)));
 
-		$results = $stmt->fetchAll(\Doctrine\DBAL\FetchMode::ASSOCIATIVE);
-		foreach ($results as $key => $entry) {
-			unset($results[$key]);
+		$slice = 1;
+		while (isset($fdnsSlice[999])) {
+			// Oracle does not allow more than 1000 values in the IN list,
+			// but allows slicing
+			$fdnsSlice = array_slice($fdns, 1000 * $slice, 1000);
+			if (!empty($fdnsSlice)) {
+				$qb->orWhere($qb->expr()->in('ldap_dn', $qb->createNamedParameter($fdnsSlice, QueryBuilder::PARAM_STR_ARRAY)));
+			}
+			$slice++;
+		}
+
+		$stmt = $qb->execute();
+		$results = [];
+		while ($entry = $stmt->fetch(\Doctrine\DBAL\FetchMode::ASSOCIATIVE)) {
 			$results[$entry['ldap_dn']] = $entry['owncloud_name'];
 			$this->cache[$entry['ldap_dn']] = $entry['owncloud_name'];
 		}
+		$stmt->closeCursor();
 
 		return $results;
 	}

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -281,4 +281,23 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 		$results = $mapper->getList(1, 1);
 		$this->assertSame(1, count($results));
 	}
+
+	public function testGetListOfIdsByDn() {
+		/** @var AbstractMapping $mapper */
+		list($mapper,) = $this->initTest();
+
+		$listOfDNs = [];
+		for ($i = 0; $i < 65640; $i++) {
+			// Postgres has a limit of 65535 values in a single IN list
+			$name = 'as_' . $i;
+			$dn = 'uid=' . $name . ',dc=example,dc=org';
+			$listOfDNs[] = $dn;
+			if ($i % 20 === 0) {
+				$mapper->map($dn, $name, 'fake-uuid-' . $i);
+			}
+		}
+
+		$result = $mapper->getListOfIdsByDn($listOfDNs);
+		$this->assertSame(65640 / 20, count($result));
+	}
 }


### PR DESCRIPTION
Try to get a big list of users or groups from LDAP (you need to have them), for instance via `php occ ldap:search --limit=3500 ''`. The actual number of users depends on the database in use. When it is too many, you may run into `SQLSTATE[HY000]: General error: 7 number of parameters must be between 0 and 65535` (Postgres) or `ORA-01795: maximum number of expressions in a list is 1000` (Oracle). Both MySQL/MariaDB and Sqlite do not have a specific limit of arguments, but of total bytes per statement. With 1000 entries (currently limited to 255bytes each) default values are not being exceeded.

Background: when fetching users or groups from LDAP we collect the DN and fetch information from the database. In order to avoid a single read operation per entry, we collect them. Normally we do not need to deal with this huge numbers. Although, depending on the perspective, 1000 is already low. This is relevant when all users or groups are being fetched, which might happen. The prominent case for groups is the users page, as they are not paginated.