### PR TITLE
App config to use custom email link template in ContactsMenu items

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ActionFactory.php
+++ b/lib/private/Contacts/ContactsMenu/ActionFactory.php
@@ -47,9 +47,12 @@ class ActionFactory implements IActionFactory {
 	 * @param string $icon
 	 * @param string $name
 	 * @param string $email
+	 * @param ?string $linkTemplate
 	 * @return ILinkAction
 	 */
-	public function newEMailAction($icon, $name, $email) {
-		return $this->newLinkAction($icon, $name, 'mailto:' . $email);
+	public function newEMailAction($icon, $name, $email, $linkTemplate) {
+		return $linkTemplate
+			? $this->newLinkAction($icon, $name, str_replace('%s', $email, $linkTemplate))
+			: $this->newLinkAction($icon, $name, 'mailto:' . $email);
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
@@ -27,6 +27,7 @@ use OCP\Contacts\ContactsMenu\IActionFactory;
 use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IURLGenerator;
+use OCP\IConfig;
 
 class EMailProvider implements IProvider {
 
@@ -36,13 +37,18 @@ class EMailProvider implements IProvider {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
+	/** @var IConfig */
+	private $serverConfig;
+
 	/**
 	 * @param IActionFactory $actionFactory
 	 * @param IURLGenerator $urlGenerator
+	 * @param IConfig $serverConfig
 	 */
-	public function __construct(IActionFactory $actionFactory, IURLGenerator $urlGenerator) {
+	public function __construct(IActionFactory $actionFactory, IURLGenerator $urlGenerator, IConfig $serverConfig) {
 		$this->actionFactory = $actionFactory;
 		$this->urlGenerator = $urlGenerator;
+		$this->serverConfig = $serverConfig;
 	}
 
 	/**
@@ -50,12 +56,13 @@ class EMailProvider implements IProvider {
 	 */
 	public function process(IEntry $entry) {
 		$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/mail.svg'));
+		$emailTemplate = $this->serverConfig->getAppValue('contacts', 'email_link_template', '') ?: null;
 		foreach ($entry->getEMailAddresses() as $address) {
 			if (empty($address)) {
 				// Skip
 				continue;
 			}
-			$action = $this->actionFactory->newEMailAction($iconUrl, $address, $address);
+			$action = $this->actionFactory->newEMailAction($iconUrl, $address, $address, $emailTemplate);
 			$entry->addAction($action);
 		}
 	}

--- a/lib/public/Contacts/ContactsMenu/IActionFactory.php
+++ b/lib/public/Contacts/ContactsMenu/IActionFactory.php
@@ -48,7 +48,8 @@ interface IActionFactory {
 	 * @param string $icon full path to the action's icon
 	 * @param string $name localized name of the action
 	 * @param string $email target e-mail address
+	 * @param ?string $linkTemplate optional link template to use instead of 'mailto:'
 	 * @return ILinkAction
 	 */
-	public function newEMailAction($icon, $name, $email);
+	public function newEMailAction($icon, $name, $email, $linkTemplate);
 }


### PR DESCRIPTION
This allows an admin to replace the `mailto:` link by an HTTP link pointing to a webmail for example.

As this option will most likely not be used very often, it could stay invisible in the settings UI.
It could be documented somewhere though. In the server admin doc? In the Contacts app?