### PR TITLE
Rewrite birthday calendar tests without $this->at()

### DIFF
--- a/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
@@ -82,7 +82,7 @@ class EnablePluginTest extends TestCase {
 
 		$plugin = new EnablePlugin($this->config, $this->birthdayService);
 
-		$server->expects($this->at(0))
+		$server->expects($this->once())
 			->method('on')
 			->with('method:POST', [$plugin, 'httpPost']);
 
@@ -120,11 +120,11 @@ class EnablePluginTest extends TestCase {
 			->with('/bar/foo')
 			->willReturn($calendarHome);
 
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getBodyAsString')
 			->willReturn('<nc:disable-birthday-calendar xmlns:nc="http://nextcloud.com/ns"/>');
 
-		$this->request->expects($this->at(1))
+		$this->request->expects($this->once())
 			->method('getUrl')
 			->willReturn('url_abc');
 
@@ -158,11 +158,11 @@ class EnablePluginTest extends TestCase {
 			->method('getOwner')
 			->willReturn('principals/users/BlaBlub');
 
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getBodyAsString')
 			->willReturn('<nc:enable-birthday-calendar xmlns:nc="http://nextcloud.com/ns"/>');
 
-		$this->request->expects($this->at(1))
+		$this->request->expects($this->once())
 			->method('getUrl')
 			->willReturn('url_abc');
 

--- a/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
+++ b/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
@@ -96,15 +96,13 @@ class BirthdayCalendarControllerTest extends TestCase {
 				$closure($user3);
 			});
 
-		$this->jobList->expects($this->at(0))
+		$this->jobList->expects($this->exactly(3))
 			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid1']);
-		$this->jobList->expects($this->at(1))
-			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid2']);
-		$this->jobList->expects($this->at(2))
-			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid3']);
+			->withConsecutive(
+				[GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid1']],
+				[GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid2']],
+				[GenerateBirthdayCalendarBackgroundJob::class, ['userId' => 'uid3']],
+			);
 
 		$response = $this->controller->enable();
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);

--- a/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
@@ -62,7 +62,7 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 	}
 
 	public function testRun() {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'regeneratedBirthdayCalendarsForYearFix')
 			->willReturn(null);
@@ -72,11 +72,11 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 			->method('info')
 			->with('Adding background jobs to regenerate birthday calendar');
 
-		$this->jobList->expects($this->at(0))
+		$this->jobList->expects($this->once())
 			->method('add')
 			->with(RegisterRegenerateBirthdayCalendars::class);
 
-		$this->config->expects($this->at(1))
+		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('dav', 'regeneratedBirthdayCalendarsForYearFix', 'yes');
 


### PR DESCRIPTION
Removes warnings:

```
The at() matcher has been deprecated. It will be removed in PHPUnit 10.
Please refactor your test to not rely on the order in which methods are
invoked.
```