### PR TITLE
Log when a storage is marked as unavailable

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -30,6 +30,7 @@
 namespace OC\Files\Cache;
 
 use OCP\Files\Storage\IStorage;
+use Psr\Log\LoggerInterface;
 
 /**
  * Handle the mapping between the string and numeric storage ids
@@ -175,6 +176,9 @@ class Storage {
 	 */
 	public function setAvailability($isAvailable, int $delay = 0) {
 		$available = $isAvailable ? 1 : 0;
+		if (!$isAvailable) {
+			\OC::$server->get(LoggerInterface::class)->info('Storage with ' . $this->storageId . ' marked as unavailable', ['app' => 'lib']);
+		}
 
 		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->update('storages')


### PR DESCRIPTION
Sometimes it might be good to trace when a storage gets unavailable.