### PR TITLE
Do not check Oracle column constraints in unrelated migrations

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -587,12 +587,12 @@ class MigrationService {
 					throw new \InvalidArgumentException('Column name "' . $table->getName() . '"."' . $thing->getName() . '" is too long.');
 				}
 
-				if ($thing->getNotnull() && $thing->getDefault() === ''
+				if ((!$sourceTable instanceof Table || !$sourceTable->hasColumn($thing->getName())) && $thing->getNotnull() && $thing->getDefault() === ''
 					&& $sourceTable instanceof Table && !$sourceTable->hasColumn($thing->getName())) {
 					throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is NotNull, but has empty string or null as default.');
 				}
 
-				if ($thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
+				if ((!$sourceTable instanceof Table || !$sourceTable->hasColumn($thing->getName())) && $thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
 					throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is type Bool and also NotNull, so it can not store "false".');
 				}
 			}


### PR DESCRIPTION
Today I was blocked with a

```
2021-04-19T10:54:11+00:00 InvalidArgumentException: OCA\Mail\Migration\Version1096Date20210407150016: Column oc_social_3_cache_actor.local is type Bool and also NotNull, so it can not store "false".
```

while running a migration for Mail. The weird thing was that the migration that triggered the error was one from Mail. Unrelated migrations shouldn't trigger this, only the ones that cause it with a diff between old a new schema.