### PR TITLE
Dark mode adjustments for popover

### DIFF
--- a/apps/accessibility/css/dark.scss
+++ b/apps/accessibility/css/dark.scss
@@ -53,11 +53,12 @@ $color-border-dark: lighten($color-main-background, 14%);
 
 .bubble,
 .app-navigation-entry-menu,
-.popovermenu {
+.popovermenu,
+.popover__menu {
 	li {
 		> button,
 		> a,
-		> .menuitem {
+		> .menuitem, > .popover__menuitem {
 			> img {
 				filter: invert(100%);
 			}
@@ -68,6 +69,22 @@ $color-border-dark: lighten($color-main-background, 14%);
 .app-navigation-entry-menu,
 .popovermenu,
 #header .menu {
+	border: 1px solid var(--color-border);
+}
+
+.popover[x-placement^='top'] .popover__arrow {
+	border-top-color: var(--color-border);
+}
+.popover[x-placement^='bottom'] .popover__arrow {
+	border-bottom-color: var(--color-border);
+}
+.popover[x-placement^='left'] .popover__arrow {
+	border-left-color: var(--color-border);
+}
+.popover[x-placement^='right'] .popover__arrow {
+	border-right-color: var(--color-border);
+}
+.popover .popover__inner {
 	border: 1px solid var(--color-border);
 }
 


### PR DESCRIPTION
Add new popover classes from @nextcloud/vue's Popover and PopoverMenu*
components. This fixes issues where the menu icons were not inverted.
This fixes the icons are reported in https://github.com/nextcloud/spreed/pull/4976#pullrequestreview-572044198

Adjusted border for both the avatar popover menu and also actions
popover menu to make them easier to distinguish from the background.

Now using border color for the popover arrow to make it more visible
outside the border.

Required these to produce the screenshots:
- [x] Talk app PR https://github.com/nextcloud/spreed/pull/4976
- [x] Nextcloud-vue PR https://github.com/nextcloud/nextcloud-vue/pull/1674 npm-linked to the talk app PR

**Before**:
Icons not inverted, border missing and arrow not visible.
<img width="209" alt="image" src="https://user-images.githubusercontent.com/277525/105163333-15507500-5b14-11eb-9ff2-ba51e7c821d5.png">
<img width="223" alt="image" src="https://user-images.githubusercontent.com/277525/105163317-0d90d080-5b14-11eb-8b84-9531d0915a78.png">

**After**:
Icons correctly inverted, border is back. Arrow more visible.
<img width="279" alt="image" src="https://user-images.githubusercontent.com/277525/105163216-ed611180-5b13-11eb-90d0-f03eb85f456e.png">
And actions border menu added.
<img width="223" alt="image" src="https://user-images.githubusercontent.com/277525/105163240-f651e300-5b13-11eb-8a50-087559d316ad.png">
