### PR TITLE
Fix a php8 warning

### DIFF
--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -97,7 +97,10 @@ class PublicTemplateResponse extends TemplateResponse {
 			$this->headerActions[] = $action;
 		}
 		usort($this->headerActions, function (IMenuAction $a, IMenuAction $b) {
-			return $a->getPriority() > $b->getPriority();
+			if ($a->getPriority() == $b->getPriority()) {
+				return 0;
+			}
+			return ($a->getPriority() > $b->getPriority()) ? -1 : 1;
 		});
 	}
 


### PR DESCRIPTION
The usort's callback must return values in {-1, 0, 1} and not
a boolean, since this behaviour is deprecated.

This should also fix the following warning:
"Error: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero at /var/www/nextcloud/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php#101"

This partially addresses #25806