### PR TITLE
Don't try a transaction for the migrator on MySQL

### DIFF
--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -32,6 +32,7 @@
 namespace OC\DB;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Index;
@@ -238,14 +239,18 @@ class Migrator {
 
 		$schemaDiff = $this->getDiff($targetSchema, $connection);
 
-		$connection->beginTransaction();
+		if (!$connection->getDatabasePlatform() instanceof MySQLPlatform) {
+			$connection->beginTransaction();
+		}
 		$sqls = $schemaDiff->toSql($connection->getDatabasePlatform());
 		$step = 0;
 		foreach ($sqls as $sql) {
 			$this->emit($sql, $step++, count($sqls));
 			$connection->query($sql);
 		}
-		$connection->commit();
+		if (!$connection->getDatabasePlatform() instanceof MySQLPlatform) {
+			$connection->commit();
+		}
 	}
 
 	/**

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -10,7 +10,9 @@
 namespace Test\DB;
 
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use OC\DB\SchemaWrapper;
@@ -122,7 +124,11 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	private function isSQLite() {
-		return $this->connection->getDriver() instanceof \Doctrine\DBAL\Driver\PDOSqlite\Driver;
+		return $this->connection->getDatabasePlatform() instanceof SqlitePlatform;
+	}
+
+	private function isMySQL() {
+		return $this->connection->getDatabasePlatform() instanceof MySQLPlatform;
 	}
 
 
@@ -143,7 +149,9 @@ class MigratorTest extends \Test\TestCase {
 		try {
 			$migrator->migrate($endSchema);
 		} catch (Exception\UniqueConstraintViolationException $e) {
-			$this->connection->rollBack();
+			if (!$this->isMySQL()) {
+				$this->connection->rollBack();
+			}
 			throw $e;
 		}
 	}


### PR DESCRIPTION
As per https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
CREATE TABLE statements automatically commit always. The only reason
this worked in the past was that PHPs PDO connection didn't check the
actual state on commit, but only checked their internal state.
But in PHP8 this was fixed:
https://github.com/php/php-src/blob/PHP-8.0/UPGRADING#L446-L450
So now commit() fails because the internal PDO connection implicitly
commited already.
