### PR TITLE
Do not stop directory listing when ACL is blocking access

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -257,7 +257,7 @@ class SMB extends Common implements INotifyStorage {
 						// additionally, it's better to have false negatives here then false positives
 						if ($acl->denies(ACL::MASK_READ) || $acl->denies(ACL::MASK_EXECUTE)) {
 							$this->logger->debug('Hiding non readable entry ' . $file->getName());
-							return false;
+							continue;
 						}
 					}
 


### PR DESCRIPTION
When iterating over the files in a directory of an SMB share the the directory the iterable would stop after the first ACL that denies access instead of just hiding those entries. This may lead to incomplete directory listings on SMB shares with the ACL check enabled.