### PR TITLE
22.0.0 beta 3

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 5];
+$OC_Version = [22, 0, 0, 6];
 
 // The human readable string
-$OC_VersionString = '22.0.0 beta 2';
+$OC_VersionString = '22.0.0 beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
changes compared to beta 3

* #24295 First attempt to check against core routes before loading all app routes
* #25658 Dav respect disallow sharing with groups
* #25770 Don't allow executing cli if cache backend is unavailable
* #26083 Add a trashbin for calendars and calendar objects
* #26410 Add proper PHPDoc tags to files ApiController
* #26706 L10n: Spelling unification
* #26792 Better cleanup of user files on user deletion
* #27053 Don't throw when comments is disabled
* #27061 ⚡ Activities for addressbook and contacts
* #27063 L10n: Spelling unification
* #27088 Allow removing apps with app store disabled
* #27090 Bump browserslist from 4.16.3 to 4.16.6
* #27118 Add dependabot config with proper ignore for stable branches
* #27125 Use GitHub container registry
* #27130 Bump @nextcloud/vue from 3.7.2 to 3.10.0
* #27168 Bump @nextcloud/vue-dashboard from 1.1.0 to 2.0.1
* #27172 Bump eslint-plugin-import from 2.22.1 to 2.23.3
* #27175 Bump webdav from 3.6.2 to 4.6.0
* #27180 Bump mochapack from 2.0.6 to 2.1.2
* #27185 Replace node-sass with sass & bump css-loader
* #27187 Fix Oracle query limit compliance in Comments
* #27188 Fix the get editable fields endpoint without a user id
* #27193 Bump webpack-cli from 4.6.0 to 4.7.0
* #27197 L10n: Remove space from translation
* #27199 Use noreply@ as email address for share emails
* #27202 Add dependabot reviewer team
* #27211 Use GHCR PHP 7.3 container
* #27212 Use GHCR for services
* #27213 Use GHCR for Git Pull image
* #27214 Use GHCR PHP 7.3 Acceptance Container
* #27215 Use GHCR Selenium Container
* #27238 Bump vue-loader from 15.9.6 to 15.9.7
* #27243 Fix test on master
* #27244 Migrate more services to GHCR
* #27246 Bump ws from 7.4.1 to 7.4.6 in /build
* #27251 Bump sinon-chai from 3.6.0 to 3.7.0
* #27253 Bump @babel/core from 7.14.2 to 7.14.3
* #27260 Bump webpack-node-externals from 2.5.2 to 3.0.0
* #27263 Bump sinon from 9.2.4 to 11.1.1
* #27265 Replace proposal-class-private-properties by regular properties
* #27267 Add fixup.yml
* #27274 Bump various npm deps master
* #27275 Fixing invalid classes and methods for circles 22
* #27286 Rewrite requesttoken.spec.js with Jest
* #27291 L10n: Correct spelling
* #27295 Set app to settings for translate
* #27298 Expose deletion timestamp for deleted CalDAV objects
* #27310 Expose calendar-uri as property of deleted caldav events
* #27311 Fix loading of delete caldav objet URIs
* #27312 Rewrite birthday calendar tests without $this->at()
* #27314 [Automated] Update psalm-baseline.xml
* #27316 Fix populating the array and closing the cursors
* #27317 L10n: Split sentences
* #27320 Add XDEBUG_MODE=coverage
* #27327 [Fast Review] Fix grammar
* #27328 Emit UserLoggedInEvent on apache auth
* #27329 Propagate throttling on OCS response
* #27331 Add mbstring dependency
* #27340 [Automated] Update psalm-baseline.xml
* #27343 Add missing ACLs for deleted calendar objects to fix deletion
* #27352 Fix translation phpunit test
* #27354 Escape filename in Content-Disposition
* [files_pdfviewer#395](https://github.com/nextcloud/files_pdfviewer/pull/395) Bump browserslist from 4.16.3 to 4.16.6
* [files_pdfviewer#402](https://github.com/nextcloud/files_pdfviewer/pull/402) Bump @babel/preset-env from 7.14.2 to 7.14.4
* [files_pdfviewer#403](https://github.com/nextcloud/files_pdfviewer/pull/403) Bump @babel/eslint-parser from 7.14.3 to 7.14.4
* [files_pdfviewer#404](https://github.com/nextcloud/files_pdfviewer/pull/404) Bump sass from 1.33.0 to 1.34.0
* [files_pdfviewer#405](https://github.com/nextcloud/files_pdfviewer/pull/405) Bump eslint-config-standard from 16.0.2 to 16.0.3
* [files_pdfviewer#406](https://github.com/nextcloud/files_pdfviewer/pull/406) Bump webpack from 5.37.1 to 5.38.1
* [firstrunwizard#534](https://github.com/nextcloud/firstrunwizard/pull/534) Bump eslint-plugin-import from 2.22.1 to 2.23.3
* [firstrunwizard#536](https://github.com/nextcloud/firstrunwizard/pull/536) Bump @babel/preset-env from 7.14.2 to 7.14.4
* [notifications#980](https://github.com/nextcloud/notifications/pull/980) Bump sass from 1.33.0 to 1.34.0
* [notifications#981](https://github.com/nextcloud/notifications/pull/981) Bump @babel/preset-env from 7.14.2 to 7.14.4
* [notifications#982](https://github.com/nextcloud/notifications/pull/982) Bump webpack from 5.37.1 to 5.38.1
* [notifications#983](https://github.com/nextcloud/notifications/pull/983) Bump eslint-config-standard from 16.0.2 to 16.0.3
* [notifications#984](https://github.com/nextcloud/notifications/pull/984) Bump @babel/eslint-parser from 7.14.3 to 7.14.4
* [notifications#985](https://github.com/nextcloud/notifications/pull/985) Bump @nextcloud/vue from 3.9.0 to 3.10.0
* [notifications#986](https://github.com/nextcloud/notifications/pull/986) Bump eslint from 7.26.0 to 7.27.0
* [password_policy#189](https://github.com/nextcloud/password_policy/pull/189) Bump @babel/preset-env from 7.14.2 to 7.14.4
* [password_policy#191](https://github.com/nextcloud/password_policy/pull/191) Bump sass from 1.33.0 to 1.34.0
* [password_policy#192](https://github.com/nextcloud/password_policy/pull/192) Bump @babel/eslint-parser from 7.14.3 to 7.14.4
* [password_policy#193](https://github.com/nextcloud/password_policy/pull/193) Bump webpack from 5.37.1 to 5.38.1
* [photos#774](https://github.com/nextcloud/photos/pull/774) Fix l10n
* [photos#780](https://github.com/nextcloud/photos/pull/780) Bump eslint-config-standard from 16.0.2 to 16.0.3
* [photos#781](https://github.com/nextcloud/photos/pull/781) Bump @babel/preset-env from 7.14.2 to 7.14.4
* [photos#782](https://github.com/nextcloud/photos/pull/782) Bump @nextcloud/vue from 3.9.0 to 3.10.0
* [photos#783](https://github.com/nextcloud/photos/pull/783) Fix sorting if one of the file name is only composed with number
* [recommendations#378](https://github.com/nextcloud/recommendations/pull/378) Bump eslint-plugin-promise from 4.2.1 to 4.3.1
* [recommendations#386](https://github.com/nextcloud/recommendations/pull/386) Bump @nextcloud/vue-dashboard from 1.0.1 to 1.1.0
* [recommendations#401](https://github.com/nextcloud/recommendations/pull/401) Show file path on hover
* [recommendations#403](https://github.com/nextcloud/recommendations/pull/403) Bump @babel/preset-env from 7.14.0 to 7.14.4
* [recommendations#404](https://github.com/nextcloud/recommendations/pull/404) Bump stylelint from 13.13.0 to 13.13.1
* [recommendations#405](https://github.com/nextcloud/recommendations/pull/405) Bump @babel/core from 7.14.0 to 7.14.3
* [recommendations#406](https://github.com/nextcloud/recommendations/pull/406) Bump webpack-cli from 4.4.0 to 4.7.0
* [recommendations#407](https://github.com/nextcloud/recommendations/pull/407) Bump vue-loader from 15.9.6 to 15.9.7
* [recommendations#409](https://github.com/nextcloud/recommendations/pull/409) Bump eslint-plugin-import from 2.22.1 to 2.23.4
* [serverinfo#302](https://github.com/nextcloud/serverinfo/pull/302) Set Null Speed and Duplex to 'unknown'
* [serverinfo#312](https://github.com/nextcloud/serverinfo/pull/312) Add ratelimit to ServerInfo API endpoint
* [viewer#873](https://github.com/nextcloud/viewer/pull/873) Bump eslint-webpack-plugin from 2.5.3 to 2.5.4
* [viewer#887](https://github.com/nextcloud/viewer/pull/887) Bump @babel/plugin-transform-modules-commonjs from 7.13.8 to 7.14.0
* [viewer#891](https://github.com/nextcloud/viewer/pull/891) Bump lodash from 4.17.19 to 4.17.21
* [viewer#892](https://github.com/nextcloud/viewer/pull/892) Bump hosted-git-info from 2.8.5 to 2.8.9
* [viewer#920](https://github.com/nextcloud/viewer/pull/920) Bump @babel/eslint-parser from 7.13.14 to 7.14.4
* [viewer#922](https://github.com/nextcloud/viewer/pull/922) Bump ws from 7.4.1 to 7.4.6


Pending PRs:

* [ ] #16708 Replace usage of "addslashes" with prepared statements @tianon
* [ ] #20605 Remove confusing placeholder in Sharing Settings @matthiasbe
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22628 Coalesce RewriteCond lines in .htaccess @Sp1l
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #24318 Use proper methods for display name retrieval @MorrisJobke
* [ ] #24727 Enhance signature algorithm for code signatures @rullzer
* [ ] #24827 Run oci tests against phpunit9/php8 @juliushaertl
* [ ] #25023 Fixes visual bug by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25109 Add command to scan external storages directly @icewind1991
* [ ] #25249 Moving between storages is not a rename @rullzer
* [ ] #25392 Dont return private storage interface from public mount interface @icewind1991
* [ ] #25418 Update variables.scss - Fallback font before Noto Color Emoji @kaktuspalme
* [ ] #25471 Add optional index API @rullzer
* [ ] #25540 ACLs without \ in the username throw exception @anikrooz
* [ ] #25768 Use mimetype from cache for workflow checks @icewind1991
* [ ] #25950 Add dedicated product name to OCP\Defaults @juliushaertl
* [ ] #26023 PoC: Emit events on files_versions frontend actions to allow apps to hook into them @juliushaertl
* [ ] #26142 Allow appdata being stored in a separate object storage multibucket @MorrisJobke
* [ ] #26178 Ability to add some entries out of rfc7033 @daita
* [ ] #26300 Add dedicated activities for file uploads to public shares @MorrisJobke
* [ ] #26318 Add typed event for loading additional external storage backends @icewind1991
* [ ] #26319 Move files_external to IBootstrap and remove some depricated stuff in the process @icewind1991
* [ ] #26320 Cleanup files sidebar navigation manager @icewind1991
* [ ] #26397 Allow using any ldap property as login name when using external storage login credentials @icewind1991
* [ ] #26408 Sign in form best practice @kevin147147
* [ ] #26411 Catch node for share not found @skjnldsv
* [ ] #26421 OCC command to delete calendars @mattian
* [ ] #26463 Fix S3 ObjectStore proxy option @maxbes
* [ ] #26571 Only allow removing existing shares that would not be allowed due to reshare restrictions @juliushaertl
* [ ] #26585 Drone: drop MariaDB 10.1 (EOL) add MariaDB 10.5 @acsfer
* [ ] #26681 Move HintException to OCP @juliushaertl
* [ ] #26688 Add proper message to created share not found @skjnldsv
* [ ] #26701 [3rdparty] streams-0.7.4 @icewind1991
* [ ] #26725 Fix federated scope not shown when public addressbook upload is disabled @danxuliu
* [ ] #26874 Rework search api to allow searching on multiple caches at once @icewind1991
* [ ] #26899 Add S3 SSE KMS key and bucketkey encryption @tsdicloud
* [ ] #26939 Let apps toggle an unread counter on app icons @juliushaertl
* [ ] #26982 Add some high level filesystem documention @icewind1991
* [ ] #27051 Add timestamp tooltip @Pytal
* [ ] #27098 Force 'name' key in array @daita
* [ ] #27102 Trigger the default action when scrollTo is set @artonge
* [ ] #27119 Fix getTableNamesWithoutPrefix() @daita
* [ ] #27123 Emit Sidebar events on nextcloud-bus @artonge
* [ ] #27189 Extend Accounts with multivalue properties (PropertyCollection) @skjnldsv
* [ ] #27190 Deduplicate translations and fix double . @nickvergessen
* [ ] #27191 Make the database user backend cache case insensitive like the DB table @MorrisJobke
* [ ] #27196 Fix setUserValue bool test on testShowHiddenFiles & testCropImagePreviews @skjnldsv
* [ ] #27252 Bump @nextcloud/event-bus from 1.2.0 to 2.0.0 
* [ ] #27254 Bump @nextcloud/files from 1.1.0 to 2.0.0 
* [ ] #27259 Bump autosize from 4.0.2 to 5.0.0 
* [ ] #27261 Prevent supplied resource is not a valid stream resource @liamdemafelix
* [ ] #27306 Set local domain for swiftmailer @kesselb
* [ ] #27348 Export the CalDAV trash bin retention duration as property @ChristophWurst
* [ ] [text#1574](https://github.com/nextcloud/text/pull/1574) Fix: rich workspaces overlap with new file dropdown @gary-kim
* [ ] [viewer#913](https://github.com/nextcloud/viewer/pull/913) React to sidebar events from nextcloud-bus @artonge