### PR TITLE
Disable basic PHP completion in Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,4 +16,7 @@
 		"felixfbecker.php-intellisense",
 		"ms-azuretools.vscode-docker"
 	],
+	"settings": {
+		"php.suggest.basic": false,
+	}
 }


### PR DESCRIPTION
This competes with the completions provided by
https://github.com/felixfbecker/vscode-php-intellisense.

Thus disabling the completions is recommended.

**Before (lots of wrong recommendations)**

![Screenshot 2021-02-22 at 12 30 00](https://user-images.githubusercontent.com/878997/108703315-bdd66800-750a-11eb-80fb-f9a0d705b406.png)

**After (correct recommendations)**

![Screenshot 2021-02-22 at 12 36 51](https://user-images.githubusercontent.com/878997/108703313-bd3dd180-750a-11eb-9074-5f953defcd5f.png)
