### PR TITLE
Fix valid storages removed when cleaning remote storages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -769,7 +769,7 @@ steps:
     - bash tests/drone-run-integration-tests.sh || exit 0
     - ./occ maintenance:install --admin-pass=admin
     - cd build/integration
-    - ./run.sh federation_features/federated.feature
+    - ./run.sh federation_features/
 
 trigger:
   branch:

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -26,6 +26,8 @@
 namespace OCA\Files_Sharing\Tests\Command;
 
 use OCA\Files_Sharing\Command\CleanupRemoteStorages;
+use OCP\Federation\ICloudId;
+use OCP\Federation\ICloudIdManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -48,6 +50,11 @@ class CleanupRemoteStoragesTest extends TestCase {
 	 * @var \OCP\IDBConnection
 	 */
 	private $connection;
+
+	/**
+	 * @var ICloudIdManager|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $cloudIdManager;
 
 	private $storages = [
 		['id' => 'shared::7b4a322b22f9d0047c38d77d471ce3cf', 'share_token' => 'f2c69dad1dc0649f26976fd210fc62e1', 'remote' => 'https://hostname.tld/owncloud1', 'user' => 'user1'],
@@ -109,7 +116,9 @@ class CleanupRemoteStoragesTest extends TestCase {
 			}
 		}
 
-		$this->command = new CleanupRemoteStorages($this->connection);
+		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);
+
+		$this->command = new CleanupRemoteStorages($this->connection, $this->cloudIdManager);
 	}
 
 	protected function tearDown(): void {
@@ -190,6 +199,22 @@ class CleanupRemoteStoragesTest extends TestCase {
 			->expects($this->at($at++))
 			->method('writeln')
 			->with('5 remote share(s) exist');
+
+		$this->cloudIdManager
+			->expects($this->any())
+			->method('getCloudId')
+			->will($this->returnCallback(function (string $user, string $remote) {
+				$cloudIdMock = $this->createMock(ICloudId::class);
+
+				// The remotes are already sanitized in the original data, so
+				// they can be directly returned.
+				$cloudIdMock
+					->expects($this->any())
+					->method('getRemote')
+					->willReturn($remote);
+
+				return $cloudIdMock;
+			}));
 
 		$this->command->execute($input, $output);
 

--- a/build/integration/features/bootstrap/FederationContext.php
+++ b/build/integration/features/bootstrap/FederationContext.php
@@ -37,6 +37,20 @@ require __DIR__ . '/../../vendor/autoload.php';
 class FederationContext implements Context, SnippetAcceptingContext {
 	use WebDav;
 	use AppConfiguration;
+	use CommandLine;
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function cleanupRemoteStorages() {
+		// Ensure that dangling remote storages from previous tests will not
+		// interfere with the current scenario.
+		// The storages must be cleaned before each scenario; they can not be
+		// cleaned after each scenario, as this hook is executed before the hook
+		// that removes the users, so the shares would be still valid and thus
+		// the storages would not be dangling yet.
+		$this->runOcc(['sharing:cleanup-remote-storages']);
+	}
 
 	/**
 	 * @Given /^User "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/

--- a/build/integration/federation_features/cleanup-remote-storage.feature
+++ b/build/integration/federation_features/cleanup-remote-storage.feature
@@ -1,0 +1,53 @@
+Feature: cleanup-remote-storage
+  Background:
+    Given using api version "1"
+
+  Scenario: cleanup remote storage with active storages
+    Given Using server "LOCAL"
+    And user "user0" exists
+    Given Using server "REMOTE"
+    And user "user1" exists
+    # Rename file so it has a unique name in the target server (as the target
+    # server may have its own /textfile0.txt" file)
+    And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+    And User "user1" from server "REMOTE" shares "/remote-share.txt" with user "user0" from server "LOCAL"
+    And Using server "LOCAL"
+    # Accept and download the file to ensure that a storage is created for the
+    # federated share
+    And User "user0" from server "LOCAL" accepts last pending share
+    And As an "user0"
+    And Downloading file "/remote-share.txt"
+    And the HTTP status code should be "200"
+    When invoking occ with "sharing:cleanup-remote-storage"
+    Then the command was successful
+    And the command output contains the text "1 remote storage(s) need(s) to be checked"
+    And the command output contains the text "1 remote share(s) exist"
+    And the command output contains the text "no storages deleted"
+
+  Scenario: cleanup remote storage with inactive storages
+    Given Using server "LOCAL"
+    And user "user0" exists
+    Given Using server "REMOTE"
+    And user "user1" exists
+    # Rename file so it has a unique name in the target server (as the target
+    # server may have its own /textfile0.txt" file)
+    And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+    And User "user1" from server "REMOTE" shares "/remote-share.txt" with user "user0" from server "LOCAL"
+    And Using server "LOCAL"
+    # Accept and download the file to ensure that a storage is created for the
+    # federated share
+    And User "user0" from server "LOCAL" accepts last pending share
+    And As an "user0"
+    And Downloading file "/remote-share.txt"
+    And the HTTP status code should be "200"
+    And Using server "REMOTE"
+    And As an "user1"
+    And Deleting last share
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When Using server "LOCAL"
+    And invoking occ with "sharing:cleanup-remote-storage"
+    Then the command was successful
+    And the command output contains the text "1 remote storage(s) need(s) to be checked"
+    And the command output contains the text "0 remote share(s) exist"
+    And the command output contains the text "deleted 1 storage"


### PR DESCRIPTION
The remote URL of a share [is always stored in the database with a trailing slash](https://github.com/nextcloud/server/blob/2a054e6c04e0a40421510eb889cbf59f153c5177/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php#L187-L191). However, when a cloud ID is generated [trailing slashes are removed](https://github.com/nextcloud/server/blob/d89a75be0b01f0423a7c1ad2d58aac73c3cc1f3a/lib/private/Federation/CloudIdManager.php#L112).

The ID of a remote storage [is generated from the cloud ID](https://github.com/nextcloud/server/blob/d89a75be0b01f0423a7c1ad2d58aac73c3cc1f3a/apps/files_sharing/lib/External/Storage.php#L135), but the `cleanup-remote-storage` command directly used the remote URL stored in the database. Due to this, even if the remote storage was valid, its ID did not match the ID of the remote share generated by the command and ended being removed.

Now the command generates the ID of remote shares using the cloud ID instead, just like done by the remote storage, so there is no longer a mismatch.
