### PR TITLE
Add missing waits and asserts in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/AppNavigationContext.php
+++ b/tests/acceptance/features/bootstrap/AppNavigationContext.php
@@ -112,14 +112,24 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 	 * @Then I see that the section :section is shown
 	 */
 	public function iSeeThatTheSectionIsShown($section) {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::appNavigationSectionItemFor($section));
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::appNavigationSectionItemFor($section),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The section $section in the app navigation is not shown yet after $timeout seconds");
+		}
 	}
 
 	/**
 	 * @Then I see that the section :section is not shown
 	 */
 	public function iSeeThatTheSectionIsNotShown($section) {
-		WaitFor::elementToBeEventuallyNotShown($this->actor, self::appNavigationSectionItemFor($section));
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::appNavigationSectionItemFor($section),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The section $section in the app navigation is still shown after $timeout seconds");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/AppSettingsContext.php
@@ -95,6 +95,11 @@ class AppSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the settings are opened
 	 */
 	public function iSeeThatTheSettingsAreOpened() {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::appSettingsContent());
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::appSettingsContent(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The app settings are not open yet after $timeout seconds");
+		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/AppSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/AppSettingsContext.php
@@ -81,14 +81,7 @@ class AppSettingsContext implements Context, ActorAwareInterface {
 	 * @Given I toggle the :id checkbox in the settings
 	 */
 	public function iToggleTheCheckboxInTheSettingsTo($id) {
-		$locator = self::CheckboxInTheSettings($id);
-
-		// If locator is not visible, fallback to label
-		if (!$this->actor->find(self::CheckboxInTheSettings($id), 10)->isVisible()) {
-			$locator = self::checkboxLabelInTheSettings($id);
-		}
-
-		$this->actor->find($locator, 10)->click();
+		$this->actor->find(self::checkboxLabelInTheSettings($id), 10)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/AppSettingsContext.php
@@ -74,7 +74,7 @@ class AppSettingsContext implements Context, ActorAwareInterface {
 	 * @Given I open the settings
 	 */
 	public function iOpenTheSettings() {
-		$this->actor->find(self::appSettingsOpenButton())->click();
+		$this->actor->find(self::appSettingsOpenButton(), 10)->click();
 	}
 
 	/**
@@ -84,11 +84,11 @@ class AppSettingsContext implements Context, ActorAwareInterface {
 		$locator = self::CheckboxInTheSettings($id);
 
 		// If locator is not visible, fallback to label
-		if (!$this->actor->find(self::CheckboxInTheSettings($id))->isVisible()) {
+		if (!$this->actor->find(self::CheckboxInTheSettings($id), 10)->isVisible()) {
 			$locator = self::checkboxLabelInTheSettings($id);
 		}
 
-		$this->actor->find($locator)->click();
+		$this->actor->find($locator, 10)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -48,6 +48,15 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function enableButtonForAnyApp() {
+		return Locator::forThe()->button("Enable")->
+				descendantOf(self::appsList())->
+				describedAs("Enable button in the app list for any app");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function downloadAndEnableButtonForApp($app) {
 		return Locator::forThe()->button("Download and enable")->
 				descendantOf(self::rowForApp($app))->
@@ -61,6 +70,15 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 		return Locator::forThe()->button("Disable")->
 				descendantOf(self::rowForApp($app))->
 				describedAs("Disable button in the app list for $app");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function disableButtonForAnyApp() {
+		return Locator::forThe()->button("Disable")->
+				descendantOf(self::appsList())->
+				describedAs("Disable button in the app list for any app");
 	}
 
 	/**
@@ -195,16 +213,24 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Given /^I see that there are only disabled apps$/
 	 */
 	public function iSeeThatThereAreOnlyDisabledApps() {
-		$buttons = $this->actor->getSession()->getDriver()->find("//input[@value = 'Disable']");
-		PHPUnit\Framework\Assert::assertEmpty($buttons, 'Found disabled apps');
+		try {
+			$this->actor->find(self::disableButtonForAnyApp(), 2);
+
+			PHPUnit_Framework_Assert::fail("Found enabled apps");
+		} catch (NoSuchElementException $exception) {
+		}
 	}
 
 	/**
 	 * @Given /^I see that there are only enabled apps$/
 	 */
 	public function iSeeThatThereAreOnlyEnabledApps() {
-		$buttons = $this->actor->getSession()->getDriver()->find("//input[@value = 'Enable']");
-		PHPUnit\Framework\Assert::assertEmpty($buttons, 'Found disabled apps');
+		try {
+			$this->actor->find(self::enableButtonForAnyApp(), 2);
+
+			PHPUnit_Framework_Assert::fail("Found disabled apps");
+		} catch (NoSuchElementException $exception) {
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -84,10 +84,10 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
-	public static function bundleButton($bundle) {
-		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input")->
+	public static function enableAllBundleButton($bundle) {
+		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input[@value='Enable all']")->
 				descendantOf(self::appsList())->
-				describedAs("Button to enable / disable bundles");
+				describedAs("Button to enable bundles");
 	}
 
 	/**
@@ -245,14 +245,16 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @When /^I enable all apps from the "([^"]*)"$/
 	 */
 	public function iEnableAllAppsFromThe($bundle) {
-		$this->actor->find(self::bundleButton($bundle), 2)->click();
+		$this->actor->find(self::enableAllBundleButton($bundle), 2)->click();
 	}
 
 	/**
 	 * @Given /^I see that the "([^"]*)" is disabled$/
 	 */
 	public function iSeeThatTheIsDisabled($bundle) {
-		PHPUnit\Framework\Assert::assertEquals('Enable all', $this->actor->find(self::bundleButton($bundle), 2)->getValue());
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::enableAllBundleButton($bundle), 2)->isVisible()
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -164,7 +164,12 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Then /^I see that there some apps listed from the app store$/
 	 */
 	public function iSeeThatThereSomeAppsListedFromTheAppStore() {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::appEntries(), 10);
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::appEntries(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The apps from the app store were not shown yet after $timeout seconds");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -170,7 +170,9 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheAppHasBeenEnabled($app) {
 		// TODO: Find a way to check if the enable button is removed
-		$this->actor->find(self::disableButtonForApp($app), 10);
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::disableButtonForApp($app), 10)->isVisible()
+		);
 	}
 
 	/**
@@ -178,7 +180,9 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheAppHasBeenDisabled($app) {
 		// TODO: Find a way to check if the disable button is removed
-		$this->actor->find(self::enableButtonForApp($app), 10);
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::enableButtonForApp($app), 10)->isVisible()
+		);
 	}
 
 	/**
@@ -237,8 +241,12 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Given /^I see the app bundles$/
 	 */
 	public function iSeeTheAppBundles() {
-		$this->actor->find(self::rowForApp('Auditing / Logging'), 2);
-		$this->actor->find(self::rowForApp('LDAP user and group backend'), 2);
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::rowForApp('Auditing / Logging'), 2)->isVisible()
+		);
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->actor->find(self::rowForApp('LDAP user and group backend'), 2)->isVisible()
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -33,8 +33,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function enableButtonForApp($app) {
 		return Locator::forThe()->button("Enable")->
-			descendantOf(self::rowForApp($app))->
-			describedAs("Enable button in the app list for $app");
+				descendantOf(self::rowForApp($app))->
+				describedAs("Enable button in the app list for $app");
 	}
 
 	/**
@@ -42,8 +42,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function downloadAndEnableButtonForApp($app) {
 		return Locator::forThe()->button("Download and enable")->
-		descendantOf(self::rowForApp($app))->
-		describedAs("Download & enable button in the app list for $app");
+				descendantOf(self::rowForApp($app))->
+				describedAs("Download & enable button in the app list for $app");
 	}
 
 	/**
@@ -51,8 +51,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function disableButtonForApp($app) {
 		return Locator::forThe()->button("Disable")->
-		descendantOf(self::rowForApp($app))->
-		describedAs("Disable button in the app list for $app");
+				descendantOf(self::rowForApp($app))->
+				describedAs("Disable button in the app list for $app");
 	}
 
 	/**
@@ -60,7 +60,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function bundleButton($bundle) {
 		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input")->
-		describedAs("Button to enable / disable bundles");
+				describedAs("Button to enable / disable bundles");
 	}
 
 	/**
@@ -76,7 +76,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function emptyAppList() {
 		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@id='apps-list-empty']")->
-			describedAs("Empty apps list view");
+				describedAs("Empty apps list view");
 	}
 
 	/**
@@ -84,7 +84,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function appEntries() {
 		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@class='section']")->
-			describedAs("Entries in apps list");
+				describedAs("Entries in apps list");
 	}
 
 	/**
@@ -92,8 +92,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function disabledAppEntries() {
 		return Locator::forThe()->button("Disable")->
-		descendantOf(self::appEntries())->
-		describedAs("Disable button in the app list");
+				descendantOf(self::appEntries())->
+				describedAs("Disable button in the app list");
 	}
 
 	/**
@@ -101,8 +101,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function enabledAppEntries() {
 		return Locator::forThe()->button("Enable")->
-		descendantOf(self::appEntries())->
-		describedAs("Enable button in the app list");
+				descendantOf(self::appEntries())->
+				describedAs("Enable button in the app list");
 	}
 
 	/**
@@ -110,7 +110,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public static function sidebar() {
 		return Locator::forThe()->xpath("//*[@id=\"app-sidebar\" or contains(@class, 'app-sidebar')]")->
-		describedAs("Sidebar in apps management");
+				describedAs("Sidebar in apps management");
 	}
 
 

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -209,7 +209,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Given /^I see that the "([^"]*)" is disabled$/
 	 */
 	public function iSeeThatTheIsDisabled($bundle) {
-		PHPUnit\Framework\Assert::assertEquals('Enable all', $this->actor->find(self::bundleButton($bundle))->getValue());
+		PHPUnit\Framework\Assert::assertEquals('Enable all', $this->actor->find(self::bundleButton($bundle), 2)->getValue());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -31,6 +31,14 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	/**
 	 * @return Locator
 	 */
+	public static function appsList() {
+		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@id='apps-list']")->
+				describedAs("Apps list in Apps Management");
+	}
+
+	/**
+	 * @return Locator
+	 */
 	public static function enableButtonForApp($app) {
 		return Locator::forThe()->button("Enable")->
 				descendantOf(self::rowForApp($app))->
@@ -59,7 +67,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function bundleButton($bundle) {
-		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input")->
+		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input")->
+				descendantOf(self::appsList())->
 				describedAs("Button to enable / disable bundles");
 	}
 
@@ -67,7 +76,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function rowForApp($app) {
-		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@class='app-name'][normalize-space() = '$app']/..")->
+		return Locator::forThe()->xpath("//div[@class='app-name'][normalize-space() = '$app']/..")->
+				descendantOf(self::appsList())->
 				describedAs("Row for app $app in Apps Management");
 	}
 
@@ -75,7 +85,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function emptyAppList() {
-		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@id='apps-list-empty']")->
+		return Locator::forThe()->xpath("//div[@id='apps-list-empty']")->
+				descendantOf(self::appsList())->
 				describedAs("Empty apps list view");
 	}
 
@@ -83,7 +94,8 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function appEntries() {
-		return Locator::forThe()->xpath("//main[@id='app-content' or contains(@class, 'app-content')]//div[@class='section']")->
+		return Locator::forThe()->xpath("//div[@class='section']")->
+				descendantOf(self::appsList())->
 				describedAs("Entries in apps list");
 	}
 

--- a/tests/acceptance/features/bootstrap/DialogContext.php
+++ b/tests/acceptance/features/bootstrap/DialogContext.php
@@ -38,7 +38,7 @@ class DialogContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function theDialogButton($text) {
-		return Locator::forThe()->xpath("//button[normalize-space() = '$text']")->
+		return Locator::forThe()->xpath("//button[normalize-space() = \"$text\"]")->
 			descendantOf(self::theDialog())->
 			describedAs($text . " button of the dialog");
 	}

--- a/tests/acceptance/features/bootstrap/DialogContext.php
+++ b/tests/acceptance/features/bootstrap/DialogContext.php
@@ -54,13 +54,23 @@ class DialogContext implements Context, ActorAwareInterface {
 	 * @Then I see that the confirmation dialog is shown
 	 */
 	public function iSeeThatTheConfirmationDialogIsShown() {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::theDialog());
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::theDialog(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The confirmation dialog was not shown yet after $timeout seconds");
+		}
 	}
 
 	/**
 	 * @Then I see that the confirmation dialog is not shown
 	 */
 	public function iSeeThatTheConfirmationDialogIsNotShown() {
-		WaitFor::elementToBeEventuallyNotShown($this->actor, self::theDialog());
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::theDialog(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The confirmation dialog is still shown after $timeout seconds");
+		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -176,21 +176,21 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @When I click the New user button
 	 */
 	public function iClickTheNewUserButton() {
-		$this->actor->find(self::newUserButton())->click();
+		$this->actor->find(self::newUserButton(), 10)->click();
 	}
 
 	/**
 	 * @When I click the :action action in the :user actions menu
 	 */
 	public function iClickTheAction($action, $user) {
-		$this->actor->find(self::theAction($action, $user))->click();
+		$this->actor->find(self::theAction($action, $user), 10)->click();
 	}
 
 	/**
 	 * @When I open the actions menu for the user :user
 	 */
 	public function iOpenTheActionsMenuOf($user) {
-		$this->actor->find(self::actionsMenuOf($user))->click();
+		$this->actor->find(self::actionsMenuOf($user), 10)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -267,14 +267,24 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the list of users contains the user :user
 	 */
 	public function iSeeThatTheListOfUsersContainsTheUser($user) {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::rowForUser($user));
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::rowForUser($user),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The user $user in the list of users is not shown yet after $timeout seconds");
+		}
 	}
 
 	/**
 	 * @Then I see that the list of users does not contains the user :user
 	 */
 	public function iSeeThatTheListOfUsersDoesNotContainsTheUser($user) {
-		WaitFor::elementToBeEventuallyNotShown($this->actor, self::rowForUser($user));
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::rowForUser($user),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The user $user in the list of users is still shown after $timeout seconds");
+		}
 	}
 
 	/**
@@ -321,8 +331,26 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :cell cell for user :user is done loading
 	 */
 	public function iSeeThatTheCellForUserIsDoneLoading($cell, $user) {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::classCellForUser($cell . ' icon-loading-small', $user));
-		WaitFor::elementToBeEventuallyNotShown($this->actor, self::classCellForUser($cell . ' icon-loading-small', $user));
+		// It could happen that the cell for the user was done loading and thus
+		// the loading icon hidden again even before finding the loading icon
+		// started. Therefore, if the loading icon could not be found it is just
+		// assumed that it was already hidden again. Nevertheless, this check
+		// should be done anyway to ensure that the following scenario steps are
+		// not executed before the cell for the user was done loading.
+		try {
+			$this->actor->find(self::classCellForUser($cell . ' icon-loading-small', $user), 1);
+		} catch (NoSuchElementException $exception) {
+			echo "The loading icon for user $user was not found after " . (1 * $this->actor->getFindTimeoutMultiplier()) . " seconds, assumming that it was shown and hidden again before the check started and continuing";
+
+			return;
+		}
+
+		if (!WaitFor::elementToBeEventuallyNotShown(
+				$this->actor,
+				self::classCellForUser($cell . ' icon-loading-small', $user),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The loading icon for user $user is still shown after $timeout seconds");
+		}
 	}
 
 	/**
@@ -337,6 +365,11 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the edit mode is on for user :user
 	 */
 	public function iSeeThatTheEditModeIsOn($user) {
-		WaitFor::elementToBeEventuallyShown($this->actor, self::editModeOn($user));
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::editModeOn($user),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			PHPUnit_Framework_Assert::fail("The edit mode for user $user in the list of users is not on yet after $timeout seconds");
+		}
 	}
 }

--- a/tests/acceptance/features/users.feature
+++ b/tests/acceptance/features/users.feature
@@ -30,6 +30,7 @@ Feature: users
     And I open the actions menu for the user user0
     And I see that the "Delete user" action in the user0 actions menu is shown
     When I click the "Delete user" action in the user0 actions menu
+    And I click the "Delete user0's account" button of the confirmation dialog
     Then I see that the list of users does not contains the user user0
 
   Scenario: disable a user


### PR DESCRIPTION
This pull request should make some acceptance tests more robust as now it will be properly waited for the elements. Additionally, as some asserts were added too, it should make the tests fail at the right step if something does not pass. Ironically adding the missing asserts could cause some tests to start failing sometimes if they were flaky, but based on a few runs it should be fine. I hope :-)

Due to all that and as it only touches the acceptance tests I would suggest to backport it (but if the backport fails feel free to ignore it).
