### PR TITLE
Add Username and Logout Link to FlowV2

### DIFF
--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -43,6 +43,8 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
+use OCP\IConfig;
+use OCP\IServerContainer;
 
 class ClientFlowLoginV2Controller extends Controller {
 	public const TOKEN_NAME = 'client.flow.v2.login.token';
@@ -62,6 +64,14 @@ class ClientFlowLoginV2Controller extends Controller {
 	private $userId;
 	/** @var IL10N */
 	private $l10n;
+	/** @var serverContainer */
+	private $serverContainer;
+	/** @var IConfig */
+	private $config;
+	/** @var boolean */
+	private $userAvatarSet;
+	/** @var string */
+	private $userAvatarVersion;
 
 	public function __construct(string $appName,
 								IRequest $request,
@@ -71,7 +81,8 @@ class ClientFlowLoginV2Controller extends Controller {
 								ISecureRandom $random,
 								Defaults $defaults,
 								?string $userId,
-								IL10N $l10n) {
+								IL10N $l10n,
+				IServerContainer $serverContainer) {
 		parent::__construct($appName, $request);
 		$this->loginFlowV2Service = $loginFlowV2Service;
 		$this->urlGenerator = $urlGenerator;
@@ -80,6 +91,20 @@ class ClientFlowLoginV2Controller extends Controller {
 		$this->defaults = $defaults;
 		$this->userId = $userId;
 		$this->l10n = $l10n;
+		$this->serverContainer = $serverContainer;
+		$this->config = $this->serverContainer->getConfig();
+		$this->userAvatarSet = false;
+		$this->userAvatarVersion = "Test1234";
+
+		if (\OC_User::getUser() === false) {
+			$this->userAvatarSet = false;
+		
+			$this->userAvatarVersion = "false";
+		} else {
+			$this->userAvatarSet = true;
+			$this->userAvatarVersion = $this->config->getUserValue(\OC_User::getUser(), 'avatar', 'version', 0);
+			$this->userAvatarVersion = "true";
+		}
 	}
 
 	/**

--- a/core/templates/loginflowv2/grant.php
+++ b/core/templates/loginflowv2/grant.php
@@ -30,10 +30,16 @@ $urlGenerator = $_['urlGenerator'];
 <div class="picker-window">
 	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
-		<?php print_unescaped($l->t('You are about to grant %1$s access to your %2$s account.', [
+		<?php print_unescaped($l->t('You are about to grant %1$s access to your %2$s %3$s account.', [
 			'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
+			'<strong>' . \OCP\Util::sanitizeHTML(strval(\OC_User::getUser())) . '</strong>',
 			\OCP\Util::sanitizeHTML($_['instanceName'])
-		])) ?>
+		]));
+			print_unescaped('<br/>');
+			print_unescaped($l->t('Click %1$shere%2$s to logout.', [
+				'<a href="' . \OC_User::getLogoutUrl($urlGenerator) . '">',
+				'</a>'
+			]))?> 
 	</p>
 
 	<br/>

--- a/core/templates/loginflowv2/grant.php
+++ b/core/templates/loginflowv2/grant.php
@@ -25,21 +25,40 @@ style('core', 'login/authpicker');
 /** @var array $_ */
 /** @var \OCP\IURLGenerator $urlGenerator */
 $urlGenerator = $_['urlGenerator'];
+/** @var string $userAvatarVersion*/
+$userAvatarVersion = $_['userAvatarVersion'];
 ?>
 
 <div class="picker-window">
 	<h2><?php p($l->t('Account access')) ?></h2>
 	<p class="info">
 		<?php print_unescaped($l->t('You are about to grant %1$s access to your %2$s %3$s account.', [
-			'<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
-			'<strong>' . \OCP\Util::sanitizeHTML(strval(\OC_User::getUser())) . '</strong>',
-			\OCP\Util::sanitizeHTML($_['instanceName'])
-		]));
-			print_unescaped('<br/>');
-			print_unescaped($l->t('Click %1$shere%2$s to logout.', [
-				'<a href="' . \OC_User::getLogoutUrl($urlGenerator) . '">',
-				'</a>'
-			]))?> 
+            '<strong>' . \OCP\Util::sanitizeHTML($_['client']) . '</strong>',
+            '<strong>' . \OCP\Util::sanitizeHTML(strval(\OC_User::getUser())) . '</strong>',
+            \OCP\Util::sanitizeHTML($_['instanceName'])
+        ]));
+            /**print_unescaped('<br/>');
+            print_unescaped(\OCP\Util::sanitizeHTML(strval(\OC_User::getUser()));
+            print_unescaped('<br/>');
+             //print_unescaped(\OCP\Util::sanitizeHTML(strval(\OC_User::getUser()->getUID()))); */
+            print_unescaped('<br/>');
+            //print_unescaped(\OCP\Util::sanitizeHTML(\OCP\Util::sanitizeHTML(strval(\OC_User::getUser()->getUID()))));
+            print_unescaped('<br/>');
+            print_unescaped($_['userId']);
+            print_unescaped('<br/>');
+            print_unescaped('<br/>');
+            var_dump($userAvatarVersion);
+            print_unescaped('<br/>');
+            print_unescaped('<br/>');
+            print_unescaped($_['userAvatarVersion']);
+            print_unescaped('<br/>');
+
+
+
+            print_unescaped($l->t('You are not click here %1$shere%2$s to logout.', [
+                '<a href="' . \OC_User::getLogoutUrl($urlGenerator) . '">',
+                '</a>'
+            ]))?> 
 	</p>
 
 	<br/>


### PR DESCRIPTION
As stated here https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html the Webview should be a one time view.

> This should be a one time webview. Which means:
> 
>     There should be no cookies set when creating the webview
>     Passwords should not be stored
>     No state should be preserved after the webview has terminated
This is simply not correct in a few Applications for example the Enpass iOS App and the Nextcloud Desktop Client which opens the default Browser on Windows.
On Windows you can simply navigate in your Browser and logout and use another Account.
In the iOS Webview you cannot navigate away from the page and so you can't logout to use another Account.

I added the Username and the Logout URL to the Flow V2 which look now like this:
![grafik](https://user-images.githubusercontent.com/10107699/111285024-02a07b00-8641-11eb-9d4d-943dc2284351.png)
Can somebody give me a hint how to change the translation correct ?
I found this file for example: https://github.com/nextcloud/server/blob/310e6550b1c71b1415c6e7e25b892eebe231139f/core/l10n/de.json#L328 Do I need to add this manual to every language file ?