### PR TITLE
21 beta6

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 12];
+$OC_Version = [21, 0, 0, 13];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta5';
+$OC_VersionString = '21.0.0 beta6';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #24606 Add 'allow Symlinks' as an option to config.php
* #24661 Dont offer to edit external config settings if we can't edit them
* #24910 Bump scssphp/scssphp from 1.0.3 to 1.4.0
* #25016 Add setup check to verify that the used DB version is still supported…
* #25034 Make sure to do priority app upgrades first
* #25038 Don't try a transaction for the migrator on MySQL
* #25039 Only use libxml_disable_entity_loader on php older than 8
* #25047 Bump sinon from 9.2.2 to 9.2.3
* #25048 Bump webdav from 3.6.1 to 3.6.2
* #25049 Bump webpack from 4.44.2 to 4.45.0
* #25050 [Automated] Update psalm-baseline.xml
* #25069 Don't remove assignable column for now
* #25070 Deck Rich-Object-String definitions for deck boards and cards
* #25073 Remove unneeded casts that were found by Psalm
* #25080 Fix database connection usage in the files scanner
* #25087 Update psalm baseline to remove obsolete stuff
* #25088 Allow installing/updating of apps again
* #25089 Add our own db column types via the public API
* #25105 [Automated] Update psalm-baseline.xml
* [3rdparty#574](https://github.com/nextcloud/3rdparty/pull/574) Bump scssphp/scssphp from 1.0.3 to 1.4.1
* [3rdparty#595](https://github.com/nextcloud/3rdparty/pull/595) Fix missing, outdated and extra files
* [files_pdfviewer#282](https://github.com/nextcloud/files_pdfviewer/pull/282) Bump webpack from 4.44.2 to 4.45.0
* [firstrunwizard#464](https://github.com/nextcloud/firstrunwizard/pull/464) Bump webpack from 4.44.2 to 4.45.0
* [notifications#830](https://github.com/nextcloud/notifications/pull/830) Bump @nextcloud/axios from 1.5.0 to 1.6.0
* [notifications#831](https://github.com/nextcloud/notifications/pull/831) Bump webpack from 4.44.2 to 4.45.0
* [notifications#832](https://github.com/nextcloud/notifications/pull/832) Bump core-js from 3.8.1 to 3.8.2
* [notifications#833](https://github.com/nextcloud/notifications/pull/833) Bump nextcloud/coding-standard from 0.3.0 to 0.5.0
* [notifications#834](https://github.com/nextcloud/notifications/pull/834) Bump ini from 1.3.5 to 1.3.8
* [notifications#835](https://github.com/nextcloud/notifications/pull/835) Support using notify_push to get push notifications
* [photos#617](https://github.com/nextcloud/photos/pull/617) Bump eslint-plugin-vue from 7.4.0 to 7.4.1
* [photos#620](https://github.com/nextcloud/photos/pull/620) Bump eslint from 7.16.0 to 7.17.0
* [text#1313](https://github.com/nextcloud/text/pull/1313) Fix dbal types
* [viewer#743](https://github.com/nextcloud/viewer/pull/743) Bump @nextcloud/axios from 1.5.0 to 1.6.0


Pending PRs:

* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #25036 Respect DB restrictions on number of arguments in statements and queries @blizzz
* [ ] #25059 Bump web-auth/webauthn-lib from 3.1.1 to 3.3.1 @ChristophWurst
* [ ] #25084 Update DAVx5 in AuthToken.vue @rfc2822
* [ ] #25091 Add our own DB exception abstraction @ChristophWurst
* [ ] #25093 Fix CacheJail::filterCacheEntry when entry is already filtered @icewind1991
* [ ] #25101 LDAP: make actually use of batch read known groups @blizzz
* [ ] #25110 Fix night condition in dashboard greeting @eneiluj
* [ ] #25112 Dont error the entire repair process when a repair step errors @icewind1991
* [ ] #25114 Dismiss reminder notifications from passed events @tcitworld
* [ ] [3rdparty#592](https://github.com/nextcloud/3rdparty/pull/592) Bump phpseclib/phpseclib from 2.0.25 to 2.0.30 
* [ ] [3rdparty#594](https://github.com/nextcloud/3rdparty/pull/594) Bump web-auth/webauthn-lib from 3.1.1 to 3.3.1 
* [ ] [text#1296](https://github.com/nextcloud/text/pull/1296) Temporary editor colors during editing sessions @juliushaertl
