### PR TITLE
Register service aliases und parameters just once

### DIFF
--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -46,6 +46,7 @@ use OCP\ILogger;
 use OCP\Search\IProvider;
 use OCP\Support\CrashReport\IReporter;
 use Throwable;
+use function array_shift;
 
 class RegistrationContext {
 
@@ -370,7 +371,7 @@ class RegistrationContext {
 			}
 		}
 
-		foreach ($this->aliases as $registration) {
+		while (($registration = array_shift($this->aliases)) !== null) {
 			try {
 				$apps[$registration->getAppId()]
 					->getContainer()
@@ -387,7 +388,7 @@ class RegistrationContext {
 			}
 		}
 
-		foreach ($this->parameters as $registration) {
+		while (($registration = array_shift($this->parameters)) !== null) {
 			try {
 				$apps[$registration->getAppId()]
 					->getContainer()


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/24711

Leftover of https://github.com/nextcloud/server/pull/24164

So basically what happened is that registration is run for all enabled apps, all the things are delegated and cleaned up but not the aliases and params. Then a new app gets enabled, we do async registration but the previous aliases and params are also re-registered, but the `$apps` then won't have the other application instances any more -> :boom: 