### PR TITLE
21 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 0, 15];
+$OC_Version = [21, 0, 0, 16];
 
 // The human readable string
-$OC_VersionString = '21.0.0 beta8';
+$OC_VersionString = '21.0.0 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #25101 LDAP: make actually use of batch read known groups
* #25218 Do not remove valid group shares
* #25302 Use RFC-compliant URL encoding for cookies
* #25369 The objectid is a string
* #25372 [Automated] Update psalm-baseline.xml
* #25377 Fix initializing the template directory on first login
* #25383 Properly handle SMB ACL blocking scanning a directory
* #25400 Bump marked from 1.2.7 to 1.2.8
* #25402 Bump sinon from 9.2.3 to 9.2.4
* #25405 [Automated] Update psalm-baseline.xml
* #25424 Keep direct login active when redirecting
* #25429 Bump Symfony from 4.4.18 to 4.4.19
* #25444 Check for generic errors at last.
* #25446 Avoid template creators being registered multiple times
* #25457 Update stable21 target versions
* #25462 Emit calendar interaction events
* #25466 Parse calendar object for attendees and emit interaction events
* [3rdparty#614](https://github.com/nextcloud/3rdparty/pull/614) Bump Symfony from 4.4.18 to 4.4.19
* [activity#557](https://github.com/nextcloud/activity/pull/557) Update stable21 target versions
* [files_pdfviewer#300](https://github.com/nextcloud/files_pdfviewer/pull/300) Bump pdfjs-dist from 2.4.456 to 2.6.347
* [firstrunwizard#471](https://github.com/nextcloud/firstrunwizard/pull/471) Bump @nextcloud/vue from 3.3.2 to 3.5.4
* [firstrunwizard#472](https://github.com/nextcloud/firstrunwizard/pull/472) Bump acorn from 8.0.4 to 8.0.5
* [firstrunwizard#473](https://github.com/nextcloud/firstrunwizard/pull/473) Update stable21 target versions
* [notifications#843](https://github.com/nextcloud/notifications/pull/843) Bump core-js from 3.8.2 to 3.8.3
* [notifications#850](https://github.com/nextcloud/notifications/pull/850) Bump @nextcloud/vue from 3.3.2 to 3.5.4
* [notifications#851](https://github.com/nextcloud/notifications/pull/851) Update stable21 target versions
* [text#1353](https://github.com/nextcloud/text/pull/1353) Simplify save indicator
* [text#1413](https://github.com/nextcloud/text/pull/1413) Update stable21 target versions