### PR TITLE
Set local domain for swiftmailer

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -45,11 +45,11 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Mail\Events\BeforeMessageSent;
 use OCP\Mail\IAttachment;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
-use OCP\Mail\Events\BeforeMessageSent;
 
 /**
  * Class Mailer provides some basic functions to create a mail message that can be used in combination with
@@ -291,6 +291,15 @@ class Mailer implements IMailer {
 		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', []);
 		if (is_array($streamingOptions) && !empty($streamingOptions)) {
 			$transport->setStreamOptions($streamingOptions);
+		}
+
+		$overwriteCliUrl = parse_url(
+			$this->config->getSystemValueString('overwrite.cli.url', ''),
+			PHP_URL_HOST
+		);
+
+		if (!empty($overwriteCliUrl)) {
+			$transport->setLocalDomain($overwriteCliUrl);
 		}
 
 		return $transport;

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -22,8 +22,8 @@ use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Mail\Events\BeforeMessageSent;
-use Test\TestCase;
 use Swift_SwiftException;
+use Test\TestCase;
 
 class MailerTest extends TestCase {
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
@@ -217,5 +217,43 @@ class MailerTest extends TestCase {
 			]);
 		$mailer = self::invokePrivate($this->mailer, 'getInstance');
 		$this->assertEquals(0, count($mailer->getTransport()->getStreamOptions()));
+	}
+
+	public function testLocalDomain(): void {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['mail_smtpmode', 'smtp', 'smtp']
+			]);
+		$this->config->method('getSystemValueString')
+			->with('overwrite.cli.url', '')
+			->willReturn('https://some.valid.url.com:8080');
+
+		/** @var \Swift_Mailer $mailer */
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		self::assertInstanceOf(\Swift_Mailer::class, $mailer);
+
+		/** @var \Swift_Transport_EsmtpTransport $transport */
+		$transport = $mailer->getTransport();
+		self::assertInstanceOf(\Swift_Transport_EsmtpTransport::class, $transport);
+		self::assertEquals('some.valid.url.com', $transport->getLocalDomain());
+	}
+
+	public function testLocalDomainInvalidUrl(): void {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['mail_smtpmode', 'smtp', 'smtp']
+			]);
+		$this->config->method('getSystemValueString')
+			->with('overwrite.cli.url', '')
+			->willReturn('https:only.slash.does.not.work:8080');
+
+		/** @var \Swift_Mailer $mailer */
+		$mailer = self::invokePrivate($this->mailer, 'getInstance');
+		self::assertInstanceOf(\Swift_Mailer::class, $mailer);
+
+		/** @var \Swift_Transport_EsmtpTransport $transport */
+		$transport = $mailer->getTransport();
+		self::assertInstanceOf(\Swift_Transport_EsmtpTransport::class, $transport);
+		self::assertEquals('[127.0.0.1]', $transport->getLocalDomain());
 	}
 }


### PR DESCRIPTION
Fix #14941
Fix #25716

SwiftMailer uses the local domain for the ehlo command. 

By default the server_name (mostly for web requests) or 127.0.0.1 is used: https://github.com/nextcloud/3rdparty/blob/cdbf02e814d84b2186b9b1de7a36789d61e7e06a/swiftmailer/swiftmailer/lib/dependency_maps/transport_deps.php#L4-L8

This patch uses `parse_url` to parse `overwrite.cli.url` and use the host value for the ehlo command. In addition we could use https://www.php.net/manual/en/function.gethostname as fallback if overwriteCliUrl is empty. That might be better than 127.0.0.1 or the server_name.
