### PR TITLE
Drop \OCP\Defaults::getLogoClaim

### DIFF
--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -142,16 +142,6 @@ class Defaults {
 	}
 
 	/**
-	 * logo claim
-	 * @return string
-	 * @since 6.0.0
-	 * @deprecated 13.0.0
-	 */
-	public function getLogoClaim() {
-		return '';
-	}
-
-	/**
 	 * footer, short version
 	 * @return string
 	 * @since 6.0.0

--- a/themes/example/defaults.php
+++ b/themes/example/defaults.php
@@ -77,15 +77,6 @@ class OC_Theme {
 	}
 
 	/**
-	 * Returns logo claim
-	 * @return string logo claim
-	 * @deprecated 13.0.0 not used anymore
-	 */
-	public function getLogoClaim() {
-		return '';
-	}
-
-	/**
 	 * Returns short version of the footer
 	 * @return string short footer
 	 */


### PR DESCRIPTION
This was deprecated three years ago -> :fire: 