### PR TITLE
reuse usermanager instance when processing search results

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1643,6 +1643,7 @@ class View {
 		$mount = $this->getMount('');
 		$mountPoint = $mount->getMountPoint();
 		$storage = $mount->getStorage();
+		$userManager = \OC::$server->getUserManager();
 		if ($storage) {
 			$cache = $storage->getCache('');
 
@@ -1652,7 +1653,7 @@ class View {
 					$internalPath = $result['path'];
 					$path = $mountPoint . $result['path'];
 					$result['path'] = substr($mountPoint . $result['path'], $rootLength);
-					$owner = \OC::$server->getUserManager()->get($storage->getOwner($internalPath));
+					$owner = $userManager->get($storage->getOwner($internalPath));
 					$files[] = new FileInfo($path, $storage, $internalPath, $result, $mount, $owner);
 				}
 			}
@@ -1671,7 +1672,7 @@ class View {
 							$internalPath = $result['path'];
 							$result['path'] = rtrim($relativeMountPoint . $result['path'], '/');
 							$path = rtrim($mountPoint . $internalPath, '/');
-							$owner = \OC::$server->getUserManager()->get($storage->getOwner($internalPath));
+							$owner = $userManager->get($storage->getOwner($internalPath));
 							$files[] = new FileInfo($path, $storage, $internalPath, $result, $mount, $owner);
 						}
 					}


### PR DESCRIPTION
saves some time when processing large search results

Signed-off-by: Robin Appelman <robin@icewind.nl>