### PR TITLE
[stable21] ensure redis returns bool for hasKey

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -69,7 +69,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function hasKey($key) {
-		return self::$cache->exists($this->getNameSpace() . $key);
+		return (bool)self::$cache->exists($this->getNameSpace() . $key);
 	}
 
 	public function remove($key) {


### PR DESCRIPTION
backport of #26551 (apart of the NegativDNS Cache which isn't in NC<=21)