### PR TITLE
Rename IQueryBuilder::executeUpdate to IQueryBuilder::executeStatement

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -805,7 +805,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		foreach ($values as $column => $value) {
 			$query->setValue($column, $query->createNamedParameter($value));
 		}
-		$query->executeUpdate();
+		$query->executeStatement();
 		$calendarId = $query->getLastInsertId();
 
 		$calendarData = $this->getCalendarById($calendarId);
@@ -860,7 +860,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				$query->set($fieldName, $query->createNamedParameter($value));
 			}
 			$query->where($query->expr()->eq('id', $query->createNamedParameter($calendarId)));
-			$query->executeUpdate();
+			$query->executeStatement();
 
 			$this->addChange($calendarId, "", 2);
 
@@ -905,7 +905,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->delete($this->dbObjectPropertiesTable)
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_CALENDAR)))
-			->executeUpdate();
+			->executeStatement();
 
 		// Only dispatch if we actually deleted anything
 		if ($calendarData) {
@@ -1130,7 +1130,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'uid' => $query->createNamedParameter($extraData['uid']),
 				'calendartype' => $query->createNamedParameter($calendarType),
 			])
-			->executeUpdate();
+			->executeStatement();
 
 		$this->updateProperties($calendarId, $objectUri, $calendarData, $calendarType);
 		$this->addChange($calendarId, $objectUri, 1, $calendarType);
@@ -1203,7 +1203,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType)))
-			->executeUpdate();
+			->executeStatement();
 
 		$this->updateProperties($calendarId, $objectUri, $calendarData, $calendarType);
 		$this->addChange($calendarId, $objectUri, 2, $calendarType);
@@ -1257,7 +1257,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->update('calendarobjects')
 			->set('classification', $query->createNamedParameter($classification))
 			->where($query->expr()->eq('id', $query->createNamedParameter($calendarObjectId)))
-			->executeUpdate();
+			->executeStatement();
 	}
 
 	/**
@@ -2151,7 +2151,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		$query->insert('calendarsubscriptions')
 			->values($valuesToInsert)
-			->executeUpdate();
+			->executeStatement();
 
 		$subscriptionId = $query->getLastInsertId();
 
@@ -2206,7 +2206,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				$query->set($fieldName, $query->createNamedParameter($value));
 			}
 			$query->where($query->expr()->eq('id', $query->createNamedParameter($subscriptionId)))
-				->executeUpdate();
+				->executeStatement();
 
 			$subscriptionRow = $this->getSubscriptionById($subscriptionId);
 			$this->dispatcher->dispatchTyped(new SubscriptionUpdatedEvent((int)$subscriptionId, $subscriptionRow, [], $mutations));
@@ -2241,23 +2241,23 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query = $this->db->getQueryBuilder();
 		$query->delete('calendarsubscriptions')
 			->where($query->expr()->eq('id', $query->createNamedParameter($subscriptionId)))
-			->executeUpdate();
+			->executeStatement();
 
 		$query = $this->db->getQueryBuilder();
 		$query->delete('calendarobjects')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		$query->delete('calendarchanges')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		$query->delete($this->dbObjectPropertiesTable)
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		if ($subscriptionRow) {
 			$this->dispatcher->dispatchTyped(new SubscriptionDeletedEvent((int)$subscriptionId, $subscriptionRow, []));
@@ -2347,7 +2347,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->delete('schedulingobjects')
 				->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)))
 				->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
-				->executeUpdate();
+				->executeStatement();
 	}
 
 	/**
@@ -2369,7 +2369,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'etag' => $query->createNamedParameter(md5($objectData)),
 				'size' => $query->createNamedParameter(strlen($objectData))
 			])
-			->executeUpdate();
+			->executeStatement();
 	}
 
 	/**
@@ -2401,7 +2401,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				'operation' => $query->createNamedParameter($operation),
 				'calendartype' => $query->createNamedParameter($calendarType),
 			])
-			->executeUpdate();
+			->executeStatement();
 
 		$stmt = $this->db->prepare("UPDATE `*PREFIX*$table` SET `synctoken` = `synctoken` + 1 WHERE `id` = ?");
 		$stmt->execute([
@@ -2584,7 +2584,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					'resourceid' => $query->createNamedParameter($calendar->getResourceId()),
 					'publicuri' => $query->createNamedParameter($publicUri)
 				]);
-			$query->executeUpdate();
+			$query->executeStatement();
 
 			$this->dispatcher->dispatchTyped(new CalendarPublishedEvent((int)$calendarId, $calendarData, $publicUri));
 			return $publicUri;
@@ -2592,7 +2592,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->delete('dav_shares')
 			->where($query->expr()->eq('resourceid', $query->createNamedParameter($calendar->getResourceId())))
 			->andWhere($query->expr()->eq('access', $query->createNamedParameter(self::ACCESS_PUBLIC)));
-		$query->executeUpdate();
+		$query->executeStatement();
 
 		$this->dispatcher->dispatchTyped(new CalendarUnpublishedEvent((int)$calendarId, $calendarData));
 		return null;
@@ -2676,7 +2676,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					$query->setParameter('name', $property->name);
 					$query->setParameter('parameter', null);
 					$query->setParameter('value', $value);
-					$query->executeUpdate();
+					$query->executeStatement();
 				}
 
 				if (array_key_exists($property->name, self::$indexParameters)) {
@@ -2693,7 +2693,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 							$query->setParameter('name', $property->name);
 							$query->setParameter('parameter', mb_strcut($key, 0, 254));
 							$query->setParameter('value', mb_strcut($value, 0, 254));
-							$query->executeUpdate();
+							$query->executeStatement();
 						}
 					}
 				}
@@ -2737,17 +2737,17 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->delete('calendarobjects')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		$query->delete('calendarchanges')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		$query->delete($this->dbObjectPropertiesTable)
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($subscriptionId)))
 			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter(self::CALENDAR_TYPE_SUBSCRIPTION)))
-			->executeUpdate();
+			->executeStatement();
 
 		foreach ($uris as $uri) {
 			$this->addChange($subscriptionId, $uri, 3, self::CALENDAR_TYPE_SUBSCRIPTION);
@@ -2769,7 +2769,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			->set('uri', $query->createNamedParameter($newUriName ?: $uriName))
 			->where($query->expr()->eq('principaluri', $query->createNamedParameter($uriOrigin)))
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($uriName)))
-			->executeUpdate();
+			->executeStatement();
 	}
 
 	/**
@@ -2793,7 +2793,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->delete($this->dbObjectPropertiesTable)
 			->where($query->expr()->eq('objectid', $query->createNamedParameter($objectId)))
 			->andWhere($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)));
-		$query->executeUpdate();
+		$query->executeStatement();
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -442,7 +442,7 @@ class RequestHandlerController extends OCSController {
 			->set('remote_id', $qb->createNamedParameter($newRemoteId))
 			->where($qb->expr()->eq('remote_id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('share_token', $qb->createNamedParameter($token)));
-		$affected = $query->executeUpdate();
+		$affected = $query->executeStatement();
 
 		if ($affected > 0) {
 			return new Http\DataResponse(['remote' => $cloudId->getRemote(), 'owner' => $cloudId->getUser()]);

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -226,7 +226,7 @@ class Trashbin {
 				->setValue('timestamp', $query->createNamedParameter($timestamp))
 				->setValue('location', $query->createNamedParameter($targetLocation))
 				->setValue('user', $query->createNamedParameter($user));
-			$result = $query->executeUpdate();
+			$result = $query->executeStatement();
 			if (!$result) {
 				\OC::$server->getLogger()->error('trash bin database couldn\'t be updated for the files owner', ['app' => 'files_trashbin']);
 			}
@@ -353,7 +353,7 @@ class Trashbin {
 				->setValue('timestamp', $query->createNamedParameter($timestamp))
 				->setValue('location', $query->createNamedParameter($location))
 				->setValue('user', $query->createNamedParameter($owner));
-			$result = $query->executeUpdate();
+			$result = $query->executeStatement();
 			if (!$result) {
 				\OC::$server->getLogger()->error('trash bin database couldn\'t be updated', ['app' => 'files_trashbin']);
 			}
@@ -516,7 +516,7 @@ class Trashbin {
 					->where($query->expr()->eq('user', $query->createNamedParameter($user)))
 					->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
 					->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-				$query->executeUpdate();
+				$query->executeStatement();
 			}
 
 			return true;
@@ -606,7 +606,7 @@ class Trashbin {
 		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->delete('files_trash')
 			->where($query->expr()->eq('user', $query->createNamedParameter($user)));
-		$query->executeUpdate();
+		$query->executeStatement();
 
 		// Bulk PostDelete-Hook
 		\OC_Hook::emit('\OCP\Trashbin', 'deleteAll', ['paths' => $filePaths]);
@@ -660,7 +660,7 @@ class Trashbin {
 				->where($query->expr()->eq('user', $query->createNamedParameter($user)))
 				->andWhere($query->expr()->eq('id', $query->createNamedParameter($filename)))
 				->andWhere($query->expr()->eq('timestamp', $query->createNamedParameter($timestamp)));
-			$query->executeUpdate();
+			$query->executeStatement();
 
 			$file = $filename . '.d' . $timestamp;
 		} else {
@@ -746,7 +746,7 @@ class Trashbin {
 		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->delete('files_trash')
 			->where($query->expr()->eq('user', $query->createNamedParameter($uid)));
-		return (bool) $query->executeUpdate();
+		return (bool) $query->executeStatement();
 	}
 
 	/**

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -77,6 +77,6 @@ class AccessTokenMapper extends QBMapper {
 		$qb
 			->delete($this->tableName)
 			->where($qb->expr()->eq('client_id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$qb->executeUpdate();
+		$qb->executeStatement();
 	}
 }

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -696,7 +696,7 @@ class ShareByMailProvider implements IShareProvider {
 		 */
 		$qb->setValue('file_target', $qb->createNamedParameter(''));
 
-		$qb->executeUpdate();
+		$qb->executeStatement();
 		return $qb->getLastInsertId();
 	}
 
@@ -732,7 +732,7 @@ class ShareByMailProvider implements IShareProvider {
 			->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 			->set('note', $qb->createNamedParameter($share->getNote()))
 			->set('hide_download', $qb->createNamedParameter((int)$share->getHideDownload(), IQueryBuilder::PARAM_INT))
-			->executeUpdate();
+			->executeStatement();
 
 		if ($originalShare->getNote() !== $share->getNote() && $share->getNote() !== '') {
 			$this->sendNote($share);
@@ -964,7 +964,7 @@ class ShareByMailProvider implements IShareProvider {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->delete('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($shareId)));
-		$qb->executeUpdate();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -1058,7 +1058,7 @@ class ShareByMailProvider implements IShareProvider {
 		$qb->delete('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_EMAIL)))
 			->andWhere($qb->expr()->eq('uid_owner', $qb->createNamedParameter($uid)))
-			->executeUpdate();
+			->executeStatement();
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -309,9 +309,24 @@ class QueryBuilder implements IQueryBuilder {
 		throw new \RuntimeException('Invalid return type for query');
 	}
 
+	/**
+	 * Monkey-patched compatibility layer for apps that were adapted for Nextcloud 22 before
+	 * the first beta, where executeStatement was named executeUpdate.
+	 *
+	 * Static analysis should catch those misuses, but until then let's try to keep things
+	 * running.
+	 *
+	 * @internal
+	 * @deprecated
+	 * @todo drop ASAP
+	 */
 	public function executeUpdate(): int {
+		return $this->executeStatement();
+	}
+
+	public function executeStatement(): int {
 		if ($this->getType() === \Doctrine\DBAL\Query\QueryBuilder::SELECT) {
-			throw new \RuntimeException('Invalid query type, expected INSERT, DELETE or UPDATE query');
+			throw new \RuntimeException('Invalid query type, expected INSERT, DELETE or UPDATE statement');
 		}
 
 		try {
@@ -321,7 +336,7 @@ class QueryBuilder implements IQueryBuilder {
 		}
 
 		if (!is_int($result)) {
-			throw new \RuntimeException('Invalid return type for query');
+			throw new \RuntimeException('Invalid return type for statement');
 		}
 
 		return $result;

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -101,7 +101,7 @@ abstract class QBMapper {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($entity->getId(), $idType))
 			);
-		$qb->executeUpdate();
+		$qb->executeStatement();
 		return $entity;
 	}
 
@@ -132,7 +132,7 @@ abstract class QBMapper {
 			$qb->setValue($column, $qb->createNamedParameter($value, $type));
 		}
 
-		$qb->executeUpdate();
+		$qb->executeStatement();
 
 		if ($entity->id === null) {
 			// When autoincrement is used id is always an int
@@ -211,7 +211,7 @@ abstract class QBMapper {
 		$qb->where(
 			$qb->expr()->eq('id', $qb->createNamedParameter($id, $idType))
 		);
-		$qb->executeUpdate();
+		$qb->executeStatement();
 
 		return $entity;
 	}

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -149,7 +149,7 @@ interface IQueryBuilder {
 	/**
 	 * Executes this query using the bound parameters and their types.
 	 *
-	 * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeUpdate}
+	 * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeStatement}
 	 * for insert, update and delete statements.
 	 *
 	 * Warning: until Nextcloud 20, this method could return a \Doctrine\DBAL\Driver\Statement but since
@@ -175,15 +175,15 @@ interface IQueryBuilder {
 	public function executeQuery(): IResult;
 
 	/**
-	 * Execute  for insert, update and delete statements
+	 * Execute insert, update and delete statements
 	 *
-	 * @return int
+	 * @return int the number of affected rows
 	 * @since 22.0.0
 	 *
 	 * @throws Exception
 	 * @throws \RuntimeException in case of usage with select query
 	 */
-	public function executeUpdate(): int;
+	public function executeStatement(): int;
 
 	/**
 	 * Gets the complete SQL string formed by the current specifications of this QueryBuilder.


### PR DESCRIPTION
Because executeUpdate wasn't a great name. And in DBAL they also use
executeStatement more consistently now.

Ref https://github.com/doctrine/dbal/issues/4607

This is a follow-up to @rullzer's https://github.com/nextcloud/server/pull/23665.

To lower the breakage of apps that were adapted early I added a monkey patched compatibility with a method of the old name in the implementation.