### PR TITLE
[l10n] Let the welcome letter's language default to admin user

### DIFF
--- a/apps/settings/lib/Mailer/NewUserMailHelper.php
+++ b/apps/settings/lib/Mailer/NewUserMailHelper.php
@@ -99,7 +99,7 @@ class NewUserMailHelper {
 	 */
 	public function generateTemplate(IUser $user, $generatePasswordResetToken = false) {
 		$userId = $user->getUID();
-		$lang = $this->l10nFactory->getUserLanguage($user);
+		$lang = $this->l10nFactory->getUserLanguage(\OC::$server->getUserSession()->getUser());
 		$l10n = $this->l10nFactory->get('settings', $lang);
 
 		if ($generatePasswordResetToken) {


### PR DESCRIPTION
Currently, the weclome mail for new user is written in default new user language.
We should let the letter written in admin's language.