### PR TITLE
Make new result parts optional

### DIFF
--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -115,10 +115,10 @@ class AutoCompleteController extends Controller {
 				$output[] = [
 					'id' => (string) $result['value']['shareWith'],
 					'label' => $result['label'],
-					'icon' => $result['icon'],
+					'icon' => $result['icon'] ?? '',
 					'source' => $type,
-					'status' => $result['status'],
-					'subline' => $result['subline']
+					'status' => $result['status'] ?? '',
+					'subline' => $result['subline'] ?? '',
 				];
 			}
 		}


### PR DESCRIPTION
Found in company log:
```
"message":{"Exception":"Error","Message":"Undefined index: icon at /var/www/html/core/Controller/AutoCompleteController.php#118"
"message":{"Exception":"Error","Message":"Undefined index: status at /var/www/html/core/Controller/AutoCompleteController.php#120"
"message":{"Exception":"Error","Message":"Undefined index: subline at /var/www/html/core/Controller/AutoCompleteController.php#121"
```

Regression from e7f5516b4d04c16ed2c12dcc9c9c5f34d9f1f73b