### PR TITLE
Avoid template creators being registered multiple times

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -115,6 +115,9 @@ class TemplateManager implements ITemplateManager {
 	}
 
 	public function getTypes(): array {
+		if (!empty($this->types)) {
+			return $this->types;
+		}
 		foreach ($this->registeredTypes as $registeredType) {
 			$this->types[] = $registeredType();
 		}


### PR DESCRIPTION
This seems to happen on our cloud instance for some reason though I cannot really reproduce it locally it should fix the issue where a registered file create action would be displayed multiple times.