### PR TITLE
Set overwriteprotocol to HTTPS in Codespace

### DIFF
--- a/.devcontainer/codespace.config.php
+++ b/.devcontainer/codespace.config.php
@@ -14,4 +14,5 @@ $CONFIG = [
 
 if($cloudEnvironmentId !== true) {
     $CONFIG['overwritehost'] = $cloudEnvironmentId . '-80.apps.codespaces.githubusercontent.com';
+    $CONFIG['overwriteprotocol'] = 'https';
 }


### PR DESCRIPTION
Codespace is serving everything only as HTTPS. To keep the URLs valid, we also need to overwrite the protocol. (otherwise e.g. you can't develop the SAML app as the URLs are invalid)

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>