### PR TITLE
add a prefix index to filecache.path

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -112,6 +112,10 @@ class Application extends App {
 					if (!$table->hasIndex('fs_size')) {
 						$subject->addHintForMissingSubject($table->getName(), 'fs_size');
 					}
+
+					if (!$table->hasIndex('fs_path_prefix')) {
+						$subject->addHintForMissingSubject($table->getName(), 'fs_path_prefix');
+					}
 				}
 
 				if ($schema->hasTable('twofactor_providers')) {

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -144,6 +144,13 @@ class AddMissingIndices extends Command {
 				$updated = true;
 				$output->writeln('<info>Filecache table updated successfully.</info>');
 			}
+			if (!$table->hasIndex('fs_path_prefix')) {
+				$output->writeln('<info>Adding additional path index to the filecache table, this can take some time...</info>');
+				$table->addIndex(['size'], 'fs_path_prefix', [], ["lengths" => [128]]);
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>Filecache table updated successfully.</info>');
+			}
 		}
 
 		$output->writeln('<info>Check indices of the twofactor_providers table.</info>');

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -262,6 +262,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage', 'size', 'fileid'], 'fs_storage_size');
 			$table->addIndex(['mtime'], 'fs_mtime');
 			$table->addIndex(['size'], 'fs_size');
+			$table->addIndex(['path'], 'fs_path_prefix', [], ["lengths" => [128]]);
 		}
 
 		if (!$schema->hasTable('group_user')) {


### PR DESCRIPTION
The reason that `filecache.path` hasn't had an index added is the mysql limitation of ~1kb for indexeded fields,
which is to small for the `path`, however mysql supports indexing only the first N bytes of a column instead of the entire column,
allowing us to add an index even if the column is to long.

Because the index doesn't cover the entire column it can't be used in all situations where a normal index would be used, but it does cover the `path like 'folder/path/%'` queries that are used in various places.

Sqlite and Postgresql don't support prefix indexes, but they also don't have the 1kb limit and DBAL handles the differences in index creation.

Signed-off-by: Robin Appelman <robin@icewind.nl>