### PR TITLE
Dismiss reminder notifications from passed events

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/Notifier.php
+++ b/apps/dav/lib/CalDAV/Reminder/Notifier.php
@@ -36,6 +36,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
@@ -223,6 +224,12 @@ class Notifier implements INotifier {
 	private function generateDateString(array $parameters):string {
 		$startDateTime = DateTime::createFromFormat(\DateTime::ATOM, $parameters['start_atom']);
 		$endDateTime = DateTime::createFromFormat(\DateTime::ATOM, $parameters['end_atom']);
+
+		// If the event has already ended, dismiss the notification
+		if ($endDateTime < $this->timeFactory->getDateTime()) {
+			throw new AlreadyProcessedException();
+		}
+
 		$isAllDay = $parameters['all_day'];
 		$diff = $startDateTime->diff($endDateTime);
 


### PR DESCRIPTION
Reminder notifications are now dismissed after the event ends.

~~I've given a 10 minutes grace period (so that you still see the notification if you are late for an event) but we can configure/remove this.~~

Closes #25111