### PR TITLE
Export the CalDAV trash bin retention duration as property

### DIFF
--- a/apps/dav/lib/CalDAV/RetentionService.php
+++ b/apps/dav/lib/CalDAV/RetentionService.php
@@ -51,8 +51,8 @@ class RetentionService {
 		$this->calDavBackend = $calDavBackend;
 	}
 
-	public function cleanUp(): void {
-		$retentionTime = max(
+	public function getDuration(): int {
+		return max(
 			(int) $this->config->getAppValue(
 				Application::APP_ID,
 				self::RETENTION_CONFIG_KEY,
@@ -60,6 +60,10 @@ class RetentionService {
 			),
 			0 // Just making sure we don't delete things in the future when a negative number is passed
 		);
+	}
+
+	public function cleanUp(): void {
+		$retentionTime = $this->getDuration();
 		$now = $this->time->getTime();
 
 		$calendars = $this->calDavBackend->getDeletedCalendars($now - $retentionTime);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -165,7 +165,7 @@ class Server {
 				$this->server->addPlugin(\OC::$server->query(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
 			}
 
-			$this->server->addPlugin(new \OCA\DAV\CalDAV\Trashbin\Plugin($request));
+			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\WebcalCaching\Plugin($request));
 			$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 


### PR DESCRIPTION
As required for https://github.com/nextcloud/calendar/pull/3130. We want to show the users how long the trash bin will keep its elements. This will also allow Calendar to detect when trash bin is disabled by the admin (duration=0), where we can hide the trash bin section from the sidebar.