### PR TITLE
Fix casing of core test folder, bring back missing tests

### DIFF
--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -68,18 +68,18 @@ class AppsDisableTest extends TestCase {
 
 	public function dataCommandInput(): array {
 		return [
-			[['admin_audit'], 0, 'admin_audit 1.10.0 disabled'],
-			[['comments'], 0, 'comments 1.10.0 disabled'],
+			[['admin_audit'], 0, 'admin_audit 1.11.0 disabled'],
+			[['comments'], 0, 'comments 1.11.0 disabled'],
 			[['invalid_app'], 0, 'No such app enabled: invalid_app'],
 
-			[['admin_audit', 'comments'], 0, "admin_audit 1.10.0 disabled\ncomments 1.10.0 disabled"],
-			[['admin_audit', 'comments', 'invalid_app'], 0, "admin_audit 1.10.0 disabled\ncomments 1.10.0 disabled\nNo such app enabled: invalid_app"],
+			[['admin_audit', 'comments'], 0, "admin_audit 1.11.0 disabled\ncomments 1.11.0 disabled"],
+			[['admin_audit', 'comments', 'invalid_app'], 0, "admin_audit 1.11.0 disabled\ncomments 1.11.0 disabled\nNo such app enabled: invalid_app"],
 
 			[['files'], 2, "files can't be disabled"],
 			[['provisioning_api'], 2, "provisioning_api can't be disabled"],
 
-			[['files', 'admin_audit'], 2, "files can't be disabled.\nadmin_audit 1.10.0 disabled"],
-			[['provisioning_api', 'comments'], 2, "provisioning_api can't be disabled.\ncomments 1.10.0 disabled"],
+			[['files', 'admin_audit'], 2, "files can't be disabled.\nadmin_audit 1.11.0 disabled"],
+			[['provisioning_api', 'comments'], 2, "provisioning_api can't be disabled.\ncomments 1.11.0 disabled"],
 
 		];
 	}

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -73,28 +73,28 @@ class AppsEnableTest extends TestCase {
 
 	public function dataCommandInput(): array {
 		$data = [
-			[['admin_audit'], null, 0, 'admin_audit 1.10.0 enabled'],
-			[['comments'], null, 0, 'comments 1.10.0 enabled'],
-			[['comments', 'comments'], null, 0, "comments 1.10.0 enabled\ncomments already enabled"],
+			[['admin_audit'], null, 0, 'admin_audit 1.11.0 enabled'],
+			[['comments'], null, 0, 'comments 1.11.0 enabled'],
+			[['comments', 'comments'], null, 0, "comments 1.11.0 enabled\ncomments already enabled"],
 			[['invalid_app'], null, 1, 'Could not download app invalid_app'],
 
-			[['admin_audit', 'comments'], null, 0, "admin_audit 1.10.0 enabled\ncomments 1.10.0 enabled"],
-			[['admin_audit', 'comments', 'invalid_app'], null, 1, "admin_audit 1.10.0 enabled\ncomments 1.10.0 enabled\nCould not download app invalid_app"],
+			[['admin_audit', 'comments'], null, 0, "admin_audit 1.11.0 enabled\ncomments 1.11.0 enabled"],
+			[['admin_audit', 'comments', 'invalid_app'], null, 1, "admin_audit 1.11.0 enabled\ncomments 1.11.0 enabled\nCould not download app invalid_app"],
 
 			[['admin_audit'], ['admin'], 1, "admin_audit can't be enabled for groups"],
 			[['comments'], ['admin'], 1, "comments can't be enabled for groups"],
 
-			[['updatenotification'], ['admin'], 0, 'updatenotification 1.10.0 enabled for groups: admin'],
-			[['updatenotification', 'accessibility'], ['admin'], 0, "updatenotification 1.10.0 enabled for groups: admin\naccessibility 1.6.0 enabled for groups: admin"],
+			[['updatenotification'], ['admin'], 0, 'updatenotification 1.11.0 enabled for groups: admin'],
+			[['updatenotification', 'accessibility'], ['admin'], 0, "updatenotification 1.11.0 enabled for groups: admin\naccessibility 1.7.0 enabled for groups: admin"],
 
-			[['updatenotification'], ['admin', 'invalid_group'], 0, 'updatenotification 1.10.0 enabled for groups: admin'],
-			[['updatenotification', 'accessibility'], ['admin', 'invalid_group'], 0, "updatenotification 1.10.0 enabled for groups: admin\naccessibility 1.6.0 enabled for groups: admin"],
-			[['updatenotification', 'accessibility', 'invalid_app'], ['admin', 'invalid_group'], 1, "updatenotification 1.10.0 enabled for groups: admin\naccessibility 1.6.0 enabled for groups: admin\nCould not download app invalid_app"],
+			[['updatenotification'], ['admin', 'invalid_group'], 0, 'updatenotification 1.11.0 enabled for groups: admin'],
+			[['updatenotification', 'accessibility'], ['admin', 'invalid_group'], 0, "updatenotification 1.11.0 enabled for groups: admin\naccessibility 1.7.0 enabled for groups: admin"],
+			[['updatenotification', 'accessibility', 'invalid_app'], ['admin', 'invalid_group'], 1, "updatenotification 1.11.0 enabled for groups: admin\naccessibility 1.7.0 enabled for groups: admin\nCould not download app invalid_app"],
 		];
 
 		if (getenv('CI') === false) {
 			/** Tests disabled on drone/ci due to appstore dependency */
-			$data[] = [['updatenotification', 'contacts'], ['admin'], 0, "updatenotification 1.10.0 enabled for groups: admin\ncontacts 3.3.0 enabled for groups: admin"];
+			$data[] = [['updatenotification', 'contacts'], ['admin'], 0, "updatenotification 1.11.0 enabled for groups: admin\ncontacts 3.3.0 enabled for groups: admin"];
 			$data[] = [['updatenotification', 'contacts'], ['admin', 'invalid_group'], 0, "updatenotification enabled for groups: admin\ncontacts 3.3.0 enabled for groups: admin"];
 			$data[] = [['updatenotification', 'contacts', 'invalid_app'], ['admin', 'invalid_group'], 1, "updatenotification enabled for groups: admin\ncontacts enabled for groups: admin\nCould not download app invalid_app"];
 		}

--- a/tests/Core/Command/Preview/RepairTest.php
+++ b/tests/Core/Command/Preview/RepairTest.php
@@ -9,6 +9,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\IConfig;
 use OCP\ILogger;
+use OCP\Lock\ILockingProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,7 +44,13 @@ class RepairTest extends TestCase {
 			->getMock();
 		$this->iniGetWrapper = $this->getMockBuilder(IniGetWrapper::class)
 			->getMock();
-		$this->repair = new Repair($this->config, $this->rootFolder, $this->logger, $this->iniGetWrapper);
+		$this->repair = new Repair(
+			$this->config,
+			$this->rootFolder,
+			$this->logger,
+			$this->iniGetWrapper,
+			$this->createMock(ILockingProvider::class)
+		);
 		$this->input = $this->getMockBuilder(InputInterface::class)
 			->getMock();
 		$this->input->expects($this->any())

--- a/tests/Core/Controller/AppPasswordControllerTest.php
+++ b/tests/Core/Controller/AppPasswordControllerTest.php
@@ -35,11 +35,11 @@ use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\Exceptions\PasswordUnavailableException;
 use OCP\Authentication\LoginCredentials\ICredentials;
 use OCP\Authentication\LoginCredentials\IStore;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 class AppPasswordControllerTest extends TestCase {
@@ -59,7 +59,7 @@ class AppPasswordControllerTest extends TestCase {
 	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 	/** @var AppPasswordController */
@@ -73,7 +73,7 @@ class AppPasswordControllerTest extends TestCase {
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->credentialStore = $this->createMock(IStore::class);
 		$this->request = $this->createMock(IRequest::class);
-		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->controller = new AppPasswordController(
 			'core',
@@ -144,7 +144,7 @@ class AppPasswordControllerTest extends TestCase {
 			);
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$this->controller->getAppPassword();
 	}
@@ -185,7 +185,7 @@ class AppPasswordControllerTest extends TestCase {
 			);
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$this->controller->getAppPassword();
 	}

--- a/tests/Core/Controller/AutoCompleteControllerTest.php
+++ b/tests/Core/Controller/AutoCompleteControllerTest.php
@@ -75,8 +75,8 @@ class AutoCompleteControllerTest extends TestCase {
 				],
 				// expected
 				[
-					[ 'id' => 'alice', 'label' => 'Alice A.', 'source' => 'users'],
-					[ 'id' => 'bob', 'label' => 'Bob Y.', 'source' => 'users'],
+					[ 'id' => 'alice', 'label' => 'Alice A.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
+					[ 'id' => 'bob', 'label' => 'Bob Y.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
 				],
 				'',
 				'files',
@@ -96,8 +96,8 @@ class AutoCompleteControllerTest extends TestCase {
 				],
 				// expected
 				[
-					[ 'id' => 'alice', 'label' => 'Alice A.', 'source' => 'users'],
-					[ 'id' => 'bob', 'label' => 'Bob Y.', 'source' => 'users'],
+					[ 'id' => 'alice', 'label' => 'Alice A.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
+					[ 'id' => 'bob', 'label' => 'Bob Y.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
 				],
 				'',
 				null,
@@ -117,8 +117,8 @@ class AutoCompleteControllerTest extends TestCase {
 				],
 				// expected
 				[
-					[ 'id' => 'alice', 'label' => 'Alice A.', 'source' => 'users'],
-					[ 'id' => 'bob', 'label' => 'Bob Y.', 'source' => 'users'],
+					[ 'id' => 'alice', 'label' => 'Alice A.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
+					[ 'id' => 'bob', 'label' => 'Bob Y.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
 				],
 				'',
 				'files',
@@ -138,8 +138,8 @@ class AutoCompleteControllerTest extends TestCase {
 					],
 				],
 				[
-					[ 'id' => 'bob', 'label' => 'Bob Y.', 'source' => 'users'],
-					[ 'id' => 'bobby', 'label' => 'Robert R.', 'source' => 'users'],
+					[ 'id' => 'bob', 'label' => 'Bob Y.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
+					[ 'id' => 'bobby', 'label' => 'Robert R.', 'icon' => '', 'source' => 'users', 'status' => '', 'subline' => ''],
 				],
 				'bob',
 				'files',

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -32,6 +32,7 @@ use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
 use OCP\Defaults;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
@@ -41,7 +42,6 @@ use OCP\IUserSession;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 class ClientFlowLoginControllerTest extends TestCase {
@@ -67,7 +67,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 	private $accessTokenMapper;
 	/** @var ICrypto|\PHPUnit\Framework\MockObject\MockObject */
 	private $crypto;
-	/** @var EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
 	private $eventDispatcher;
 
 
@@ -94,7 +94,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 		$this->clientMapper = $this->createMock(ClientMapper::class);
 		$this->accessTokenMapper = $this->createMock(AccessTokenMapper::class);
 		$this->crypto = $this->createMock(ICrypto::class);
-		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->clientFlowLoginController = new ClientFlowLoginController(
 			'core',
@@ -392,7 +392,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->willReturn('');
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$expected = new Http\RedirectResponse('nc://login/server:http://example.com&user:MyLoginName&password:MyGeneratedToken');
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken'));
@@ -488,7 +488,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->willReturn($client);
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$expected = new Http\RedirectResponse($redirectUrl);
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken', 'MyClientIdentifier'));
@@ -563,7 +563,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->willReturn('');
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$expected = new Http\RedirectResponse('nc://login/server:http://example.com&user:MyLoginName&password:MyGeneratedToken');
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken'));
@@ -694,7 +694,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 			->willReturnMap($headers);
 
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$expected = new Http\RedirectResponse('nc://login/server:' . $expected . '://example.com&user:MyLoginName&password:MyGeneratedToken');
 		$this->assertEquals($expected, $this->clientFlowLoginController->generateAppPassword('MyStateToken'));

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -440,6 +440,7 @@ class LoginControllerTest extends TestCase {
 			->with('core.login.showLoginForm', [
 				'user' => $user,
 				'redirect_url' => '/apps/files',
+				'direct' => 1,
 			])
 			->willReturn($loginPageUrl);
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($loginPageUrl);
@@ -597,6 +598,7 @@ class LoginControllerTest extends TestCase {
 			->with('core.login.showLoginForm', [
 				'user' => 'john@doe.com',
 				'redirect_url' => '/apps/files',
+				'direct' => 1,
 			])
 			->willReturn($loginPageUrl);
 		$expected = new \OCP\AppFramework\Http\RedirectResponse($loginPageUrl);

--- a/tests/Test/Repair/Owncloud/CleanPreviewsBackgroundJobTest.php
+++ b/tests/Test/Repair/Owncloud/CleanPreviewsBackgroundJobTest.php
@@ -52,7 +52,7 @@ class CleanPreviewsBackgroundJobTest extends TestCase {
 	/** @var  IUserManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);

--- a/tests/Test/Repair/Owncloud/CleanPreviewsTest.php
+++ b/tests/Test/Repair/Owncloud/CleanPreviewsTest.php
@@ -46,7 +46,7 @@ class CleanPreviewsTest extends TestCase {
 	/** @var CleanPreviews */
 	private $repair;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->jobList = $this->createMock(IJobList::class);

--- a/tests/Test/Repair/Owncloud/InstallCoreBundleTest.php
+++ b/tests/Test/Repair/Owncloud/InstallCoreBundleTest.php
@@ -41,7 +41,7 @@ class InstallCoreBundleTest extends TestCase {
 	/** @var InstallCoreBundle */
 	private $installCoreBundle;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->bundleFetcher = $this->createMock(BundleFetcher::class);
 		$this->config = $this->createMock(IConfig::class);

--- a/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -43,7 +43,7 @@ class UpdateLanguageCodesTest extends TestCase {
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();

--- a/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -86,6 +86,7 @@ class UpdateLanguageCodesTest extends TestCase {
 			->from('preferences')
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
+			->orderBy('userid')
 			->execute();
 
 		$rows = $result->fetchAll();

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -8,7 +8,7 @@
 >
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>
-		<directory suffix='.php'>core/</directory>
+		<directory suffix='.php'>Core/</directory>
 		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
 	</testsuite>
@@ -32,4 +32,3 @@
 		<listener class="StartSessionListener" file="startsessionlistener.php" />
 	</listeners>
 </phpunit>
-

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -9,7 +9,7 @@
 	<testsuite name='ownCloud'>
 		<directory suffix='.php'>lib/</directory>
 		<directory suffix='.php'>Core/</directory>
-		<directory suffix='.php'>ocs-provider/</directory>
+		<directory suffix='.php'>Test/</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<!-- filters for code coverage -->


### PR DESCRIPTION
It seems Phpunit < 9 was case insensitive.
Fixed the phpunit config to target the correct name for the "Core" test
directory.

Fixes failing CI on PRs targetting master, like https://drone.nextcloud.com/nextcloud/server/3531/10/6