### PR TITLE
ability to add some entries out of rfc7033

### DIFF
--- a/lib/public/Http/WellKnown/JrdResponse.php
+++ b/lib/public/Http/WellKnown/JrdResponse.php
@@ -121,7 +121,8 @@ final class JrdResponse implements IResponse {
 	 * @param string|null $type https://tools.ietf.org/html/rfc7033#section-4.4.4.2
 	 * @param string|null $href https://tools.ietf.org/html/rfc7033#section-4.4.4.3
 	 * @param string[]|null $titles https://tools.ietf.org/html/rfc7033#section-4.4.4.4
-	 * @param string|null $properties https://tools.ietf.org/html/rfc7033#section-4.4.4.5
+	 * @param string[]|null $properties https://tools.ietf.org/html/rfc7033#section-4.4.4.5
+	 * @param string[] $entries
 	 *
 	 * @psalm-param array<string,(string|null)>|null $properties https://tools.ietf.org/html/rfc7033#section-4.4.4.5
 	 *
@@ -132,14 +133,21 @@ final class JrdResponse implements IResponse {
 							?string $type,
 							?string $href,
 							?array $titles = [],
-							?array $properties = []): self {
-		$this->links[] = array_filter([
-			'rel' => $rel,
-			'type' => $type,
-			'href' => $href,
-			'titles' => $titles,
-			'properties' => $properties,
-		]);
+							?array $properties = [],
+							array $entries = []
+	): self {
+		$this->links[] = array_filter(
+			array_merge(
+				[
+					'rel'        => $rel,
+					'type'       => $type,
+					'href'       => $href,
+					'titles'     => $titles,
+					'properties' => $properties
+				],
+				$entries
+			)
+		);
 
 		return $this;
 	}


### PR DESCRIPTION
Some protocol like OStatus needs a 'template' entry to add an URI Template to the to the `link`, and this is not defined in the RFC:

https://www.w3.org/community/ostatus/wiki/Workflow

This allow an app (ie. Social) to stay compatible with those protocols

