### PR TITLE
Do not redirect to logout after login

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -175,7 +175,10 @@ class LoginController extends Controller {
 		);
 
 		if (!empty($redirect_url)) {
-			$this->initialStateService->provideInitialState('core', 'loginRedirectUrl', $redirect_url);
+			[$url, ] = explode('?', $redirect_url);
+			if ($url !== $this->urlGenerator->linkToRoute('core.login.logout')) {
+				$this->initialStateService->provideInitialState('core', 'loginRedirectUrl', $redirect_url);
+			}
 		}
 
 		$this->initialStateService->provideInitialState(


### PR DESCRIPTION
This can happen when the session was killed due to a timeout. Then
logout was triggered. Nobody wants to login only to be logged out again.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>