### PR TITLE
Do not send imip email to invalid recipients

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -178,6 +178,11 @@ class IMipPlugin extends SabreIMipPlugin {
 		// Strip off mailto:
 		$sender = substr($iTipMessage->sender, 7);
 		$recipient = substr($iTipMessage->recipient, 7);
+		if (!$this->mailer->validateMailAddress($recipient)) {
+			// Nothing to send if the recipient doesn't have a valid email address
+			$iTipMessage->scheduleStatus = '5.0; EMail delivery failed';
+			return;
+		}
 
 		$senderName = $iTipMessage->senderName ?: null;
 		$recipientName = $iTipMessage->recipientName ?: null;

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -140,6 +140,7 @@ class IMipPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('dav', 'invitation_link_recipients', 'yes')
 			->willReturn('yes');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
 		$this->_expectSend();
@@ -153,6 +154,7 @@ class IMipPluginTest extends TestCase {
 			->method('getAppValue')
 			->with('dav', 'invitation_link_recipients', 'yes')
 			->willReturn('yes');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
 		$this->mailer
@@ -163,12 +165,21 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('5.0', $message->getScheduleStatus());
 	}
 
+	public function testInvalidEmailDelivery() {
+		$this->mailer->method('validateMailAddress')->willReturn(false);
+
+		$message = $this->_testMessage();
+		$this->plugin->schedule($message);
+		$this->assertEquals('5.0', $message->getScheduleStatus());
+	}
+
 	public function testDeliveryWithNoCommonName() {
 		$this->config
 	  ->expects($this->at(1))
 			->method('getAppValue')
 			->with('dav', 'invitation_link_recipients', 'yes')
 			->willReturn('yes');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
 		$message->senderName = null;
@@ -193,6 +204,7 @@ class IMipPluginTest extends TestCase {
 		$this->config
 	  ->method('getAppValue')
 	  ->willReturn('yes');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage($veventParams);
 
@@ -227,6 +239,7 @@ class IMipPluginTest extends TestCase {
 	 */
 	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons) {
 		$message = $this->_testMessage([],$recipient);
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$this->_expectSend($recipient, true, $has_buttons);
 		$this->config
@@ -256,6 +269,7 @@ class IMipPluginTest extends TestCase {
 		$this->config
 			->method('getAppValue')
 			->willReturn('yes');
+		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage(['SUMMARY' => '']);
 		$this->_expectSend('frodo@hobb.it', true, true,'Invitation: Untitled event');


### PR DESCRIPTION
I just had an error caused by Calendar as I trued to save this vcard:

```
BEGIN:VCALENDAR
PRODID:-//IDN nextcloud.com//Calendar app 2.1.3//EN
CALSCALE:GREGORIAN
VERSION:2.0
BEGIN:VEVENT
CREATED:20210211T120406Z
DTSTAMP:20210211T121704Z
LAST-MODIFIED:20210211T121704Z
SEQUENCE:3
UID:4d5ce95b-a3b3-48cd-bf3b-1d66d5560f98
DTSTART;TZID=Europe/Vienna:20210211T100000
DTEND;TZID=Europe/Vienna:20210211T173000
SUMMARY:Busy
TRANSP:OPAQUE
ATTENDEE;CN=otheruser;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTIC
 IPANT;RSVP=FALSE:mailto:
ORGANIZER;CN=admin:mailto:myemail@domain.com
END:VEVENT
BEGIN:VTIMEZONE
TZID:Europe/Vienna
BEGIN:DAYLIGHT
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
TZNAME:CEST
DTSTART:19700329T020000
RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
END:DAYLIGHT
BEGIN:STANDARD
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
TZNAME:CET
DTSTART:19701025T030000
RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
END:STANDARD
END:VTIMEZONE
END:VCALENDAR
```
<details>

```json
{
  "reqId": "nQnCxyq0HNQqfZZFuxWv",
  "level": 4,
  "time": "2021-02-11T12:18:06+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "webdav",
  "method": "PUT",
  "url": "/remote.php/dav/calendars/admin/personal/7A27E6FF-0910-46B1-A0CF-429B35126D4D.ics",
  "message": {
    "Exception": "TypeError",
    "Message": "idn_to_ascii() expects parameter 1 to be string, null given",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/christoph/workspace/nextcloud/lib/private/Mail/Message.php",
        "line": 84,
        "function": "idn_to_ascii",
        "args": [
          "*** sensitive parameter replaced ***",
          0,
          1
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/private/Mail/Message.php",
        "line": 149,
        "function": "convertAddresses",
        "class": "OC\\Mail\\Message",
        "type": "->",
        "args": [
          {
            "": "otheruser"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php",
        "line": 238,
        "function": "setTo",
        "class": "OC\\Mail\\Message",
        "type": "->",
        "args": [
          {
            "": "otheruser"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "schedule",
        "class": "OCA\\DAV\\CalDAV\\Schedule\\IMipPlugin",
        "type": "->",
        "args": [
          {
            "uid": "4d5ce95b-a3b3-48cd-bf3b-1d66d5560f98",
            "component": "VEVENT",
            "method": "REQUEST",
            "sequence": 3,
            "sender": "mailto:myemail@domain.com",
            "senderName": {
              "name": "CN",
              "noName": false,
              "parent": null,
              "__class__": "Sabre\\VObject\\Parameter"
            },
            "recipient": "mailto:",
            "recipientName": "otheruser",
            "scheduleStatus": "3.7;Could not find principal.",
            "message": {
              "name": "VCALENDAR",
              "parent": null,
              "__class__": "Sabre\\VObject\\Component\\VCalendar"
            },
            "significantChange": true,
            "__class__": "Sabre\\VObject\\ITip\\Message"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/CalDAV/Schedule/Plugin.php",
        "line": 350,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "schedule",
          [
            {
              "uid": "4d5ce95b-a3b3-48cd-bf3b-1d66d5560f98",
              "component": "VEVENT",
              "method": "REQUEST",
              "sequence": 3,
              "sender": "mailto:myemail@domain.com",
              "senderName": {
                "name": "CN",
                "noName": false,
                "parent": null,
                "__class__": "Sabre\\VObject\\Parameter"
              },
              "recipient": "mailto:",
              "recipientName": "otheruser",
              "scheduleStatus": "3.7;Could not find principal.",
              "message": {
                "name": "VCALENDAR",
                "parent": null,
                "__class__": "Sabre\\VObject\\Component\\VCalendar"
              },
              "significantChange": true,
              "__class__": "Sabre\\VObject\\ITip\\Message"
            }
          ]
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/CalDAV/Schedule/Plugin.php",
        "line": 626,
        "function": "deliver",
        "class": "Sabre\\CalDAV\\Schedule\\Plugin",
        "type": "->",
        "args": [
          {
            "uid": "4d5ce95b-a3b3-48cd-bf3b-1d66d5560f98",
            "component": "VEVENT",
            "method": "REQUEST",
            "sequence": 3,
            "sender": "mailto:myemail@domain.com",
            "senderName": {
              "name": "CN",
              "noName": false,
              "parent": null,
              "__class__": "Sabre\\VObject\\Parameter"
            },
            "recipient": "mailto:",
            "recipientName": "otheruser",
            "scheduleStatus": "3.7;Could not find principal.",
            "message": {
              "name": "VCALENDAR",
              "parent": null,
              "__class__": "Sabre\\VObject\\Component\\VCalendar"
            },
            "significantChange": true,
            "__class__": "Sabre\\VObject\\ITip\\Message"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/CalDAV/Schedule/Plugin.php",
        "line": 337,
        "function": "processICalendarChange",
        "class": "Sabre\\CalDAV\\Schedule\\Plugin",
        "type": "->",
        "args": [
          {
            "name": "VCALENDAR",
            "parent": null,
            "__class__": "Sabre\\VObject\\Component\\VCalendar"
          },
          {
            "name": "VCALENDAR",
            "parent": null,
            "__class__": "Sabre\\VObject\\Component\\VCalendar"
          },
          [
            "mailto:myemail@domain.com",
            "/remote.php/dav/principals/users/admin/"
          ],
          [],
          true
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/dav/lib/CalDAV/Schedule/Plugin.php",
        "line": 150,
        "function": "calendarObjectChange",
        "class": "Sabre\\CalDAV\\Schedule\\Plugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          },
          {
            "name": "VCALENDAR",
            "parent": null,
            "__class__": "Sabre\\VObject\\Component\\VCalendar"
          },
          "calendars/admin/personal",
          true,
          false
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "calendarObjectChange",
        "class": "OCA\\DAV\\CalDAV\\Schedule\\Plugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          },
          {
            "name": "VCALENDAR",
            "parent": null,
            "__class__": "Sabre\\VObject\\Component\\VCalendar"
          },
          "calendars/admin/personal",
          true,
          false
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/CalDAV/Plugin.php",
        "line": 897,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "calendarObjectChange",
          [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            },
            {
              "name": "VCALENDAR",
              "parent": null,
              "__class__": "Sabre\\VObject\\Component\\VCalendar"
            },
            "calendars/admin/personal",
            true,
            false
          ]
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/CalDAV/Plugin.php",
        "line": 739,
        "function": "validateICalendar",
        "class": "Sabre\\CalDAV\\Plugin",
        "type": "->",
        "args": [
          "*** sensitive parameter replaced ***",
          "*** sensitive parameter replaced ***",
          false,
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          },
          false
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "beforeWriteContent",
        "class": "Sabre\\CalDAV\\Plugin",
        "type": "->",
        "args": [
          "*** sensitive parameter replaced ***",
          {
            "__class__": "OCA\\DAV\\CalDAV\\CalendarObject"
          },
          "*** sensitive parameter replaced ***",
          false
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 1133,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "beforeWriteContent",
          [
            "*** sensitive parameter replaced ***",
            {
              "__class__": "OCA\\DAV\\CalDAV\\CalendarObject"
            },
            "*** sensitive parameter replaced ***",
            false
          ]
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 492,
        "function": "updateFile",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpPut",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "method:PUT",
          [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 253,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 321,
        "function": "start",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/dav/lib/Server.php",
        "line": 332,
        "function": "exec",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/dav/appinfo/v2/remote.php",
        "line": 35,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/home/christoph/workspace/nextcloud/remote.php",
        "line": 167,
        "args": [
          "/home/christoph/workspace/nextcloud/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/home/christoph/workspace/nextcloud/lib/private/Mail/Message.php",
    "Line": 84,
    "CustomMessage": "--"
  },
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0",
  "version": "22.0.0.0"
}
```

</details>

This smells very related to https://github.com/nextcloud/server/pull/25310.

Fixes https://github.com/nextcloud/server/issues/18941 https://github.com/nextcloud/server/issues/15243