### PR TITLE
rework search api to allow searching on multiple caches at once

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -988,8 +988,7 @@ class Trashbin {
 		$query = new CacheQueryBuilder(
 			\OC::$server->getDatabaseConnection(),
 			\OC::$server->getSystemConfig(),
-			\OC::$server->getLogger(),
-			$cache
+			\OC::$server->getLogger()
 		);
 		$normalizedParentPath = ltrim(Filesystem::normalizePath(dirname('files_trashbin/versions/'. $filename)), '/');
 		$parentId = $cache->getId($normalizedParentPath);
@@ -998,7 +997,7 @@ class Trashbin {
 		}
 
 		$query->selectFileCache()
-			->whereStorageId()
+			->whereStorageId($cache->getNumericStorageId())
 			->andWhere($query->expr()->eq('parent', $query->createNamedParameter($parentId)))
 			->andWhere($query->expr()->iLike('name', $query->createNamedParameter($pattern)));
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1061,6 +1061,7 @@ return array(
     'OC\\Files\\Cache\\Propagator' => $baseDir . '/lib/private/Files/Cache/Propagator.php',
     'OC\\Files\\Cache\\QuerySearchHelper' => $baseDir . '/lib/private/Files/Cache/QuerySearchHelper.php',
     'OC\\Files\\Cache\\Scanner' => $baseDir . '/lib/private/Files/Cache/Scanner.php',
+    'OC\\Files\\Cache\\SearchBuilder' => $baseDir . '/lib/private/Files/Cache/SearchBuilder.php',
     'OC\\Files\\Cache\\Storage' => $baseDir . '/lib/private/Files/Cache/Storage.php',
     'OC\\Files\\Cache\\StorageGlobal' => $baseDir . '/lib/private/Files/Cache/StorageGlobal.php',
     'OC\\Files\\Cache\\Updater' => $baseDir . '/lib/private/Files/Cache/Updater.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1090,6 +1090,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Files\\Cache\\Propagator' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/Propagator.php',
         'OC\\Files\\Cache\\QuerySearchHelper' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/QuerySearchHelper.php',
         'OC\\Files\\Cache\\Scanner' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/Scanner.php',
+        'OC\\Files\\Cache\\SearchBuilder' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/SearchBuilder.php',
         'OC\\Files\\Cache\\Storage' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/Storage.php',
         'OC\\Files\\Cache\\StorageGlobal' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/StorageGlobal.php',
         'OC\\Files\\Cache\\Updater' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/Updater.php',

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -803,7 +803,7 @@ class Cache implements ICache {
 	}
 
 	public function searchQuery(ISearchQuery $searchQuery) {
-		return $this->querySearchHelper->searchInCaches($searchQuery, [$this]);
+		return current($this->querySearchHelper->searchInCaches($searchQuery, [$this]));
 	}
 
 	/**

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -54,6 +54,7 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
@@ -1050,8 +1051,8 @@ class Cache implements ICache {
 		];
 	}
 
-	public function getQueryFilterForStorage(IQueryBuilder $builder) {
-		return $builder->expr()->eq('storage', $builder->createNamedParameter($this->getNumericStorageId(), IQueryBuilder::PARAM_INT));
+	public function getQueryFilterForStorage(): ISearchOperator {
+		return new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'storage', $this->getNumericStorageId());
 	}
 
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -121,12 +121,7 @@ class Cache implements ICache {
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->eventDispatcher = \OC::$server->get(IEventDispatcher::class);
-		$this->querySearchHelper = new QuerySearchHelper(
-			$this->mimetypeLoader,
-			$this->connection,
-			\OC::$server->getSystemConfig(),
-			\OC::$server->getLogger()
-		);
+		$this->querySearchHelper = \OC::$server->query(QuerySearchHelper::class);
 	}
 
 	protected function getQueryBuilder() {

--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -124,4 +124,8 @@ class CacheEntry implements ICacheEntry {
 	public function getData() {
 		return $this->data;
 	}
+
+	public function __clone() {
+		$this->data = array_merge([], $this->data);
+	}
 }

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -35,13 +35,10 @@ use OCP\ILogger;
  * Query builder with commonly used helpers for filecache queries
  */
 class CacheQueryBuilder extends QueryBuilder {
-	private $cache;
 	private $alias = null;
 
-	public function __construct(IDBConnection $connection, SystemConfig $systemConfig, ILogger $logger, Cache $cache) {
+	public function __construct(IDBConnection $connection, SystemConfig $systemConfig, ILogger $logger) {
 		parent::__construct($connection, $systemConfig, $logger);
-
-		$this->cache = $cache;
 	}
 
 	public function selectFileCache(string $alias = null) {
@@ -56,8 +53,8 @@ class CacheQueryBuilder extends QueryBuilder {
 		return $this;
 	}
 
-	public function whereStorageId() {
-		$this->andWhere($this->expr()->eq('storage', $this->createNamedParameter($this->cache->getNumericStorageId(), IQueryBuilder::PARAM_INT)));
+	public function whereStorageId(int $storageId) {
+		$this->andWhere($this->expr()->eq('storage', $this->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
 
 		return $this;
 	}

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -21,10 +21,12 @@
  */
 namespace OC\Files\Cache;
 
+use OC\Files\Search\SearchComparison;
 use OCP\Constants;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 /**
@@ -140,8 +142,8 @@ class FailedCache implements ICache {
 		throw new \Exception("Invalid cache");
 	}
 
-	public function getQueryFilterForStorage(IQueryBuilder $builder) {
-		return 'false';
+	public function getQueryFilterForStorage(): ISearchOperator {
+		return new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'storage', -1);
 	}
 
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {

--- a/lib/private/Files/Cache/FailedCache.php
+++ b/lib/private/Files/Cache/FailedCache.php
@@ -22,6 +22,7 @@
 namespace OC\Files\Cache;
 
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchQuery;
@@ -137,5 +138,13 @@ class FailedCache implements ICache {
 
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
 		throw new \Exception("Invalid cache");
+	}
+
+	public function getQueryFilterForStorage(IQueryBuilder $builder) {
+		return 'false';
+	}
+
+	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {
+		return null;
 	}
 }

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -27,41 +27,15 @@ namespace OC\Files\Cache;
 
 use OC\Files\Search\SearchBinaryOperator;
 use OC\SystemConfig;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchBinaryOperator;
-use OCP\Files\Search\ISearchComparison;
-use OCP\Files\Search\ISearchOperator;
-use OCP\Files\Search\ISearchOrder;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IDBConnection;
 use OCP\ILogger;
 
-/**
- * Tools for transforming search queries into database queries
- */
 class QuerySearchHelper {
-	protected static $searchOperatorMap = [
-		ISearchComparison::COMPARE_LIKE => 'iLike',
-		ISearchComparison::COMPARE_EQUAL => 'eq',
-		ISearchComparison::COMPARE_GREATER_THAN => 'gt',
-		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'gte',
-		ISearchComparison::COMPARE_LESS_THAN => 'lt',
-		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lte',
-	];
-
-	protected static $searchOperatorNegativeMap = [
-		ISearchComparison::COMPARE_LIKE => 'notLike',
-		ISearchComparison::COMPARE_EQUAL => 'neq',
-		ISearchComparison::COMPARE_GREATER_THAN => 'lte',
-		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'lt',
-		ISearchComparison::COMPARE_LESS_THAN => 'gte',
-		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lt',
-	];
-
-	public const TAG_FAVORITE = '_$!<Favorite>!$_';
 
 	/** @var IMimeTypeLoader */
 	private $mimetypeLoader;
@@ -71,6 +45,8 @@ class QuerySearchHelper {
 	private $systemConfig;
 	/** @var ILogger */
 	private $logger;
+	/** @var SearchBuilder */
+	private $searchBuilder;
 
 	public function __construct(
 		IMimeTypeLoader $mimetypeLoader,
@@ -82,172 +58,7 @@ class QuerySearchHelper {
 		$this->connection = $connection;
 		$this->systemConfig = $systemConfig;
 		$this->logger = $logger;
-	}
-
-	/**
-	 * Whether or not the tag tables should be joined to complete the search
-	 *
-	 * @param ISearchOperator $operator
-	 * @return boolean
-	 */
-	public function shouldJoinTags(ISearchOperator $operator) {
-		if ($operator instanceof ISearchBinaryOperator) {
-			return array_reduce($operator->getArguments(), function ($shouldJoin, ISearchOperator $operator) {
-				return $shouldJoin || $this->shouldJoinTags($operator);
-			}, false);
-		} elseif ($operator instanceof ISearchComparison) {
-			return $operator->getField() === 'tagname' || $operator->getField() === 'favorite';
-		}
-		return false;
-	}
-
-	/**
-	 * @param IQueryBuilder $builder
-	 * @param ISearchOperator $operator
-	 */
-	public function searchOperatorArrayToDBExprArray(IQueryBuilder $builder, array $operators) {
-		return array_filter(array_map(function ($operator) use ($builder) {
-			return $this->searchOperatorToDBExpr($builder, $operator);
-		}, $operators));
-	}
-
-	public function searchOperatorToDBExpr(IQueryBuilder $builder, ISearchOperator $operator) {
-		$expr = $builder->expr();
-		if ($operator instanceof ISearchBinaryOperator) {
-			if (count($operator->getArguments()) === 0) {
-				return null;
-			}
-
-			switch ($operator->getType()) {
-				case ISearchBinaryOperator::OPERATOR_NOT:
-					$negativeOperator = $operator->getArguments()[0];
-					if ($negativeOperator instanceof ISearchComparison) {
-						return $this->searchComparisonToDBExpr($builder, $negativeOperator, self::$searchOperatorNegativeMap);
-					} else {
-						throw new \InvalidArgumentException('Binary operators inside "not" is not supported');
-					}
-				// no break
-				case ISearchBinaryOperator::OPERATOR_AND:
-					return call_user_func_array([$expr, 'andX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
-				case ISearchBinaryOperator::OPERATOR_OR:
-					return call_user_func_array([$expr, 'orX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
-				default:
-					throw new \InvalidArgumentException('Invalid operator type: ' . $operator->getType());
-			}
-		} elseif ($operator instanceof ISearchComparison) {
-			return $this->searchComparisonToDBExpr($builder, $operator, self::$searchOperatorMap);
-		} else {
-			throw new \InvalidArgumentException('Invalid operator type: ' . get_class($operator));
-		}
-	}
-
-	private function searchComparisonToDBExpr(IQueryBuilder $builder, ISearchComparison $comparison, array $operatorMap) {
-		$this->validateComparison($comparison);
-
-		[$field, $value, $type] = $this->getOperatorFieldAndValue($comparison);
-		if (isset($operatorMap[$type])) {
-			$queryOperator = $operatorMap[$type];
-			return $builder->expr()->$queryOperator($field, $this->getParameterForValue($builder, $value));
-		} else {
-			throw new \InvalidArgumentException('Invalid operator type: ' . $comparison->getType());
-		}
-	}
-
-	private function getOperatorFieldAndValue(ISearchComparison $operator) {
-		$field = $operator->getField();
-		$value = $operator->getValue();
-		$type = $operator->getType();
-		if ($field === 'mimetype') {
-			if ($operator->getType() === ISearchComparison::COMPARE_EQUAL) {
-				$value = (int)$this->mimetypeLoader->getId($value);
-			} elseif ($operator->getType() === ISearchComparison::COMPARE_LIKE) {
-				// transform "mimetype='foo/%'" to "mimepart='foo'"
-				if (preg_match('|(.+)/%|', $value, $matches)) {
-					$field = 'mimepart';
-					$value = (int)$this->mimetypeLoader->getId($matches[1]);
-					$type = ISearchComparison::COMPARE_EQUAL;
-				} elseif (strpos($value, '%') !== false) {
-					throw new \InvalidArgumentException('Unsupported query value for mimetype: ' . $value . ', only values in the format "mime/type" or "mime/%" are supported');
-				} else {
-					$field = 'mimetype';
-					$value = (int)$this->mimetypeLoader->getId($value);
-					$type = ISearchComparison::COMPARE_EQUAL;
-				}
-			}
-		} elseif ($field === 'favorite') {
-			$field = 'tag.category';
-			$value = self::TAG_FAVORITE;
-		} elseif ($field === 'tagname') {
-			$field = 'tag.category';
-		} elseif ($field === 'fileid') {
-			$field = 'file.fileid';
-		} elseif ($field === 'path' && $type === ISearchComparison::COMPARE_EQUAL) {
-			$field = 'path_hash';
-			$value = md5((string)$value);
-		}
-		return [$field, $value, $type];
-	}
-
-	private function validateComparison(ISearchComparison $operator) {
-		$types = [
-			'mimetype' => 'string',
-			'mtime' => 'integer',
-			'name' => 'string',
-			'path' => 'string',
-			'size' => 'integer',
-			'tagname' => 'string',
-			'favorite' => 'boolean',
-			'fileid' => 'integer',
-			'storage' => 'integer',
-		];
-		$comparisons = [
-			'mimetype' => ['eq', 'like'],
-			'mtime' => ['eq', 'gt', 'lt', 'gte', 'lte'],
-			'name' => ['eq', 'like'],
-			'path' => ['eq', 'like'],
-			'size' => ['eq', 'gt', 'lt', 'gte', 'lte'],
-			'tagname' => ['eq', 'like'],
-			'favorite' => ['eq'],
-			'fileid' => ['eq'],
-			'storage' => ['eq'],
-		];
-
-		if (!isset($types[$operator->getField()])) {
-			throw new \InvalidArgumentException('Unsupported comparison field ' . $operator->getField());
-		}
-		$type = $types[$operator->getField()];
-		if (gettype($operator->getValue()) !== $type) {
-			throw new \InvalidArgumentException('Invalid type for field ' . $operator->getField());
-		}
-		if (!in_array($operator->getType(), $comparisons[$operator->getField()])) {
-			throw new \InvalidArgumentException('Unsupported comparison for field  ' . $operator->getField() . ': ' . $operator->getType());
-		}
-	}
-
-	private function getParameterForValue(IQueryBuilder $builder, $value) {
-		if ($value instanceof \DateTime) {
-			$value = $value->getTimestamp();
-		}
-		if (is_numeric($value)) {
-			$type = IQueryBuilder::PARAM_INT;
-		} else {
-			$type = IQueryBuilder::PARAM_STR;
-		}
-		return $builder->createNamedParameter($value, $type);
-	}
-
-	/**
-	 * @param IQueryBuilder $query
-	 * @param ISearchOrder[] $orders
-	 */
-	public function addSearchOrdersToQuery(IQueryBuilder $query, array $orders) {
-		foreach ($orders as $order) {
-			$field = $order->getField();
-			if ($field === 'fileid') {
-				$field = 'file.fileid';
-			}
-			$query->addOrderBy($field, $order->getDirection());
-		}
+		$this->searchBuilder = new SearchBuilder($this->mimetypeLoader);
 	}
 
 	protected function getQueryBuilder() {
@@ -288,7 +99,7 @@ class QuerySearchHelper {
 
 		$query = $builder->selectFileCache('file');
 
-		if ($this->shouldJoinTags($searchQuery->getSearchOperation())) {
+		if ($this->searchBuilder->shouldJoinTags($searchQuery->getSearchOperation())) {
 			$user = $searchQuery->getUser();
 			if ($user === null) {
 				throw new \InvalidArgumentException("Searching by tag requires the user to be set in the query");
@@ -303,7 +114,7 @@ class QuerySearchHelper {
 				->andWhere($builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID())));
 		}
 
-		$searchExpr = $this->searchOperatorToDBExpr($builder, $searchQuery->getSearchOperation());
+		$searchExpr = $this->searchBuilder->searchOperatorToDBExpr($builder, $searchQuery->getSearchOperation());
 		if ($searchExpr) {
 			$query->andWhere($searchExpr);
 		}
@@ -311,9 +122,9 @@ class QuerySearchHelper {
 		$storageFilters = array_values(array_map(function (ICache $cache) {
 			return $cache->getQueryFilterForStorage();
 		}, $caches));
-		$query->andWhere($this->searchOperatorToDBExpr($builder, new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, $storageFilters)));
+		$query->andWhere($this->searchBuilder->searchOperatorToDBExpr($builder, new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, $storageFilters)));
 
-		$this->addSearchOrdersToQuery($query, $searchQuery->getOrder());
+		$this->searchBuilder->addSearchOrdersToQuery($query, $searchQuery->getOrder());
 
 		if ($searchQuery->getLimit()) {
 			$query->setMaxResults($searchQuery->getLimit());

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -242,7 +242,11 @@ class QuerySearchHelper {
 	 */
 	public function addSearchOrdersToQuery(IQueryBuilder $query, array $orders) {
 		foreach ($orders as $order) {
-			$query->addOrderBy($order->getField(), $order->getDirection());
+			$field = $order->getField();
+			if ($field === 'fileid') {
+				$field = 'file.fileid';
+			}
+			$query->addOrderBy($field, $order->getDirection());
 		}
 	}
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -52,13 +52,14 @@ class QuerySearchHelper {
 		IMimeTypeLoader $mimetypeLoader,
 		IDBConnection $connection,
 		SystemConfig $systemConfig,
-		ILogger $logger
+		ILogger $logger,
+		SearchBuilder $searchBuilder
 	) {
 		$this->mimetypeLoader = $mimetypeLoader;
 		$this->connection = $connection;
 		$this->systemConfig = $systemConfig;
 		$this->logger = $logger;
-		$this->searchBuilder = new SearchBuilder($this->mimetypeLoader);
+		$this->searchBuilder = $searchBuilder;
 	}
 
 	protected function getQueryBuilder() {

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Robin Appelman <robin@icewind.nl>
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Robin Appelman <robin@icewind.nl>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Tobias Kaminsky <tobias@kaminsky.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Files\Cache;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IMimeTypeLoader;
+use OCP\Files\Search\ISearchBinaryOperator;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
+use OCP\Files\Search\ISearchOrder;
+
+/**
+ * Tools for transforming search queries into database queries
+ */
+class SearchBuilder {
+	protected static $searchOperatorMap = [
+		ISearchComparison::COMPARE_LIKE => 'iLike',
+		ISearchComparison::COMPARE_EQUAL => 'eq',
+		ISearchComparison::COMPARE_GREATER_THAN => 'gt',
+		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'gte',
+		ISearchComparison::COMPARE_LESS_THAN => 'lt',
+		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lte',
+	];
+
+	protected static $searchOperatorNegativeMap = [
+		ISearchComparison::COMPARE_LIKE => 'notLike',
+		ISearchComparison::COMPARE_EQUAL => 'neq',
+		ISearchComparison::COMPARE_GREATER_THAN => 'lte',
+		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'lt',
+		ISearchComparison::COMPARE_LESS_THAN => 'gte',
+		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lt',
+	];
+
+	public const TAG_FAVORITE = '_$!<Favorite>!$_';
+
+	/** @var IMimeTypeLoader */
+	private $mimetypeLoader;
+
+	public function __construct(
+		IMimeTypeLoader $mimetypeLoader
+	) {
+		$this->mimetypeLoader = $mimetypeLoader;
+	}
+
+	/**
+	 * Whether or not the tag tables should be joined to complete the search
+	 *
+	 * @param ISearchOperator $operator
+	 * @return boolean
+	 */
+	public function shouldJoinTags(ISearchOperator $operator) {
+		if ($operator instanceof ISearchBinaryOperator) {
+			return array_reduce($operator->getArguments(), function ($shouldJoin, ISearchOperator $operator) {
+				return $shouldJoin || $this->shouldJoinTags($operator);
+			}, false);
+		} elseif ($operator instanceof ISearchComparison) {
+			return $operator->getField() === 'tagname' || $operator->getField() === 'favorite';
+		}
+		return false;
+	}
+
+	/**
+	 * @param IQueryBuilder $builder
+	 * @param ISearchOperator $operator
+	 */
+	public function searchOperatorArrayToDBExprArray(IQueryBuilder $builder, array $operators) {
+		return array_filter(array_map(function ($operator) use ($builder) {
+			return $this->searchOperatorToDBExpr($builder, $operator);
+		}, $operators));
+	}
+
+	public function searchOperatorToDBExpr(IQueryBuilder $builder, ISearchOperator $operator) {
+		$expr = $builder->expr();
+		if ($operator instanceof ISearchBinaryOperator) {
+			if (count($operator->getArguments()) === 0) {
+				return null;
+			}
+
+			switch ($operator->getType()) {
+				case ISearchBinaryOperator::OPERATOR_NOT:
+					$negativeOperator = $operator->getArguments()[0];
+					if ($negativeOperator instanceof ISearchComparison) {
+						return $this->searchComparisonToDBExpr($builder, $negativeOperator, self::$searchOperatorNegativeMap);
+					} else {
+						throw new \InvalidArgumentException('Binary operators inside "not" is not supported');
+					}
+				// no break
+				case ISearchBinaryOperator::OPERATOR_AND:
+					return call_user_func_array([$expr, 'andX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
+				case ISearchBinaryOperator::OPERATOR_OR:
+					return call_user_func_array([$expr, 'orX'], $this->searchOperatorArrayToDBExprArray($builder, $operator->getArguments()));
+				default:
+					throw new \InvalidArgumentException('Invalid operator type: ' . $operator->getType());
+			}
+		} elseif ($operator instanceof ISearchComparison) {
+			return $this->searchComparisonToDBExpr($builder, $operator, self::$searchOperatorMap);
+		} else {
+			throw new \InvalidArgumentException('Invalid operator type: ' . get_class($operator));
+		}
+	}
+
+	private function searchComparisonToDBExpr(IQueryBuilder $builder, ISearchComparison $comparison, array $operatorMap) {
+		$this->validateComparison($comparison);
+
+		[$field, $value, $type] = $this->getOperatorFieldAndValue($comparison);
+		if (isset($operatorMap[$type])) {
+			$queryOperator = $operatorMap[$type];
+			return $builder->expr()->$queryOperator($field, $this->getParameterForValue($builder, $value));
+		} else {
+			throw new \InvalidArgumentException('Invalid operator type: ' . $comparison->getType());
+		}
+	}
+
+	private function getOperatorFieldAndValue(ISearchComparison $operator) {
+		$field = $operator->getField();
+		$value = $operator->getValue();
+		$type = $operator->getType();
+		if ($field === 'mimetype') {
+			$value = (string)$value;
+			if ($operator->getType() === ISearchComparison::COMPARE_EQUAL) {
+				$value = (int)$this->mimetypeLoader->getId($value);
+			} elseif ($operator->getType() === ISearchComparison::COMPARE_LIKE) {
+				// transform "mimetype='foo/%'" to "mimepart='foo'"
+				if (preg_match('|(.+)/%|', $value, $matches)) {
+					$field = 'mimepart';
+					$value = (int)$this->mimetypeLoader->getId($matches[1]);
+					$type = ISearchComparison::COMPARE_EQUAL;
+				} elseif (strpos($value, '%') !== false) {
+					throw new \InvalidArgumentException('Unsupported query value for mimetype: ' . $value . ', only values in the format "mime/type" or "mime/%" are supported');
+				} else {
+					$field = 'mimetype';
+					$value = (int)$this->mimetypeLoader->getId($value);
+					$type = ISearchComparison::COMPARE_EQUAL;
+				}
+			}
+		} elseif ($field === 'favorite') {
+			$field = 'tag.category';
+			$value = self::TAG_FAVORITE;
+		} elseif ($field === 'tagname') {
+			$field = 'tag.category';
+		} elseif ($field === 'fileid') {
+			$field = 'file.fileid';
+		} elseif ($field === 'path' && $type === ISearchComparison::COMPARE_EQUAL) {
+			$field = 'path_hash';
+			$value = md5((string)$value);
+		}
+		return [$field, $value, $type];
+	}
+
+	private function validateComparison(ISearchComparison $operator) {
+		$types = [
+			'mimetype' => 'string',
+			'mtime' => 'integer',
+			'name' => 'string',
+			'path' => 'string',
+			'size' => 'integer',
+			'tagname' => 'string',
+			'favorite' => 'boolean',
+			'fileid' => 'integer',
+			'storage' => 'integer',
+		];
+		$comparisons = [
+			'mimetype' => ['eq', 'like'],
+			'mtime' => ['eq', 'gt', 'lt', 'gte', 'lte'],
+			'name' => ['eq', 'like'],
+			'path' => ['eq', 'like'],
+			'size' => ['eq', 'gt', 'lt', 'gte', 'lte'],
+			'tagname' => ['eq', 'like'],
+			'favorite' => ['eq'],
+			'fileid' => ['eq'],
+			'storage' => ['eq'],
+		];
+
+		if (!isset($types[$operator->getField()])) {
+			throw new \InvalidArgumentException('Unsupported comparison field ' . $operator->getField());
+		}
+		$type = $types[$operator->getField()];
+		if (gettype($operator->getValue()) !== $type) {
+			throw new \InvalidArgumentException('Invalid type for field ' . $operator->getField());
+		}
+		if (!in_array($operator->getType(), $comparisons[$operator->getField()])) {
+			throw new \InvalidArgumentException('Unsupported comparison for field  ' . $operator->getField() . ': ' . $operator->getType());
+		}
+	}
+
+	private function getParameterForValue(IQueryBuilder $builder, $value) {
+		if ($value instanceof \DateTime) {
+			$value = $value->getTimestamp();
+		}
+		if (is_numeric($value)) {
+			$type = IQueryBuilder::PARAM_INT;
+		} else {
+			$type = IQueryBuilder::PARAM_STR;
+		}
+		return $builder->createNamedParameter($value, $type);
+	}
+
+	/**
+	 * @param IQueryBuilder $query
+	 * @param ISearchOrder[] $orders
+	 */
+	public function addSearchOrdersToQuery(IQueryBuilder $query, array $orders) {
+		foreach ($orders as $order) {
+			$field = $order->getField();
+			if ($field === 'fileid') {
+				$field = 'file.fileid';
+			}
+			$query->addOrderBy($field, $order->getDirection());
+		}
+	}
+}

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -31,9 +31,9 @@ namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\QuerySearchHelper;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 class CacheWrapper extends Cache {
@@ -309,8 +309,8 @@ class CacheWrapper extends Cache {
 		return parent::getById($id);
 	}
 
-	public function getQueryFilterForStorage(IQueryBuilder $builder) {
-		return $this->getCache()->getQueryFilterForStorage($builder);
+	public function getQueryFilterForStorage(): ISearchOperator {
+		return $this->getCache()->getQueryFilterForStorage();
 	}
 
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -226,7 +226,7 @@ class CacheWrapper extends Cache {
 	}
 
 	public function searchQuery(ISearchQuery $searchQuery) {
-		return $this->querySearchHelper->searchInCaches($searchQuery, [$this]);
+		return current($this->querySearchHelper->searchInCaches($searchQuery, [$this]));
 	}
 
 	/**

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -49,12 +49,7 @@ class CacheWrapper extends Cache {
 		$this->cache = $cache;
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->querySearchHelper = new QuerySearchHelper(
-			$this->mimetypeLoader,
-			$this->connection,
-			\OC::$server->getSystemConfig(),
-			\OC::$server->getLogger()
-		);
+		$this->querySearchHelper = \OC::$server->get(QuerySearchHelper::class);
 	}
 
 	protected function getCache() {

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -24,6 +24,7 @@ namespace OC\Lockdown\Filesystem;
 
 use OC\Files\Cache\CacheEntry;
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
@@ -125,5 +126,13 @@ class NullCache implements ICache {
 
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+	}
+
+	public function getQueryFilterForStorage(IQueryBuilder $builder) {
+		return 'false';
+	}
+
+	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {
+		return null;
 	}
 }

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -23,11 +23,13 @@
 namespace OC\Lockdown\Filesystem;
 
 use OC\Files\Cache\CacheEntry;
+use OC\Files\Search\SearchComparison;
 use OCP\Constants;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 class NullCache implements ICache {
@@ -128,8 +130,8 @@ class NullCache implements ICache {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function getQueryFilterForStorage(IQueryBuilder $builder) {
-		return 'false';
+	public function getQueryFilterForStorage(): ISearchOperator {
+		return new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'storage', -1);
 	}
 
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -22,6 +22,8 @@
  */
 namespace OCP\Files\Cache;
 
+use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Search\ISearchQuery;
 
 /**
@@ -264,4 +266,31 @@ interface ICache {
 	 * @since 9.0.0
 	 */
 	public function normalize($path);
+
+	/**
+	 * Get the query expression required to filter files within this storage.
+	 *
+	 * In the most basic case this is just `$builder->expr()->eq('storage', $this->getNumericStorageId())`
+	 * but storage wrappers can add additional expressions to filter down things further
+	 *
+	 * @param IQueryBuilder $builder
+	 * @return string|ICompositeExpression
+	 * @since 22.0.0
+	 */
+	public function getQueryFilterForStorage(IQueryBuilder $builder);
+
+	/**
+	 * Construct a cache entry from a search result row *if* the entry belongs to this storage.
+	 *
+	 * This method will be called for every item in the search results, including results from different storages.
+	 * It's the responsibility of this method to return `null` for all results that don't belong to this storage.
+	 *
+	 * Additionally some implementations might need to further process the resulting entry such as modifying the path
+	 * or permissions of the result.
+	 *
+	 * @param ICacheEntry $rawEntry
+	 * @return ICacheEntry|null
+	 * @since 22.0.0
+	 */
+	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry;
 }

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -22,8 +22,7 @@
  */
 namespace OCP\Files\Cache;
 
-use OCP\DB\QueryBuilder\ICompositeExpression;
-use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 /**
@@ -270,14 +269,13 @@ interface ICache {
 	/**
 	 * Get the query expression required to filter files within this storage.
 	 *
-	 * In the most basic case this is just `$builder->expr()->eq('storage', $this->getNumericStorageId())`
+	 * In the most basic case this is just comparing the storage id
 	 * but storage wrappers can add additional expressions to filter down things further
 	 *
-	 * @param IQueryBuilder $builder
-	 * @return string|ICompositeExpression
+	 * @return ISearchOperator
 	 * @since 22.0.0
 	 */
-	public function getQueryFilterForStorage(IQueryBuilder $builder);
+	public function getQueryFilterForStorage(): ISearchOperator;
 
 	/**
 	 * Construct a cache entry from a search result row *if* the entry belongs to this storage.

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -363,7 +363,7 @@ class CacheTest extends \Test\TestCase {
 		$this->assertEquals(3, count($results));
 
 		usort($results, function ($value1, $value2) {
-			return $value1['name'] >= $value2['name'];
+			return $value1['name'] <=> $value2['name'];
 		});
 
 		$this->assertEquals('folder', $results[0]['name']);
@@ -376,7 +376,10 @@ class CacheTest extends \Test\TestCase {
 		static::logout();
 		$user = \OC::$server->getUserManager()->get($userId);
 		if ($user !== null) {
-			$user->delete();
+			try {
+				$user->delete();
+			} catch (\Exception $e) {
+			}
 		}
 	}
 

--- a/tests/lib/Files/Cache/QuerySearchHelperTest.php
+++ b/tests/lib/Files/Cache/QuerySearchHelperTest.php
@@ -25,11 +25,14 @@ use OC\DB\QueryBuilder\Literal;
 use OC\Files\Cache\QuerySearchHelper;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
+use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
+use OCP\IDBConnection;
+use OCP\ILogger;
 use Test\TestCase;
 
 /**
@@ -75,7 +78,15 @@ class QuerySearchHelperTest extends TestCase {
 				[6, 'image']
 			]);
 
-		$this->querySearchHelper = new QuerySearchHelper($this->mimetypeLoader);
+		$systemConfig = $this->createMock(SystemConfig::class);
+		$logger = $this->createMock(ILogger::class);
+
+		$this->querySearchHelper = new QuerySearchHelper(
+			$this->mimetypeLoader,
+			\OC::$server->get(IDBConnection::class),
+			$systemConfig,
+			$logger
+		);
 		$this->numericStorageId = 10000;
 
 		$this->builder->select(['fileid'])

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -22,33 +22,30 @@
 namespace Test\Files\Cache;
 
 use OC\DB\QueryBuilder\Literal;
-use OC\Files\Cache\QuerySearchHelper;
+use OC\Files\Cache\SearchBuilder;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
-use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
-use OCP\IDBConnection;
-use OCP\ILogger;
 use Test\TestCase;
 
 /**
  * @group DB
  */
-class QuerySearchHelperTest extends TestCase {
-	/** @var  IQueryBuilder */
+class SearchBuilderTest extends TestCase {
+	/** @var IQueryBuilder */
 	private $builder;
 
-	/** @var  IMimeTypeLoader|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IMimeTypeLoader|\PHPUnit\Framework\MockObject\MockObject */
 	private $mimetypeLoader;
 
-	/** @var  QuerySearchHelper */
-	private $querySearchHelper;
+	/** @var SearchBuilder */
+	private $searchBuilder;
 
-	/** @var  integer */
+	/** @var integer */
 	private $numericStorageId;
 
 	protected function setUp(): void {
@@ -78,15 +75,7 @@ class QuerySearchHelperTest extends TestCase {
 				[6, 'image']
 			]);
 
-		$systemConfig = $this->createMock(SystemConfig::class);
-		$logger = $this->createMock(ILogger::class);
-
-		$this->querySearchHelper = new QuerySearchHelper(
-			$this->mimetypeLoader,
-			\OC::$server->get(IDBConnection::class),
-			$systemConfig,
-			$logger
-		);
+		$this->searchBuilder = new SearchBuilder($this->mimetypeLoader);
 		$this->numericStorageId = 10000;
 
 		$this->builder->select(['fileid'])
@@ -145,7 +134,7 @@ class QuerySearchHelperTest extends TestCase {
 	}
 
 	private function search(ISearchOperator $operator) {
-		$dbOperator = $this->querySearchHelper->searchOperatorToDBExpr($this->builder, $operator);
+		$dbOperator = $this->searchBuilder->searchOperatorToDBExpr($this->builder, $operator);
 		$this->builder->andWhere($dbOperator);
 
 		$result = $this->builder->execute();


### PR DESCRIPTION
Changes file search from having each storage's cache perform the cache to asking each cache for how to filter search results, combining all filters from every cache and running the search in a single query.
The results are then passed to the caches again to allow post-processing before finally turning them into the final result objects.

This way there is only a single query required for the search no matter how many storages a user has access to, this does come at the cost of a more complex query but it should still be a good improvement overall