### PR TITLE
Drop OpenSSL 0.9.8 workaround

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -270,13 +270,6 @@ class Crypt {
 			$cipher = self::DEFAULT_CIPHER;
 		}
 
-		// Workaround for OpenSSL 0.9.8. Fallback to an old cipher that should work.
-		if (OPENSSL_VERSION_NUMBER < 0x1000101f) {
-			if ($cipher === 'AES-256-CTR' || $cipher === 'AES-128-CTR') {
-				$cipher = self::LEGACY_CIPHER;
-			}
-		}
-
 		return $cipher;
 	}
 


### PR DESCRIPTION
Introduced in 3a5f58c9b0555119523c66c55a903d69e36ead6f, this behavior looks wired and is neither documented nor logged.

PHP 7.1+ [requires](https://www.php.net/manual/en/openssl.requirements.php) OpenSSL 1.0.1+  anyway and older versions are EOL.