### PR TITLE
Using empty file as ZipArchive is deprecated

### DIFF
--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -47,7 +47,7 @@ class ZIP extends Archive {
 	public function __construct($source) {
 		$this->path = $source;
 		$this->zip = new \ZipArchive();
-		if ($this->zip->open($source, \ZipArchive::CREATE)) {
+		if ($this->zip->open($source, \ZipArchive::OVERWRITE)) {
 		} else {
 			\OCP\Util::writeLog('files_archive', 'Error while opening archive '.$source, ILogger::WARN);
 		}

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -47,7 +47,7 @@ class ZIP extends Archive {
 	public function __construct($source) {
 		$this->path = $source;
 		$this->zip = new \ZipArchive();
-		if ($this->zip->open($source, \ZipArchive::OVERWRITE)) {
+		if ($this->zip->open($source, (\ZipArchive::CREATE | \ZipArchive::OVERWRITE))) {
 		} else {
 			\OCP\Util::writeLog('files_archive', 'Error while opening archive '.$source, ILogger::WARN);
 		}

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -47,8 +47,7 @@ class ZIP extends Archive {
 	public function __construct($source) {
 		$this->path = $source;
 		$this->zip = new \ZipArchive();
-		if ($this->zip->open($source, (\ZipArchive::CREATE | \ZipArchive::OVERWRITE))) {
-		} else {
+		if (!$this->zip->open($source, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
 			\OCP\Util::writeLog('files_archive', 'Error while opening archive '.$source, ILogger::WARN);
 		}
 	}

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -46,7 +46,7 @@ class ZIP extends Archive {
 	 */
 	public function __construct($source) {
 		$this->path = $source;
-		$this->zip = new \ZipArchive();
+		$this->zip = new ZipArchive();
 		if (!$this->zip->open($source, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
 			\OCP\Util::writeLog('files_archive', 'Error while opening archive '.$source, ILogger::WARN);
 		}

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -46,8 +46,8 @@ class ZIP extends Archive {
 	 */
 	public function __construct($source) {
 		$this->path = $source;
-		$this->zip = new ZipArchive();
-		if (!$this->zip->open($source, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+		$this->zip = new \ZipArchive();
+		if (!$this->zip->open($source, \ZipArchive::CREATE | \ZipArchive::OVERWRITE)) {
 			\OCP\Util::writeLog('files_archive', 'Error while opening archive '.$source, ILogger::WARN);
 		}
 	}


### PR DESCRIPTION
Try to fix #27064

https://github.com/php/php-src/blob/PHP-8.0/UPGRADING#L895-L898