### PR TITLE
Fix casing of exception string

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -588,7 +588,7 @@ class ShareAPIController extends OCSController {
 			}
 
 			if ($shareWith === null) {
-				throw new OCSNotFoundException($this->l->t('Please specify a valid federated user id'));
+				throw new OCSNotFoundException($this->l->t('Please specify a valid federated user ID'));
 			}
 
 			$share->setSharedWith($shareWith);
@@ -607,7 +607,7 @@ class ShareAPIController extends OCSController {
 			}
 
 			if ($shareWith === null) {
-				throw new OCSNotFoundException($this->l->t('Please specify a valid federated group id'));
+				throw new OCSNotFoundException($this->l->t('Please specify a valid federated group ID'));
 			}
 
 			$share->setSharedWith($shareWith);


### PR DESCRIPTION
Change to capital letters in an abbreviation.

Rebase of #26580 to re-run the CI tests.