### PR TITLE
[stable21] Use parent wrapper to properly handle moves on the same source/target storage

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -237,7 +237,7 @@ class Storage extends Wrapper {
 				/** @var Storage $sourceStorage */
 				$sourceStorage->disableTrash();
 			}
-			$result = $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 			if ($sourceIsTrashbin) {
 				/** @var Storage $sourceStorage */
 				$sourceStorage->enableTrash();


### PR DESCRIPTION
backport of https://github.com/nextcloud/server/pull/26980