### PR TITLE
fix occ command user:add-app-password

### DIFF
--- a/core/Command/User/AddAppPassword.php
+++ b/core/Command/User/AddAppPassword.php
@@ -122,7 +122,7 @@ class AddAppPassword extends Command {
 		$this->tokenProvider->generateToken(
 			$token,
 			$user->getUID(),
-			$user->getDisplayName(),
+			$user->getUID(),
 			$password,
 			'cli',
 			IToken::PERMANENT_TOKEN,


### PR DESCRIPTION
Use the UID as loginName instead of the display name. Otherwise the app password will not work for users with a display name different to the UID.

### Steps to test

1. Create a user with a display name different than the login name
2. Generate a app password on the command line: occ user:add-app-password
3. Try to use the generated app password with a webdav client or for a http request to the server

#### Before this fix

The user will not be able to login with the app password.

#### After the fix

The user will be able to login with the app password.