### PR TITLE
Make our event base class independent of Symfony and follow PSR

### DIFF
--- a/lib/public/EventDispatcher/Event.php
+++ b/lib/public/EventDispatcher/Event.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCP\EventDispatcher;
 
-use Symfony\Contracts\EventDispatcher\Event as SymfonyEvent;
+use Psr\EventDispatcher\StoppableEventInterface;
 
 /**
  * Base event class for the event dispatcher service
@@ -34,9 +34,21 @@ use Symfony\Contracts\EventDispatcher\Event as SymfonyEvent;
  * Typically this class isn't instantiated directly but sub classed for specific
  * event types
  *
+ * This class extended \Symfony\Contracts\EventDispatcher\Event until 21.0, since
+ * 22.0.0 this class directly implements the PSR StoppableEventInterface and no
+ * longer relies on Symfony. This transition does not come with any changes in API,
+ * the class has the same methods and behavior before and after this change.
+ *
  * @since 17.0.0
  */
-class Event extends SymfonyEvent {
+class Event implements StoppableEventInterface {
+
+	/**
+	 * @var bool
+	 *
+	 * @since 22.0.0
+	 */
+	private $propagationStopped = false;
 
 	/**
 	 * Compatibility constructor
@@ -50,5 +62,26 @@ class Event extends SymfonyEvent {
 	 * @since 18.0.0
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Stops the propagation of the event to further event listeners
+	 *
+	 * @return void
+	 *
+	 * @since 22.0.0
+	 */
+	public function stopPropagation(): void {
+		$this->propagationStopped = true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since 22.0.0
+	 * @see \Psr\EventDispatcher\StoppableEventInterface
+	 */
+	public function isPropagationStopped(): bool {
+		return $this->propagationStopped;
 	}
 }


### PR DESCRIPTION
Symfony is migrating towards a pure PSR event dispatcher, hence their
event class is POPO that implements the PSR stoppable event interface.
Since we can do that ourself and this change doesn't come with any API
changes (breakage), it's easy for us to become independent of Symfony
but also stay PSR-compliant at the same step.

- [x] https://github.com/nextcloud/3rdparty/pull/616
- [x] rebase