### PR TITLE
E-Mail-Reminder to all attendees is sent only by organizer

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
@@ -44,11 +44,11 @@ interface INotificationProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
-	 * @param IUser $userOfReminder
+	 * @param IUser $reminderOwner
 	 * @return void
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName,
 						 array $users = [],
-						 IUser $userOfReminder = null): void;
+						 IUser $reminderOwner = null): void;
 }

--- a/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
@@ -44,9 +44,11 @@ interface INotificationProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
+	 * @param IUser $userOfReminder
 	 * @return void
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName,
-						 array $users = []): void;
+						 array $users = [],
+						 IUser $userOfReminder = null): void;
 }

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
@@ -91,11 +91,13 @@ abstract class AbstractProvider implements INotificationProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
+	 * @param IUser $userOfReminder
 	 * @return void
 	 */
 	abstract public function send(VEvent $vevent,
 						   string $calendarDisplayName,
-						   array $users = []): void;
+						   array $users = [],
+							IUser $userOfReminder = null): void;
 
 	/**
 	 * @return string

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
@@ -91,13 +91,13 @@ abstract class AbstractProvider implements INotificationProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
-	 * @param IUser $userOfReminder
+	 * @param IUser $reminderOwner
 	 * @return void
 	 */
 	abstract public function send(VEvent $vevent,
 						   string $calendarDisplayName,
 						   array $users = [],
-							IUser $userOfReminder = null): void;
+							IUser $reminderOwner = null): void;
 
 	/**
 	 * @return string

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -81,13 +81,13 @@ class EmailProvider extends AbstractProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param array $users
-	 * @param IUser $userOfReminder
+	 * @param IUser $reminderOwner
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName,
 						 array $users = [],
-						 IUser $userOfReminder = null):void {
+						 IUser $reminderOwner = null):void {
 		$fallbackLanguage = $this->getFallbackLanguage();
 
 		$emailAddressesOfSharees = $this->getEMailAddressesOfAllUsersWithWriteAccessToCalendar($users);
@@ -96,7 +96,7 @@ class EmailProvider extends AbstractProvider {
 
 		$emailAddressesOfAttendees = [];
 
-		if ($userOfReminder && strcasecmp($userOfReminder->getEMailAddress(), key($organizer)) == 0) {
+		if ($organizer !== null && $reminderOwner instanceof IUser && strcasecmp($reminderOwner->getEMailAddress(), key($organizer)) === 0) {
 			$emailAddressesOfAttendees = $this->getAllEMailAddressesFromEvent($vevent);
 		}
 
@@ -205,7 +205,7 @@ class EmailProvider extends AbstractProvider {
 		}
 
 		$organizer = $vevent->ORGANIZER;
-		if (!str_starts_with($organizer->getValue(), 'mailto:')) {
+		if (strcasecmp($organizer->getValue(), 'mailto:') !== 0) {
 			return null;
 		}
 

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -83,13 +83,13 @@ class PushProvider extends AbstractProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
-	 * @param IUser $userOfReminder
+	 * @param IUser $reminderOwner
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName = null,
 						 array $users = [],
-						 IUser $userOfReminder = null):void {
+						 IUser $reminderOwner = null):void {
 		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'no') !== 'yes') {
 			return;
 		}

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -83,11 +83,13 @@ class PushProvider extends AbstractProvider {
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
 	 * @param IUser[] $users
+	 * @param IUser $userOfReminder
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName = null,
-						 array $users = []):void {
+						 array $users = [],
+						 IUser $userOfReminder = null):void {
 		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'no') !== 'yes') {
 			return;
 		}

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -142,13 +142,13 @@ class ReminderService {
 			}
 
 			$users = $this->getAllUsersWithWriteAccessToCalendar($reminder['calendar_id']);
-			$user = $this->getUserFromPrincipalURI($reminder['principaluri']);
-			if ($user) {
-				$users[] = $user;
+			$userOfReminder = $this->getUserFromPrincipalURI($reminder['principaluri']);
+			if ($userOfReminder) {
+				$users[] = $userOfReminder;
 			}
 
 			$notificationProvider = $this->notificationProviderManager->getProvider($reminder['type']);
-			$notificationProvider->send($vevent, $reminder['displayname'], $users);
+			$notificationProvider->send($vevent, $reminder['displayname'], $users, $userOfReminder);
 
 			$this->deleteOrProcessNext($reminder, $vevent);
 		}


### PR DESCRIPTION
When the organizer adds the reminder the nextcloud attendees only get 2 mails now.
* one from the organizer
* one for their own reminder

outside-users get only the mail from the organizer, because they have no own reminders

Fixes #21370