### PR TITLE
ensure redis returns bool for hasKey

### DIFF
--- a/lib/private/Http/Client/NegativeDnsCache.php
+++ b/lib/private/Http/Client/NegativeDnsCache.php
@@ -46,6 +46,6 @@ class NegativeDnsCache {
 	}
 
 	public function isNegativeCached(string $domain, int $type) : bool {
-		return $this->cache->hasKey($this->createCacheKey($domain, $type));
+		return (bool)$this->cache->hasKey($this->createCacheKey($domain, $type));
 	}
 }

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -69,7 +69,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function hasKey($key) {
-		return self::$cache->exists($this->getNameSpace() . $key);
+		return (bool)self::$cache->exists($this->getNameSpace() . $key);
 	}
 
 	public function remove($key) {


### PR DESCRIPTION
Fixes a `Return value of OC\\Http\\Client\\NegativeDnsCache::isNegativeCached() must be of the type bool, int returned",` with Redis. To quote the module's doc:

>  [..]
     * @since >= 4.0 Returned int, if < 4.0 returned bool
     [..]
     * @return int|bool The number of keys tested that do exist