### PR TITLE
Update acceptance tests to Selenium 3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1709,7 +1709,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1739,7 +1739,7 @@ trigger:
 #
 #services:
 #- name: selenium
-#  image: selenium/standalone-firefox:2.53.1-beryllium
+#  image: selenium/standalone-chrome:3.141.59
 #  environment:
 #    # Reduce default log level for Selenium server (INFO) as it is too
 #    # verbose.
@@ -1769,7 +1769,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1799,7 +1799,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1829,7 +1829,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1859,7 +1859,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1889,7 +1889,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1919,7 +1919,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1949,7 +1949,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -1979,7 +1979,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.
@@ -2009,7 +2009,7 @@ steps:
 
 services:
 - name: selenium
-  image: selenium/standalone-firefox:2.53.1-beryllium
+  image: selenium/standalone-chrome:3.141.59
   environment:
     # Reduce default log level for Selenium server (INFO) as it is too
     # verbose.

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -65,15 +65,39 @@ default:
         default:
           selenium2:
             wd_host: %selenium.server%
+            browser: "chrome"
+            capabilities:
+              extra_capabilities:
+                goog:chromeOptions:
+                  args: ["disable-dev-shm-usage"]
+                  w3c: false
         John:
           selenium2:
             wd_host: %selenium.server%
+            browser: "chrome"
+            capabilities:
+              extra_capabilities:
+                goog:chromeOptions:
+                  args: ["disable-dev-shm-usage"]
+                  w3c: false
         Jane:
           selenium2:
             wd_host: %selenium.server%
+            browser: "chrome"
+            capabilities:
+              extra_capabilities:
+                goog:chromeOptions:
+                  args: ["disable-dev-shm-usage"]
+                  w3c: false
         Jim:
           selenium2:
             wd_host: %selenium.server%
+            browser: "chrome"
+            capabilities:
+              extra_capabilities:
+                goog:chromeOptions:
+                  args: ["disable-dev-shm-usage"]
+                  w3c: false
         Rubeus:
           # Rubeus uses a browser that has CSS grid support.
           selenium2:

--- a/tests/acceptance/features/bootstrap/ContactsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/ContactsMenuContext.php
@@ -82,7 +82,7 @@ class ContactsMenuContext implements Context, ActorAwareInterface {
 	 * @When I search for the user :user
 	 */
 	public function iSearchForTheUser($user) {
-		$this->actor->find(self::contactsMenuSearchInput(), 10)->setValue($user . "\r");
+		$this->actor->find(self::contactsMenuSearchInput(), 10)->setValue($user);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
@@ -23,6 +23,7 @@
 
 use Behat\Behat\Context\Context;
 use PHPUnit\Framework\Assert;
+use WebDriver\Key;
 
 class FilesAppSharingContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -427,7 +428,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 		$shareLinkMenuTriggerElement = $this->actor->find(self::shareLinkMenuTrigger(), 2);
 		$this->actor->find(self::passwordProtectCheckbox($shareLinkMenuTriggerElement), 2)->click();
 
-		$this->actor->find(self::passwordProtectField($shareLinkMenuTriggerElement), 2)->setValue($password . "\r");
+		$this->actor->find(self::passwordProtectField($shareLinkMenuTriggerElement), 2)->setValue($password . Key::ENTER);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -86,7 +86,7 @@ class SearchContext implements Context, ActorAwareInterface {
 	 * @When I search for :query
 	 */
 	public function iSearchFor($query) {
-		$this->actor->find(self::searchBoxInput(), 10)->setValue($query . "\r");
+		$this->actor->find(self::searchBoxInput(), 10)->setValue($query);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/ThemingAppContext.php
+++ b/tests/acceptance/features/bootstrap/ThemingAppContext.php
@@ -65,7 +65,7 @@ class ThemingAppContext implements Context, ActorAwareInterface {
 	 * @When I set the :parameterName parameter in the Theming app to :parameterValue
 	 */
 	public function iSetTheParameterInTheThemingAppTo($parameterName, $parameterValue) {
-		$this->actor->find(self::inputFieldFor($parameterName), 10)->setValue($parameterValue . "\r");
+		$this->actor->find(self::inputFieldFor($parameterName), 10)->setValue($parameterValue);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -25,6 +25,7 @@
 
 use Behat\Behat\Context\Context;
 use PHPUnit\Framework\Assert;
+use WebDriver\Key;
 
 class UsersSettingsContext implements Context, ActorAwareInterface {
 	use ActorAware;
@@ -242,7 +243,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @When I set the :field for :user to :value
 	 */
 	public function iSetTheFieldForUserTo($field, $user, $value) {
-		$this->actor->find(self::inputForUserInCell($field, $user), 2)->setValue($value . "\r");
+		$this->actor->find(self::inputForUserInCell($field, $user), 2)->setValue($value . Key::ENTER);
 	}
 
 	/**

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -108,12 +108,12 @@ function prepareSelenium() {
 	SELENIUM_CONTAINER=selenium-nextcloud-local-test-acceptance
 
 	echo "Starting Selenium server"
-	docker run --detach --name=$SELENIUM_CONTAINER --publish 4444:4444 --publish 5900:5900 $DOCKER_OPTIONS selenium/standalone-firefox-debug:2.53.1-beryllium
+	docker run --detach --name=$SELENIUM_CONTAINER --publish 4444:4444 --publish 5900:5900 $DOCKER_OPTIONS selenium/standalone-chrome-debug:3.141.59
 
 	echo "Waiting for Selenium server to be ready"
 	if ! $TIMEOUT 10s bash -c "while ! curl 127.0.0.1:4444 >/dev/null 2>&1; do sleep 1; done"; then
 		echo "Could not start Selenium server; running" \
-		     "\"docker run --rm --publish 4444:4444 --publish 5900:5900 $DOCKER_OPTIONS selenium/standalone-firefox-debug:2.53.1-beryllium\"" \
+		     "\"docker run --rm --publish 4444:4444 --publish 5900:5900 $DOCKER_OPTIONS selenium/standalone-chrome-debug:3.141.59\"" \
 		     "could give you a hint of the problem"
 
 		exit 1


### PR DESCRIPTION
This should be rebased on master once #25983 is merged.

The acceptance tests used the last Selenium 2 Docker container available, which provides a rather old Firefox version (Firefox 47). Nevertheless, despite some rendering issues, most things still worked as expected due to the JavaScript files being built with support for older browsers. However, now that [support for Internet Explorer 11 and older browsers will be dropped](https://github.com/nextcloud/server/pull/25968) things could start to fail, so a newer browser (and thus a newer Selenium version) should be used in the acceptance tests.

[Selenium has been standardized by the W3C](https://w3c.github.io/webdriver/), and the protocol to communicate between the Selenium server and the browser has changed due to that. Firefox >= 48 only supports the new W3C protocol, but the Selenium driver for Mink does not support it yet (see issue 293 in https://github.com/minkphp/MinkSelenium2Driver/issues, not linking to prevent polluting the thread with back references).

The old protocol can still be used in recent Chromium/Chrome versions by explicitly forcing it, so for the time being the acceptance tests will need to be run on Chrome instead (although Firefox provides some interesting features like the fake streams that would be needed to test calls in Talk, so they should be moved again to Firefox once possible).

Finally, the default shm size of Docker is 64 MiB. This does not seem enough to run newer Chromium releases and causes the browser to randomly crash during the tests (`unknown error: session deleted because of page crash` is shown in the logs). Due to this [`disable-dev-shm-usage` needs to be used so Chrome writes shared memory files into _/tmp_ instead of _/dev/shm_](https://developers.google.com/web/tools/puppeteer/troubleshooting#tips) (the default shm size of Docker could have been increased instead using `docker run --shm-size...`, but that seems to be problematic when the container is run in current Drone releases).

~~**Pending:** shm size needs to be increased when run in Drone too. In theory [it should be enough to use `shm_size`](https://stackoverflow.com/questions/41546310/setting-up-drone-agents-to-have-custom-dev-shm/41640458#41640458), but [it seems that parameter no longer works](https://discourse.drone.io/t/shm-size-setting-not-respected-in-drone-1-0/4921) (although I have not actually tested it, I just hoped that for some reason our Drone had a high enough default shm size, but based on the `unknown error: session deleted because of page crash` errors in the logs it seems it does not :-( )~~