### PR TITLE
Drop \OCP\Util::isIe

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -306,7 +306,7 @@ class ViewController extends Controller {
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
 		$params['showgridview'] = $this->config->getUserValue($user, 'files', 'show_grid', false);
-		$params['isIE'] = \OCP\Util::isIE();
+		$params['isIE'] = \OC_Util::isIe();
 		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', false);
 		$params['showHiddenFiles'] = $showHidden ? 1 : 0;
 		$cropImagePreviews = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'crop_image_previews', true);

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -28,7 +28,7 @@ $userSession = \OC::$server->getUserSession();
 $publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'list', '');

--- a/apps/files/recentlist.php
+++ b/apps/files/recentlist.php
@@ -28,7 +28,7 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files', 'recentlist', '');
 

--- a/apps/files/simplelist.php
+++ b/apps/files/simplelist.php
@@ -27,7 +27,7 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'simplelist', '');

--- a/apps/files_external/list.php
+++ b/apps/files_external/list.php
@@ -28,7 +28,7 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', true);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_external', 'list', '');
 

--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -36,7 +36,7 @@ $legacyEventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher = \OC::$server->get(OCP\EventDispatcher\IEventDispatcher::class);
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_sharing', 'list', '');
 

--- a/apps/files_trashbin/list.php
+++ b/apps/files_trashbin/list.php
@@ -30,7 +30,7 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = \OCP\Util::isIE();
+$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_trashbin', 'index', '');
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -80,7 +80,7 @@ class TemplateLayout extends \OC_Template {
 		/** @var IInitialStateService */
 		$this->initialState = \OC::$server->get(IInitialStateService::class);
 
-		if (Util::isIE()) {
+		if (\OC_Util::isIe()) {
 			Util::addStyle('ie');
 		}
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -521,14 +521,4 @@ class Util {
 		}
 		return self::$needUpgradeCache;
 	}
-
-	/**
-	 * is this Internet explorer ?
-	 *
-	 * @return boolean
-	 * @since 14.0.0
-	 */
-	public static function isIe() {
-		return \OC_Util::isIe();
-	}
 }


### PR DESCRIPTION
This was deprecated more than three years ago.