### PR TITLE
Add proper message to created share not found

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -222,7 +222,7 @@ class DefaultShareProvider implements IShareProvider {
 		$cursor->closeCursor();
 
 		if ($data === false) {
-			throw new ShareNotFound();
+			throw new ShareNotFound('Newly created share could not be found');
 		}
 
 		$mailSendValue = $share->getMailSend();

--- a/lib/public/Share/Exceptions/ShareNotFound.php
+++ b/lib/public/Share/Exceptions/ShareNotFound.php
@@ -27,4 +27,18 @@ namespace OCP\Share\Exceptions;
  * @since 9.0.0
  */
 class ShareNotFound extends GenericShareException {
+
+	/**
+	 * @param string $message
+	 * @param string $hint
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 9.0.0
+	 */
+	public function __construct($message = '', ...$arguments) {
+		if (empty($message)) {
+			$message = 'Share not found';
+		}
+		parent::__construct($message, ...$arguments);
+	}
 }


### PR DESCRIPTION
Otherwise the extend of the GenericShareException replace with a completely unrelated and cryptic message
https://github.com/nextcloud/server/blob/45a474071e2245a3d2c31a193a02e707c53c5790/lib/public/Share/Exceptions/GenericShareException.php#L35-L47