### PR TITLE
Fix broken Expiration test

### DIFF
--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -24,6 +24,8 @@
  *
  */
 
+namespace OCA\Files_Trashbin\Tests;
+
 use OCA\Files_Trashbin\Expiration;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
@@ -118,16 +120,16 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	public function configData() {
+	public function timestampTestData(): array {
 		return [
-			[ 'disabled', null, null, null],
-			[ 'auto', Expiration::DEFAULT_RETENTION_OBLIGATION, Expiration::NO_OBLIGATION, true ],
-			[ 'auto,auto', Expiration::DEFAULT_RETENTION_OBLIGATION, Expiration::NO_OBLIGATION, true ],
-			[ 'auto, auto', Expiration::DEFAULT_RETENTION_OBLIGATION, Expiration::NO_OBLIGATION, true ],
-			[ 'auto, 3', Expiration::NO_OBLIGATION, 3, true ],
-			[ '5, auto', 5, Expiration::NO_OBLIGATION, true ],
-			[ '3, 5', 3, 5, false ],
-			[ '10, 3', 10, 10, false ],
+			[ 'disabled', false],
+			[ 'auto', false ],
+			[ 'auto,auto', false ],
+			[ 'auto, auto', false ],
+			[ 'auto, 3',  self::FAKE_TIME_NOW - (3 * self::SECONDS_PER_DAY) ],
+			[ '5, auto', false ],
+			[ '3, 5', self::FAKE_TIME_NOW - (5 * self::SECONDS_PER_DAY) ],
+			[ '10, 3', self::FAKE_TIME_NOW - (10 * self::SECONDS_PER_DAY) ],
 		];
 	}
 


### PR DESCRIPTION
15) Warning
The data provider specified for ExpirationTest::testGetMaxAgeAsTimestamp is invalid.
PHPUnit\Util\Exception: Method timestampTestData does not exist

Regression from https://github.com/nextcloud/server/commit/b7dd2074abf4fe1eab3dab0c611cc4bfe73aa1ab