### PR TITLE
Deprecate the internal IDBConnection event name constants

### DIFF
--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -51,11 +51,34 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  * @since 6.0.0
  */
 interface IDBConnection {
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const ADD_MISSING_INDEXES_EVENT = self::class . '::ADD_MISSING_INDEXES';
+
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const CHECK_MISSING_INDEXES_EVENT = self::class . '::CHECK_MISSING_INDEXES';
+
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const ADD_MISSING_PRIMARY_KEYS_EVENT = self::class . '::ADD_MISSING_PRIMARY_KEYS';
+
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const CHECK_MISSING_PRIMARY_KEYS_EVENT = self::class . '::CHECK_MISSING_PRIMARY_KEYS';
+
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const ADD_MISSING_COLUMNS_EVENT = self::class . '::ADD_MISSING_COLUMNS';
+
+	/**
+	 * @deprecated 22.0.0 this is an internal event
+	 */
 	public const CHECK_MISSING_COLUMNS_EVENT = self::class . '::CHECK_MISSING_COLUMNS';
 
 	/**


### PR DESCRIPTION
I'm also ok with doing this even for 21.0.0 …