### PR TITLE
Add AJAX fallback for cron

### DIFF
--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -106,7 +106,15 @@ class OC_Template extends \OC\Template\Base {
 			//so to make sure this scripts/styles here are loaded first we use OC_Util::addScript() with $prepend=true
 			//meaning the last script/style in this list will be loaded first
 			if (\OC::$server->getSystemConfig()->getValue('installed', false) && $renderAs !== TemplateResponse::RENDER_AS_ERROR && !\OCP\Util::needUpgrade()) {
-				if (\OC::$server->getConfig()->getAppValue('core', 'backgroundjobs_mode', 'ajax') == 'ajax') {
+				$cronMode = \OC::$server->getConfig()->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+				if (($cronMode !== 'none') && ($cronMode !== 'ajax')) {
+					$cronLast = \OC::$server->getConfig()->getAppValue('core', 'lastcron', false);
+					if (($cronLast !== false) && (time() - $cronLast > 60*60)) {
+						\OC::$server->getConfig()->setAppValue('core', 'backgroundjobs_mode', 'ajax');
+						$cronMode = 'ajax';
+					}
+				}
+				if ($cronMode === 'ajax') {
 					OC_Util::addScript('backgroundjobs', null, true);
 				}
 			}


### PR DESCRIPTION
If cron.php wasn't called for an hour or longer, fall back to AJAX mode. If a system cronjob is used, cron.php will reset this to 'cron' automatically anyway. For 'webcron' this isn't possible though, because cron.php can't distinguish 'ajax' and 'webcron'.

Especially webcron services are often not very reliable. A system cronjob still is the recommended solution and this change won't ever interfere with system cronjobs, because cron.php resets cron mode to 'cron' anyway as soon as the system cronjob is called.

In the future we might add a background job to send a warning email to the Nextcloud admin if the cronjob fails.