### PR TITLE
20.0.9 final

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 9, 0];
+$OC_Version = [20, 0, 9, 1];
 
 // The human readable string
-$OC_VersionString = '20.0.9 RC1';
+$OC_VersionString = '20.0.9';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #25740 Avoid creating two share links when password is enforced
* #25844 Fix detecting cyclic group memberships
* #25848 Bump the ca location
* #25858 Card::getOwner should return the actual value
* #25873 Fix namespacing
* #25876 Update psalm baseline
* #25878 Disable trasbin during the moveFromStorage fallback
* #25900 Do not die after LDAP auth failed with expired acc
* #25919 Clear multiselect after selection in share panel
* #25934 Activity: show if files are hidden or not
* #25938 Sharebymail: set expiration on creation
* #25944 Catch notfound and forbidden exception in smb::getmetadata
* #25956 Skip empty obsolete owner when adding to own NC
* #25963 Fix admin password strengthify tooltip
* #25994 Add missing waits and asserts in acceptance tests
* #26009 Bump elliptic from 6.5.3 to 6.5.4
* #26027 Hide expiration date field for remote shares
* #26040 Remove trash items from other trash backends when deleting all
* #26052 Cache baseurl in url generator
* #26059 Only clear share password model when actually saved
* #26063 Add appconfig to always show the unique label of a sharee
* #26088 Limit constructing of result objects in file search
* #26091 Apply object store copy optimization when 'cross storage' copy is wit…
* #26123 Allow overwriting isAuthenticated
* #26125 Send share notification instead of erroring on duplicate share
* #26130 Log exceptions when creating share
* #26134 Do cachejail search filtering in sql
* #26147 Return the fileid from `copyFromCache` and use it instead of doing an extra query
* #26152 Dont allow creating users with __groupfolders as uid
* #26163 Use correct exception type hint in catch statement
* #26168 Remove explicit fclose from S3->writeStream
* #26176 Adds ldap user:reset command
* #26181 Add getID function to the simplefile implementation
* #26190 Fix valid storages removed when cleaning remote storages
* #26205 Update user share must use correct expiration validation
* #26209 Expand 'path is already shared' error message
* #26217 Add (hidden) option to always show smb root as writable
* #26239 L10n: Add words user and because in ShareByMailProvider.php
* #26250 Fix non LGC glyphs in avatars and txt file previews
* #26258 Handle limit offset and sorting in files search
* #26262 Update icewind/smb to 3.4.0
* #26272 Catch invalid cache source storage path
* #26275 Fix casing of core test folder, bring back missing tests
* #26278 L10n: Separate ellipsis
* #26290 Show better error messages when a file with a forbidden path is encountered
* #26297 Fix l10n
* #26302 Log when a storage is marked as unavailable
* #26305 Delete old birthday calendar object when moving contact to another ad…
* #26356 Fix broken Calendar Event Invite email icons in Gmail by using PNGs instead of SVGs
* #26360 Bump y18n from 4.0.0 to 4.0.1
* #26364 Update cipher defaults
* #26378 Fix(translation): replace static error message
* #26381 Gracefully handle deleteFromSelf when share is already gone
* #26399 Log and continue when failing to update encryption keys during for individual files
* #26405 Remove leftover debug @NoCSRFRequired introduced with #26198
* [activity#563](https://github.com/nextcloud/activity/pull/563) Fix 'Daily activity summary' email subject translation
* [activity#567](https://github.com/nextcloud/activity/pull/567) Fix notifying own activities
* [activity#571](https://github.com/nextcloud/activity/pull/571) Send the footer with the defined language
* [files_pdfviewer#339](https://github.com/nextcloud/files_pdfviewer/pull/339) Make sure we only load the public script on public pages
* [firstrunwizard#504](https://github.com/nextcloud/firstrunwizard/pull/504) Extend reasons for email address
* [notifications#912](https://github.com/nextcloud/notifications/pull/912) Only send desktop notifications in one tab
* [photos#711](https://github.com/nextcloud/photos/pull/711) Add vue-virtual-grid to babel
* [serverinfo#281](https://github.com/nextcloud/serverinfo/pull/281) Match any non-whitespace character in filesystem type pattern
* [text#1410](https://github.com/nextcloud/text/pull/1410) Make sure the session list is always at the end
* [text#1506](https://github.com/nextcloud/text/pull/1506) Pin versions
* [text#1513](https://github.com/nextcloud/text/pull/1513) Use write permission when possible
* [updater#345](https://github.com/nextcloud/updater/pull/345) Update CLI tests to PHP 7.4 to 8.0
* [updater#352](https://github.com/nextcloud/updater/pull/352) Disable UI when web updater is disabled in config.php
* [updater#354](https://github.com/nextcloud/updater/pull/354) Remove obsolete pipeline php72-master
* [updater#360](https://github.com/nextcloud/updater/pull/360) Update used version of box
* [updater#364](https://github.com/nextcloud/updater/pull/364) Do not allow to keep maintenance mode active in web updater
* [viewer#843](https://github.com/nextcloud/viewer/pull/843) Fix fullscreen


Pending PRs:

* [x] #26449 [3rdparty]phpseclib-2.0.31 @rullzer