### PR TITLE
Fix S3 ObjectStore proxy option

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -130,8 +130,8 @@ trait S3ConnectionTrait {
 			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
 			'csm' => false,
 		];
-		if (isset($this->params['proxy'])) {
-			$options['http'] = [ 'proxy' => $this->params['proxy'] ];
+		if ($this->getProxy()) {
+			$options['http'] = [ 'proxy' => $this->getProxy() ];
 		}
 		if (isset($this->params['legacy_auth']) && $this->params['legacy_auth']) {
 			$options['signature_version'] = 'v2';

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -57,6 +57,9 @@ trait S3ConnectionTrait {
 	/** @var int */
 	protected $timeout;
 
+	/** @var string */
+	protected $proxy;
+
 	/** @var int */
 	protected $uploadPartSize;
 
@@ -71,6 +74,7 @@ trait S3ConnectionTrait {
 
 		$this->test = isset($params['test']);
 		$this->bucket = $params['bucket'];
+		$this->proxy = isset($params['proxy']) ? $params['proxy'] : false;
 		$this->timeout = !isset($params['timeout']) ? 15 : $params['timeout'];
 		$this->uploadPartSize = !isset($params['uploadPartSize']) ? 524288000 : $params['uploadPartSize'];
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
@@ -84,6 +88,10 @@ trait S3ConnectionTrait {
 
 	public function getBucket() {
 		return $this->bucket;
+	}
+
+	public function getProxy() {
+		return $this->proxy;
 	}
 
 	/**
@@ -123,7 +131,7 @@ trait S3ConnectionTrait {
 			'csm' => false,
 		];
 		if (isset($this->params['proxy'])) {
-			$options['request.options'] = ['proxy' => $this->params['proxy']];
+			$options['http'] = [ 'proxy' => $this->params['proxy'] ];
 		}
 		if (isset($this->params['legacy_auth']) && $this->params['legacy_auth']) {
 			$options['signature_version'] = 'v2';

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -51,8 +51,7 @@ trait S3ObjectTrait {
 	 */
 	public function readObject($urn) {
 		return SeekableHttpStream::open(function ($range) use ($urn) {
-			$connection = $this->getConnection();
-			$command = $connection->getCommand('GetObject', [
+			$command = $this->getConnection()->getCommand('GetObject', [
 				'Bucket' => $this->bucket,
 				'Key' => $urn,
 				'Range' => 'bytes=' . $range,
@@ -71,8 +70,9 @@ trait S3ObjectTrait {
 				],
 			];
 
-			if ($connection->getProxy()) {
-				$opts['http']['proxy'] = $connection->getProxy();
+			if ($this->getProxy()) {
+				$opts['http']['proxy'] = $this->getProxy();
+				$opts['http']['request_fulluri'] = true;
 			}
 
 			$context = stream_context_create($opts);

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -51,7 +51,8 @@ trait S3ObjectTrait {
 	 */
 	public function readObject($urn) {
 		return SeekableHttpStream::open(function ($range) use ($urn) {
-			$command = $this->getConnection()->getCommand('GetObject', [
+			$connection = $this->getConnection();
+			$command = $connection->getCommand('GetObject', [
 				'Bucket' => $this->bucket,
 				'Key' => $urn,
 				'Range' => 'bytes=' . $range,
@@ -69,6 +70,10 @@ trait S3ObjectTrait {
 					'header' => $headers,
 				],
 			];
+
+			if ($connection->getProxy()) {
+				$opts['http']['proxy'] = $connection->getProxy();
+			}
 
 			$context = stream_context_create($opts);
 			return fopen($request->getUri(), 'r', false, $context);


### PR DESCRIPTION
The `proxy` option in S3 object store does not current work

```
  'objectstore' => 
  array (
    'class' => '\\OC\\Files\\ObjectStore\\S3',
    'arguments' => 
    array (
    # other_arguments
      'proxy' => 'localhost:3128',
    ),
```
tries to set an unknown/deprecated "request.options" key when constructing a S3Client. The [correct one](https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.AwsClient.html#___construct) is "http"

Additionally, S3ObjectTrait::readObject uses fopen() directly, so object store proxy options must also be passed to it