### PR TITLE
21 beta7

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 13];
+$OC_Version = [21, 0, 0, 14];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta6';
+$OC_VersionString = '21.0.0 beta7';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #25036 Respect DB restrictions on number of arguments in statements and queries
* #25055 Add "Crop image previews" setting to files
* #25059 Bump web-auth/webauthn-lib from 3.1.1 to 3.3.1
* #25084 Update DAVx5 in AuthToken.vue
* #25085 Bump 3rdparty from `7bbfe82` to `1381d28`
* #25091 Add our own DB exception abstraction
* #25110 Fix night condition in dashboard greeting
* #25114 Dismiss reminder notifications from passed events
* #25131 Fix @nextcloud/vue imports
* #25138 Fix comparison of PHP versions
* #25141 Add a hint about the direction of priority
* #25142 Do not redirect to logout after login
* #25151 Fix IE 11 dashboard syntax error
* #25153 Force signature verification of apps on occ
* #25159 Bump sass-loader from 10.1.0 to 10.1.1
* #25160 Bump webpack from 4.45.0 to 4.46.0
* #25168 Add cards_abiduri index on install
* #25173 Add support for webp
* #25176 Add "composer.lock" for acceptance tests to git
* #25177 Only use alphanumeric chars for mysql password
* #25181 Update CRL due to revoked gravatar.crl
* #25182 Readd element ID after component mount.
* #25184 Directly add notifications element
* #25185 Show the actual error on share requests
* #25186 Don't log keys on checkSignature
* #25187 Bump symfony/polyfill-intl-normalizer from 1.20.0 to 1.22.0
* #25198 Bump pear/archive_tar from 1.4.11 to 1.4.12
* #25212 Enhance markdown file preview rendering
* #25216 Bump CA bundle
* #25217 Drop authtoken_version_index
* #25223 [Automated] Update psalm-baseline.xml
* #25224 Update handling of user credentials
* #25229 Dark mode adjustments for popover
* #25234 Fix encoding issue with OC.Notification.show
* #25236 Explicitly set permissions on newly created folders
* [3rdparty#591](https://github.com/nextcloud/3rdparty/pull/591) Bump symfony/polyfill-intl-normalizer from 1.20.0 to 1.22.0
* [3rdparty#592](https://github.com/nextcloud/3rdparty/pull/592) Bump phpseclib/phpseclib from 2.0.25 to 2.0.30
* [3rdparty#594](https://github.com/nextcloud/3rdparty/pull/594) Bump web-auth/webauthn-lib from 3.1.1 to 3.3.1
* [3rdparty#601](https://github.com/nextcloud/3rdparty/pull/601) Bump pear/archive_tar from 1.4.11 to 1.4.12
* [activity#549](https://github.com/nextcloud/activity/pull/549) Clear event array on getting them
* [files_pdfviewer#225](https://github.com/nextcloud/files_pdfviewer/pull/225) Bump pdf.js to 2.5.207
* [files_pdfviewer#287](https://github.com/nextcloud/files_pdfviewer/pull/287) Bump nextcloud/coding-standard from 0.3.0 to 0.5.0
* [files_pdfviewer#288](https://github.com/nextcloud/files_pdfviewer/pull/288) Bump webpack from 4.45.0 to 4.46.0
* [firstrunwizard#465](https://github.com/nextcloud/firstrunwizard/pull/465) Bump @nextcloud/axios from 1.5.0 to 1.6.0
* [firstrunwizard#466](https://github.com/nextcloud/firstrunwizard/pull/466) Bump ini from 1.3.5 to 1.3.8
* [firstrunwizard#467](https://github.com/nextcloud/firstrunwizard/pull/467) Bump webpack from 4.45.0 to 4.46.0
* [notifications#838](https://github.com/nextcloud/notifications/pull/838) Bump sass-loader from 10.1.0 to 10.1.1
* [notifications#840](https://github.com/nextcloud/notifications/pull/840) Directly mount notifications
* [photos#624](https://github.com/nextcloud/photos/pull/624) Bump nextcloud/coding-standard from 0.4.0 to 0.5.0
* [photos#626](https://github.com/nextcloud/photos/pull/626) Bump sass-loader from 10.1.0 to 10.1.1
* [photos#627](https://github.com/nextcloud/photos/pull/627) Bump qs from 6.9.4 to 6.9.6
* [photos#628](https://github.com/nextcloud/photos/pull/628) Bump eslint from 7.17.0 to 7.18.0
* [text#1296](https://github.com/nextcloud/text/pull/1296) Temporary editor colors during editing sessions
* [text#1345](https://github.com/nextcloud/text/pull/1345) Bump @nextcloud/axios from 1.5.0 to 1.6.0
* [updater#322](https://github.com/nextcloud/updater/pull/322) Create Dependabot config file
* [viewer#734](https://github.com/nextcloud/viewer/pull/734) Bump webpack-merge from 5.7.2 to 5.7.3
* [viewer#735](https://github.com/nextcloud/viewer/pull/735) Bump wait-on from 5.2.0 to 5.2.1
* [viewer#747](https://github.com/nextcloud/viewer/pull/747) Bump nextcloud/coding-standard from 0.3.0 to 0.5.0
* [viewer#748](https://github.com/nextcloud/viewer/pull/748) Bump webpack from 4.44.2 to 4.46.0


Pending PRs:

* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #24633 Update UpdateNotification.vue @jospoortvliet
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #25023 Fixes #24450 by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25093 Fix CacheJail::filterCacheEntry when entry is already filtered @icewind1991
* [ ] #25101 LDAP: make actually use of batch read known groups @blizzz
* [ ] #25112 Dont error the entire repair process when a repair step errors @icewind1991
* [ ] #25148 Add activity for display name change @MorrisJobke
* [ ] #25183 Bump league/flysystem from 1.0.64 to 1.1.3 @ChristophWurst
* [ ] #25189 Add command to repair broken filesystem trees @icewind1991
* [ ] #25192 LDAP: always take the display name from DB, update in the background @blizzz
* [ ] #25214 Bump phpseclib/phpseclib from 2.0.25 to 2.0.30 @ChristophWurst
* [ ] #25218 Do not remove valid group shares @blizzz
* [ ] [activity#550](https://github.com/nextcloud/activity/pull/550) Fix doctrine compatibility @nickvergessen
* [ ] [notifications#837](https://github.com/nextcloud/notifications/pull/837) Move push_notify logic to a js library @icewind1991