### PR TITLE
Return the fileid from `copyFromCache` and use it instead of doing an extra query

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -629,7 +629,7 @@ class Cache implements ICache {
 	/**
 	 * Move a file or folder in the cache
 	 *
-	 * @param \OCP\Files\Cache\ICache $sourceCache
+	 * @param ICache $sourceCache
 	 * @param string $sourcePath
 	 * @param string $targetPath
 	 * @throws \OC\DatabaseException
@@ -1075,5 +1075,45 @@ class Cache implements ICache {
 	 */
 	public function normalize($path) {
 		return trim(\OC_Util::normalizeUnicode($path), '/');
+	}
+
+	/**
+	 * Copy a file or folder in the cache
+	 *
+	 * @param ICache $sourceCache
+	 * @param ICacheEntry $sourceEntry
+	 * @param string $targetPath
+	 * @return int fileid of copied entry
+	 */
+	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
+		$data = $this->cacheEntryToArray($sourceEntry);
+		$fileId = $this->put($targetPath, $data);
+		if ($fileId <= 0) {
+			throw new \RuntimeException("Failed to copy to " . $targetPath . " from cache with source data " . json_encode($data) . " ");
+		}
+		if ($sourceEntry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE) {
+			$folderContent = $sourceCache->getFolderContentsById($sourceEntry->getId());
+			foreach ($folderContent as $subEntry) {
+				$subTargetPath = $targetPath . '/' . $subEntry->getName();
+				$this->copyFromCache($sourceCache, $subEntry, $subTargetPath);
+			}
+		}
+		return $fileId;
+	}
+
+	private function cacheEntryToArray(ICacheEntry $entry): array {
+		return [
+			'size' => $entry->getSize(),
+			'mtime' => $entry->getMTime(),
+			'storage_mtime' => $entry->getStorageMTime(),
+			'mimetype' => $entry->getMimeType(),
+			'mimepart' => $entry->getMimePart(),
+			'etag' => $entry->getEtag(),
+			'permissions' => $entry->getPermissions(),
+			'encrypted' => $entry->isEncrypted(),
+			'creation_time' => $entry->getCreationTime(),
+			'upload_time' => $entry->getUploadTime(),
+			'metadata_etag' => $entry->getMetadataEtag(),
+		];
 	}
 }

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -1086,6 +1086,9 @@ class Cache implements ICache {
 	 * @return int fileid of copied entry
 	 */
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
+		if ($sourceEntry->getId() < 0) {
+			throw new \RuntimeException("Invalid source cache entry on copyFromCache");
+		}
 		$data = $this->cacheEntryToArray($sourceEntry);
 		$fileId = $this->put($targetPath, $data);
 		if ($fileId <= 0) {

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -24,6 +24,7 @@ namespace OC\Files\Cache;
 
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchQuery;
 
 /**
@@ -133,5 +134,9 @@ class FailedCache implements ICache {
 
 	public function normalize($path) {
 		return $path;
+	}
+
+	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
+		throw new \Exception("Invalid cache");
 	}
 }

--- a/lib/private/Files/Cache/MoveFromCacheTrait.php
+++ b/lib/private/Files/Cache/MoveFromCacheTrait.php
@@ -41,6 +41,8 @@ trait MoveFromCacheTrait {
 	 */
 	abstract public function put($file, array $data);
 
+	abstract public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int;
+
 	/**
 	 * Move a file or folder in the cache
 	 *
@@ -54,39 +56,5 @@ trait MoveFromCacheTrait {
 		$this->copyFromCache($sourceCache, $sourceEntry, $targetPath);
 
 		$sourceCache->remove($sourcePath);
-	}
-
-	/**
-	 * Copy a file or folder in the cache
-	 *
-	 * @param \OCP\Files\Cache\ICache $sourceCache
-	 * @param ICacheEntry $sourceEntry
-	 * @param string $targetPath
-	 */
-	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, $targetPath) {
-		$this->put($targetPath, $this->cacheEntryToArray($sourceEntry));
-		if ($sourceEntry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE) {
-			$folderContent = $sourceCache->getFolderContentsById($sourceEntry->getId());
-			foreach ($folderContent as $subEntry) {
-				$subTargetPath = $targetPath . '/' . $subEntry->getName();
-				$this->copyFromCache($sourceCache, $subEntry, $subTargetPath);
-			}
-		}
-	}
-
-	private function cacheEntryToArray(ICacheEntry $entry) {
-		return [
-			'size' => $entry->getSize(),
-			'mtime' => $entry->getMTime(),
-			'storage_mtime' => $entry->getStorageMTime(),
-			'mimetype' => $entry->getMimeType(),
-			'mimepart' => $entry->getMimePart(),
-			'etag' => $entry->getEtag(),
-			'permissions' => $entry->getPermissions(),
-			'encrypted' => $entry->isEncrypted(),
-			'creation_time' => $entry->getCreationTime(),
-			'upload_time' => $entry->getUploadTime(),
-			'metadata_etag' => $entry->getMetadataEtag(),
-		];
 	}
 }

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -33,6 +33,7 @@ namespace OC\Files\ObjectStore;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\CountWrapper;
 use Icewind\Streams\IteratorDirectory;
+use OC\Files\Cache\Cache;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\PolyFill\CopyDirectory;
 use OCP\Files\Cache\ICacheEntry;
@@ -581,14 +582,13 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 		$sourceUrn = $this->getURN($sourceEntry->getId());
 
-		$cache->copyFromCache($cache, $sourceEntry, $to);
-		$targetEntry = $cache->get($to);
-
-		if (!$targetEntry) {
-			throw new \Exception('Target not in cache after copy');
+		if (!$cache instanceof Cache) {
+			throw new \Exception("Invalid source cache for object store copy");
 		}
 
-		$targetUrn = $this->getURN($targetEntry->getId());
+		$targetId = $cache->copyFromCache($cache, $sourceEntry, $to);
+
+		$targetUrn = $this->getURN($targetId);
 
 		try {
 			$this->objectStore->copyObject($sourceUrn, $targetUrn);

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -26,6 +26,7 @@ namespace OC\Lockdown\Filesystem;
 use OC\Files\Cache\CacheEntry;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\Search\ISearchQuery;
 
@@ -121,5 +122,9 @@ class NullCache implements ICache {
 
 	public function normalize($path) {
 		return $path;
+	}
+
+	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
+		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 }

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -180,6 +180,17 @@ interface ICache {
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath);
 
 	/**
+	 * Copy a file or folder in the cache
+	 *
+	 * @param ICache $sourceCache
+	 * @param ICacheEntry $sourceEntry
+	 * @param string $targetPath
+	 * @return int fileid of copied entry
+	 * @since 22.0.0
+	 */
+	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int;
+
+	/**
 	 * Get the scan status of a file
 	 *
 	 * - ICache::NOT_FOUND: File is not in the cache


### PR DESCRIPTION
Also move the existing `copyFromCache` code around and expose it trough the public interface.