### PR TITLE
ACLs without \ in the username throw exception

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -219,7 +219,7 @@ class SMB extends Common implements INotifyStorage {
 	private function getACL(IFileInfo $file): ?ACL {
 		$acls = $file->getAcls();
 		foreach ($acls as $user => $acl) {
-			[, $user] = explode('\\', $user); // strip domain
+			[, $user] = strpos($user, '\\') ? explode('\\', $user) : ['','']; // strip domain
 			if ($user === $this->server->getAuth()->getUsername()) {
 				return $acl;
 			}


### PR DESCRIPTION
Getting:
Error: Undefined offset: 1 at /var/www/html/nextcloud/apps/files_external/lib/Lib/Storage/SMB.php#222
 for every ACL with no \ in the username
This change deals with users eg. S-5-1-xxx just returning no username for them. Returning a plain username eg. ['', $user] could be a security risk or at least would be incorrect