### PR TITLE
Use file search for recent files and optimize getting share types

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -35,7 +35,6 @@ use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchOrder;
 use OC\Files\Search\SearchQuery;
-use OC\Files\Storage\Storage;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\FileInfo;

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -773,6 +773,10 @@ class FolderTest extends NodeTest {
 		$folderInfo->expects($this->any())
 			->method('getMountPoint')
 			->willReturn($mount);
+		$root->method('getMount')
+			->willReturn($mount);
+		$root->method('getMountsIn')
+			->willReturn([]);
 
 		$cache = $storage->getCache();
 
@@ -837,6 +841,11 @@ class FolderTest extends NodeTest {
 		$folderInfo->expects($this->any())
 			->method('getMountPoint')
 			->willReturn($mount);
+
+		$root->method('getMount')
+			->willReturn($mount);
+		$root->method('getMountsIn')
+			->willReturn([]);
 
 		$cache = $storage->getCache();
 
@@ -903,6 +912,10 @@ class FolderTest extends NodeTest {
 		$folderInfo->expects($this->any())
 			->method('getMountPoint')
 			->willReturn($mount);
+		$root->method('getMount')
+			->willReturn($mount);
+		$root->method('getMountsIn')
+			->willReturn([]);
 
 		$cache = $storage->getCache();
 


### PR DESCRIPTION
- Use the search api to get recent files instead of implementing custom logic
- Improve finding share types for results, saving up to 693 queries (having a single `getSharesForNodes` would be better but I didn't want to go that deep)

Comparison https://blackfire.io/profiles/compare/a294f43a-6ba1-46b8-a70e-56b7c7de15d6/graph