### PR TITLE
Fix warning in AppFetcher.php when appstore is disabled

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -86,6 +86,10 @@ class AppFetcher extends Fetcher {
 	protected function fetch($ETag, $content, $allowUnstable = false) {
 		/** @var mixed[] $response */
 		$response = parent::fetch($ETag, $content);
+		
+		if (empty($response)) {
+			return [];
+		}
 
 		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily';
 		$allowNightly = $allowUnstable || $this->getChannel() === 'daily';


### PR DESCRIPTION
`fetch()` can return empty array when `appstoreenabled` is set to `false`.

https://github.com/nextcloud/server/blob/62929cc646134fbd409cfb4eacb7039d15763b96/lib/private/App/AppStore/Fetcher/Fetcher.php#L94-L102