### PR TITLE
Update variables.scss - Fallback font before Noto Color Emoji

### DIFF
--- a/core/css/variables.scss
+++ b/core/css/variables.scss
@@ -86,7 +86,7 @@ $border-radius-large: 10px !default;
 // Pill-style button, value is large so big buttons also have correct roundness
 $border-radius-pill: 100px !default;
 
-$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
+$font-face: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, sans-serif, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 $default-font-size: 15px;
 
 $default-line-height: 24px;


### PR DESCRIPTION

![nextcloud-noto-color-emoji](https://user-images.githubusercontent.com/13868450/106427735-29776900-6468-11eb-9612-54ac6aacab9b.png)
I would put sans-serif before Noto Color Emoji. If you have none of the previous fonts installed but Noto Color Emoji is, the interface looks very ugly because it uses Noto Color Emoji then. That's exactly the case on my linux distribution. See screenshot.