### PR TITLE
Fixed username and domain separation in getACL

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -219,7 +219,7 @@ class SMB extends Common implements INotifyStorage {
 	private function getACL(IFileInfo $file): ?ACL {
 		$acls = $file->getAcls();
 		foreach ($acls as $user => $acl) {
-			[, $user] = explode('\\', $user); // strip domain
+			[, $user] = $this->splitUser($user); // strip domain
 			if ($user === $this->server->getAuth()->getUsername()) {
 				return $acl;
 			}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -142,7 +142,7 @@ class SMB extends Common implements INotifyStorage {
 	private function splitUser($user) {
 		if (strpos($user, '/')) {
 			return explode('/', $user, 2);
-		} elseif (strpos($user, '\\')) {
+		} elseif (strpos($user, '\\') !== false) {
 			return explode('\\', $user);
 		} else {
 			return [null, $user];


### PR DESCRIPTION
Inspired by anikrooz commit
https://github.com/nextcloud/server/commit/1f95f9b4791880e8d054b27fd4b9f50a7434cc65

Addresses issue mentioned here: https://github.com/nextcloud/server/issues/26457#issuecomment-822648601

Signed-off-by: Christopher Gabriel <stuff@c-gabriel.at>