### PR TITLE
Use noreply@ as email address for share emails

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -903,7 +903,7 @@ class Manager implements IManager {
 				$instanceName,
 			]
 		);
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([\OCP\Util::getDefaultEmailAddress('noreply') => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.


### PR DESCRIPTION
Fixes #26683

Before it used the instance name, which a) doesn't make sense to randomly guess email addresses and b) could contain characters that are not allowed in email addresses like spaces.
