### PR TITLE
Log and continue when failing to update encryption keys during for individual files

### DIFF
--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -31,6 +31,7 @@ use OC\Memcache\ArrayCache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class EncryptionWrapper
@@ -100,6 +101,7 @@ class EncryptionWrapper {
 				Filesystem::getMountManager(),
 				$this->manager,
 				$fileHelper,
+				\OC::$server->get(LoggerInterface::class),
 				$uid
 			);
 			return new Encryption(

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -25,6 +25,7 @@ namespace OC\Encryption;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use Psr\Log\LoggerInterface;
 
 class HookManager {
 	/**
@@ -67,6 +68,7 @@ class HookManager {
 				Filesystem::getMountManager(),
 				\OC::$server->getEncryptionManager(),
 				\OC::$server->getEncryptionFilesHelper(),
+				\OC::$server->get(LoggerInterface::class),
 				$uid
 			);
 		}

--- a/lib/private/Encryption/Update.php
+++ b/lib/private/Encryption/Update.php
@@ -26,40 +26,43 @@
 
 namespace OC\Encryption;
 
+use Exception;
+use InvalidArgumentException;
+use OC;
 use OC\Files\Filesystem;
 use OC\Files\Mount;
 use OC\Files\View;
+use OCP\Encryption\Exceptions\GenericEncryptionException;
+use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * update encrypted files, e.g. because a file was shared
  */
 class Update {
 
-	/** @var \OC\Files\View */
+	/** @var View */
 	protected $view;
 
-	/** @var \OC\Encryption\Util */
+	/** @var Util */
 	protected $util;
 
 	/** @var \OC\Files\Mount\Manager */
 	protected $mountManager;
 
-	/** @var \OC\Encryption\Manager */
+	/** @var Manager */
 	protected $encryptionManager;
 
 	/** @var string */
 	protected $uid;
 
-	/** @var \OC\Encryption\File */
+	/** @var File */
 	protected $file;
 
+	/** @var LoggerInterface */
+	protected $logger;
+
 	/**
-	 *
-	 * @param \OC\Files\View $view
-	 * @param \OC\Encryption\Util $util
-	 * @param \OC\Files\Mount\Manager $mountManager
-	 * @param \OC\Encryption\Manager $encryptionManager
-	 * @param \OC\Encryption\File $file
 	 * @param string $uid
 	 */
 	public function __construct(
@@ -68,6 +71,7 @@ class Update {
 			Mount\Manager $mountManager,
 			Manager $encryptionManager,
 			File $file,
+			LoggerInterface $logger,
 			$uid
 		) {
 		$this->view = $view;
@@ -75,6 +79,7 @@ class Update {
 		$this->mountManager = $mountManager;
 		$this->encryptionManager = $encryptionManager;
 		$this->file = $file;
+		$this->logger = $logger;
 		$this->uid = $uid;
 	}
 
@@ -155,7 +160,7 @@ class Update {
 		$view = new View('/' . $owner . '/files');
 		$path = $view->getPath($info->getId());
 		if ($path === null) {
-			throw new \InvalidArgumentException('No file found for ' . $info->getId());
+			throw new InvalidArgumentException('No file found for ' . $info->getId());
 		}
 
 		return [$owner, $path];
@@ -187,7 +192,12 @@ class Update {
 
 		foreach ($allFiles as $file) {
 			$usersSharing = $this->file->getAccessList($file);
-			$encryptionModule->update($file, $this->uid, $usersSharing);
+			try {
+				$encryptionModule->update($file, $this->uid, $usersSharing);
+			} catch (GenericEncryptionException $e) {
+				// If the update of an individual file fails e.g. due to a corrupt key we should continue the operation and just log the failure
+				$this->logger->error('Failed to update encryption module for ' . $this->uid . ' ' . $file, [ 'exception' => $e ]);
+			}
 		}
 	}
 }

--- a/lib/private/Encryption/Update.php
+++ b/lib/private/Encryption/Update.php
@@ -26,14 +26,11 @@
 
 namespace OC\Encryption;
 
-use Exception;
 use InvalidArgumentException;
-use OC;
 use OC\Files\Filesystem;
 use OC\Files\Mount;
 use OC\Files\View;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
-use OCP\ILogger;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -22,9 +22,13 @@
 namespace Test\Encryption;
 
 use OC\Encryption\Update;
+use OC\Encryption\Util;
 use OC\Files\Mount\Manager;
 use OC\Files\View;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
+use OC\Encryption\File;
+use OCP\Encryption\IEncryptionModule;
 
 class UpdateTest extends TestCase {
 
@@ -37,7 +41,7 @@ class UpdateTest extends TestCase {
 	/** @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject */
 	private $view;
 
-	/** @var \OC\Encryption\Util | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var Util | \PHPUnit\Framework\MockObject\MockObject */
 	private $util;
 
 	/** @var \OC\Files\Mount\Manager | \PHPUnit\Framework\MockObject\MockObject */
@@ -52,21 +56,19 @@ class UpdateTest extends TestCase {
 	/** @var \OC\Encryption\File | \PHPUnit\Framework\MockObject\MockObject */
 	private $fileHelper;
 
+	/** @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface */
+	private $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()->getMock();
-		$this->util = $this->getMockBuilder('\OC\Encryption\Util')
-			->disableOriginalConstructor()->getMock();
-		$this->mountManager = $this->getMockBuilder(Manager::class)
-			->disableOriginalConstructor()->getMock();
-		$this->encryptionManager = $this->getMockBuilder('\OC\Encryption\Manager')
-			->disableOriginalConstructor()->getMock();
-		$this->fileHelper = $this->getMockBuilder('\OC\Encryption\File')
-			->disableOriginalConstructor()->getMock();
-		$this->encryptionModule = $this->getMockBuilder('\OCP\Encryption\IEncryptionModule')
-			->disableOriginalConstructor()->getMock();
+		$this->view = $this->createMock(View::class);
+		$this->util = $this->createMock(Util::class);
+		$this->mountManager = $this->createMock(Manager::class);
+		$this->encryptionManager = $this->createMock(\OC\Encryption\Manager::class);
+		$this->fileHelper = $this->createMock(File::class);
+		$this->encryptionModule = $this->createMock(IEncryptionModule::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->uid = 'testUser1';
 
@@ -76,6 +78,7 @@ class UpdateTest extends TestCase {
 			$this->mountManager,
 			$this->encryptionManager,
 			$this->fileHelper,
+			$this->logger,
 			$this->uid);
 	}
 
@@ -223,6 +226,7 @@ class UpdateTest extends TestCase {
 					$this->mountManager,
 					$this->encryptionManager,
 					$this->fileHelper,
+					$this->logger,
 					$this->uid
 				]
 			)->setMethods($methods)->getMock();


### PR DESCRIPTION
In cases where a single file update of encryption keys fails e.g. when creating a share, the share is created as the update is handled in the postShared/postUnshared hook though the actual request to create the share fails and will be in some inconsistent state. 

In the specific case there was a single file that had somehow corrupted keys so the original owner also wasn't able to open it anymore. Now when the folder containing the file was shared to a group only the files that were updated before the failing file became accessible, but since the Sharing API request fails the UI didn't get a proper response that the folder was shared and all files after the corrupt one were inaccessible.

Logging helps to get a clue about the actual affected file here and makes share operations work again.

Example trace to the original exception thrown that blocks the unshare request:
```
{
  "reqId": "YEniiKnnCEzjeqCBhknDOgAAAAQ",
  "level": 3,
  "time": "March 11, 2021 09:28:08",
  "remoteAddr": "REMOVED",
  "user": "REMOVED",
  "app": "no app in context",
  "method": "DELETE",
  "url": "/ocs/v2.php/apps/files_sharing/api/v1/shares/134782",
  "message": {
    "Exception": "OCA\\Encryption\\Exceptions\\MultiKeyDecryptException",
    "Message": "multikeydecrypt with share key failed:error:0906D06C:PEM routines:PEM_read_bio:no start line",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/nextcloud/apps/encryption/lib/KeyManager.php",
        "line": 480,
        "function": "multiKeyDecrypt",
        "class": "OCA\\Encryption\\Crypto\\Crypt",
        "type": "->",
        "args": [
          null,
          "REMOVED",
          "-----BEGIN PRIVATE KEY-----\nREMOVED"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/apps/encryption/lib/Crypto/Encryption.php",
        "line": 396,
        "function": "getFileKey",
        "class": "OCA\\Encryption\\KeyManager",
        "type": "->",
        "args": [
          "*** sensitive parameter replaced ***",
          "*** sensitive parameter replaced ***"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Encryption/Update.php",
        "line": 190,
        "function": "update",
        "class": "OCA\\Encryption\\Crypto\\Encryption",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Encryption/Update.php",
        "line": 108,
        "function": "update",
        "class": "OC\\Encryption\\Update",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Encryption/HookManager.php",
        "line": 39,
        "function": "postUnshared",
        "class": "OC\\Encryption\\Update",
        "type": "->",
        "args": [
          {
            "id": "134782",
            "itemType": "folder",
            "itemSource": 19095,
            "shareType": 1,
            "shareWith": "1001874",
            "0": "And 5 more entries, set log level to debug to see all entries"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/legacy/OC_Hook.php",
        "line": 110,
        "function": "postUnshared",
        "class": "OC\\Encryption\\HookManager",
        "type": "::",
        "args": [
          {
            "id": "134782",
            "itemType": "folder",
            "itemSource": 19095,
            "shareType": 1,
            "shareWith": "1001874",
            "0": "And 5 more entries, set log level to debug to see all entries"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Share20/LegacyHooks.php",
        "line": 85,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OCP\\Share",
          "post_unshare",
          {
            "id": "134782",
            "itemType": "folder",
            "itemSource": 19095,
            "shareType": 1,
            "shareWith": "1001874",
            "0": "And 5 more entries, set log level to debug to see all entries"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 264,
        "function": "postUnshare",
        "class": "OC\\Share20\\LegacyHooks",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          },
          "OCP\\Share::postUnshare",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 239,
        "function": "doDispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\Share::postUnshare",
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\Share::postUnshare",
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/SymfonyAdapter.php",
        "line": 85,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          },
          {
            "__class__": "OC\\EventDispatcher\\GenericEventWrapper"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Share20/Manager.php",
        "line": 1175,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\SymfonyAdapter",
        "type": "->",
        "args": [
          "OCP\\Share::postUnshare",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\GenericEvent"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/apps/files_sharing/lib/Controller/ShareAPIController.php",
        "line": 405,
        "function": "deleteShare",
        "class": "OC\\Share20\\Manager",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\Share20\\Share"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 169,
        "function": "deleteShare",
        "class": "OCA\\Files_Sharing\\Controller\\ShareAPIController",
        "type": "->",
        "args": [
          "134782"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 100,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files_Sharing\\Controller\\ShareAPIController"
          },
          "deleteShare"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/App.php",
        "line": 152,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files_Sharing\\Controller\\ShareAPIController"
          },
          "deleteShare"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Route/Router.php",
        "line": 309,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Files_Sharing\\Controller\\ShareAPIController",
          "deleteShare",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "id": "134782",
            "_route": "ocs.files_sharing.ShareAPI.deleteShare"
          }
        ]
      },
      {
        "file": "/var/www/html/nextcloud/ocs/v1.php",
        "line": 88,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/ocsapp/apps/files_sharing/api/v1/shares/134782"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/ocs/v2.php",
        "line": 24,
        "args": [
          "/var/www/html/nextcloud/ocs/v1.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/html/nextcloud/apps/encryption/lib/Crypto/Crypt.php",
    "Line": 682,
    "Hint": "multikeydecrypt with share key failed:error:0906D06C:PEM routines:PEM_read_bio:no start line",
    "CustomMessage": "--"
  },
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:86.0) Gecko/20100101 Firefox/86.0",
  "version": "20.0.7.1"
}
```