### PR TITLE
Fix loading of delete caldav objet URIs

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1112,7 +1112,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		while ($row = $stmt->fetch()) {
 			$result[] = [
 				'id' => $row['id'],
-				'uri' => $row['co.uri'],
+				'uri' => $row['uri'],
 				'lastmodified' => $row['lastmodified'],
 				'etag' => '"' . $row['etag'] . '"',
 				'calendarid' => $row['calendarid'],
@@ -2156,7 +2156,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		return [
 			'id' => $row['id'],
-			'uri' => $row['c.uri'],
+			'uri' => $row['uri'],
 			'lastmodified' => $row['lastmodified'],
 			'etag' => '"' . $row['etag'] . '"',
 			'calendarid' => $row['calendarid'],


### PR DESCRIPTION
Regression of 462962197d0d711abc7b57352d4ef24528e28096

Since I added an alias the prefix for the table is not needed anymore. Otherwise the URIs will always be null -> :boom: 