### PR TITLE
Include RichObject for forms

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -349,6 +349,31 @@ class Definitions {
 				],
 			],
 		],
+		'forms-form' => [
+			'author' => 'Nextcloud',
+			'app' => 'forms',
+			'since' => '21.0.1',
+			'parameters' => [
+				'id' => [
+					'since' => '21.0.1',
+					'required' => true,
+					'description' => 'The form-hash of the form',
+					'example' => 'q72GGqbfbLBC6xNB',
+				],
+				'name' => [
+					'since' => '21.0.1',
+					'required' => true,
+					'description' => 'The title of the form',
+					'example' => 'Nice Form',
+				],
+				'link' => [
+					'since' => '21.0.1',
+					'required' => true,
+					'description' => 'The full URL to the board',
+					'example' => 'http://localhost/index.php/apps/forms/q72GGqbfbLBC6xNB',
+				],
+			],
+		],
 		'guest' => [
 			'author' => 'Nextcloud',
 			'app' => 'spreed',


### PR DESCRIPTION
Includes the form-richObject for Events/Activities. Ref. https://github.com/nextcloud/forms/pull/789

@nickvergessen I'm not completely sure, what to set as `since`. I now set `21.0.1` as this seems to me like the 'next' release. However, this PR is now on master (so `22.0.0`?), Forms still supports 19, so `19.0.10` with a backport? 🙈