### PR TITLE
Handle limit offset and sorting in files search

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -29,10 +29,13 @@ declare(strict_types=1);
 
 namespace OCA\Files\Search;
 
-use OC\Search\Provider\File;
-use OC\Search\Result\File as FileResult;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchQuery;
+use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Node;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -42,9 +45,6 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class FilesSearchProvider implements IProvider {
-
-	/** @var File */
-	private $fileSearch;
 
 	/** @var IL10N */
 	private $l10n;
@@ -58,13 +58,13 @@ class FilesSearchProvider implements IProvider {
 	/** @var IRootFolder */
 	private $rootFolder;
 
-	public function __construct(File $fileSearch,
-								IL10N $l10n,
-								IURLGenerator $urlGenerator,
-								IMimeTypeDetector $mimeTypeDetector,
-								IRootFolder $rootFolder) {
+	public function __construct(
+		IL10N $l10n,
+		IURLGenerator $urlGenerator,
+		IMimeTypeDetector $mimeTypeDetector,
+		IRootFolder $rootFolder
+	) {
 		$this->l10n = $l10n;
-		$this->fileSearch = $fileSearch;
 		$this->urlGenerator = $urlGenerator;
 		$this->mimeTypeDetector = $mimeTypeDetector;
 		$this->rootFolder = $rootFolder;
@@ -99,29 +99,40 @@ class FilesSearchProvider implements IProvider {
 	 * @inheritDoc
 	 */
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
-
-		// Make sure we setup the users filesystem
-		$this->rootFolder->getUserFolder($user->getUID());
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$fileQuery = new SearchQuery(
+			new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query->getTerm() . '%'),
+			$query->getLimit(),
+			(int)$query->getCursor(),
+			[],
+			$user
+		);
 
 		return SearchResult::paginated(
 			$this->l10n->t('Files'),
-			array_map(function (FileResult $result) {
+			array_map(function (Node $result) use ($userFolder) {
 				// Generate thumbnail url
-				$thumbnailUrl = $result->has_preview
-					? $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->id])
-					: '';
+				$thumbnailUrl = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->getId()]);
+				$path = $userFolder->getRelativePath($result->getPath());
+				$link = $this->urlGenerator->linkToRoute(
+					'files.view.index',
+					[
+						'dir' => dirname($path),
+						'scrollto' => $result->getName(),
+					]
+				);
 
 				$searchResultEntry = new SearchResultEntry(
 					$thumbnailUrl,
-					$result->name,
-					$this->formatSubline($result),
-					$this->urlGenerator->getAbsoluteURL($result->link),
-					$result->type === 'folder' ? 'icon-folder' : $this->mimeTypeDetector->mimeTypeIcon($result->mime_type)
+					$result->getName(),
+					$this->formatSubline($path),
+					$this->urlGenerator->getAbsoluteURL($link),
+					$result->getMimetype() === FileInfo::MIMETYPE_FOLDER ? 'icon-folder' : $this->mimeTypeDetector->mimeTypeIcon($result->getMimetype())
 				);
-				$searchResultEntry->addAttribute('fileId', (string)$result->id);
-				$searchResultEntry->addAttribute('path', $result->path);
+				$searchResultEntry->addAttribute('fileId', (string)$result->getId());
+				$searchResultEntry->addAttribute('path', $path);
 				return $searchResultEntry;
-			}, $this->fileSearch->search($query->getTerm(), $query->getLimit(), (int)$query->getCursor())),
+			}, $userFolder->search($fileQuery)),
 			$query->getCursor() + $query->getLimit()
 		);
 	}
@@ -129,16 +140,16 @@ class FilesSearchProvider implements IProvider {
 	/**
 	 * Format subline for files
 	 *
-	 * @param FileResult $result
+	 * @param string $path
 	 * @return string
 	 */
-	private function formatSubline($result): string {
+	private function formatSubline(string $path): string {
 		// Do not show the location if the file is in root
-		if ($result->path === '/' . $result->name) {
+		if (strrpos($path, '/') > 0) {
+			$path = ltrim(dirname($path), '/');
+			return $this->l10n->t('in %s', [$path]);
+		} else {
 			return '';
 		}
-
-		$path = ltrim(dirname($result->path), '/');
-		return $this->l10n->t('in %s', [$path]);
 	}
 }

--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -30,12 +30,14 @@ declare(strict_types=1);
 namespace OCA\Files\Search;
 
 use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
 use OC\Files\Search\SearchQuery;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Node;
+use OCP\Files\Search\ISearchOrder;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -104,7 +106,9 @@ class FilesSearchProvider implements IProvider {
 			new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query->getTerm() . '%'),
 			$query->getLimit(),
 			(int)$query->getCursor(),
-			[],
+			$query->getSortOrder() === ISearchQuery::SORT_DATE_DESC ? [
+				new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime'),
+			] : [],
 			$user
 		);
 

--- a/core/Controller/SearchController.php
+++ b/core/Controller/SearchController.php
@@ -55,6 +55,7 @@ class SearchController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 */
 	public function search(string $query, array $inApps = [], int $page = 1, int $size = 30): JSONResponse {
 		$results = $this->searcher->searchPaged($query, $inApps, $page, $size);

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -198,10 +198,10 @@ class Cache implements ICache {
 		}
 		$data['permissions'] = (int)$data['permissions'];
 		if (isset($data['creation_time'])) {
-			$data['creation_time'] = (int) $data['creation_time'];
+			$data['creation_time'] = (int)$data['creation_time'];
 		}
 		if (isset($data['upload_time'])) {
-			$data['upload_time'] = (int) $data['upload_time'];
+			$data['upload_time'] = (int)$data['upload_time'];
 		}
 		return new CacheEntry($data);
 	}
@@ -841,6 +841,10 @@ class Cache implements ICache {
 		$query->whereStorageId();
 
 		if ($this->querySearchHelper->shouldJoinTags($searchQuery->getSearchOperation())) {
+			$user = $searchQuery->getUser();
+			if ($user === null) {
+				throw new \InvalidArgumentException("Searching by tag requires the user to be set in the query");
+			}
 			$query
 				->innerJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
 				->innerJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
@@ -848,7 +852,7 @@ class Cache implements ICache {
 					$builder->expr()->eq('tagmap.categoryid', 'tag.id')
 				))
 				->andWhere($builder->expr()->eq('tag.type', $builder->createNamedParameter('files')))
-				->andWhere($builder->expr()->eq('tag.uid', $builder->createNamedParameter($searchQuery->getUser()->getUID())));
+				->andWhere($builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID())));
 		}
 
 		$searchExpr = $this->querySearchHelper->searchOperatorToDBExpr($builder, $searchQuery->getSearchOperation());
@@ -1031,7 +1035,7 @@ class Cache implements ICache {
 			return null;
 		}
 
-		return (string) $path;
+		return (string)$path;
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -46,7 +46,6 @@ use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IUserManager;
-use OCP\IUserSession;
 
 class Folder extends Node implements \OCP\Files\Folder {
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -32,7 +32,6 @@
 namespace OC\Files\Node;
 
 use OC\DB\QueryBuilder\Literal;
-use OC\Files\Mount\MountPoint;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
@@ -232,23 +231,18 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query . '%'));
 		}
 
-		// Limit+offset for queries without ordering
+		// Limit+offset for queries with ordering
 		//
-		// assume a setup where the root mount matches 15 items,
-		//   sub mount1 matches 7 items and mount2 matches 1 item
-		// a search with (0..10) returns 10 results from root with internal offset 0 and limit 10
-		// follow up search with (10..20) returns 5 results from root with internal offset 10 and limit 10
-		//   and 5 results from mount1 with internal offset 0 and limit 5
-		// next search with (20..30) return 0 results from root with internal offset 20 and limit 10
-		//   2 results from mount1 with internal offset 5[1] and limit 5
-		//   and 1 result from mount2 with internal offset 0[1] and limit 8
+		// Because we currently can't do ordering between the results from different storages in sql
+		// The only way to do ordering is requesting the $limit number of entries from all storages
+		// sorting them and returning the first $limit entries.
 		//
-		// Because of the difficulty of calculating the offset for a sub-query if the previous one returns no results
-		//   (we don't know how many results the previous sub-query has skipped with it's own offset)
-		// we instead discard the offset for the sub-queries and filter it afterwards and add the offset to limit.
-		// this is sub-optimal but shouldn't hurt to much since large offsets are uncommon in practice
+		// For offset we have the same problem, we don't know how many entries from each storage should be skipped
+		// by a given $offset, so instead we query $offset + $limit from each storage and return entries $offset..($offset+$limit)
+		// after merging and sorting them.
 		//
-		// All of this is only possible for queries without ordering
+		// This is suboptimal but because limit and offset tend to be fairly small in real world use cases it should
+		// still be significantly better than disabling paging altogether
 
 		$limitToHome = $query->limitToHome();
 		if ($limitToHome && count(explode('/', $this->path)) !== 3) {
@@ -264,13 +258,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$internalPath = $internalPath . '/';
 		}
 
-		$subQueryLimit = $query->getLimit() > 0 ? $query->getLimit() + $query->getOffset() : PHP_INT_MAX;
-		$subQueryOffset = $query->getOffset();
+		$subQueryLimit = $query->getLimit() > 0 ? $query->getLimit() + $query->getOffset() : 0;
 		$rootQuery = new SearchQuery(
 			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
-					new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', $internalPath . '%'),
-					$query->getSearchOperation(),
-				]
+				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', $internalPath . '%'),
+				$query->getSearchOperation(),
+			]
 			),
 			$subQueryLimit,
 			0,
@@ -283,11 +276,6 @@ class Folder extends Node implements \OCP\Files\Folder {
 		$cache = $storage->getCache('');
 
 		$results = $cache->searchQuery($rootQuery);
-		$count = count($results);
-		$results = array_slice($results, $subQueryOffset, $subQueryLimit);
-		$subQueryOffset = max(0, $subQueryOffset - $count);
-		$subQueryLimit = max(0, $subQueryLimit - $count);
-
 		foreach ($results as $result) {
 			$files[] = $this->cacheEntryToFileInfo($mount, '', $internalPath, $result);
 		}
@@ -295,10 +283,6 @@ class Folder extends Node implements \OCP\Files\Folder {
 		if (!$limitToHome) {
 			$mounts = $this->root->getMountsIn($this->path);
 			foreach ($mounts as $mount) {
-				if ($subQueryLimit <= 0) {
-					break;
-				}
-
 				$subQuery = new SearchQuery(
 					$query->getSearchOperation(),
 					$subQueryLimit,
@@ -313,18 +297,26 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 					$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
 					$results = $cache->searchQuery($subQuery);
-
-					$count = count($results);
-					$results = array_slice($results, $subQueryOffset, $subQueryLimit);
-					$subQueryOffset -= $count;
-					$subQueryLimit -= $count;
-
 					foreach ($results as $result) {
 						$files[] = $this->cacheEntryToFileInfo($mount, $relativeMountPoint, '', $result);
 					}
 				}
 			}
 		}
+
+		$order = $query->getOrder();
+		if ($order) {
+			usort($files, function (FileInfo $a,FileInfo  $b) use ($order) {
+				foreach ($order as $orderField) {
+					$cmp = $orderField->sortFileInfo($a, $b);
+					if ($cmp !== 0) {
+						return $cmp;
+					}
+				}
+				return 0;
+			});
+		}
+		$files = array_values(array_slice($files, $query->getOffset(), $query->getLimit() > 0 ? $query->getLimit() : null));
 
 		return array_map(function (FileInfo $file) {
 			return $this->createNode($file->getPath(), $file);

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -32,11 +32,14 @@
 namespace OC\Files\Node;
 
 use OC\DB\QueryBuilder\Literal;
+use OC\Files\Mount\MountPoint;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
+use OC\Files\Storage\Storage;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountPoint;
@@ -227,6 +230,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query . '%'));
 		}
 
+		// Limit+offset for queries without ordering
+		//
 		// assume a setup where the root mount matches 15 items,
 		//   sub mount1 matches 7 items and mount2 matches 1 item
 		// a search with (0..10) returns 10 results from root with internal offset 0 and limit 10
@@ -240,6 +245,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 		//   (we don't know how many results the previous sub-query has skipped with it's own offset)
 		// we instead discard the offset for the sub-queries and filter it afterwards and add the offset to limit.
 		// this is sub-optimal but shouldn't hurt to much since large offsets are uncommon in practice
+		//
+		// All of this is only possible for queries without ordering
 
 		$limitToHome = $query->limitToHome();
 		if ($limitToHome && count(explode('/', $this->path)) !== 3) {
@@ -277,10 +284,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 		foreach ($results as $result) {
 			if ($internalRootLength === 0 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
-				$result['internalPath'] = $result['path'];
-				$result['path'] = substr($result['path'], $internalRootLength);
-				$result['storage'] = $storage;
-				$files[] = new \OC\Files\FileInfo($this->path . '/' . $result['path'], $storage, $result['internalPath'], $result, $mount);
+				$files[] = $this->cacheEntryToFileInfo($mount, '', $internalPath, $result);
 			}
 		}
 
@@ -312,11 +316,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 					$subQueryLimit -= $count;
 
 					foreach ($results as $result) {
-						$result['internalPath'] = $result['path'];
-						$result['path'] = $relativeMountPoint . $result['path'];
-						$result['storage'] = $storage;
-						$files[] = new \OC\Files\FileInfo($this->path . '/' . $result['path'], $storage,
-							$result['internalPath'], $result, $mount);
+						$files[] = $this->cacheEntryToFileInfo($mount, $relativeMountPoint, '', $result);
 					}
 				}
 			}
@@ -325,6 +325,13 @@ class Folder extends Node implements \OCP\Files\Folder {
 		return array_map(function (FileInfo $file) {
 			return $this->createNode($file->getPath(), $file);
 		}, $files);
+	}
+
+	private function cacheEntryToFileInfo(IMountPoint $mount, string $appendRoot, string $trimRoot, ICacheEntry $cacheEntry): FileInfo {
+		$trimLength = strlen($trimRoot);
+		$cacheEntry['internalPath'] = $cacheEntry['path'];
+		$cacheEntry['path'] = $appendRoot .  substr($cacheEntry['path'], $trimLength);
+		return new \OC\Files\FileInfo($this->path . '/' . $cacheEntry['path'], $mount->getStorage(), $cacheEntry['internalPath'], $cacheEntry, $mount);
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -33,6 +33,7 @@ namespace OC\Files\Node;
 
 use OC\DB\QueryBuilder\Literal;
 use OC\Files\Mount\MountPoint;
+use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
@@ -45,6 +46,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
@@ -253,17 +255,6 @@ class Folder extends Node implements \OCP\Files\Folder {
 			throw new \InvalidArgumentException('searching by owner is only allows on the users home folder');
 		}
 
-		$subQueryLimit = $query->getLimit() > 0 ? $query->getLimit() + $query->getOffset() : PHP_INT_MAX;
-		$subQueryOffset = $query->getOffset();
-		$noLimitQuery = new SearchQuery(
-			$query->getSearchOperation(),
-			$subQueryLimit,
-			0,
-			$query->getOrder(),
-			$query->getUser()
-		);
-
-		$files = [];
 		$rootLength = strlen($this->path);
 		$mount = $this->root->getMount($this->path);
 		$storage = $mount->getStorage();
@@ -272,20 +263,33 @@ class Folder extends Node implements \OCP\Files\Folder {
 		if ($internalPath !== '') {
 			$internalPath = $internalPath . '/';
 		}
-		$internalRootLength = strlen($internalPath);
+
+		$subQueryLimit = $query->getLimit() > 0 ? $query->getLimit() + $query->getOffset() : PHP_INT_MAX;
+		$subQueryOffset = $query->getOffset();
+		$rootQuery = new SearchQuery(
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', $internalPath . '%'),
+					$query->getSearchOperation(),
+				]
+			),
+			$subQueryLimit,
+			0,
+			$query->getOrder(),
+			$query->getUser()
+		);
+
+		$files = [];
 
 		$cache = $storage->getCache('');
 
-		$results = $cache->searchQuery($noLimitQuery);
+		$results = $cache->searchQuery($rootQuery);
 		$count = count($results);
 		$results = array_slice($results, $subQueryOffset, $subQueryLimit);
 		$subQueryOffset = max(0, $subQueryOffset - $count);
 		$subQueryLimit = max(0, $subQueryLimit - $count);
 
 		foreach ($results as $result) {
-			if ($internalRootLength === 0 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
-				$files[] = $this->cacheEntryToFileInfo($mount, '', $internalPath, $result);
-			}
+			$files[] = $this->cacheEntryToFileInfo($mount, '', $internalPath, $result);
 		}
 
 		if (!$limitToHome) {
@@ -330,7 +334,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	private function cacheEntryToFileInfo(IMountPoint $mount, string $appendRoot, string $trimRoot, ICacheEntry $cacheEntry): FileInfo {
 		$trimLength = strlen($trimRoot);
 		$cacheEntry['internalPath'] = $cacheEntry['path'];
-		$cacheEntry['path'] = $appendRoot .  substr($cacheEntry['path'], $trimLength);
+		$cacheEntry['path'] = $appendRoot . substr($cacheEntry['path'], $trimLength);
 		return new \OC\Files\FileInfo($this->path . '/' . $cacheEntry['path'], $mount->getStorage(), $cacheEntry['internalPath'], $cacheEntry, $mount);
 	}
 

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -207,10 +207,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 	}
 
 	private function queryFromOperator(ISearchOperator $operator, string $uid = null): ISearchQuery {
-		if (!$uid) {
-			/** @var IUserSession $session */
-			$session = \OC::$server->query(IUserSession::class);
-			$user = $session->getUser();
+		if ($uid === null) {
+			$user = null;
 		} else {
 			/** @var IUserManager $userManager */
 			$userManager = \OC::$server->query(IUserManager::class);
@@ -230,10 +228,34 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query . '%'));
 		}
 
+		// assume a setup where the root mount matches 15 items,
+		//   sub mount1 matches 7 items and mount2 matches 1 item
+		// a search with (0..10) returns 10 results from root with internal offset 0 and limit 10
+		// follow up search with (10..20) returns 5 results from root with internal offset 10 and limit 10
+		//   and 5 results from mount1 with internal offset 0 and limit 5
+		// next search with (20..30) return 0 results from root with internal offset 20 and limit 10
+		//   2 results from mount1 with internal offset 5[1] and limit 5
+		//   and 1 result from mount2 with internal offset 0[1] and limit 8
+		//
+		// Because of the difficulty of calculating the offset for a sub-query if the previous one returns no results
+		//   (we don't know how many results the previous sub-query has skipped with it's own offset)
+		// we instead discard the offset for the sub-queries and filter it afterwards and add the offset to limit.
+		// this is sub-optimal but shouldn't hurt to much since large offsets are uncommon in practice
+
 		$limitToHome = $query->limitToHome();
 		if ($limitToHome && count(explode('/', $this->path)) !== 3) {
 			throw new \InvalidArgumentException('searching by owner is only allows on the users home folder');
 		}
+
+		$subQueryLimit = $query->getLimit() > 0 ? $query->getLimit() + $query->getOffset() : PHP_INT_MAX;
+		$subQueryOffset = $query->getOffset();
+		$noLimitQuery = new SearchQuery(
+			$query->getSearchOperation(),
+			$subQueryLimit,
+			0,
+			$query->getOrder(),
+			$query->getUser()
+		);
 
 		$files = [];
 		$rootLength = strlen($this->path);
@@ -248,7 +270,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 		$cache = $storage->getCache('');
 
-		$results = $cache->searchQuery($query);
+		$results = $cache->searchQuery($noLimitQuery);
+		$count = count($results);
+		$results = array_slice($results, $subQueryOffset, $subQueryLimit);
+		$subQueryOffset = max(0, $subQueryOffset - $count);
+		$subQueryLimit = max(0, $subQueryLimit - $count);
+
 		foreach ($results as $result) {
 			if ($internalRootLength === 0 or substr($result['path'], 0, $internalRootLength) === $internalPath) {
 				$result['internalPath'] = $result['path'];
@@ -261,12 +288,30 @@ class Folder extends Node implements \OCP\Files\Folder {
 		if (!$limitToHome) {
 			$mounts = $this->root->getMountsIn($this->path);
 			foreach ($mounts as $mount) {
+				if ($subQueryLimit <= 0) {
+					break;
+				}
+
+				$subQuery = new SearchQuery(
+					$query->getSearchOperation(),
+					$subQueryLimit,
+					0,
+					$query->getOrder(),
+					$query->getUser()
+				);
+
 				$storage = $mount->getStorage();
 				if ($storage) {
 					$cache = $storage->getCache('');
 
 					$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
-					$results = $cache->searchQuery($query);
+					$results = $cache->searchQuery($subQuery);
+
+					$count = count($results);
+					$results = array_slice($results, $subQueryOffset, $subQueryLimit);
+					$subQueryOffset -= $count;
+					$subQueryLimit -= $count;
+
 					foreach ($results as $result) {
 						$result['internalPath'] = $result['path'];
 						$result['path'] = $relativeMountPoint . $result['path'];

--- a/lib/private/Files/Search/SearchOrder.php
+++ b/lib/private/Files/Search/SearchOrder.php
@@ -23,6 +23,7 @@
 
 namespace OC\Files\Search;
 
+use OCP\Files\FileInfo;
 use OCP\Files\Search\ISearchOrder;
 
 class SearchOrder implements ISearchOrder {
@@ -54,5 +55,29 @@ class SearchOrder implements ISearchOrder {
 	 */
 	public function getField() {
 		return $this->field;
+	}
+
+	public function sortFileInfo(FileInfo $a, FileInfo $b): int {
+		$cmp = $this->sortFileInfoNoDirection($a, $b);
+		return $cmp * ($this->direction === ISearchOrder::DIRECTION_ASCENDING ? 1 : -1);
+	}
+
+	private function sortFileInfoNoDirection(FileInfo $a, FileInfo $b): int {
+		switch ($this->field) {
+			case 'name':
+				return $a->getName() <=> $b->getName();
+			case 'mimetype':
+				return $a->getMimetype() <=> $b->getMimetype();
+			case 'mtime':
+				return $a->getMtime() <=> $b->getMtime();
+			case 'size':
+				return $a->getSize() <=> $b->getSize();
+			case 'fileid':
+				return $a->getId() <=> $b->getId();
+			case 'permissions':
+				return $a->getPermissions() <=> $b->getPermissions();
+			default:
+				return 0;
+		}
 	}
 }

--- a/lib/private/Files/Search/SearchQuery.php
+++ b/lib/private/Files/Search/SearchQuery.php
@@ -37,7 +37,7 @@ class SearchQuery implements ISearchQuery {
 	private $offset;
 	/** @var  ISearchOrder[] */
 	private $order;
-	/** @var IUser */
+	/** @var ?IUser */
 	private $user;
 	private $limitToHome;
 
@@ -48,7 +48,7 @@ class SearchQuery implements ISearchQuery {
 	 * @param int $limit
 	 * @param int $offset
 	 * @param array $order
-	 * @param IUser $user
+	 * @param ?IUser $user
 	 * @param bool $limitToHome
 	 */
 	public function __construct(
@@ -56,7 +56,7 @@ class SearchQuery implements ISearchQuery {
 		int $limit,
 		int $offset,
 		array $order,
-		IUser $user,
+		?IUser $user = null,
 		bool $limitToHome = false
 	) {
 		$this->searchOperation = $searchOperation;
@@ -96,7 +96,7 @@ class SearchQuery implements ISearchQuery {
 	}
 
 	/**
-	 * @return IUser
+	 * @return ?IUser
 	 */
 	public function getUser() {
 		return $this->user;

--- a/lib/private/Search/Provider/File.php
+++ b/lib/private/Search/Provider/File.php
@@ -29,7 +29,14 @@
 
 namespace OC\Search\Provider;
 
-use OC\Files\Filesystem;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
+use OC\Files\Search\SearchQuery;
+use OCP\Files\FileInfo;
+use OCP\Files\IRootFolder;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOrder;
+use OCP\IUserSession;
 use OCP\Search\PagedProvider;
 
 /**
@@ -48,35 +55,38 @@ class File extends PagedProvider {
 	 * @deprecated 20.0.0
 	 */
 	public function search($query, int $limit = null, int $offset = null) {
-		if ($offset === null) {
-			$offset = 0;
+		/** @var IRootFolder $rootFolder */
+		$rootFolder = \OC::$server->query(IRootFolder::class);
+		/** @var IUserSession $userSession */
+		$userSession = \OC::$server->query(IUserSession::class);
+		$user = $userSession->getUser();
+		if (!$user) {
+			return [];
 		}
-		\OC_Util::setupFS();
-		$files = Filesystem::search($query);
+		$userFolder = $rootFolder->getUserFolder($user->getUID());
+		$fileQuery = new SearchQuery(
+			new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%' . $query . '%'),
+			(int)$limit,
+			(int)$offset,
+			[
+				new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime'),
+			],
+			$user
+		);
+		$files = $userFolder->search($fileQuery);
 		$results = [];
-		if ($limit !== null) {
-			$files = array_slice($files, $offset, $offset + $limit);
-		}
 		// edit results
 		foreach ($files as $fileData) {
-			// skip versions
-			if (strpos($fileData['path'], '_versions') === 0) {
-				continue;
-			}
-			// skip top-level folder
-			if ($fileData['name'] === 'files' && $fileData['parent'] === -1) {
-				continue;
-			}
 			// create audio result
-			if ($fileData['mimepart'] === 'audio') {
+			if ($fileData->getMimePart() === 'audio') {
 				$result = new \OC\Search\Result\Audio($fileData);
 			}
 			// create image result
-			elseif ($fileData['mimepart'] === 'image') {
+			elseif ($fileData->getMimePart() === 'image') {
 				$result = new \OC\Search\Result\Image($fileData);
 			}
 			// create folder result
-			elseif ($fileData['mimetype'] === 'httpd/unix-directory') {
+			elseif ($fileData->getMimetype() === FileInfo::MIMETYPE_FOLDER) {
 				$result = new \OC\Search\Result\Folder($fileData);
 			}
 			// or create file result

--- a/lib/private/Search/Result/File.php
+++ b/lib/private/Search/Result/File.php
@@ -97,14 +97,13 @@ class File extends \OCP\Search\Result {
 	public function __construct(FileInfo $data) {
 		$path = $this->getRelativePath($data->getPath());
 
-		$info = pathinfo($path);
 		$this->id = $data->getId();
-		$this->name = $info['basename'];
+		$this->name = $data->getName();
 		$this->link = \OC::$server->getURLGenerator()->linkToRoute(
 			'files.view.index',
 			[
-				'dir' => $info['dirname'],
-				'scrollto' => $info['basename'],
+				'dir' => dirname($path),
+				'scrollto' => $data->getName(),
 			]
 		);
 		$this->permissions = $data->getPermissions();

--- a/lib/public/Files/Search/ISearchOrder.php
+++ b/lib/public/Files/Search/ISearchOrder.php
@@ -24,6 +24,8 @@
 
 namespace OCP\Files\Search;
 
+use OCP\Files\FileInfo;
+
 /**
  * @since 12.0.0
  */
@@ -46,4 +48,14 @@ interface ISearchOrder {
 	 * @since 12.0.0
 	 */
 	public function getField();
+
+	/**
+	 * Apply the sorting on 2 FileInfo objects
+	 *
+	 * @param FileInfo $a
+	 * @param FileInfo $b
+	 * @return int -1 if $a < $b, 0 if $a = $b, 1 if $a > $b (for ascending, reverse for descending)
+	 * @since 22.0.0
+	 */
+	public function sortFileInfo(FileInfo $a, FileInfo $b): int;
 }

--- a/lib/public/Files/Search/ISearchQuery.php
+++ b/lib/public/Files/Search/ISearchQuery.php
@@ -62,7 +62,7 @@ interface ISearchQuery {
 	/**
 	 * The user that issued the search
 	 *
-	 * @return IUser
+	 * @return ?IUser
 	 * @since 12.0.0
 	 */
 	public function getUser();

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -290,38 +290,31 @@ class FolderTest extends NodeTest {
 		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager])
 			->getMock();
-		$root->expects($this->any())
-			->method('getUser')
+		$root->method('getUser')
 			->willReturn($this->user);
 		$storage = $this->createMock(Storage::class);
 		$storage->method('getId')->willReturn('');
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([$storage])->getMock();
 
-		$storage->expects($this->once())
-			->method('getCache')
+		$storage->method('getCache')
 			->willReturn($cache);
 
 		$mount = $this->createMock(IMountPoint::class);
-		$mount->expects($this->once())
-			->method('getStorage')
+		$mount->method('getStorage')
 			->willReturn($storage);
-		$mount->expects($this->once())
-			->method('getInternalPath')
+		$mount->method('getInternalPath')
 			->willReturn('foo');
 
-		$cache->expects($this->once())
-			->method('searchQuery')
+		$cache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
-		$root->expects($this->once())
-			->method('getMountsIn')
+		$root->method('getMountsIn')
 			->with('/bar/foo')
 			->willReturn([]);
 
-		$root->expects($this->once())
-			->method('getMount')
+		$root->method('getMount')
 			->with('/bar/foo')
 			->willReturn($mount);
 
@@ -350,31 +343,25 @@ class FolderTest extends NodeTest {
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([$storage])->getMock();
 
 		$mount = $this->createMock(IMountPoint::class);
-		$mount->expects($this->once())
-			->method('getStorage')
+		$mount->method('getStorage')
 			->willReturn($storage);
-		$mount->expects($this->once())
-			->method('getInternalPath')
+		$mount->method('getInternalPath')
 			->willReturn('files');
 
-		$storage->expects($this->once())
-			->method('getCache')
+		$storage->method('getCache')
 			->willReturn($cache);
 
-		$cache->expects($this->once())
-			->method('searchQuery')
+		$cache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 3, 'path' => 'files/foo', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 				new CacheEntry(['fileid' => 3, 'path' => 'files_trashbin/foo2.d12345', 'name' => 'foo2.d12345', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
-		$root->expects($this->once())
-			->method('getMountsIn')
+		$root->method('getMountsIn')
 			->with('')
 			->willReturn([]);
 
-		$root->expects($this->once())
-			->method('getMount')
+		$root->method('getMount')
 			->with('')
 			->willReturn($mount);
 
@@ -392,38 +379,31 @@ class FolderTest extends NodeTest {
 		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager])
 			->getMock();
-		$root->expects($this->any())
-			->method('getUser')
+		$root->method('getUser')
 			->willReturn($this->user);
 		$storage = $this->createMock(Storage::class);
 		$storage->method('getId')->willReturn('');
 		$cache = $this->getMockBuilder(Cache::class)->setConstructorArgs([$storage])->getMock();
 
 		$mount = $this->createMock(IMountPoint::class);
-		$mount->expects($this->once())
-			->method('getStorage')
+		$mount->method('getStorage')
 			->willReturn($storage);
-		$mount->expects($this->once())
-			->method('getInternalPath')
+		$mount->method('getInternalPath')
 			->willReturn('');
 
-		$storage->expects($this->once())
-			->method('getCache')
+		$storage->method('getCache')
 			->willReturn($cache);
 
-		$cache->expects($this->once())
-			->method('searchQuery')
+		$cache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
-		$root->expects($this->once())
-			->method('getMountsIn')
+		$root->method('getMountsIn')
 			->with('/bar')
 			->willReturn([]);
 
-		$root->expects($this->once())
-			->method('getMount')
+		$root->method('getMount')
 			->with('/bar')
 			->willReturn($mount);
 
@@ -453,48 +433,38 @@ class FolderTest extends NodeTest {
 		$subMount = $this->getMockBuilder(MountPoint::class)->setConstructorArgs([null, ''])->getMock();
 
 		$mount = $this->createMock(IMountPoint::class);
-		$mount->expects($this->once())
-			->method('getStorage')
+		$mount->method('getStorage')
 			->willReturn($storage);
-		$mount->expects($this->once())
-			->method('getInternalPath')
+		$mount->method('getInternalPath')
 			->willReturn('foo');
 
-		$subMount->expects($this->once())
-			->method('getStorage')
+		$subMount->method('getStorage')
 			->willReturn($subStorage);
 
-		$subMount->expects($this->once())
-			->method('getMountPoint')
+		$subMount->method('getMountPoint')
 			->willReturn('/bar/foo/bar/');
 
-		$storage->expects($this->once())
-			->method('getCache')
+		$storage->method('getCache')
 			->willReturn($cache);
 
-		$subStorage->expects($this->once())
-			->method('getCache')
+		$subStorage->method('getCache')
 			->willReturn($subCache);
 
-		$cache->expects($this->once())
-			->method('searchQuery')
+		$cache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
-		$subCache->expects($this->once())
-			->method('searchQuery')
+		$subCache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 4, 'path' => 'asd/qweasd', 'name' => 'qweasd', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
-		$root->expects($this->once())
-			->method('getMountsIn')
+		$root->method('getMountsIn')
 			->with('/bar/foo')
 			->willReturn([$subMount]);
 
-		$root->expects($this->once())
-			->method('getMount')
+		$root->method('getMount')
 			->with('/bar/foo')
 			->willReturn($mount);
 

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -305,10 +305,9 @@ class FolderTest extends NodeTest {
 			->willReturn('foo');
 
 		$cache->expects($this->once())
-			->method('search')
-			->with('%qw%')
+			->method('searchQuery')
 			->willReturn([
-				['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']
+				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'])
 			]);
 
 		$root->expects($this->once())
@@ -358,11 +357,10 @@ class FolderTest extends NodeTest {
 			->willReturn($cache);
 
 		$cache->expects($this->once())
-			->method('search')
-			->with('%qw%')
+			->method('searchQuery')
 			->willReturn([
-				['fileid' => 3, 'path' => 'files/foo', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'],
-				['fileid' => 3, 'path' => 'files_trashbin/foo2.d12345', 'name' => 'foo2.d12345', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'],
+				new CacheEntry(['fileid' => 3, 'path' => 'files/foo', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
+				new CacheEntry(['fileid' => 3, 'path' => 'files_trashbin/foo2.d12345', 'name' => 'foo2.d12345', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
 		$root->expects($this->once())
@@ -409,10 +407,9 @@ class FolderTest extends NodeTest {
 			->willReturn($cache);
 
 		$cache->expects($this->once())
-			->method('search')
-			->with('%qw%')
+			->method('searchQuery')
 			->willReturn([
-				['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']
+				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'])
 			]);
 
 		$root->expects($this->once())
@@ -475,17 +472,15 @@ class FolderTest extends NodeTest {
 			->willReturn($subCache);
 
 		$cache->expects($this->once())
-			->method('search')
-			->with('%qw%')
+			->method('searchQuery')
 			->willReturn([
-				['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']
+				new CacheEntry(['fileid' => 3, 'path' => 'foo/qwerty', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'])
 			]);
 
 		$subCache->expects($this->once())
-			->method('search')
-			->with('%qw%')
+			->method('searchQuery')
 			->willReturn([
-				['fileid' => 4, 'path' => 'asd/qweasd', 'name' => 'qweasd', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']
+				new CacheEntry(['fileid' => 4, 'path' => 'asd/qweasd', 'name' => 'qweasd', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain'])
 			]);
 
 		$root->expects($this->once())

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -354,7 +354,6 @@ class FolderTest extends NodeTest {
 		$cache->method('searchQuery')
 			->willReturn([
 				new CacheEntry(['fileid' => 3, 'path' => 'files/foo', 'name' => 'qwerty', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
-				new CacheEntry(['fileid' => 3, 'path' => 'files_trashbin/foo2.d12345', 'name' => 'foo2.d12345', 'size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']),
 			]);
 
 		$root->method('getMountsIn')


### PR DESCRIPTION
- Use Node search api directly from files' search provider, skipping a few deprecated layers
- Unify handling of node search methods by transforming all search methods into "new" search queries
- Handle limit, offset and order in node search api (in a somewhat suboptimal way)