### PR TITLE
Move exception logging to separate field

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -82,13 +82,17 @@ abstract class LogDetails {
 			'version'
 		);
 
-		if (is_array($message) && !array_key_exists('Exception', $message)) {
-			// Exception messages should stay as they are,
+		if (is_array($message)) {
+			// Exception messages are extracted and the exception is put into a separate field
 			// anything else modern is split to 'message' (string) and
 			// data (array) fields
-			$shortMessage = $message['message'] ?? '(no message provided)';
-			$entry['data'] = $message;
-			$entry['message'] = $shortMessage;
+			if (array_key_exists('Exception', $message)) {
+				$entry['exception'] = $message;
+				$entry['message'] = $message['CustomMessage'] !== '--' ? $message['CustomMessage'] : $message['Message'];
+			} else {
+				$entry['data'] = $message;
+				$entry['message'] = $message['message'] ?? '(no message provided)';
+			}
 		}
 
 		return $entry;


### PR DESCRIPTION
This is a proposal to adjust the log format when exceptions are logged to move them to a separate field in the log json output. The current approach basically leads to the message field being either a string or an object which always bugged me a bit as it is not a unified format. This would also allow easier extraction for some log collection solutions when storing the log details in elastic search for example.

As it is a breaking change on the format we'd need to properly document that in the changelog. 

Any oppinions @ChristophWurst @nickvergessen @MorrisJobke @skjnldsv @kesselb 

Before:
```
{
  ...
  "message": {
    "Exception": "Exception",
    "Message": "Unauthorized",
    "Code": 0,
    "Trace": [
      ....
    ],
    "File": "/var/www/html/apps-extra/sharepoint/vendor/vgrem/php-spo/src/Runtime/OData/ODataRequest.php",
    "Line": 51,
    "CustomMessage": "--"
  }
}

```

After:
```
{
  ...
  "message": "Unauthorized",
  "exception": {
    "Exception": "Exception",
    "Message": "Unauthorized",
    "Code": 0,
    "Trace": [
      ...
    ],
    "File": "/var/www/html/apps-extra/sharepoint/vendor/vgrem/php-spo/src/Runtime/OData/ODataRequest.php",
    "Line": 51,
    "CustomMessage": "--"
  }
}
```
