### PR TITLE
Use parent wrapper to properly handle moves on the same source/target storage

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -237,7 +237,7 @@ class Storage extends Wrapper {
 				/** @var Storage $sourceStorage */
 				$sourceStorage->disableTrash();
 			}
-			$result = $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 			if ($sourceIsTrashbin) {
 				/** @var Storage $sourceStorage */
 				$sourceStorage->enableTrash();


### PR DESCRIPTION
Steps to reproduce:
- Share a folder from a groupfolder to another user
- Try to upload a file to the shared folder as the user without access to the original groupfolder

Moving the part file to the final one failed after https://github.com/nextcloud/server/pull/25568 as the general wrapper logic to use a rename instead of a moveFromStorage from https://github.com/nextcloud/server/blob/3e69ed8849a47170a523956646fc31e7be9c2ba7/lib/private/Files/Storage/Wrapper/Wrapper.php#L573-L577 was not called anymore.

Fixes https://github.com/nextcloud/groupfolders/issues/1453 
Fixes https://github.com/nextcloud/groupfolders/issues/1445