### PR TITLE
Only set copy etag if the destination source can be found

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CopyEtagHeaderPlugin.php
@@ -25,6 +25,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use Sabre\DAV\Exception\NotFound;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 
@@ -74,7 +75,13 @@ class CopyEtagHeaderPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return void
 	 */
 	public function afterMove($source, $destination) {
-		$node = $this->server->tree->getNodeForPath($destination);
+		try {
+			$node = $this->server->tree->getNodeForPath($destination);
+		} catch (NotFound $e) {
+			// Don't care
+			return;
+		}
+
 		if ($node instanceof File) {
 			$eTag = $node->getETag();
 			$this->server->httpResponse->setHeader('OC-ETag', $eTag);

--- a/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
@@ -29,6 +29,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\CopyEtagHeaderPlugin;
 use OCA\DAV\Connector\Sabre\File;
+use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Sabre\DAV\Tree;
 use Test\TestCase;
@@ -71,6 +72,19 @@ class CopyEtagHeaderPluginTest extends TestCase {
 		$this->plugin->afterMethod($request, $response);
 
 		$this->assertNull($response->getHeader('OC-Etag'));
+	}
+
+	public function testAfterMoveNodeNotFound(): void {
+		$tree = $this->createMock(Tree::class);
+		$tree->expects(self::once())
+			->method('getNodeForPath')
+			->with('test.txt')
+			->willThrowException(new NotFound());
+
+		$this->server->tree = $tree;
+		$this->plugin->afterMove('', 'test.txt');
+
+		// Nothing to assert, we are just testing if the exception is handled
 	}
 
 	public function testAfterMove() {


### PR DESCRIPTION
The etag is only set for files, but it's also possible that in edge
cases the copy destination node can't be found. In that case we don't
need to set any etag.

Required for #26083