### PR TITLE
Fix log error when creating files from an empty template

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -159,6 +159,7 @@ class TemplateManager implements ITemplateManager {
 			}
 			$folder = $userFolder->get(dirname($filePath));
 			$targetFile = $folder->newFile(basename($filePath));
+			$template = null;
 			if ($templateType === 'user' && $templateId !== '') {
 				$template = $userFolder->get($templateId);
 				$template->copy($targetFile->getPath());


### PR DESCRIPTION
Without the event might be called with an undefined variable in https://github.com/nextcloud/server/blob/d55f83f032a6199406e30328eac54802a63b4436/lib/private/Files/Template/TemplateManager.php#L176

Fixes https://github.com/nextcloud/server/issues/26817