### PR TITLE
Fix federated scope not shown when public addressbook upload is disabled

### DIFF
--- a/apps/provisioning_api/lib/Capabilities.php
+++ b/apps/provisioning_api/lib/Capabilities.php
@@ -41,20 +41,23 @@ class Capabilities implements ICapability {
 	 * @return array Array containing the apps capabilities
 	 */
 	public function getCapabilities() {
-		$federationScopesEnabled = false;
+		$federatedScopeEnabled = $this->appManager->isEnabledForUser('federation');
+
+		$publishedScopeEnabled = false;
 
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
 			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
-			$federationScopesEnabled = $shareProvider->isLookupServerUploadEnabled();
+			$publishedScopeEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 
 		return [
 			'provisioning_api' => [
 				'version' => $this->appManager->getAppVersion('provisioning_api'),
 				'AccountPropertyScopesVersion' => 2,
-				'AccountPropertyScopesFederationEnabled' => $federationScopesEnabled,
+				'AccountPropertyScopesFederatedEnabled' => $federatedScopeEnabled,
+				'AccountPropertyScopesPublishedEnabled' => $publishedScopeEnabled,
 			]
 		];
 	}

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -57,20 +57,25 @@ class CapabilitiesTest extends TestCase {
 
 	public function getCapabilitiesProvider() {
 		return [
-			[false, false, false],
-			[true, false, false],
-			[true, true, true],
+			[true, false, false, true, false],
+			[true, true, false, true, false],
+			[true, true, true, true, true],
+			[false, false, false, false, false],
+			[false, true, false, false, false],
+			[false, true, true, false, true],
 		];
 	}
 
 	/**
 	 * @dataProvider getCapabilitiesProvider
 	 */
-	public function testGetCapabilities($federationAppEnabled, $lookupServerEnabled, $expectedFederationScopesEnabled) {
-		$this->appManager->expects($this->once())
-		   ->method('isEnabledForUser')
-		   ->with('federatedfilesharing')
-		   ->willReturn($federationAppEnabled);
+	public function testGetCapabilities($federationAppEnabled, $federatedFileSharingAppEnabled, $lookupServerEnabled, $expectedFederatedScopeEnabled, $expectedPublishedScopeEnabled) {
+		$this->appManager->expects($this->any())
+			->method('isEnabledForUser')
+			->will($this->returnValueMap([
+				['federation', null, $federationAppEnabled],
+				['federatedfilesharing', null, $federatedFileSharingAppEnabled],
+			]));
 
 		$federatedShareProvider = $this->createMock(FederatedShareProvider::class);
 		$this->overwriteService(FederatedShareProvider::class, $federatedShareProvider);
@@ -83,7 +88,8 @@ class CapabilitiesTest extends TestCase {
 			'provisioning_api' => [
 				'version' => '1.12',
 				'AccountPropertyScopesVersion' => 2,
-				'AccountPropertyScopesFederationEnabled' => $expectedFederationScopesEnabled,
+				'AccountPropertyScopesFederatedEnabled' => $expectedFederatedScopeEnabled,
+				'AccountPropertyScopesPublishedEnabled' => $expectedPublishedScopeEnabled,
 			],
 		];
 		$this->assertSame($expected, $this->capabilities->getCapabilities());

--- a/apps/settings/js/federationsettingsview.js
+++ b/apps/settings/js/federationsettingsview.js
@@ -15,7 +15,8 @@
 	 * @constructs FederationScopeMenu
 	 * @memberof OC.Settings
 	 * @param {object} options
-	 * @param {bool} [options.lookupServerUploadEnabled=false] whether uploading to the lookup server is enabled
+	 * @param {bool} [options.showPublishedScope=false] whether show the
+	 *        "v2-published" scope or not
 	 */
 	var FederationSettingsView = OC.Backbone.View.extend({
 		_inputFields: undefined,
@@ -31,7 +32,7 @@
 			} else {
 				this._config = new OC.Settings.UserSettings();
 			}
-			this.showFederationScopes = !!options.showFederationScopes;
+			this.showPublishedScope = !!options.showPublishedScope;
 
 			this._inputFields = [
 				'displayname',
@@ -85,8 +86,7 @@
 					excludedScopes.push('v2-private');
 				}
 
-				if (!self.showFederationScopes) {
-					excludedScopes.push('v2-federated');
+				if (!self.showPublishedScope) {
 					excludedScopes.push('v2-published');
 				}
 

--- a/apps/settings/js/federationsettingsview.js
+++ b/apps/settings/js/federationsettingsview.js
@@ -15,6 +15,8 @@
 	 * @constructs FederationScopeMenu
 	 * @memberof OC.Settings
 	 * @param {object} options
+	 * @param {bool} [options.showFederatedScope=false] whether show the
+	 *        "v2-federated" scope or not
 	 * @param {bool} [options.showPublishedScope=false] whether show the
 	 *        "v2-published" scope or not
 	 */
@@ -32,6 +34,7 @@
 			} else {
 				this._config = new OC.Settings.UserSettings();
 			}
+			this.showFederatedScope = !!options.showFederatedScope;
 			this.showPublishedScope = !!options.showPublishedScope;
 
 			this._inputFields = [
@@ -84,6 +87,10 @@
 
 				if (fieldsWithV2Private.indexOf(field) === -1) {
 					excludedScopes.push('v2-private');
+				}
+
+				if (!self.showFederatedScope) {
+					excludedScopes.push('v2-federated');
 				}
 
 				if (!self.showPublishedScope) {

--- a/apps/settings/js/settings/personalInfo.js
+++ b/apps/settings/js/settings/personalInfo.js
@@ -204,6 +204,7 @@ window.addEventListener('DOMContentLoaded', function () {
 	var federationSettingsView = new OC.Settings.FederationSettingsView({
 		el: settingsEl,
 		config: userSettings,
+		showFederatedScope: !!settingsEl.data('federation-enabled'),
 		showPublishedScope: !!settingsEl.data('lookup-server-upload-enabled'),
 	});
 

--- a/apps/settings/js/settings/personalInfo.js
+++ b/apps/settings/js/settings/personalInfo.js
@@ -204,7 +204,7 @@ window.addEventListener('DOMContentLoaded', function () {
 	var federationSettingsView = new OC.Settings.FederationSettingsView({
 		el: settingsEl,
 		config: userSettings,
-		showFederationScopes: !!settingsEl.data('lookup-server-upload-enabled'),
+		showPublishedScope: !!settingsEl.data('lookup-server-upload-enabled'),
 	});
 
 	userSettings.on("sync", function() {

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -92,6 +92,7 @@ class PersonalInfo implements ISettings {
 	}
 
 	public function getForm(): TemplateResponse {
+		$federationEnabled = $this->appManager->isEnabledForUser('federation');
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		$lookupServerUploadEnabled = false;
 		if ($federatedFileSharingEnabled) {
@@ -124,6 +125,7 @@ class PersonalInfo implements ISettings {
 			'usage_relative' => round($storageInfo['relative']),
 			'quota' => $storageInfo['quota'],
 			'avatarChangeSupported' => $user->canChangeAvatar(),
+			'federationEnabled' => $federationEnabled,
 			'lookupServerUploadEnabled' => $lookupServerUploadEnabled,
 			'avatarScope' => $account->getProperty(IAccountManager::PROPERTY_AVATAR)->getScope(),
 			'displayNameChangeSupported' => $user->canChangeDisplayName(),

--- a/apps/settings/templates/settings/personal/personal.info.php
+++ b/apps/settings/templates/settings/personal/personal.info.php
@@ -35,7 +35,8 @@ script('settings', [
 ]);
 ?>
 
-<div id="personal-settings" data-lookup-server-upload-enabled="<?php p($_['lookupServerUploadEnabled'] ? 'true' : 'false') ?>">
+<div id="personal-settings" data-federation-enabled="<?php p($_['federationEnabled'] ? 'true' : 'false') ?>"
+							data-lookup-server-upload-enabled="<?php p($_['lookupServerUploadEnabled'] ? 'true' : 'false') ?>">
 	<h2 class="hidden-visually"><?php p($l->t('Personal info')); ?></h2>
 	<div id="personal-settings-avatar-container" class="personal-settings-container">
 		<div>

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -78,6 +78,7 @@ class AccountPropertyTest extends TestCase {
 			// current values
 			[IAccountManager::SCOPE_PRIVATE, IAccountManager::SCOPE_PRIVATE],
 			[IAccountManager::SCOPE_LOCAL, IAccountManager::SCOPE_LOCAL],
+			[IAccountManager::SCOPE_FEDERATED, IAccountManager::SCOPE_FEDERATED],
 			[IAccountManager::SCOPE_PUBLISHED, IAccountManager::SCOPE_PUBLISHED],
 			// legacy values
 			[IAccountManager::VISIBILITY_PRIVATE, IAccountManager::SCOPE_LOCAL],


### PR DESCRIPTION
Follow up to #26243

Besides a small change in a test, when the public address book is disabled now it is possible to select the _Federated_ scope for the profile attributes, as the address books can still be exchanged between trusted servers. Besides that the _Federated_ option is now hidden when the Federation app is disabled

Please note that this might need to be adjusted in the mobile apps as well. ~~Should [the property in the capabilities](https://github.com/nextcloud/server/pull/26243/commits/00d83a5db056a9c466831fd45347f414bd81f3ae#diff-583c5d160112290d35096fc2cd08f70ad41e9ef8cf7c0d108c10c67c0ae8854fR58) be renamed too?~~ The capability `AccountPropertyScopesFederationEnabled` was split in `AccountPropertyScopesFederatedEnabled` and `AccountPropertyScopesPublishedEnabled`.

## How to test (scenario 1)

- Log in as an admin
- Open the settings
- Open the _Sharing_ section under _Administration_
- Disable _Allow users to publish their data to a global and public address book_
- Open the _Personal info_ section
- Show the visibility menu on any of the elements, like _Phone number_

### Result with this pull request

The _Federated_ option is still available, although the _Published_ option is not

### Result without this pull request

Neither the _Federated_ nor the _Published_ options are available

## How to test (scenario 2)

- Log in as an admin
- Disable the _Federation_ app
- Open the settings
- Open the _Personal info_ section
- Show the visibility menu on any of the elements, like _Phone number_

### Result with this pull request

The _Federated_ option is no longer available

### Result without this pull request

The _Federated_ option is still available

## Additional context

It can be checked that even if uploads to the lookup server are disabled the address book is still exchanged between trusted servers in the following way:
- Start server A
- Create user A in server A
- Start server B
- Create user B in server B
- In server A, open the (Administration) Sharing section
- Disable _Allow users to publish their data to a global and public address book_
- In server B, open the (Administration) Sharing section
- Disable _Allow users to publish their data to a global and public address book_
- In server A, add server B as a trusted server
- In server B, add server A as a trusted server

Now both servers need to trust each other. This is done using background jobs, so either force somehow the jobs to run or wait patiently until they run :-) (or, if you are using the AJAX method, entertain yourself reloading pages on each server around 30 times, although you need to do it alternatively as the jobs need to run in both servers :party:). There are probably much better ways to do it, but in order to know when the servers have trusted each other you can print a log message in [TrustedServers::addSharedSecret](https://github.com/nextcloud/server/blob/cb057829f72c70e819f456edfadbb29d72dba832/apps/federation/lib/TrustedServers.php#L172)

Once the servers trust each other, synchronize their address books running `occ federation:sync-addressbooks` in both servers. If the sharing settings are then opened again the other server should be shown as trusted and synchronized.

Now, if you open the Contacts menu in any of the servers you will see the users from the other server.
