### PR TITLE
Do not attempt to read 0 bytes when manually iterating over a non-seekable file

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -456,7 +456,7 @@ class View {
 				// forward file handle via chunked fread because fseek seem to have failed
 
 				$end = $from + 1;
-				while (!feof($handle) && ftell($handle) < $end) {
+				while (!feof($handle) && ftell($handle) < $end && ftell($handle) !== $from) {
 					$len = $from - ftell($handle);
 					if ($len > $chunkSize) {
 						$len = $chunkSize;


### PR DESCRIPTION
This makes sure that when fseek fails and we iterate over a file with fread in order to get to the requested chunk, the manual seek doesn't error by trying to read 0 bytes when the expected from position is reached.

Should fix occurences of: `fread(): Length parameter must be greater than 0 at /var/www/nextcloud/lib/private/Files/View.php#460`