### PR TITLE
"Symfony\Component\Translation\PluralizationRules" is deprecated

### DIFF
--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -49,7 +49,7 @@ foreach ($directories as $dir) {
 		$json = json_decode($content, true);
 
 		$translations = json_encode($json['translations']);
-		if (strpos($content, '|') !== false) {
+		if (strpos($translations, '|') !== false) {
 			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a | in the translations' . "\n";
 		}
 

--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -48,6 +48,11 @@ foreach ($directories as $dir) {
 		$content = file_get_contents($file->getPathname());
 		$json = json_decode($content, true);
 
+		$translations = json_encode($json['translations']);
+		if (strpos($content, '|') !== false) {
+			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a | in the translations' . "\n";
+		}
+
 		if (json_last_error() !== JSON_ERROR_NONE) {
 			$errors[] = $file->getPathname() . "\n" . '  ' . json_last_error_msg() . "\n";
 		} else {

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -32,7 +32,7 @@ namespace OC\L10N;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use Punic\Calendar;
-use Symfony\Component\Translation\PluralizationRules;
+use Symfony\Component\Translation\IdentityTranslator;
 
 class L10N implements IL10N {
 
@@ -48,11 +48,8 @@ class L10N implements IL10N {
 	/** @var string Locale of this object */
 	protected $locale;
 
-	/** @var string Plural forms (string) */
-	private $pluralFormString = 'nplurals=2; plural=(n != 1);';
-
-	/** @var string Plural forms (function) */
-	private $pluralFormFunction = null;
+	/** @var IdentityTranslator */
+	private $identityTranslator;
 
 	/** @var string[] */
 	private $translations = [];
@@ -214,20 +211,16 @@ class L10N implements IL10N {
 	}
 
 	/**
-	 * Returnsed function accepts the argument $n
-	 *
-	 * Called by \OC_L10N_String
-	 * @return \Closure the plural form function
+	 * @internal
+	 * @return IdentityTranslator
 	 */
-	public function getPluralFormFunction(): \Closure {
-		if (\is_null($this->pluralFormFunction)) {
-			$lang = $this->getLanguageCode();
-			$this->pluralFormFunction = function ($n) use ($lang) {
-				return PluralizationRules::get($n, $lang);
-			};
+	public function getIdentityTranslator(): IdentityTranslator {
+		if (\is_null($this->identityTranslator)) {
+			$this->identityTranslator = new IdentityTranslator();
+			$this->identityTranslator->setLocale($this->getLocaleCode());
 		}
 
-		return $this->pluralFormFunction;
+		return $this->identityTranslator;
 	}
 
 	/**
@@ -242,9 +235,6 @@ class L10N implements IL10N {
 			return false;
 		}
 
-		if (!empty($json['pluralForm'])) {
-			$this->pluralFormString = $json['pluralForm'];
-		}
 		$this->translations = array_merge($this->translations, $json['translations']);
 		return true;
 	}

--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -59,12 +59,6 @@ class L10NString implements \JsonSerializable {
 
 	public function __toString(): string {
 		$translations = $this->l10n->getTranslations();
-
-		$pipeCheck = implode('', $translations[$this->text]);
-		if (strpos($pipeCheck, '|') !== false) {
-			return 'Can not use pipe character in translations';
-		}
-
 		$identityTranslator = $this->l10n->getIdentityTranslator();
 
 		$parameters = $this->parameters;
@@ -72,7 +66,22 @@ class L10NString implements \JsonSerializable {
 		$parameters['%count%'] = $this->count;
 
 		// Use the indexed version as per \Symfony\Contracts\Translation\TranslatorInterface
-		$identity = implode('|', $translations[$this->text]);
+		$identity = $this->text;
+		if (array_key_exists($this->text, $translations)) {
+			$identity = $translations[$this->text];
+		}
+
+		if (is_array($identity)) {
+			$pipeCheck = implode('', $identity);
+			if (strpos($pipeCheck, '|') !== false) {
+				return 'Can not use pipe character in translations';
+			}
+
+			$identity = implode('|', $identity);
+		} else if (strpos($identity, '|') !== false) {
+			return 'Can not use pipe character in translations';
+		}
+
 		$identity = str_replace('%n', '%count%', $identity);
 
 		return $identityTranslator->trans($identity, $parameters);

--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -61,10 +61,6 @@ class L10NString implements \JsonSerializable {
 		$translations = $this->l10n->getTranslations();
 		$identityTranslator = $this->l10n->getIdentityTranslator();
 
-		$parameters = $this->parameters;
-		// Add $count as %count% as per \Symfony\Contracts\Translation\TranslatorInterface
-		$parameters['%count%'] = $this->count;
-
 		// Use the indexed version as per \Symfony\Contracts\Translation\TranslatorInterface
 		$identity = $this->text;
 		if (array_key_exists($this->text, $translations)) {
@@ -84,7 +80,10 @@ class L10NString implements \JsonSerializable {
 
 		$identity = str_replace('%n', '%count%', $identity);
 
-		return $identityTranslator->trans($identity, $parameters);
+		// $count as %count% as per \Symfony\Contracts\Translation\TranslatorInterface
+		$text = $identityTranslator->trans($identity, ['%count%' => $this->count]);
+
+		return vsprintf($text, $this->parameters);
 	}
 
 

--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -59,6 +59,12 @@ class L10NString implements \JsonSerializable {
 
 	public function __toString(): string {
 		$translations = $this->l10n->getTranslations();
+
+		$pipeCheck = implode('', $translations[$this->text]);
+		if (strpos($pipeCheck, '|') !== false) {
+			return 'Can not use pipe character in translations';
+		}
+
 		$identityTranslator = $this->l10n->getIdentityTranslator();
 
 		$parameters = $this->parameters;

--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -74,7 +74,7 @@ class L10NString implements \JsonSerializable {
 			}
 
 			$identity = implode('|', $identity);
-		} else if (strpos($identity, '|') !== false) {
+		} elseif (strpos($identity, '|') !== false) {
 			return 'Can not use pipe character in translations';
 		}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -441,7 +441,7 @@ class Manager implements IManager {
 			$date->setTime(0, 0, 0);
 			$date->add(new \DateInterval('P' . $defaultExpireDays . 'D'));
 			if ($date < $expirationDate) {
-				$message = $this->l->t('Can’t set expiration date more than %s days in the future', [$defaultExpireDays]);
+				$message = $this->l->n('Can’t set expiration date more than %n day in the future', 'Can’t set expiration date more than %n days in the future', $defaultExpireDays);
 				throw new GenericShareException($message, $message, 404);
 			}
 		}
@@ -517,7 +517,7 @@ class Manager implements IManager {
 			$date->setTime(0, 0, 0);
 			$date->add(new \DateInterval('P' . $this->shareApiLinkDefaultExpireDays() . 'D'));
 			if ($date < $expirationDate) {
-				$message = $this->l->t('Can’t set expiration date more than %s days in the future', [$this->shareApiLinkDefaultExpireDays()]);
+				$message = $this->l->n('Can’t set expiration date more than %n day in the future', 'Can’t set expiration date more than %n days in the future', $this->shareApiLinkDefaultExpireDays());
 				throw new GenericShareException($message, $message, 404);
 			}
 		}

--- a/tests/data/l10n/de.json
+++ b/tests/data/l10n/de.json
@@ -1,6 +1,9 @@
 {
 	"translations" : {
-		"_%n file_::_%n files_": ["%n Datei", "%n Dateien"]
+		"_%n file_::_%n files_": ["%n Datei", "%n Dateien"],
+		"Ordered placeholders one %s two %s": "Placeholder one %s two %s",
+		"Reordered placeholders one %s two %s": "Placeholder two %2$s one %1$s",
+		"Reordered placeholders one %1$s two %2$s": "Placeholder two %2$s one %1$s"
 	},
 	"pluralForm" :	"nplurals=2; plural=(n != 1);"
 }

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -76,6 +76,27 @@ class L10nTest extends TestCase {
 		$this->assertEquals('5 oken', (string)$l->n('%n window', '%n windows', 5));
 	}
 
+	public function dataPlaceholders(): array {
+		return [
+			['Ordered placeholders one %s two %s', 'Placeholder one 1 two 2'],
+			['Reordered placeholders one %s two %s', 'Placeholder two 2 one 1'],
+			['Reordered placeholders one %1$s two %2$s', 'Placeholder two 2 one 1'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataPlaceholders
+	 *
+	 * @param $string
+	 * @param $expected
+	 */
+	public function testPlaceholders($string, $expected): void {
+		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/de.json';
+		$l = new L10N($this->getFactory(), 'test', 'de', 'de_AT', [$transFile]);
+
+		$this->assertEquals($expected, $l->t($string, ['1', '2']));
+	}
+
 	public function localizationData() {
 		return [
 			// timestamp as string

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -126,6 +126,10 @@ class ManagerTest extends \Test\TestCase {
 			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
+		$this->l->method('n')
+			->willReturnCallback(function ($singular, $plural, $count, $parameters = []) {
+				return vsprintf(str_replace('%n', $count, ($count === 1) ? $singular : $plural), $parameters);
+			});
 
 		$this->factory = new DummyFactory(\OC::$server);
 
@@ -1957,7 +1961,7 @@ class ManagerTest extends \Test\TestCase {
 		$data = [];
 
 		// No exclude groups
-		$data[] = ['no', null, null, null, false];
+		$data[] = ['no', null, null, [], false];
 
 		// empty exclude list, user no groups
 		$data[] = ['yes', '', json_encode(['']), [], false];


### PR DESCRIPTION
* `Symfony\Component\Translation\PluralizationRules` is deprecated, replacement is `Symfony\Component\Translation\IdentityTranslator`
* Symfony\Component\Translation\IdentityTranslator does not allow overwriting the plural function anymore, but hopefully the functions from our `l10n/*.js` files always had the same result anyway. At least our unit tests for L10NString still pass, so looks promising.
* Plural strings are now separated by `|` and count argument is `%count%` instead of `%n`
  https://github.com/nextcloud/3rdparty/blob/03eb378a5c8f29da9d0240b142bc0e7e66c31694/symfony/translation-contracts/TranslatorInterface.php#L20-L62
* Translation checker has been extended to throw on `|` inside translations.