### PR TITLE
fix return value of getStorageInfo when 'quota_include_external_storage' is enabled

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -45,6 +45,8 @@
  */
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OCP\Files\Mount\IMountPoint;
+use OCP\IUser;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
@@ -518,7 +520,7 @@ class OC_Helper {
 			$quota = OC_Util::getUserQuota($user);
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				// always get free space / total space from root + mount points
-				return self::getGlobalStorageInfo($quota);
+				return self::getGlobalStorageInfo($quota, $user, $mount);
 			}
 		}
 
@@ -570,11 +572,8 @@ class OC_Helper {
 
 	/**
 	 * Get storage info including all mount points and quota
-	 *
-	 * @param int $quota
-	 * @return array
 	 */
-	private static function getGlobalStorageInfo($quota) {
+	private static function getGlobalStorageInfo(int $quota, IUser $user, IMountPoint $mount): array {
 		$rootInfo = \OC\Files\Filesystem::getFileInfo('', 'ext');
 		$used = $rootInfo['size'];
 		if ($used < 0) {
@@ -594,12 +593,22 @@ class OC_Helper {
 			$relative = 0;
 		}
 
+		if (substr_count($mount->getMountPoint(), '/') < 3) {
+			$mountPoint = '';
+		} else {
+			[,,,$mountPoint] = explode('/', $mount->getMountPoint(), 4);
+		}
+
 		return [
 			'free' => $free,
 			'used' => $used,
 			'total' => $total,
 			'relative' => $relative,
-			'quota' => $quota
+			'quota' => $quota,
+			'owner' => $user->getUID(),
+			'ownerDisplayName' => $user->getDisplayName(),
+			'mountType' => $mount->getMountType(),
+			'mountPoint' => trim($mountPoint, '/'),
 		];
 	}
 


### PR DESCRIPTION
To test:

- `occ config:system:set quota_include_external_storage --value true --type boolean`
- set the user quota to something other than unlimited
- load the webui and check the dev tools for the `getstoragestats.php` request

currently the `owner`, `ownerDisplayName`, `mountType` and `mountPoint` are set to `null`
with this PR they should be set to the correct values.