### PR TITLE
cache baseurl in url generator

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -59,6 +59,8 @@ class URLGenerator implements IURLGenerator {
 	private $request;
 	/** @var Router */
 	private $router;
+	/** @var null|string */
+	private $baseUrl = null;
 
 	public function __construct(IConfig $config,
 								ICacheFactory $cacheFactory,
@@ -269,6 +271,9 @@ class URLGenerator implements IURLGenerator {
 	 * @return string base url of the current request
 	 */
 	public function getBaseUrl(): string {
-		return $this->request->getServerProtocol() . '://' . $this->request->getServerHost() . \OC::$WEBROOT;
+		if ($this->baseUrl === null) {
+			$this->baseUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost() . \OC::$WEBROOT;
+		}
+		return $this->baseUrl;
 	}
 }


### PR DESCRIPTION
Servers don't tend to change their url in the middle of a request

The per-call cost is low, but when a request generates thousands of urls it adds up.