### PR TITLE
Handle files with `is_file` instead of `file_exists`

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -391,7 +391,7 @@ class Encryption extends Wrapper {
 		if ($this->util->isExcluded($fullPath) === false) {
 			$size = $unencryptedSize = 0;
 			$realFile = $this->util->stripPartialFileExtension($path);
-			$targetExists = $this->file_exists($realFile) || $this->file_exists($path);
+			$targetExists = $this->is_file($realFile) || $this->file_exists($path);
 			$targetIsEncrypted = false;
 			if ($targetExists) {
 				// in case the file exists we require the explicit module as
@@ -855,7 +855,7 @@ class Encryption extends Wrapper {
 	 */
 	protected function readFirstBlock($path) {
 		$firstBlock = '';
-		if ($this->storage->file_exists($path)) {
+		if ($this->storage->is_file($path)) {
 			$handle = $this->storage->fopen($path, 'r');
 			$firstBlock = fread($handle, $this->util->getHeaderSize());
 			fclose($handle);
@@ -872,7 +872,7 @@ class Encryption extends Wrapper {
 	protected function getHeaderSize($path) {
 		$headerSize = 0;
 		$realFile = $this->util->stripPartialFileExtension($path);
-		if ($this->storage->file_exists($realFile)) {
+		if ($this->storage->is_file($realFile)) {
 			$path = $realFile;
 		}
 		$firstBlock = $this->readFirstBlock($path);
@@ -920,7 +920,7 @@ class Encryption extends Wrapper {
 	 */
 	protected function getHeader($path) {
 		$realFile = $this->util->stripPartialFileExtension($path);
-		$exists = $this->storage->file_exists($realFile);
+		$exists = $this->storage->is_file($realFile);
 		if ($exists) {
 			$path = $realFile;
 		}

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -624,7 +624,7 @@ class EncryptionTest extends Storage {
 		$util->expects($this->once())->method('stripPartialFileExtension')
 			->with($path)->willReturn($strippedPath);
 		$sourceStorage->expects($this->once())
-			->method('file_exists')
+			->method('is_file')
 			->with($strippedPath)
 			->willReturn($strippedPathExists);
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -652,7 +652,7 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()->getMock();
 
 		$sourceStorage->expects($this->once())
-			->method('file_exists')
+			->method('is_file')
 			->willReturn($exists);
 
 		$util = $this->getMockBuilder('\OC\Encryption\Util')


### PR DESCRIPTION
Should fix things like `fread(): read of 8192 bytes failed with errno=21 Is a directory` since `is_file()` will return `false` if the given `$path` points to a directory, where `file_exists()` will return `true` if the given `$path` points to a valid file **or** directory.

Since we're expecting **files** only, this should make sense.
