### PR TITLE
Add support for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# PHP
+RUN apt-get update -y
+RUN apt-get install --no-install-recommends -y \
+    php7.4 \
+    php7.4-gd \
+    php7.4-zip \
+    php7.4-curl \
+    php7.4-xml \
+    php7.4-mbstring \
+    php7.4-sqlite \
+    php7.4-xdebug \
+    php7.4-pgsql \
+    php7.4-intl \
+    curl \
+    vim \
+    lsof
+
+RUN echo "xdebug.remote_enable = 1" >> /etc/php/7.4/cli/conf.d/20-xdebug.ini
+RUN echo "xdebug.remote_autostart = 1" >> /etc/php/7.4/cli/conf.d/20-xdebug.ini
+
+# Docker
+RUN apt-get -y install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update -y
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN ln -s /var/run/docker-host.sock /var/run/docker.sock  

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,11 @@ RUN apt-get install --no-install-recommends -y \
     php7.4-xdebug \
     php7.4-pgsql \
     php7.4-intl \
+    php7.4-imagick \
+    php7.4-gmp \
+    php7.4-acpu \
+    php7.4-bcmath \
+    libmagickcore-6.q16-3-extra \
     curl \
     vim \
     lsof

--- a/.devcontainer/codespace.config.php
+++ b/.devcontainer/codespace.config.php
@@ -8,7 +8,8 @@ $CONFIG = [
     'mail_sendmailmode' => 'smtp',
     'mail_domain' => 'example.com',
     'mail_smtphost' => 'localhost',
-    'mail_smtpport' => '1025'
+    'mail_smtpport' => '1025',
+    'memcache.local' => '\OC\Memcache\APCu',
 ];
 
 if($cloudEnvironmentId !== true) {

--- a/.devcontainer/codespace.config.php
+++ b/.devcontainer/codespace.config.php
@@ -1,0 +1,9 @@
+<?php
+
+$cloudEnvironmentId = getenv('CLOUDENV_ENVIRONMENT_ID');
+
+if($cloudEnvironmentId !== false) {
+    $CONFIG = array (
+    'overwritehost' => $cloudEnvironmentId . '-80.apps.codespaces.githubusercontent.com',
+    );
+}

--- a/.devcontainer/codespace.config.php
+++ b/.devcontainer/codespace.config.php
@@ -2,8 +2,15 @@
 
 $cloudEnvironmentId = getenv('CLOUDENV_ENVIRONMENT_ID');
 
-if($cloudEnvironmentId !== false) {
-    $CONFIG = array (
-    'overwritehost' => $cloudEnvironmentId . '-80.apps.codespaces.githubusercontent.com',
-    );
+$CONFIG = [
+    'mail_from_address' => 'no-reply',
+    'mail_smtpmode' => 'smtp',
+    'mail_sendmailmode' => 'smtp',
+    'mail_domain' => 'example.com',
+    'mail_smtphost' => 'localhost',
+    'mail_smtpport' => '1025'
+];
+
+if($cloudEnvironmentId !== true) {
+    $CONFIG['overwritehost'] = $cloudEnvironmentId . '-80.apps.codespaces.githubusercontent.com';
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "NextcloudServer",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "nextclouddev",
+	"postCreateCommand": ".devcontainer/setup.sh",
+	"forwardPorts": [
+		80,
+		8080,
+		8025
+	],
+	"runArgs": [
+		"--privileged"
+	],
+	"extensions": [
+		"felixfbecker.php-debug",
+		"felixfbecker.php-intellisense",
+		"ms-azuretools.vscode-docker"
+	],
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  nextclouddev:
+    build: .
+    volumes:
+      - .:/workspace:cached
+      - /var/run/docker.sock:/var/run/docker-host.sock
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    ports:
+      - 80:80
+      - 8080:8080
+      - 8025:8025
+
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+    network_mode: service:nextclouddev
+
+  adminer:
+    image: adminer
+    restart: always
+    network_mode: service:nextclouddev
+
+  mailhog:
+    image: mailhog/mailhog
+    restart: always
+    network_mode: service:nextclouddev

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
+
+cd $DIR/
+git submodule update --init
+
+# Codespace config
+cp .devcontainer/codespace.config.php config/codespace.config.php


### PR DESCRIPTION
This allows setting up a Nextcloud instance within Visual Studio Code (locally) or GitHub code spaces (cloud) within a minute.

Just running the following, should result in a running Nextcloud instance: 

```
php -S 0.0.0.0:80
```

In addition, this ships with:

**XDebug**
![Screenshot 2021-02-08 at 17 07 52](https://user-images.githubusercontent.com/878997/107252355-8c9f6780-6a35-11eb-8f73-6c5990a431ee.png)

**Language Server**
![Screenshot 2021-02-08 at 17 46 05](https://user-images.githubusercontent.com/878997/107252351-8b6e3a80-6a35-11eb-88ac-d72f0644f49d.png)

**MailHog**
![Screenshot 2021-02-08 at 17 44 40](https://user-images.githubusercontent.com/878997/107252352-8c06d100-6a35-11eb-86a1-d0d5a6da8332.png)

**Adminer**
![Screenshot 2021-02-08 at 17 44 24](https://user-images.githubusercontent.com/878997/107252354-8c06d100-6a35-11eb-99e6-550fa86801fa.png)
