### PR TITLE
remove explicit fclose from S3->writeStream

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -104,8 +104,6 @@ trait S3ObjectTrait {
 				throw $e;
 			}
 		}
-
-		fclose($countStream);
 	}
 
 	/**


### PR DESCRIPTION
streams get closed automatically when dropped, and in some cases the stream seems to be already closed by the S3 library, in which case trying to close it again will raise an error

Signed-off-by: Robin Appelman <robin@icewind.nl>