### PR TITLE
Add option to exclude groups from creating link shares

### DIFF
--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -28,11 +28,9 @@
 
 namespace OCA\DAV\Tests\unit\CardDAV;
 
-use OC\Accounts\AccountManager;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\Converter;
 use OCA\DAV\CardDAV\SyncService;
-use OCP\Accounts\IAccountManager;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -55,6 +55,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\Share\IManager;
 
 /**
  * Class ViewController
@@ -86,6 +87,8 @@ class ViewController extends Controller {
 	private $initialState;
 	/** @var ITemplateManager */
 	private $templateManager;
+	/** @var IManager */
+	private $shareManager;
 
 	public function __construct(string $appName,
 		IRequest $request,
@@ -98,7 +101,8 @@ class ViewController extends Controller {
 		IRootFolder $rootFolder,
 		Helper $activityHelper,
 		IInitialState $initialState,
-		ITemplateManager $templateManager
+		ITemplateManager $templateManager,
+		IManager $shareManager
 	) {
 		parent::__construct($appName, $request);
 		$this->appName = $appName;
@@ -113,6 +117,7 @@ class ViewController extends Controller {
 		$this->activityHelper = $activityHelper;
 		$this->initialState = $initialState;
 		$this->templateManager = $templateManager;
+		$this->shareManager = $shareManager;
 	}
 
 	/**
@@ -302,7 +307,7 @@ class ViewController extends Controller {
 		$params['owner'] = $storageInfo['owner'] ?? '';
 		$params['ownerDisplayName'] = $storageInfo['ownerDisplayName'] ?? '';
 		$params['isPublic'] = false;
-		$params['allowShareWithLink'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes');
+		$params['allowShareWithLink'] = $this->shareManager->shareApiAllowLinks() ? 'yes' : 'no';
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
 		$params['showgridview'] = $this->config->getUserValue($user, 'files', 'show_grid', false);

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -22,10 +22,14 @@
  *
  */
 
+use OCP\Share\IManager;
+
 $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 // TODO: move this to the generated config.js
-$publicUploadEnabled = $config->getAppValue('core', 'shareapi_allow_public_upload', 'yes');
+/** @var IManager $shareManager */
+$shareManager = \OC::$server->get(IManager::class);
+$publicUploadEnabled = $shareManager->shareApiLinkAllowPublicUpload() ? 'yes' : 'no';;
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
 $isIE = OC_Util::isIe();

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -48,6 +48,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Share\IManager;
 use OCP\Template;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
@@ -84,6 +85,8 @@ class ViewControllerTest extends TestCase {
 	private $initialState;
 	/** @var ITemplateManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $templateManager;
+	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	private $shareManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -105,6 +108,7 @@ class ViewControllerTest extends TestCase {
 		$this->activityHelper = $this->createMock(Helper::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->templateManager = $this->createMock(ITemplateManager::class);
+		$this->shareManager = $this->createMock(IManager::class);
 		$this->viewController = $this->getMockBuilder('\OCA\Files\Controller\ViewController')
 			->setConstructorArgs([
 				'files',
@@ -119,6 +123,7 @@ class ViewControllerTest extends TestCase {
 				$this->activityHelper,
 				$this->initialState,
 				$this->templateManager,
+				$this->shareManager,
 			])
 		->setMethods([
 			'getStorageInfo',
@@ -153,6 +158,8 @@ class ViewControllerTest extends TestCase {
 				->expects($this->any())
 				->method('getAppValue')
 				->willReturnArgument(2);
+		$this->shareManager->method('shareApiAllowLinks')
+			->willReturn(true);
 
 		$nav = new Template('files', 'appnavigation');
 		$nav->assign('usage_relative', 123);

--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -28,6 +28,7 @@ namespace OCA\Files_Sharing;
 use OCP\Capabilities\ICapability;
 use OCP\Constants;
 use OCP\IConfig;
+use OCP\Share\IManager;
 
 /**
  * Class Capabilities
@@ -38,9 +39,12 @@ class Capabilities implements ICapability {
 
 	/** @var IConfig */
 	private $config;
+	/** @var IManager */
+	private $shareManager;
 
-	public function __construct(IConfig $config) {
+	public function __construct(IConfig $config, IManager $shareManager) {
 		$this->config = $config;
+		$this->shareManager = $shareManager;
 	}
 
 	/**
@@ -51,7 +55,7 @@ class Capabilities implements ICapability {
 	public function getCapabilities() {
 		$res = [];
 
-		if ($this->config->getAppValue('core', 'shareapi_enabled', 'yes') !== 'yes') {
+		if (!$this->shareManager->shareApiEnabled()) {
 			$res['api_enabled'] = false;
 			$res['public'] = ['enabled' => false];
 			$res['user'] = ['send_mail' => false];
@@ -60,10 +64,10 @@ class Capabilities implements ICapability {
 			$res['api_enabled'] = true;
 
 			$public = [];
-			$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
+			$public['enabled'] = $this->shareManager->shareApiAllowLinks();
 			if ($public['enabled']) {
 				$public['password'] = [];
-				$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
+				$public['password']['enforced'] = $this->shareManager->shareApiLinkEnforcePassword();
 
 				if ($public['password']['enforced']) {
 					$public['password']['askForOptionalPassword'] = false;
@@ -73,28 +77,28 @@ class Capabilities implements ICapability {
 
 				$public['expire_date'] = [];
 				$public['multiple_links'] = true;
-				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';
+				$public['expire_date']['enabled'] = $this->shareManager->shareApiLinkDefaultExpireDate();
 				if ($public['expire_date']['enabled']) {
-					$public['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7');
-					$public['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no') === 'yes';
+					$public['expire_date']['days'] = $this->shareManager->shareApiLinkDefaultExpireDays();
+					$public['expire_date']['enforced'] = $this->shareManager->shareApiLinkDefaultExpireDateEnforced();
 				}
 
 				$public['expire_date_internal'] = [];
-				$public['expire_date_internal']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_internal_expire_date', 'no') === 'yes';
+				$public['expire_date_internal']['enabled'] = $this->shareManager->shareApiInternalDefaultExpireDate();
 				if ($public['expire_date_internal']['enabled']) {
-					$public['expire_date_internal']['days'] = $this->config->getAppValue('core', 'shareapi_internal_expire_after_n_days', '7');
-					$public['expire_date_internal']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_internal_expire_date', 'no') === 'yes';
+					$public['expire_date_internal']['days'] = $this->shareManager->shareApiInternalDefaultExpireDays();
+					$public['expire_date_internal']['enforced'] = $this->shareManager->shareApiInternalDefaultExpireDateEnforced();
 				}
 
 				$public['expire_date_remote'] = [];
-				$public['expire_date_remote']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_remote_expire_date', 'no') === 'yes';
+				$public['expire_date_remote']['enabled'] = $this->shareManager->shareApiRemoteDefaultExpireDate();
 				if ($public['expire_date_remote']['enabled']) {
-					$public['expire_date_remote']['days'] = $this->config->getAppValue('core', 'shareapi_remote_expire_after_n_days', '7');
-					$public['expire_date_remote']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_remote_expire_date', 'no') === 'yes';
+					$public['expire_date_remote']['days'] = $this->shareManager->shareApiRemoteDefaultExpireDays();
+					$public['expire_date_remote']['enforced'] = $this->shareManager->shareApiRemoteDefaultExpireDateEnforced();
 				}
 
 				$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
-				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
+				$public['upload'] = $this->shareManager->shareApiLinkAllowPublicUpload();
 				$public['upload_files_drop'] = $public['upload'];
 			}
 			$res['public'] = $public;
@@ -106,17 +110,17 @@ class Capabilities implements ICapability {
 
 			// deprecated in favour of 'group', but we need to keep it for now
 			// in order to stay compatible with older clients
-			$res['group_sharing'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+			$res['group_sharing'] = $this->shareManager->allowGroupSharing();
 
 			$res['group'] = [];
-			$res['group']['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+			$res['group']['enabled'] = $this->shareManager->allowGroupSharing();
 			$res['group']['expire_date']['enabled'] = true;
 			$res['default_permissions'] = (int)$this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL);
 		}
 
 		//Federated sharing
 		$res['federation'] = [
-			'outgoing' => $this->config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes',
+			'outgoing' => $this->shareManager->outgoingServer2ServerSharesAllowed(),
 			'incoming' => $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes') === 'yes',
 			// old bogus one, expire_date was not working before, keeping for compatibility
 			'expire_date' => ['enabled' => true],

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -27,8 +27,24 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Share20\Manager;
 use OCA\Files_Sharing\Capabilities;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\L10N\IFactory;
+use OCP\Mail\IMailer;
+use OCP\Security\IHasher;
+use OCP\Security\ISecureRandom;
+use OCP\Share\IProviderFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class CapabilitiesTest
@@ -60,7 +76,26 @@ class CapabilitiesTest extends \Test\TestCase {
 	private function getResults(array $map) {
 		$config = $this->getMockBuilder(IConfig::class)->disableOriginalConstructor()->getMock();
 		$config->method('getAppValue')->willReturnMap($map);
-		$cap = new Capabilities($config);
+		$shareManager = new Manager(
+			$this->createMock(ILogger::class),
+			$config,
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IHasher::class),
+			$this->createMock(IMountManager::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(IFactory::class),
+			$this->createMock(IProviderFactory::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(IRootFolder::class),
+			$this->createMock(EventDispatcherInterface::class),
+			$this->createMock(IMailer::class),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(\OC_Defaults::class),
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class)
+		);
+		$cap = new Capabilities($config, $shareManager);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());
 		return $result;
 	}

--- a/apps/settings/js/admin.js
+++ b/apps/settings/js/admin.js
@@ -1,5 +1,5 @@
 window.addEventListener('DOMContentLoaded', function(){
-	$('#excludedGroups').each(function (index, element) {
+	$('#excludedGroups,#linksExcludedGroups').each(function (index, element) {
 		OC.Settings.setupGroupsSelect($(element));
 		$(element).change(function(ev) {
 			var groups = ev.val || [];

--- a/apps/settings/lib/Settings/Admin/Sharing.php
+++ b/apps/settings/lib/Settings/Admin/Sharing.php
@@ -64,11 +64,15 @@ class Sharing implements ISettings {
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 		$excludeGroupsList = !is_null(json_decode($excludedGroups))
 			? implode('|', json_decode($excludedGroups, true)) : '';
+		$linksExcludedGroups = $this->config->getAppValue('core', 'shareapi_allow_links_exclude_groups', '');
+		$linksExcludeGroupsList = !is_null(json_decode($linksExcludedGroups))
+			? implode('|', json_decode($linksExcludedGroups, true)) : '';
 
 		$parameters = [
 			// Built-In Sharing
 			'allowGroupSharing' => $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes'),
 			'allowLinks' => $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'),
+			'allowLinksExcludeGroups' => $linksExcludeGroupsList,
 			'allowPublicUpload' => $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'),
 			'allowResharing' => $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes'),
 			'allowShareDialogUserEnumeration' => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'),

--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -138,6 +138,14 @@
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
 	p('hidden');
 }?>">
+	<p class="indent">
+		<?php p($l->t('Exclude groups from creating link shares:'));?>
+	</p>
+	<p id="selectLinksExcludedGroups" class="indent <?php if ($_['allowLinks'] === 'no') {
+	p('hidden');
+} ?>">
+		<input name="shareapi_allow_links_exclude_groups" type="hidden" id="linksExcludedGroups" value="<?php p($_['allowLinksExcludeGroups']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
+	</p>
 		<input type="checkbox" name="shareapi_allow_resharing" id="allowResharing" class="checkbox"
 			   value="1" <?php if ($_['allowResharing'] === 'yes') {
 	print_unescaped('checked="checked"');
@@ -176,7 +184,7 @@
 } ?>">
 		<input name="shareapi_exclude_groups_list" type="hidden" id="excludedGroups" value="<?php p($_['shareExcludedGroupsList']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
 		<br />
-		<em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
+		 <em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
 	</p>
 
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -90,6 +90,8 @@ class SharingTest extends TestCase {
 				['core', 'shareapi_remote_expire_after_n_days', '7', '7'],
 				['core', 'shareapi_enforce_remote_expire_date', 'no', 'no'],
 			]);
+		$this->shareManager->method('shareWithGroupMembersOnly')
+			->willReturn(false);
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -121,6 +123,7 @@ class SharingTest extends TestCase {
 				'shareDefaultRemoteExpireDateSet' => 'no',
 				'shareRemoteExpireAfterNDays' => '7',
 				'shareRemoteEnforceExpireDate' => 'no',
+				'allowLinksExcludeGroups' => '',
 			],
 			''
 		);
@@ -156,6 +159,8 @@ class SharingTest extends TestCase {
 				['core', 'shareapi_remote_expire_after_n_days', '7', '7'],
 				['core', 'shareapi_enforce_remote_expire_date', 'no', 'no'],
 			]);
+		$this->shareManager->method('shareWithGroupMembersOnly')
+			->willReturn(false);
 
 		$expected = new TemplateResponse(
 			'settings',
@@ -187,6 +192,7 @@ class SharingTest extends TestCase {
 				'shareDefaultRemoteExpireDateSet' => 'no',
 				'shareRemoteExpireAfterNDays' => '7',
 				'shareRemoteEnforceExpireDate' => 'no',
+				'allowLinksExcludeGroups' => '',
 			],
 			''
 		);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1234,7 +1234,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IMailer::class),
 				$c->get(IURLGenerator::class),
 				$c->get('ThemingDefaults'),
-				$c->get(IEventDispatcher::class)
+				$c->get(IEventDispatcher::class),
+				$c->get(IUserSession::class)
 			);
 
 			return $manager;

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -347,6 +347,54 @@ interface IManager {
 	public function shareApiLinkDefaultExpireDays();
 
 	/**
+	 * Is default internal expire date enabled
+	 *
+	 * @return bool
+	 * @since 22.0.0
+	 */
+	public function shareApiInternalDefaultExpireDate(): bool;
+
+	/**
+	 * Is default remote expire date enabled
+	 *
+	 * @return bool
+	 * @since 22.0.0
+	 */
+	public function shareApiRemoteDefaultExpireDate(): bool;
+
+	/**
+	 * Is default expire date enforced
+	 *
+	 * @return bool
+	 * @since 22.0.0
+	 */
+	public function shareApiInternalDefaultExpireDateEnforced(): bool;
+
+	/**
+	 * Is default expire date enforced for remote shares
+	 *
+	 * @return bool
+	 * @since 22.0.0
+	 */
+	public function shareApiRemoteDefaultExpireDateEnforced(): bool;
+
+	/**
+	 * Number of default expire days
+	 *
+	 * @return int
+	 * @since 22.0.0
+	 */
+	public function shareApiInternalDefaultExpireDays(): int;
+
+	/**
+	 * Number of default expire days for remote shares
+	 *
+	 * @return int
+	 * @since 22.0.0
+	 */
+	public function shareApiRemoteDefaultExpireDays(): int;
+
+	/**
 	 * Allow public upload on link shares
 	 *
 	 * @return bool

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -45,6 +45,7 @@ use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
@@ -104,6 +105,7 @@ class ManagerTest extends \Test\TestCase {
 	protected $urlGenerator;
 	/** @var  \OC_Defaults|MockObject */
 	protected $defaults;
+	protected $userSession;
 
 	protected function setUp(): void {
 		$this->logger = $this->createMock(ILogger::class);
@@ -119,6 +121,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->defaults = $this->createMock(\OC_Defaults::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l = $this->createMock(IL10N::class);
@@ -149,7 +152,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
@@ -178,7 +182,8 @@ class ManagerTest extends \Test\TestCase {
 				$this->mailer,
 				$this->urlGenerator,
 				$this->defaults,
-				$this->dispatcher
+				$this->dispatcher,
+				$this->userSession
 			]);
 	}
 
@@ -2690,7 +2695,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2734,7 +2740,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2785,7 +2792,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -4123,7 +4131,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 		$this->assertSame($expected,
 			$manager->shareProviderExists($shareType)
@@ -4156,7 +4165,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4220,7 +4230,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4336,7 +4347,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4461,7 +4473,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->mailer,
 			$this->urlGenerator,
 			$this->defaults,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->userSession
 		);
 
 		$factory->setProvider($this->defaultProvider);

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -10,8 +10,6 @@ namespace Test;
 
 use OC_Util;
 use OCP\App\IAppManager;
-use OCP\IConfig;
-use OCP\IUser;
 
 /**
  * Class UtilTest
@@ -168,53 +166,6 @@ class UtilTest extends \Test\TestCase {
 			// part in the middle is ok
 			['super movie part one.mkv', true],
 			['super.movie.part.mkv', true],
-		];
-	}
-
-	/**
-	 * @dataProvider dataProviderForTestIsSharingDisabledForUser
-	 * @param array $groups existing groups
-	 * @param array $membership groups the user belong to
-	 * @param array $excludedGroups groups which should be excluded from sharing
-	 * @param bool $expected expected result
-	 */
-	public function testIsSharingDisabledForUser($groups, $membership, $excludedGroups, $expected) {
-		$config = $this->getMockBuilder(IConfig::class)->disableOriginalConstructor()->getMock();
-		$groupManager = $this->getMockBuilder('OCP\IGroupManager')->disableOriginalConstructor()->getMock();
-		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-
-		$config
-				->expects($this->at(0))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups', 'no')
-				->willReturn('yes');
-		$config
-				->expects($this->at(1))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups_list')
-				->willReturn(json_encode($excludedGroups));
-
-		$groupManager
-				->expects($this->at(0))
-				->method('getUserGroupIds')
-				->with($user)
-				->willReturn($membership);
-
-		$result = \OC_Util::isSharingDisabledForUser($config, $groupManager, $user);
-
-		$this->assertSame($expected, $result);
-	}
-
-	public function dataProviderForTestIsSharingDisabledForUser() {
-		return [
-			// existing groups, groups the user belong to, groups excluded from sharing, expected result
-			[['g1', 'g2', 'g3'], [], ['g1'], false],
-			[['g1', 'g2', 'g3'], [], [], false],
-			[['g1', 'g2', 'g3'], ['g2'], ['g1'], false],
-			[['g1', 'g2', 'g3'], ['g2'], [], false],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1'], false],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2'], true],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2', 'g3'], true],
 		];
 	}
 


### PR DESCRIPTION
I would have hoped to solve this in a more generic "per group share settings" way but the way the code base interacts with the share settings is to messy to do that without a lot of rework (this PR includes *some* improvement in this area).