### PR TITLE
Mention MariaDB in MySQL support warning

### DIFF
--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -74,7 +74,7 @@ class SupportedDatabase {
 					}
 				} else {
 					if (version_compare($version, '8', '<')) {
-						$this->description = $this->l10n->t('MySQL version "%s" is used. Nextcloud 21 will no longer support this version and requires MySQL 8 or higher.', $row['Value']);
+						$this->description = $this->l10n->t('MySQL version "%s" is used. Nextcloud 21 will no longer support this version and requires MySQL 8.0 or MariaDB 10.2 or higher.', $row['Value']);
 						return;
 					}
 				}


### PR DESCRIPTION
Nextcloud warns if MySQL 5.7 is installed, as this version is no longer (officially) supported by Nextcloud 21.

Some hosters (like ALL-INKL) don't offer MySQL 8.0 yet, but offer MariaDB 10.2+ as an alternative instead. However, users of these hosters can only find out about Nextcloud's compatibility with MariaDB via the [System requirements](https://docs.nextcloud.com/server/21/admin_manual/installation/system_requirements.html) in the Administration manual.

This change informs users about the alternative by mentioning MariaDB directly in the warning.

PS: It might also make sense to link to the System requirements from all three warnings (MariaDB, MySQL, PostgreSQL).