### PR TITLE
Only write checksum if we have a valid file info

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -680,9 +680,12 @@ class File extends Node implements IFile {
 	/**
 	 * Get the checksum for this file
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function getChecksum() {
+		if (!$this->info) {
+			return null;
+		}
 		return $this->info->getChecksum();
 	}
 


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/issues/16263 https://github.com/nextcloud/server/issues/10359

I don't yet know why this happens or if we also have to fix the missing file info. But this code is not checking for the possible `false` value of the file info after it had been "refreshed".