### PR TITLE
Fix constraint violation detection in QB Mapper

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Db;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -157,8 +157,11 @@ abstract class QBMapper {
 	public function insertOrUpdate(Entity $entity): Entity {
 		try {
 			return $this->insert($entity);
-		} catch (UniqueConstraintViolationException $ex) {
-			return $this->update($entity);
+		} catch (Exception $ex) {
+			if ($ex->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				return $this->update($entity);
+			}
+			throw $ex;
 		}
 	}
 


### PR DESCRIPTION
Unbreaks e.g. the webauthn login

Do we need to backport this?