### PR TITLE
Migrate custom loggers to PSR

### DIFF
--- a/apps/workflowengine/lib/Service/Logger.php
+++ b/apps/workflowengine/lib/Service/Logger.php
@@ -31,11 +31,12 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Log\IDataLogger;
 use OCP\Log\ILogFactory;
+use Psr\Log\LoggerInterface;
 
 class Logger {
 	/** @var ILogger */
 	protected $generalLogger;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	protected $flowLogger;
 	/** @var IConfig */
 	private $config;
@@ -54,7 +55,7 @@ class Logger {
 		$default = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/flow.log';
 		$logFile = trim((string)$this->config->getAppValue(Application::APP_ID, 'logfile', $default));
 		if ($logFile !== '') {
-			$this->flowLogger = $this->logFactory->getCustomLogger($logFile);
+			$this->flowLogger = $this->logFactory->getCustomPsrLogger($logFile);
 		}
 	}
 

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -31,6 +31,7 @@ use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\Log\ILogFactory;
 use OCP\Log\IWriter;
+use Psr\Log\LoggerInterface;
 
 class LogFactory implements ILogFactory {
 	/** @var IServerContainer */
@@ -68,6 +69,13 @@ class LogFactory implements ILogFactory {
 	public function getCustomLogger(string $path):ILogger {
 		$log = $this->buildLogFile($path);
 		return new Log($log, $this->systemConfig);
+	}
+
+	public function getCustomPsrLogger(string $path): LoggerInterface {
+		$log = $this->buildLogFile($path);
+		return new PsrLoggerAdapter(
+			new Log($log, $this->systemConfig)
+		);
 	}
 
 	protected function buildLogFile(string $logFile = ''):File {

--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -26,19 +26,21 @@ declare(strict_types=1);
 
 namespace OC\Log;
 
+use OC\Log;
 use OCP\ILogger;
+use OCP\Log\IDataLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use function array_key_exists;
 use function array_merge;
 
-final class PsrLoggerAdapter implements LoggerInterface {
+final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 
-	/** @var ILogger */
+	/** @var Log */
 	private $logger;
 
-	public function __construct(ILogger $logger) {
+	public function __construct(Log $logger) {
 		$this->logger = $logger;
 	}
 
@@ -259,5 +261,9 @@ final class PsrLoggerAdapter implements LoggerInterface {
 		} else {
 			$this->logger->log($level, $message, $context);
 		}
+	}
+
+	public function logData(string $message, array $data, array $context = []): void {
+		$this->logger->logData($message, $data, $context);
 	}
 }

--- a/lib/public/Log/ILogFactory.php
+++ b/lib/public/Log/ILogFactory.php
@@ -25,6 +25,7 @@
 namespace OCP\Log;
 
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Interface ILogFactory
@@ -43,6 +44,15 @@ interface ILogFactory {
 	 * @param string $path
 	 * @return ILogger
 	 * @since 14.0.0
+	 * @deprecated use \OCP\Log\ILogFactory::getCustomPsrLogger
+	 * @see \OCP\Log\ILogFactory::getCustomPsrLogger
 	 */
 	public function getCustomLogger(string $path): ILogger;
+
+	/**
+	 * @param string $path
+	 * @return LoggerInterface
+	 * @since 22.0.0
+	 */
+	public function getCustomPsrLogger(string $path): LoggerInterface;
 }


### PR DESCRIPTION
This will help phase out the deprecated ILogger interface.

This is a follow-up to my old PR https://github.com/nextcloud/server/pull/18200.

Once we have a real logger that directly implements the PSR interface we can work without an adapter. But right now this is fine and the API change is more important than clean internals, because internals we can change any time.