### PR TITLE
Add our own db column types via the public API

### DIFF
--- a/apps/dav/lib/Migration/Version1005Date20180413093149.php
+++ b/apps/dav/lib/Migration/Version1005Date20180413093149.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1005Date20180530124431.php
+++ b/apps/dav/lib/Migration/Version1005Date20180530124431.php
@@ -27,7 +27,7 @@
 
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1006Date20180619154313.php
+++ b/apps/dav/lib/Migration/Version1006Date20180619154313.php
@@ -26,7 +26,7 @@
  */
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1006Date20180628111625.php
+++ b/apps/dav/lib/Migration/Version1006Date20180628111625.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1008Date20181030113700.php
+++ b/apps/dav/lib/Migration/Version1008Date20181030113700.php
@@ -28,7 +28,7 @@ namespace OCA\DAV\Migration;
 
 use Closure;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1008Date20181105104826.php
+++ b/apps/dav/lib/Migration/Version1008Date20181105104826.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/apps/dav/lib/Migration/Version1008Date20181105110300.php
+++ b/apps/dav/lib/Migration/Version1008Date20181105110300.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/apps/dav/lib/Migration/Version1011Date20190725113607.php
+++ b/apps/dav/lib/Migration/Version1011Date20190725113607.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1011Date20190806104428.php
+++ b/apps/dav/lib/Migration/Version1011Date20190806104428.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/dav/lib/Migration/Version1012Date20190808122342.php
+++ b/apps/dav/lib/Migration/Version1012Date20190808122342.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/federatedfilesharing/lib/Migration/Version1010Date20200630191755.php
+++ b/apps/federatedfilesharing/lib/Migration/Version1010Date20200630191755.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 namespace OCA\FederatedFileSharing\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php
+++ b/apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php
@@ -27,7 +27,7 @@ namespace OCA\FederatedFileSharing\Migration;
 
 use Closure;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/apps/federation/lib/Migration/Version1010Date20200630191302.php
+++ b/apps/federation/lib/Migration/Version1010Date20200630191302.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 namespace OCA\Federation\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/files_external/lib/Migration/Version1011Date20200630192246.php
+++ b/apps/files_external/lib/Migration/Version1011Date20200630192246.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OCA\Files_External\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
+++ b/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
@@ -29,7 +29,7 @@ namespace OCA\Files_Sharing\Migration;
 
 use Closure;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/apps/files_sharing/lib/Migration/Version21000Date20201223143245.php
+++ b/apps/files_sharing/lib/Migration/Version21000Date20201223143245.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OCA\Files_Sharing\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/files_trashbin/lib/Migration/Version1010Date20200630192639.php
+++ b/apps/files_trashbin/lib/Migration/Version1010Date20200630192639.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -47,7 +47,7 @@ use DirectoryIterator;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\TransactionIsolationLevel;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use GuzzleHttp\Exception\ClientException;
 use OC;
 use OC\AppFramework\Http;

--- a/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
+++ b/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 namespace OCA\User_LDAP\Migration;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/user_status/lib/Migration/Version0001Date20200602134824.php
+++ b/apps/user_status/lib/Migration/Version0001Date20200602134824.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\UserStatus\Migration;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
+++ b/apps/workflowengine/lib/Migration/Version2000Date20190808074233.php
@@ -6,7 +6,7 @@ namespace OCA\WorkflowEngine\Migration;
 
 use Closure;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCA\WorkflowEngine\Entity\File;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -33,7 +33,7 @@ namespace OC\Core\Command\Db;
 
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OC\DB\Connection;
 use OC\DB\SchemaWrapper;
 use Symfony\Component\Console\Command\Command;

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -36,7 +36,7 @@ namespace OC\Core\Command\Db;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\AbstractAsset;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OC\DB\Connection;
 use OC\DB\ConnectionFactory;
 use OC\DB\MigrationService;

--- a/core/Migrations/Version13000Date20170705121758.php
+++ b/core/Migrations/Version13000Date20170705121758.php
@@ -25,7 +25,7 @@
 
 namespace OC\Core\Migrations;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -30,7 +30,7 @@
 
 namespace OC\Core\Migrations;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version14000Date20180710092004.php
+++ b/core/Migrations/Version14000Date20180710092004.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Migrations;
 
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version16000Date20190207141427.php
+++ b/core/Migrations/Version16000Date20190207141427.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version16000Date20190212081545.php
+++ b/core/Migrations/Version16000Date20190212081545.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version16000Date20190428150708.php
+++ b/core/Migrations/Version16000Date20190428150708.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version17000Date20190514105811.php
+++ b/core/Migrations/Version17000Date20190514105811.php
@@ -31,7 +31,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version18000Date20190920085628.php
+++ b/core/Migrations/Version18000Date20190920085628.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version18000Date20191014105105.php
+++ b/core/Migrations/Version18000Date20191014105105.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;

--- a/core/Migrations/Version20000Date20201109081918.php
+++ b/core/Migrations/Version20000Date20201109081918.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version21000Date20201202095923.php
+++ b/core/Migrations/Version21000Date20201202095923.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 namespace OC\Core\Migrations;
 
 use Closure;
-use Doctrine\DBAL\Types\Types;
+use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -171,6 +171,7 @@ return array(
     'OCP\\DB\\QueryBuilder\\IParameter' => $baseDir . '/lib/public/DB/QueryBuilder/IParameter.php',
     'OCP\\DB\\QueryBuilder\\IQueryBuilder' => $baseDir . '/lib/public/DB/QueryBuilder/IQueryBuilder.php',
     'OCP\\DB\\QueryBuilder\\IQueryFunction' => $baseDir . '/lib/public/DB/QueryBuilder/IQueryFunction.php',
+    'OCP\\DB\\Types' => $baseDir . '/lib/public/DB/Types.php',
     'OCP\\Dashboard\\Exceptions\\DashboardAppNotAvailableException' => $baseDir . '/lib/public/Dashboard/Exceptions/DashboardAppNotAvailableException.php',
     'OCP\\Dashboard\\IDashboardManager' => $baseDir . '/lib/public/Dashboard/IDashboardManager.php',
     'OCP\\Dashboard\\IDashboardWidget' => $baseDir . '/lib/public/Dashboard/IDashboardWidget.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -200,6 +200,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\DB\\QueryBuilder\\IParameter' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/IParameter.php',
         'OCP\\DB\\QueryBuilder\\IQueryBuilder' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/IQueryBuilder.php',
         'OCP\\DB\\QueryBuilder\\IQueryFunction' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/IQueryFunction.php',
+        'OCP\\DB\\Types' => __DIR__ . '/../../..' . '/lib/public/DB/Types.php',
         'OCP\\Dashboard\\Exceptions\\DashboardAppNotAvailableException' => __DIR__ . '/../../..' . '/lib/public/Dashboard/Exceptions/DashboardAppNotAvailableException.php',
         'OCP\\Dashboard\\IDashboardManager' => __DIR__ . '/../../..' . '/lib/public/Dashboard/IDashboardManager.php',
         'OCP\\Dashboard\\IDashboardWidget' => __DIR__ . '/../../..' . '/lib/public/Dashboard/IDashboardWidget.php',

--- a/lib/public/DB/Types.php
+++ b/lib/public/DB/Types.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\DB;
+
+/**
+ * Database types supported by Nextcloud's DBs
+ *
+ * Use these constants instead of \Doctrine\DBAL\Types\Type or \Doctrine\DBAL\Types\Types
+ *
+ * @since 21.0.0
+ */
+final class Types {
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const BIGINT = 'bigint';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const BINARY = 'binary';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const BLOB = 'blob';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const BOOLEAN = 'boolean';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const DATE = 'date';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const DATETIME = 'datetime';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const DECIMAL = 'decimal';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const FLOAT = 'float';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const INTEGER = 'integer';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const SMALLINT = 'smallint';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const STRING = 'string';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const TEXT = 'text';
+
+	/**
+	 * @var string
+	 * @since 21.0.0
+	 */
+	public const TIME = 'time';
+}


### PR DESCRIPTION
Because of #24948 we need to adjust lots of apps since the doctrine type constants were used directly. To prevent this data leakage, we should have our own set of supported db column types.

So this is not a simple copy of the upstream types, but a shortened version that only has the things that works across all of our DBs.

One might argue that some of the more advanced types do not make sense in combination with our query builder or db mappers, because those either map to string or another primitive. But I think it still makes sense to have the db column types in the desired format, if applicable. Then the DB will not only ensure the type is correct, it can also optimize for storage and retrieval.

Ref https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html

This PR consists of two commits/parts. The first one adds the new constants, the second one updates the server code to make use of them.

I'll update the docs accordingly when we settled on the exported types.