### PR TITLE
[stable20] Limit size of properties to 2048 characters

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -93,6 +93,14 @@ class AccountManager implements IAccountManager {
 	public function updateUser(IUser $user, $data) {
 		$userData = $this->getUser($user);
 		$updated = true;
+
+		// set a max length
+		foreach ($data as $propertyName => $propertyData) {
+			if (isset($data[$propertyName]) && isset($data[$propertyName]['value']) && strlen($data[$propertyName]['value']) > 2048) {
+				$data[$propertyName]['value'] = '';
+			}
+		}
+
 		if (empty($userData)) {
 			$this->insertNewUser($user, $data);
 		} elseif ($userData !== $data) {


### PR DESCRIPTION
It is unreasonable to expect that one of these fields would be longer
than 2048 characters. Whilst some have definitely lower limits (such as
for phone numbers or domain names), a upper bound as sanity check makes
sense.

Backport of https://github.com/nextcloud/server/pull/26433

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>