### PR TITLE
fix getTableNamesWithoutPrefix()

### DIFF
--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -82,7 +82,7 @@ class SchemaWrapper implements ISchemaWrapper {
 				return $fullName;
 			}
 
-			return substr($fullName, $pos+1);
+			return substr($fullName, $pos + 1);
 		}, $this->schema->getTableNames());
 	}
 

--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -60,15 +60,14 @@ class SchemaWrapper implements ISchemaWrapper {
 	 *
 	 * @return array
 	 */
-	public function getTableNamesWithoutPrefix() {
-		$tableNames = $this->schema->getTableNames();
+	public function getTableNamesWithoutPrefix(): array {
 		return array_map(function ($tableName) {
 			if (strpos($tableName, $this->connection->getPrefix()) === 0) {
 				return substr($tableName, strlen($this->connection->getPrefix()));
 			}
 
 			return $tableName;
-		}, $tableNames);
+		}, $this->getTableNames());
 	}
 
 	// Overwritten methods
@@ -76,8 +75,15 @@ class SchemaWrapper implements ISchemaWrapper {
 	/**
 	 * @return array
 	 */
-	public function getTableNames() {
-		return $this->schema->getTableNames();
+	public function getTableNames(): array {
+		return array_map(function (string $fullName) {
+			$pos = strpos($fullName, '.');
+			if ($pos === false) {
+				return $fullName;
+			}
+
+			return substr($fullName, $pos+1);
+		}, $this->schema->getTableNames());
 	}
 
 	/**

--- a/lib/private/DB/SchemaWrapper.php
+++ b/lib/private/DB/SchemaWrapper.php
@@ -76,7 +76,7 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return array
 	 */
 	public function getTableNames(): array {
-		return array_map(function (string $fullName) {
+		return array_map(static function (string $fullName) {
 			$pos = strpos($fullName, '.');
 			if ($pos === false) {
 				return $fullName;

--- a/tests/lib/DB/SchemaWrapperTest.php
+++ b/tests/lib/DB/SchemaWrapperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\DB;
+
+use OC\DB\Connection;
+use OC\DB\SchemaWrapper;
+
+/**
+ * Class SchemaWrapperTest
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
+class SchemaWrapperTest extends \Test\TestCase {
+	/** @var \Doctrine\DBAL\Connection $connection */
+	private $connection;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->connection = \OC::$server->get(Connection::class);
+	}
+
+	public function testGetTableNames(): void {
+		$schema = new SchemaWrapper($this->connection);
+		self::assertContains('oc_share', $schema->getTableNames());
+	}
+
+	public function testGetTableNamesWithoutPrefix(): void {
+		$schema = new SchemaWrapper($this->connection);
+		self::assertContains('share', $schema->getTableNamesWithoutPrefix());
+	}
+}


### PR DESCRIPTION
Looking at the code, it seems that getTableNamesWithoutPrefix() is not working as expected.

The method getTableNames() from the dbal will returns 'database.prefix_table_name' instead of 'prefix_table_name' making the strpos() condition always invalid.

This fix will make getTableNames() extracting the `database` from the list returned by dbal, getTableNamesWithoutPrefix() will use this new list and remove the prefix.

The idea is that even getTableNames() should not contains the name of the database.