### PR TITLE
Fix LDAP AD add-on not loading issue

### DIFF
--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -25,6 +25,8 @@
  *
  */
 
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\Mapping\GroupMapping;
 

--- a/apps/user_ldap/ajax/deleteConfiguration.php
+++ b/apps/user_ldap/ajax/deleteConfiguration.php
@@ -28,6 +28,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();

--- a/apps/user_ldap/ajax/getConfiguration.php
+++ b/apps/user_ldap/ajax/getConfiguration.php
@@ -27,6 +27,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();

--- a/apps/user_ldap/ajax/getNewServerConfigPrefix.php
+++ b/apps/user_ldap/ajax/getNewServerConfigPrefix.php
@@ -25,6 +25,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();

--- a/apps/user_ldap/ajax/setConfiguration.php
+++ b/apps/user_ldap/ajax/setConfiguration.php
@@ -26,6 +26,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -28,6 +28,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -29,6 +29,9 @@
  */
 
 // Check user and app status
+
+require_once($_SERVER['DOCUMENT_ROOT'].'/lib/base.php');
+
 \OC_JSON::checkAdminUser();
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();


### PR DESCRIPTION
Myself and multiple others have had issues when trying to set-up the LDAP/AD add-on. Seemed like no matter what we tried it would not load anything. After making these changes it now works perfectly!

Thanks @lbarnett83 for the pointing this out to me and helping to get my instance working!