### PR TITLE
Remove trash items from other trash backends when deleting all

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -50,6 +50,9 @@ class TrashRoot implements ICollection {
 
 	public function delete() {
 		\OCA\Files_Trashbin\Trashbin::deleteAll();
+		foreach ($this->trashManager->listTrashRoot($this->user) as $trashItem) {
+			$this->trashManager->removeItem($trashItem);
+		}
 	}
 
 	public function getName(): string {


### PR DESCRIPTION
When selecting all files from the trashbin to delete other trash backend implementations like groupfolders were never triggered so the files were still kept in the trashbin.