### PR TITLE
Get the parent directory before creating a file from a template

### DIFF
--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -27,6 +27,7 @@
 namespace OC\DirectEditing;
 
 use Doctrine\DBAL\FetchMode;
+use OC\Files\Node\Folder;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -130,7 +131,12 @@ class Manager implements IManager {
 		if ($userFolder->nodeExists($path)) {
 			throw new \RuntimeException('File already exists');
 		} else {
-			$file = $userFolder->newFile($path);
+			if (!$userFolder->nodeExists(dirname($path))) {
+				throw new \RuntimeException('Invalid path');
+			}
+			/** @var Folder $folder */
+			$folder = $userFolder->get(dirname($path));
+			$file = $folder->newFile(basename($path));
 			$editor = $this->getEditor($editorId);
 			$creators = $editor->getCreators();
 			foreach ($creators as $creator) {

--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -36,7 +36,6 @@ use OCP\Files\GenericFileException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\Files\Template\ICustomTemplateProvider;
 use OCP\Files\Template\ITemplateManager;
@@ -300,9 +299,10 @@ class TemplateManager implements ITemplateManager {
 			}
 
 			try {
-				$folder = $userFolder->newFolder($userTemplatePath);
-			} catch (NotPermittedException $e) {
 				$folder = $userFolder->get($userTemplatePath);
+			} catch (NotFoundException $e) {
+				$folder = $userFolder->get(dirname($userTemplatePath));
+				$folder = $folder->newFolder(basename($userTemplatePath));
 			}
 
 			$folderIsEmpty = count($folder->getDirectoryListing()) === 0;

--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -155,7 +155,11 @@ class TemplateManager implements ITemplateManager {
 		} catch (NotFoundException $e) {
 		}
 		try {
-			$targetFile = $userFolder->newFile($filePath);
+			if (!$userFolder->nodeExists(dirname($filePath))) {
+				throw new GenericFileException($this->l10n->t('Invalid path'));
+			}
+			$folder = $userFolder->get(dirname($filePath));
+			$targetFile = $folder->newFile(basename($filePath));
 			if ($templateType === 'user' && $templateId !== '') {
 				$template = $userFolder->get($templateId);
 				$template->copy($targetFile->getPath());

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -154,11 +154,16 @@ class ManagerTest extends TestCase {
 		$this->random->expects($this->once())
 			->method('generate')
 			->willReturn($expectedToken);
+		$folder = $this->createMock(Folder::class);
 		$this->userFolder
 			->method('nodeExists')
-			->with('/File.txt')
-			->willReturn(false);
-		$this->userFolder->expects($this->once())
+			->withConsecutive(['/File.txt'], ['/'])
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->userFolder
+			->method('get')
+			->with('/')
+			->willReturn($folder);
+		$folder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
 		$token = $this->manager->create('/File.txt', 'testeditor', 'createEmpty');
@@ -174,11 +179,16 @@ class ManagerTest extends TestCase {
 		$this->random->expects($this->once())
 			->method('generate')
 			->willReturn($expectedToken);
+		$folder = $this->createMock(Folder::class);
 		$this->userFolder
 			->method('nodeExists')
-			->with('/File.txt')
-			->willReturn(false);
-		$this->userFolder->expects($this->once())
+			->withConsecutive(['/File.txt'], ['/'])
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->userFolder
+			->method('get')
+			->with('/')
+			->willReturn($folder);
+		$folder->expects($this->once())
 			->method('newFile')
 			->willReturn($file);
 		$this->manager->create('/File.txt', 'testeditor', 'createEmpty');


### PR DESCRIPTION
Permissions when creating a new file or folder [are always issued on the current node](https://github.com/nextcloud/server/blob/8a92229485095dbd8f379e2b489a3aa48cc37c79/lib/private/Files/Node/Folder.php#L193) so when using the relative path directly on the user directory creating a new file will fail in scenarios where there is a read only mount on the user root.

Fixes nextcloud/android#8010
Fixes #25787