### PR TITLE
Skip empty obsolete owner when adding to own NC

### DIFF
--- a/apps/federatedfilesharing/js/external.js
+++ b/apps/federatedfilesharing/js/external.js
@@ -99,7 +99,7 @@
 			var fileList = this.filesApp.fileList;
 			var params = OC.Util.History.parseUrlQuery();
 			// manually add server-to-server share
-			if (params.remote && params.token && params.owner && params.name) {
+			if (params.remote && params.token && params.name) {
 
 				var callbackAddShare = function(result, share) {
 					var password = share.password || '';


### PR DESCRIPTION
### Description

The owner field is nowadays always empty when adding a federated share
using "Add to your Nextcloud", so don't check for it.

Fixes an issue where "Add to your Nextcloud" doesn't add anything.

I could confirm that the owner is not relevant looking at this code here from the related API: https://github.com/nextcloud/server/blob/bugfix/noid/fix-fed-share-add-to-nc/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php#L184

### Issue
#### Steps to reproduce

1. Setup two NC instances A and B (I used NC 22 / git master for A and NC 20.0.7.1 for B)
2. Make sure to set `allow_local_remote_servers` => true to config.php of both instances
3. Login to B as admin
4. Create a folder "add_to_nc"
5. Share "add_to_nc" with link and copy the link
6. Open the link
7. Click the three dots on the top right and pick "Add to your Nextcloud"
8. Enter the address of A then confirm
9. Observe the URL and when the "#remote" part appears, try to copy it quickly for further inspection
10. Wait

#### Before the fix
No dialog appears, nothing is mounted.

#### After the fix
A dialog appears and asks you to confirm that you want to mount it.
After confirming, a notification is received later on.
Accepting the notification properly mounts the share

#### Further information

If you check the "#remote" hash URL part you'll see that "owner" is empty.
The JS code was still expecting the owner to be set, otherwise it would ignore the request.
The fix removes that requirement.

Not sure what NC version stopped setting the owner field in the public link page ?
