### PR TITLE
Fix update notification tests

### DIFF
--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -331,8 +331,7 @@ class BackgroundJobTest extends TestCase {
 				\call_user_func_array([$mockedMethod, 'withConsecutive'], $userNotifications);
 
 				$this->notificationManager->expects($this->exactly(\count($userNotifications)))
-					->method('notify')
-					->willReturn($notification);
+					->method('notify');
 			}
 
 			$this->notificationManager->expects($this->once())


### PR DESCRIPTION
18) OCA\UpdateNotification\Tests\Notification\BackgroundJobTest::testCreateNotifications with data set #1 ('app2', '1.0.1', '1.0.0', '1.0.0', true, array('user1'), array(array('user1')))
Method notify may not return value of type Mock_INotification_2134ee38, its return declaration is ": void"

19) OCA\UpdateNotification\Tests\Notification\BackgroundJobTest::testCreateNotifications with data set #2 ('app3', '1.0.1', false, false, true, array('user2', 'user3'), array(array('user2'), array('user3')))
Method notify may not return value of type Mock_INotification_2134ee38, its return declaration is ": void"

Signed-off-by: Joas Schilling <coding@schilljs.com>