### PR TITLE
Don't allow executing cli if cache backend is unavailable

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -86,34 +86,14 @@ class Factory implements ICacheFactory {
 		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
 		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
 		if (!class_exists($localCacheClass) || !$localCacheClass::isAvailable()) {
-			if (\OC::$CLI && !defined('PHPUNIT_RUN')) {
-				// CLI should not hard-fail on broken memcache
-				$this->logger->info($missingCacheMessage, [
-					'class' => $localCacheClass,
-					'use' => 'local',
-					'app' => 'cli'
-				]);
-				$localCacheClass = self::NULL_CACHE;
-			} else {
-				throw new \OC\HintException(strtr($missingCacheMessage, [
-					'{class}' => $localCacheClass, '{use}' => 'local'
-				]), $missingCacheHint);
-			}
+			throw new \OC\HintException(strtr($missingCacheMessage, [
+				'{class}' => $localCacheClass, '{use}' => 'local'
+			]), $missingCacheHint);
 		}
 		if (!class_exists($distributedCacheClass) || !$distributedCacheClass::isAvailable()) {
-			if (\OC::$CLI && !defined('PHPUNIT_RUN')) {
-				// CLI should not hard-fail on broken memcache
-				$this->logger->info($missingCacheMessage, [
-					'class' => $distributedCacheClass,
-					'use' => 'distributed',
-					'app' => 'cli'
-				]);
-				$distributedCacheClass = self::NULL_CACHE;
-			} else {
-				throw new \OC\HintException(strtr($missingCacheMessage, [
-					'{class}' => $distributedCacheClass, '{use}' => 'distributed'
-				]), $missingCacheHint);
-			}
+			throw new \OC\HintException(strtr($missingCacheMessage, [
+				'{class}' => $distributedCacheClass, '{use}' => 'distributed'
+			]), $missingCacheHint);
 		}
 		if (!($lockingCacheClass && class_exists($distributedCacheClass) && $lockingCacheClass::isAvailable())) {
 			// don't fallback since the fallback might not be suitable for storing lock


### PR DESCRIPTION
Fix #25742 

# Bug
Currently, cli code can be executed even if the configured cache backend is unavailable. In this case, the cache factory is logging a warning instead of throwing an exception.

**Problem:** The cache factory is pulling a logger dependency which pulls the user manager and since https://github.com/nextcloud/server/pull/25440 it is pulling a cache factory. Now the the whole thing starts over and repeats until the process runs out of memory.

# Solution
I propose the cli to fail if a cache backend is unavailable because some pieces of the server code expect a cache backend to be initialized in any case. Furthermore, there is an explicit warning regarding APCu setups in the admin documentation because it needs some extra configuration to be available in cli environments.

![warning](https://user-images.githubusercontent.com/1479486/108887162-2b1cf280-760a-11eb-85ef-3cdd421e1de1.png)

# Debugging
I added a print statement to `ServerContainer.php/query()` that prints the name of the requested dependency. 
<details>
<summary>Here is an excerpt showing the recursion</summary>

Look for OC\Log -> OC\User\Manager -> OC\Memcache\Factory -> OC\Log -> ...

```
Querying OC\EventDispatcher\SymfonyAdapter
Querying OC\EventDispatcher\EventDispatcher
Querying Symfony\Component\EventDispatcher\EventDispatcher
Querying OCP\IServerContainer
Querying Psr\Log\LoggerInterface
Querying OC\Log\PsrLoggerAdapter
Querying OCP\ILogger
Querying OC\Log
Querying OC\AllConfig
Querying OC\SystemConfig
Querying OC\SystemConfig
Querying OCP\Support\CrashReport\IRegistry
Querying OC\Support\CrashReport\Registry
Querying OCP\IServerContainer
Querying OC\SystemConfig
Querying OCP\ILogger
Querying OC\Log
Querying OCP\EventDispatcher\IEventDispatcher
Querying OC\EventDispatcher\EventDispatcher
Querying OC\Files\Node\HookConnector
Querying OCP\Files\IRootFolder
Querying OCP\Lock\ILockingProvider
Querying bantu\IniGetWrapper\IniGetWrapper
Querying OCP\IConfig
Querying OC\AllConfig
Querying OCP\ICacheFactory
Querying OC\Memcache\Factory
Querying OCP\ILogger
Querying OC\Log
Querying OCP\IConfig
Querying OC\AllConfig
Querying OCP\IAppConfig
Querying OC\AppConfig
Querying OC\DB\Connection
Querying OC\SystemConfig
Querying OC\SystemConfig
Querying OCP\ILogger
Querying OC\Log
Querying OCP\Diagnostics\IQueryLogger
Querying OC\SystemConfig
Querying OC\SystemConfig
Querying OCP\ILogger
Querying OC\Log
Querying bantu\IniGetWrapper\IniGetWrapper
Querying bantu\IniGetWrapper\IniGetWrapper
Querying OCP\IRequest
Querying OCP\Security\ISecureRandom
Querying OC\Security\SecureRandom
Querying OCP\IConfig
Querying OC\AllConfig
Querying OC\Security\CSRF\CsrfTokenManager
Querying OC\Security\CSRF\CsrfTokenGenerator
Querying OCP\Security\ISecureRandom
Querying OC\Security\SecureRandom
Querying OC\Security\CSRF\TokenStorage\SessionStorage
Querying OCP\ISession
Querying OCP\IUserSession
Querying OC\User\Session
Querying OCP\IUserManager
Querying OC\User\Manager
Querying OCP\IConfig
Querying OC\AllConfig
Querying Symfony\Component\EventDispatcher\EventDispatcherInterface
Querying OC\EventDispatcher\SymfonyAdapter
Querying OCP\ICacheFactory
Querying OC\Memcache\Factory
Querying OCP\ILogger
Querying OC\Log
Querying OCP\IConfig
Querying OC\AllConfig
Querying OC\SystemConfig
Querying OCP\ILogger
Querying OC\Log
Querying bantu\IniGetWrapper\IniGetWrapper
Querying bantu\IniGetWrapper\IniGetWrapper
Querying OCP\IRequest
Querying OCP\Security\ISecureRandom
Querying OC\Security\SecureRandom
Querying OCP\IConfig
Querying OC\AllConfig
Querying OC\Security\CSRF\CsrfTokenManager
Querying OC\Security\CSRF\CsrfTokenGenerator
Querying OC\Security\CSRF\TokenStorage\SessionStorage
Querying OCP\ISession
Querying OCP\IUserSession
Querying OC\User\Session
Querying OCP\IUserManager
Querying OC\User\Manager
Querying OCP\IConfig
Querying OC\AllConfig
Querying Symfony\Component\EventDispatcher\EventDispatcherInterface
Querying OC\EventDispatcher\SymfonyAdapter
Querying OCP\ICacheFactory
Querying OC\Memcache\Factory
Querying OCP\ILogger
Querying OC\Log
Querying OCP\IConfig
Querying OC\AllConfig
Querying OC\SystemConfig
Querying OCP\ILogger
Querying OC\Log
```
</details>

---

This is a breaking change because occ and cron jobs won't be working anymore on some (misconfigured) ACPu setups. If someone can come up with a better solution or this is too much of a breaking change, feel free to close the PR.