### PR TITLE
Catch invalid cache source storage path

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -642,6 +642,10 @@ class Cache implements ICache {
 			$targetPath = $this->normalize($targetPath);
 
 			$sourceData = $sourceCache->get($sourcePath);
+			if ($sourceData === false) {
+				throw new \Exception('Invalid source storage path: ' . $sourcePath);
+			}
+
 			$sourceId = $sourceData['fileid'];
 			$newParentId = $this->getParentId($targetPath);
 


### PR DESCRIPTION
`OC\Files\Cache\Cache::get` can also return false