### PR TITLE
Remove double space in sharebymail SettingsManager

### DIFF
--- a/apps/sharebymail/lib/Settings/SettingsManager.php
+++ b/apps/sharebymail/lib/Settings/SettingsManager.php
@@ -70,7 +70,7 @@ class SettingsManager {
 	 * @return bool
 	 */
 	public function replyToInitiator(): bool {
-		$replyToInitiator =  $this->config->getAppValue('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
+		$replyToInitiator = $this->config->getAppValue('sharebymail', 'replyToInitiator', $this->replyToInitiatorDefault);
 		return $replyToInitiator === 'yes';
 	}
 }


### PR DESCRIPTION
so php-cs stops complaining