### PR TITLE
FIx Oracle by testing on Ubuntu 20.04 until oci8.so is available for …

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   phpunit-oci8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       # do not stop on another job's failure


### PR DESCRIPTION
…21.04

Signed-off-by: Joas Schilling <coding@schilljs.com>