### PR TITLE
Always renew apppasswords on login

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -414,11 +414,6 @@ class PublicKeyTokenProvider implements IProvider {
 	public function updatePasswords(string $uid, string $password) {
 		$this->cache->clear();
 
-		if (!$this->mapper->hasExpiredTokens($uid)) {
-			// Nothing to do here
-			return;
-		}
-
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
 		foreach ($tokens as $t) {

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -548,8 +548,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 			IToken::PERMANENT_TOKEN,
 			IToken::REMEMBER);
 
-		$this->mapper->expects($this->once())
-			->method('hasExpiredTokens')
+		$this->mapper->method('hasExpiredTokens')
 			->with($uid)
 			->willReturn(true);
 		$this->mapper->expects($this->once())
@@ -561,21 +560,6 @@ class PublicKeyTokenProviderTest extends TestCase {
 			->with($this->callback(function (PublicKeyToken $t) use ($token1, $token2) {
 				return $t === $token1 || $t === $token2;
 			}));
-
-		$this->tokenProvider->updatePasswords($uid, 'bar2');
-	}
-
-	public function testUpdatePasswordsNotRequired() {
-		$uid = 'myUID';
-
-		$this->mapper->expects($this->once())
-			->method('hasExpiredTokens')
-			->with($uid)
-			->willReturn(false);
-		$this->mapper->expects($this->never())
-			->method('getTokenByUser');
-		$this->mapper->expects($this->never())
-			->method('update');
 
 		$this->tokenProvider->updatePasswords($uid, 'bar2');
 	}


### PR DESCRIPTION
Else you can end up that you renewed your password (LDAP for example).
But they still don't work because you did not use them before you logged
in.