### PR TITLE
Convert 2FA token type to string

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -339,7 +339,7 @@ class Manager {
 				$tokenId = $token->getId();
 				$tokensNeeding2FA = $this->config->getUserKeys($user->getUID(), 'login_token_2fa');
 
-				if (!\in_array($tokenId, $tokensNeeding2FA, true)) {
+				if (!\in_array((string) $tokenId, $tokensNeeding2FA, true)) {
 					$this->session->set(self::SESSION_UID_DONE, $user->getUID());
 					return false;
 				}
@@ -376,14 +376,14 @@ class Manager {
 
 		$id = $this->session->getId();
 		$token = $this->tokenProvider->getToken($id);
-		$this->config->setUserValue($user->getUID(), 'login_token_2fa', $token->getId(), $this->timeFactory->getTime());
+		$this->config->setUserValue($user->getUID(), 'login_token_2fa', (string) $token->getId(), $this->timeFactory->getTime());
 	}
 
 	public function clearTwoFactorPending(string $userId) {
 		$tokensNeeding2FA = $this->config->getUserKeys($userId, 'login_token_2fa');
 
 		foreach ($tokensNeeding2FA as $tokenId) {
-			$this->tokenProvider->invalidateTokenById($userId, $tokenId);
+			$this->tokenProvider->invalidateTokenById($userId, (int)$tokenId);
 		}
 	}
 }

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -420,7 +420,7 @@ class ManagerTest extends TestCase {
 			->willReturn(42);
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
-			->with('jos', 'login_token_2fa', 42);
+			->with('jos', 'login_token_2fa', '42');
 
 		$result = $this->manager->verifyChallenge('email', $this->user, $challenge);
 
@@ -515,7 +515,7 @@ class ManagerTest extends TestCase {
 		$this->config->method('getUserKeys')
 			->with('user', 'login_token_2fa')
 			->willReturn([
-				42
+				'42'
 			]);
 
 		$manager = $this->getMockBuilder(Manager::class)
@@ -588,7 +588,7 @@ class ManagerTest extends TestCase {
 			->willReturn(1337);
 
 		$this->config->method('setUserValue')
-			->with('ferdinand', 'login_token_2fa', 42, 1337);
+			->with('ferdinand', 'login_token_2fa', '42', '1337');
 
 
 		$this->manager->prepareTwoFactorLogin($this->user, true);
@@ -618,7 +618,7 @@ class ManagerTest extends TestCase {
 			->willReturn(1337);
 
 		$this->config->method('setUserValue')
-			->with('ferdinand', 'login_token_2fa', 42, 1337);
+			->with('ferdinand', 'login_token_2fa', '42', '1337');
 
 		$this->manager->prepareTwoFactorLogin($this->user, false);
 	}
@@ -666,7 +666,7 @@ class ManagerTest extends TestCase {
 		$this->config->method('getUserKeys')
 			->with('user', 'login_token_2fa')
 			->willReturn([
-				42, 43, 44
+				'42', '43', '44'
 			]);
 
 		$this->session->expects($this->once())


### PR DESCRIPTION
The IConfig service is documented to handle its data as strings, hence
this changes the code a bit to ensure we store keys as string and
convert them back when reading.