### PR TITLE
Corrected package name used in .devcontainer/Dockerfile (php7.4-acpu => php7.4-apcu)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install --no-install-recommends -y \
     php7.4-intl \
     php7.4-imagick \
     php7.4-gmp \
-    php7.4-acpu \
+    php7.4-apcu \
     php7.4-bcmath \
     libmagickcore-6.q16-3-extra \
     curl \


### PR DESCRIPTION
In `.devcontainer/Dockerfile` package `php7.4-acpu` is not available.

If you run `docker build .` or `docker-compose up` you will get the following error:

```
Sending build context to Docker daemon   7.68kB
Step 1/12 : FROM ubuntu:focal
 ---> f63181f19b2f
Step 2/12 : ARG DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> 9e5a3dc49019
Step 3/12 : RUN apt-get update -y
 ---> Using cache
 ---> 27230e571c57
Step 4/12 : RUN apt-get install --no-install-recommends -y     php7.4     php7.4-gd     php7.4-zip
     php7.4-curl     php7.4-xml     php7.4-mbstring     php7.4-sqlite     php7.4-xdebug     php7.4-pgsql
     php7.4-intl     php7.4-imagick     php7.4-gmp     php7.4-acpu     php7.4-bcmath
     libmagickcore-6.q16-3-extra     curl     vim     lsof
 ---> Running in 11c6ccea809d
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package php7.4-acpu
E: Couldn't find any package by glob 'php7.4-acpu'
E: Couldn't find any package by regex 'php7.4-acpu'
The command '/bin/sh -c apt-get install --no-install-recommends -y     php7.4     php7.4-gd     php7.4-zip
     php7.4-curl     php7.4-xml     php7.4-mbstring     php7.4-sqlite     php7.4-xdebug     php7.4-pgsql
     php7.4-intl     php7.4-imagick     php7.4-gmp     php7.4-acpu     php7.4-bcmath
     libmagickcore-6.q16-3-extra     curl     vim     lsof' returned a non-zero code: 100
```

The package must be named `php7.4-apcu`. **This PR corrects that.**