### PR TITLE
explicitly close source stream on object store upload even if count…

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -493,6 +493,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				$stat['size'] = $size;
 			} else {
 				$this->objectStore->writeObject($urn, $stream, $mimetype);
+				if (is_resource($stream)) {
+					fclose($stream);
+				}
 			}
 		} catch (\Exception $ex) {
 			if (!$exists) {


### PR DESCRIPTION
wrapper isn't needed

This *might* solve some issues around gc getting triggered before stream_close callbacks