### PR TITLE
Bugfix/noid/product name on updater

### DIFF
--- a/core/js/update.js
+++ b/core/js/update.js
@@ -11,6 +11,7 @@
 (function() {
 	OC.Update = {
 		_started : false,
+		options: {},
 
 		/**
 		 * Start the update process.
@@ -22,6 +23,7 @@
 				return;
 			}
 
+			this.options = options;
 			var hasWarnings = false;
 
 			this.$el = $el;
@@ -72,7 +74,7 @@
 				var updateUnsuccessful = $('<p>');
 				if(message === 'Exception: Updates between multiple major versions and downgrades are unsupported.') {
 					updateUnsuccessful.append(t('core', 'The update was unsuccessful. For more information <a href="{url}">check our forum post</a> covering this issue.', {'url': 'https://help.nextcloud.com/t/updates-between-multiple-major-versions-are-unsupported/7094'}));
-				} else {
+				} else if (OC.Update.options.productName === 'Nextcloud') {
 					updateUnsuccessful.append(t('core', 'The update was unsuccessful. ' +
 						'Please report this issue to the ' +
 						'<a href="https://github.com/nextcloud/server/issues" target="_blank">Nextcloud community</a>.'));
@@ -86,18 +88,15 @@
 
 				$('#update-progress-icon')
 					.addClass('icon-checkmark-white')
-				        .removeClass('icon-loading-dark');
+					.removeClass('icon-loading-dark');
 
 				if (hasWarnings) {
 					$el.find('.update-show-detailed').before(
-						$('<input type="button" class="update-continue" value="'+t('core', 'Continue to Nextcloud')+'">').on('click', function() {
+						$('<input type="button" class="update-continue" value="'+t('core', 'Continue to {productName}', OC.Update.options)+'">').on('click', function() {
 							window.location.reload();
 						})
 					);
 				} else {
-					// FIXME: use product name
-
-
 					$el.find('.update-show-detailed').before(
 						$('<p id="redirect-countdown"></p>')
 					);
@@ -115,7 +114,9 @@
 
 		updateCountdown: function (i, total) {
 			setTimeout(function(){
-				 $("#redirect-countdown").text(n('core', 'The update was successful. Redirecting you to Nextcloud in %n second.', 'The update was successful. Redirecting you to Nextcloud in %n seconds.', i));
+				$("#redirect-countdown").text(
+					n('core', 'The update was successful. Redirecting you to {productName} in %n second.', 'The update was successful. Redirecting you to {productName} in %n seconds.', i, OC.Update.options)
+				);
 			}, (total - i) * 1000);
 		},
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -392,7 +392,12 @@ class OC {
 
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
 		$tmpl->assign('incompatibleAppsList', $incompatibleApps);
-		$tmpl->assign('productName', 'Nextcloud'); // for now
+		try {
+			$defaults = new \OC_Defaults();
+			$tmpl->assign('productName', $defaults->getName());
+		} catch (Throwable $error) {
+			$tmpl->assign('productName', 'Nextcloud');
+		}
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();
 	}


### PR DESCRIPTION
I modified `$tmpl->assign('productName', $defaults->getName());` in lib/base.php and prepended some `#` to take screenshots.

### Update screen in beginning
![Bildschirmfoto von 2021-03-22 16-29-21](https://user-images.githubusercontent.com/213943/112016282-e0b96380-8b2c-11eb-94a3-2d665908acd6.png)

### Update with success
![Bildschirmfoto von 2021-03-22 16-29-25](https://user-images.githubusercontent.com/213943/112016338-eca52580-8b2c-11eb-9646-1bbe780a48fb.png)

### Update with warnings
![Bildschirmfoto von 2021-03-22 16-29-07](https://user-images.githubusercontent.com/213943/112016395-f6c72400-8b2c-11eb-8d8f-183717fdb5b8.png)
