### PR TITLE
Prefer string $file over 1-element array in script()

### DIFF
--- a/apps/dav/templates/settings-admin-caldav.php
+++ b/apps/dav/templates/settings-admin-caldav.php
@@ -21,9 +21,7 @@
  *
  */
 
-script('dav', [
-	'settings-admin-caldav'
-]);
+script('dav', 'settings-admin-caldav');
 
 /** @var \OCP\IL10N $l */
 /** @var array $_ */

--- a/apps/settings/templates/settings/personal/security/authtokens.php
+++ b/apps/settings/templates/settings/personal/security/authtokens.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
  *
  */
 
-script('settings', [
-	'vue-settings-personal-security',
-]);
+script('settings', 'vue-settings-personal-security');
 
 ?>
 

--- a/apps/settings/templates/settings/personal/security/webauthn.php
+++ b/apps/settings/templates/settings/personal/security/webauthn.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
  *
  */
 
-script('settings', [
-	'vue-settings-personal-webauthn',
-]);
+script('settings', 'vue-settings-personal-webauthn');
 
 ?>
 

--- a/apps/systemtags/templates/admin.php
+++ b/apps/systemtags/templates/admin.php
@@ -19,9 +19,7 @@
  *
  */
 
-script('core', [
-	'dist/systemtags',
-]);
+script('core', 'dist/systemtags');
 
 script('systemtags', 'admin');
 style('systemtags', 'settings');

--- a/apps/user_ldap/templates/renewpassword.php
+++ b/apps/user_ldap/templates/renewpassword.php
@@ -1,8 +1,6 @@
 <?php /** @var \OCP\IL10N $l */ ?>
 <?php
-script('user_ldap', [
-	'renewPassword',
-]);
+script('user_ldap', 'renewPassword');
 style('user_ldap', 'renewPassword');
 ?>
 

--- a/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
+++ b/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
@@ -40,9 +40,7 @@ class LoadAdditionalSettingsScriptsListener implements IEventListener {
 			class_exists(Template::class, true);
 		}
 
-		script('core', [
-			'dist/systemtags',
-		]);
+		script('core', 'dist/systemtags');
 
 		script(Application::APP_ID, [
 			'workflowengine',

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -1,7 +1,5 @@
 <?php
-script('core', [
-	'dist/install'
-]);
+script('core', 'dist/install');
 ?>
 <input type='hidden' id='hasMySQL' value='<?php p($_['hasMySQL']) ?>'>
 <input type='hidden' id='hasSQLite' value='<?php p($_['hasSQLite']) ?>'>


### PR DESCRIPTION
The string syntax is more obvious. There should be one (and preferably
only one) way of doing things.