### PR TITLE
Fix twofactor backup code tests

### DIFF
--- a/apps/twofactor_backupcodes/tests/Unit/Controller/SettingsControllerTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Controller/SettingsControllerTest.php
@@ -75,11 +75,11 @@ class SettingsControllerTest extends TestCase {
 		$this->storage->expects($this->once())
 			->method('getBackupCodesState')
 			->with($user)
-			->willReturn('state');
+			->willReturn(['state']);
 
 		$expected = [
 			'codes' => $codes,
-			'state' => 'state',
+			'state' => ['state'],
 		];
 		$response = $this->controller->createCodes();
 		$this->assertInstanceOf(JSONResponse::class, $response);

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ActivityPublisherTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ActivityPublisherTest.php
@@ -89,8 +89,7 @@ class ActivityPublisherTest extends TestCase {
 			->with('fritz')
 			->willReturnSelf();
 		$this->activityManager->expects($this->once())
-			->method('publish')
-			->willReturn($activityEvent);
+			->method('publish');
 
 		$this->listener->handle($event);
 	}


### PR DESCRIPTION
16) OCA\TwoFactorBackupCodes\Tests\Unit\Listener\ActivityPublisherTest::testHandleCodesGeneratedEvent
Method publish may not return value of type Mock_IEvent_11bf8381, its return declaration is ": void"

17) OCA\TwoFactorBackupCodes\Tests\Unit\Controller\SettingsControllerTest::testCreateCodes
Method getBackupCodesState may not return value of type string, its return declaration is ": array"

Signed-off-by: Joas Schilling <coding@schilljs.com>