### PR TITLE
21.0.1 final

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 1, 0];
+$OC_Version = [21, 0, 1, 1];
 
 // The human readable string
-$OC_VersionString = '21.0.1 RC1';
+$OC_VersionString = '21.0.1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #25571 Always renew apppasswords on login
* #25573 Improve mention matches
* #25843 Fix detecting cyclic group memberships
* #25875 Do not trigger a full filelist reload after creating a new file from a template
* #25877 Disable trasbin during the moveFromStorage fallback
* #25899 Do not die after LDAP auth failed with expired acc
* #25918 Clear multiselect after selection in share panel
* #25922 Filter out tables that does not belong to Nextcloud
* #25935 Activity: show if files are hidden or not
* #25937 Sharebymail: set expiration on creation
* #25943 Catch notfound and forbidden exception in smb::getmetadata
* #25955 Skip empty obsolete owner when adding to own NC
* #25962 Fix admin password strengthify tooltip
* #25993 Add missing waits and asserts in acceptance tests
* #26026 Hide expiration date field for remote shares
* #26039 Remove trash items from other trash backends when deleting all
* #26042 Fix SCSS compiler deprecated function usages
* #26044 Provisioning API to IBootstrap
* #26051 Cache baseurl in url generator
* #26056 Allow autocomplete based on phone sync
* #26058 Only clear share password model when actually saved
* #26062 Add appconfig to always show the unique label of a sharee
* #26081 Only clear known users when we had at least one phonebook entry
* #26084 Chunk the array of phone numbers
* #26087 Limit constructing of result objects in file search
* #26090 Apply object store copy optimization when 'cross storage' copy is wit…
* #26119 Add getID function to the simplefile implementation
* #26122 Allow overwriting isAuthenticated
* #26124 Send share notification instead of erroring on duplicate share
* #26128 Log exceptions when creating share
* #26133 Do cachejail search filtering in sql
* #26146 Return the fileid from `copyFromCache` and use it instead of doing an extra query
* #26151 Dont allow creating users with __groupfolders as uid
* #26162 Use correct exception type hint in catch statement
* #26166 Fix default missing initial state for templates
* #26167 Remove explicit fclose from S3->writeStream
* #26175 Adds ldap user:reset command
* #26177 Improve search results when only phonebook-matches can we autocompleted
* #26192 Fix valid storages removed when cleaning remote storages
* #26204 Update user share must use correct expiration validation
* #26211 Expand 'path is already shared' error message
* #26215 Add (hidden) option to always show smb root as writable
* #26227 Removed unnecessary padding
* #26238 L10n: Add words user and because in ShareByMailProvider.php
* #26249 Fix non LGC glyphs in avatars and txt file previews
* #26257 Handle limit offset and sorting in files search
* #26263 Update icewind/smb to 3.4.0
* #26271 Catch invalid cache source storage path
* #26276 Fix casing of core test folder, bring back missing tests
* #26279 L10n: Separate ellipsis
* #26291 Show better error messages when a file with a forbidden path is encountered
* #26298 Fix l10n
* #26301 Log when a storage is marked as unavailable
* #26307 Delete old birthday calendar object when moving contact to another ad…
* #26326 Add a prefix index to filecache.path
* #26352 Avatar privacy and new scope
* #26357 Fix broken Calendar Event Invite email icons in Gmail by using PNGs instead of SVGs
* #26363 Update cipher defaults
* #26366 Fix wording for phone number integration
* #26371 Remove notifications when retesting profile field input
* #26376 Do not attempt to read 0 bytes when manually iterating over a non-seekable file
* #26377 Fix(translation): replace static error message
* #26379 Only mark migrations as installed after execution
* #26382 Gracefully handle deleteFromSelf when share is already gone
* #26391 Also check the default phone region when the number has no country code
* #26398 Allow apps to write/update account data
* #26400 Log and continue when failing to update encryption keys during for individual files
* #26402 Make ILDAPProviderFactory usable when there is no ldap setup
* #26404 Remove leftover debug @NoCSRFRequired introduced with #26198
* #26406 Get the parent directory before creating a file from a template
* #26413 Bump y18n from 4.0.0 to 4.0.1
* [activity#562](https://github.com/nextcloud/activity/pull/562) Fix 'Daily activity summary' email subject translation
* [activity#566](https://github.com/nextcloud/activity/pull/566) Fix notifying own activities
* [activity#570](https://github.com/nextcloud/activity/pull/570) Send the footer with the defined language
* [files_pdfviewer#340](https://github.com/nextcloud/files_pdfviewer/pull/340) Make sure we only load the public script on public pages
* [firstrunwizard#503](https://github.com/nextcloud/firstrunwizard/pull/503) Extend reasons for email address
* [notifications#911](https://github.com/nextcloud/notifications/pull/911) Only send desktop notifications in one tab
* [photos#689](https://github.com/nextcloud/photos/pull/689) Fix Photos not shown in large browser windows #630
* [photos#710](https://github.com/nextcloud/photos/pull/710) Add vue-virtual-grid to babel
* [serverinfo#280](https://github.com/nextcloud/serverinfo/pull/280) Match any non-whitespace character in filesystem type pattern
* [serverinfo#287](https://github.com/nextcloud/serverinfo/pull/287) Fix Internal Server Error @ /settings/admin/serverinfo in 21.0.0
* [text#1504](https://github.com/nextcloud/text/pull/1504) Disable cypress recording for now
* [text#1512](https://github.com/nextcloud/text/pull/1512) Use write permission when possible
* [text#1516](https://github.com/nextcloud/text/pull/1516) Fix clicking links with color annotations
* [updater#346](https://github.com/nextcloud/updater/pull/346) Update CLI tests to PHP 7.4 to 8.0
* [updater#351](https://github.com/nextcloud/updater/pull/351) Disable UI when web updater is disabled in config.php
* [updater#355](https://github.com/nextcloud/updater/pull/355) Remove obsolete pipeline php72-master
* [updater#359](https://github.com/nextcloud/updater/pull/359) Update used version of box
* [updater#363](https://github.com/nextcloud/updater/pull/363) Do not allow to keep maintenance mode active in web updater
* [viewer#842](https://github.com/nextcloud/viewer/pull/842) Fix fullscreen


Pending PRs:

* [x] #26447 [3rdparty]phpseclib-2.0.31 @rullzer
* [x] #26451 Revert "add a prefix index to filecache.path" @rullzer
* [x] #26459 Show icon-phone when setting is set to private instead of local @nickvergessen 