### PR TITLE
Improve exception when auto-wiring fails

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -93,7 +93,12 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 
 				if ($parameterType !== null && !$parameterType->isBuiltin()) {
 					$resolveName = $parameter->getName();
-					return $this->query($resolveName);
+					try {
+						return $this->query($resolveName);
+					} catch (QueryException $e2) {
+						// don't lose the error we got while trying to query by type
+						throw new QueryException($e2->getMessage(), $e2->getCode(), $e);
+					}
 				}
 
 				throw $e;

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -97,7 +97,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 						return $this->query($resolveName);
 					} catch (QueryException $e2) {
 						// don't lose the error we got while trying to query by type
-						throw new QueryException($e2->getMessage(), $e2->getCode(), $e);
+						throw new QueryException($e2->getMessage(), (int) $e2->getCode(), $e);
 					}
 				}
 

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -221,7 +221,11 @@ class Application {
 				$c = \OC::$server->query($command);
 			} catch (QueryException $e) {
 				if (class_exists($command)) {
-					$c = new $command();
+					try {
+						$c = new $command();
+					} catch (\ArgumentCountError $e2) {
+						throw new \Exception("Failed to construct console command '$command': " . $e->getMessage(), 0, $e);
+					}
 				} else {
 					throw new \Exception("Console command '$command' is unknown and could not be loaded");
 				}


### PR DESCRIPTION
Fixes 2 annoyances when dealing with failing auto-wiring

- When the fallback of querying a parameter by name fails, the original error from querying by type is lost
- When auto-wiring of a command fails and the fallback also fails, the original error is lost