### PR TITLE
dont allow creating users with __groupfolders as uid

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -681,6 +681,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		if (\in_array($uid, [
 			'.htaccess',
 			'files_external',
+			'__groupfolders',
 			'.ocdata',
 			'owncloud.log',
 			'nextcloud.log',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/338

Signed-off-by: Robin Appelman <robin@icewind.nl>