### PR TITLE
Fix invalid check after constructing DateTime

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1455,10 +1455,6 @@ class ShareAPIController extends OCSController {
 			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
 		}
 
-		if ($date === false) {
-			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
-		}
-
 		$date->setTime(0, 0, 0);
 
 		return $date;


### PR DESCRIPTION
We construct an object. Either that works on not.But the result can't be
false.

Found by psalm

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>