### PR TITLE
Allow IBootstrap::boot to have services injected directly

### DIFF
--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -64,6 +64,7 @@ use OCP\IUserSession;
 use OCP\Share\IManager as IShareManager;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'files';
@@ -121,12 +122,16 @@ class Application extends App implements IBootstrap {
 		$context->registerNotifierService(Notifier::class);
 	}
 
-	public function boot(IBootContext $context): void {
-		$context->injectFn(Closure::fromCallable([$this, 'registerCollaboration']));
-		$context->injectFn([Listener::class, 'register']);
-		$context->injectFn(Closure::fromCallable([$this, 'registerSearchProvider']));
+	public function boot(IBootContext $context,
+						 IProviderManager $providerManager,
+						 EventDispatcherInterface $dispatcher,
+						 ISearch $search,
+						 IL10N $l10n): void {
+		$this->registerCollaboration($providerManager);
+		Listener::register($dispatcher);
+		$this->registerSearchProvider($search);
 		$this->registerTemplates();
-		$context->injectFn(Closure::fromCallable([$this, 'registerNavigation']));
+		$this->registerNavigation($l10n);
 		$this->registerHooks();
 	}
 

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -32,6 +32,7 @@ namespace OC\AppFramework\Bootstrap;
 use OC\Support\CrashReport\Registry;
 use OC_App;
 use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\QueryException;
 use OCP\Dashboard\IManager;
@@ -173,7 +174,10 @@ class Coordinator {
 			if ($application instanceof IBootstrap) {
 				/** @var BootContext $context */
 				$context = new BootContext($application->getContainer());
-				$application->boot($context);
+				$injector = new FunctionInjector($application->getContainer(), [
+					IBootContext::class => $context,
+				]);
+				$injector->injectFn([$application, 'boot']);
 			}
 		} catch (QueryException $e) {
 			$this->logger->logException($e, [

--- a/lib/public/AppFramework/Bootstrap/IBootstrap.php
+++ b/lib/public/AppFramework/Bootstrap/IBootstrap.php
@@ -28,6 +28,7 @@ namespace OCP\AppFramework\Bootstrap;
 
 /**
  * @since 20.0.0
+ * @method void boot(IBootContext $context, ...$params) Boot the application
  */
 interface IBootstrap {
 
@@ -37,18 +38,4 @@ interface IBootstrap {
 	 * @since 20.0.0
 	 */
 	public function register(IRegistrationContext $context): void;
-
-	/**
-	 * Boot the application
-	 *
-	 * At this stage you can assume that all services are registered and the DI
-	 * container(s) are ready to be queried.
-	 *
-	 * This is also the state where an optional `appinfo/app.php` was loaded.
-	 *
-	 * @param IBootContext $context
-	 *
-	 * @since 20.0.0
-	 */
-	public function boot(IBootContext $context): void;
 }

--- a/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/FunctionInjectorTest.php
@@ -81,4 +81,17 @@ class FunctionInjectorTest extends TestCase {
 		// Nothing to assert. No errors means everything is fine.
 		$this->addToAssertionCount(1);
 	}
+
+	public function testInjectWithOverride(): void {
+		$obj = new class() implements Foo {};
+
+		$injector = new FunctionInjector($this->container, [
+			Foo::class => $obj,
+		]);
+		$injector->injectFn(static function (Foo $f): void {
+		});
+
+		// Nothing to assert. No errors means everything is fine.
+		$this->addToAssertionCount(1);
+	}
 }


### PR DESCRIPTION
I might be doing something uncontroversial that is totally against my very own principals but I think I found a legit use case for duck typing with php.

Currently when you implement your ``\OCP\AppFramework\Bootstrap\IBootstrap::boot`` you are likely to need stuff from the DI container. As we all know *service locators* are bad, so we don't query the things but use the ``\OCP\AppFramework\Bootstrap\IBootContext::injectFn`` to indirectly call another method and some magic injects the parameters of the method/function. So far, so good, but we can do better than this.

What if you can add arbitrary services to your ``boot`` and type hint them, and Nextcloud will inject them for you? No more explicit ``injectFn``, yay.

This is nice from an app developer perspective. The downside is that the design gets a bit impure. We are breaking the Liskov substitution principle and the application classes are not interchangeable anymore. But frankly that is not really what they are meant for, especially the boot method, so I would accept this.

Another downside is that the documentation of the method isn't as nice anymore as there is no docblock for the method but just a one-liner. That means no ``@since``, no parameter description and so on. This sucks, but documentation can help and we can link to those docs from there.

Phpunit and psalm also seem to be okay with this.

This same concept can be reused for other similar code like occ commands (when we finally have our own API, background jobs, tasks, and so on.

Ref https://psalm.dev/r/a9d551181c some experiments with the duck typing and Psalm

Edit: forgot to mention that the idea came from https://laravel.com/docs/8.x/providers#boot-method-dependency-injection. Taking a look at their approach we might drop the ``boot`` method from the interface call it after a ``method_exists`` check on the application instance. That way apps can also omit the method if there is no need for it.