### PR TITLE
token login: emit preLogin event with LoginName

### DIFF
--- a/apps/sharebymail/lib/Settings/SettingsManager.php
+++ b/apps/sharebymail/lib/Settings/SettingsManager.php
@@ -70,7 +70,7 @@ class SettingsManager {
 	 * @return bool
 	 */
 	public function replyToInitiator(): bool {
-		$replyToInitiator =  $this->config->getAppValue('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
+		$replyToInitiator = $this->config->getAppValue('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
 		return $replyToInitiator === 'yes';
 	}
 }

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -647,7 +647,7 @@ class Session implements IUserSession, Emitter {
 			// Ignore and use empty string instead
 		}
 
-		$this->manager->emit('\OC\User', 'preLogin', [$uid, $password]);
+		$this->manager->emit('\OC\User', 'preLogin', [$dbToken->getLoginName(), $password]);
 
 		$user = $this->manager->get($uid);
 		if (is_null($user)) {


### PR DESCRIPTION
to bring it in line with normal (non-token) login.

Signed-off-by: Lionel Elie Mamane <lionel@mamane.lu>