### PR TITLE
add dav plugin to trigger recalculating of checksums

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -140,6 +140,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\BlockLegacyClientPlugin' => $baseDir . '/../lib/Connector/Sabre/BlockLegacyClientPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\CachingTree' => $baseDir . '/../lib/Connector/Sabre/CachingTree.php',
     'OCA\\DAV\\Connector\\Sabre\\ChecksumList' => $baseDir . '/../lib/Connector/Sabre/ChecksumList.php',
+    'OCA\\DAV\\Connector\\Sabre\\ChecksumUpdatePlugin' => $baseDir . '/../lib/Connector/Sabre/ChecksumUpdatePlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\CommentPropertiesPlugin' => $baseDir . '/../lib/Connector/Sabre/CommentPropertiesPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\CopyEtagHeaderPlugin' => $baseDir . '/../lib/Connector/Sabre/CopyEtagHeaderPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\DavAclPlugin' => $baseDir . '/../lib/Connector/Sabre/DavAclPlugin.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -155,6 +155,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\BlockLegacyClientPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/BlockLegacyClientPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\CachingTree' => __DIR__ . '/..' . '/../lib/Connector/Sabre/CachingTree.php',
         'OCA\\DAV\\Connector\\Sabre\\ChecksumList' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ChecksumList.php',
+        'OCA\\DAV\\Connector\\Sabre\\ChecksumUpdatePlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ChecksumUpdatePlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\CommentPropertiesPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/CommentPropertiesPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\CopyEtagHeaderPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/CopyEtagHeaderPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\DavAclPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/DavAclPlugin.php',

--- a/apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class ChecksumUpdatePlugin extends ServerPlugin {
+	/**
+	 * @var \Sabre\DAV\Server
+	 */
+	protected $server;
+
+	public function initialize(\Sabre\DAV\Server $server) {
+		$this->server = $server;
+		$server->on('method:PATCH', [$this, 'httpPatch']);
+	}
+
+	public function getPluginName(): string {
+		return 'checksumupdate';
+	}
+
+	public function getHTTPMethods($path): array {
+		$tree = $this->server->tree;
+
+		if ($tree->nodeExists($path)) {
+			$node = $tree->getNodeForPath($path);
+			if ($node instanceof File) {
+				return ['PATCH'];
+			}
+		}
+
+		return [];
+	}
+
+	public function getFeatures(): array {
+		return ['nextcloud-checksum-update'];
+	}
+
+	public function httpPatch(RequestInterface $request, ResponseInterface $response) {
+		$path = $request->getPath();
+
+		$node = $this->server->tree->getNodeForPath($path);
+		if ($node instanceof File) {
+			$type = strtolower(
+				(string)$request->getHeader('X-Recalculate-Hash')
+			);
+
+			$hash = $node->hash($type);
+			if ($hash) {
+				$checksum = strtoupper($type) . ':' . $hash;
+				$node->setChecksum($checksum);
+				$response->addHeader('OC-Checksum', $checksum);
+				$response->setHeader('Content-Length', '0');
+				$response->setStatus(204);
+
+				return false;
+			}
+		}
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -343,11 +343,9 @@ class File extends Node implements IFile {
 
 			if (isset($this->request->server['HTTP_OC_CHECKSUM'])) {
 				$checksum = trim($this->request->server['HTTP_OC_CHECKSUM']);
-				$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
-				$this->refreshInfo();
+				$this->setChecksum($checksum);
 			} elseif ($this->getChecksum() !== null && $this->getChecksum() !== '') {
-				$this->fileView->putFileInfo($this->path, ['checksum' => '']);
-				$this->refreshInfo();
+				$this->setChecksum('');
 			}
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage(), 0, $e);
@@ -688,9 +686,18 @@ class File extends Node implements IFile {
 		return $this->info->getChecksum();
 	}
 
+	public function setChecksum(string $checksum) {
+		$this->fileView->putFileInfo($this->path, ['checksum' => $checksum]);
+		$this->refreshInfo();
+	}
+
 	protected function header($string) {
 		if (!\OC::$CLI) {
 			\header($string);
 		}
+	}
+
+	public function hash(string $type) {
+		return $this->fileView->hash($type, $this->path);
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -177,6 +177,7 @@ class ServerFactory {
 				)
 			);
 			$server->addPlugin(new \OCA\DAV\Connector\Sabre\QuotaPlugin($view, true));
+			$server->addPlugin(new \OCA\DAV\Connector\Sabre\ChecksumUpdatePlugin());
 
 			if ($this->userSession->isLoggedIn()) {
 				$server->addPlugin(new \OCA\DAV\Connector\Sabre\TagsPlugin($objectTree, $this->tagManager));

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -46,6 +46,7 @@ use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Connector\Sabre\CachingTree;
+use OCA\DAV\Connector\Sabre\ChecksumUpdatePlugin;
 use OCA\DAV\Connector\Sabre\CommentPropertiesPlugin;
 use OCA\DAV\Connector\Sabre\CopyEtagHeaderPlugin;
 use OCA\DAV\Connector\Sabre\DavAclPlugin;
@@ -243,6 +244,7 @@ class Server {
 						!\OC::$server->getConfig()->getSystemValue('debug', false)
 					)
 				);
+				$this->server->addPlugin(new ChecksumUpdatePlugin());
 
 				$this->server->addPlugin(
 					new \Sabre\DAV\PropertyStorage\Plugin(

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1082,7 +1082,7 @@ class View {
 	 * @param string $type
 	 * @param string $path
 	 * @param bool $raw
-	 * @return bool|null|string
+	 * @return bool|string
 	 */
 	public function hash($type, $path, $raw = false) {
 		$postFix = (substr($path, -1) === '/') ? '/' : '';
@@ -1099,12 +1099,13 @@ class View {
 					[Filesystem::signal_param_path => $this->getHookPath($path)]
 				);
 			}
+			/** @var Storage|null $storage */
 			[$storage, $internalPath] = Filesystem::resolvePath($absolutePath . $postFix);
 			if ($storage) {
 				return $storage->hash($type, $internalPath, $raw);
 			}
 		}
-		return null;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Allows clients to ask the server to recalculate the stored checksums by sending a `PATCH` request with the `X-Recalculate-Hash` hash set.

For example

    curl -X PATCH -u admin:admin -H 'X-Recalculate-Hash: sha1' https://cloud.example.com/remote.php/dav/files/admin/test.md

This will both update the stored checksum using the provided algorithm and return the new checksum in the `OC-Checksum` header

cc @allexzander 