### PR TITLE
Fix some php 8 warnings

### DIFF
--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -217,7 +217,7 @@ class Helper {
 	 * @param ITagManager $tagManager
 	 * @return array file list populated with tags
 	 */
-	public static function populateTags(array $fileList, $fileIdentifier = 'fileid', ITagManager $tagManager) {
+	public static function populateTags(array $fileList, $fileIdentifier, ITagManager $tagManager) {
 		$ids = [];
 		foreach ($fileList as $fileData) {
 			$ids[] = $fileData[$fileIdentifier];

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -156,8 +156,8 @@ class PreviewController extends Controller {
 		Node $node,
 		int $x,
 		int $y,
-		bool $a = false,
-		bool $forceIcon = true,
+		bool $a,
+		bool $forceIcon,
 		string $mode) : Http\Response {
 		if (!($node instanceof File) || (!$forceIcon && !$this->preview->isAvailable($node))) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/lib/private/Files/Config/CachedMountFileInfo.php
+++ b/lib/private/Files/Config/CachedMountFileInfo.php
@@ -31,7 +31,7 @@ class CachedMountFileInfo extends CachedMountInfo implements ICachedMountFileInf
 	/** @var string */
 	private $internalPath;
 
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null, $rootInternalPath = '', $internalPath) {
+	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId, $rootInternalPath, $internalPath) {
 		parent::__construct($user, $storageId, $rootId, $mountPoint, $mountId, $rootInternalPath);
 		$this->internalPath = $internalPath;
 	}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -422,7 +422,9 @@ class View {
 	 */
 	public function readfile($path) {
 		$this->assertPathLength($path);
-		@ob_end_clean();
+		if (ob_get_level()) {
+			ob_end_clean();
+		}
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
 			$chunkSize = 524288; // 512 kB chunks
@@ -446,7 +448,9 @@ class View {
 	 */
 	public function readfilePart($path, $from, $to) {
 		$this->assertPathLength($path);
-		@ob_end_clean();
+		if (ob_get_level()) {
+			ob_end_clean();
+		}
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
 			$chunkSize = 524288; // 512 kB chunks

--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -97,7 +97,7 @@ class PublicTemplateResponse extends TemplateResponse {
 			$this->headerActions[] = $action;
 		}
 		usort($this->headerActions, function (IMenuAction $a, IMenuAction $b) {
-			return $a->getPriority() > $b->getPriority();
+			return $a->getPriority() <=> $b->getPriority();
 		});
 	}
 


### PR DESCRIPTION
Fixes PHP 8 warnings mentioned in #25806:

- Error: Required parameter $internalPath follows optional parameter $mountId at /path/to/cloud/lib/private/Files/Config/CachedMountFileInfo.php#34
- Error: Required parameter $tagManager follows optional parameter $fileIdentifier at /path/to/cloud/apps/files/lib/Helper.php#220
- Error: ob_end_clean(): Failed to delete buffer. No buffer to delete at /path/to/cloud/lib/private/Files/View.php#449
- Error: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero at /path/to/cloud/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php#101 

This only fixes the PHP 8 warnings, not deprecation warnings by `3rdparty` code.