### PR TITLE
Allow defaultTableOptions to be overridden from configuration

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1513,6 +1513,21 @@ $CONFIG = [
 'mysql.utf8mb4' => false,
 
 /**
+ * This configuration parameter can be used to override the default options used for table creation.
+ * This parameter will take precedence over mysql.utf8mb4 if that is set to true.
+ *
+ * An example use for this parameter is where MariaDB page compression is enabled by default as the
+ * COMPRESSED row format is not allowed there, and thus table creation will fail.
+ * This option can then be used to override this and change/remove the row_format option.
+ *
+ */
+'dbdefaulttableoptions' => [
+	'collate' => 'utf8mb4_bin',
+	'charset' => 'utf8mb4',
+	'row_format' => 'compressed'
+],
+
+/**
  * Database types that are supported for installation.
  *
  * Available:

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1513,18 +1513,17 @@ $CONFIG = [
 'mysql.utf8mb4' => false,
 
 /**
- * This configuration parameter can be used to override the default options used for table creation.
- * This parameter will take precedence over mysql.utf8mb4 if that is set to true.
+ * This configuration parameter can be used to add or change the default options used for table creation.
+ * For changing charset / collation see mysql.utf8mb4
  *
  * An example use for this parameter is where MariaDB page compression is enabled by default as the
  * COMPRESSED row format is not allowed there, and thus table creation will fail.
- * This option can then be used to override this and change/remove the row_format option.
+ * This option can then be used to override this and change the row_format option.
  *
  */
 'dbdefaulttableoptions' => [
-	'collate' => 'utf8mb4_bin',
-	'charset' => 'utf8mb4',
-	'row_format' => 'compressed'
+	'row_format' => 'dynamic',
+	'page_compressed' => '1'
 ],
 
 /**

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -216,19 +216,19 @@ class ConnectionFactory {
 		}
 
 		// set default table creation options
-		$connectionParams['defaultTableOptions'] = [
-			'collate' => 'utf8_bin',
-			'tablePrefix' => $connectionParams['tablePrefix']
-		];
+		$connectionParams['defaultTableOptions'] = $this->config->getValue('dbdefaulttableoptions', [
+			'collate' => 'utf8_bin'
+		]);
 
-		if ($this->config->getValue('mysql.utf8mb4', false)) {
+		if ($this->config->getValue('mysql.utf8mb4', false) && is_null($this->config->getValue('dbdefaulttableoptions'))) {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',
-				'row_format' => 'compressed',
-				'tablePrefix' => $connectionParams['tablePrefix']
+				'row_format' => 'compressed'
 			];
 		}
+
+		$connectionParams['defaultTableOptions']['tablePrefix'] = $connectionParams['tablePrefix'];
 
 		return $connectionParams;
 	}

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -216,19 +216,34 @@ class ConnectionFactory {
 		}
 
 		// set default table creation options
-		$connectionParams['defaultTableOptions'] = $this->config->getValue('dbdefaulttableoptions', [
-			'collate' => 'utf8_bin'
-		]);
+		$defaultTableOptions = [
+			'collate' => 'utf8_bin',
+			'tablePrefix' => $connectionParams['tablePrefix']
+		];
 
-		if ($this->config->getValue('mysql.utf8mb4', false) && is_null($this->config->getValue('dbdefaulttableoptions'))) {
-			$connectionParams['defaultTableOptions'] = [
+		if ($this->config->getValue('mysql.utf8mb4', false)) {
+			$defaultTableOptions = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',
-				'row_format' => 'compressed'
+				'row_format' => 'compressed',
+				'tablePrefix' => $connectionParams['tablePrefix']
 			];
 		}
 
-		$connectionParams['defaultTableOptions']['tablePrefix'] = $connectionParams['tablePrefix'];
+		$configTableOptions = $this->config->getValue('dbdefaulttableoptions', []);
+
+		// prevent user from overriding collation / charset and tablePrefix here (previous behavior.)
+		if (array_key_exists('collate', $configTableOptions)) {
+			unset($configTableOptions['collate']);
+		}
+		if (array_key_exists('charset', $configTableOptions)) {
+			unset($configTableOptions['charset']);
+		}
+		if (array_key_exists('tablePrefix', $configTableOptions)) {
+			unset($configTableOptions['tablePrefix']);
+		}
+
+		$connectionParams['defaultTableOptions'] = array_merge($defaultTableOptions, $configTableOptions);
 
 		return $connectionParams;
 	}


### PR DESCRIPTION
In my installation, MariaDB is configured to enable page compression by default while supporting utf8mb4.
The default table creation options in that case causes issue as the COMPRESSED row format is not compatible with MariaDB page compression.

Therefore, this allows the default table creation options to be overridden from the configuration if required and will take precedence over the defaults where mysql.utf8m4 is true. If not specified, it should behave exactly as it was.

That being said, I think that it shouldn't be defaulting to compressed especially since according to (https://mariadb.com/kb/en/innodb-compressed-row-format/) 

> From MariaDB 10.6.0, tables that are of the COMPRESSED row format are read-only by default. This is the first step towards removing write support and deprecating the feature.


Closes #25436 