### PR TITLE
Only clear known users when we had at least one phonebook entry

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -240,9 +240,6 @@ class UsersController extends AUserData {
 		$user = $this->userSession->getUser();
 		$knownTo = $user->getUID();
 
-		// Cleanup all previous entries and only allow new matches
-		$this->knownUserService->deleteKnownTo($knownTo);
-
 		$normalizedNumberToKey = [];
 		foreach ($search as $key => $phoneNumbers) {
 			foreach ($phoneNumbers as $phone) {
@@ -262,6 +259,9 @@ class UsersController extends AUserData {
 		if (empty($phoneNumbers)) {
 			return new DataResponse();
 		}
+
+		// Cleanup all previous entries and only allow new matches
+		$this->knownUserService->deleteKnownTo($knownTo);
 
 		$userMatches = $this->accountManager->searchUsers(IAccountManager::PROPERTY_PHONE, $phoneNumbers);
 


### PR DESCRIPTION
### Steps
1. Set up phonebook sync with 2 devices
2. On device 1 fill your phonebook and enable sync
3. On you testing device (device 2) have an empty phonebook and enable sync by accident
4. All your entries are now removed again.