### PR TITLE
limit constructing of result objects in file search

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -103,7 +103,7 @@ class FilesSearchProvider implements IProvider {
 		// Make sure we setup the users filesystem
 		$this->rootFolder->getUserFolder($user->getUID());
 
-		return SearchResult::complete(
+		return SearchResult::paginated(
 			$this->l10n->t('Files'),
 			array_map(function (FileResult $result) {
 				// Generate thumbnail url
@@ -121,7 +121,8 @@ class FilesSearchProvider implements IProvider {
 				$searchResultEntry->addAttribute('fileId', (string)$result->id);
 				$searchResultEntry->addAttribute('path', $result->path);
 				return $searchResultEntry;
-			}, $this->fileSearch->search($query->getTerm()))
+			}, $this->fileSearch->search($query->getTerm(), $query->getLimit(), (int)$query->getCursor())),
+			$query->getCursor() + $query->getLimit()
 		);
 	}
 

--- a/lib/private/Search/Provider/File.php
+++ b/lib/private/Search/Provider/File.php
@@ -39,14 +39,23 @@ class File extends \OCP\Search\Provider {
 
 	/**
 	 * Search for files and folders matching the given query
+	 *
 	 * @param string $query
+	 * @param int|null $limit
+	 * @param int|null $offset
 	 * @return \OCP\Search\Result[]
 	 * @deprecated 20.0.0
 	 */
-	public function search($query) {
+	public function search($query, int $limit = null, int $offset = null) {
+		if ($offset === null) {
+			$offset = 0;
+		}
 		\OC_Util::setupFS();
 		$files = Filesystem::search($query);
 		$results = [];
+		if ($limit !== null) {
+			$files = array_slice($files, $offset, $offset + $limit);
+		}
 		// edit results
 		foreach ($files as $fileData) {
 			// skip versions

--- a/lib/private/Search/Provider/File.php
+++ b/lib/private/Search/Provider/File.php
@@ -30,12 +30,13 @@
 namespace OC\Search\Provider;
 
 use OC\Files\Filesystem;
+use OCP\Search\PagedProvider;
 
 /**
  * Provide search results from the 'files' app
  * @deprecated 20.0.0
  */
-class File extends \OCP\Search\Provider {
+class File extends PagedProvider {
 
 	/**
 	 * Search for files and folders matching the given query
@@ -87,5 +88,13 @@ class File extends \OCP\Search\Provider {
 		}
 		// return
 		return $results;
+	}
+
+	public function searchPaged($query, $page, $size) {
+		if ($size === 0) {
+			return $this->search($query);
+		} else {
+			return $this->search($query, $size, ($page - 1) * $size);
+		}
 	}
 }


### PR DESCRIPTION
even thought we currently have no proper way of limiting the search itself, we can at least limit the construction of the result objects.

this saves about 40% of the time spend in the search request in my local testing when the search query matches a large number of files.

Signed-off-by: Robin Appelman <robin@icewind.nl>