### PR TITLE
Change defaultapp in config.sample.php to dashboard to improve docs and align it to source code

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -220,11 +220,11 @@ $CONFIG = [
  * URL after clicking them in the Apps menu, such as documents, calendar, and
  * gallery. You can use a comma-separated list of app names, so if the first
  * app is not enabled for a user then Nextcloud will try the second one, and so
- * on. If no enabled apps are found it defaults to the Files app.
+ * on. If no enabled apps are found it defaults to the dashboard app.
  *
- * Defaults to ``files``
+ * Defaults to ``dashboard,files``
  */
-'defaultapp' => 'files',
+'defaultapp' => 'dashboard,files',
 
 /**
  * ``true`` enables the Help menu item in the user menu (top right of the


### PR DESCRIPTION
Result of discussion at https://help.nextcloud.com/t/enable-dashboard-on-per-user-basis/94872

Code reference:
https://github.com/nextcloud/server/blob/db86bea18ce41ad73e9c1a06f2b2d89d8d4f2ef8/lib/private/legacy/OC_Util.php#L1106

Signed-off-by: rakekniven <mark.ziegler@rakekniven.de>