### PR TITLE
also use storage copy when dav copying directories

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -452,7 +452,7 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 
 
 	public function copyInto($targetName, $sourcePath, INode $sourceNode) {
-		if ($sourceNode instanceof File) {
+		if ($sourceNode instanceof File || $sourceNode instanceof Directory) {
 			$destinationPath = $this->getPath() . '/' . $targetName;
 			$sourcePath = $sourceNode->getPath();
 


### PR DESCRIPTION
Fixes an oversight from #24358