### PR TITLE
Fix docblock return type for IShareProvider

### DIFF
--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -124,7 +124,7 @@ interface IShareProvider {
 	 * @param string $userId
 	 * @param Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the shares where $user is the initiator
-	 * @return \OCP\Share\IShare[]
+	 * @return \OCP\Share\IShare[][]
 	 * @since 11.0.0
 	 */
 	public function getSharesInFolder($userId, Folder $node, $reshares);


### PR DESCRIPTION
All the implementations already returned an array of array of shares. So
better to make sure the docblock also doesn't lie.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>