### PR TITLE
[stable21] Replace OCSController with OCP\API

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -534,7 +534,7 @@ class UsersController extends AUserData {
 	public function getEditableFields(): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 		if (!$currentLoggedInUser instanceof IUser) {
-			throw new OCSException('', OCSController::RESPOND_NOT_FOUND);
+			throw new OCSException('', \OCP\API::RESPOND_NOT_FOUND);
 		}
 
 		return $this->getEditableFieldsForUser($currentLoggedInUser->getUID());


### PR DESCRIPTION
Psalm is unhappy about the missing import for `OCSController`. `OCSController` on stable21 does not have a constant RESPOND_NOT_FOUND. `OCP\API` seems the right one.