### PR TITLE
fix CacheJail::filterCacheEntry when entry is already filtered

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -93,6 +93,9 @@ class CacheJail extends CacheWrapper {
 	}
 
 	protected function filterCacheEntry($entry) {
+		if ($entry === false) {
+			return false;
+		}
 		$rootLength = strlen($this->getRoot()) + 1;
 		return $rootLength === 1 || ($entry['path'] === $this->getRoot()) || (substr($entry['path'], 0, $rootLength) === $this->getRoot() . '/');
 	}


### PR DESCRIPTION
Signed-off-by: Robin Appelman <robin@icewind.nl>