### PR TITLE
Remove old unused handlebar systemtags template

### DIFF
--- a/build/compile-handlebars-templates.sh
+++ b/build/compile-handlebars-templates.sh
@@ -10,9 +10,6 @@ node node_modules/handlebars/bin/handlebars -n OCA.Comments.Templates  apps/comm
 # Settings
 node node_modules/handlebars/bin/handlebars -n OC.Settings.Templates  apps/settings/js/templates -f apps/settings/js/templates.js
 
-# Systemtags
-node node_modules/handlebars/bin/handlebars -n OC.SystemTags.Templates core/js/systemtags/templates -f core/js/systemtags/templates.js
-
 # Files app
 node node_modules/handlebars/bin/handlebars -n OCA.Files.Templates apps/files/js/templates -f apps/files/js/templates.js
 


### PR DESCRIPTION
After @rullzer migrated the systemtags to webpack, we don't need to compile them manually