### PR TITLE
apply object store copy optimization when 'cross storage' copy is wit…

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -39,6 +39,7 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
+use OCP\Files\Storage\IStorage;
 
 class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	use CopyDirectory;
@@ -528,6 +529,19 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 	public function getObjectStore(): IObjectStore {
 		return $this->objectStore;
+	}
+
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class)) {
+			/** @var ObjectStoreStorage $sourceStorage */
+			if ($sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
+				$sourceEntry = $sourceStorage->getCache()->get($sourceInternalPath);
+				$this->copyInner($sourceEntry, $targetInternalPath);
+				return true;
+			}
+		}
+
+		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
 	public function copy($path1, $path2) {

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -48,7 +48,7 @@ class Jail extends Wrapper {
 	protected $rootPath;
 
 	/**
-	 * @param array $arguments ['storage' => $storage, 'mask' => $root]
+	 * @param array $arguments ['storage' => $storage, 'root' => $root]
 	 *
 	 * $storage: The storage that will be wrapper
 	 * $root: The folder in the wrapped storage that will become the root folder of the wrapped storage

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -22,6 +22,7 @@ namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\StorageObjectStore;
 use OC\Files\Storage\Temporary;
+use OC\Files\Storage\Wrapper\Jail;
 use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\Storage;
 
@@ -203,5 +204,28 @@ class ObjectStoreStorageTest extends Storage {
 
 		$this->assertTrue($cache->inCache('foo'));
 		$this->assertTrue($cache->inCache('foo/test.txt'));
+	}
+
+	public function testCopyBetweenJails() {
+		$this->instance->mkdir('a');
+		$this->instance->mkdir('b');
+		$jailA = new Jail([
+			'storage' => $this->instance,
+			'root' => 'a'
+		]);
+		$jailB = new Jail([
+			'storage' => $this->instance,
+			'root' => 'b'
+		]);
+		$jailA->mkdir('sub');
+		$jailA->file_put_contents('1.txt', '1');
+		$jailA->file_put_contents('sub/2.txt', '2');
+		$jailA->file_put_contents('sub/3.txt', '3');
+
+		$jailB->copyFromStorage($jailA, '', 'target');
+
+		$this->assertEquals('1', $this->instance->file_get_contents('b/target/1.txt'));
+		$this->assertEquals('2', $this->instance->file_get_contents('b/target/sub/2.txt'));
+		$this->assertEquals('3', $this->instance->file_get_contents('b/target/sub/3.txt'));
 	}
 }


### PR DESCRIPTION
…hin the same object store

This applies to copying from/to groupfolders, shares, etc.