### PR TITLE
Fix/app fetcher php compat comparison

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -113,12 +113,12 @@ class AppFetcher extends Fetcher {
 							$phpVersion = $versionParser->getVersion($release['rawPhpVersionSpec']);
 							$minPhpVersion = $phpVersion->getMinimumVersion();
 							$maxPhpVersion = $phpVersion->getMaximumVersion();
-							$minPhpFulfilled = $minPhpVersion === '' || version_compare(
+							$minPhpFulfilled = $minPhpVersion === '' || $this->compareVersion->isCompatible(
 									PHP_VERSION,
 									$minPhpVersion,
 									'>='
 								);
-							$maxPhpFulfilled = $maxPhpVersion === '' || version_compare(
+							$maxPhpFulfilled = $maxPhpVersion === '' || $this->compareVersion->isCompatible(
 									PHP_VERSION,
 									$maxPhpVersion,
 									'<='

--- a/lib/private/App/CompareVersion.php
+++ b/lib/private/App/CompareVersion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -24,12 +27,13 @@
 namespace OC\App;
 
 use InvalidArgumentException;
+use function explode;
 
 class CompareVersion {
-	public const REGEX_MAJOR = '/^\d+$/';
-	public const REGEX_MAJOR_MINOR = '/^\d+.\d+$/';
-	public const REGEX_MAJOR_MINOR_PATCH = '/^\d+.\d+.\d+$/';
-	public const REGEX_SERVER = '/^\d+.\d+.\d+(.\d+)?$/';
+	private const REGEX_MAJOR = '/^\d+$/';
+	private const REGEX_MAJOR_MINOR = '/^\d+\.\d+$/';
+	private const REGEX_MAJOR_MINOR_PATCH = '/^\d+\.\d+\.\d+(?!\.\d+)/';
+	private const REGEX_ACTUAL = '/^\d+(\.\d+){1,2}/';
 
 	/**
 	 * Checks if the given server version fulfills the given (app) version requirements.
@@ -45,18 +49,19 @@ class CompareVersion {
 	 */
 	public function isCompatible(string $actual, string $required,
 		string $comparator = '>='): bool {
-		if (!preg_match(self::REGEX_SERVER, $actual)) {
-			throw new InvalidArgumentException('server version is invalid');
+		if (!preg_match(self::REGEX_ACTUAL, $actual, $matches)) {
+			throw new InvalidArgumentException("version specification $actual is invalid");
 		}
+		$cleanActual = $matches[0];
 
 		if (preg_match(self::REGEX_MAJOR, $required) === 1) {
-			return $this->compareMajor($actual, $required, $comparator);
+			return $this->compareMajor($cleanActual, $required, $comparator);
 		} elseif (preg_match(self::REGEX_MAJOR_MINOR, $required) === 1) {
-			return $this->compareMajorMinor($actual, $required, $comparator);
+			return $this->compareMajorMinor($cleanActual, $required, $comparator);
 		} elseif (preg_match(self::REGEX_MAJOR_MINOR_PATCH, $required) === 1) {
-			return $this->compareMajorMinorPatch($actual, $required, $comparator);
+			return $this->compareMajorMinorPatch($cleanActual, $required, $comparator);
 		} else {
-			throw new InvalidArgumentException('required version is invalid');
+			throw new InvalidArgumentException("required version $required is invalid");
 		}
 	}
 

--- a/tests/lib/App/CompareVersionTest.php
+++ b/tests/lib/App/CompareVersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -49,11 +51,17 @@ class CompareVersionTest extends TestCase {
 			['13.0.0', '13', '>=', true],
 			['13.0.1', '13', '>=', true],
 			['13.0.1', '13', '<=', true],
+			['13.0.1.9', '13', '<=', true],
+			['13.0.1-beta.1', '13', '<=', true],
+			['7.4.14', '7.4', '<=', true],
+			['7.4.14-ubuntu', '7.4', '<=', true],
+			['7.4.14-ubuntu', '7.4.15', '<=', true],
 			// Incompatible major versions
 			['13.0.0.3', '13.0.0', '<', false],
 			['12.0.0', '13.0.0', '>=', false],
 			['12.0.0', '13.0', '>=', false],
 			['12.0.0', '13', '>=', false],
+			['7.4.15-ubuntu', '7.4.15', '>=', true],
 			// Incompatible minor and patch versions
 			['13.0.0', '13.0.1', '>=', false],
 			['13.0.0', '13.1', '>=', false],


### PR DESCRIPTION
Reverts bedd9acf7874b836bef224989c2ce7f5e3b0a2fa.

This is how https://github.com/nextcloud/server/pull/24416 was meant to work.

Fixes https://github.com/nextcloud/mail/issues/4383

Note to testers: there is some caching that might make it impossible to see the fix immediately. Apply the changes as patch from https://patch-diff.githubusercontent.com/raw/nextcloud/server/pull/25335.patch, give the cache an hour or so to expire and try again