### PR TITLE
Do not show 2FA settings if the user has no providers available

### DIFF
--- a/lib/public/Settings/ISettings.php
+++ b/lib/public/Settings/ISettings.php
@@ -38,7 +38,7 @@ interface ISettings {
 	public function getForm();
 
 	/**
-	 * @return string the section ID, e.g. 'sharing'
+	 * @return string|null the section ID, e.g. 'sharing' or null to not show the setting
 	 * @since 9.1
 	 */
 	public function getSection();


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/13971

To test install a 2FA provider, then you will see the 2FA settings as a user. Once there is only the backup codes one left, the settings vanish.