### PR TITLE
Fix a php8 warning

### DIFF
--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -217,7 +217,7 @@ class Helper {
 	 * @param ITagManager $tagManager
 	 * @return array file list populated with tags
 	 */
-	public static function populateTags(array $fileList, $fileIdentifier = 'fileid', ITagManager $tagManager) {
+	public static function populateTags(array $fileList, $fileIdentifier, ITagManager $tagManager) {
 		$ids = [];
 		foreach ($fileList as $fileData) {
 			$ids[] = $fileData[$fileIdentifier];


### PR DESCRIPTION
There is no need to provide a default value for fileIdentifier,
since the parameter is always used on every callsite.
This also fixes the following warning:

"Required parameter $tagManager follows optional parameter $fileIdentifier at /var/www/nextcloud/apps/files/lib/Helper.php#220"

This should partially address #25806