### PR TITLE
Fix support tests

### DIFF
--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -23,6 +23,7 @@
 namespace Test\Support\Subscription;
 
 use OC\Support\Subscription\Registry;
+use OC\User\Database;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -31,6 +32,8 @@ use OCP\IUserManager;
 use OCP\Notification\IManager;
 use OCP\Support\Subscription\ISubscription;
 use OCP\Support\Subscription\ISupportedApps;
+use OCP\User\Backend\ICountUsersBackend;
+use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -212,8 +215,8 @@ class RegistryTest extends TestCase {
 			->method('getUsersForUserValue')
 			->with('core', 'enabled', 'false')
 			->willReturn(array_fill(0, $disabledUsers, ''));
-		/* @var UserInterface|\PHPUnit\Framework\MockObject\MockObject $dummyBackend */
-		$dummyBackend = $this->createMock(UserInterface::class);
+		/* @var UserInterface|ICountUsersBackend|\PHPUnit\Framework\MockObject\MockObject $dummyBackend */
+		$dummyBackend = $this->createMock(Database::class);
 		$dummyBackend->expects($this->once())
 			->method('implementsActions')
 			->willReturn(true);


### PR DESCRIPTION
2) Test\Support\Subscription\RegistryTest::testDelegateIsHardUserLimitReachedWithoutSupportAppAndUserCount with data set #0 (35, 15, 2, false)
Cannot stub or mock class or interface "Test\Support\Subscription\UserInterface" which does not exist

3) Test\Support\Subscription\RegistryTest::testDelegateIsHardUserLimitReachedWithoutSupportAppAndUserCount with data set #1 (35, 45, 15, false)
Cannot stub or mock class or interface "Test\Support\Subscription\UserInterface" which does not exist

4) Test\Support\Subscription\RegistryTest::testDelegateIsHardUserLimitReachedWithoutSupportAppAndUserCount with data set #2 (35, 45, 5, true)
Cannot stub or mock class or interface "Test\Support\Subscription\UserInterface" which does not exist

5) Test\Support\Subscription\RegistryTest::testDelegateIsHardUserLimitReachedWithoutSupportAppAndUserCount with data set #3 (35, 45, 55, false)
Cannot stub or mock class or interface "Test\Support\Subscription\UserInterface" which does not exist

Had to use the Database user backend, as using multiple interfaces is deprecated:
https://github.com/sebastianbergmann/phpunit/issues/3955
> This functionality should be deprecated as "having to use it" is almost always a symptom of bad design.
> More importantly, though, the support for the creation of test doubles that implement multiple interfaces
> resulted in code that is hard to maintain.

Signed-off-by: Joas Schilling <coding@schilljs.com>