### PR TITLE
Add json, yaml output options to ldap:show-config

### DIFF
--- a/apps/user_ldap/lib/Command/ShowConfig.php
+++ b/apps/user_ldap/lib/Command/ShowConfig.php
@@ -28,16 +28,16 @@
 
 namespace OCA\User_LDAP\Command;
 
+use OC\Core\Command\Base;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Helper;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ShowConfig extends Command {
+class ShowConfig extends Base {
 	/** @var \OCA\User_LDAP\Helper */
 	protected $helper;
 
@@ -64,6 +64,13 @@ class ShowConfig extends Command {
 					InputOption::VALUE_NONE,
 					'show ldap bind password'
 					 )
+			->addOption(
+					'output',
+					null,
+					InputOption::VALUE_OPTIONAL,
+					'Output format (table, plain, json or json_pretty, default is table)',
+					'table'
+					 )
 		;
 	}
 
@@ -80,36 +87,55 @@ class ShowConfig extends Command {
 			$configIDs = $availableConfigs;
 		}
 
-		$this->renderConfigs($configIDs, $output, $input->getOption('show-password'));
+		$this->renderConfigs($configIDs, $input, $output);
 		return 0;
 	}
 
 	/**
 	 * prints the LDAP configuration(s)
 	 * @param string[] configID(s)
+	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @param bool $withPassword      Set to TRUE to show plaintext passwords in output
 	 */
-	protected function renderConfigs($configIDs, $output, $withPassword) {
+	protected function renderConfigs($configIDs, $input, $output) {
+		$renderTable = $input->getOption('output') === 'table' or $input->getOption('output') === null;
+		$showPassword = $input->getOption('show-password');
+
+		$configs = [];
 		foreach ($configIDs as $id) {
 			$configHolder = new Configuration($id);
 			$configuration = $configHolder->getConfiguration();
 			ksort($configuration);
 
-			$table = new Table($output);
-			$table->setHeaders(['Configuration', $id]);
 			$rows = [];
-			foreach ($configuration as $key => $value) {
-				if ($key === 'ldapAgentPassword' && !$withPassword) {
-					$value = '***';
+			if ($renderTable) {
+				foreach ($configuration as $key => $value) {
+					if (is_array($value)) {
+						$value = implode(';', $value);
+					}
+					if ($key === 'ldapAgentPassword' && !$showPassword) {
+						$rows[] = [$key, '***'];
+					} else {
+						$rows[] = [$key, $value];
+					}
 				}
-				if (is_array($value)) {
-					$value = implode(';', $value);
+				$table = new Table($output);
+				$table->setHeaders(['Configuration', $id]);
+				$table->setRows($rows);
+				$table->render();
+			} else {
+				foreach ($configuration as $key => $value) {
+					if ($key === 'ldapAgentPassword' && !$showPassword) {
+						$rows[$key] = '***';
+					} else {
+						$rows[$key] = $value;
+					}
 				}
-				$rows[] = [$key, $value];
+				$configs[$id] = $rows;
 			}
-			$table->setRows($rows);
-			$table->render();
+		}
+		if (!$renderTable) {
+			$this->writeArrayInOutputFormat($input, $output, $configs);
 		}
 	}
 }


### PR DESCRIPTION
Makes the output of the `ldap:show-config` command optionally machine-readable. I decided to leave the table format as the default so I don't introduce a breaking change. It might be worth it to ditch the table format altogether, or make yaml (= 'plain') the default for consistency.