### PR TITLE
make ILDAPProviderFactory usable when there is no ldap setup

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1178,6 +1178,7 @@ return array(
     'OC\\L10N\\LanguageIterator' => $baseDir . '/lib/private/L10N/LanguageIterator.php',
     'OC\\L10N\\LanguageNotFoundException' => $baseDir . '/lib/private/L10N/LanguageNotFoundException.php',
     'OC\\L10N\\LazyL10N' => $baseDir . '/lib/private/L10N/LazyL10N.php',
+    'OC\\LDAP\\NullLDAPProviderFactory' => $baseDir . '/lib/private/LDAP/NullLDAPProviderFactory.php',
     'OC\\LargeFileHelper' => $baseDir . '/lib/private/LargeFileHelper.php',
     'OC\\Lock\\AbstractLockingProvider' => $baseDir . '/lib/private/Lock/AbstractLockingProvider.php',
     'OC\\Lock\\DBLockingProvider' => $baseDir . '/lib/private/Lock/DBLockingProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1207,6 +1207,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\L10N\\LanguageIterator' => __DIR__ . '/../../..' . '/lib/private/L10N/LanguageIterator.php',
         'OC\\L10N\\LanguageNotFoundException' => __DIR__ . '/../../..' . '/lib/private/L10N/LanguageNotFoundException.php',
         'OC\\L10N\\LazyL10N' => __DIR__ . '/../../..' . '/lib/private/L10N/LazyL10N.php',
+        'OC\\LDAP\\NullLDAPProviderFactory' => __DIR__ . '/../../..' . '/lib/private/LDAP/NullLDAPProviderFactory.php',
         'OC\\LargeFileHelper' => __DIR__ . '/../../..' . '/lib/private/LargeFileHelper.php',
         'OC\\Lock\\AbstractLockingProvider' => __DIR__ . '/../../..' . '/lib/private/Lock/AbstractLockingProvider.php',
         'OC\\Lock\\DBLockingProvider' => __DIR__ . '/../../..' . '/lib/private/Lock/DBLockingProvider.php',

--- a/lib/private/LDAP/NullLDAPProviderFactory.php
+++ b/lib/private/LDAP/NullLDAPProviderFactory.php
@@ -1,11 +1,8 @@
 <?php
+
+declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2016, Roger Szabo (roger.szabo@web.de)
- *
- * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
- * @author Roeland Jago Douma <roeland@famdouma.nl>
- * @author Roger Szabo <roger.szabo@web.de>
- * @author root <root@localhost.localdomain>
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,29 +17,24 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-namespace OCA\User_LDAP;
+namespace OC\LDAP;
 
 use OCP\IServerContainer;
-use OCP\LDAP\ILDAPProvider;
 use OCP\LDAP\ILDAPProviderFactory;
 
-class LDAPProviderFactory implements ILDAPProviderFactory {
-	/** * @var IServerContainer */
-	private $serverContainer;
-
+class NullLDAPProviderFactory implements ILDAPProviderFactory {
 	public function __construct(IServerContainer $serverContainer) {
-		$this->serverContainer = $serverContainer;
 	}
 
-	public function getLDAPProvider(): ILDAPProvider {
-		return $this->serverContainer->get(LDAPProvider::class);
+	public function getLDAPProvider() {
+		throw new \Exception("No LDAP provider is available");
 	}
 
 	public function isAvailable(): bool {
-		return true;
+		return false;
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -104,6 +104,7 @@ use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\IntegrityCheck\Helpers\EnvironmentHelper;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OC\LDAP\NullLDAPProviderFactory;
 use OC\KnownUser\KnownUserService;
 use OC\Lock\DBLockingProvider;
 use OC\Lock\MemcacheLockingProvider;
@@ -206,6 +207,8 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\LDAP\ILDAPProvider;
+use OCP\LDAP\ILDAPProviderFactory;
 use OCP\Lock\ILockingProvider;
 use OCP\Log\ILogFactory;
 use OCP\Mail\IMailer;
@@ -1003,14 +1006,20 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Mailer', IMailer::class);
 
-		$this->registerService('LDAPProvider', function (ContainerInterface $c) {
+		/** @deprecated 21.0.0 */
+		$this->registerDeprecatedAlias('LDAPProvider', ILDAPProvider::class);
+
+		$this->registerService(ILDAPProviderFactory::class, function (ContainerInterface $c) {
 			$config = $c->get(\OCP\IConfig::class);
 			$factoryClass = $config->getSystemValue('ldapProviderFactory', null);
 			if (is_null($factoryClass)) {
-				throw new \Exception('ldapProviderFactory not set');
+				return new NullLDAPProviderFactory($this);
 			}
 			/** @var \OCP\LDAP\ILDAPProviderFactory $factory */
-			$factory = new $factoryClass($this);
+			return new $factoryClass($this);
+		});
+		$this->registerService(ILDAPProvider::class, function (ContainerInterface $c) {
+			$factory = $c->get(ILDAPProviderFactory::class);
 			return $factory->getLDAPProvider();
 		});
 		$this->registerService(ILockingProvider::class, function (ContainerInterface $c) {

--- a/lib/public/LDAP/ILDAPProviderFactory.php
+++ b/lib/public/LDAP/ILDAPProviderFactory.php
@@ -44,7 +44,7 @@ interface ILDAPProviderFactory {
 	 * @since 11.0.0
 	 */
 	public function __construct(IServerContainer $serverContainer);
-	
+
 	/**
 	 * creates and returns an instance of the ILDAPProvider
 	 *
@@ -52,4 +52,12 @@ interface ILDAPProviderFactory {
 	 * @since 11.0.0
 	 */
 	public function getLDAPProvider();
+
+	/**
+	 * Check if an ldap provider is available
+	 *
+	 * @return bool
+	 * @since 21.0.0
+	 */
+	public function isAvailable(): bool;
 }


### PR DESCRIPTION
Currently there is no nice way to inject an `LDAPProvider` into a class that has optional ldap support, by adding a dummy `ILDAPProviderFactory` one can be injected even if no ldap is setup, `ILDAPProviderFactory::isAvailable` can then be used to determine if ldap is available.