### PR TITLE
Deprecate getHTMLName on \OCP\Defaults

### DIFF
--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -118,6 +118,7 @@ class Defaults {
 	 * name of your ownCloud instance containing HTML styles
 	 * @return string
 	 * @since 8.0.0
+	 * @depreacted 22.0.0
 	 */
 	public function getHTMLName() {
 		return $this->defaults->getHTMLName();


### PR DESCRIPTION
There is no use of this I could find in my checked out projects and with the theming app we also don't support adding html to the instance name