### PR TITLE
Moving between storages is not a rename

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -624,7 +624,7 @@ class Encryption extends Wrapper {
 			return false;
 		}
 
-		$result = $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, true);
+		$result = $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, false);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {
 				$result &= $sourceStorage->rmdir($sourceInternalPath);


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/16419
Based on https://github.com/nextcloud/server/pull/16696
