### PR TITLE
Fail when creating new files with an empty path

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -190,6 +190,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function newFile($path, $content = null) {
+		if (empty($path)) {
+			throw new NotPermittedException('Could not create as provided path is empty');
+		}
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFile($this->root, $this->view, $fullPath);


### PR DESCRIPTION
This PR makes sure to properly check if a path is provided before trying to create a file in a folder.

This can become an issue when using object storage if some code calls newFile with an empty string for some reason. The ObjectStoreStorage would in that case try to detect the mimetype by path and update the parent folder (as the path is empty) with an `application/octet-stream` mimetype in the filecache.