### PR TITLE
Fix Chinese date time format display incorrect issue

### DIFF
--- a/resources/locales.json
+++ b/resources/locales.json
@@ -2952,43 +2952,43 @@
         "name": "Standard Moroccan Tamazight (Morocco)"
     },
     {
-        "code": "zh",
+        "code": "zh_CN",
         "name": "Chinese"
     },
     {
-        "code": "zh_Hans",
+        "code": "zh_CN",
         "name": "Chinese (Simplified)"
     },
     {
-        "code": "zh_Hans_CN",
+        "code": "zh_CN",
         "name": "Chinese (Simplified, China)"
     },
     {
-        "code": "zh_Hans_HK",
+        "code": "zh_HK",
         "name": "Chinese (Simplified, Hong Kong SAR China)"
     },
     {
-        "code": "zh_Hans_MO",
+        "code": "zh_HK",
         "name": "Chinese (Simplified, Macao SAR China)"
     },
     {
-        "code": "zh_Hans_SG",
+        "code": "zh_HK",
         "name": "Chinese (Simplified, Singapore)"
     },
     {
-        "code": "zh_Hant",
+        "code": "zh_HK",
         "name": "Chinese (Traditional)"
     },
     {
-        "code": "zh_Hant_HK",
+        "code": "zh_HK",
         "name": "Chinese (Traditional, Hong Kong SAR China)"
     },
     {
-        "code": "zh_Hant_MO",
+        "code": "zh_HK",
         "name": "Chinese (Traditional, Macao SAR China)"
     },
     {
-        "code": "zh_Hant_TW",
+        "code": "zh_TW",
         "name": "Chinese (Traditional, Taiwan)"
     },
     {


### PR DESCRIPTION
Chinese locale code in resources/locales.json "zh","zh_Hans_CN","zh_Hant_TW" not match "zh_CN/zh_HK/zh_TW", so the date time text display incorrect.
![moment-lang-issue](https://user-images.githubusercontent.com/197311/119110588-e829ba00-ba54-11eb-9b3e-9269e4a45f86.png)
