### PR TITLE
Update acceptance tests dependencies

### DIFF
--- a/tests/acceptance/composer.json
+++ b/tests/acceptance/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
-    "behat/behat": "3.7.0",
+    "behat/behat": "3.8.1",
     "behat/mink": "1.7.1",
     "behat/mink-extension": "2.3.1",
     "behat/mink-selenium2-driver": "1.3.1",

--- a/tests/acceptance/composer.json
+++ b/tests/acceptance/composer.json
@@ -4,7 +4,7 @@
     "behat/mink": "1.7.1",
     "behat/mink-extension": "2.3.1",
     "behat/mink-selenium2-driver": "1.3.1",
-    "phpunit/phpunit": "4.8.36"
+    "phpunit/phpunit": "6.5.14"
   },
   "autoload": {
     "psr-4": {

--- a/tests/acceptance/composer.json
+++ b/tests/acceptance/composer.json
@@ -1,7 +1,7 @@
 {
   "require-dev": {
     "behat/behat": "3.8.1",
-    "behat/mink": "1.7.1",
+    "behat/mink": "1.8.1",
     "behat/mink-extension": "2.3.1",
     "behat/mink-selenium2-driver": "1.4.0",
     "phpunit/phpunit": "6.5.14"

--- a/tests/acceptance/composer.json
+++ b/tests/acceptance/composer.json
@@ -3,7 +3,7 @@
     "behat/behat": "3.8.1",
     "behat/mink": "1.7.1",
     "behat/mink-extension": "2.3.1",
-    "behat/mink-selenium2-driver": "1.3.1",
+    "behat/mink-selenium2-driver": "1.4.0",
     "phpunit/phpunit": "6.5.14"
   },
   "autoload": {

--- a/tests/acceptance/composer.lock
+++ b/tests/acceptance/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f75fc126df5999c922c96e1593eabf31",
+    "content-hash": "23dccfe6d77917642d1be256dc842b55",
     "packages": [],
     "packages-dev": [
         {
@@ -265,30 +265,30 @@
         },
         {
             "name": "behat/mink-selenium2-driver",
-            "version": "v1.3.1",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/MinkSelenium2Driver.git",
-                "reference": "473a9f3ebe0c134ee1e623ce8a9c852832020288"
+                "reference": "312a967dd527f28980cce40850339cd5316da092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/MinkSelenium2Driver/zipball/473a9f3ebe0c134ee1e623ce8a9c852832020288",
-                "reference": "473a9f3ebe0c134ee1e623ce8a9c852832020288",
+                "url": "https://api.github.com/repos/minkphp/MinkSelenium2Driver/zipball/312a967dd527f28980cce40850339cd5316da092",
+                "reference": "312a967dd527f28980cce40850339cd5316da092",
                 "shasum": ""
             },
             "require": {
                 "behat/mink": "~1.7@dev",
                 "instaclick/php-webdriver": "~1.1",
-                "php": ">=5.3.1"
+                "php": ">=5.4"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "mink/driver-testsuite": "dev-master"
             },
             "type": "mink-driver",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
@@ -302,14 +302,14 @@
             ],
             "authors": [
                 {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
                     "name": "Pete Otaqui",
                     "email": "pete@otaqui.com",
                     "homepage": "https://github.com/pete-otaqui"
+                },
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
                 }
             ],
             "description": "Selenium2 (WebDriver) driver for Mink framework",
@@ -322,7 +322,7 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2016-03-05T09:10:18+00:00"
+            "time": "2020-03-11T14:43:21+00:00"
         },
         {
             "name": "behat/transliterator",

--- a/tests/acceptance/composer.lock
+++ b/tests/acceptance/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2680419ed5b247f3b4d21687a84ea2cf",
+    "content-hash": "9de2660d48d5c6093450dd25ddcbecd9",
     "packages": [],
     "packages-dev": [
         {
@@ -480,6 +480,156 @@
             "time": "2019-09-25T09:05:11+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.2.0",
             "source": {
@@ -690,39 +840,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -737,7 +888,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -748,7 +899,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -889,29 +1040,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -935,45 +1086,57 @@
                 "tokenizer"
             ],
             "abandoned": true,
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -981,7 +1144,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1007,30 +1170,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1038,7 +1204,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1053,7 +1219,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1064,7 +1230,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "psr/container",
@@ -1162,31 +1328,76 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2020-11-30T08:15:22+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1217,38 +1428,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1275,32 +1486,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1325,34 +1536,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1366,6 +1577,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1374,16 +1589,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1392,27 +1603,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2020-11-30T07:47:53+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1420,7 +1631,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1443,27 +1654,169 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2020-11-30T07:40:27+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-11-30T07:34:24+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
             },
             "type": "library",
             "extra": {
@@ -1482,37 +1835,37 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
                 }
             ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1531,7 +1884,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/config",
@@ -2659,31 +3012,35 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.47",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
+                "reference": "290ea5e03b8cf9b42c783163123f54441fb06939"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/290ea5e03b8cf9b42c783163123f54441fb06939",
+                "reference": "290ea5e03b8cf9b42c783163123f54441fb06939",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/console": "<3.4"
+                "symfony/console": "<4.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
             },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -2709,7 +3066,47 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2020-12-08T17:02:38+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/tests/acceptance/composer.lock
+++ b/tests/acceptance/composer.lock
@@ -4,41 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9de2660d48d5c6093450dd25ddcbecd9",
+    "content-hash": "f75fc126df5999c922c96e1593eabf31",
     "packages": [],
     "packages-dev": [
         {
             "name": "behat/behat",
-            "version": "v3.7.0",
+            "version": "v3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Behat.git",
-                "reference": "08052f739619a9e9f62f457a67302f0715e6dd13"
+                "reference": "fbb065457d523d9856d4b50775b4151a7598b510"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Behat/zipball/08052f739619a9e9f62f457a67302f0715e6dd13",
-                "reference": "08052f739619a9e9f62f457a67302f0715e6dd13",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/fbb065457d523d9856d4b50775b4151a7598b510",
+                "reference": "fbb065457d523d9856d4b50775b4151a7598b510",
                 "shasum": ""
             },
             "require": {
                 "behat/gherkin": "^4.6.0",
                 "behat/transliterator": "^1.2",
                 "ext-mbstring": "*",
-                "php": ">=5.3.3",
+                "php": "^7.2 || ^8.0",
                 "psr/container": "^1.0",
-                "symfony/config": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/console": "^2.7.51 || ^2.8.33 || ^3.3.15 || ^3.4.3 || ^4.0.3 || ^5.0",
-                "symfony/dependency-injection": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/event-dispatcher": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/translation": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/yaml": "^2.7.51 || ^3.0 || ^4.0 || ^5.0"
+                "symfony/config": "^4.4 || ^5.0",
+                "symfony/console": "^4.4 || ^5.0",
+                "symfony/dependency-injection": "^4.4 || ^5.0",
+                "symfony/event-dispatcher": "^4.4 || ^5.0",
+                "symfony/translation": "^4.4 || ^5.0",
+                "symfony/yaml": "^4.4 || ^5.0"
             },
             "require-dev": {
                 "container-interop/container-interop": "^1.2",
                 "herrera-io/box": "~1.6.1",
-                "phpunit/phpunit": "^4.8.36 || ^6.5.14 || ^7.5.20",
-                "symfony/process": "~2.5 || ^3.0 || ^4.0 || ^5.0"
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "symfony/process": "^4.4 || ^5.0"
             },
             "suggest": {
                 "ext-dom": "Needed to output test results in JUnit format."
@@ -49,7 +49,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.6.x-dev"
+                    "dev-master": "3.8.x-dev"
                 }
             },
             "autoload": {
@@ -69,7 +69,7 @@
                     "homepage": "http://everzet.com"
                 }
             ],
-            "description": "Scenario-oriented BDD framework for PHP 5.3",
+            "description": "Scenario-oriented BDD framework for PHP",
             "homepage": "http://behat.org/",
             "keywords": [
                 "Agile",
@@ -85,7 +85,7 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2020-06-03T13:08:44+00:00"
+            "time": "2020-11-07T15:55:18+00:00"
         },
         {
             "name": "behat/gherkin",

--- a/tests/acceptance/composer.lock
+++ b/tests/acceptance/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "23dccfe6d77917642d1be256dc842b55",
+    "content-hash": "d2c44a0ea2452a05e7f45d8ca6ef0387",
     "packages": [],
     "packages-dev": [
         {
@@ -148,35 +148,38 @@
         },
         {
             "name": "behat/mink",
-            "version": "v1.7.1",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/Mink.git",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9"
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/Mink/zipball/e6930b9c74693dff7f4e58577e1b1743399f3ff9",
-                "reference": "e6930b9c74693dff7f4e58577e1b1743399f3ff9",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
+                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.1",
-                "symfony/css-selector": "~2.1|~3.0"
+                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
                 "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
-                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)"
+                "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
+                "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -202,7 +205,7 @@
                 "testing",
                 "web"
             ],
-            "time": "2016-03-05T08:26:18+00:00"
+            "time": "2020-03-11T15:45:53+00:00"
         },
         {
             "name": "behat/mink-extension",
@@ -2027,20 +2030,20 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.47",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33"
+                "reference": "f789e7ead4c79e04ca9a6d6162fc629c89bd8054"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
-                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f789e7ead4c79e04ca9a6d6162fc629c89bd8054",
+                "reference": "f789e7ead4c79e04ca9a6d6162fc629c89bd8054",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5"
             },
             "type": "library",
             "autoload": {
@@ -2071,7 +2074,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2020-12-08T17:02:38+00:00"
         },
         {
             "name": "symfony/dependency-injection",

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -2,7 +2,7 @@ default:
   suites:
     default:
       paths:
-        - %paths.base%/../features
+        - "%paths.base%/../features"
       contexts:
         - ActorContext
         - NextcloudTestServerContext
@@ -31,7 +31,7 @@ default:
         tags: "~@apache"
     apache:
       paths:
-        - %paths.base%/../features
+        - "%paths.base%/../features"
       contexts:
         - ActorContext
         - NextcloudTestServerContext:

--- a/tests/acceptance/features/bootstrap/AppNavigationContext.php
+++ b/tests/acceptance/features/bootstrap/AppNavigationContext.php
@@ -23,6 +23,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class AppNavigationContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -105,7 +106,7 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current section is :section
 	 */
 	public function iSeeThatTheCurrentSectionIs($section) {
-		PHPUnit_Framework_Assert::assertEquals($this->actor->find(self::appNavigationCurrentSectionItem(), 10)->getText(), $section);
+		Assert::assertEquals($this->actor->find(self::appNavigationCurrentSectionItem(), 10)->getText(), $section);
 	}
 
 	/**
@@ -116,7 +117,7 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::appNavigationSectionItemFor($section),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The section $section in the app navigation is not shown yet after $timeout seconds");
+			Assert::fail("The section $section in the app navigation is not shown yet after $timeout seconds");
 		}
 	}
 
@@ -128,7 +129,7 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::appNavigationSectionItemFor($section),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The section $section in the app navigation is still shown after $timeout seconds");
+			Assert::fail("The section $section in the app navigation is still shown after $timeout seconds");
 		}
 	}
 
@@ -136,7 +137,7 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 	 * @Then I see that the section :section has a count of :count
 	 */
 	public function iSeeThatTheSectionHasACountOf($section, $count) {
-		PHPUnit_Framework_Assert::assertEquals($this->actor->find(self::counterForTheSection($section), 10)->getText(), $count);
+		Assert::assertEquals($this->actor->find(self::counterForTheSection($section), 10)->getText(), $count);
 	}
 
 	/**
@@ -147,7 +148,7 @@ class AppNavigationContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::counterForTheSection($section),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The counter for section $section is still shown after $timeout seconds");
+			Assert::fail("The counter for section $section is still shown after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/AppSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/AppSettingsContext.php
@@ -23,6 +23,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class AppSettingsContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -92,7 +93,7 @@ class AppSettingsContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::appSettingsContent(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The app settings are not open yet after $timeout seconds");
+			Assert::fail("The app settings are not open yet after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -24,6 +24,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class AppsManagementContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -170,7 +171,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheAppHasBeenEnabled($app) {
 		// TODO: Find a way to check if the enable button is removed
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::disableButtonForApp($app), 10)->isVisible()
 		);
 	}
@@ -180,7 +181,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheAppHasBeenDisabled($app) {
 		// TODO: Find a way to check if the disable button is removed
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::enableButtonForApp($app), 10)->isVisible()
 		);
 	}
@@ -189,7 +190,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Then /^I see that there are no available updates$/
 	 */
 	public function iSeeThatThereAreNoAvailableUpdates() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::emptyAppList(), 10)->isVisible()
 		);
 	}
@@ -202,7 +203,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::appEntries(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The apps from the app store were not shown yet after $timeout seconds");
+			Assert::fail("The apps from the app store were not shown yet after $timeout seconds");
 		}
 	}
 
@@ -220,7 +221,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 		try {
 			$this->actor->find(self::disableButtonForAnyApp(), 2);
 
-			PHPUnit_Framework_Assert::fail("Found enabled apps");
+			Assert::fail("Found enabled apps");
 		} catch (NoSuchElementException $exception) {
 		}
 	}
@@ -232,7 +233,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 		try {
 			$this->actor->find(self::enableButtonForAnyApp(), 2);
 
-			PHPUnit_Framework_Assert::fail("Found disabled apps");
+			Assert::fail("Found disabled apps");
 		} catch (NoSuchElementException $exception) {
 		}
 	}
@@ -241,10 +242,10 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Given /^I see the app bundles$/
 	 */
 	public function iSeeTheAppBundles() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::rowForApp('Auditing / Logging'), 2)->isVisible()
 		);
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::rowForApp('LDAP user and group backend'), 2)->isVisible()
 		);
 	}
@@ -260,7 +261,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @Given /^I see that the "([^"]*)" is disabled$/
 	 */
 	public function iSeeThatTheIsDisabled($bundle) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::enableAllBundleButton($bundle), 2)->isVisible()
 		);
 	}
@@ -276,7 +277,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 			$this->actor,
 			self::sidebar(),
 			$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The sidebar was not shown yet after $timeout seconds");
+			Assert::fail("The sidebar was not shown yet after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/CommentsAppContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsAppContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class CommentsAppContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -87,7 +88,7 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::emptyContent(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The no comments message is not visible yet after $timeout seconds");
+			Assert::fail("The no comments message is not visible yet after $timeout seconds");
 		}
 	}
 
@@ -95,7 +96,7 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	 * @Then /^I see a comment with "([^"]*)" as message$/
 	 */
 	public function iSeeACommentWithAsMessage($commentText) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::commentWithText($commentText), 10)->isVisible());
 	}
 
@@ -104,7 +105,7 @@ class CommentsAppContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatThereIsNoCommentWithAsMessage($commentText) {
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::commentWithText($commentText))->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}

--- a/tests/acceptance/features/bootstrap/ContactsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/ContactsMenuContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class ContactsMenuContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -88,7 +89,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the Contacts menu is shown
 	 */
 	public function iSeeThatTheContactsMenuIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::contactsMenu(), 10)->isVisible());
 	}
 
@@ -96,7 +97,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the Contacts menu search input is shown
 	 */
 	public function iSeeThatTheContactsMenuSearchInputIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::contactsMenuSearchInput(), 10)->isVisible());
 	}
 
@@ -104,7 +105,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the no results message in the Contacts menu is shown
 	 */
 	public function iSeeThatTheNoResultsMessageInTheContactsMenuIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::noResultsMessage(), 10)->isVisible());
 	}
 
@@ -112,7 +113,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the contact :contactName in the Contacts menu is shown
 	 */
 	public function iSeeThatTheContactInTheContactsMenuIsShown($contactName) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::menuItemFor($contactName), 10)->isVisible());
 	}
 
@@ -123,7 +124,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 		$this->iSeeThatThecontactsMenuIsShown();
 
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::menuItemFor($contactName))->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}
@@ -139,7 +140,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::menuItemFor($contactName),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The $contactName contact in Contacts menu is still shown after $timeout seconds");
+			Assert::fail("The $contactName contact in Contacts menu is still shown after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/DialogContext.php
+++ b/tests/acceptance/features/bootstrap/DialogContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class DialogContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -58,7 +59,7 @@ class DialogContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::theDialog(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The confirmation dialog was not shown yet after $timeout seconds");
+			Assert::fail("The confirmation dialog was not shown yet after $timeout seconds");
 		}
 	}
 
@@ -70,7 +71,7 @@ class DialogContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::theDialog(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The confirmation dialog is still shown after $timeout seconds");
+			Assert::fail("The confirmation dialog is still shown after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -126,9 +126,18 @@ class FileListContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function createNewFolderMenuItemNameInput($fileListAncestor) {
-		return Locator::forThe()->css(".filenameform input")->
+		return Locator::forThe()->css(".filenameform input[type=text]")->
 				descendantOf(self::createNewFolderMenuItem($fileListAncestor))->
 				describedAs("Name input in create new folder menu item in file list");
+	}
+
+	/**
+	 * @return Locator
+	 */
+	public static function createNewFolderMenuItemConfirmButton($fileListAncestor) {
+		return Locator::forThe()->css(".filenameform input[type=submit]")->
+				descendantOf(self::createNewFolderMenuItem($fileListAncestor))->
+				describedAs("Confirm button in create new folder menu item in file list");
 	}
 
 	/**
@@ -356,7 +365,8 @@ class FileListContext implements Context, ActorAwareInterface {
 		$this->actor->find(self::createMenuButton($this->fileListAncestor), 10)->click();
 
 		$this->actor->find(self::createNewFolderMenuItem($this->fileListAncestor), 2)->click();
-		$this->actor->find(self::createNewFolderMenuItemNameInput($this->fileListAncestor), 2)->setValue($folderName . "\r");
+		$this->actor->find(self::createNewFolderMenuItemNameInput($this->fileListAncestor), 2)->setValue($folderName);
+		$this->actor->find(self::createNewFolderMenuItemConfirmButton($this->fileListAncestor), 2)->click();
 	}
 
 	/**
@@ -410,7 +420,7 @@ class FileListContext implements Context, ActorAwareInterface {
 		// This should not be a problem, though, as the default behaviour is to
 		// bring the browser window to the foreground when switching to a
 		// different actor.
-		$this->actor->find(self::renameInputForFile($this->fileListAncestor, $fileName1), 10)->setValue($fileName2 . "\r");
+		$this->actor->find(self::renameInputForFile($this->fileListAncestor, $fileName1), 10)->setValue($fileName2);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FileListContext.php
+++ b/tests/acceptance/features/bootstrap/FileListContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class FileListContext implements Context, ActorAwareInterface {
 
@@ -476,7 +477,7 @@ class FileListContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::mainWorkingIcon($this->fileListAncestor),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The main working icon for the file list is still shown after $timeout seconds");
+			Assert::fail("The main working icon for the file list is still shown after $timeout seconds");
 		}
 	}
 
@@ -486,7 +487,7 @@ class FileListContext implements Context, ActorAwareInterface {
 	public function iSeeThatTheFileListIsCurrentlyIn($path) {
 		// The text of the breadcrumbs is the text of all the crumbs separated
 		// by white spaces.
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			str_replace('/', ' ', $path), $this->actor->find(self::breadcrumbs($this->fileListAncestor), 10)->getText());
 	}
 
@@ -496,14 +497,14 @@ class FileListContext implements Context, ActorAwareInterface {
 	public function iSeeThatItIsNotPossibleToCreateNewFiles() {
 		// Once a file list is loaded the "Create" menu button is always in the
 		// DOM, so it is checked if it is visible or not.
-		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::createMenuButton($this->fileListAncestor))->isVisible());
+		Assert::assertFalse($this->actor->find(self::createMenuButton($this->fileListAncestor))->isVisible());
 	}
 
 	/**
 	 * @Then I see that the file list contains a file named :fileName
 	 */
 	public function iSeeThatTheFileListContainsAFileNamed($fileName) {
-		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFile($this->fileListAncestor, $fileName), 10));
+		Assert::assertNotNull($this->actor->find(self::rowForFile($this->fileListAncestor, $fileName), 10));
 	}
 
 	/**
@@ -514,7 +515,7 @@ class FileListContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::rowForFile($this->fileListAncestor, $fileName),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The file list still contains a file named $fileName after $timeout seconds");
+			Assert::fail("The file list still contains a file named $fileName after $timeout seconds");
 		}
 	}
 
@@ -522,35 +523,35 @@ class FileListContext implements Context, ActorAwareInterface {
 	 * @Then I see that :fileName1 precedes :fileName2 in the file list
 	 */
 	public function iSeeThatPrecedesInTheFileList($fileName1, $fileName2) {
-		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::rowForFilePreceding($this->fileListAncestor, $fileName1, $fileName2), 10));
+		Assert::assertNotNull($this->actor->find(self::rowForFilePreceding($this->fileListAncestor, $fileName1, $fileName2), 10));
 	}
 
 	/**
 	 * @Then I see that :fileName is not selected
 	 */
 	public function iSeeThatIsNotSelected($fileName) {
-		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::selectionCheckboxInputForFile($this->fileListAncestor, $fileName), 10)->isChecked());
+		Assert::assertFalse($this->actor->find(self::selectionCheckboxInputForFile($this->fileListAncestor, $fileName), 10)->isChecked());
 	}
 
 	/**
 	 * @Then I see that :fileName is marked as favorite
 	 */
 	public function iSeeThatIsMarkedAsFavorite($fileName) {
-		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::favoritedStateIconForFile($this->fileListAncestor, $fileName), 10));
+		Assert::assertNotNull($this->actor->find(self::favoritedStateIconForFile($this->fileListAncestor, $fileName), 10));
 	}
 
 	/**
 	 * @Then I see that :fileName is not marked as favorite
 	 */
 	public function iSeeThatIsNotMarkedAsFavorite($fileName) {
-		PHPUnit_Framework_Assert::assertNotNull($this->actor->find(self::notFavoritedStateIconForFile($this->fileListAncestor, $fileName), 10));
+		Assert::assertNotNull($this->actor->find(self::notFavoritedStateIconForFile($this->fileListAncestor, $fileName), 10));
 	}
 
 	/**
 	 * @Then I see that :fileName has unread comments
 	 */
 	public function iSeeThatHasUnreadComments($fileName) {
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::commentActionForFile($this->fileListAncestor, $fileName), 10)->isVisible());
+		Assert::assertTrue($this->actor->find(self::commentActionForFile($this->fileListAncestor, $fileName), 10)->isVisible());
 	}
 
 	private function waitForRowForFileToBeFullyOpaque($fileName) {
@@ -567,7 +568,7 @@ class FileListContext implements Context, ActorAwareInterface {
 		};
 
 		if (!Utils::waitFor($fileRowIsFullyOpaqueCallback, $timeout = 2 * $this->actor->getFindTimeoutMultiplier(), $timeoutStep = 1)) {
-			PHPUnit_Framework_Assert::fail("The row for file $fileName in file list is not fully opaque after $timeout seconds");
+			Assert::fail("The row for file $fileName in file list is not fully opaque after $timeout seconds");
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class FilesAppContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -295,7 +296,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the Files app
 	 */
 	public function iSeeThatTheCurrentPageIsTheFilesApp() {
-		PHPUnit_Framework_Assert::assertStringStartsWith(
+		Assert::assertStringStartsWith(
 				$this->actor->locatePath("/apps/files/"),
 				$this->actor->getSession()->getCurrentUrl());
 
@@ -313,7 +314,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::detailsView(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The details view is not open yet after $timeout seconds");
+			Assert::fail("The details view is not open yet after $timeout seconds");
 		}
 	}
 
@@ -325,7 +326,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::detailsView(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The details view is not closed yet after $timeout seconds");
+			Assert::fail("The details view is not closed yet after $timeout seconds");
 		}
 	}
 
@@ -333,7 +334,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the file name shown in the details view is :fileName
 	 */
 	public function iSeeThatTheFileNameShownInTheDetailsViewIs($fileName) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::fileNameInDetailsView(), 10)->getText(), $fileName);
 	}
 
@@ -341,7 +342,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the file is marked as favorite in the details view
 	 */
 	public function iSeeThatTheFileIsMarkedAsFavoriteInTheDetailsView() {
-		PHPUnit_Framework_Assert::assertNotNull(
+		Assert::assertNotNull(
 				$this->actor->find(self::favoritedStateIconInFileDetailsInDetailsView(), 10));
 	}
 
@@ -349,7 +350,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the file is not marked as favorite in the details view
 	 */
 	public function iSeeThatTheFileIsNotMarkedAsFavoriteInTheDetailsView() {
-		PHPUnit_Framework_Assert::assertNotNull(
+		Assert::assertNotNull(
 				$this->actor->find(self::notFavoritedStateIconInFileDetailsInDetailsView(), 10));
 	}
 
@@ -357,7 +358,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the input field for tags in the details view is shown
 	 */
 	public function iSeeThatTheInputFieldForTagsInTheDetailsViewIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::inputFieldForTagsInDetailsView(), 10)->isVisible());
 	}
 
@@ -365,7 +366,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the input field for tags in the details view contains the tag :tag
 	 */
 	public function iSeeThatTheInputFieldForTagsInTheDetailsViewContainsTheTag($tag) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::itemInInputFieldForTagsInDetailsViewForTag($tag), 10)->isVisible());
 	}
 
@@ -376,7 +377,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 		$this->iSeeThatTheInputFieldForTagsInTheDetailsViewIsShown();
 
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::itemInInputFieldForTagsInDetailsViewForTag($tag))->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}
@@ -386,7 +387,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the tag :tag in the dropdown for tags in the details view is checked
 	 */
 	public function iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsChecked($tag) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::checkmarkInItemInDropdownForTag($tag), 10)->isVisible());
 	}
 
@@ -394,10 +395,10 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the tag :tag in the dropdown for tags in the details view is not checked
 	 */
 	public function iSeeThatTheTagInTheDropdownForTagsInTheDetailsViewIsNotChecked($tag) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::itemInDropdownForTag($tag), 10)->isVisible());
 
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::checkmarkInItemInDropdownForTag($tag))->isVisible());
 	}
 
@@ -409,7 +410,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::loadingIconForTabInDetailsViewNamed($tabName),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The $tabName tab in the details view has not been loaded after $timeout seconds");
+			Assert::fail("The $tabName tab in the details view has not been loaded after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
@@ -372,8 +372,8 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 				self::shareLinkMenu($shareLinkMenuTriggerElement),
 				$timeout = 2 * $this->actor->getFindTimeoutMultiplier())) {
 			// It may not be possible to click on the menu button (due to the
-			// menu itself covering it), so "Esc" key is pressed instead.
-			$this->actor->find(self::shareLinkMenu($shareLinkMenuTriggerElement), 2)->getWrappedElement()->keyPress(27);
+			// menu itself covering it), so "Enter" key is pressed instead.
+			$this->actor->find(self::shareLinkMenuButton(), 2)->getWrappedElement()->keyPress(13);
 		}
 
 		$this->actor->find(self::copyLinkButton(), 10)->click();

--- a/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class FilesAppSharingContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -513,7 +514,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 	 * @Then I see that the file is shared with me by :sharedByName
 	 */
 	public function iSeeThatTheFileIsSharedWithMeBy($sharedByName) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::sharedByLabel(), 10)->getText(), "Shared with you by $sharedByName");
 	}
 
@@ -521,7 +522,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 	 * @Then I see that the file is shared with :sharedWithName
 	 */
 	public function iSeeThatTheFileIsSharedWith($sharedWithName) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::sharedWithRow($sharedWithName), 10)->isVisible());
 	}
 
@@ -533,7 +534,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::sharedWithRow($sharedWithName),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The shared with $sharedWithName row is still shown after $timeout seconds");
+			Assert::fail("The shared with $sharedWithName row is still shown after $timeout seconds");
 		}
 	}
 
@@ -541,9 +542,9 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 	 * @Then I see that resharing the file is not allowed
 	 */
 	public function iSeeThatResharingTheFileIsNotAllowed() {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::shareWithInput(), 10)->getWrappedElement()->getAttribute("disabled"), "disabled");
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::shareWithInput(), 10)->getWrappedElement()->getAttribute("placeholder"), "Resharing is not allowed");
 	}
 
@@ -555,7 +556,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::shareLinkAddNewButton(),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The add new share link button is still shown after $timeout seconds");
+			Assert::fail("The add new share link button is still shown after $timeout seconds");
 		}
 	}
 
@@ -566,7 +567,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::canEditCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->getWrappedElement()->getAttribute("disabled"), "disabled");
 	}
 
@@ -577,7 +578,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::canEditCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -588,7 +589,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::canEditCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -599,7 +600,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->find(self::canCreateCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->getWrappedElement()->getAttribute("disabled"), "disabled");
 	}
 
@@ -610,7 +611,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::canCreateCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -621,7 +622,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::canCreateCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -636,7 +637,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::canReshareCheckbox($sharedWithName, $shareWithMenuTriggerElement),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The resharing checkbox for $sharedWithName is still shown after $timeout seconds");
+			Assert::fail("The resharing checkbox for $sharedWithName is still shown after $timeout seconds");
 		}
 	}
 
@@ -647,7 +648,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::canReshareCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -658,7 +659,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareWithMenuIfNeeded($sharedWithName);
 
 		$shareWithMenuTriggerElement = $this->actor->find(self::shareWithMenuTrigger($sharedWithName), 10);
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::canReshareCheckboxInput($sharedWithName, $shareWithMenuTriggerElement), 10)->isChecked());
 	}
 
@@ -669,7 +670,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareLinkMenuIfNeeded();
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::hideDownloadCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
+		Assert::assertTrue($this->actor->find(self::hideDownloadCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
 	}
 
 	/**
@@ -679,7 +680,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareLinkMenuIfNeeded();
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
-		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::hideDownloadCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
+		Assert::assertFalse($this->actor->find(self::hideDownloadCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
 	}
 
 	/**
@@ -708,7 +709,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::disabledPasswordProtectField($shareLinkMenuTriggerElement),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The password protect field is still disabled after $timeout seconds");
+			Assert::fail("The password protect field is still disabled after $timeout seconds");
 		}
 	}
 
@@ -719,8 +720,8 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareLinkMenuIfNeeded();
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked(), "Password protect checkbox is checked");
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectField($shareLinkMenuTriggerElement), 10)->isVisible(), "Password protect field is visible");
+		Assert::assertTrue($this->actor->find(self::passwordProtectCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked(), "Password protect checkbox is checked");
+		Assert::assertTrue($this->actor->find(self::passwordProtectField($shareLinkMenuTriggerElement), 10)->isVisible(), "Password protect field is visible");
 	}
 
 	/**
@@ -730,7 +731,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareLinkMenuIfNeeded();
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::passwordProtectByTalkCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
+		Assert::assertTrue($this->actor->find(self::passwordProtectByTalkCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
 	}
 
 	/**
@@ -740,7 +741,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$this->showShareLinkMenuIfNeeded();
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
-		PHPUnit_Framework_Assert::assertFalse($this->actor->find(self::passwordProtectByTalkCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
+		Assert::assertFalse($this->actor->find(self::passwordProtectByTalkCheckboxInput($shareLinkMenuTriggerElement), 10)->isChecked());
 	}
 
 	/**
@@ -751,7 +752,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 10);
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::passwordProtectByTalkCheckbox($shareLinkMenuTriggerElement))->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}

--- a/tests/acceptance/features/bootstrap/LoginPageContext.php
+++ b/tests/acceptance/features/bootstrap/LoginPageContext.php
@@ -23,6 +23,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 
 class LoginPageContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -90,7 +91,7 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the Login page
 	 */
 	public function iSeeThatTheCurrentPageIsTheLoginPage() {
-		PHPUnit_Framework_Assert::assertStringStartsWith(
+		Assert::assertStringStartsWith(
 				$this->actor->locatePath("/login"),
 				$this->actor->getSession()->getCurrentUrl());
 	}
@@ -99,7 +100,7 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	 * @Then I see that a wrong password message is shown
 	 */
 	public function iSeeThatAWrongPasswordMessageIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::wrongPasswordMessage(), 10)->isVisible());
 	}
 
@@ -107,7 +108,7 @@ class LoginPageContext implements Context, ActorAwareInterface {
 	 * @Then I see that the disabled user message is shown
 	 */
 	public function iSeeThatTheDisabledUserMessageIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::userDisabledMessage(), 10)->isVisible());
 	}
 

--- a/tests/acceptance/features/bootstrap/PublicShareContext.php
+++ b/tests/acceptance/features/bootstrap/PublicShareContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class PublicShareContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -143,7 +144,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the Authenticate page for the shared link I wrote down
 	 */
 	public function iSeeThatTheCurrentPageIsTheAuthenticatePageForTheSharedLinkIWroteDown() {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->getSharedNotebook()["shared link"] . "/authenticate/showShare",
 				$this->actor->getSession()->getCurrentUrl());
 	}
@@ -152,7 +153,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the Authenticate page for the direct download shared link I wrote down
 	 */
 	public function iSeeThatTheCurrentPageIsTheAuthenticatePageForTheDirectDownloadSharedLinkIWroteDown() {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->getSharedNotebook()["shared link"] . "/authenticate/downloadShare",
 				$this->actor->getSession()->getCurrentUrl());
 	}
@@ -161,7 +162,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the shared link I wrote down
 	 */
 	public function iSeeThatTheCurrentPageIsTheSharedLinkIWroteDown() {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->getSharedNotebook()["shared link"],
 				$this->actor->getSession()->getCurrentUrl());
 
@@ -172,7 +173,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that the current page is the direct download shared link I wrote down
 	 */
 	public function iSeeThatTheCurrentPageIsTheDirectDownloadSharedLinkIWroteDown() {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$this->actor->getSharedNotebook()["shared link"] . "/download",
 				$this->actor->getSession()->getCurrentUrl());
 	}
@@ -181,7 +182,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that a wrong password for the shared file message is shown
 	 */
 	public function iSeeThatAWrongPasswordForTheSharedFileMessageIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::wrongPasswordMessage(), 10)->isVisible());
 	}
 
@@ -194,19 +195,19 @@ class PublicShareContext implements Context, ActorAwareInterface {
 		// command not having been processed by the browser.
 		if (!WaitFor::elementToBeEventuallyShown(
 				$this->actor, self::shareMenu(), $timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The Share menu is not visible yet after $timeout seconds");
+			Assert::fail("The Share menu is not visible yet after $timeout seconds");
 		}
 
 		// The acceptance tests are run in a window wider than the mobile breakpoint, so the
 		// download item should not be shown in the menu (although it will be in
 		// the DOM).
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::downloadItemInShareMenu())->isVisible(),
 				"Download item in share menu is visible");
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::directLinkItemInShareMenu())->isVisible(),
 				"Direct link item in share menu is not visible");
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::saveItemInShareMenu())->isVisible(),
 				"Save item in share menu is not visible");
 	}
@@ -216,7 +217,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheShareMenuButtonIsNotShown() {
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::shareMenuButton())->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}
@@ -226,7 +227,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @Then I see that the shared file preview shows the text :text
 	 */
 	public function iSeeThatTheSharedFilePreviewShowsTheText($text) {
-		PHPUnit_Framework_Assert::assertContains($text, $this->actor->find(self::textPreview(), 10)->getText());
+		Assert::assertContains($text, $this->actor->find(self::textPreview(), 10)->getText());
 	}
 
 	/**
@@ -235,7 +236,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	public function iSeeThatTheDownloadButtonIsShown() {
 		if (!WaitFor::elementToBeEventuallyShown(
 				$this->actor, self::downloadButton(), $timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The download button is not visible yet after $timeout seconds");
+			Assert::fail("The download button is not visible yet after $timeout seconds");
 		}
 	}
 
@@ -244,7 +245,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheDownloadButtonIsNotShown() {
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::downloadButton())->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class SearchContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -99,7 +100,7 @@ class SearchContext implements Context, ActorAwareInterface {
 	 * @Then I see that the search result :number is :name
 	 */
 	public function iSeeThatTheSearchResultIs($number, $name) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$name, $this->actor->find(self::searchResultName($number), 10)->getText());
 	}
 
@@ -107,7 +108,7 @@ class SearchContext implements Context, ActorAwareInterface {
 	 * @Then I see that the search result :number was found in :path
 	 */
 	public function iSeeThatTheSearchResultWasFoundIn($number, $path) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 				$path, $this->actor->find(self::searchResultPath($number), 10)->getText());
 	}
 }

--- a/tests/acceptance/features/bootstrap/SettingsContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class SettingsContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -180,7 +181,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that shares are accepted by default
 	 */
 	public function iSeeThatSharesAreAcceptedByDefault() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::acceptSharesByDefaultCheckboxInput(), 10)->isChecked());
 	}
 
@@ -188,7 +189,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that resharing is enabled
 	 */
 	public function iSeeThatResharingIsEnabled() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::allowResharingCheckboxInput(), 10)->isChecked());
 	}
 
@@ -196,7 +197,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that resharing is disabled
 	 */
 	public function iSeeThatResharingIsDisabled() {
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::allowResharingCheckboxInput(), 10)->isChecked());
 	}
 
@@ -204,7 +205,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that username autocompletion is restricted to groups
 	 */
 	public function iSeeThatUsernameAutocompletionIsRestrictedToGroups() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::restrictUsernameAutocompletionToGroupsCheckboxInput(), 10)->isChecked());
 	}
 
@@ -212,7 +213,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that username autocompletion is not restricted to groups
 	 */
 	public function iSeeThatUsernameAutocompletionIsNotRestrictedToGroups() {
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::restrictUsernameAutocompletionToGroupsCheckboxInput(), 10)->isChecked());
 	}
 
@@ -220,7 +221,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that shares are not accepted by default
 	 */
 	public function iSeeThatSharesAreNotAcceptedByDefault() {
-		PHPUnit_Framework_Assert::assertFalse(
+		Assert::assertFalse(
 				$this->actor->find(self::acceptSharesByDefaultCheckboxInput(), 10)->isChecked());
 	}
 
@@ -228,7 +229,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the button to select tags is shown
 	 */
 	public function iSeeThatTheButtonToSelectTagsIsShown() {
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
+		Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
 	}
 
 	/**
@@ -243,7 +244,7 @@ class SettingsContext implements Context, ActorAwareInterface {
 		// necessary to repeatedly open the dropdown until the tag is shown in
 		// the dropdown (or the limit of tries is reached).
 
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
+		Assert::assertTrue($this->actor->find(self::systemTagsSelectTagButton(), 10)->isVisible());
 
 		$actor = $this->actor;
 
@@ -277,6 +278,6 @@ class SettingsContext implements Context, ActorAwareInterface {
 			}
 		}
 
-		PHPUnit_Framework_Assert::fail("The dropdown in system tags section in Administration Settings does not contain the tag $tag after $numberOfTries tries");
+		Assert::fail("The dropdown in system tags section in Administration Settings does not contain the tag $tag after $numberOfTries tries");
 	}
 }

--- a/tests/acceptance/features/bootstrap/SettingsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsMenuContext.php
@@ -23,6 +23,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class SettingsMenuContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -155,7 +156,7 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the Settings menu is shown
 	 */
 	public function iSeeThatTheSettingsMenuIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::settingsMenu(), 10)->isVisible());
 	}
 
@@ -163,14 +164,14 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the Settings menu has only :items items
 	 */
 	public function iSeeThatTheSettingsMenuHasOnlyXItems($items) {
-		PHPUnit_Framework_Assert::assertCount(intval($items), self::menuItems());
+		Assert::assertCount(intval($items), self::menuItems());
 	}
 
 	/**
 	 * @Then I see that the :itemText item in the Settings menu is shown
 	 */
 	public function iSeeThatTheItemInTheSettingsMenuIsShown($itemText) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 				$this->actor->find(self::menuItemFor($itemText), 10)->isVisible());
 	}
 
@@ -181,7 +182,7 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 		$this->iSeeThatTheSettingsMenuIsShown();
 
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 					$this->actor->find(self::menuItemFor($itemText))->isVisible());
 		} catch (NoSuchElementException $exception) {
 		}
@@ -191,7 +192,7 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :itemText settings panel is shown
 	 */
 	public function iSeeThatTheItemSettingsPanelIsShown($itemText) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::settingsPanelFor($itemText), 10)->isVisible()
 		);
 	}
@@ -200,7 +201,7 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :itemText entry in the settings panel is shown
 	 */
 	public function iSeeThatTheItemEntryInTheSettingsPanelIsShown($itemText) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::settingsPanelEntryFor($itemText), 10)->isVisible()
 		);
 	}
@@ -210,7 +211,7 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	 */
 	public function iSeeThatTheItemSettingsPanelIsNotShown($itemText) {
 		try {
-			PHPUnit_Framework_Assert::assertFalse(
+			Assert::assertFalse(
 				$this->actor->find(self::settingsPanelFor($itemText), 10)->isVisible()
 			);
 		} catch (NoSuchElementException $exception) {

--- a/tests/acceptance/features/bootstrap/ThemingAppContext.php
+++ b/tests/acceptance/features/bootstrap/ThemingAppContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class ThemingAppContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -88,7 +89,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 		// background of the input element, it means the color element has been
 		// initialized.
 
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::inputFieldFor("Color"), 10)->isVisible());
+		Assert::assertTrue($this->actor->find(self::inputFieldFor("Color"), 10)->isVisible());
 
 		$actor = $this->actor;
 
@@ -103,7 +104,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 		};
 
 		if (!Utils::waitFor($colorSelectorLoadedCallback, $timeout = 10 * $this->actor->getFindTimeoutMultiplier(), $timeoutStep = 1)) {
-			PHPUnit_Framework_Assert::fail("The color selector in Theming app has not been loaded after $timeout seconds");
+			Assert::fail("The color selector in Theming app has not been loaded after $timeout seconds");
 		}
 	}
 
@@ -117,7 +118,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 			// HEX Color, convert to RGB array.
 			$tmpColor = sscanf($color, "%02X%02X%02X");
 		} else {
-			PHPUnit_Framework_Assert::fail("The acceptance test does not know how to handle the color string : '$color'. "
+			Assert::fail("The acceptance test does not know how to handle the color string : '$color'. "
 			. "Please provide # before HEX colors in your features.");
 		}
 		return $tmpColor;
@@ -136,7 +137,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 		};
 
 		if (!Utils::waitFor($headerColorMatchesCallback, $timeout = 10 * $this->actor->getFindTimeoutMultiplier(), $timeoutStep = 1)) {
-			PHPUnit_Framework_Assert::fail("The header color is not $color yet after $timeout seconds");
+			Assert::fail("The header color is not $color yet after $timeout seconds");
 		}
 	}
 
@@ -144,7 +145,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 	 * @Then I see that the parameters in the Theming app are eventually saved
 	 */
 	public function iSeeThatTheParametersInTheThemingAppAreEventuallySaved() {
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(self::statusMessage(), 10)->isVisible());
+		Assert::assertTrue($this->actor->find(self::statusMessage(), 10)->isVisible());
 
 		$actor = $this->actor;
 
@@ -157,7 +158,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 		};
 
 		if (!Utils::waitFor($savedStatusMessageShownCallback, $timeout = 10 * $this->actor->getFindTimeoutMultiplier(), $timeoutStep = 1)) {
-			PHPUnit_Framework_Assert::fail("The 'Saved' status messages in Theming app has not been shown after $timeout seconds");
+			Assert::fail("The 'Saved' status messages in Theming app has not been shown after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/ToastContext.php
+++ b/tests/acceptance/features/bootstrap/ToastContext.php
@@ -22,6 +22,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class ToastContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -47,7 +48,7 @@ class ToastContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :message toast is shown
 	 */
 	public function iSeeThatTheToastIsShown($message) {
-		PHPUnit_Framework_Assert::assertTrue($this->actor->find(
+		Assert::assertTrue($this->actor->find(
 				self::toastMessage($message), 10)->isVisible());
 	}
 }

--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -24,6 +24,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use PHPUnit\Framework\Assert;
 
 class UsersSettingsContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -271,7 +272,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::rowForUser($user),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The user $user in the list of users is not shown yet after $timeout seconds");
+			Assert::fail("The user $user in the list of users is not shown yet after $timeout seconds");
 		}
 	}
 
@@ -283,7 +284,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::rowForUser($user),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The user $user in the list of users is still shown after $timeout seconds");
+			Assert::fail("The user $user in the list of users is still shown after $timeout seconds");
 		}
 	}
 
@@ -291,7 +292,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the new user form is shown
 	 */
 	public function iSeeThatTheNewUserFormIsShown() {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::newUserForm(), 10)->isVisible());
 	}
 
@@ -299,7 +300,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :action action in the :user actions menu is shown
 	 */
 	public function iSeeTheAction($action, $user) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::theAction($action, $user), 10)->isVisible());
 	}
 
@@ -307,7 +308,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :column column is shown
 	 */
 	public function iSeeThatTheColumnIsShown($column) {
-		PHPUnit_Framework_Assert::assertTrue(
+		Assert::assertTrue(
 			$this->actor->find(self::theColumn($column), 10)->isVisible());
 	}
 
@@ -315,7 +316,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the :field of :user is :value
 	 */
 	public function iSeeThatTheFieldOfUserIs($field, $user, $value) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$this->actor->find(self::inputForUserInCell($field, $user), 10)->getValue(), $value);
 	}
 
@@ -323,7 +324,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the display name for the user :user is :displayName
 	 */
 	public function iSeeThatTheDisplayNameForTheUserIs($user, $displayName) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$displayName, $this->actor->find(self::displayNameCellForUser($user), 10)->getValue());
 	}
 
@@ -349,7 +350,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::classCellForUser($cell . ' icon-loading-small', $user),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The loading icon for user $user is still shown after $timeout seconds");
+			Assert::fail("The loading icon for user $user is still shown after $timeout seconds");
 		}
 	}
 
@@ -357,7 +358,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the user quota of :user is :quota
 	 */
 	public function iSeeThatTheuserQuotaIs($user, $quota) {
-		PHPUnit_Framework_Assert::assertEquals(
+		Assert::assertEquals(
 			$this->actor->find(self::selectedSelectOption('quota', $user), 2)->getText(), $quota);
 	}
 
@@ -369,7 +370,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 				$this->actor,
 				self::editModeOn($user),
 				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
-			PHPUnit_Framework_Assert::fail("The edit mode for user $user in the list of users is not on yet after $timeout seconds");
+			Assert::fail("The edit mode for user $user in the list of users is not on yet after $timeout seconds");
 		}
 	}
 }

--- a/tests/acceptance/features/core/ActorContext.php
+++ b/tests/acceptance/features/core/ActorContext.php
@@ -135,6 +135,8 @@ class ActorContext extends RawMinkContext {
 		$this->actors = [];
 		$this->sharedNotebook = [];
 
+		$this->getSession()->start();
+
 		$this->actors["default"] = new Actor("default", $this->getSession(), $this->getMinkParameter("base_url"), $this->sharedNotebook);
 		$this->actors["default"]->setFindTimeoutMultiplier($this->actorTimeoutMultiplier);
 
@@ -159,6 +161,8 @@ class ActorContext extends RawMinkContext {
 	 */
 	public function iActAs($actorName) {
 		if (!array_key_exists($actorName, $this->actors)) {
+			$this->getSession($actorName)->start();
+
 			$this->actors[$actorName] = new Actor($actorName, $this->getSession($actorName), $this->getMinkParameter("base_url"), $this->sharedNotebook);
 			$this->actors[$actorName]->setFindTimeoutMultiplier($this->actorTimeoutMultiplier);
 		}


### PR DESCRIPTION
This should be rebased on master once #25975 is merged (it is set as draft to prevent that, but it is ready for review nevertheless).

This pull request updates the acceptance tests dependencies, which requires some syntax changes (mostly `PHPUnit_Framework_Assert` to `Assert`). Due to that, and to ease future backports I would suggest to backport it (so please do not merge before the backports of #25975 are also merged to ensure that backportbot can do its magic :-) ). In any case if the backport fails feel free to ignore it ;-)
