### PR TITLE
Make sure to do priority app upgrades first

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -267,7 +267,6 @@ class Updater extends BasicEmitter {
 		$this->upgradeAppStoreApps($autoDisabledApps, true);
 
 		// install new shipped apps on upgrade
-		OC_App::loadApps(['authentication']);
 		$errors = Installer::installShippedApps(true);
 		foreach ($errors as $appId => $exception) {
 			/** @var \Exception $exception */
@@ -332,7 +331,8 @@ class Updater extends BasicEmitter {
 				$stacks[$pseudoOtherType][] = $appId;
 			}
 		}
-		foreach ($stacks as $type => $stack) {
+		foreach (array_merge($priorityTypes, [$pseudoOtherType]) as $type) {
+			$stack = $stacks[$type];
 			foreach ($stack as $appId) {
 				if (\OC_App::shouldUpgrade($appId)) {
 					$this->emit('\OC\Updater', 'appUpgradeStarted', [$appId, \OC_App::getAppVersion($appId)]);


### PR DESCRIPTION
Otherwise those apps might not be loaded when the others app migrations are running. The previous loading of authentication apps in the upgrade step never worked as it just returns in maintenance mode.

This has shown causing issues with deck for example where we have a cleanup migration step that checks if a user exists. Now when running this post-migration step with LDAP users the user_ldap app would have never been loaded as the `others` apps get upgraded first, which leads to the user existance check to always return false.