### PR TITLE
Remove unused apps/dav/js/schedule-response.js

### DIFF
--- a/apps/dav/js/schedule-response.js
+++ b/apps/dav/js/schedule-response.js
@@ -1,3 +1,0 @@
-// window.addEventListener('DOMContentLoaded', function() {
-// 	$('#selectPartStatForm').buttonset();
-// });

--- a/apps/dav/templates/schedule-response-options.php
+++ b/apps/dav/templates/schedule-response-options.php
@@ -1,6 +1,5 @@
 <?php
 style('dav', 'schedule-response');
-//script('dav', 'schedule-response');
 ?>
 
 <div class="update">


### PR DESCRIPTION
File is not included in the schedule-response-options template and is
commented out. The commented code relies on the buttonset() jQuery
plugin, which is deprecated.
https://api.jqueryui.com/buttonset/

If this code was to be re-introduced, it would take a different form.