### PR TITLE
Limit size of properties to 2048 characters

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -144,6 +144,17 @@ class AccountManager implements IAccountManager {
 			}
 		}
 
+		// set a max length
+		foreach ($data as $propertyName => $propertyData) {
+			if (isset($data[$propertyName]) && isset($data[$propertyName]['value']) && strlen($data[$propertyName]['value']) > 2048) {
+				if ($throwOnData) {
+					throw new \InvalidArgumentException($propertyName);
+				} else {
+					$data[$propertyName]['value'] = '';
+				}
+			}
+		}
+
 		$allowedScopes = [
 			self::SCOPE_PRIVATE,
 			self::SCOPE_LOCAL,


### PR DESCRIPTION
It is unreasonable to expect that one of these fields would be longer
than 2048 characters. Whilst some have definitely lower limits (such as
for phone numbers or domain names), a upper bound as sanity check makes
sense.

