### PR TITLE
Update tag_ident index when removing assignable column

### DIFF
--- a/core/Migrations/Version21000Date20201120141228.php
+++ b/core/Migrations/Version21000Date20201120141228.php
@@ -63,6 +63,8 @@ class Version21000Date20201120141228 extends SimpleMigrationStep {
 		if ($schema->hasTable('systemtag')) {
 			$table = $schema->getTable('systemtag');
 			if ($table->hasColumn('assignable')) {
+				$table->dropIndex('tag_ident');
+				$table->addUniqueIndex(['name', 'visibility', 'editable'], 'tag_ident');
 				$table->dropColumn('assignable');
 			}
 		}


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/24813#issuecomment-757861825 as follow up of https://github.com/nextcloud/server/pull/25001

- [ ] what to do with potential duplicate entries ?
- [ ] add extra migration for those who already ran that one ?
- [ ] test
