### PR TITLE
Use correct exception type hint in catch statement

### DIFF
--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -193,7 +193,7 @@ class MountConfig {
 	 * @param array $options backend configuration options
 	 * @param boolean $isPersonal
 	 * @return int see self::STATUS_*
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function getBackendStatus($class, $options, $isPersonal, $testOnly = true) {
 		if (self::$skipTest) {
@@ -221,7 +221,7 @@ class MountConfig {
 					$storage->setAvailability(false);
 					throw $e;
 				}
-			} catch (Exception $exception) {
+			} catch (\Exception $exception) {
 				\OC::$server->getLogger()->logException($exception, ['app' => 'files_external']);
 				throw $exception;
 			}


### PR DESCRIPTION
Found by psalm update 4.6.2 to 4.6.3 in #26111

The behaviour should be the same as the exception is then translated to the same exception one layer above, but now includes proper logging. 