### PR TITLE
Do not allow adding file drop shares to your own cloud

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -37,6 +37,7 @@ use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Constants;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
@@ -151,6 +152,15 @@ class MountPublicLinkController extends Controller {
 		if (!empty($storedPassword) && !$authenticated) {
 			$response = new JSONResponse(
 				['message' => 'No permission to access the share'],
+				Http::STATUS_BAD_REQUEST
+			);
+			$response->throttle();
+			return $response;
+		}
+
+		if (($share->getPermissions() & Constants::PERMISSION_READ) === 0) {
+			$response = new JSONResponse(
+				['message' => 'Mounting file drop not supported'],
 				Http::STATUS_BAD_REQUEST
 			);
 			$response->throttle();

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -139,7 +139,8 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 											 $token,
 											 $validToken,
 											 $createSuccessful,
-											 $expectedReturnData
+											 $expectedReturnData,
+											 $permissions
 	) {
 		$this->federatedShareProvider->expects($this->any())
 			->method('isOutgoingServer2serverShareEnabled')
@@ -157,6 +158,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 			);
 
 		$share = $this->share;
+		$share->setPermissions($permissions);
 
 		$this->shareManager->expects($this->any())->method('getShareByToken')
 			->with($token)
@@ -199,15 +201,16 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 	public function dataTestCreateFederatedShare() {
 		return [
 			//shareWith, outgoingSharesAllowed, validShareWith, token, validToken, createSuccessful, expectedReturnData
-			['user@server', true, true, 'token', true, true, 'server'],
-			['user@server', true, false, 'token', true, true, 'invalid federated cloud id'],
-			['user@server', true, false, 'token', false, true, 'invalid federated cloud id'],
-			['user@server', true, false, 'token', false, false, 'invalid federated cloud id'],
-			['user@server', true, false, 'token', true, false, 'invalid federated cloud id'],
-			['user@server', true, true, 'token', false, true, 'invalid token'],
-			['user@server', true, true, 'token', false, false, 'invalid token'],
-			['user@server', true, true, 'token', true, false, 'can not create share'],
-			['user@server', false, true, 'token', true, true, 'This server doesn\'t support outgoing federated shares'],
+			['user@server', true, true, 'token', true, true, 'server', 31],
+			['user@server', true, true, 'token', false, false, 'server', 4],
+			['user@server', true, false, 'token', true, true, 'invalid federated cloud id', 31],
+			['user@server', true, false, 'token', false, true, 'invalid federated cloud id', 31],
+			['user@server', true, false, 'token', false, false, 'invalid federated cloud id', 31],
+			['user@server', true, false, 'token', true, false, 'invalid federated cloud id', 31],
+			['user@server', true, true, 'token', false, true, 'invalid token', 31],
+			['user@server', true, true, 'token', false, false, 'invalid token', 31],
+			['user@server', true, true, 'token', true, false, 'can not create share', 31],
+			['user@server', false, true, 'token', true, true, 'This server doesn\'t support outgoing federated shares', 31],
 		];
 	}
 }


### PR DESCRIPTION
There is no reason for this and you can't create such shares normally
anyway.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>