### PR TITLE
Use findBinaryPath for previews

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4319,16 +4319,6 @@
       <code>$second</code>
     </InvalidScalarArgument>
   </file>
-  <file src="lib/private/Preview/Office.php">
-    <ForbiddenCode occurrences="3">
-      <code>shell_exec($exec)</code>
-      <code>shell_exec('command -v libreoffice')</code>
-      <code>shell_exec('command -v openoffice')</code>
-    </ForbiddenCode>
-    <ImplicitToStringCast occurrences="1">
-      <code>$png</code>
-    </ImplicitToStringCast>
-  </file>
   <file src="lib/private/Preview/ProviderV1Adapter.php">
     <InvalidReturnStatement occurrences="1">
       <code>$thumbnail === false ? null: $thumbnail</code>
@@ -4349,12 +4339,6 @@
     <ImplicitToStringCast occurrences="1">
       <code>$svg</code>
     </ImplicitToStringCast>
-  </file>
-  <file src="lib/private/PreviewManager.php">
-    <ForbiddenCode occurrences="2">
-      <code>shell_exec('command -v libreoffice')</code>
-      <code>shell_exec('command -v openoffice')</code>
-    </ForbiddenCode>
   </file>
   <file src="lib/private/RedisFactory.php">
     <InvalidScalarArgument occurrences="1">

--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 namespace OC\Preview;
 
 use OCP\Files\File;
+use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\ILogger;
 
@@ -49,7 +50,7 @@ class HEIC extends ProviderV2 {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function isAvailable(\OCP\Files\FileInfo $file): bool {
+	public function isAvailable(FileInfo $file): bool {
 		return in_array('HEIC', \Imagick::queryFormats("HEI*"));
 	}
 
@@ -57,6 +58,10 @@ class HEIC extends ProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
+		if (!$this->isAvailable($file)) {
+			return null;
+		}
+
 		$tmpPath = $this->getLocalFile($file);
 
 		// Creates \Imagick object from the heic file

--- a/lib/private/Preview/ProviderV2.php
+++ b/lib/private/Preview/ProviderV2.php
@@ -31,8 +31,10 @@ use OCP\IImage;
 use OCP\Preview\IProviderV2;
 
 abstract class ProviderV2 implements IProviderV2 {
-	private $options;
+	/** @var array */
+	protected $options;
 
+	/** @var array */
 	private $tmpFiles = [];
 
 	/**

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -52,6 +52,10 @@ class TXT extends ProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
+		if (!$this->isAvailable($file)) {
+			return null;
+		}
+
 		$content = $file->fopen('r');
 
 		if ($content === false) {


### PR DESCRIPTION
findBinaryPath uses cache: https://github.com/nextcloud/server/blob/4be2e1601e80a09aebac57eabb0aaf60e744362e/lib/private/legacy/OC_Helper.php#L460-L464

I think avconv can be removed completely in near future, the fork is no longer maintained: https://lists.libav.org/pipermail/libav-devel/2020-April/086589.html