### PR TITLE
Added 301 redirect for favicon.ico

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -519,6 +519,9 @@ class Setup {
 		$htaccessContent = file_get_contents($setupHelper->pathToHtaccess());
 		$content = "#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####\n";
 		$htaccessContent = explode($content, $htaccessContent, 2)[0];
+		
+		// 301 redirect for /favicon.ico
+		$content .= "\nRedirect 301 /favicon.ico /core/img/favicon.ico";
 
 		//custom 403 error page
 		$content .= "\nErrorDocument 403 " . $webRoot . '/';


### PR DESCRIPTION
This is a potential fix for https://github.com/nextcloud/server/issues/24821.

I haven't been able to test it, yet.