### PR TITLE
file-upload: Correctly handle error responses for HTTP2

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -345,7 +345,7 @@ OC.FileUpload.prototype = {
 	 */
 	getResponse: function() {
 		var response = this.data.response();
-		if (response.errorThrown) {
+		if (response.errorThrown || response.textStatus === 'error') {
 			// attempt parsing Sabre exception is available
 			var xml = response.jqXHR.responseXML;
 			if (xml && xml.documentElement.localName === 'error' && xml.documentElement.namespaceURI === 'DAV:') {


### PR DESCRIPTION
For HTTP2, `errorThrown` variable can be empty string:

> When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." **(in HTTP/2 it may instead be an empty string)**
– https://api.jquery.com/jquery.ajax/ (https://github.com/jquery/api.jquery.com/pull/1146)

So for Chrome or Safari, that follows HTTP/2 specs, Nextcloud will not parse error message. This makes problem at least for AV plugin – see https://github.com/nextcloud/files_antivirus/issues/119

I would be happy if it is be possible to also apply this patchto version 19.X.


