### PR TITLE
Deprecate all remaining event constants

### DIFF
--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -32,12 +32,24 @@ use OCP\EventDispatcher\Event;
  * @since 9.0.0
  */
 class ManagerEvent extends Event {
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_APP_ENABLE = 'OCP\App\IAppManager::enableApp';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_APP_ENABLE_FOR_GROUPS = 'OCP\App\IAppManager::enableAppForGroups';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_APP_DISABLE = 'OCP\App\IAppManager::disableApp';
 
 	/**
 	 * @since 9.1.0
+	 * @deprecated 22.0.0
 	 */
 	public const EVENT_APP_UPDATE = 'OCP\App\IAppManager::updateApp';
 

--- a/lib/public/Authentication/TwoFactorAuth/IProvider.php
+++ b/lib/public/Authentication/TwoFactorAuth/IProvider.php
@@ -36,8 +36,13 @@ interface IProvider {
 
 	/**
 	 * @since 14.0.0
+	 * @deprecated 22.0.0
 	 */
 	public const EVENT_SUCCESS = self::class . '::success';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_FAILED = self::class . '::failed';
 
 	/**

--- a/lib/public/Authentication/TwoFactorAuth/IRegistry.php
+++ b/lib/public/Authentication/TwoFactorAuth/IRegistry.php
@@ -39,7 +39,14 @@ use OCP\IUser;
  * @since 14.0.0
  */
 interface IRegistry {
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_PROVIDER_ENABLED = self::class . '::enable';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_PROVIDER_DISABLED = self::class . '::disable';
 
 	/**

--- a/lib/public/Comments/CommentsEntityEvent.php
+++ b/lib/public/Comments/CommentsEntityEvent.php
@@ -32,6 +32,9 @@ use OCP\EventDispatcher\Event;
  * @since 9.1.0
  */
 class CommentsEntityEvent extends Event {
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_ENTITY = 'OCP\Comments\ICommentsManager::registerEntity';
 
 	/** @var string */

--- a/lib/public/Comments/CommentsEvent.php
+++ b/lib/public/Comments/CommentsEvent.php
@@ -32,9 +32,25 @@ use OCP\EventDispatcher\Event;
  * @since 9.0.0
  */
 class CommentsEvent extends Event {
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_ADD = 'OCP\Comments\ICommentsManager::addComment';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_PRE_UPDATE = 'OCP\Comments\ICommentsManager::preUpdateComment';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_UPDATE = 'OCP\Comments\ICommentsManager::updateComment';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_DELETE = 'OCP\Comments\ICommentsManager::deleteComment';
 
 	/** @var string */

--- a/lib/public/Console/ConsoleEvent.php
+++ b/lib/public/Console/ConsoleEvent.php
@@ -32,6 +32,10 @@ use OCP\EventDispatcher\Event;
  * @since 9.0.0
  */
 class ConsoleEvent extends Event {
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_RUN = 'OC\Console\Application::run';
 
 	/** @var string */

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -48,6 +48,7 @@ interface IPreview {
 
 	/**
 	 * @since 9.2.0
+	 * @deprecated 22.0.0
 	 */
 	public const EVENT = self::class . ':' . 'PreviewRequested';
 

--- a/lib/public/SystemTag/ManagerEvent.php
+++ b/lib/public/SystemTag/ManagerEvent.php
@@ -37,8 +37,20 @@ use OCP\EventDispatcher\Event;
  * @since 9.0.0
  */
 class ManagerEvent extends Event {
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_CREATE = 'OCP\SystemTag\ISystemTagManager::createTag';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_UPDATE = 'OCP\SystemTag\ISystemTagManager::updateTag';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_DELETE = 'OCP\SystemTag\ISystemTagManager::deleteTag';
 
 	/** @var string */

--- a/lib/public/SystemTag/MapperEvent.php
+++ b/lib/public/SystemTag/MapperEvent.php
@@ -36,7 +36,15 @@ use OCP\EventDispatcher\Event;
  * @since 9.0.0
  */
 class MapperEvent extends Event {
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_ASSIGN = 'OCP\SystemTag\ISystemTagObjectMapper::assignTags';
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_UNASSIGN = 'OCP\SystemTag\ISystemTagObjectMapper::unassignTags';
 
 	/** @var string */

--- a/lib/public/SystemTag/SystemTagsEntityEvent.php
+++ b/lib/public/SystemTag/SystemTagsEntityEvent.php
@@ -36,6 +36,10 @@ use OCP\EventDispatcher\Event;
  * @since 9.1.0
  */
 class SystemTagsEntityEvent extends Event {
+
+	/**
+	 * @deprecated 22.0.0
+	 */
 	public const EVENT_ENTITY = 'OCP\SystemTag\ISystemTagManager::registerEntity';
 
 	/** @var string */

--- a/lib/public/WorkflowEngine/IManager.php
+++ b/lib/public/WorkflowEngine/IManager.php
@@ -46,10 +46,18 @@ interface IManager {
 	public const MAX_OPERATION_VALUE_BYTES = 4096;
 
 	/**
-	 * @deprecated Will be removed in NC19. Use the dedicated events in OCP\WorkflowEngine\Events
+	 * @deprecated 17.0.0 Will be removed in NC19. Use the dedicated events in OCP\WorkflowEngine\Events
 	 */
 	public const EVENT_NAME_REG_OPERATION = 'OCP\WorkflowEngine::registerOperations';
+
+	/**
+	 * @deprecated 17.0.0
+	 */
 	public const EVENT_NAME_REG_ENTITY = 'OCP\WorkflowEngine::registerEntities';
+
+	/**
+	 * @deprecated 17.0.0
+	 */
 	public const EVENT_NAME_REG_CHECK = 'OCP\WorkflowEngine::registerChecks';
 
 	/**


### PR DESCRIPTION
And then in follow-up changes we can add the new event classes for the stuff that is actually still used.