### PR TITLE
Fix the get editable fields endpoint without a user id

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -53,7 +53,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#getUser', 'url' => '/users/{userId}', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getEditableFields', 'url' => '/user/fields', 'verb' => 'GET'],
-		['root' => '/cloud', 'name' => 'Users#getEditableFields', 'url' => '/user/fields/{userId}', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'Users#getEditableFieldsForUser', 'url' => '/user/fields/{userId}', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#editUser', 'url' => '/users/{userId}', 'verb' => 'PUT'],
 		['root' => '/cloud', 'name' => 'Users#wipeUserDevices', 'url' => '/users/{userId}/wipe', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'Users#deleteUser', 'url' => '/users/{userId}', 'verb' => 'DELETE'],

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -543,7 +543,24 @@ class UsersController extends AUserData {
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function getEditableFields(?string $userId = null): DataResponse {
+	public function getEditableFields(): DataResponse {
+		$currentLoggedInUser = $this->userSession->getUser();
+		if (!$currentLoggedInUser instanceof IUser) {
+			throw new OCSException('', OCSController::RESPOND_NOT_FOUND);
+		}
+
+		return $this->getEditableFieldsForUser($currentLoggedInUser->getUID());
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 *
+	 * @param string $userId
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getEditableFieldsForUser(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 		if (!$currentLoggedInUser instanceof IUser) {
 			throw new OCSException('', OCSController::RESPOND_NOT_FOUND);

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -178,6 +178,36 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" has editable fields$/
+	 *
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode|null $fields
+	 */
+	public function userHasEditableFields($user, $fields) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/user/fields";
+		if ($user !== 'self') {
+			$fullUrl .= '/' . $user;
+		}
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		} else {
+			$options['auth'] = [$this->currentUser, $this->regularUser];
+		}
+		$options['headers'] = [
+			'OCS-APIREQUEST' => 'true',
+		];
+
+		$response = $client->get($fullUrl, $options);
+		$fieldsArray = json_decode(json_encode(simplexml_load_string($response->getBody())->data->element), 1);
+
+		$expectedFields = $fields->getRows();
+		$expectedFields = $this->simplifyArray($expectedFields);
+		Assert::assertEquals($expectedFields, $fieldsArray);
+	}
+
+	/**
 	 * @Then /^search users by phone for region "([^"]*)" with$/
 	 *
 	 * @param string $user

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -56,6 +56,32 @@ Feature: provisioning
 			| brand-new-user |
 			| admin |
 
+  Scenario: Get editable fields
+    Given As an "admin"
+    And user "brand-new-user" exists
+    Then user "brand-new-user" has editable fields
+      | displayname |
+      | email |
+      | phone |
+      | address |
+      | website |
+      | twitter |
+    Given As an "brand-new-user"
+    Then user "brand-new-user" has editable fields
+      | displayname |
+      | email |
+      | phone |
+      | address |
+      | website |
+      | twitter |
+    Then user "self" has editable fields
+      | displayname |
+      | email |
+      | phone |
+      | address |
+      | website |
+      | twitter |
+
 	Scenario: Edit a user
 		Given As an "admin"
 		And user "brand-new-user" exists


### PR DESCRIPTION
Apparently I broke the old URL (without userid) when adding the option to get the fields for other users. The router does not allow to have the same method in use multiple times.

Fix https://github.com/nextcloud/talk-android/issues/1294