### PR TITLE
21 beta8

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 14];
+$OC_Version = [21, 0, 0, 15];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta7';
+$OC_VersionString = '21.0.0 beta8';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #21810 Do not target vue progressbar with server styles
* #24633 Update UpdateNotification.vue
* #25090 File templates
* #25128 Extend ILDAPProvider to allow reading arbitrairy ldap attributes for users
* #25183 Bump league/flysystem from 1.0.64 to 1.1.3
* #25189 Add command to repair broken filesystem trees
* #25214 Bump phpseclib/phpseclib from 2.0.25 to 2.0.30
* #25238 Apps folder is defacto in root folder and not above
* #25240 Re-use fetched dependencies in lib/base.php
* #25241 Bump socket.io from 2.3.0 to 2.4.1 in /build
* #25252 Bump giggsey/libphonenumber-for-php from 8.12.4 to 8.12.16
* #25253 Silence log message
* #25255 Also use storage copy when dav copying directories
* #25257 Bump sabre/dav from 4.1.3 to 4.1.4
* #25268 Add SGI and TGA preview support
* #25269 Bump swiftmailer/swiftmailer from 6.2.4 to 6.2.5
* #25271 Bump aws/aws-sdk-php from 3.133.27 to 3.171.21
* #25273 Do not show 2FA settings if the user has no providers available
* #25274 Do not obtain userFolder of a federated user
* #25275 Convert 2FA token type to string
* #25279 Fully deprecate the old initial state interface, not just the methods
* #25281 Only include moments once in comments
* #25286 Bump core-js from 3.8.2 to 3.8.3
* #25287 Bump bootstrap from 4.5.3 to 4.6.0
* #25288 Bump webpack-cli from 4.3.1 to 4.4.0
* #25289 [Automated] Update psalm-baseline.xml
* #25309 Add config to specify a default dashboard layout
* #25310 [CalDAV] Validate notified emails
* #25312 Do not lower case search provider names on web ui
* #25313 Catch NotFoundException when querying quota
* #25321 Update facebook.com URL to prevent a redirect
* #25335 Fix/app fetcher php compat comparison
* #25348 Add negative version comparison test for version suffixes
* [3rdparty#579](https://github.com/nextcloud/3rdparty/pull/579) Bump league/flysystem from 1.0.64 to 1.1.3
* [3rdparty#597](https://github.com/nextcloud/3rdparty/pull/597) Bump giggsey/libphonenumber-for-php from 8.12.4 to 8.12.16
* [3rdparty#598](https://github.com/nextcloud/3rdparty/pull/598) Bump sabre/dav from 4.1.3 to 4.1.4
* [3rdparty#599](https://github.com/nextcloud/3rdparty/pull/599) Bump swiftmailer/swiftmailer from 6.2.4 to 6.2.5
* [3rdparty#605](https://github.com/nextcloud/3rdparty/pull/605) Bump aws/aws-sdk-php from 3.133.27 to 3.171.21
* [activity#550](https://github.com/nextcloud/activity/pull/550) Fix doctrine compatibility
* [activity#552](https://github.com/nextcloud/activity/pull/552) Bye travis, hello actions
* [activity#553](https://github.com/nextcloud/activity/pull/553) Fix doctrine Types class
* [activity#555](https://github.com/nextcloud/activity/pull/555) Don't break completely when creating the digest fail for one user
* [example-files#12](https://github.com/nextcloud/example-files/pull/12) Add templates
* [files_pdfviewer#291](https://github.com/nextcloud/files_pdfviewer/pull/291) Fix opening PDF files with special characters in their name
* [files_pdfviewer#292](https://github.com/nextcloud/files_pdfviewer/pull/292) Only attempt to use a secure view if hide download is actually set
* [files_pdfviewer#293](https://github.com/nextcloud/files_pdfviewer/pull/293) Bump phpunit/phpunit from 8.5.13 to 8.5.14
* [files_pdfviewer#294](https://github.com/nextcloud/files_pdfviewer/pull/294) Bump stylelint from 13.8.0 to 13.9.0
* [files_pdfviewer#297](https://github.com/nextcloud/files_pdfviewer/pull/297) Fix PDF viewer failing on Edge (not based on Chromium)
* [firstrunwizard#468](https://github.com/nextcloud/firstrunwizard/pull/468) Bump stylelint from 13.8.0 to 13.9.0
* [notifications#837](https://github.com/nextcloud/notifications/pull/837) Move push_notify logic to a js library
* [notifications#839](https://github.com/nextcloud/notifications/pull/839) Bump webpack from 4.45.0 to 4.46.0
* [notifications#844](https://github.com/nextcloud/notifications/pull/844) Bump stylelint from 13.8.0 to 13.9.0
* [notifications#845](https://github.com/nextcloud/notifications/pull/845) Cannot unfold plain text notifications
* [photos#634](https://github.com/nextcloud/photos/pull/634) Bump postcss-loader from 4.1.0 to 4.2.0
* [photos#636](https://github.com/nextcloud/photos/pull/636) Bump eslint-plugin-vue from 7.4.1 to 7.5.0
* [photos#638](https://github.com/nextcloud/photos/pull/638) Bump eslint-webpack-plugin from 2.4.1 to 2.4.3
* [photos#639](https://github.com/nextcloud/photos/pull/639) Bump stylelint from 13.8.0 to 13.9.0
* [recommendations#302](https://github.com/nextcloud/recommendations/pull/302) Bump @nextcloud/vue-dashboard from 0.1.8 to 1.0.1
* [recommendations#311](https://github.com/nextcloud/recommendations/pull/311) Bump @nextcloud/eslint-plugin from 1.4.0 to 1.5.0
* [recommendations#317](https://github.com/nextcloud/recommendations/pull/317) Bump stylelint-webpack-plugin from 2.1.0 to 2.1.1
* [recommendations#326](https://github.com/nextcloud/recommendations/pull/326) Bump css-loader from 3.6.0 to 5.0.1
* [recommendations#327](https://github.com/nextcloud/recommendations/pull/327) Bump node-sass from 4.14.1 to 5.0.0
* [recommendations#332](https://github.com/nextcloud/recommendations/pull/332) Bump @nextcloud/vue from 2.6.1 to 2.9.0
* [recommendations#347](https://github.com/nextcloud/recommendations/pull/347) Bump @babel/core from 7.11.6 to 7.12.10
* [recommendations#350](https://github.com/nextcloud/recommendations/pull/350) Bump @babel/preset-env from 7.11.5 to 7.12.11
* [recommendations#355](https://github.com/nextcloud/recommendations/pull/355) Bump sass-loader from 9.0.3 to 10.1.1
* [recommendations#357](https://github.com/nextcloud/recommendations/pull/357) Bump webpack-cli from 3.3.12 to 4.4.0
* [recommendations#358](https://github.com/nextcloud/recommendations/pull/358) Move remaining CI to Github actions
* [recommendations#359](https://github.com/nextcloud/recommendations/pull/359) Fix css-loader config regression due to major version bump
* [recommendations#360](https://github.com/nextcloud/recommendations/pull/360) Create Dependabot config file
* [recommendations#361](https://github.com/nextcloud/recommendations/pull/361) Bump eslint-plugin-standard from 4.0.1 to 4.1.0
* [recommendations#362](https://github.com/nextcloud/recommendations/pull/362) Bump stylelint from 13.7.2 to 13.9.0
* [recommendations#363](https://github.com/nextcloud/recommendations/pull/363) Bump vuex from 3.5.1 to 3.6.2
* [recommendations#364](https://github.com/nextcloud/recommendations/pull/364) Bump webpack from 4.44.2 to 4.46.0
* [recommendations#365](https://github.com/nextcloud/recommendations/pull/365) Bump vue-loader from 15.9.3 to 15.9.6
* [recommendations#366](https://github.com/nextcloud/recommendations/pull/366) Bump webpack-merge from 5.3.0 to 5.7.3
* [recommendations#367](https://github.com/nextcloud/recommendations/pull/367) Bump babel-loader from 8.1.0 to 8.2.2
* [recommendations#368](https://github.com/nextcloud/recommendations/pull/368) Bump @nextcloud/axios from 1.4.0 to 1.6.0
* [recommendations#369](https://github.com/nextcloud/recommendations/pull/369) Add, apply and enforce the Nextcloud PHP coding standards
* [text#1352](https://github.com/nextcloud/text/pull/1352) Implement support for creating files from templates
* [text#1356](https://github.com/nextcloud/text/pull/1356) Bump nextcloud/coding-standard from 0.4.0 to 0.5.0
* [text#1358](https://github.com/nextcloud/text/pull/1358) Bump webpack from 4.44.2 to 4.46.0
* [text#1365](https://github.com/nextcloud/text/pull/1365) Bump sass-loader from 10.1.0 to 10.1.1
* [text#1369](https://github.com/nextcloud/text/pull/1369) Bump christophwurst/nextcloud from 20.0.4 to 20.0.5
* [text#1384](https://github.com/nextcloud/text/pull/1384) Remove EPUB mimetype
* [text#1385](https://github.com/nextcloud/text/pull/1385) Track authors by step rather than transaction
* [text#1386](https://github.com/nextcloud/text/pull/1386) Only increase refetch timer if we have all initial steps loaded
* [text#1388](https://github.com/nextcloud/text/pull/1388) Bump stylelint from 13.8.0 to 13.9.0
* [text#1389](https://github.com/nextcloud/text/pull/1389) Bump cypress from 6.2.0 to 6.3.0
* [viewer#749](https://github.com/nextcloud/viewer/pull/749) Bump eslint from 7.16.0 to 7.18.0
* [viewer#750](https://github.com/nextcloud/viewer/pull/750) Bump sass-loader from 10.1.0 to 10.1.1
* [viewer#754](https://github.com/nextcloud/viewer/pull/754) Bump stylelint from 13.8.0 to 13.9.0
* [viewer#755](https://github.com/nextcloud/viewer/pull/755) Bump eslint-webpack-plugin from 2.4.1 to 2.4.3
* [viewer#758](https://github.com/nextcloud/viewer/pull/758) Bump cypress from 6.1.0 to 6.3.0
* [viewer#759](https://github.com/nextcloud/viewer/pull/759) Bump cypress-image-snapshot from 4.0.0 to 4.0.1


Pending PRs:

* [ ] #23036 Activity notifications for groupmates by Comments (when using Group Folder app) @chrisfritsche
* [ ] #24700 Resolves #24699, Support ES2 and ECS instance providers for S3 buckets @Imajie
* [ ] #25023 Fixes #24450 by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25093 Fix CacheJail::filterCacheEntry when entry is already filtered @icewind1991
* [ ] #25101 LDAP: make actually use of batch read known groups @blizzz
* [ ] #25112 Dont error the entire repair process when a repair step errors @icewind1991
* [ ] #25148 Add activity for display name change @MorrisJobke
* [ ] #25192 LDAP: always take the display name from DB, update in the background @blizzz
* [ ] #25218 Do not remove valid group shares @blizzz
* [ ] #25249 Moving between storages is not a rename @rullzer
* [ ] #25320 Save expiration date for federated share when passed over API @PVince81
* [ ] #25326 Make ILDAPProviderFactory usable when there is no ldap setup @icewind1991
* [ ] #25331 Fix valid storages removed when cleaning remote storages @danxuliu
* [ ] #25332 Fix removing remote shares when the remote server is unreachable @danxuliu
* [ ] #25345 Bump @nextcloud/vue from 3.2.0 to 3.5.4
* [x] #25360 Update all composer autoloader files @ChristophWurst
* [x] #25361 Fix parameter provided as string not array @blizzz
* [x] [notifications#848](https://github.com/nextcloud/notifications/pull/848) Bumb @nextcloud/notify_push from 1.0.0 to 1.0.1 @icewind1991
* [ ] [text#1353](https://github.com/nextcloud/text/pull/1353) Simplify save indicator @juliushaertl