### PR TITLE
Use RFC-compliant URL encoding for cookies

### DIFF
--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -43,7 +43,7 @@ class CookieHelper {
 		$header = sprintf(
 			'Set-Cookie: %s=%s',
 			$name,
-			urlencode($value)
+			rawurlencode($value)
 		);
 
 		if ($path !== '') {


### PR DESCRIPTION
PHP 7.4.2 changed the way how cookies are decoded, applying RFC-compliant raw URL decoding. This leads to a conflict Nextcloud's own cookie encoding, breaking the remember-me function if the UID contains a space character.

Fixes #24438

Signed-off-by: Marco Ziech <marco@ziech.net>