### PR TITLE
22.0.0 Beta 4

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 6];
+$OC_Version = [22, 0, 0, 7];
 
 // The human readable string
-$OC_VersionString = '22.0.0 beta 3';
+$OC_VersionString = '22.0.0 beta 4';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog since beta3:

* #24295 First attempt to check against core routes before loading all app routes
* #26397 Allow using any ldap property as login name when using external storage login credentials
* #26494 Fix some php 8 warnings
* #26701 [3rdparty] streams-0.7.4
* #26792 Better cleanup of user files on user deletion
* #27008 Port dav calendar settings page to Vue.js
* #27053 Don't throw when comments is disabled
* #27063 L10n: Spelling unification
* #27088 Allow removing apps with app store disabled
* #27089 [ProvisioningAPI] Allow specifying group display name during creation
* #27102 Trigger the default action when openfile URL param is set
* #27123 Emit Sidebar events on nextcloud-bus
* #27189 Extend Accounts with multivalue properties (PropertyCollection)
* #27265 Replace proposal-class-private-properties by regular properties
* #27282 Bump @babel/preset-env from 7.13.15 to 7.14.4
* #27306 Set local domain for swiftmailer
* #27343 Add missing ACLs for deleted calendar objects to fix deletion
* #27348 Export the CalDAV trash bin retention duration as property
* #27352 Fix translation phpunit test
* #27354 Escape filename in Content-Disposition
* #27374 Bugfix/noid/adjust unit tests
* #27375 Don't update statuses to offline again and again
* #27381 Update php licenses
* #27387 Bump sass from 1.34.0 to 1.34.1
* #27410 Bump Symfony from 4.4.19 to 4.4.25
* #27414 Rewrite LegacyHelperTest without $this->at()
* #27417 Bump webpack-cli from 4.7.0 to 4.7.2
* #27418 Bump glob-parent from 5.1.1 to 5.1.2 in /build
* #27419 Bump webpack-merge from 5.7.3 to 5.8.0
* #27420 [Automated] Update psalm-baseline.xml
* #27426 Allow certain custom DAV props to be readable by everyone
* #27429 Don't pass a column object to addOrderBy
* #27430 Correctly check the reception of a remote feedback
* #27436 Allow apps to get photos of VObjects
* #27439 Bump giggsey/libphonenumber-for-php from 8.12.20 to 8.12.24
* #27444 Header must contain a colon
* #27449 Bump 3rdparty from `8c6da7b` to `e924cba`
* #27450 [Automated] Update psalm-baseline.xml
* #27451 Move exception logging to separate field
* [3rdparty#654](https://github.com/nextcloud/3rdparty/pull/654) Bump opis/closure from 3.6.1 to 3.6.2
* [3rdparty#662](https://github.com/nextcloud/3rdparty/pull/662) Bump nikic/php-parser from 4.10.4 to 4.10.5
* [3rdparty#672](https://github.com/nextcloud/3rdparty/pull/672) Bump giggsey/libphonenumber-for-php from 8.12.20 to 8.12.24
* [3rdparty#678](https://github.com/nextcloud/3rdparty/pull/678) Bump Symfony from 4.4.19 to 4.4.25
* [3rdparty#680](https://github.com/nextcloud/3rdparty/pull/680) Bump Symfony from 4.4.19 to 4.4.25
* [3rdparty#683](https://github.com/nextcloud/3rdparty/pull/683) Bump icewind/streams from 0.7.2 to 0.7.4
* [circles#603](https://github.com/nextcloud/circles/pull/603) Add default_enable to app
* [circles#607](https://github.com/nextcloud/circles/pull/607) L10n: Spelling unification
* [circles#609](https://github.com/nextcloud/circles/pull/609) +invitedBy
* [files_pdfviewer#389](https://github.com/nextcloud/files_pdfviewer/pull/389) Bump eslint-plugin-standard from 4.1.0 to 5.0.0
* [files_pdfviewer#408](https://github.com/nextcloud/files_pdfviewer/pull/408) Bump eslint-plugin-vue from 7.9.0 to 7.10.0
* [files_pdfviewer#409](https://github.com/nextcloud/files_pdfviewer/pull/409) Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1
* [files_pdfviewer#410](https://github.com/nextcloud/files_pdfviewer/pull/410) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [files_pdfviewer#411](https://github.com/nextcloud/files_pdfviewer/pull/411) Bump sass from 1.34.0 to 1.34.1
* [files_pdfviewer#412](https://github.com/nextcloud/files_pdfviewer/pull/412) Bump eslint from 7.26.0 to 7.28.0
* [files_pdfviewer#413](https://github.com/nextcloud/files_pdfviewer/pull/413) Bump vue-template-compiler from 2.6.12 to 2.6.13
* [files_pdfviewer#415](https://github.com/nextcloud/files_pdfviewer/pull/415) Bump trim-newlines from 3.0.0 to 3.0.1
* [files_pdfviewer#416](https://github.com/nextcloud/files_pdfviewer/pull/416) Bump glob-parent from 5.1.1 to 5.1.2
* [firstrunwizard#537](https://github.com/nextcloud/firstrunwizard/pull/537) Bump vue and vue-template-compiler
* [firstrunwizard#538](https://github.com/nextcloud/firstrunwizard/pull/538) Bump acorn from 8.2.4 to 8.3.0
* [firstrunwizard#539](https://github.com/nextcloud/firstrunwizard/pull/539) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [notifications#987](https://github.com/nextcloud/notifications/pull/987) Bump vue and vue-template-compiler
* [notifications#988](https://github.com/nextcloud/notifications/pull/988) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [notifications#989](https://github.com/nextcloud/notifications/pull/989) Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1
* [notifications#990](https://github.com/nextcloud/notifications/pull/990) Bump eslint-plugin-vue from 7.9.0 to 7.10.0
* [notifications#991](https://github.com/nextcloud/notifications/pull/991) Bump @nextcloud/vue from 3.10.0 to 3.10.1
* [notifications#992](https://github.com/nextcloud/notifications/pull/992) Bump eslint from 7.27.0 to 7.28.0
* [notifications#993](https://github.com/nextcloud/notifications/pull/993) Bump sass from 1.34.0 to 1.34.1
* [password_policy#194](https://github.com/nextcloud/password_policy/pull/194) Bump eslint-plugin-vue from 7.9.0 to 7.10.0
* [password_policy#195](https://github.com/nextcloud/password_policy/pull/195) Bump eslint from 7.27.0 to 7.28.0
* [password_policy#197](https://github.com/nextcloud/password_policy/pull/197) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [password_policy#198](https://github.com/nextcloud/password_policy/pull/198) Bump sass from 1.34.0 to 1.34.1
* [photos#787](https://github.com/nextcloud/photos/pull/787) Bump eslint-plugin-vue from 7.9.0 to 7.10.0
* [photos#789](https://github.com/nextcloud/photos/pull/789) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [photos#790](https://github.com/nextcloud/photos/pull/790) Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1
* [photos#792](https://github.com/nextcloud/photos/pull/792) Bump eslint from 7.27.0 to 7.28.0
* [recommendations#410](https://github.com/nextcloud/recommendations/pull/410) Use new viewer syntax with destructuring object
* [text#1642](https://github.com/nextcloud/text/pull/1642) Bump ws from 6.2.1 to 6.2.2
* [viewer#899](https://github.com/nextcloud/viewer/pull/899) Use physical pixel size for preview resolution
* [viewer#904](https://github.com/nextcloud/viewer/pull/904) Bump eslint-plugin-cypress from 2.11.2 to 2.11.3
* [viewer#911](https://github.com/nextcloud/viewer/pull/911) Bump browserslist from 4.16.1 to 4.16.6
* [viewer#921](https://github.com/nextcloud/viewer/pull/921) Bump eslint-plugin-vue from 7.8.0 to 7.10.0
* [viewer#930](https://github.com/nextcloud/viewer/pull/930) Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1
* [viewer#931](https://github.com/nextcloud/viewer/pull/931) Bump cypress from 7.2.0 to 7.4.0
* [viewer#932](https://github.com/nextcloud/viewer/pull/932) Bump sass from 1.33.0 to 1.34.1
* [viewer#933](https://github.com/nextcloud/viewer/pull/933) Bump vue and vue-template-compiler
* [viewer#934](https://github.com/nextcloud/viewer/pull/934) Bump webpack-cli from 4.6.0 to 4.7.0
* [viewer#935](https://github.com/nextcloud/viewer/pull/935) Bump node-polyfill-webpack-plugin from 1.1.0 to 1.1.2
* [viewer#938](https://github.com/nextcloud/viewer/pull/938) Bump eslint-plugin-import from 2.22.1 to 2.23.4
* [viewer#940](https://github.com/nextcloud/viewer/pull/940) Bump vue-loader from 15.9.6 to 15.9.7
* [viewer#941](https://github.com/nextcloud/viewer/pull/941) Bump eslint from 7.25.0 to 7.28.0


Pending PRs:

* [ ] #16708 Replace usage of "addslashes" with prepared statements @tianon
* [ ] #20605 Remove confusing placeholder in Sharing Settings @matthiasbe
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22628 Coalesce RewriteCond lines in .htaccess @Sp1l
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #24318 Use proper methods for display name retrieval @MorrisJobke
* [ ] #24827 Run oci tests against phpunit9/php8 @juliushaertl
* [ ] #25023 Fixes visual bug by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25109 Add command to scan external storages directly @icewind1991
* [ ] #25249 Moving between storages is not a rename @rullzer
* [ ] #25392 Dont return private storage interface from public mount interface @icewind1991
* [ ] #25418 Update variables.scss - Fallback font before Noto Color Emoji @kaktuspalme
* [ ] #25471 Add optional index API @rullzer
* [ ] #25540 ACLs without \ in the username throw exception @anikrooz
* [ ] #25768 Use mimetype from cache for workflow checks @icewind1991
* [ ] #25950 Add dedicated product name to OCP\Defaults @juliushaertl
* [ ] #26023 PoC: Emit events on files_versions frontend actions to allow apps to hook into them @juliushaertl
* [ ] #26178 Ability to add some entries out of rfc7033 @daita
* [ ] #26300 Add dedicated activities for file uploads to public shares @MorrisJobke
* [ ] #26318 Add typed event for loading additional external storage backends @icewind1991
* [ ] #26319 Move files_external to IBootstrap and remove some depricated stuff in the process @icewind1991
* [ ] #26320 Cleanup files sidebar navigation manager @icewind1991
* [ ] #26408 Sign in form best practice @kevin147147
* [ ] #26411 Catch node for share not found @skjnldsv
* [ ] #26421 OCC command to delete calendars @mattian
* [ ] #26430 Dashboard API for clients @eneiluj
* [ ] #26463 Fix S3 ObjectStore proxy option @maxbes
* [ ] #26571 Only allow removing existing shares that would not be allowed due to reshare restrictions @juliushaertl
* [ ] #26585 Drone: drop MariaDB 10.1 (EOL) add MariaDB 10.5 @acsfer
* [ ] #26681 Move HintException to OCP @juliushaertl
* [ ] #26688 Add proper message to created share not found @skjnldsv
* [ ] #26725 Fix federated scope not shown when public addressbook upload is disabled @danxuliu
* [ ] #26874 Rework search api to allow searching on multiple caches at once @icewind1991
* [ ] #26899 Add S3 SSE KMS key and bucketkey encryption @tsdicloud
* [ ] #26939 Let apps toggle an unread counter on app icons @juliushaertl
* [ ] #26982 Add some high level filesystem documention @icewind1991
* [ ] #27051 Add timestamp tooltip @Pytal
* [ ] #27098 Force 'name' key in array @daita
* [ ] #27119 Fix getTableNamesWithoutPrefix() @daita
* [ ] #27190 Deduplicate translations and fix double . @nickvergessen
* [ ] #27191 Make the database user backend cache case insensitive like the DB table @MorrisJobke
* [ ] #27196 Fix setUserValue bool test on testShowHiddenFiles & testCropImagePreviews @skjnldsv
* [ ] #27252 Bump @nextcloud/event-bus from 1.2.0 to 2.0.0 
* [ ] #27254 Bump @nextcloud/files from 1.1.0 to 2.0.0 
* [ ] #27259 Bump autosize from 4.0.2 to 5.0.0 
* [ ] #27261 Prevent supplied resource is not a valid stream resource @liamdemafelix
* [ ] #27378 Add dav plugin to trigger recalculating of checksums @icewind1991
* [ ] #27379 Multiple Emails UI and Integration @Pytal
* [ ] #27390 Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1 
* [ ] #27392 Bump dompurify from 2.2.8 to 2.2.9 
* [ ] #27393 Bump marked from 2.0.6 to 2.0.7 
* [ ] #27416 Bump vue and vue-template-compiler 
* [ ] #27452 Bump opis/closure from 3.6.1 to 3.6.2 @ChristophWurst
* [ ] [3rdparty#686](https://github.com/nextcloud/3rdparty/pull/686) Bump christophwurst/id3parser from 0.1.1 to 0.1.2 
* [ ] [files_pdfviewer#414](https://github.com/nextcloud/files_pdfviewer/pull/414) Disable content copy for PDF files that specify it @danxuliu
* [ ] [text#1574](https://github.com/nextcloud/text/pull/1574) Fix: rich workspaces overlap with new file dropdown @gary-kim
* [ ] [viewer#913](https://github.com/nextcloud/viewer/pull/913) React to sidebar events from nextcloud-bus @artonge
* [ ] [viewer#936](https://github.com/nextcloud/viewer/pull/936) Remove deprecation on open method @skjnldsv