### PR TITLE
Add dependabot reviewer team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
 
 # Main master npm
 - package-ecosystem: npm
@@ -24,6 +26,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
 
 # Testing master npm
 - package-ecosystem: npm
@@ -62,6 +66,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
@@ -78,6 +84,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
@@ -94,6 +102,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
@@ -111,6 +121,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
@@ -127,6 +139,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
@@ -143,6 +157,8 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"


### PR DESCRIPTION
Add a review team https://github.com/orgs/nextcloud/teams/server-dependabot/members

cc @nextcloud/server-dependabot

I know this can be frustrating, but I assume it's best to make sure updates gets in. 

I enabled the following so that it balances the reviews between the team members. That way it smooth things a bit :)
![image](https://user-images.githubusercontent.com/14975046/119972012-fbd3a400-bfb1-11eb-9a72-1dd3ebfaa481.png)

