### PR TITLE
Fix files_external:notify command when running withing a subdirectory

### DIFF
--- a/apps/files_external/lib/Lib/Notify/SMBNotifyHandler.php
+++ b/apps/files_external/lib/Lib/Notify/SMBNotifyHandler.php
@@ -50,7 +50,7 @@ class SMBNotifyHandler implements INotifyHandler {
 	 */
 	public function __construct(\Icewind\SMB\INotifyHandler $shareNotifyHandler, $root) {
 		$this->shareNotifyHandler = $shareNotifyHandler;
-		$this->root = $root;
+		$this->root = str_replace('\\', '/', $root);
 	}
 
 	private function relativePath($fullPath) {


### PR DESCRIPTION
To reproduce, mount an SMB storage with a path like `Path\To\Subdirectory` and try to run the files_external:notify command. The self-test will fail as the root and change path in https://github.com/nextcloud/server/blob/9ee7d0b718b6aa1d10b7ed66326dd0a6d7490a0f/apps/files_external/lib/Lib/Notify/SMBNotifyHandler.php#L59 won't match due to the wrong path separator being used.

The [change object itself already uses UNIX path separators](https://github.com/nextcloud/server/blob/89b0d28cb44e556159bdb7e5bd99dfb6f7b54880/apps/files_external/3rdparty/icewind/smb/src/Wrapped/NotifyHandler.php#L86) so this makes sure we have a normalized root as well.

I've recognized when testing that using `Path/To/Subdirectory` as subdirectory in the external storage config solves the issue as well, however since entering backslash separated paths there is supported i feel this patch solves causing confusion there for admins who might be used to the Windows path separators.