### PR TITLE
Catch NotFoundException when querying quota

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -339,6 +339,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 				$free
 			];
 			return $this->quotaInfo;
+		} catch (\OCP\Files\NotFoundException $e) {
+			return [0, 0];
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
 			return [0, 0];
 		}


### PR DESCRIPTION
Fixes parent folder that becomes inaccessible when it contains a
non-existing / broken entry because the quota check made the PROPFIND
on parent fail altogether.

### Steps to reproduce

1. Create a folder "test/regular"
2. Create a folder "test/broken"
3. Patch Filesystem::isValidPath and make it return false in case it detects the word "broken" (to simulate non-existence), see patch below
4. Try accessing the "test" and then "regular" folder in web UI

### Before the fix
Error that "test" folder cannot be accessed. This also makes "test/regular" inaccessible.

### After the fix
Entering the "test" folder works and "regular" accessible.
The "broken" entry is still there and cannot be entered, but that's ok for now as it's broken. Most important is to not block access to the other working entries.


### Patch for reproduction
```diff
diff --git a/lib/private/Files/Filesystem.php b/lib/private/Files/Filesystem.php
index bf94be273f..d3d83f0b6d 100644
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -587,6 +587,10 @@ class Filesystem {
         * @return bool
         */
        public static function isValidPath($path) {
+               if (stripos($path, 'broken') !== false) {
+                       // simulate broken entry
+                       return false;
+               }
                $path = self::normalizePath($path);
                if (!$path || $path[0] !== '/') {
                        $path = '/' . $path;
```