### PR TITLE
support for custom memberOf attribute

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -388,6 +388,10 @@ class Access extends LDAPUtility {
 			// memberOf is an "operational" attribute, without a definition in any RFC
 			'memberof'
 		];
+		$customMemberOf = $this->connection->ldapCustomMemberOf;
+		if (!empty($customMemberOf)) {
+			$resemblingAttributes[] = $customMemberOf;
+		}
 		return in_array($attr, $resemblingAttributes);
 	}
 
@@ -543,7 +547,7 @@ class Access extends LDAPUtility {
 		if (is_null($ldapName)) {
 			$ldapName = $this->readAttribute($fdn, $nameAttribute, $filter);
 			if (!isset($ldapName[0]) && empty($ldapName[0])) {
-				\OCP\Util::writeLog('user_ldap', 'No or empty name for ' . $fdn . ' with filter ' . $filter . '.', ILogger::INFO);
+				\OCP\Util::writeLog('user_ldap', 'No or empty name for ' . $fdn . ' with filter ' . $filter . '.', ILogger::DEBUG);
 				return false;
 			}
 			$ldapName = $ldapName[0];
@@ -2073,5 +2077,21 @@ class Access extends LDAPUtility {
 			return \count($attr) > 1;
 		}
 		return false;
+	}
+
+	public function getMemberOfAttribute(): string {
+		$customMemberOf = $this->connection->ldapCustomMemberOf;
+		return !empty($customMemberOf) ? $customMemberOf : 'memberof';
+	}
+
+	public function getMemberOfValuesFromRecord(array $record): ?array {
+		if (isset($record['memberof'])) {
+			return $record['memberof'];
+		}
+		$customMemberOf = $this->connection->ldapCustomMemberOf;
+		if (!empty($customMemberOf) && isset($record[$customMemberOf])) {
+			return $record[$customMemberOf];
+		}
+		return null;
 	}
 }

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -114,6 +114,7 @@ class Configuration {
 		'ldapDefaultPPolicyDN' => null,
 		'ldapExtStorageHomeAttribute' => null,
 		'ldapMatchingRuleInChainState' => self::LDAP_SERVER_FEATURE_UNKNOWN,
+		'ldapCustomMemberOf' => null,
 	];
 
 	/**
@@ -487,6 +488,7 @@ class Configuration {
 			'ldap_user_avatar_rule' => 'default',
 			'ldap_ext_storage_home_attribute' => '',
 			'ldap_matching_rule_in_chain_state' => self::LDAP_SERVER_FEATURE_UNKNOWN,
+			'ldap_custom_member_of' => '',
 		];
 	}
 
@@ -549,6 +551,7 @@ class Configuration {
 			'ldap_default_ppolicy_dn' => 'ldapDefaultPPolicyDN',
 			'ldap_ext_storage_home_attribute' => 'ldapExtStorageHomeAttribute',
 			'ldap_matching_rule_in_chain_state' => 'ldapMatchingRuleInChainState',
+			'ldap_custom_member_of' => 'ldapCustomMemberOf',
 			'ldapIgnoreNamingRules' => 'ldapIgnoreNamingRules',	// sysconfig
 		];
 		return $array;

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -73,6 +73,7 @@ use OCP\ILogger;
  * @property int hasMemberOfFilterSupport
  * @property int useMemberOfToDetectMembership
  * @property string ldapMatchingRuleInChainState
+ * @property string ldapCustomMemberOf
  */
 class Connection extends LDAPUtility {
 	private $ldapConnectionRes = null;

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -278,6 +278,7 @@ class ConfigAPIController extends OCSController {
 	 *     <ldapPagingSize>500</ldapPagingSize>
 	 *     <turnOnPasswordChange>1</turnOnPasswordChange>
 	 *     <ldapDynamicGroupMemberURL></ldapDynamicGroupMemberURL>
+	 *     <ldapCustomMemberOf></ldapCustomMemberOf>
 	 *   </data>
 	 * </ocs>
 	 *

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -267,7 +267,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$filter = $this->access->combineFilterWithAnd([
 				$this->access->connection->ldapUserFilter,
 				$this->access->connection->ldapUserDisplayName . '=*',
-				'memberof:1.2.840.113556.1.4.1941:=' . $dnGroup
+				$this->access->getMemberOfAttribute() . ':1.2.840.113556.1.4.1941:=' . $dnGroup
 			]);
 			$memberRecords = $this->access->fetchListOfUsers(
 				$filter,
@@ -313,7 +313,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	 * @throws ServerNotAvailableException
 	 */
 	private function _getGroupDNsFromMemberOf(string $dn): array {
-		$groups = $this->access->readAttribute($dn, 'memberOf');
+		$groups = $this->access->readAttribute($dn, $this->access->getMemberOfAttribute());
 		if (!is_array($groups)) {
 			return [];
 		}
@@ -322,7 +322,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			if (isset($this->cachedNestedGroups[$groupDN])) {
 				$nestedGroups = $this->cachedNestedGroups[$groupDN];
 			} else {
-				$nestedGroups = $this->access->readAttribute($groupDN, 'memberOf');
+				$nestedGroups = $this->access->readAttribute($groupDN, $this->access->getMemberOfAttribute());
 				if (!is_array($nestedGroups)) {
 					$nestedGroups = [];
 				}

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -168,7 +168,7 @@ class Manager {
 	 * @return string[]
 	 */
 	public function getAttributes($minimal = false) {
-		$baseAttributes = array_merge(Access::UUID_ATTRIBUTES, ['dn', 'uid', 'samaccountname', 'memberof']);
+		$baseAttributes = array_merge(Access::UUID_ATTRIBUTES, ['dn', 'uid', 'samaccountname']);
 		$attributes = [
 			$this->access->getConnection()->ldapExpertUUIDUserAttr,
 			$this->access->getConnection()->ldapQuotaAttribute,
@@ -176,6 +176,7 @@ class Manager {
 			$this->access->getConnection()->ldapUserDisplayName,
 			$this->access->getConnection()->ldapUserDisplayName2,
 			$this->access->getConnection()->ldapExtStorageHomeAttribute,
+			$this->access->getMemberOfAttribute()
 		];
 
 		$homeRule = $this->access->getConnection()->homeFolderNamingRule;

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -227,9 +227,9 @@ class User {
 
 		//memberOf groups
 		$cacheKey = 'getMemberOf'.$this->getUsername();
-		$groups = false;
-		if (isset($ldapEntry['memberof'])) {
-			$groups = $ldapEntry['memberof'];
+		$groups = $this->access->getMemberOfValuesFromRecord($ldapEntry);
+		if ($groups === null) {
+			$groups = false;
 		}
 		$this->connection->writeToCache($cacheKey, $groups);
 
@@ -322,17 +322,6 @@ class User {
 		//false will apply default behaviour as defined and done by OC_User
 		$this->config->setUserValue($this->getUsername(), 'user_ldap', 'homePath', '');
 		return false;
-	}
-
-	public function getMemberOfGroups() {
-		$cacheKey = 'getMemberOf'.$this->getUsername();
-		$memberOfGroups = $this->connection->getFromCache($cacheKey);
-		if (!is_null($memberOfGroups)) {
-			return $memberOfGroups;
-		}
-		$groupDNs = $this->access->readAttribute($this->getDN(), 'memberOf');
-		$this->connection->writeToCache($cacheKey, $groupDNs);
-		return $groupDNs;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -870,7 +870,8 @@ class Wizard extends LDAPUtility {
 		if (!$cr) {
 			throw new \Exception('Could not connect to LDAP');
 		}
-		$result = $this->access->countUsers('memberOf=*', ['memberOf'], 1);
+		$attribute = $this->access->getMemberOfAttribute();
+		$result = $this->access->countUsers($attribute . '=*', [$attribute], 1);
 		if (is_int($result) && $result > 0) {
 			return true;
 		}
@@ -921,7 +922,7 @@ class Wizard extends LDAPUtility {
 							if ($dn === false || $dn === '') {
 								continue;
 							}
-							$filterPart = '(memberof=' . $dn . ')';
+							$filterPart = '(' . $this->access->getMemberOfAttribute() . '=' . $dn . ')';
 							if (isset($attrs['primaryGroupToken'])) {
 								$pgt = $attrs['primaryGroupToken'][0];
 								$primaryFilterPart = '(primaryGroupID=' . $pgt .')';


### PR DESCRIPTION
This PR allows to overwrite "memberof" with a custom attribute, that replicates its behaviour. As of now it is a direct drop-in replacement and thus expecting to support the 1.2.840.113556.1.4.1941 extensible match filter. But probably this expectation has to be dropped.

At the moment the only way to set this attribute is via occ: `php occ ldap:set-config $CONFIG_ID ldapCustomMemberOf $ATTRIBUTE_NAME`