### PR TITLE
Auto-Submitted mail header added

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -188,6 +188,10 @@ class Mailer implements IMailer {
 		if (empty($message->getFrom())) {
 			$message->setFrom([\OCP\Util::getDefaultEmailAddress('no-reply') => $this->defaults->getName()]);
 		}
+		
+		// Add Auto-Submitted mail header. 'auto-generated' value should be set when email is sent by a script such as CRON jobs, etc.
+		$headers = $message->getSwiftMessage()->getHeaders();
+		$headers->addTextHeader('Auto-Submitted', 'auto-generated');
 
 		$failedRecipients = [];
 


### PR DESCRIPTION
Auto-Submitted header should be added to every mail sent by an automatic system, such as CRON jobs, etc. Auto-Reply systems should NOT reply when this header is set to 'auto-generated'.

cf. #16538

(First PR of my life here... might have forgot something)