### PR TITLE
Add HTTP client method to allow unsafe local connections

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -609,7 +609,7 @@ $CONFIG = [
  *
  * Defaults to false
  */
-'allow_local_remote_servers' => true,
+'allow_local_remote_servers' => false,
 
 /**
  * Deleted Items (trash bin)

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -57,6 +57,8 @@ class Client implements IClient {
 	private $logger;
 	/** @var ICertificateManager */
 	private $certificateManager;
+	/** @var bool */
+	private $localConnectionsAllowed = false;
 
 	public function __construct(
 		IConfig $config,
@@ -156,7 +158,8 @@ class Client implements IClient {
 	}
 
 	protected function preventLocalAddress(string $uri, array $options): void {
-		if (($options['nextcloud']['allow_local_address'] ?? false) ||
+		if ($this->localConnectionsAllowed ||
+			($options['nextcloud']['allow_local_address'] ?? false) ||
 			$this->config->getSystemValueBool('allow_local_remote_servers', false)) {
 			return;
 		}
@@ -200,6 +203,19 @@ class Client implements IClient {
 				throw new LocalServerException('Host violates local access rules');
 			}
 		}
+	}
+
+	/**
+	 * @internal
+	 *
+	 * Override allow_local_remote_servers config value
+	 * **Warning** Only use this method if you know what you are doing.
+	 *
+	 * @return IClient The client itself
+	 */
+	public function allowUnsafeLocalConnection_I_KNOW_WHAT_I_AM_DOING(): IClient {
+		$this->localConnectionsAllowed = true;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
After this method is called, `preventLocalAddress()` does not check things anymore (for this Client instance only).

This is one solution to let apps (like whiteboard integration) make requests to localhost while having `allow_local_remote_servers` server setting disabled.