### PR TITLE
allow using any ldap property as login name when using external storage login credentials

### DIFF
--- a/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
+++ b/apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php
@@ -36,6 +36,8 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\IUserBackend;
+use OCP\LDAP\ILDAPProviderFactory;
 use OCP\Security\ICredentialsManager;
 use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserLoggedInEvent;
@@ -55,10 +57,21 @@ class LoginCredentials extends AuthMechanism {
 	/** @var CredentialsStore */
 	private $credentialsStore;
 
-	public function __construct(IL10N $l, ISession $session, ICredentialsManager $credentialsManager, CredentialsStore $credentialsStore, IEventDispatcher $eventDispatcher) {
+	/** @var ILDAPProviderFactory */
+	private $ldapFactory;
+
+	public function __construct(
+		IL10N $l,
+		ISession $session,
+		ICredentialsManager $credentialsManager,
+		CredentialsStore $credentialsStore,
+		IEventDispatcher $eventDispatcher,
+		ILDAPProviderFactory $ldapFactory
+	) {
 		$this->session = $session;
 		$this->credentialsManager = $credentialsManager;
 		$this->credentialsStore = $credentialsStore;
+		$this->ldapFactory = $ldapFactory;
 
 		$this
 			->setIdentifier('password::logincredentials')
@@ -86,7 +99,7 @@ class LoginCredentials extends AuthMechanism {
 
 				$credentials = [
 					'user' => $sessionCredentials->getLoginName(),
-					'password' => $sessionCredentials->getPassword()
+					'password' => $sessionCredentials->getPassword(),
 				];
 
 				$this->credentialsManager->store($user->getUID(), self::CREDENTIALS_IDENTIFIER, $credentials);
@@ -104,7 +117,25 @@ class LoginCredentials extends AuthMechanism {
 		}
 		$credentials = $this->getCredentials($user);
 
-		$storage->setBackendOption('user', $credentials['user']);
+		$loginKey = $storage->getBackendOption("login_ldap_attr");
+		if ($loginKey) {
+			$backend = $user->getBackend();
+			if ($backend instanceof IUserBackend && $backend->getBackendName() === 'LDAP') {
+				$value = $this->getLdapPropertyForUser($user, $loginKey);
+				if ($value === null) {
+					throw new InsufficientDataForMeaningfulAnswerException('Custom ldap attribute not set for user ' . $user->getUID());
+				}
+				$storage->setBackendOption('user', $value);
+			} else {
+				throw new InsufficientDataForMeaningfulAnswerException('Custom ldap attribute configured but user ' . $user->getUID() . ' is not an ldap user');
+			}
+		} else {
+			$storage->setBackendOption('user', $credentials['user']);
+		}
 		$storage->setBackendOption('password', $credentials['password']);
+	}
+
+	private function getLdapPropertyForUser(IUser $user, string $property): ?string {
+		return $this->ldapFactory->getLDAPProvider()->getUserAttribute($user->getUID(), $property);
 	}
 }


### PR DESCRIPTION
New try for https://github.com/nextcloud/server/pull/24955

- [x] https://github.com/nextcloud/server/pull/25326 to make it not hard-depend on user_ldap