### PR TITLE
forward invalid argument message to frontend when creating a user fails

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -441,6 +441,13 @@ class UsersController extends AUserData {
 				'app' => 'ocs_api',
 			]);
 			throw $e;
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->logException($e, [
+				'message' => 'Failed addUser attempt with invalid argument exeption.',
+				'level' => ILogger::ERROR,
+				'app' => 'ocs_api',
+			]);
+			throw new OCSException($e->getMessage(), 101);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed addUser attempt with exception.',


### PR DESCRIPTION
Provide the user with some more info than just 'Bad request'.

Source of the messages in question: https://github.com/nextcloud/server/blob/master/lib/private/User/Manager.php#L351