### PR TITLE
Only mark migrations as installed after execution

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -453,8 +453,6 @@ class MigrationService {
 			$toSchema = $instance->changeSchema($this->output, function () use ($toSchema) {
 				return $toSchema ?: new SchemaWrapper($this->connection);
 			}, ['tablePrefix' => $this->connection->getPrefix()]) ?: $toSchema;
-
-			$this->markAsExecuted($version);
 		}
 
 		if ($toSchema instanceof SchemaWrapper) {
@@ -465,6 +463,10 @@ class MigrationService {
 			}
 			$this->connection->migrateToSchema($targetSchema);
 			$toSchema->performDropTableCalls();
+		}
+
+		foreach ($toBeExecuted as $version) {
+			$this->markAsExecuted($version);
 		}
 	}
 


### PR DESCRIPTION
The problem is that if a developer creates a structural error in their migration file,
they will already be marked as executed and an not be rerun.

Happened to @Rello in the analytics app.