### PR TITLE
Propagate throttling on OCS response

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -75,6 +75,11 @@ abstract class BaseResponse extends Response {
 		$this->setLastModified($dataResponse->getLastModified());
 		$this->setCookies($dataResponse->getCookies());
 
+		if ($dataResponse->isThrottled()) {
+			$throttleMetadata = $dataResponse->getThrottleMetadata();
+			$this->throttle($throttleMetadata);
+		}
+
 		if ($format === 'json') {
 			$this->addHeader(
 				'Content-Type', 'application/json; charset=utf-8'


### PR DESCRIPTION
The BaseResponse converter did not take over any throttling state from the DataResponse.

See https://github.com/nextcloud/serverinfo/pull/312 for a usage.