### PR TITLE
use the configured forwarded headers for the setup check

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -309,7 +309,14 @@ class CheckSetupController extends Controller {
 		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
 		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
 
-		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host') !== '') {
+		$forwardedForHeaders = $this->config->getSystemValue('forwarded_for_headers', [
+			'HTTP_X_FORWARDED_FOR'
+		]);
+		$hasForwardedHeaderSet = array_reduce($forwardedForHeaders, function($set, $header) {
+			return $set || ($this->request->getHeader($header) !== '');
+		}, false);
+
+		if (empty($trustedProxies) && $hasForwardedHeaderSet) {
 			return false;
 		}
 


### PR DESCRIPTION
instead of always checking against the same header (which isn't even the correct one 🙈 )