### PR TITLE
Fix LDAP unit tests

### DIFF
--- a/apps/user_ldap/tests/Jobs/UpdateGroupsTest.php
+++ b/apps/user_ldap/tests/Jobs/UpdateGroupsTest.php
@@ -26,9 +26,9 @@ declare(strict_types=1);
 
 namespace OCA\user_ldap\tests\Jobs;
 
-use Doctrine\DBAL\Driver\Statement;
 use OCA\User_LDAP\Group_Proxy;
 use OCA\User_LDAP\Jobs\UpdateGroups;
+use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -124,7 +124,7 @@ class UpdateGroupsTest extends TestCase {
 			->method('expr')
 			->willReturn($this->createMock(IExpressionBuilder::class));
 
-		$stmt = $this->createMock(Statement::class);
+		$stmt = $this->createMock(IResult::class);
 		$stmt->expects($this->once())
 			->method('fetchAll')
 			->willReturn($knownGroupsDB);


### PR DESCRIPTION
20) OCA\user_ldap\tests\Jobs\UpdateGroupsTest::testHandleKnownGroups
Trying to configure method "fetchAll" which cannot be configured because it does not exist, has not been specified, is final, or is static

Signed-off-by: Joas Schilling <coding@schilljs.com>