### PR TITLE
Don't pass a column object to addOrderBy

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -337,14 +337,11 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		try {
 			$orderColumns = $table->getPrimaryKeyColumns();
 		} catch (Exception $e) {
-			$orderColumns = [];
-			foreach ($table->getColumns() as $column) {
-				$orderColumns[] = $column->getName();
-			}
+			$orderColumns = $table->getColumns();
 		}
 
 		foreach ($orderColumns as $column) {
-			$query->addOrderBy($column);
+			$query->addOrderBy($column->getName());
 		}
 
 		$insertQuery = $toDB->getQueryBuilder();


### PR DESCRIPTION
Fix #26085
Close #26855

addOrderBy expects a order expression. For the migration scenario we have column objects. Column objects are not supported by quoteColumnName yet. A column object as order expression is most likely an edgy thing when migration database information. 

I run into the issue today when migration some data for a test and had a chance to test it. 