### PR TITLE
add command to repair broken filesystem trees

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -34,6 +34,7 @@
 		<command>OCA\Files\Command\DeleteOrphanedFiles</command>
 		<command>OCA\Files\Command\TransferOwnership</command>
 		<command>OCA\Files\Command\ScanAppData</command>
+		<command>OCA\Files\Command\RepairTree</command>
 	</commands>
 
 	<activity>

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -27,6 +27,7 @@ return array(
     'OCA\\Files\\Collaboration\\Resources\\Listener' => $baseDir . '/../lib/Collaboration/Resources/Listener.php',
     'OCA\\Files\\Collaboration\\Resources\\ResourceProvider' => $baseDir . '/../lib/Collaboration/Resources/ResourceProvider.php',
     'OCA\\Files\\Command\\DeleteOrphanedFiles' => $baseDir . '/../lib/Command/DeleteOrphanedFiles.php',
+    'OCA\\Files\\Command\\RepairTree' => $baseDir . '/../lib/Command/RepairTree.php',
     'OCA\\Files\\Command\\Scan' => $baseDir . '/../lib/Command/Scan.php',
     'OCA\\Files\\Command\\ScanAppData' => $baseDir . '/../lib/Command/ScanAppData.php',
     'OCA\\Files\\Command\\TransferOwnership' => $baseDir . '/../lib/Command/TransferOwnership.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -42,6 +42,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Collaboration\\Resources\\Listener' => __DIR__ . '/..' . '/../lib/Collaboration/Resources/Listener.php',
         'OCA\\Files\\Collaboration\\Resources\\ResourceProvider' => __DIR__ . '/..' . '/../lib/Collaboration/Resources/ResourceProvider.php',
         'OCA\\Files\\Command\\DeleteOrphanedFiles' => __DIR__ . '/..' . '/../lib/Command/DeleteOrphanedFiles.php',
+        'OCA\\Files\\Command\\RepairTree' => __DIR__ . '/..' . '/../lib/Command/RepairTree.php',
         'OCA\\Files\\Command\\Scan' => __DIR__ . '/..' . '/../lib/Command/Scan.php',
         'OCA\\Files\\Command\\ScanAppData' => __DIR__ . '/..' . '/../lib/Command/ScanAppData.php',
         'OCA\\Files\\Command\\TransferOwnership' => __DIR__ . '/..' . '/../lib/Command/TransferOwnership.php',

--- a/apps/files/lib/Command/RepairTree.php
+++ b/apps/files/lib/Command/RepairTree.php
@@ -69,10 +69,10 @@ class RepairTree extends Command {
 			$output->writeln("Path of file ${row['fileid']} is ${row['path']} but should be ${row['parent_path']}/${row['name']} based on it's parent", OutputInterface::VERBOSITY_VERBOSE);
 
 			if ($fix) {
-				$fileId = $this->getFileId($row['parent_storage'], $row['parent_path'] . '/' . $row['name']);
+				$fileId = $this->getFileId((int)$row['parent_storage'], $row['parent_path'] . '/' . $row['name']);
 				if ($fileId > 0) {
 					$output->writeln("Cache entry has already be recreated with id $fileId, deleting instead");
-					$this->deleteById($row['fileid']);
+					$this->deleteById((int)$row['fileid']);
 				} else {
 					$query->setParameters([
 						'fileid' => $row['fileid'],

--- a/apps/files/lib/Command/RepairTree.php
+++ b/apps/files/lib/Command/RepairTree.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files\Command;
+
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RepairTree extends Command {
+	public const CHUNK_SIZE = 200;
+
+	/**
+	 * @var IDBConnection
+	 */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('files:repair-tree')
+			->setDescription('Try and repair malformed filesystem tree structures')
+			->addOption('dry-run');
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$rows = $this->findBrokenTreeBits();
+		$fix = !$input->getOption('dry-run');
+
+		$output->writeln("Found " . count($rows) . " file entries with an invalid path");
+
+		if ($fix) {
+			$this->connection->beginTransaction();
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->update('filecache')
+			->set('path', $query->createParameter('path'))
+			->set('path_hash', $query->func()->md5($query->createParameter('path')))
+			->where($query->expr()->eq('fileid', $query->createParameter('fileid')));
+
+		foreach ($rows as $row) {
+			$output->writeln("Path of file ${row['fileid']} is ${row['path']} but should be ${row['parent_path']}/${row['name']} based on it's parent", OutputInterface::VERBOSITY_VERBOSE);
+
+			if ($fix) {
+				$query->setParameters([
+					'fileid' => $row['fileid'],
+					'path' => $row['parent_path'] . '/' . $row['name'],
+				]);
+				$query->execute();
+			}
+		}
+
+		if ($fix) {
+			$this->connection->commit();
+		}
+
+		return 0;
+	}
+
+	private function findBrokenTreeBits(): array {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select('f.fileid', 'f.path', 'f.parent', 'f.name')
+			->selectAlias('p.path', 'parent_path')
+			->from('filecache', 'f')
+			->innerJoin('f', 'filecache', 'p', $query->expr()->eq('f.parent', 'p.fileid'))
+			->where($query->expr()->orX(
+				$query->expr()->andX(
+					$query->expr()->neq('p.path_hash', $query->createNamedParameter(md5(''))),
+					$query->expr()->neq('f.path', $query->func()->concat('p.path', $query->func()->concat($query->createNamedParameter('/'), 'f.name')))
+				),
+				$query->expr()->andX(
+					$query->expr()->eq('p.path_hash', $query->createNamedParameter(md5(''))),
+					$query->expr()->neq('f.path', 'f.name')
+				),
+				$query->expr()->neq('f.storage', 'p.storage')
+			));
+
+		return $query->execute()->fetchAll();
+	}
+}

--- a/apps/files/lib/Command/RepairTree.php
+++ b/apps/files/lib/Command/RepairTree.php
@@ -62,6 +62,7 @@ class RepairTree extends Command {
 		$query->update('filecache')
 			->set('path', $query->createParameter('path'))
 			->set('path_hash', $query->func()->md5($query->createParameter('path')))
+			->set('storage', $query->createParameter('storage'))
 			->where($query->expr()->eq('fileid', $query->createParameter('fileid')));
 
 		foreach ($rows as $row) {
@@ -71,6 +72,7 @@ class RepairTree extends Command {
 				$query->setParameters([
 					'fileid' => $row['fileid'],
 					'path' => $row['parent_path'] . '/' . $row['name'],
+					'storage' => $row['parent_storage'],
 				]);
 				$query->execute();
 			}
@@ -88,6 +90,7 @@ class RepairTree extends Command {
 
 		$query->select('f.fileid', 'f.path', 'f.parent', 'f.name')
 			->selectAlias('p.path', 'parent_path')
+			->selectAlias('p.storage', 'parent_storage')
 			->from('filecache', 'f')
 			->innerJoin('f', 'filecache', 'p', $query->expr()->eq('f.parent', 'p.fileid'))
 			->where($query->expr()->orX(


### PR DESCRIPTION
If for any reason the path of an entry in the filecache doesn't match with it's expected path based on the path of it's parent node you end up with an entry in the filecache that exists in different places based on how the entry is generated. For example, while listing folder `/foo` is contains a file `bar.txt`, but when trying to do anything with `/foo/bar.txt` the file doesn't exists.

This command attempts to repair such entries by querying for entries there the path doesn't match the expected path based on it's parent path and filename and resets it's path to the expected one.

It is not guaranteed that the "new" path is the correct one, but while that would leave the filecache and actual filesystem out of sync, various automated and manual processes to fix that already exist as filecache synchronization is a much wider topic.
By comparison there isn't currently any way (short of manual database editing) to repair a broken file tree.