### PR TITLE
Removing useless call to external class

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -625,12 +625,6 @@ class ShareAPIController extends OCSController {
 				throw new OCSNotFoundException($this->l->t('You cannot share to a Circle if the app is not enabled'));
 			}
 
-			$circle = \OCA\Circles\Api\v1\Circles::detailsCircle($shareWith);
-
-			// Valid circle is required to share
-			if ($circle === null) {
-				throw new OCSNotFoundException($this->l->t('Please specify a valid circle'));
-			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} elseif ($shareType === IShare::TYPE_ROOM) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -245,10 +245,6 @@ class Manager implements IManager {
 				throw new \InvalidArgumentException('SharedWith should not be empty');
 			}
 		} elseif ($share->getShareType() === IShare::TYPE_CIRCLE) {
-			$circle = \OCA\Circles\Api\v1\Circles::detailsCircle($share->getSharedWith());
-			if ($circle === null) {
-				throw new \InvalidArgumentException('SharedWith is not a valid circle');
-			}
 		} elseif ($share->getShareType() === IShare::TYPE_ROOM) {
 		} elseif ($share->getShareType() === IShare::TYPE_DECK) {
 		} else {


### PR DESCRIPTION
Redundant check done in the provider itself, useless in here