### PR TITLE
disable trasbin during the moveFromStorage fallback

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -37,6 +37,7 @@ use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Node;
+use OCP\Files\Storage\IStorage;
 use OCP\ILogger;
 use OCP\IUserManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -59,6 +60,8 @@ class Storage extends Wrapper {
 
 	/** @var ITrashManager */
 	private $trashManager;
+
+	private $trashEnabled = true;
 
 	/**
 	 * Storage constructor.
@@ -95,14 +98,18 @@ class Storage extends Wrapper {
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
 	public function unlink($path) {
-		try {
-			return $this->doDelete($path, 'unlink');
-		} catch (GenericEncryptionException $e) {
-			// in case of a encryption exception we delete the file right away
-			$this->logger->info(
-				"Can't move file " . $path .
-				" to the trash bin, therefore it was deleted right away");
+		if ($this->trashEnabled) {
+			try {
+				return $this->doDelete($path, 'unlink');
+			} catch (GenericEncryptionException $e) {
+				// in case of a encryption exception we delete the file right away
+				$this->logger->info(
+					"Can't move file " . $path .
+					" to the trash bin, therefore it was deleted right away");
 
+				return $this->storage->unlink($path);
+			}
+		} else {
 			return $this->storage->unlink($path);
 		}
 	}
@@ -115,7 +122,11 @@ class Storage extends Wrapper {
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
 	public function rmdir($path) {
-		return $this->doDelete($path, 'rmdir');
+		if ($this->trashEnabled) {
+			return $this->doDelete($path, 'rmdir');
+		} else {
+			return $this->storage->rmdir($path);
+		}
 	}
 
 	/**
@@ -215,5 +226,37 @@ class Storage extends Wrapper {
 
 	public function getMountPoint() {
 		return $this->mountPoint;
+	}
+
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		$sourceIsTrashbin = $sourceStorage->instanceOfStorage(Storage::class);
+		try {
+			// the fallback for moving between storage involves a copy+delete
+			// we don't want to trigger the trashbin when doing the delete
+			if ($sourceIsTrashbin) {
+				/** @var Storage $sourceStorage */
+				$sourceStorage->disableTrash();
+			}
+			$result = $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			if ($sourceIsTrashbin) {
+				/** @var Storage $sourceStorage */
+				$sourceStorage->enableTrash();
+			}
+			return $result;
+		} catch (\Exception $e) {
+			if ($sourceIsTrashbin) {
+				/** @var Storage $sourceStorage */
+				$sourceStorage->enableTrash();
+			}
+			throw $e;
+		}
+	}
+
+	protected function disableTrash() {
+		$this->trashEnabled = false;
+	}
+
+	protected function enableTrash() {
+		$this->trashEnabled = true;
 	}
 }


### PR DESCRIPTION
The `moveFromStorage` fallback does a `copy`+`delete`, currently the second half triggers the trashbin logic which causes it to move the sourcefile to the trashbin and give the move target a different fileid.