### PR TITLE
Add missing ACLs for deleted calendar objects to fix deletion

### DIFF
--- a/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObjectsCollection.php
+++ b/apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObjectsCollection.php
@@ -78,6 +78,7 @@ class DeletedCalendarObjectsCollection implements ICalendarObjectContainer {
 		return new DeletedCalendarObject(
 			$this->getRelativeObjectPath($data),
 			$data,
+			$this->principalInfo['uri'],
 			$this->caldavBackend
 		);
 	}
@@ -117,8 +118,8 @@ class DeletedCalendarObjectsCollection implements ICalendarObjectContainer {
 	}
 
 	public function calendarQuery(array $filters) {
-		return array_map(function (array $calendarInfo) {
-			return $this->getRelativeObjectPath($calendarInfo);
+		return array_map(function (array $calendarObjectInfo) {
+			return $this->getRelativeObjectPath($calendarObjectInfo);
 		}, $this->caldavBackend->getDeletedCalendarObjectsByPrincipal($this->principalInfo['uri']));
 	}
 


### PR DESCRIPTION
Due to a bug in Sabre it's necessary for calendar objects to implement
ACLs. Otherwise the scheduling plugin will throw an error when it tries
to fetch the owner of a calendar object that is being deleted.

Ref https://github.com/sabre-io/dav/issues/1345

Required for https://github.com/nextcloud/calendar/pull/3129