### PR TITLE
Log exceptions when creating share

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -631,9 +631,11 @@ class ShareAPIController extends OCSController {
 		try {
 			$share = $this->shareManager->createShare($share);
 		} catch (GenericShareException $e) {
+			\OC::$server->getLogger()->logException($e);
 			$code = $e->getCode() === 0 ? 403 : $e->getCode();
 			throw new OCSException($e->getHint(), $code);
 		} catch (\Exception $e) {
+			\OC::$server->getLogger()->logException($e);
 			throw new OCSForbiddenException($e->getMessage(), $e);
 		}
 


### PR DESCRIPTION
Because the exceptions don't always contain a useful message for the UI,
but also because in some cases we need to find out what went wrong and look at a stack trace.

In some setups, a ShareNotFound exception might happen during creation
when we try to re-read the just written share. Usually related to Galera
Cluster where node syncing wait is not enabled.

Without this, nothing is log and it's almost impossible to debug.