### PR TITLE
Fix favorite dark icon

### DIFF
--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -176,7 +176,7 @@
 					var isFavorite = $file.data('favorite') === true;
 
 					if (isFavorite) {
-						return 'icon-star-dark';
+						return 'icon-favorite';
 					}
 
 					return 'icon-starred';


### PR DESCRIPTION
As proposed by Jan here: https://github.com/nextcloud/mail/pull/4382#issuecomment-771586047 
all menu action items should have the same colour when they are dark.