### PR TITLE
Filter mounts for file id before trying to get user information

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -326,18 +326,30 @@ class UserMountCache implements IUserMountCache {
 		} catch (NotFoundException $e) {
 			return [];
 		}
-		$mountsForStorage = $this->getMountsForStorageId($storageId, $user);
+		$builder = $this->connection->getQueryBuilder();
+		$query = $builder->select('storage_id', 'root_id', 'user_id', 'mount_point', 'mount_id', 'f.path')
+			->from('mounts', 'm')
+			->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
+			->where($builder->expr()->eq('storage_id', $builder->createPositionalParameter($storageId, IQueryBuilder::PARAM_INT)));
 
+		if ($user) {
+			$query->andWhere($builder->expr()->eq('user_id', $builder->createPositionalParameter($user)));
+		}
+
+		$result = $query->execute();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
 		// filter mounts that are from the same storage but a different directory
-		$filteredMounts = array_filter($mountsForStorage, function (ICachedMountInfo $mount) use ($internalPath, $fileId) {
-			if ($fileId === $mount->getRootId()) {
+		$filteredMounts = array_filter($rows, function (array $row) use ($internalPath, $fileId) {
+			if ($fileId === (int)$row['root_id']) {
 				return true;
 			}
-			$internalMountPath = $mount->getRootInternalPath();
+			$internalMountPath = isset($row['path']) ? $row['path'] : '';
 
 			return $internalMountPath === '' || substr($internalPath, 0, strlen($internalMountPath) + 1) === $internalMountPath . '/';
 		});
 
+		$filteredMounts = array_filter(array_map([$this, 'dbRowToMountInfo'], $filteredMounts));
 		return array_map(function (ICachedMountInfo $mount) use ($internalPath) {
 			return new CachedMountFileInfo(
 				$mount->getUser(),


### PR DESCRIPTION
When fetching the mountpoints for a given fileid the results were previously returning all mountpoints of the given storage id and passing those to dbRowToMountInfo. This is generally ok, but with groupfolders all being located on the same storage id this will cause unnecessary calls for checking the user since we are only interested in the ones that match the path of the fileid.

This especially becomes an issue if there are lots of groupfolders setup and `activity_use_cached_mountpoints` is enabled where the list of mounts is obtained on each file operation for generating activites, see the below blackfire profiling:

![image](https://user-images.githubusercontent.com/3404133/115026176-78a73480-9ec2-11eb-9952-b80eaf4fd4ae.png)

![image](https://user-images.githubusercontent.com/3404133/115027853-82ca3280-9ec4-11eb-8e2d-6bf60a542dfb.png)

