### PR TITLE
Fix the legacy dispatcher argument order

### DIFF
--- a/tests/lib/EventDispatcher/SymfonyAdapterTest.php
+++ b/tests/lib/EventDispatcher/SymfonyAdapterTest.php
@@ -100,6 +100,26 @@ class SymfonyAdapterTest extends TestCase {
 		self::assertEquals($result, $wrapped);
 	}
 
+	public function testDispatchOldSymfonyEventWithFlippedArgumentOrder(): void {
+		$event = new SymfonyEvent();
+		$eventName = 'symfony';
+		$symfonyDispatcher = $this->createMock(SymfonyDispatcher::class);
+		$this->eventDispatcher->expects(self::once())
+			->method('getSymfonyDispatcher')
+			->willReturn($symfonyDispatcher);
+		$symfonyDispatcher->expects(self::once())
+			->method('dispatch')
+			->with(
+				$event,
+				$eventName
+			)
+			->willReturnArgument(0);
+
+		$result = $this->adapter->dispatch($event, $eventName);
+
+		self::assertSame($result, $event);
+	}
+
 	public function testDispatchOldSymfonyEvent(): void {
 		$event = new SymfonyEvent();
 		$eventName = 'symfony';
@@ -116,6 +136,22 @@ class SymfonyAdapterTest extends TestCase {
 			->willReturnArgument(0);
 
 		$result = $this->adapter->dispatch($eventName, $event);
+
+		self::assertSame($result, $event);
+	}
+
+	public function testDispatchCustomGenericEventWithFlippedArgumentOrder(): void {
+		$event = new GenericEvent();
+		$eventName = 'symfony';
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatch')
+			->with(
+				$eventName,
+				$event
+			)
+			->willReturnArgument(0);
+
+		$result = $this->adapter->dispatch($event, $eventName);
 
 		self::assertSame($result, $event);
 	}


### PR DESCRIPTION
Symfony switched the argument order to comply with the PSR dispatcher but we still use it wrong in many places. Also the way we extend the interface is technically wrong …

![Bildschirmfoto von 2021-02-09 10-46-08](https://user-images.githubusercontent.com/1374172/107345908-5d840700-6ac4-11eb-87c6-2684c5dbc643.png)

So this all works more or less by chance. After the PR it's a bit more reliable: you can use the adapter in both fashions.