### PR TITLE
issue#16412 trashbin sorts by ascending mtime on initialization

### DIFF
--- a/apps/files_trashbin/src/filelist.js
+++ b/apps/files_trashbin/src/filelist.js
@@ -90,7 +90,7 @@
 			this.$el.find('.undelete').click('click', _.bind(this._onClickRestoreSelected, this))
 
 			// Sort by most recently deleted first
-			this.setSort('mtime', 'asc')
+			this.setSort('mtime', 'desc')
 
 			/**
 			 * Override crumb making to add "Deleted Files" entry

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -136,7 +136,7 @@ describe('OCA.Trashbin.FileList tests', function () {
 	describe('Initialization', function () {
 		it('Sorts by mtime by default', function () {
 			expect(fileList._sort).toEqual('mtime');
-			expect(fileList._sortDirection).toEqual('asc');
+			expect(fileList._sortDirection).toEqual('desc');
 		});
 		it('Always returns read and delete permission', function () {
 			expect(fileList.getDirectoryPermissions()).toEqual(OC.PERMISSION_READ | OC.PERMISSION_DELETE);


### PR DESCRIPTION
updated trashbin filelist init to sort desc. also associated test file was updated to confirm desc sort direction.

did not look into any double click issues as latest comment in issue thread (https://github.com/nextcloud/server/issues/16412) suggesting the issue has already be merged into the master branch.

Signed-off-by: Tony Morris <morris.anthony.paul@gmail.com>