### PR TITLE
Fix CS in CacheTest

### DIFF
--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -548,7 +548,7 @@ class CacheTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		/** @var SharedStorage $sharedStorage */
-		list($sharedStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/sub');
+		[$sharedStorage] = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/sub');
 
 		$results = $sharedStorage->getCache()->search("foo.txt");
 		$this->assertCount(1, $results);


### PR DESCRIPTION
I ran `composer cs:fix` to fix a mysterious issue in https://github.com/nextcloud/server/pull/25320 and it pointed at the line in this PR. So this PR fixes it on master. Maybe we ignored this warning before merging ?