### PR TITLE
Filter out tables that does not belong to Nextcloud

### DIFF
--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -181,9 +181,9 @@ class Migrator {
 			/** @var string|AbstractAsset $asset */
 			$filterExpression = $this->getFilterExpression();
 			if ($asset instanceof AbstractAsset) {
-				return preg_match($filterExpression, $asset->getName()) !== false;
+				return preg_match($filterExpression, $asset->getName()) === 1;
 			}
-			return preg_match($filterExpression, $asset) !== false;
+			return preg_match($filterExpression, $asset) === 1;
 		});
 		return $this->connection->getSchemaManager()->createSchema();
 	}
@@ -210,9 +210,9 @@ class Migrator {
 			/** @var string|AbstractAsset $asset */
 			$filterExpression = $this->getFilterExpression();
 			if ($asset instanceof AbstractAsset) {
-				return preg_match($filterExpression, $asset->getName()) !== false;
+				return preg_match($filterExpression, $asset->getName()) === 1;
 			}
-			return preg_match($filterExpression, $asset) !== false;
+			return preg_match($filterExpression, $asset) === 1;
 		});
 		$sourceSchema = $connection->getSchemaManager()->createSchema();
 


### PR DESCRIPTION
Fix #25748 

Some people run into `Unknown database type enum requested, Doctrine\\DBAL\\Platforms\\MariaDb1027Platform may not support it.` on upgrade to 21. Yet we are not using enums in Nextcloud. But phpmyadmin does and some have tables by phpMyAdmin in their Nextcloud database. 

Turns out our filter for the database tables does not work. 

**How to test:**

```
Index: core/Command/Maintenance/Repair.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/core/Command/Maintenance/Repair.php b/core/Command/Maintenance/Repair.php
--- a/core/Command/Maintenance/Repair.php	(revision fc6b5a25f0233f7de3e46a546f4604a5b19df4f0)
+++ b/core/Command/Maintenance/Repair.php	(date 1614700816722)
@@ -86,6 +86,8 @@
 			$repairSteps = array_merge($repairSteps, $this->repair::getExpensiveRepairSteps());
 		}
 
+		$repairSteps = $this->repair::getBeforeUpgradeRepairSteps();
+
 		foreach ($repairSteps as $step) {
 			$this->repair->addStep($step);
 		}
```

- Create a table `testtest` in your Nextcloud database
- Patch occ maintenance:repair like above
- Set a breakpoint `lib/private/DB/Migrator.createSchema`
- Run occ maintenance:repair