### PR TITLE
Do not obtain userFolder of a federated user

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -135,7 +135,7 @@ class Storage extends Wrapper {
 		// check if there is a app which want to disable the trash bin for this file
 		$fileId = $this->storage->getCache()->getId($path);
 		$owner = $this->storage->getOwner($path);
-		if ($owner === false) {
+		if ($owner === false || $this->storage->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class)) {
 			$nodes = $this->rootFolder->getById($fileId);
 		} else {
 			$nodes = $this->rootFolder->getUserFolder($owner)->getById($fileId);


### PR DESCRIPTION
Fixes #19647 

Federated shares are somewhat special. So we can't move the files from
the main user and we should try to get it from the intialized root
already.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>