### PR TITLE
Add hint about possible limit when setting a session_lifetime

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -249,6 +249,9 @@ $CONFIG = [
 /**
  * The lifetime of a session after inactivity.
  *
+ * The maximum possible time is limited by the session.gc_maxlifetime php.ini setting
+ * which would overwrite this option if it is less than the value in the config.php
+ *
  * Defaults to ``60*60*24`` seconds (24 hours)
  */
 'session_lifetime' => 60 * 60 * 24,


### PR DESCRIPTION
We always take the lower value of `session_lifetime` and the PHP `session.gc_maxlifetime` configuration, so this could cause the session_lifetime to not being picked up as expected.

https://github.com/nextcloud/server/blob/68ec18323d07e7293fd59c82d51300a6d9d68176/lib/private/Template/JSConfigHelper.php#L186