### PR TITLE
fix error when using CORS with no auth credentials

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -83,14 +83,13 @@ class CORSMiddleware extends Middleware {
 	public function beforeController($controller, $methodName) {
 		// ensure that @CORS annotated API routes are not used in conjunction
 		// with session authentication since this enables CSRF attack vectors
-		if ($this->reflector->hasAnnotation('CORS') &&
-			!$this->reflector->hasAnnotation('PublicPage')) {
-			$user = $this->request->server['PHP_AUTH_USER'];
-			$pass = $this->request->server['PHP_AUTH_PW'];
+		if ($this->reflector->hasAnnotation('CORS') && !$this->reflector->hasAnnotation('PublicPage')) {
+			$user = array_key_exists('PHP_AUTH_USER', $this->request->server) ? $this->request->server['PHP_AUTH_USER'] : null;
+			$pass = array_key_exists('PHP_AUTH_PW', $this->request->server) ? $this->request->server['PHP_AUTH_PW'] : null;
 
 			$this->session->logout();
 			try {
-				if (!$this->session->logClientIn($user, $pass, $this->request, $this->throttler)) {
+				if ($user === null || $pass === null || !$this->session->logClientIn($user, $pass, $this->request, $this->throttler)) {
 					throw new SecurityException('CORS requires basic auth', Http::STATUS_UNAUTHORIZED);
 				}
 			} catch (PasswordLoginForbiddenException $ex) {


### PR DESCRIPTION
When using an `ApiController` with `CORS` annotation, basic authentication is required. However, currently the following exception occurs when a request does not contain any authentication:

```
Argument 1 passed to OCP\User\Events\BeforeUserLoggedInEvent::__construct() must be of the type string, null given, called in /home/owncloud/nextcloud/lib/private/Server.php on line 577

0.  /home/owncloud/nextcloud/lib/private/Server.php - line 577:
    OCP\User\Events\BeforeUserLoggedInEvent->__construct("*** sensiti ... *", "*** sensiti ... *")

1.  <<closure>>
    OC\Server->OC\{closure}("*** sensiti ... *")

2.  /home/owncloud/nextcloud/lib/private/Hooks/EmitterTrait.php - line 107:
    call_user_func_array(Closure {}, [ "*** sensi ... "])

3.  /home/owncloud/nextcloud/lib/private/Hooks/PublicEmitter.php - line 41:
    OC\Hooks\BasicEmitter->emit("\\OC\\User", "preLogin", [ "*** sensi ... "])

4.  /home/owncloud/nextcloud/lib/private/User/Session.php - line 444:
    OC\Hooks\PublicEmitter->emit("\\OC\\User", "preLogin", [ "*** sensi ... "])

5.  /home/owncloud/nextcloud/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php - line 93:
    OC\User\Session->logClientIn("*** sensiti ... *")

6.  /home/owncloud/nextcloud/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php - line 98:
    OC\AppFramework\Middleware\Security\CORSMiddleware->beforeController(OCA\Notes\Co ... {}, "index")

7.  /home/owncloud/nextcloud/lib/private/AppFramework/Http/Dispatcher.php - line 119:
    OC\AppFramework\Middleware\MiddlewareDispatcher->beforeController(OCA\Notes\Co ... {}, "index")

8.  /home/owncloud/nextcloud/lib/private/AppFramework/App.php - line 157:
    OC\AppFramework\Http\Dispatcher->dispatch(OCA\Notes\Co ... {}, "index")

9.  /home/owncloud/nextcloud/lib/private/Route/Router.php - line 302:
    OC\AppFramework\App::main("OCA\\Notes\ ... r", "index", OC\AppFramew ... {}, { apiVersion ... "})

10. /home/owncloud/nextcloud/lib/base.php - line 993:
    OC\Route\Router->match("/apps/notes/api/v1/notes")

11. /home/owncloud/nextcloud/index.php - line 37:
    OC::handleRequest()
```

In consultation with @nickvergessen , this PR fixes this by checking if `$user` and `$pass` are not null before trying to login.

Furthermore, I fixed an `Undefined index error` for `PHP_AUTH_USER` and `PHP_AUTH_PW`.

I suggest backporting this to the stable branches.