### PR TITLE
[20] change reconect wrapper to only check connection after inactivity

### DIFF
--- a/lib/private/DB/ReconnectWrapper.php
+++ b/lib/private/DB/ReconnectWrapper.php
@@ -31,21 +31,22 @@ use Doctrine\DBAL\Driver;
 class ReconnectWrapper extends \Doctrine\DBAL\Connection {
 	public const CHECK_CONNECTION_INTERVAL = 60;
 
-	private $lastConnectionCheck = null;
+	private $lastQuery = null;
 
 	public function __construct(array $params, Driver $driver, Configuration $config = null, EventManager $eventManager = null) {
 		parent::__construct($params, $driver, $config, $eventManager);
-		$this->lastConnectionCheck = time();
+		$this->lastQuery = time();
 	}
 
 	public function connect() {
 		$now = time();
 		$checkTime = $now - self::CHECK_CONNECTION_INTERVAL;
 
-		if ($this->lastConnectionCheck > $checkTime || $this->isTransactionActive()) {
+		if ($this->lastQuery > $checkTime || $this->isTransactionActive()) {
+			$this->lastQuery = $now;
 			return parent::connect();
 		} else {
-			$this->lastConnectionCheck = $now;
+			$this->lastQuery = $now;
 			if (!$this->ping()) {
 				$this->close();
 			}


### PR DESCRIPTION
instead of always checking every minute, only check the connection after a minute of inactivity.
this should better reflect how idle timeouts of sql servers work and remove most of the cases where this check was previously done.

The reason for getting rid of the needless checks is that the `ping` can trigger another connection to be opened in some cases.

Note that this change isn't needed for >=21 since upstream changes made the entire reconnect wrapper unnecessary.