### PR TITLE
Drop redundant indes

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>WebDAV</name>
 	<summary>WebDAV endpoint</summary>
 	<description>WebDAV endpoint</description>
-	<version>1.17.1</version>
+	<version>1.17.2</version>
 	<licence>agpl</licence>
 	<author>owncloud.org</author>
 	<namespace>DAV</namespace>

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -236,6 +236,7 @@ return array(
     'OCA\\DAV\\Migration\\Version1011Date20190806104428' => $baseDir . '/../lib/Migration/Version1011Date20190806104428.php',
     'OCA\\DAV\\Migration\\Version1012Date20190808122342' => $baseDir . '/../lib/Migration/Version1012Date20190808122342.php',
     'OCA\\DAV\\Migration\\Version1016Date20201109085907' => $baseDir . '/../lib/Migration/Version1016Date20201109085907.php',
+    'OCA\\DAV\\Migration\\Version1017Date20210216083742' => $baseDir . '/../lib/Migration/Version1017Date20210216083742.php',
     'OCA\\DAV\\Provisioning\\Apple\\AppleProvisioningNode' => $baseDir . '/../lib/Provisioning/Apple/AppleProvisioningNode.php',
     'OCA\\DAV\\Provisioning\\Apple\\AppleProvisioningPlugin' => $baseDir . '/../lib/Provisioning/Apple/AppleProvisioningPlugin.php',
     'OCA\\DAV\\RootCollection' => $baseDir . '/../lib/RootCollection.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -251,6 +251,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Migration\\Version1011Date20190806104428' => __DIR__ . '/..' . '/../lib/Migration/Version1011Date20190806104428.php',
         'OCA\\DAV\\Migration\\Version1012Date20190808122342' => __DIR__ . '/..' . '/../lib/Migration/Version1012Date20190808122342.php',
         'OCA\\DAV\\Migration\\Version1016Date20201109085907' => __DIR__ . '/..' . '/../lib/Migration/Version1016Date20201109085907.php',
+        'OCA\\DAV\\Migration\\Version1017Date20210216083742' => __DIR__ . '/..' . '/../lib/Migration/Version1017Date20210216083742.php',
         'OCA\\DAV\\Provisioning\\Apple\\AppleProvisioningNode' => __DIR__ . '/..' . '/../lib/Provisioning/Apple/AppleProvisioningNode.php',
         'OCA\\DAV\\Provisioning\\Apple\\AppleProvisioningPlugin' => __DIR__ . '/..' . '/../lib/Provisioning/Apple/AppleProvisioningPlugin.php',
         'OCA\\DAV\\RootCollection' => __DIR__ . '/..' . '/../lib/RootCollection.php',

--- a/apps/dav/lib/Migration/Version1017Date20210216083742.php
+++ b/apps/dav/lib/Migration/Version1017Date20210216083742.php
@@ -3,11 +3,8 @@
 declare(strict_types=1);
 
 /**
+ * @copyright Copyright (c) 2021 Roeland Jago Douma <roeland@famdouma.nl>
  *
- *
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author Daniel Kesselberg <mail@danielkesselberg.de>
- * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @license GNU AGPL version 3 or any later version
@@ -26,10 +23,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\DAV\Migration;
 
 use Closure;
-use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -37,41 +34,21 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version1011Date20190806104428 extends SimpleMigrationStep {
+class Version1017Date20210216083742 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->createTable('dav_cal_proxy');
-		$table->addColumn('id', Types::BIGINT, [
-			'autoincrement' => true,
-			'notnull' => true,
-			'length' => 11,
-			'unsigned' => true,
-		]);
-		$table->addColumn('owner_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('proxy_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('permissions', Types::INTEGER, [
-			'notnull' => false,
-			'length' => 4,
-			'unsigned' => true,
-		]);
-
-		$table->setPrimaryKey(['id']);
-		$table->addUniqueIndex(['owner_id', 'proxy_id', 'permissions'], 'dav_cal_proxy_uidx');
-		$table->addIndex(['proxy_id'], 'dav_cal_proxy_ipid');
+		$table = $schema->getTable('dav_cal_proxy');
+		if ($table->hasIndex('dav_cal_proxy_ioid')) {
+			$table->dropIndex('dav_cal_proxy_ioid');
+		}
 
 		return $schema;
 	}

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -9,7 +9,7 @@ This application enables administrators to configure connections to external sto
 
 External storage can be configured using the GUI or at the command line. This second option provides the advanced user with more flexibility for configuring bulk external storage mounts and setting mount priorities. More information is available in the external storage GUI documentation and the external storage Configuration File documentation.
 	</description>
-	<version>1.12.0</version>
+	<version>1.12.1</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<author>Michael Gapczynski</author>

--- a/apps/files_external/lib/Migration/Version1011Date20200630192246.php
+++ b/apps/files_external/lib/Migration/Version1011Date20200630192246.php
@@ -96,7 +96,6 @@ class Version1011Date20200630192246 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['applicable_id']);
 			$table->addIndex(['mount_id'], 'applicable_mount');
-			$table->addIndex(['type', 'value'], 'applicable_type_value');
 			$table->addUniqueIndex(['type', 'value', 'mount_id'], 'applicable_type_value_mount');
 		}
 
@@ -120,7 +119,6 @@ class Version1011Date20200630192246 extends SimpleMigrationStep {
 				'length' => 4096,
 			]);
 			$table->setPrimaryKey(['config_id']);
-			$table->addIndex(['mount_id'], 'config_mount');
 			$table->addUniqueIndex(['mount_id', 'key'], 'config_mount_key');
 		} else {
 			$table = $schema->getTable('external_config');
@@ -150,7 +148,6 @@ class Version1011Date20200630192246 extends SimpleMigrationStep {
 				'length' => 256,
 			]);
 			$table->setPrimaryKey(['option_id']);
-			$table->addIndex(['mount_id'], 'option_mount');
 			$table->addUniqueIndex(['mount_id', 'key'], 'option_mount_key');
 		}
 		return $schema;

--- a/apps/files_external/lib/Migration/Version22000Date20210216084416.php
+++ b/apps/files_external/lib/Migration/Version22000Date20210216084416.php
@@ -3,11 +3,8 @@
 declare(strict_types=1);
 
 /**
+ * @copyright Copyright (c) 2021 Roeland Jago Douma <roeland@famdouma.nl>
  *
- *
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author Daniel Kesselberg <mail@danielkesselberg.de>
- * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @license GNU AGPL version 3 or any later version
@@ -26,10 +23,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\DAV\Migration;
+
+namespace OCA\Files_External\Migration;
 
 use Closure;
-use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -37,41 +34,31 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version1011Date20190806104428 extends SimpleMigrationStep {
+class Version22000Date20210216084416 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->createTable('dav_cal_proxy');
-		$table->addColumn('id', Types::BIGINT, [
-			'autoincrement' => true,
-			'notnull' => true,
-			'length' => 11,
-			'unsigned' => true,
-		]);
-		$table->addColumn('owner_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('proxy_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('permissions', Types::INTEGER, [
-			'notnull' => false,
-			'length' => 4,
-			'unsigned' => true,
-		]);
+		$table = $schema->getTable('external_applicable');
+		if ($table->hasIndex('applicable_type_value')) {
+			$table->dropIndex('applicable_type_value');
+		}
 
-		$table->setPrimaryKey(['id']);
-		$table->addUniqueIndex(['owner_id', 'proxy_id', 'permissions'], 'dav_cal_proxy_uidx');
-		$table->addIndex(['proxy_id'], 'dav_cal_proxy_ipid');
+		$table = $schema->getTable('external_config');
+		if ($table->hasIndex('config_mount')) {
+			$table->dropIndex('config_mount');
+		}
+
+		$table = $schema->getTable('external_options');
+		if ($table->hasIndex('option_mount')) {
+			$table->dropIndex('option_mount');
+		}
 
 		return $schema;
 	}

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -9,7 +9,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.13.1</version>
+	<version>1.13.2</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -65,6 +65,7 @@ return array(
     'OCA\\Files_Sharing\\Migration\\SetPasswordColumn' => $baseDir . '/../lib/Migration/SetPasswordColumn.php',
     'OCA\\Files_Sharing\\Migration\\Version11300Date20201120141438' => $baseDir . '/../lib/Migration/Version11300Date20201120141438.php',
     'OCA\\Files_Sharing\\Migration\\Version21000Date20201223143245' => $baseDir . '/../lib/Migration/Version21000Date20201223143245.php',
+    'OCA\\Files_Sharing\\Migration\\Version22000Date20210216084241' => $baseDir . '/../lib/Migration/Version22000Date20210216084241.php',
     'OCA\\Files_Sharing\\MountProvider' => $baseDir . '/../lib/MountProvider.php',
     'OCA\\Files_Sharing\\Notification\\Listener' => $baseDir . '/../lib/Notification/Listener.php',
     'OCA\\Files_Sharing\\Notification\\Notifier' => $baseDir . '/../lib/Notification/Notifier.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -80,6 +80,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Migration\\SetPasswordColumn' => __DIR__ . '/..' . '/../lib/Migration/SetPasswordColumn.php',
         'OCA\\Files_Sharing\\Migration\\Version11300Date20201120141438' => __DIR__ . '/..' . '/../lib/Migration/Version11300Date20201120141438.php',
         'OCA\\Files_Sharing\\Migration\\Version21000Date20201223143245' => __DIR__ . '/..' . '/../lib/Migration/Version21000Date20201223143245.php',
+        'OCA\\Files_Sharing\\Migration\\Version22000Date20210216084241' => __DIR__ . '/..' . '/../lib/Migration/Version22000Date20210216084241.php',
         'OCA\\Files_Sharing\\MountProvider' => __DIR__ . '/..' . '/../lib/MountProvider.php',
         'OCA\\Files_Sharing\\Notification\\Listener' => __DIR__ . '/..' . '/../lib/Notification/Listener.php',
         'OCA\\Files_Sharing\\Notification\\Notifier' => __DIR__ . '/..' . '/../lib/Notification/Notifier.php',

--- a/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
+++ b/apps/files_sharing/lib/Migration/Version11300Date20201120141438.php
@@ -105,7 +105,6 @@ class Version11300Date20201120141438 extends SimpleMigrationStep {
 				'default' => 0,
 			]);
 			$table->setPrimaryKey(['id']);
-			$table->addIndex(['user'], 'sh_external_user');
 			$table->addUniqueIndex(['user', 'mountpoint_hash'], 'sh_external_mp');
 		} else {
 			$table = $schema->getTable('share_external');

--- a/apps/files_sharing/lib/Migration/Version22000Date20210216084241.php
+++ b/apps/files_sharing/lib/Migration/Version22000Date20210216084241.php
@@ -3,11 +3,8 @@
 declare(strict_types=1);
 
 /**
+ * @copyright Copyright (c) 2021 Roeland Jago Douma <roeland@famdouma.nl>
  *
- *
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author Daniel Kesselberg <mail@danielkesselberg.de>
- * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @license GNU AGPL version 3 or any later version
@@ -26,10 +23,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\DAV\Migration;
+
+namespace OCA\Files_Sharing\Migration;
 
 use Closure;
-use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -37,41 +34,21 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version1011Date20190806104428 extends SimpleMigrationStep {
+class Version22000Date20210216084241 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->createTable('dav_cal_proxy');
-		$table->addColumn('id', Types::BIGINT, [
-			'autoincrement' => true,
-			'notnull' => true,
-			'length' => 11,
-			'unsigned' => true,
-		]);
-		$table->addColumn('owner_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('proxy_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('permissions', Types::INTEGER, [
-			'notnull' => false,
-			'length' => 4,
-			'unsigned' => true,
-		]);
-
-		$table->setPrimaryKey(['id']);
-		$table->addUniqueIndex(['owner_id', 'proxy_id', 'permissions'], 'dav_cal_proxy_uidx');
-		$table->addIndex(['proxy_id'], 'dav_cal_proxy_ipid');
+		$table = $schema->getTable('share_external');
+		if ($table->hasIndex('sh_external_user')) {
+			$table->dropIndex('sh_external_user');
+		}
 
 		return $schema;
 	}

--- a/core/Migrations/Version22000Date20210216080825.php
+++ b/core/Migrations/Version22000Date20210216080825.php
@@ -3,11 +3,8 @@
 declare(strict_types=1);
 
 /**
+ * @copyright Copyright (c) 2021 Roeland Jago Douma <roeland@famdouma.nl>
  *
- *
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author Daniel Kesselberg <mail@danielkesselberg.de>
- * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @license GNU AGPL version 3 or any later version
@@ -26,10 +23,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OCA\DAV\Migration;
+
+namespace OC\Core\Migrations;
 
 use Closure;
-use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -37,41 +34,31 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version1011Date20190806104428 extends SimpleMigrationStep {
+class Version22000Date20210216080825 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->createTable('dav_cal_proxy');
-		$table->addColumn('id', Types::BIGINT, [
-			'autoincrement' => true,
-			'notnull' => true,
-			'length' => 11,
-			'unsigned' => true,
-		]);
-		$table->addColumn('owner_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('proxy_id', Types::STRING, [
-			'notnull' => true,
-			'length' => 64,
-		]);
-		$table->addColumn('permissions', Types::INTEGER, [
-			'notnull' => false,
-			'length' => 4,
-			'unsigned' => true,
-		]);
+		$table = $schema->getTable('appconfig');
+		if ($table->hasIndex('appconfig_appid_key')) {
+			$table->dropIndex('appconfig_appid_key');
+		}
 
-		$table->setPrimaryKey(['id']);
-		$table->addUniqueIndex(['owner_id', 'proxy_id', 'permissions'], 'dav_cal_proxy_uidx');
-		$table->addIndex(['proxy_id'], 'dav_cal_proxy_ipid');
+		$table = $schema->getTable('collres_accesscache');
+		if ($table->hasIndex('collres_user_coll')) {
+			$table->dropIndex('collres_user_coll');
+		}
+
+		$table = $schema->getTable('mounts');
+		if ($table->hasIndex('mounts_user_index')) {
+			$table->dropIndex('mounts_user_index');
+		}
 
 		return $schema;
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -945,6 +945,7 @@ return array(
     'OC\\Core\\Migrations\\Version21000Date20201120141228' => $baseDir . '/core/Migrations/Version21000Date20201120141228.php',
     'OC\\Core\\Migrations\\Version21000Date20201202095923' => $baseDir . '/core/Migrations/Version21000Date20201202095923.php',
     'OC\\Core\\Migrations\\Version21000Date20210119195004' => $baseDir . '/core/Migrations/Version21000Date20210119195004.php',
+    'OC\\Core\\Migrations\\Version22000Date20210216080825' => $baseDir . '/core/Migrations/Version22000Date20210216080825.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -974,6 +974,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version21000Date20201120141228' => __DIR__ . '/../../..' . '/core/Migrations/Version21000Date20201120141228.php',
         'OC\\Core\\Migrations\\Version21000Date20201202095923' => __DIR__ . '/../../..' . '/core/Migrations/Version21000Date20201202095923.php',
         'OC\\Core\\Migrations\\Version21000Date20210119195004' => __DIR__ . '/../../..' . '/core/Migrations/Version21000Date20210119195004.php',
+        'OC\\Core\\Migrations\\Version22000Date20210216080825' => __DIR__ . '/../../..' . '/core/Migrations/Version22000Date20210216080825.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 0];
+$OC_Version = [22, 0, 0, 1];
 
 // The human readable string
 $OC_VersionString = '22.0.0 alpha';


### PR DESCRIPTION
Those indexes are already covered by others. So those can just be used.
THose extra indexes just take up space.