### PR TITLE
Fix DAV unit tests

### DIFF
--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -437,7 +437,8 @@ EOD;
 				->with('Busy')
 				->willReturn("Translated busy");
 		} else {
-			$l10n->expects($this->never());
+			$l10n->expects($this->never())
+				->method('t');
 		}
 		$c = new Calendar($backend, $calendarInfo, $l10n, $this->config);
 

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -34,6 +34,8 @@ use OCA\DAV\CalDAV\InvitationResponse\InvitationResponseServer;
 use OCA\DAV\Controller\InvitationResponseController;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IRequest;
@@ -408,8 +410,8 @@ EOF;
 
 	private function buildQueryExpects($token, $return, $time) {
 		$queryBuilder = $this->createMock(IQueryBuilder::class);
-		$stmt = $this->createMock(\Doctrine\DBAL\Driver\Statement::class);
-		$expr = $this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class);
+		$stmt = $this->createMock(IResult::class);
+		$expr = $this->createMock(IExpressionBuilder::class);
 
 		$this->dbConnection->expects($this->once())
 			->method('getQueryBuilder')

--- a/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
+++ b/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
@@ -29,6 +29,7 @@ namespace OCA\DAV\Tests\unit\DAV\Migration;
 use OCA\DAV\BackgroundJob\RefreshWebcalJob;
 use OCA\DAV\Migration\RefreshWebcalJobRegistrar;
 use OCP\BackgroundJob\IJobList;
+use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -62,7 +63,7 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 		$output = $this->createMock(IOutput::class);
 
 		$queryBuilder = $this->createMock(IQueryBuilder::class);
-		$statement = $this->createMock(\Doctrine\DBAL\Driver\Statement::class);
+		$statement = $this->createMock(IResult::class);
 
 		$this->db->expects($this->once())
 			->method('getQueryBuilder')


### PR DESCRIPTION
6) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testAccept
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

7) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testAcceptSequence
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

8) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testAcceptRecurrenceId
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

9) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testAcceptTokenNotFound
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

10) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testAcceptExpiredToken
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

11) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testDecline
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

12) OCA\DAV\Tests\Unit\DAV\Controller\InvitationResponseControllerTest::testProcessMoreOptionsResult
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

13) OCA\DAV\Tests\unit\CalDAV\CalendarTest::testConfidentialClassification with data set #0 (3, false)
No method rule is set

14) OCA\DAV\Tests\unit\DAV\Migration\RefreshWebcalJobRegistrarTest::testRun
Trying to configure method "fetch" which cannot be configured because it does not exist, has not been specified, is final, or is static

Signed-off-by: Joas Schilling <coding@schilljs.com>