### PR TITLE
Fix "searchUsers" usage in Group_LDAP.php

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -222,7 +222,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$pos = strpos($memberURLs[0], '(');
 			if ($pos !== false) {
 				$memberUrlFilter = substr($memberURLs[0], $pos);
-				$foundMembers = $this->access->searchUsers($memberUrlFilter, 'dn');
+				$foundMembers = $this->access->searchUsers($memberUrlFilter, ['dn']);
 				$dynamicMembers = [];
 				foreach ($foundMembers as $value) {
 					$dynamicMembers[$value['dn'][0]] = 1;


### PR DESCRIPTION
`Access::searchUsers` expects an array as the second parameter, `Group_LDAP.php` called the method with a simple string, resulting in an exception and preventing folders shared with dynamic groups from working. This trivial change fixes the usage in Group_LDAP.

Fixes #25163