### PR TITLE
Set default max_chunk_size for files app to 100MB

### DIFF
--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -55,7 +55,7 @@ class App {
 	public static function extendJsConfig($settings) {
 		$appConfig = json_decode($settings['array']['oc_appconfig'], true);
 
-		$maxChunkSize = (int)\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', 10 * 1024 * 1024);
+		$maxChunkSize = (int)\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', 100 * 1024 * 1024);
 		$appConfig['files'] = [
 			'max_chunk_size' => $maxChunkSize
 		];


### PR DESCRIPTION
fix #26977
Signed-off-by: szaimen <szaimen@e.mail.de>