### PR TITLE
dont error the entire repair process when a repair step errors

### DIFF
--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -154,7 +154,7 @@ class Repair extends Command {
 				$this->output->writeln('     - WARNING: ' . $event->getArgument(0));
 				break;
 			case '\OC\Repair::error':
-				$this->output->writeln('     - ERROR: ' . $event->getArgument(0));
+				$this->output->writeln('<error>     - ERROR: ' . $event->getArgument(0) . '</error>');
 				break;
 		}
 	}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -46,6 +46,8 @@
 
 /** @var Symfony\Component\Console\Application $application */
 
+use Psr\Log\LoggerInterface;
+
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status);
 $application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
@@ -161,7 +163,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
-		new \OC\Repair([], \OC::$server->getEventDispatcher()),
+		new \OC\Repair([], \OC::$server->getEventDispatcher(), \OC::$server->get(LoggerInterface::class)),
 		\OC::$server->getConfig(),
 		\OC::$server->getEventDispatcher(),
 		\OC::$server->getAppManager()

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -33,6 +33,7 @@ use OC\Repair;
 use OC_App;
 use OCP\BackgroundJob\IJobList;
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -92,7 +93,7 @@ class BackgroundRepair extends TimedJob {
 		}
 
 		$step = $argument['step'];
-		$repair = new Repair([], $this->dispatcher);
+		$repair = new Repair([], $this->dispatcher, \OC::$server->get(LoggerInterface::class));
 		try {
 			$repair->addStep($step);
 		} catch (\Exception $ex) {

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -114,7 +114,11 @@ class Repair implements IOutput {
 		foreach ($this->repairSteps as $step) {
 			$this->currentStep = $step->getName();
 			$this->emit('\OC\Repair', 'step', [$this->currentStep]);
-			$step->run($this);
+			try {
+				$step->run($this);
+			} catch (\Exception $e) {
+				$this->emit('\OC\Repair', 'error', [$e->getMessage()]);
+			}
 		}
 	}
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -76,6 +76,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Resources\IManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -90,15 +91,18 @@ class Repair implements IOutput {
 	/** @var string */
 	private $currentStep;
 
+	private $logger;
+
 	/**
 	 * Creates a new repair step runner
 	 *
 	 * @param IRepairStep[] $repairSteps array of RepairStep instances
 	 * @param EventDispatcherInterface $dispatcher
 	 */
-	public function __construct(array $repairSteps, EventDispatcherInterface $dispatcher) {
+	public function __construct(array $repairSteps, EventDispatcherInterface $dispatcher, LoggerInterface $logger) {
 		$this->repairSteps = $repairSteps;
 		$this->dispatcher = $dispatcher;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -117,6 +121,7 @@ class Repair implements IOutput {
 			try {
 				$step->run($this);
 			} catch (\Exception $e) {
+				$this->logger->error("Exception while executing repair step " . $step->getName(), ['exception' => $e]);
 				$this->emit('\OC\Repair', 'error', [$e->getMessage()]);
 			}
 		}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -45,6 +45,7 @@ use OC_App;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -243,7 +244,7 @@ class Updater extends BasicEmitter {
 		file_put_contents($this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/.ocdata', '');
 
 		// pre-upgrade repairs
-		$repair = new Repair(Repair::getBeforeUpgradeRepairSteps(), \OC::$server->getEventDispatcher());
+		$repair = new Repair(Repair::getBeforeUpgradeRepairSteps(), \OC::$server->getEventDispatcher(), \OC::$server->get(LoggerInterface::class));
 		$repair->run();
 
 		$this->doCoreUpgrade();
@@ -276,7 +277,7 @@ class Updater extends BasicEmitter {
 		}
 
 		// post-upgrade repairs
-		$repair = new Repair(Repair::getRepairSteps(), \OC::$server->getEventDispatcher());
+		$repair = new Repair(Repair::getRepairSteps(), \OC::$server->getEventDispatcher(), \OC::$server->get(LoggerInterface::class));
 		$repair->run();
 
 		//Invalidate update feed

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -61,6 +61,7 @@ use OCP\App\ManagerEvent;
 use OCP\AppFramework\QueryException;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
@@ -1041,7 +1042,7 @@ class OC_App {
 		$dispatcher = OC::$server->getEventDispatcher();
 
 		// load the steps
-		$r = new Repair([], $dispatcher);
+		$r = new Repair([], $dispatcher, \OC::$server->get(LoggerInterface::class));
 		foreach ($steps as $step) {
 			try {
 				$r->addStep($step);

--- a/tests/lib/RepairStepTest.php
+++ b/tests/lib/RepairStepTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class RepairStepTest implements IRepairStep {
@@ -41,7 +42,7 @@ class RepairTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$dispatcher = new EventDispatcher();
-		$this->repair = new \OC\Repair([], $dispatcher);
+		$this->repair = new \OC\Repair([], $dispatcher, $this->createMock(LoggerInterface::class));
 
 		$dispatcher->addListener('\OC\Repair::warning', function ($event) {
 			/** @var \Symfony\Component\EventDispatcher\GenericEvent $event */


### PR DESCRIPTION
Instead show the error as any other repair step error

Also includes formatting changes to keep the errors from being drowned out by the rest of the repair output