### PR TITLE
Fix filesize error on log rotation, if file does not exist 

### DIFF
--- a/lib/public/Log/RotationTrait.php
+++ b/lib/public/Log/RotationTrait.php
@@ -58,7 +58,7 @@ trait RotationTrait {
 	 * @since 14.0.0
 	 */
 	protected function shouldRotateBySize():bool {
-		if ((int)$this->maxSize > 0) {
+		if ((int)$this->maxSize > 0 && file_exist($this->filePath)) {
 			$filesize = @filesize($this->filePath);
 			if ($filesize >= (int)$this->maxSize) {
 				return true;

--- a/lib/public/Log/RotationTrait.php
+++ b/lib/public/Log/RotationTrait.php
@@ -58,7 +58,7 @@ trait RotationTrait {
 	 * @since 14.0.0
 	 */
 	protected function shouldRotateBySize():bool {
-		if ((int)$this->maxSize > 0 && file_exist($this->filePath)) {
+		if ((int)$this->maxSize > 0 && file_exists($this->filePath)) {
 			$filesize = @filesize($this->filePath);
 			if ($filesize >= (int)$this->maxSize) {
 				return true;


### PR DESCRIPTION
fixes #25813

Error was thrown, if file did not exist.

