### PR TITLE
Expose calendar-uri as property of deleted caldav events

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1101,6 +1101,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	public function getDeletedCalendarObjectsByPrincipal(string $principalUri): array {
 		$query = $this->db->getQueryBuilder();
 		$query->select(['co.id', 'co.uri', 'co.lastmodified', 'co.etag', 'co.calendarid', 'co.size', 'co.componenttype', 'co.classification', 'co.deleted_at'])
+			->selectAlias('c.uri', 'calendaruri')
 			->from('calendarobjects', 'co')
 			->join('co', 'calendars', 'c', $query->expr()->eq('c.id', 'co.calendarid', IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('principaluri', $query->createNamedParameter($principalUri)))
@@ -1111,10 +1112,11 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		while ($row = $stmt->fetch()) {
 			$result[] = [
 				'id' => $row['id'],
-				'uri' => $row['uri'],
+				'uri' => $row['co.uri'],
 				'lastmodified' => $row['lastmodified'],
 				'etag' => '"' . $row['etag'] . '"',
 				'calendarid' => $row['calendarid'],
+				'calendaruri' => $row['calendaruri'],
 				'size' => (int)$row['size'],
 				'component' => strtolower($row['componenttype']),
 				'classification' => (int)$row['classification'],
@@ -2139,6 +2141,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	public function getCalendarObjectById(string $principalUri, int $id): ?array {
 		$query = $this->db->getQueryBuilder();
 		$query->select(['co.id', 'co.uri', 'co.lastmodified', 'co.etag', 'co.calendarid', 'co.size', 'co.calendardata', 'co.componenttype', 'co.classification', 'co.deleted_at'])
+			->selectAlias('c.uri', 'calendaruri')
 			->from('calendarobjects', 'co')
 			->join('co', 'calendars', 'c', $query->expr()->eq('c.id', 'co.calendarid', IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('c.principaluri', $query->createNamedParameter($principalUri)))
@@ -2153,10 +2156,11 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		return [
 			'id' => $row['id'],
-			'uri' => $row['uri'],
+			'uri' => $row['c.uri'],
 			'lastmodified' => $row['lastmodified'],
 			'etag' => '"' . $row['etag'] . '"',
 			'calendarid' => $row['calendarid'],
+			'calendaruri' => $row['calendaruri'],
 			'size' => (int)$row['size'],
 			'calendardata' => $this->readBlob($row['calendardata']),
 			'component' => strtolower($row['componenttype']),

--- a/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObject.php
+++ b/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObject.php
@@ -97,4 +97,8 @@ class DeletedCalendarObject implements ICalendarObject, IRestorable {
 	public function getDeletedAt(): ?int {
 		return $this->objectData['deleted_at'] ? (int) $this->objectData['deleted_at'] : null;
 	}
+
+	public function getCalendarUri(): string {
+		return $this->objectData['calendaruri'];
+	}
 }

--- a/apps/dav/lib/CalDAV/Trashbin/Plugin.php
+++ b/apps/dav/lib/CalDAV/Trashbin/Plugin.php
@@ -40,6 +40,7 @@ use function implode;
 
 class Plugin extends ServerPlugin {
 	public const PROPERTY_DELETED_AT = '{http://nextcloud.com/ns}deleted-at';
+	public const PROPERTY_CALENDAR_URI = '{http://nextcloud.com/ns}calendar-uri';
 
 	/** @var bool */
 	private $disableTrashbin;
@@ -94,6 +95,9 @@ class Plugin extends ServerPlugin {
 		if ($node instanceof DeletedCalendarObject) {
 			$propFind->handle(self::PROPERTY_DELETED_AT, function () use ($node) {
 				return $node->getDeletedAt();
+			});
+			$propFind->handle(self::PROPERTY_CALENDAR_URI, function () use ($node) {
+				return $node->getCalendarUri();
 			});
 		}
 	}


### PR DESCRIPTION
The trashbin is one report across all calendars of a user. In order to
refresh the data of a single calendar when one of its events is
restored, we need to know what calendar the event belongs to. There
doesn't seem to be a standard property for a URI, so this adds a custom
Nextcloud prop for the calendar-uri.

Required for https://github.com/nextcloud/calendar/pull/3118.