### PR TITLE
Do not try to add an existing user again in acceptance tests

### DIFF
--- a/tests/acceptance/features/header.feature
+++ b/tests/acceptance/features/header.feature
@@ -46,12 +46,13 @@ Feature: header
     And I open the User settings
     And I click the New user button
     And I see that the new user form is shown
-    And I create user user1 with password 123456acb
-    And I see that the list of users contains the user user1
+    And I create user user2 with password 123456acb
+    And I see that the list of users contains the user user2
     When I open the Contacts menu
     Then I see that the Contacts menu is shown
     And I see that the contact "user0" in the Contacts menu is shown
     And I see that the contact "user1" in the Contacts menu is shown
+    And I see that the contact "user2" in the Contacts menu is shown
     And I see that the contact "admin" in the Contacts menu is not shown
 
   Scenario: search for other users in the contacts menu

--- a/tests/acceptance/features/header.feature
+++ b/tests/acceptance/features/header.feature
@@ -57,11 +57,6 @@ Feature: header
 
   Scenario: search for other users in the contacts menu
     Given I am logged in as the admin
-    And I open the User settings
-    And I click the New user button
-    And I see that the new user form is shown
-    And I create user user1 with password 123456acb
-    And I see that the list of users contains the user user1
     And I open the Contacts menu
     And I see that the Contacts menu is shown
     And I see that the contact "user0" in the Contacts menu is shown


### PR DESCRIPTION
[User "user1" is added when installing and configuring the server](https://github.com/nextcloud/server/blob/4679926511c9e845a26eb4c9ab606ce889feea21/tests/acceptance/installAndConfigureServer.sh#L38), so it is already added in all tests. As the test verifies that just added users can be searched in the contacts menu a new user should be actually added.

Note that this is independent from the changes in #25975 (although the adjusted tests should be more robust once #25975 is merged).
