### PR TITLE
Don't break OCC if an app is breaking in it's Application class

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -113,21 +113,24 @@ class Coordinator {
 			 */
 			$appNameSpace = App::buildAppNamespace($appId);
 			$applicationClassName = $appNameSpace . '\\AppInfo\\Application';
-			if (class_exists($applicationClassName) && in_array(IBootstrap::class, class_implements($applicationClassName), true)) {
-				try {
-					/** @var IBootstrap|App $application */
-					$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
-				} catch (QueryException $e) {
-					// Weird, but ok
-					continue;
-				}
-				try {
+			try {
+				if (class_exists($applicationClassName) && in_array(IBootstrap::class, class_implements($applicationClassName), true)) {
+					try {
+						/** @var IBootstrap|App $application */
+						$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
+					} catch (QueryException $e) {
+						// Weird, but ok
+						continue;
+					}
+
 					$application->register($this->registrationContext->for($appId));
-				} catch (Throwable $e) {
-					$this->logger->emergency('Error during app service registration: ' . $e->getMessage(), [
-						'exception' => $e,
-					]);
 				}
+			} catch (Throwable $e) {
+				$this->logger->emergency('Error during app service registration: ' . $e->getMessage(), [
+					'exception' => $e,
+					'app' => $appId,
+				]);
+				continue;
 			}
 		}
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -135,7 +135,14 @@ class OC_App {
 		ob_start();
 		foreach ($apps as $app) {
 			if (!isset(self::$loadedApps[$app]) && ($types === [] || self::isType($app, $types))) {
-				self::loadApp($app);
+				try {
+					self::loadApp($app);
+				} catch (\Throwable $e) {
+					\OC::$server->get(LoggerInterface::class)->emergency('Error during app loading: ' . $e->getMessage(), [
+						'exception' => $e,
+						'app' => $app,
+					]);
+				}
 			}
 		}
 		ob_end_clean();


### PR DESCRIPTION
### Steps

1. Put the code from https://github.com/NastuzziSamy/files_external_gdrive/releases in place
2. Enable the app directly in the database, or comment out the `implements IBackendProvider` part in the Application class only for enabling
3. Try to disable it via OCC or do anything else in OCC