### PR TITLE
Correctly check the reception of a remote feedback

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -405,7 +405,7 @@ class Notifications {
 	 * @param $fields
 	 * @param $action
 	 *
-	 * @return bool
+	 * @return array|false
 	 */
 	protected function tryOCMEndPoint($remoteDomain, $fields, $action) {
 		switch ($action) {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -365,7 +365,7 @@ class Manager {
 	private function sendFeedbackToRemote($remote, $token, $remoteId, $feedback) {
 		$result = $this->tryOCMEndPoint($remote, $token, $remoteId, $feedback);
 
-		if ($result === true) {
+		if (is_array($result)) {
 			return true;
 		}
 
@@ -401,7 +401,7 @@ class Manager {
 	 * @param string $token
 	 * @param string $remoteId id of the share
 	 * @param string $feedback
-	 * @return bool
+	 * @return array|false
 	 */
 	protected function tryOCMEndPoint($remoteDomain, $token, $remoteId, $feedback) {
 		switch ($feedback) {

--- a/lib/private/Federation/CloudFederationProviderManager.php
+++ b/lib/private/Federation/CloudFederationProviderManager.php
@@ -167,7 +167,7 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 	/**
 	 * @param string $url
 	 * @param ICloudFederationNotification $notification
-	 * @return mixed
+	 * @return array|false
 	 */
 	public function sendNotification($url, ICloudFederationNotification $notification) {
 		$ocmEndPoint = $this->getOCMEndPoint($url);

--- a/lib/public/Federation/ICloudFederationProviderManager.php
+++ b/lib/public/Federation/ICloudFederationProviderManager.php
@@ -89,7 +89,7 @@ interface ICloudFederationProviderManager {
 	 *
 	 * @param string $url
 	 * @param ICloudFederationNotification $notification
-	 * @return mixed
+	 * @return array|false
 	 *
 	 * @since 14.0.0
 	 */


### PR DESCRIPTION
On the creation of a federated share, the receiving server wrongly check the notification response which lead to sending a notification twice.

emitting server | receiving server
-- | --
send share --> | _
_ | --> receive share
_ | --- user accept share
_ | <-- send accepted_share notification
receive notification <--- | -
_ | --- check the result of the notification, it's an array and not true
_ | <-- assume the request failed and send the notification to the legacy endpoint
receive duplicate notification <--- | _

Here is an example of duplicate notification:

![Screenshot from 2021-06-08 19-01-25](https://user-images.githubusercontent.com/6653109/121227661-1cdaa580-c88c-11eb-8798-c13bcbd33412.png)


