### PR TITLE
dont stop expiring versions if we cant check if the source file still exists

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -53,6 +53,7 @@ use OCA\Files_Versions\Command\Expire;
 use OCA\Files_Versions\Events\CreateVersionEvent;
 use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IUser;
 use OCP\Lock\ILockingProvider;
 use OCP\User;
@@ -724,8 +725,14 @@ class Storage {
 
 			\OC_Util::setupFS($uid);
 
-			if (!Filesystem::file_exists($filename)) {
-				return false;
+			try {
+				if (!Filesystem::file_exists($filename)) {
+					return false;
+				}
+			} catch (StorageNotAvailableException $e) {
+				// if we can't check that the file hasn't been deleted we can only assume that it hasn't
+				// note that this `StorageNotAvailableException` is about the file the versions originate from,
+				// not the storage that the versions are stored on
 			}
 
 			if (empty($filename)) {


### PR DESCRIPTION
instead continue assuming it still exists

As far as I can tell/remember the check was added [originally](https://github.com/nextcloud/server/commit/282f67dad126da438bfe8a0a89ad0aba21651c75) to prevent having to unnecessary work loading the versions that would have already been removed if the source file is deleted.