### PR TITLE
Fixes visual bug by making the icon grey only on hover and white otherwise.

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -184,7 +184,9 @@ select {
 		border-color: var(--color-primary) !important;
 	}
 
-	&.icon-file {
+	&.icon-file,
+	&.icon-file-white
+	{
 		padding-left: 48px;
 		background-position: 24px;
 	}

--- a/apps/settings/templates/settings/personal/development.notice.php
+++ b/apps/settings/templates/settings/personal/development.notice.php
@@ -1,6 +1,6 @@
 <div class="section development-notice">
 	<p>
-		<a href="<?php p($_['reasons-use-nextcloud-pdf-link']); ?>" id="open-reasons-use-nextcloud-pdf" class="link-button icon-file" target="_blank"><?php p($l->t('Reasons to use Nextcloud in your organization'));?></a>
+		<a href="<?php p($_['reasons-use-nextcloud-pdf-link']); ?>" id="open-reasons-use-nextcloud-pdf" class="link-button icon-file-white" target="_blank"><?php p($l->t('Reasons to use Nextcloud in your organization'));?></a>
 	</p>
 	<p>
 		<?php print_unescaped(str_replace(

--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -92,8 +92,12 @@ $invert: luma($color-primary) > 0.6;
 }
 
 /* Colorized svg images */
-.icon-file, .icon-filetype-text {
+.icon-file, .icon-filetype-text, .icon-file-white:hover {
 	background-image: url(./img/core/filetypes/text.svg?v=#{$theming-cachebuster});
+}
+
+.icon-file-white, .icon-filetype-text-white {
+	background-image: url(./img/core/filetypes/text-white.svg?v=#{$theming-cachebuster});
 }
 
 .icon-folder, .icon-filetype-folder {

--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -92,12 +92,8 @@ $invert: luma($color-primary) > 0.6;
 }
 
 /* Colorized svg images */
-.icon-file, .icon-filetype-text, .icon-file-white:hover {
+.icon-file, .icon-filetype-text, .icon-file-white:hover, .icon-file-white:focus {
 	background-image: url(./img/core/filetypes/text.svg?v=#{$theming-cachebuster});
-}
-
-.icon-file-white, .icon-filetype-text-white {
-	background-image: url(./img/core/filetypes/text-white.svg?v=#{$theming-cachebuster});
 }
 
 .icon-folder, .icon-filetype-folder {

--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -384,10 +384,13 @@ audio, canvas, embed, iframe, img, input, object, video {
 }
 
 .icon-file,
-.icon-file-white,
-.icon-filetype-text,
 .icon-filetype-text {
 	@include icon-color('text', 'filetypes', #969696, 1, true);
+}
+
+.icon-file-white,
+.icon-filetype-text-white {
+	@include icon-color('text', 'filetypes', $color-white, 1, true);
 }
 
 .icon-filetype-file {

--- a/core/css/icons.scss
+++ b/core/css/icons.scss
@@ -384,6 +384,8 @@ audio, canvas, embed, iframe, img, input, object, video {
 }
 
 .icon-file,
+.icon-file-white,
+.icon-filetype-text,
 .icon-filetype-text {
 	@include icon-color('text', 'filetypes', #969696, 1, true);
 }

--- a/core/img/filetypes/text-white.svg
+++ b/core/img/filetypes/text-white.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<!-- Created using Karbon, part of Calligra: http://www.calligra.org/karbon -->
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12.8pt" height="12.8pt">
-<defs/>
-<g id="layer0">
-  <path id="shape0" transform="translate(2, 1)" fill="#ffffff" d="M0.5 0C0.22 0 0 0.22 0 0.5L0 13.5C0 13.78 0.22 14 0.5 14L11.5 14C11.78 14 12 13.78 12 13.5L12 3L9 0ZM2 2L8 2L8 3L2 3ZM2 5L7 5L7 6L2 6ZM2 8L10 8L10 9L2 9ZM2 11L6 11L6 12L2 12Z"/>
- </g>
-</svg>

--- a/core/img/filetypes/text-white.svg
+++ b/core/img/filetypes/text-white.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<!-- Created using Karbon, part of Calligra: http://www.calligra.org/karbon -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="12.8pt" height="12.8pt">
+<defs/>
+<g id="layer0">
+  <path id="shape0" transform="translate(2, 1)" fill="#ffffff" d="M0.5 0C0.22 0 0 0.22 0 0.5L0 13.5C0 13.78 0.22 14 0.5 14L11.5 14C11.78 14 12 13.78 12 13.5L12 3L9 0ZM2 2L8 2L8 3L2 3ZM2 5L7 5L7 6L2 6ZM2 8L10 8L10 9L2 9ZM2 11L6 11L6 12L2 12Z"/>
+ </g>
+</svg>


### PR DESCRIPTION
As described in #24450, the icon looks off in grey but, if just changed to white, it would be a white icon on white background on hover, which I solved by making the icon grey only on hover and otherwise white.