### PR TITLE
19.0.10 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [19, 0, 9, 1];
+$OC_Version = [19, 0, 10, 0];
 
 // The human readable string
-$OC_VersionString = '19.0.9';
+$OC_VersionString = '19.0.10 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #25351 Show the actual error on share requests
* #25741 Avoid creating two share links when password is enforced
* #25845 Fix detecting cyclic group memberships
* #25849 Bump the ca location
* #25859 Card::getOwner should return the actual value
* #25901 Do not die after LDAP auth failed with expired acc
* #25957 Skip empty obsolete owner when adding to own NC
* #25964 Fix admin password strengthify tooltip
* #26010 Bump elliptic from 6.5.3 to 6.5.4
* #26028 Hide expiration date field for remote shares
* #26041 Remove trash items from other trash backends when deleting all
* #26060 Only clear share password model when actually saved
* #26073 Limit constructing of result objects in file search
* #26092 Apply object store copy optimization when 'cross storage' copy is wit…
* #26095 Bump yargs-parser from 5.0.0 to 5.0.1
* #26129 Log exceptions when creating share
* #26135 Do cachejail search filtering in sql
* #26148 Return the fileid from `copyFromCache` and use it instead of doing an extra query
* #26164 Use correct exception type hint in catch statement
* #26169 Remove explicit fclose from S3->writeStream
* #26191 Fix valid storages removed when cleaning remote storages
* #26206 Update user share must use correct expiration validation
* #26216 Add (hidden) option to always show smb root as writable
* #26240 L10n: Add words user and because in ShareByMailProvider.php
* #26264 Handle limit offset and sorting in files search
* #26273 Catch invalid cache source storage path
* #26277 L10n: Separate ellipsis
* #26296 Fix l10n
* #26306 Delete old birthday calendar object when moving contact to another ad…
* #26359 Bump y18n from 3.2.1 to 3.2.2
* #26365 Update cipher defaults
* #26380 Gracefully handle deleteFromSelf when share is already gone
* [serverinfo#282](https://github.com/nextcloud/serverinfo/pull/282) Match any non-whitespace character in filesystem type pattern
* [text#1392](https://github.com/nextcloud/text/pull/1392) Remove EPUB mimetype
* [text#1411](https://github.com/nextcloud/text/pull/1411) Make sure the session list is always at the end
* [text#1435](https://github.com/nextcloud/text/pull/1435) Bump @babel/plugin-transform-modules-commonjs from 7.12.1 to 7.12.13
* [text#1437](https://github.com/nextcloud/text/pull/1437) Bump @babel/plugin-proposal-class-properties from 7.12.1 to 7.12.13
* [text#1465](https://github.com/nextcloud/text/pull/1465) Bump @babel/plugin-transform-runtime from 7.12.10 to 7.12.17
* [text#1467](https://github.com/nextcloud/text/pull/1467) Bump @babel/preset-env from 7.12.11 to 7.12.17
* [text#1469](https://github.com/nextcloud/text/pull/1469) Bump @babel/core from 7.12.10 to 7.12.17
* [text#1514](https://github.com/nextcloud/text/pull/1514) Use write permission when possible
* [updater#344](https://github.com/nextcloud/updater/pull/344) Update CLI tests to PHP 7.4 to 8.0
* [updater#350](https://github.com/nextcloud/updater/pull/350) Disable UI when web updater is disabled in config.php
* [updater#353](https://github.com/nextcloud/updater/pull/353) Remove obsolete pipeline php72-master