### PR TITLE
Separate Email Logo

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -82,6 +82,7 @@ class Capabilities implements IPublicCapability {
 				'color-element-bright' => $this->util->elementColor($color),
 				'color-element-dark' => $this->util->elementColor($color, false),
 				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
+				'emailLogo' => $this->url->getAbsoluteURL($this->theming->getLogo(false, true)),
 				'background' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9') ?
 					$this->theming->getColorPrimary() :
 					$this->url->getAbsoluteURL($this->theming->getBackground()),

--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -82,7 +82,7 @@ class Capabilities implements IPublicCapability {
 				'color-element-bright' => $this->util->elementColor($color),
 				'color-element-dark' => $this->util->elementColor($color, false),
 				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
-				'emailLogo' => $this->url->getAbsoluteURL($this->theming->getLogo(false, true)),
+				'emailLogo' => $this->url->getAbsoluteURL($this->theming->getEmailLogo()),
 				'background' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9') ?
 					$this->theming->getColorPrimary() :
 					$this->url->getAbsoluteURL($this->theming->getBackground()),

--- a/apps/theming/lib/Command/UpdateConfig.php
+++ b/apps/theming/lib/Command/UpdateConfig.php
@@ -38,7 +38,7 @@ class UpdateConfig extends Command {
 	];
 
 	public const SUPPORTED_IMAGE_KEYS = [
-		'background', 'logo', 'favicon', 'logoheader'
+		'background', 'logo', 'emailLogo', 'favicon', 'logoheader'
 	];
 
 	private $themingDefaults;

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -53,7 +53,7 @@ class ImageManager {
 	/** @var IURLGenerator */
 	private $urlGenerator;
 	/** @var array */
-	private $supportedImageKeys = ['background', 'logo', 'logoheader', 'favicon'];
+	private $supportedImageKeys = ['background', 'logo', 'emailLogo', 'logoheader', 'favicon'];
 	/** @var ICacheFactory */
 	private $cacheFactory;
 	/** @var ILogger */
@@ -86,6 +86,7 @@ class ImageManager {
 
 		switch ($key) {
 			case 'logo':
+			case 'emailLogo':
 			case 'logoheader':
 			case 'favicon':
 				return $this->urlGenerator->imagePath('core', 'logo/logo.png') . '?v=' . $cacheBusterCounter;

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -223,10 +223,8 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @param bool $useSvg Whether to point to the SVG image or a fallback
 	 * @return string
 	 */
-	public function getLogo($useSvg = true, $emailLogo = false): string {
-		$logoKey = $emailLogo ? 'emailLogo' : 'logo';
-		$logo = $this->config->getAppValue('theming', $logoKey . 'Mime', '');
-		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
+	public function getLogo($useSvg = true): string {
+		$logo = $this->config->getAppValue('theming', 'logoMime', '');
 
 		// short cut to avoid setting up the filesystem just to check if the logo is there
 		//
@@ -237,23 +235,14 @@ class ThemingDefaults extends \OC_Defaults {
 			$logoExists = true;
 		} else {
 			try {
-				$this->imageManager->getImage($logoKey, $useSvg);
+				$this->imageManager->getImage('logo', $useSvg);
 				$logoExists = true;
 			} catch (\Exception $e) {
 				$logoExists = false;
 			}
-
-			if (!$logoExists) {
-				try {
-					$logoKey = 'logo';
-					$logo = $this->config->getAppValue('theming', $logoKey . 'Mime', '');
-					$this->imageManager->getImage($logoKey, $useSvg);
-					$logoExists = true;
-				} catch (\Exception $e) {
-					$logoExists = false;
-				}
-			}
 		}
+
+		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
 
 		if (!$logo || !$logoExists) {
 			if ($useSvg) {
@@ -264,7 +253,7 @@ class ThemingDefaults extends \OC_Defaults {
 			return $logo . '?v=' . $cacheBusterCounter;
 		}
 
-		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => $logoKey, 'useSvg' => $useSvg, 'v' => $cacheBusterCounter ]);
+		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => 'logo', 'useSvg' => $useSvg, 'v' => $cacheBusterCounter ]);
 	}
 
 	/**

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -257,6 +257,40 @@ class ThemingDefaults extends \OC_Defaults {
 	}
 
 	/**
+	 * Themed email logo url
+	 *
+	 * @return string
+	 */
+	public function getEmailLogo(): string {
+		$logoKey = 'emailLogo';
+		$emailLogo = $this->config->getAppValue('theming', $logoKey . 'Mime', '');
+		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
+
+		// short cut to avoid setting up the filesystem just to check if the logo is there
+		//
+		// explanation: if an SVG is requested and the app config value for logoMime is set then the logo is there.
+		// otherwise we need to check it and maybe also generate a PNG from the SVG (that's done in getImage() which
+		// needs to be called then)
+		if ($emailLogo !== false) {
+			$logoExists = true;
+		} else {
+			try {
+				$this->imageManager->getImage($logoKey, false);
+				$logoExists = true;
+			} catch (\Exception $e) {
+				$logoExists = false;
+			}
+		}
+
+		if (!$emailLogo || !$logoExists) {
+			$emailLogo = $this->urlGenerator->imagePath('core', 'logo/logo.png');
+			return $emailLogo . '?v=' . $cacheBusterCounter;
+		}
+
+		return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => $logoKey, 'useSvg' => false, 'v' => $cacheBusterCounter ]);
+	}
+
+	/**
 	 * Themed background image url
 	 *
 	 * @return string

--- a/apps/theming/templates/settings-admin.php
+++ b/apps/theming/templates/settings-admin.php
@@ -78,6 +78,16 @@ style('theming', 'settings-admin');
 		</form>
 	</div>
 	<div>
+		<form class="uploadButton" method="post" action="<?php p($_['uploadLogoRoute']) ?>" data-image-key="emailLogo">
+			<input type="hidden" id="theming-emailLogoMime" value="<?php p($_['images']['emailLogo']['mime']); ?>" />
+			<input type="hidden" name="key" value="emailLogo" />
+			<label for="upload-email-logo"><span><?php p($l->t('Email Logo')) ?></span></label>
+			<input id="upload-email-logo" class="fileupload" name="image" type="file" />
+			<label for="upload-email-logo" class="button icon-upload svg" id="upload-email-log" title="<?php p($l->t('Upload new email logo')) ?>"></label>
+			<div data-setting="emailLogoMime" data-toggle="tooltip" data-original-title="<?php p($l->t('Reset to default')); ?>" class="theme-undo icon icon-history"></div>
+		</form>
+	</div>
+	<div>
 		<form class="uploadButton" method="post" action="<?php p($_['uploadLogoRoute']) ?>" data-image-key="background">
 			<input type="hidden" id="theming-backgroundMime" value="<?php p($_['images']['background']['mime']); ?>" />
 			<input type="hidden" name="key" value="background" />

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -634,6 +634,24 @@ class ThemingDefaultsTest extends TestCase {
 		$this->assertEquals('custom-logo' . '?v=0', $this->template->getLogo());
 	}
 
+	public function testGetEmailLogoCustom() {
+		$this->config
+			->expects($this->at(0))
+			->method('getAppValue')
+			->with('theming', 'emailLogoMime', false)
+			->willReturn('image/svg+xml');
+		$this->config
+			->expects($this->at(1))
+			->method('getAppValue')
+			->with('theming', 'cachebuster', '0')
+			->willReturn('0');
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('theming.Theming.getImage')
+			->willReturn('custom-email-logo?v=0');
+		$this->assertEquals('custom-email-logo' . '?v=0', $this->template->getLogo(false, true));
+	}
+
 	public function testGetScssVariablesCached() {
 		$this->config->expects($this->any())->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('1');
 		$this->cacheFactory->expects($this->once())
@@ -647,14 +665,15 @@ class ThemingDefaultsTest extends TestCase {
 	public function testGetScssVariables() {
 		$this->config->expects($this->at(0))->method('getAppValue')->with('theming', 'cachebuster', '0')->willReturn('0');
 		$this->config->expects($this->at(1))->method('getAppValue')->with('theming', 'logoMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'logoheaderMime', false)->willReturn('jpeg');
-		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'faviconMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(2))->method('getAppValue')->with('theming', 'emailLogoMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(3))->method('getAppValue')->with('theming', 'backgroundMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(4))->method('getAppValue')->with('theming', 'logoheaderMime', false)->willReturn('jpeg');
+		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'faviconMime', false)->willReturn('jpeg');
 
-		$this->config->expects($this->at(5))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
-		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(6))->method('getAppValue')->with('theming', 'color', null)->willReturn($this->defaults->getColorPrimary());
 		$this->config->expects($this->at(7))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 		$this->config->expects($this->at(8))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
+		$this->config->expects($this->at(9))->method('getAppValue')->with('theming', 'color', $this->defaults->getColorPrimary())->willReturn($this->defaults->getColorPrimary());
 
 		$this->util->expects($this->any())->method('invertTextColor')->with($this->defaults->getColorPrimary())->willReturn(false);
 		$this->util->expects($this->any())->method('elementColor')->with($this->defaults->getColorPrimary())->willReturn('#aaaaaa');
@@ -664,15 +683,18 @@ class ThemingDefaultsTest extends TestCase {
 			->willReturn($this->cache);
 		$this->cache->expects($this->once())->method('get')->with('getScssVariables')->willReturn(null);
 		$this->imageManager->expects($this->at(0))->method('getImageUrl')->with('logo')->willReturn('custom-logo?v=0');
-		$this->imageManager->expects($this->at(1))->method('getImageUrl')->with('logoheader')->willReturn('custom-logoheader?v=0');
-		$this->imageManager->expects($this->at(2))->method('getImageUrl')->with('favicon')->willReturn('custom-favicon?v=0');
-		$this->imageManager->expects($this->at(3))->method('getImageUrl')->with('background')->willReturn('custom-background?v=0');
+		$this->imageManager->expects($this->at(1))->method('getImageUrl')->with('emailLogo')->willReturn('custom-emailLogo?v=0');
+		$this->imageManager->expects($this->at(2))->method('getImageUrl')->with('logoheader')->willReturn('custom-logoheader?v=0');
+		$this->imageManager->expects($this->at(3))->method('getImageUrl')->with('favicon')->willReturn('custom-favicon?v=0');
+		$this->imageManager->expects($this->at(4))->method('getImageUrl')->with('background')->willReturn('custom-background?v=0');
 
 		$expected = [
 			'theming-cachebuster' => '\'0\'',
 			'theming-logo-mime' => '\'jpeg\'',
+			'theming-email-logo-mime' => '\'jpeg\'',
 			'theming-background-mime' => '\'jpeg\'',
 			'image-logo' => "url('custom-logo?v=0')",
+			'image-email-logo' => "url('custom-emailLogo?v=0')",
 			'image-login-background' => "url('custom-background?v=0')",
 			'color-primary' => $this->defaults->getColorPrimary(),
 			'color-primary-text' => '#ffffff',

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -649,7 +649,7 @@ class ThemingDefaultsTest extends TestCase {
 			->method('linkToRoute')
 			->with('theming.Theming.getImage')
 			->willReturn('custom-email-logo?v=0');
-		$this->assertEquals('custom-email-logo' . '?v=0', $this->template->getLogo(false, true));
+		$this->assertEquals('custom-email-logo' . '?v=0', $this->template->getEmailLogo());
 	}
 
 	public function testGetScssVariablesCached() {

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -380,7 +380,7 @@ EOF;
 		}
 		$this->headerAdded = true;
 
-		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false, true));
+		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getEmailLogo());
 		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getColorPrimary(), $logoUrl, $this->themingDefaults->getName()]);
 	}
 

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -380,7 +380,7 @@ EOF;
 		}
 		$this->headerAdded = true;
 
-		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
+		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false, true));
 		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getColorPrimary(), $logoUrl, $this->themingDefaults->getName()]);
 	}
 

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -324,6 +324,20 @@ class OC_Defaults {
 		return $logo . '?v=' . hash('sha1', implode('.', \OCP\Util::getVersion()));
 	}
 
+	/**
+	 * Themed email logo url
+	 *
+	 * @return string
+	 */
+	public function getEmailLogo() {
+		if ($this->themeExist('getEmailLogo')) {
+			return $this->theme->getEmailLogo();
+		}
+
+		$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo/logo.png');
+		return $logo . '?v=' . hash('sha1', implode('.', \OCP\Util::getVersion()));
+	}
+
 	public function getTextColorPrimary() {
 		if ($this->themeExist('getTextColorPrimary')) {
 			return $this->theme->getTextColorPrimary();

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -176,11 +176,12 @@ class Defaults {
 	 * Themed logo url
 	 *
 	 * @param bool $useSvg Whether to point to the SVG image or a fallback
+	 * @param bool $emailLogo Whether to return the email logo (if one exists)
 	 * @return string
 	 * @since 12.0.0
 	 */
-	public function getLogo(bool $useSvg = true): string {
-		return $this->defaults->getLogo($useSvg);
+	public function getLogo(bool $useSvg = true, $emailLogo = false): string {
+		return $this->defaults->getLogo($useSvg, $emailLogo);
 	}
 
 	/**

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -180,8 +180,18 @@ class Defaults {
 	 * @return string
 	 * @since 12.0.0
 	 */
-	public function getLogo(bool $useSvg = true, $emailLogo = false): string {
-		return $this->defaults->getLogo($useSvg, $emailLogo);
+	public function getLogo(bool $useSvg = true): string {
+		return $this->defaults->getLogo($useSvg);
+	}
+
+	/**
+	 * Themed email logo url
+	 *
+	 * @return string
+	 * @since 12.0.0
+	 */
+	public function getEmailLogo(): string {
+		return $this->defaults->getEmailLogo();
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the ability to upload a separate logo for notification emails. 

![Screenshot - Google Chrome Canary - 2021-05-04 at 15-11](https://user-images.githubusercontent.com/459512/117010177-d3c38e80-acec-11eb-9109-65fdd47808ba.png)

I basically copied most of the funtionality from the 'logo' upload field and added a fallback check in `apps/theming/lib/ThemingDefaults.php`. If no email logo is provided, the default logo will be used and if that's not present either, the default nextcloud logo will be used.

### Related Issues:
- [Svg logo does not display correctly in email #15930](https://github.com/nextcloud/server/pull/13895)
- [SVG-logo not displaying in emails due to wrong useSvg flag in html src-code #25984](https://github.com/nextcloud/server/pull/25984) (could use separate PNG logo for emails)
- [Generated PNG logo images in in activity emails are blurry #11162](https://github.com/nextcloud/server/pull/11162)
- [SVG logo URL embedded in emails return SVG content, despite useSvg=0 #13895](https://github.com/nextcloud/server/pull/13895)

### Kind of related:
- [Logo not correctly displayed in share mails in Outlook #25463](https://github.com/nextcloud/server/pull/25463)