### PR TITLE
force 'name' key in array

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -536,7 +536,7 @@ class AppManager implements IAppManager {
 		foreach ($apps as $appId) {
 			$info = $this->getAppInfo($appId);
 			if ($info === null) {
-				$incompatibleApps[] = ['id' => $appId];
+				$incompatibleApps[] = ['id' => $appId, 'name' => $appId];
 			} elseif (!\OC_App::isAppCompatible($version, $info)) {
 				$incompatibleApps[] = $info;
 			}


### PR DESCRIPTION
Fixing

```
{
  "reqId": "qW4roGNYhHs9LVnTeC6h",
  "level": 3,
  "time": "2021-05-25T10:28:01+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "--",
  "app": "PHP",
  "method": "PUT",
  "url": "/index.php/apps/user_status/heartbeat",
  "message": {
    "Exception": "Error",
    "Message": "Undefined index: name at /home/maxence/sites/federated/orange/nextcloud/lib/base.php#383",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/maxence/sites/federated/orange/nextcloud/lib/base.php",
        "line": 383,
        "function": "onError",
        "class": "OC\\Log\\ErrorHandler",
        "type": "::"
      },
      {
        "file": "/home/maxence/sites/federated/orange/nextcloud/lib/base.php",
        "line": 954,
        "function": "printUpgradePage",
        "class": "OC",
        "type": "::"
      },
      {
        "file": "/home/maxence/sites/federated/orange/nextcloud/index.php",
        "line": 37,
        "function": "handleRequest",
        "class": "OC",
        "type": "::"
      }
    ],
    "File": "/home/maxence/sites/federated/orange/nextcloud/lib/private/Log/ErrorHandler.php",
    "Line": 92,
    "CustomMessage": "--"
  },
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0",
  "version": "22.0.0.2"
}
```