### PR TITLE
Allow upgrades in Nextcloud 22 / Disallow upgrade from 20

### DIFF
--- a/version.php
+++ b/version.php
@@ -39,6 +39,7 @@ $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
 		'20.0' => true,
 		'21.0' => true,
+		'22.0' => true,
 	],
 	'owncloud' => [
 		'10.5' => true,

--- a/version.php
+++ b/version.php
@@ -37,7 +37,6 @@ $OC_VersionString = '22.0.0 alpha';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
-		'20.0' => true,
 		'21.0' => true,
 		'22.0' => true,
 	],


### PR DESCRIPTION
Otherwise we can't update any apps with 22 :wink: 

```
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Setting log level to debug
Exception: Updates between multiple major versions and downgrades are unsupported.
Update failed
Maintenance mode is kept active
Resetting log level
```