### PR TITLE
fix creating vcards with multiple string values

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -150,13 +150,17 @@ class AddressBookImpl implements IAddressBook {
 			if (is_array($value)) {
 				$vCard->remove($key);
 				foreach ($value as $entry) {
-					if (($key === "ADR" || $key === "PHOTO") && is_string($entry["value"])) {
-						$entry["value"] = stripslashes($entry["value"]);
-						$entry["value"] = explode(';', $entry["value"]);
-					}
-					$property = $vCard->createProperty($key, $entry["value"]);
-					if (isset($entry["type"])) {
-						$property->add('TYPE', $entry["type"]);
+					if (is_string($entry)) {
+						$property = $vCard->createProperty($key, $entry);
+					} else {
+						if (($key === "ADR" || $key === "PHOTO") && is_string($entry["value"])) {
+							$entry["value"] = stripslashes($entry["value"]);
+							$entry["value"] = explode(';', $entry["value"]);
+						}
+						$property = $vCard->createProperty($key, $entry["value"]);
+						if (isset($entry["type"])) {
+							$property->add('TYPE', $entry["type"]);
+						}
 					}
 					$vCard->add($property);
 				}

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -154,11 +154,20 @@ class AddressBookImplTest extends TestCase {
 			->setMethods(['vCard2Array', 'createUid', 'createEmptyVCard'])
 			->getMock();
 
+		$expectedProperties = 0;
+		foreach ($properties as $data) {
+			if (is_string($data)) {
+				$expectedProperties++;
+			} else {
+				$expectedProperties += count($data);
+			}
+		}
+
 		$addressBookImpl->expects($this->once())->method('createUid')
 			->willReturn($uid);
 		$addressBookImpl->expects($this->once())->method('createEmptyVCard')
 			->with($uid)->willReturn($this->vCard);
-		$this->vCard->expects($this->exactly(count($properties)))
+		$this->vCard->expects($this->exactly($expectedProperties))
 			->method('createProperty');
 		$this->backend->expects($this->once())->method('createCard');
 		$this->backend->expects($this->never())->method('updateCard');
@@ -172,7 +181,8 @@ class AddressBookImplTest extends TestCase {
 	public function dataTestCreate() {
 		return [
 			[[]],
-			[['FN' => 'John Doe']]
+			[['FN' => 'John Doe']],
+			[['FN' => 'John Doe', 'EMAIL' => ['john@doe.cloud', 'john.doe@example.org']]],
 		];
 	}
 


### PR DESCRIPTION
Internally it is valid to provide multiple values for a property as plain string. An exampe is given in the PhpDoc of AddressBookImpl::search().

This solves a regression [introduced into 21](https://github.com/nextcloud/server/pull/23317) reported in https://github.com/nextcloud/ldap_contacts_backend/issues/19.