### PR TITLE
add typed event for loading additional external storage backends

### DIFF
--- a/apps/files_external/lib/Events/LoadAdditionalStorageBackendsEvent.php
+++ b/apps/files_external/lib/Events/LoadAdditionalStorageBackendsEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_External\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 22.0.0
+ */
+class LoadAdditionalStorageBackendsEvent extends Event {
+}

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -28,12 +28,14 @@
 namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Config\IConfigHandler;
+use OCA\Files_External\Events\LoadAdditionalStorageBackendsEvent;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 
 use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
 use OCP\EventDispatcher\GenericEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 
 /**
@@ -117,6 +119,9 @@ class BackendService {
 				'OCA\\Files_External::loadAdditionalBackends',
 				new GenericEvent()
 			);
+			/** @var IEventDispatcher $dispatcher */
+			$dispatcher = \OC::$server->get(IEventDispatcher::class);
+			$dispatcher->dispatchTyped(new LoadAdditionalStorageBackendsEvent());
 			$eventSent = true;
 		}
 	}


### PR DESCRIPTION
Allow apps to load backends without using deprecated stuff