### PR TITLE
Update psalm baseline to remove obsolete stuff

### DIFF
--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -29,7 +29,7 @@ namespace OCA\Settings\SetupChecks;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
@@ -61,7 +61,7 @@ class SupportedDatabase {
 			case MySQL80Platform::class: # extends MySQL57Platform
 			case MySQL57Platform::class: # extends MySQLPlatform
 			case MariaDb1027Platform::class: # extends MySQLPlatform
-			case MySqlPlatform::class:
+			case MySQLPlatform::class:
 				$result = $this->connection->prepare('SHOW VARIABLES LIKE "version";');
 				$result->execute();
 				$row = $result->fetch();

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3038,9 +3038,6 @@
     <InvalidArrayOffset occurrences="1">
       <code>$action['url-postfix']</code>
     </InvalidArrayOffset>
-    <RedundantCondition occurrences="1">
-      <code>strtolower</code>
-    </RedundantCondition>
   </file>
   <file src="lib/private/AppFramework/Services/AppConfig.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -5034,11 +5031,6 @@
       <code>$this-&gt;appendIfExist($this-&gt;serverroot, 'apps/'.$script.'.js')</code>
       <code>$this-&gt;appendIfExist($this-&gt;serverroot, 'core/'.$script.'.js')</code>
     </InvalidOperand>
-  </file>
-  <file src="lib/private/Template/SCSSCacher.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>Compiler::LINE_COMMENTS</code>
-    </InvalidScalarArgument>
   </file>
   <file src="lib/private/TemplateLayout.php">
     <InvalidParamDefault occurrences="2">


### PR DESCRIPTION
As seen in CI static checks, some blocks in the baseline were not needed any
more.

This will fix static checks in CI which were failing in multiple PRs, like https://github.com/nextcloud/server/pull/25086/checks?check_run_id=1685442983 and https://github.com/nextcloud/server/pull/24606/checks?check_run_id=1682178510

This is the result of running locally `composer run psalm -- --update-baseline --threads=1`

Signed-off-by: Vincent Petry <vincent@nextcloud.com>