### PR TITLE
Prevent supplied resource is not a valid stream resource

### DIFF
--- a/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
+++ b/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
@@ -92,6 +92,11 @@ abstract class Wrapper extends WrapperHandler implements File, Directory {
 	}
 
 	public function stream_close() {
+		if (is_resource($this->source)
+			return fclose($this->source);
+			
+		// Silently return true if source is not a resource
+		return true;
 		return fclose($this->source);
 	}
 

--- a/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
+++ b/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
@@ -97,7 +97,6 @@ abstract class Wrapper extends WrapperHandler implements File, Directory {
 			
 		// Silently return true if source is not a resource
 		return true;
-		return fclose($this->source);
 	}
 
 	public function dir_readdir() {

--- a/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
+++ b/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php
@@ -92,7 +92,7 @@ abstract class Wrapper extends WrapperHandler implements File, Directory {
 	}
 
 	public function stream_close() {
-		if (is_resource($this->source)
+		if (is_resource($this->source))
 			return fclose($this->source);
 			
 		// Silently return true if source is not a resource


### PR DESCRIPTION
The logs are spammed with `fclose()` not being able to close a non-resource:

![image](https://user-images.githubusercontent.com/798476/120054111-968abc00-c060-11eb-8e73-7f0f5cef2a39.png)

This happens for every file. This pull request aims to check if a source is a valid resource before `fclose()`-ing, otherwise it silently returns `true` to avoid breaking compatibility.

This occurs when the primary storage backend is S3/S3-compatible. Probably also happens in non-standard backends (Openstack, etc.) but wasn't tested.

This has been tested to work on my setup:

* Nextcloud 21.0.2
* PHP 7.4
* Deployed through the linuxserver/nextcloud Docker image
* Primary Object Storage: S3 (Wasabi)