### PR TITLE
Files external: ignore system folders by default

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -247,6 +247,12 @@ class SMB extends Common implements INotifyStorage {
 
 			foreach ($files as $file) {
 				try {
+					if ($file->isSystem()) {
+						// Ignore system files
+						$this->logger->debug('hiding system file ' . $file->getName());
+						continue;
+					}
+
 					// the isHidden check is done before checking the config boolean to ensure that the metadata is always fetch
 					// so we trigger the below exceptions where applicable
 					$hide = $file->isHidden() && !$this->showHidden;


### PR DESCRIPTION
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/65e0c225-5925-44b0-8104-6b91339c709f

ATTR_SYSTEM
File is part of or is used exclusively by the operating system.

I guess we should hide such system files as they can cause trouble when
not accessible etc.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>