### PR TITLE
Show informative errors on avatar upload error

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -193,8 +193,20 @@ class AvatarController extends Controller {
 				$content = $this->cache->get('avatar_upload');
 				unlink($files['tmp_name'][0]);
 			} else {
+				$phpFileUploadErrors = [
+					UPLOAD_ERR_OK => $this->l->t('The file was uploaded'),
+					UPLOAD_ERR_INI_SIZE => $this->l->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
+					UPLOAD_ERR_FORM_SIZE => $this->l->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
+					UPLOAD_ERR_PARTIAL => $this->l->t('The file was only partially uploaded'),
+					UPLOAD_ERR_NO_FILE => $this->l->t('No file was uploaded'),
+					UPLOAD_ERR_NO_TMP_DIR => $this->l->t('Missing a temporary folder'),
+					UPLOAD_ERR_CANT_WRITE => $this->l->t('Could not write file to disk'),
+					UPLOAD_ERR_EXTENSION => $this->l->t('A PHP extension stopped the file upload'),
+				];
+				$message = $phpFileUploadErrors[$files['error'][0]] ?? $this->l->t('Invalid file provided');
+				$this->logger->warning($message, ['app' => 'core']);
 				return new JSONResponse(
-					['data' => ['message' => $this->l->t('Invalid file provided')]],
+					['data' => ['message' => $message]],
 					Http::STATUS_BAD_REQUEST
 				);
 			}


### PR DESCRIPTION
As default php.ini `max_upload_filesize` value is often pretty low (like 2 MB), a lot of people can't upload things in simple forms and they don't know why.

This logs the reason why the upload failed and shows in in the UI.
It's done like in theming settings 
https://github.com/nextcloud/server/blob/68d364007691750a5e8ec218c87e6cd8b0919245/apps/theming/lib/Controller/ThemingController.php#L219-L228