### PR TITLE
Rewrite LegacyHelperTest without $this->at()

### DIFF
--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -108,58 +108,98 @@ class LegacyHelperTest extends \Test\TestCase {
 		$this->assertEquals('/filename', OC_Helper::buildNotExistingFileNameForView('/', 'filename', $viewMock));
 		$this->assertEquals('dir/filename.ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename.ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename.ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   // Conflict on filename.ext
+			   ['dir/filename.ext'],
+			   ['dir/filename (2).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename (2).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename.ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename.ext exists
-		$viewMock->expects($this->at(1))
-			->method('file_exists')
-			->willReturn(true); // filename (2).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(3))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename.ext'],
+			   ['dir/filename (2).ext'],
+			   ['dir/filename (3).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, true, false));
 		$this->assertEquals('dir/filename (3).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename.ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename (1).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename (1).ext'],
+			   ['dir/filename (2).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename (2).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename (1).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename (2).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename (2).ext'],
+			   ['dir/filename (3).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename (3).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename (2).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename (2).ext exists
-		$viewMock->expects($this->at(1))
-			->method('file_exists')
-			->willReturn(true); // filename (3).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(3))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename (2).ext'],
+			   ['dir/filename (3).ext'],
+			   ['dir/filename (4).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, true, false));
 		$this->assertEquals('dir/filename (4).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename (2).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename(1).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename(1).ext'],
+			   ['dir/filename(2).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename(2).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename(1) (1).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename(1) (1).ext'],
+			   ['dir/filename(1) (2).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename(1) (2).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (1).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename(1) (1).ext exists
-		$viewMock->expects($this->at(1))
-			->method('file_exists')
-			->willReturn(true); // filename(1) (2).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(3))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename(1) (1).ext'],
+			   ['dir/filename(1) (2).ext'],
+			   ['dir/filename(1) (3).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, true, false));
 		$this->assertEquals('dir/filename(1) (3).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (1).ext', $viewMock));
 
-		$viewMock->expects($this->at(0))
-			->method('file_exists')
-			->willReturn(true); // filename(1) (2) (3).ext exists
+		$viewMock = $this->createMock(View::class);
+		$viewMock->expects($this->exactly(2))
+		   ->method('file_exists')
+		   ->withConsecutive(
+			   ['dir/filename(1) (2) (3).ext'],
+			   ['dir/filename(1) (2) (4).ext'],
+		   )
+		   ->will($this->onConsecutiveCalls(true, false));
 		$this->assertEquals('dir/filename(1) (2) (4).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (2) (3).ext', $viewMock));
 	}
 


### PR DESCRIPTION
The at() matcher has been deprecated. It will be removed in PHPUnit 10.
Please refactor your test to not rely on the order in which methods are
invoked.