### PR TITLE
Fix comparison of PHP versions

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -113,12 +113,12 @@ class AppFetcher extends Fetcher {
 							$phpVersion = $versionParser->getVersion($release['rawPhpVersionSpec']);
 							$minPhpVersion = $phpVersion->getMinimumVersion();
 							$maxPhpVersion = $phpVersion->getMaximumVersion();
-							$minPhpFulfilled = $minPhpVersion === '' || $this->compareVersion->isCompatible(
+							$minPhpFulfilled = $minPhpVersion === '' || version_compare(
 									PHP_VERSION,
 									$minPhpVersion,
 									'>='
 								);
-							$maxPhpFulfilled = $maxPhpVersion === '' || $this->compareVersion->isCompatible(
+							$maxPhpFulfilled = $maxPhpVersion === '' || version_compare(
 									PHP_VERSION,
 									$maxPhpVersion,
 									'<='


### PR DESCRIPTION
Use the builtin function `version_compare` to check an app's
compatibility with the available PHP version, instead of reusing
the `OC\App\CompareVersion::isCompatible` method which is intended
to compare Nextcloud versions. PHP version strings do not always
necessarily follow the simple Major.Minor.Patch format used by
Nextcloud and therefore cannot be properly compared by that method.

This tentatively fixes issue #25137.