### PR TITLE
dont show trusted proxy warning when the proxy and remote are both localhost

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -313,7 +313,7 @@ class CheckSetupController extends Controller {
 			return false;
 		}
 
-		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies, true)) {
+		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies, true) && $remoteAddress !== '127.0.0.1') {
 			return $remoteAddress !== $this->request->getRemoteAddress();
 		}
 


### PR DESCRIPTION
This is a pretty small edge case, since it requires accessing nextcloud on localhost.

When 127.0.0.1 is setup as a trusted proxy (notify_push wants this as it acts as a proxy for it's auth request) and you're accessing the nextcloud instance from localhost, it triggers the setup warning against insecure trusted proxy setups.

Since localhost should always be trusted, this warning only adds confusion.