### PR TITLE
Add force option to app install command

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -50,11 +50,18 @@ class Install extends Command {
 				InputOption::VALUE_NONE,
 				'don\'t enable the app afterwards'
 			)
+			->addOption(
+				'force',
+				'f',
+				InputOption::VALUE_NONE,
+				'install the app regardless of the Nextcloud version requirement'
+			)
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
+		$forceEnable = (bool) $input->getOption('force');
 
 		if (\OC_App::getAppPath($appId)) {
 			$output->writeln($appId . ' already installed');
@@ -65,7 +72,7 @@ class Install extends Command {
 			/** @var Installer $installer */
 			$installer = \OC::$server->query(Installer::class);
 			$installer->downloadApp($appId);
-			$result = $installer->installApp($appId);
+			$result = $installer->installApp($appId, $forceEnable);
 		} catch (\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());
 			return 1;


### PR DESCRIPTION
Some apps don't publish releases for newer nextcloud versions, but work perfectly fine on them. 
The app enable command [already offers a flag to ignore version conflicts ](https://github.com/nextcloud/server/blob/master/core/Command/App/Enable.php#L79), this commit adds an equivalent one for the install command. 