### PR TITLE
Fix hover background for dark mode

### DIFF
--- a/apps/accessibility/css/dark.scss
+++ b/apps/accessibility/css/dark.scss
@@ -2,8 +2,9 @@
 $color-main-text: #d8d8d8;
 $color-main-background: #181818;
 
-$color-background-dark: lighten($color-main-background, 4%);
-$color-background-darker: lighten($color-main-background, 8%);
+$color-background-hover: lighten($color-main-background, 4%);
+$color-background-dark: lighten($color-main-background, 7%);
+$color-background-darker: lighten($color-main-background, 14%);
 
 $color-placeholder-light: lighten($color-main-background, 10%);
 $color-placeholder-dark: lighten($color-main-background, 20%);


### PR DESCRIPTION
To me it always felt a bit weird that hovering is still darker in dark mode. Now I noticed that `$color-background-hover` is missing from dark.scss and I think it's an oversight.

![Bildschirmfoto von 2021-02-12 13-14-10](https://user-images.githubusercontent.com/213943/107767220-f15c0a00-6d34-11eb-95bb-12bc43eea874.png)

Also I adjusted the percentages a bit to properly match the shades of "non-dark"