### PR TITLE
Print an exception trace for setup exceptions

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -43,6 +43,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Throwable;
+use function get_class;
 
 class Install extends Command {
 
@@ -201,11 +203,25 @@ class Install extends Command {
 	protected function printErrors(OutputInterface $output, $errors) {
 		foreach ($errors as $error) {
 			if (is_array($error)) {
-				$output->writeln('<error>' . (string)$error['error'] . '</error>');
-				$output->writeln('<info> -> ' . (string)$error['hint'] . '</info>');
+				$output->writeln('<error>' . $error['error'] . '</error>');
+				if (isset($error['hint']) && !empty($error['hint'])) {
+					$output->writeln('<info> -> ' . $error['hint'] . '</info>');
+				}
+				if (isset($error['exception']) && $error['exception'] instanceof Throwable) {
+					$this->printThrowable($output, $error['exception']);
+				}
 			} else {
-				$output->writeln('<error>' . (string)$error . '</error>');
+				$output->writeln('<error>' . $error . '</error>');
 			}
+		}
+	}
+
+	private function printThrowable(OutputInterface $output, Throwable $t): void {
+		$output->write('<info>Trace: ' . $t->getTraceAsString() . '</info>');
+		if ($t->getPrevious() !== null) {
+			$output->writeln('');
+			$output->writeln('<info>Previous: ' . get_class($t->getPrevious()) . ': ' . $t->getPrevious()->getMessage() . '</info>');
+			$this->printThrowable($output, $t->getPrevious());
 		}
 	}
 }

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -218,6 +218,7 @@ class Install extends Command {
 
 	private function printThrowable(OutputInterface $output, Throwable $t): void {
 		$output->write('<info>Trace: ' . $t->getTraceAsString() . '</info>');
+		$output->writeln('');
 		if ($t->getPrevious() !== null) {
 			$output->writeln('');
 			$output->writeln('<info>Previous: ' . get_class($t->getPrevious()) . ': ' . $t->getPrevious()->getMessage() . '</info>');

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -236,6 +236,7 @@ class Setup {
 			} catch (\OC\HintException $e) {
 				$errors[] = [
 					'error' => $e->getMessage(),
+					'exception' => $e,
 					'hint' => $e->getHint(),
 				];
 				$htAccessWorking = false;
@@ -360,12 +361,14 @@ class Setup {
 		} catch (\OC\DatabaseSetupException $e) {
 			$error[] = [
 				'error' => $e->getMessage(),
+				'exception' => $e,
 				'hint' => $e->getHint(),
 			];
 			return $error;
 		} catch (Exception $e) {
 			$error[] = [
 				'error' => 'Error while trying to create admin user: ' . $e->getMessage(),
+				'exception' => $e,
 				'hint' => '',
 			];
 			return $error;
@@ -376,6 +379,7 @@ class Setup {
 		} catch (Exception $e) {
 			$error[] = [
 				'error' => 'Error while trying to initialise the database: ' . $e->getMessage(),
+				'exception' => $e,
 				'hint' => '',
 			];
 			return $error;

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -66,7 +66,7 @@ class MySQL extends AbstractDatabase {
 		} catch (\Exception $e) {
 			$this->logger->logException($e);
 			throw new \OC\DatabaseSetupException($this->trans->t('MySQL username and/or password not valid'),
-				$this->trans->t('You need to enter details of an existing account.'));
+				$this->trans->t('You need to enter details of an existing account.'), 0, $e);
 		}
 	}
 

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -74,14 +74,14 @@ class OCI extends AbstractDatabase {
 					. ' ORACLE_SID=' . getenv('ORACLE_SID')
 					. ' LD_LIBRARY_PATH=' . getenv('LD_LIBRARY_PATH')
 					. ' NLS_LANG=' . getenv('NLS_LANG')
-					. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable');
+					. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable', 0, $e);
 			}
 			throw new \OC\DatabaseSetupException($this->trans->t('Oracle username and/or password not valid'),
 				'Check environment: ORACLE_HOME=' . getenv('ORACLE_HOME')
 				. ' ORACLE_SID=' . getenv('ORACLE_SID')
 				. ' LD_LIBRARY_PATH=' . getenv('LD_LIBRARY_PATH')
 				. ' NLS_LANG=' . getenv('NLS_LANG')
-				. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable');
+				. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable', 0, $e);
 		}
 
 		$this->config->setValues([

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -99,7 +99,7 @@ class PostgreSQL extends AbstractDatabase {
 		} catch (\Exception $e) {
 			$this->logger->logException($e);
 			throw new \OC\DatabaseSetupException($this->trans->t('PostgreSQL username and/or password not valid'),
-				$this->trans->t('You need to enter details of an existing account.'));
+				$this->trans->t('You need to enter details of an existing account.'), 0, $e);
 		}
 	}
 


### PR DESCRIPTION
Doing this because in https://github.com/nextcloud/mail/pull/4319 I received

![Bildschirmfoto von 2021-01-07 20-12-34](https://user-images.githubusercontent.com/1374172/103934103-b4449c80-5124-11eb-98e7-e189739831f3.png)

Right now any setup error will just result in the exception message
being printed. In some cases this doesn't give any insights into what
went wrong. This adds some dedicated logic to print the exception trace
and any previous exceptions to the CLI.
