### PR TITLE
Allow removing apps with app store disabled

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -460,10 +460,6 @@ class OC_App {
 	 * @return string|false
 	 */
 	public static function getInstallPath() {
-		if (\OC::$server->getSystemConfig()->getValue('appstoreenabled', true) == false) {
-			return false;
-		}
-
 		foreach (OC::$APPSROOTS as $dir) {
 			if (isset($dir['writable']) && $dir['writable'] === true) {
 				return $dir['path'];


### PR DESCRIPTION
Fixes #27074 

The `appFetcher` returns an empty array if the app store is disabled for downloading an app so there's no reason for the install path to return differently if the app store is disabled as far as I can tell (feel free to correct me).