### PR TITLE
Fully deprecate the old initial state interface, not just the methods

### DIFF
--- a/lib/public/IInitialStateService.php
+++ b/lib/public/IInitialStateService.php
@@ -31,6 +31,8 @@ use Closure;
 
 /**
  * @since 16.0.0
+ * @deprecated 21 Use OCP\AppFramework\Services\IInitialState or OCP\AppFramework\Services\InitialStateProvider
+ * @see \OCP\AppFramework\Services\IInitialState
  */
 interface IInitialStateService {
 	/**
@@ -45,6 +47,7 @@ interface IInitialStateService {
 	 * @param bool|int|float|string|array|\JsonSerializable $data
 	 *
 	 * @deprecated 21 Use OCP\AppFramework\Services\IInitialState or OCP\AppFramework\Services\InitialStateProvider
+	 * @see \OCP\AppFramework\Services\IInitialState::provideInitialState()
 	 */
 	public function provideInitialState(string $appName, string $key, $data): void;
 
@@ -62,6 +65,7 @@ interface IInitialStateService {
 	 * @param Closure $closure returns a primitive or an object that implements JsonSerializable
 	 *
 	 * @deprecated 21 Use OCP\AppFramework\Services\IInitialState or OCP\AppFramework\Services\InitialStateProvider
+	 * @see \OCP\AppFramework\Services\IInitialState::provideLazyInitialState()
 	 */
 	public function provideLazyInitialState(string $appName, string $key, Closure $closure): void;
 }


### PR DESCRIPTION
We won't keep the empty interface when the methods are gone.