### PR TITLE
Properly handle SMB ACL blocking scanning a directory

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -41,6 +41,7 @@ use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
+use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
@@ -342,6 +343,8 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 		} catch (\OCP\Files\NotFoundException $e) {
 			return [0, 0];
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
+			return [0, 0];
+		} catch (NotPermittedException $e) {
 			return [0, 0];
 		}
 	}


### PR DESCRIPTION
This makes sure that a possible ForbiddenException is properly passed through the storage as a ForbiddenException and can be catched when trying to fetch the quota info of a parent folder.

Should fix https://github.com/nextcloud/server/issues/24893

For some background the issue has been showing itself since we started to also fetch the quota info with the regular files app propfind in https://github.com/nextcloud/server/pull/24102 which basically lead to an uncatched ForbiddenException when the scanner tried to get the size of the children of an SMB mount that had some directories with ACL that blocks the access.