### PR TITLE
Update TwoFactorChallengeController.php

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -36,6 +36,7 @@ use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IProvidesCustomCSP;
 use OCP\Authentication\TwoFactorAuth\TwoFactorException;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
@@ -52,6 +53,9 @@ class TwoFactorChallengeController extends Controller {
 	/** @var ISession */
 	private $session;
 
+	/** @var ILogger */
+	private $logger;
+
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
@@ -62,14 +66,16 @@ class TwoFactorChallengeController extends Controller {
 	 * @param IUserSession $userSession
 	 * @param ISession $session
 	 * @param IURLGenerator $urlGenerator
+	 * @param ILogger $logger
 	 */
 	public function __construct($appName, IRequest $request, Manager $twoFactorManager, IUserSession $userSession,
-		ISession $session, IURLGenerator $urlGenerator) {
+		ISession $session, IURLGenerator $urlGenerator, ILogger $logger) {
 		parent::__construct($appName, $request);
 		$this->twoFactorManager = $twoFactorManager;
 		$this->userSession = $userSession;
 		$this->session = $session;
 		$this->urlGenerator = $urlGenerator;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -209,6 +215,9 @@ class TwoFactorChallengeController extends Controller {
 			$this->session->set('two_factor_auth_error_message', $e->getMessage());
 		}
 
+		$ip = $this->request->getRemoteAddress();
+		$uid = $user->getUID();
+		$this->logger->warning("Two-factor challenge failed: $uid (Remote IP: $ip)");
 		$this->session->set('two_factor_auth_error', true);
 		return new RedirectResponse($this->urlGenerator->linkToRoute('core.TwoFactorChallenge.showChallenge', [
 			'challengeProviderId' => $provider->getId(),

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -57,6 +57,9 @@ class TwoFactorChallengeControllerTest extends TestCase {
 	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
 
+	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	private $logger;
+
 	/** @var TwoFactorChallengeController|\PHPUnit\Framework\MockObject\MockObject */
 	private $controller;
 
@@ -68,6 +71,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(ILogger::class);
 
 		$this->controller = $this->getMockBuilder(TwoFactorChallengeController::class)
 			->setConstructorArgs([
@@ -77,6 +81,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 				$this->userSession,
 				$this->session,
 				$this->urlGenerator,
+				$this->logger,
 			])
 			->setMethods(['getLogoutUrl'])
 			->getMock();


### PR DESCRIPTION
For security reasons, we may want to monitor failures of 2FA challenges in order to ban attackers who might try to access compromised accounts but are stopped by the 2FA challenge.
Right now, the only hindrance is rate-limiting, but it's probably not enough.
It's my first attempt at doing any such changes, so I'm open to feedback or inputs here.
Keep up the great work.