### PR TITLE
Deprecate the GenericEvent wrapper

### DIFF
--- a/lib/public/EventDispatcher/GenericEvent.php
+++ b/lib/public/EventDispatcher/GenericEvent.php
@@ -40,17 +40,23 @@ use function array_key_exists;
  * \OCP\EventDispatcher\Event
  *
  * @since 18.0.0
+ * @deprecated 22.0.0 use \OCP\EventDispatcher\Event
  */
 class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
+	/** @deprecated 22.0.0 */
 	protected $subject;
+
+	/** @deprecated 22.0.0 */
 	protected $arguments;
 
 	/**
 	 * Encapsulate an event with $subject and $args.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function __construct($subject = null, array $arguments = []) {
+		parent::__construct();
 		$this->subject = $subject;
 		$this->arguments = $arguments;
 	}
@@ -59,6 +65,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * Getter for subject property.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function getSubject() {
 		return $this->subject;
@@ -69,6 +76,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @throws InvalidArgumentException if key is not found
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function getArgument(string $key) {
 		if ($this->hasArgument($key)) {
@@ -82,6 +90,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * Add argument to event.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function setArgument($key, $value): GenericEvent {
 		$this->arguments[$key] = $value;
@@ -92,6 +101,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * Getter for all arguments.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function getArguments(): array {
 		return $this->arguments;
@@ -101,6 +111,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * Set args property.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function setArguments(array $args = []): GenericEvent {
 		$this->arguments = $args;
@@ -111,6 +122,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 * Has argument.
 	 *
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function hasArgument($key): bool {
 		return array_key_exists($key, $this->arguments);
@@ -121,6 +133,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @link https://php.net/manual/en/iteratoraggregate.getiterator.php
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function getIterator(): Traversable {
 		return new ArrayIterator($this->arguments);
@@ -131,6 +144,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @link https://php.net/manual/en/arrayaccess.offsetexists.php
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function offsetExists($offset): bool {
 		return $this->hasArgument($offset);
@@ -141,6 +155,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @link https://php.net/manual/en/arrayaccess.offsetget.php
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function offsetGet($offset) {
 		return $this->arguments[$offset];
@@ -151,6 +166,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @link https://php.net/manual/en/arrayaccess.offsetset.php
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function offsetSet($offset, $value): void {
 		$this->setArgument($offset, $value);
@@ -161,6 +177,7 @@ class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
 	 * @since 18.0.0
+	 * @deprecated 22.0.0
 	 */
 	public function offsetUnset($offset): void {
 		if ($this->hasArgument($offset)) {


### PR DESCRIPTION
This class is a convenience type to replace the old Symfony GenericEvent
with our own type, to ease the transition from Symfony events to our
(PSR) events. Hence we can deprecate the class as precaution to smoothen
the next transition step in the future.

Technically this one isn't directly influenced by changes in Symfony. Nevertheless we don't need it for any new stuff.