### PR TITLE
Card::getOwner should return the actual value

### DIFF
--- a/apps/contactsinteraction/lib/Card.php
+++ b/apps/contactsinteraction/lib/Card.php
@@ -53,7 +53,7 @@ class Card implements ICard, IACL {
 	 * @inheritDoc
 	 */
 	public function getOwner(): ?string {
-		$this->principal;
+		return $this->principal;
 	}
 
 	/**


### PR DESCRIPTION
I guess we never call this at runtime or it would already ahve done boom
very loudly.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>