### PR TITLE
Keep direct login active when redirecting

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -337,7 +337,7 @@ class LoginController extends Controller {
 		$user, $originalUser, $redirect_url, string $loginMessage) {
 		// Read current user and append if possible we need to
 		// return the unmodified user otherwise we will leak the login name
-		$args = $user !== null ? ['user' => $originalUser] : [];
+		$args = $user !== null ? ['user' => $originalUser, 'direct' => 1] : [];
 		if ($redirect_url !== null) {
 			$args['redirect_url'] = $redirect_url;
 		}


### PR DESCRIPTION
When SAML is configured with allowing multiple auth backends and the user uses the direct login method the user was just redirected to the auth picker again. This makes sure that we always end up in the direct login form where the error about the wrong credentials is displayed.