### PR TITLE
Sharebymail: set expiration on creation

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -321,7 +321,8 @@ class ShareByMailProvider implements IShareProvider {
 			$share->getToken(),
 			$share->getPassword(),
 			$share->getSendPasswordByTalk(),
-			$share->getHideDownload()
+			$share->getHideDownload(),
+			$share->getExpirationDate()
 		);
 
 		try {
@@ -658,9 +659,10 @@ class ShareByMailProvider implements IShareProvider {
 	 * @param string $password
 	 * @param bool $sendPasswordByTalk
 	 * @param bool $hideDownload
+	 * @param \DateTime|null $expirationTime
 	 * @return int
 	 */
-	protected function addShareToDB($itemSource, $itemType, $shareWith, $sharedBy, $uidOwner, $permissions, $token, $password, $sendPasswordByTalk, $hideDownload) {
+	protected function addShareToDB($itemSource, $itemType, $shareWith, $sharedBy, $uidOwner, $permissions, $token, $password, $sendPasswordByTalk, $hideDownload, $expirationTime) {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->insert('share')
 			->setValue('share_type', $qb->createNamedParameter(IShare::TYPE_EMAIL))
@@ -676,6 +678,10 @@ class ShareByMailProvider implements IShareProvider {
 			->setValue('password_by_talk', $qb->createNamedParameter($sendPasswordByTalk, IQueryBuilder::PARAM_BOOL))
 			->setValue('stime', $qb->createNamedParameter(time()))
 			->setValue('hide_download', $qb->createNamedParameter((int)$hideDownload, IQueryBuilder::PARAM_INT));
+
+		if ($expirationTime !== null) {
+			$qb->setValue('expiration', $qb->createNamedParameter($expirationTime, IQueryBuilder::PARAM_DATE));
+		}
 
 		/*
 		 * Added to fix https://github.com/owncloud/core/issues/22215

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -524,6 +524,7 @@ class ShareByMailProviderTest extends TestCase {
 		$password = 'password';
 		$sendPasswordByTalk = true;
 		$hideDownload = true;
+		$expiration = new \DateTime();
 
 
 		$instance = $this->getInstance();
@@ -540,7 +541,8 @@ class ShareByMailProviderTest extends TestCase {
 				$token,
 				$password,
 				$sendPasswordByTalk,
-				$hideDownload
+				$hideDownload,
+				$expiration
 			]
 		);
 
@@ -565,6 +567,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->assertSame($password, $result[0]['password']);
 		$this->assertSame($sendPasswordByTalk, (bool)$result[0]['password_by_talk']);
 		$this->assertSame($hideDownload, (bool)$result[0]['hide_download']);
+		$this->assertSame($expiration->getTimestamp(), \DateTime::createFromFormat('Y-m-d H:i:s', $result[0]['expiration'])->getTimestamp());
 	}
 
 	public function testUpdate() {


### PR DESCRIPTION
@tobiasKaminsky now sure if this is used by clients at all? But they can now.