### PR TITLE
make Provisioning API aware of multiple mails

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -54,6 +54,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#getEditableFields', 'url' => '/user/fields', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getEditableFieldsForUser', 'url' => '/user/fields/{userId}', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#editUser', 'url' => '/users/{userId}', 'verb' => 'PUT'],
+		['root' => '/cloud', 'name' => 'Users#editUserMultiValue', 'url' => '/users/{userId}/{collectionName}', 'verb' => 'PUT', 'requirements' => ['collectionName' => '[^(enable|disable)]']],
 		['root' => '/cloud', 'name' => 'Users#wipeUserDevices', 'url' => '/users/{userId}/wipe', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'Users#deleteUser', 'url' => '/users/{userId}', 'verb' => 'DELETE'],
 		['root' => '/cloud', 'name' => 'Users#enableUser', 'url' => '/users/{userId}/enable', 'verb' => 'PUT'],

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -54,7 +54,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#getEditableFields', 'url' => '/user/fields', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getEditableFieldsForUser', 'url' => '/user/fields/{userId}', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#editUser', 'url' => '/users/{userId}', 'verb' => 'PUT'],
-		['root' => '/cloud', 'name' => 'Users#editUserMultiValue', 'url' => '/users/{userId}/{collectionName}', 'verb' => 'PUT', 'requirements' => ['collectionName' => '[^(enable|disable)]']],
+		['root' => '/cloud', 'name' => 'Users#editUserMultiValue', 'url' => '/users/{userId}/{collectionName}', 'verb' => 'PUT', 'requirements' => ['collectionName' => '^(?!enable$|disable$)[a-zA-Z0-0_]*$']],
 		['root' => '/cloud', 'name' => 'Users#wipeUserDevices', 'url' => '/users/{userId}/wipe', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'Users#deleteUser', 'url' => '/users/{userId}', 'verb' => 'DELETE'],
 		['root' => '/cloud', 'name' => 'Users#enableUser', 'url' => '/users/{userId}/enable', 'verb' => 'PUT'],

--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -150,6 +150,20 @@ abstract class AUserData extends OCSController {
 			if ($includeScopes) {
 				$data[IAccountManager::PROPERTY_EMAIL . self::SCOPE_SUFFIX] = $userAccount->getProperty(IAccountManager::PROPERTY_EMAIL)->getScope();
 			}
+
+			$additionalEmails = $additionalEmailScopes = [];
+			$emailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
+			foreach ($emailCollection->getProperties() as $property) {
+				$additionalEmails[] = $property->getValue();
+				if ($includeScopes) {
+					$additionalEmailScopes = $property->getScope();
+				}
+			}
+			$data[IAccountManager::COLLECTION_EMAIL] = $additionalEmails;
+			if ($includeScopes) {
+				$data[IAccountManager::COLLECTION_EMAIL . self::SCOPE_SUFFIX] = $additionalEmailScopes;
+			}
+
 			$data[IAccountManager::PROPERTY_DISPLAYNAME] = $targetUserObject->getDisplayName();
 			if ($includeScopes) {
 				$data[IAccountManager::PROPERTY_DISPLAYNAME . self::SCOPE_SUFFIX] = $userAccount->getProperty(IAccountManager::PROPERTY_DISPLAYNAME)->getScope();

--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -156,7 +156,7 @@ abstract class AUserData extends OCSController {
 			foreach ($emailCollection->getProperties() as $property) {
 				$additionalEmails[] = $property->getValue();
 				if ($includeScopes) {
-					$additionalEmailScopes = $property->getScope();
+					$additionalEmailScopes[] = $property->getScope();
 				}
 			}
 			$data[IAccountManager::COLLECTION_EMAIL] = $additionalEmails;

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -592,6 +592,7 @@ class UsersController extends AUserData {
 			$permittedFields[] = IAccountManager::PROPERTY_EMAIL;
 		}
 
+		$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
 		$permittedFields[] = IAccountManager::PROPERTY_PHONE;
 		$permittedFields[] = IAccountManager::PROPERTY_ADDRESS;
 		$permittedFields[] = IAccountManager::PROPERTY_WEBSITE;

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -673,8 +673,12 @@ class UsersController extends AUserData {
 					}
 				}
 				if ($targetProperty instanceof IAccountProperty) {
-					$targetProperty->setScope($value);
-					$this->accountManager->updateAccount($userAccount);
+					try {
+						$targetProperty->setScope($value);
+						$this->accountManager->updateAccount($userAccount);
+					} catch (\InvalidArgumentException $e) {
+						throw new OCSException('', 102);
+					}
 				} else {
 					throw new OCSException('', 102);
 				}

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -54,7 +54,6 @@ use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\PropertyDoesNotExistException;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
@@ -77,8 +76,6 @@ use Psr\Log\LoggerInterface;
 
 class UsersController extends AUserData {
 
-	/** @var IAppManager */
-	private $appManager;
 	/** @var IURLGenerator */
 	protected $urlGenerator;
 	/** @var LoggerInterface */
@@ -100,7 +97,6 @@ class UsersController extends AUserData {
 								IRequest $request,
 								IUserManager $userManager,
 								IConfig $config,
-								IAppManager $appManager,
 								IGroupManager $groupManager,
 								IUserSession $userSession,
 								IAccountManager $accountManager,
@@ -121,7 +117,6 @@ class UsersController extends AUserData {
 							$accountManager,
 							$l10nFactory);
 
-		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
 		$this->logger = $logger;
 		$this->l10nFactory = $l10nFactory;
@@ -656,7 +651,6 @@ class UsersController extends AUserData {
 				$mailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
 				$mailCollection->removePropertyByValue($key);
 				if ($value !== '') {
-					// "replace on"
 					$mailCollection->addPropertyWithDefaults($value);
 				}
 				$this->accountManager->updateAccount($userAccount);

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -604,6 +604,10 @@ class UsersController extends AUserData {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 * @PasswordConfirmationRequired
+	 *
 	 * @throws OCSException
 	 */
 	public function editUserMultiValue(
@@ -663,7 +667,7 @@ class UsersController extends AUserData {
 				$mailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
 				$targetProperty = null;
 				foreach ($mailCollection->getProperties() as $property) {
-					if ($property->getValue() === $value) {
+					if ($property->getValue() === $key) {
 						$targetProperty = $property;
 						break;
 					}

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -3851,6 +3851,7 @@ class UsersControllerTest extends TestCase {
 	public function dataGetEditableFields() {
 		return [
 			[false, ISetDisplayNameBackend::class, [
+				IAccountManager::COLLECTION_EMAIL,
 				IAccountManager::PROPERTY_PHONE,
 				IAccountManager::PROPERTY_ADDRESS,
 				IAccountManager::PROPERTY_WEBSITE,
@@ -3859,6 +3860,7 @@ class UsersControllerTest extends TestCase {
 			[true, ISetDisplayNameBackend::class, [
 				IAccountManager::PROPERTY_DISPLAYNAME,
 				IAccountManager::PROPERTY_EMAIL,
+				IAccountManager::COLLECTION_EMAIL,
 				IAccountManager::PROPERTY_PHONE,
 				IAccountManager::PROPERTY_ADDRESS,
 				IAccountManager::PROPERTY_WEBSITE,
@@ -3866,6 +3868,7 @@ class UsersControllerTest extends TestCase {
 			]],
 			[true, UserInterface::class, [
 				IAccountManager::PROPERTY_EMAIL,
+				IAccountManager::COLLECTION_EMAIL,
 				IAccountManager::PROPERTY_PHONE,
 				IAccountManager::PROPERTY_ADDRESS,
 				IAccountManager::PROPERTY_WEBSITE,

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1071,7 +1071,8 @@ class UsersControllerTest extends TestCase {
 			'backendCapabilities' => [
 				'setDisplayName' => true,
 				'setPassword' => true,
-			]
+			],
+			'additional_mail' => [],
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UID']));
 	}
@@ -1198,7 +1199,8 @@ class UsersControllerTest extends TestCase {
 			'backendCapabilities' => [
 				'setDisplayName' => true,
 				'setPassword' => true,
-			]
+			],
+			'additional_mail' => [],
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UID']));
 	}
@@ -1363,7 +1365,8 @@ class UsersControllerTest extends TestCase {
 			'backendCapabilities' => [
 				'setDisplayName' => false,
 				'setPassword' => false,
-			]
+			],
+			'additional_mail' => [],
 		];
 		$this->assertEquals($expected, $this->invokePrivate($this->api, 'getUserData', ['UID']));
 	}

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -50,7 +50,6 @@ use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -77,8 +76,6 @@ class UsersControllerTest extends TestCase {
 	protected $userManager;
 	/** @var IConfig|MockObject */
 	protected $config;
-	/** @var IAppManager|MockObject */
-	protected $appManager;
 	/** @var Manager|MockObject */
 	protected $groupManager;
 	/** @var IUserSession|MockObject */
@@ -111,7 +108,6 @@ class UsersControllerTest extends TestCase {
 
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->appManager = $this->createMock(IAppManager::class);
 		$this->groupManager = $this->createMock(Manager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -131,7 +127,6 @@ class UsersControllerTest extends TestCase {
 				$this->request,
 				$this->userManager,
 				$this->config,
-				$this->appManager,
 				$this->groupManager,
 				$this->userSession,
 				$this->accountManager,
@@ -395,7 +390,6 @@ class UsersControllerTest extends TestCase {
 				$this->request,
 				$this->userManager,
 				$this->config,
-				$this->appManager,
 				$this->groupManager,
 				$this->userSession,
 				$this->accountManager,
@@ -3440,7 +3434,6 @@ class UsersControllerTest extends TestCase {
 				$this->request,
 				$this->userManager,
 				$this->config,
-				$this->appManager,
 				$this->groupManager,
 				$this->userSession,
 				$this->accountManager,
@@ -3513,7 +3506,6 @@ class UsersControllerTest extends TestCase {
 				$this->request,
 				$this->userManager,
 				$this->config,
-				$this->appManager,
 				$this->groupManager,
 				$this->userSession,
 				$this->accountManager,

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -168,9 +168,6 @@ trait Provisioning {
 		$response = $client->get($fullUrl, $options);
 		foreach ($settings->getRows() as $setting) {
 			$value = json_decode(json_encode(simplexml_load_string($response->getBody())->data->{$setting[0]}), 1);
-			if (in_array($setting[0], ['additional_mail', 'additional_mailScope'], true)) {
-				var_dump($value);
-			}
 			if (isset($value['element']) && in_array($setting[0], ['additional_mail', 'additional_mailScope'], true)) {
 				$expectedValues = explode(';', $setting[1]);
 				foreach ($expectedValues as $expected) {

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -168,15 +168,16 @@ trait Provisioning {
 		$response = $client->get($fullUrl, $options);
 		foreach ($settings->getRows() as $setting) {
 			$value = json_decode(json_encode(simplexml_load_string($response->getBody())->data->{$setting[0]}), 1);
-			if (isset($value[0])) {
-				if (in_array($setting[0], ['additional_mail', 'additional_mailScope'], true)) {
-					$expectedValues = explode(';', $setting[1]);
-					foreach ($expectedValues as $expected) {
-						Assert::assertTrue(in_array($expected, $value, true));
-					}
-				} else {
-					Assert::assertEquals($setting[1], $value[0], "", 0.0, 10, true);
+			if (in_array($setting[0], ['additional_mail', 'additional_mailScope'], true)) {
+				var_dump($value);
+			}
+			if (isset($value['element']) && in_array($setting[0], ['additional_mail', 'additional_mailScope'], true)) {
+				$expectedValues = explode(';', $setting[1]);
+				foreach ($expectedValues as $expected) {
+					Assert::assertTrue(in_array($expected, $value['element'], true));
 				}
+			} elseif (isset($value[0])) {
+				Assert::assertEquals($setting[1], $value[0], "", 0.0, 10, true);
 			} else {
 				Assert::assertEquals('', $setting[1]);
 			}

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -62,6 +62,7 @@ Feature: provisioning
     Then user "brand-new-user" has editable fields
       | displayname |
       | email |
+      | additional_mail |
       | phone |
       | address |
       | website |
@@ -70,6 +71,7 @@ Feature: provisioning
     Then user "brand-new-user" has editable fields
       | displayname |
       | email |
+      | additional_mail |
       | phone |
       | address |
       | website |
@@ -77,6 +79,7 @@ Feature: provisioning
     Then user "self" has editable fields
       | displayname |
       | email |
+      | additional_mail |
       | phone |
       | address |
       | website |
@@ -233,7 +236,7 @@ Feature: provisioning
 		And group "new-group" exists
 		And group "new-group" has
 			| displayname | new-group |
-			
+
 	Scenario: Create a group with custom display name
 		Given As an "admin"
 		And group "new-group" does not exist

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -103,6 +103,16 @@ Feature: provisioning
 			| value | no-reply@nextcloud.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
+    And sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | no.reply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | noreply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
 		And sending "PUT" to "/cloud/users/brand-new-user" with
 			| key | phone |
 			| value | +49 711 / 25 24 28-90 |
@@ -127,6 +137,7 @@ Feature: provisioning
 			| id | brand-new-user |
 			| displayname | Brand New User |
 			| email | no-reply@nextcloud.com |
+      | additional_mail | no.reply@nextcloud.com;noreply@nextcloud.com |
 			| phone | +4971125242890 |
 			| address | Foo Bar Town |
 			| website | https://nextcloud.com |
@@ -180,6 +191,33 @@ Feature: provisioning
 			| displaynameScope | v2-federated |
 			| avatarScope | v2-local |
 
+  Scenario: Edit a user account multivalue property scopes
+    Given user "brand-new-user" exists
+    And As an "brand-new-user"
+    When sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | no.reply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | noreply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
+      | key | no.reply@nextcloud.com |
+      | value | v2-federated |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
+      | key | noreply@nextcloud.com |
+      | value | v2-published |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then user "brand-new-user" has
+      | id | brand-new-user |
+      | additional_mailScope | v2-federated;v2-published |
+
 	Scenario: Edit a user account properties scopes with invalid or unsupported value
 		Given user "brand-new-user" exists
     And As an "brand-new-user"
@@ -198,6 +236,43 @@ Feature: provisioning
 			| value | v2-private |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
+
+  Scenario: Edit a user account multi-value property scopes with invalid or unsupported value
+    Given user "brand-new-user" exists
+    And As an "brand-new-user"
+    When sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | no.reply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
+      | key | no.reply@nextcloud.com |
+      | value | invalid |
+    Then the OCS status code should be "102"
+    And the HTTP status code should be "200"
+
+  Scenario: Delete a user account multi-value property value
+    Given user "brand-new-user" exists
+    And As an "brand-new-user"
+    When sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | no.reply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | additional_mail |
+      | value | noreply@nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When sending "PUT" to "/cloud/users/brand-new-user/additional_mail" with
+      | key | no.reply@nextcloud.com |
+      | value | |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then user "brand-new-user" has
+      | additional_mail | noreply@nextcloud.com |
+    Then user "brand-new-user" has not
+      | additional_mail | no.reply@nextcloud.com |
 
 	Scenario: An admin cannot edit user account property scopes
     Given As an "admin"

--- a/lib/base.php
+++ b/lib/base.php
@@ -68,6 +68,7 @@ use OCP\Share;
 use OC\Encryption\HookManager;
 use OC\Files\Filesystem;
 use OC\Share20\Hooks;
+use OCP\User\Events\UserChangedEvent;
 
 require_once 'public/Constants.php';
 
@@ -843,8 +844,9 @@ class OC {
 	}
 
 	private static function registerAccountHooks() {
-		$hookHandler = \OC::$server->get(\OC\Accounts\Hooks::class);
-		\OCP\Util::connectHook('OC_User', 'changeUser', $hookHandler, 'changeUserHook');
+		/** @var IEventDispatcher $dispatcher */
+		$dispatcher = \OC::$server->get(IEventDispatcher::class);
+		$dispatcher->addServiceListener(UserChangedEvent::class, \OC\Accounts\Hooks::class);
 	}
 
 	private static function registerAppRestrictionsHooks() {

--- a/lib/private/Accounts/Account.php
+++ b/lib/private/Accounts/Account.php
@@ -33,6 +33,7 @@ use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\IAccountPropertyCollection;
 use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\IUser;
+use RuntimeException;
 
 class Account implements IAccount {
 	use TAccountsHelper;
@@ -116,13 +117,16 @@ class Account implements IAccount {
 		return $this;
 	}
 
-	public function getPropertyCollection(string $propertyCollection): IAccountPropertyCollection {
-		if (!array_key_exists($propertyCollection, $this->properties)) {
-			throw new PropertyDoesNotExistException($propertyCollection);
+	public function getPropertyCollection(string $propertyCollectionName): IAccountPropertyCollection {
+		if (!$this->isCollection($propertyCollectionName)) {
+			throw new PropertyDoesNotExistException($propertyCollectionName);
 		}
-		if (!$this->properties[$propertyCollection] instanceof IAccountPropertyCollection) {
-			throw new \RuntimeException('Requested collection is not an IAccountPropertyCollection');
+		if (!array_key_exists($propertyCollectionName, $this->properties)) {
+			$this->properties[$propertyCollectionName] = new AccountPropertyCollection($propertyCollectionName);
 		}
-		return $this->properties[$propertyCollection];
+		if (!$this->properties[$propertyCollectionName] instanceof IAccountPropertyCollection) {
+			throw new RuntimeException('Requested collection is not an IAccountPropertyCollection');
+		}
+		return $this->properties[$propertyCollectionName];
 	}
 }

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -419,7 +419,7 @@ class AccountManager implements IAccountManager {
 		}
 	}
 
-	protected function 	dataArrayToJson(array $accountData): string {
+	protected function dataArrayToJson(array $accountData): string {
 		$jsonData = [];
 		foreach ($accountData as $property => $data) {
 			//$property = $data['name'];

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -228,7 +228,6 @@ class AccountManager implements IAccountManager {
 		$updated = true;
 
 		if ($oldUserData !== $data) {
-
 			$this->updateExistingUser($user, $data);
 		} else {
 			// nothing needs to be done if new and old data set are the same
@@ -297,7 +296,6 @@ class AccountManager implements IAccountManager {
 
 		$userDataArray = $this->importFromJson($accountData[0]['data'], $uid);
 		if ($userDataArray === null || $userDataArray === []) {
-
 			return $this->buildDefaultUserRecord($user);
 		}
 
@@ -339,7 +337,7 @@ class AccountManager implements IAccountManager {
 
 	/**
 	 * check if we need to ask the server for email verification, if yes we create a cronjob
-
+	 *
 	 */
 	protected function checkEmailVerification(IAccount $updatedAccount, array $oldData): void {
 		try {
@@ -369,14 +367,13 @@ class AccountManager implements IAccountManager {
 
 	/**
 	 * make sure that all expected data are set
-
+	 *
 	 */
 	protected function addMissingDefaultValues(array $userData): array {
 		foreach ($userData as $i => $value) {
 			if (!isset($value['verified'])) {
 				$userData[$i]['verified'] = self::NOT_VERIFIED;
 			}
-
 		}
 
 		return $userData;
@@ -612,7 +609,6 @@ class AccountManager implements IAccountManager {
 	}
 
 	public function updateAccount(IAccount $account): void {
-
 		$this->testValueLengths(iterator_to_array($account->getAllProperties()), true);
 		try {
 			$property = $account->getProperty(self::PROPERTY_PHONE);

--- a/lib/private/Accounts/AccountPropertyCollection.php
+++ b/lib/private/Accounts/AccountPropertyCollection.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OC\Accounts;
 
 use InvalidArgumentException;
+use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\IAccountPropertyCollection;
 
@@ -60,6 +61,18 @@ class AccountPropertyCollection implements IAccountPropertyCollection {
 			throw new InvalidArgumentException('Provided property does not match collection name');
 		}
 		$this->properties[] = $property;
+		return $this;
+	}
+
+	public function addPropertyWithDefaults(string $value): IAccountPropertyCollection {
+		$property = new AccountProperty(
+			$this->collectionName,
+			$value,
+			IAccountManager::SCOPE_LOCAL,
+			IAccountManager::NOT_VERIFIED,
+			''
+		);
+		$this->addProperty($property);
 		return $this;
 	}
 

--- a/lib/private/Accounts/Hooks.php
+++ b/lib/private/Accounts/Hooks.php
@@ -25,66 +25,55 @@
 namespace OC\Accounts;
 
 use OCP\Accounts\IAccountManager;
+use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
 use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
 use Psr\Log\LoggerInterface;
 
-class Hooks {
+class Hooks implements IEventListener {
 
-	/** @var AccountManager|null */
+	/** @var IAccountManager */
 	private $accountManager;
-
 	/** @var LoggerInterface */
 	private $logger;
 
-	public function __construct(LoggerInterface $logger) {
+	public function __construct(LoggerInterface $logger, IAccountManager $accountManager) {
 		$this->logger = $logger;
+		$this->accountManager = $accountManager;
 	}
 
 	/**
 	 * update accounts table if email address or display name was changed from outside
-	 *
-	 * @param array $params
 	 */
-	public function changeUserHook($params) {
-		$accountManager = $this->getAccountManager();
+	public function changeUserHook(IUser $user, string $feature, $newValue): void {
+		$account = $this->accountManager->getAccount($user);
 
-		/** @var IUser $user */
-		$user = isset($params['user']) ? $params['user'] : null;
-		$feature = isset($params['feature']) ? $params['feature'] : null;
-		$newValue = isset($params['value']) ? $params['value'] : null;
-
-		if (is_null($user) || is_null($feature) || is_null($newValue)) {
-			$this->logger->warning('Missing expected parameters in change user hook');
+		try {
+			switch ($feature) {
+				case 'eMailAddress':
+					$property = $account->getProperty(IAccountManager::PROPERTY_EMAIL);
+					break;
+				case 'displayName':
+					$property = $account->getProperty(IAccountManager::PROPERTY_DISPLAYNAME);
+					break;
+			}
+		} catch (PropertyDoesNotExistException $e) {
+			$this->logger->debug($e->getMessage(), ['exception' => $e]);
 			return;
 		}
 
-		$accountData = $accountManager->getUser($user);
-
-		switch ($feature) {
-			case 'eMailAddress':
-				if ($accountData[IAccountManager::PROPERTY_EMAIL]['value'] !== $newValue) {
-					$accountData[IAccountManager::PROPERTY_EMAIL]['value'] = $newValue;
-					$accountManager->updateUser($user, $accountData);
-				}
-				break;
-			case 'displayName':
-				if ($accountData[IAccountManager::PROPERTY_DISPLAYNAME]['value'] !== $newValue) {
-					$accountData[IAccountManager::PROPERTY_DISPLAYNAME]['value'] = $newValue;
-					$accountManager->updateUser($user, $accountData);
-				}
-				break;
+		if (isset($property) && $property->getValue() !== (string)$newValue) {
+			$property->setValue($newValue);
+			$this->accountManager->updateAccount($account);
 		}
 	}
 
-	/**
-	 * return instance of accountManager
-	 *
-	 * @return AccountManager
-	 */
-	protected function getAccountManager(): AccountManager {
-		if ($this->accountManager === null) {
-			$this->accountManager = \OC::$server->query(AccountManager::class);
+	public function handle(Event $event): void {
+		if(!$event instanceof UserChangedEvent) {
+			return;
 		}
-		return $this->accountManager;
+		$this->changeUserHook($event->getUser(), $event->getFeature(), $event->getValue());
 	}
 }

--- a/lib/private/Accounts/Hooks.php
+++ b/lib/private/Accounts/Hooks.php
@@ -71,7 +71,7 @@ class Hooks implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if(!$event instanceof UserChangedEvent) {
+		if (!$event instanceof UserChangedEvent) {
 			return;
 		}
 		$this->changeUserHook($event->getUser(), $event->getFeature(), $event->getValue());

--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -39,6 +39,7 @@ use OC\KnownUser\KnownUserService;
 use OC\User\Manager;
 use OC\User\NoUserException;
 use OCP\Accounts\IAccountManager;
+use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -126,9 +127,13 @@ class AvatarManager implements IAvatarManager {
 			$folder = $this->appData->newFolder($userId);
 		}
 
-		$account = $this->accountManager->getAccount($user);
-		$avatarProperties = $account->getProperty(IAccountManager::PROPERTY_AVATAR);
-		$avatarScope = $avatarProperties->getScope();
+		try {
+			$account = $this->accountManager->getAccount($user);
+			$avatarProperties = $account->getProperty(IAccountManager::PROPERTY_AVATAR);
+			$avatarScope = $avatarProperties->getScope();
+		} catch (PropertyDoesNotExistException $e) {
+			$avatarScope = '';
+		}
 
 		if (
 			// v2-private scope hides the avatar from public access and from unknown users

--- a/lib/public/Accounts/IAccount.php
+++ b/lib/public/Accounts/IAccount.php
@@ -94,9 +94,10 @@ interface IAccount extends \JsonSerializable {
 	/**
 	 * Returns the requestes propery collection (multi-value properties)
 	 *
+	 * @throws PropertyDoesNotExistException against invalid collection name
 	 * @since 22.0.0
 	 */
-	public function getPropertyCollection(string $propertyCollection): IAccountPropertyCollection;
+	public function getPropertyCollection(string $propertyCollectionName): IAccountPropertyCollection;
 
 	/**
 	 * Get all properties that match the provided filters for scope and verification status

--- a/lib/public/Accounts/IAccountPropertyCollection.php
+++ b/lib/public/Accounts/IAccountPropertyCollection.php
@@ -69,6 +69,14 @@ interface IAccountPropertyCollection extends JsonSerializable {
 	public function addProperty(IAccountProperty $property): IAccountPropertyCollection;
 
 	/**
+	 * adds a property to this collection with only specifying the value
+	 *
+	 * @throws InvalidArgumentException
+	 * @since 22.0.0
+	 */
+	public function addPropertyWithDefaults(string $value): IAccountPropertyCollection;
+
+	/**
 	 * removes a property of this collection
 	 *
 	 * @since 22.0.0

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -464,6 +464,7 @@ class AccountManagerTest extends TestCase {
 		$expected = [
 			'key1' => ['value' => 'value1', 'verified' => '0'],
 			'key2' => ['value' => 'value1', 'verified' => '0'],
+			'additional_mail' => []
 		];
 
 		$result = $this->invokePrivate($this->accountManager, 'addMissingDefaultValues', [$input]);

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -278,7 +278,7 @@ class AccountManagerTest extends TestCase {
 	 * @param bool $updateExisting
 	 */
 	public function testUpdateUser($newData, $oldData, $insertNew, $updateExisting) {
-		$accountManager = $this->getInstance(['getUser', 'insertNewUser', 'updateExistingUser', 'checkEmailVerification']);
+		$accountManager = $this->getInstance(['getUser', 'insertNewUser', 'updateExistingUser']);
 		/** @var IUser $user */
 		$user = $this->createMock(IUser::class);
 
@@ -286,8 +286,6 @@ class AccountManagerTest extends TestCase {
 		$accountManager->expects($this->once())->method('getUser')->with($user)->willReturn($oldData);
 
 		if ($updateExisting) {
-			$accountManager->expects($this->once())->method('checkEmailVerification')
-				->with($oldData, $newData, $user)->willReturn($newData);
 			$accountManager->expects($this->once())->method('updateExistingUser')
 				->with($user, $newData);
 			$accountManager->expects($this->never())->method('insertNewUser');
@@ -300,7 +298,6 @@ class AccountManagerTest extends TestCase {
 
 		if (!$insertNew && !$updateExisting) {
 			$accountManager->expects($this->never())->method('updateExistingUser');
-			$accountManager->expects($this->never())->method('checkEmailVerification');
 			$accountManager->expects($this->never())->method('insertNewUser');
 			$this->eventDispatcher->expects($this->never())->method('dispatch');
 		} else {

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -108,23 +108,71 @@ class AccountManagerTest extends TestCase {
 			[
 				'user' => $this->makeUser('j.doe', 'Jane Doe', 'jane.doe@acme.com'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Jane Doe', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'jane.doe@acme.com', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://acme.com', 'scope' => IAccountManager::SCOPE_PRIVATE],
+					IAccountManager::PROPERTY_DISPLAYNAME => [
+						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
+						'value' => 'Jane Doe',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					IAccountManager::PROPERTY_EMAIL => [
+						'name' => IAccountManager::PROPERTY_EMAIL,
+						'value' => 'jane.doe@acme.com',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_TWITTER => [
+						'name' => IAccountManager::PROPERTY_TWITTER,
+						'value' => '@sometwitter',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					IAccountManager::PROPERTY_PHONE => [
+						'name' => IAccountManager::PROPERTY_PHONE,
+						'value' => '+491601231212',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					IAccountManager::PROPERTY_ADDRESS => [
+						'name' => IAccountManager::PROPERTY_ADDRESS,
+						'value' => 'some street',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_WEBSITE => [
+						'name' => IAccountManager::PROPERTY_WEBSITE,
+						'value' => 'https://acme.com',
+						'scope' => IAccountManager::SCOPE_PRIVATE
+					],
 				],
 			],
 			[
 				'user' => $this->makeUser('a.allison', 'Alice Allison', 'a.allison@example.org'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Alice Allison', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'a.allison@example.org', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@a_alice', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491602312121', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'Dundee Road 45', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_LOCAL],
+					IAccountManager::PROPERTY_DISPLAYNAME => [
+						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
+						'value' => 'Alice Allison',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_EMAIL => [
+						'name' => IAccountManager::PROPERTY_EMAIL,
+						'value' => 'a.allison@example.org',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_TWITTER => [
+						'name' => IAccountManager::PROPERTY_TWITTER,
+						'value' => '@a_alice',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					IAccountManager::PROPERTY_PHONE => [
+						'name' => IAccountManager::PROPERTY_PHONE,
+						'value' => '+491602312121',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_ADDRESS => [
+						'name' => IAccountManager::PROPERTY_ADDRESS,
+						'value' => 'Dundee Road 45',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_WEBSITE => [
+						'name' => IAccountManager::PROPERTY_WEBSITE,
+						'value' => 'https://example.org',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
 				],
 			],
 			[
@@ -148,20 +196,52 @@ class AccountManagerTest extends TestCase {
 					IAccountManager::PROPERTY_ADDRESS => ['value' => 'Pinapple Street 22', 'scope' => IAccountManager::SCOPE_LOCAL],
 					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://emca.com', 'scope' => IAccountManager::SCOPE_FEDERATED],
 					IAccountManager::COLLECTION_EMAIL => [
-						['value' => 'k.cheng@emca.com', 'scope' => IAccountManager::SCOPE_LOCAL],
-						['value' => 'kai.cheng@emca.com', 'scope' => IAccountManager::SCOPE_LOCAL],
+						[
+							'name' => IAccountManager::COLLECTION_EMAIL,
+							'value' => 'k.cheng@emca.com',
+							'scope' => IAccountManager::SCOPE_LOCAL
+						],
+						[
+							'name' => IAccountManager::COLLECTION_EMAIL,
+							'value' => 'kai.cheng@emca.com',
+							'scope' => IAccountManager::SCOPE_LOCAL
+						],
 					],
 				],
 			],
 			[
 				'user' => $this->makeUser('goodpal@elpmaxe.org', 'Goodpal, Kim', 'goodpal@elpmaxe.org'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Goodpal, Kim', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'goodpal@elpmaxe.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+71602121231', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'Octopus Ave 17', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://elpmaxe.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
+					IAccountManager::PROPERTY_DISPLAYNAME => [
+						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
+						'value' => 'Goodpal, Kim',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					IAccountManager::PROPERTY_EMAIL => [
+						'name' => IAccountManager::PROPERTY_EMAIL,
+						'value' => 'goodpal@elpmaxe.org',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					IAccountManager::PROPERTY_TWITTER => [
+						'name' => IAccountManager::PROPERTY_TWITTER,
+						'value' => '',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					IAccountManager::PROPERTY_PHONE => [
+						'name' => IAccountManager::PROPERTY_PHONE,
+						'value' => '+71602121231',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					IAccountManager::PROPERTY_ADDRESS => [
+						'name' => IAccountManager::PROPERTY_ADDRESS,
+						'value' => 'Octopus Ave 17',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					IAccountManager::PROPERTY_WEBSITE => [
+						'name' => IAccountManager::PROPERTY_WEBSITE,
+						'value' => 'https://elpmaxe.org',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
 				],
 			],
 		];
@@ -250,144 +330,6 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	public function updateUserSetScopeProvider() {
-		return [
-			// regular scope switching
-			[
-				[
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_AVATAR => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_PRIVATE],
-				],
-				[
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PRIVATE],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-				],
-				[
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PRIVATE],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-				],
-			],
-			// legacy scope mapping, the given visibility values get converted to scopes
-			[
-				[
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_PRIVATE],
-				],
-				[
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::VISIBILITY_PUBLIC],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::VISIBILITY_CONTACTS_ONLY],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::VISIBILITY_PRIVATE],
-				],
-				[
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_LOCAL],
-				],
-			],
-			// invalid or unsupported scope values get converted to SCOPE_LOCAL
-			[
-				[
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-				],
-				[
-					// SCOPE_PRIVATE is not allowed for display name and email
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_PRIVATE],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_PRIVATE],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_LOCAL],
-				],
-				[
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_LOCAL],
-				],
-				false, false,
-			],
-			// illegal scope values
-			[
-				[
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => IAccountManager::SCOPE_PRIVATE],
-				],
-				[
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491601231212', 'scope' => ''],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'some street', 'scope' => 'v2-invalid'],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.org', 'scope' => 'invalid'],
-				],
-				[],
-				true, true
-			],
-			// invalid or unsupported scope values throw an exception when passing $throwOnData=true
-			[
-				[IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_PUBLISHED]],
-				[IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Display Name', 'scope' => IAccountManager::SCOPE_PRIVATE]],
-				null,
-				// throw exception
-				true, true,
-			],
-			[
-				[IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_PUBLISHED]],
-				[IAccountManager::PROPERTY_EMAIL => ['value' => 'test@example.org', 'scope' => IAccountManager::SCOPE_PRIVATE]],
-				null,
-				// throw exception
-				true, true,
-			],
-			[
-				[IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => IAccountManager::SCOPE_PUBLISHED]],
-				[IAccountManager::PROPERTY_TWITTER => ['value' => '@sometwitter', 'scope' => 'invalid']],
-				null,
-				// throw exception
-				true, true,
-			],
-		];
-	}
-
-	/**
-	 * @dataProvider updateUserSetScopeProvider
-	 */
-	public function testUpdateUserSetScope($oldData, $newData, $savedData, $throwOnData = true, $expectedThrow = false) {
-		$accountManager = $this->getInstance(['getUser', 'insertNewUser', 'updateExistingUser', 'updateVerifyStatus', 'checkEmailVerification']);
-		/** @var IUser $user */
-		$user = $this->createMock(IUser::class);
-
-		$accountManager->expects($this->once())->method('getUser')->with($user)->willReturn($oldData);
-
-		if ($expectedThrow) {
-			$accountManager->expects($this->never())->method('updateExistingUser');
-			$this->expectException(\InvalidArgumentException::class);
-			$this->expectExceptionMessage('scope');
-		} else {
-			$accountManager->expects($this->once())->method('checkEmailVerification')
-				->with($oldData, $savedData, $user)->willReturn($savedData);
-			$accountManager->expects($this->once())->method('updateVerifyStatus')
-				->with($oldData, $savedData)->willReturn($savedData);
-			$accountManager->expects($this->once())->method('updateExistingUser')
-				->with($user, $savedData);
-			$accountManager->expects($this->never())->method('insertNewUser');
-		}
-
-		$accountManager->updateUser($user, $newData, $throwOnData);
-	}
-
 	/**
 	 * @dataProvider dataTestGetUser
 	 *
@@ -433,8 +375,8 @@ class AccountManagerTest extends TestCase {
 	public function testUpdateExistingUser() {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->atLeastOnce())->method('getUID')->willReturn('uid');
-		$oldData = ['key' => ['value' => 'value']];
-		$newData = ['newKey' => ['value' => 'newValue']];
+		$oldData = ['key' => ['value' => 'value', 'name' => 'name']];
+		$newData = ['newKey' => ['value' => 'newValue', 'name' => 'name']];
 
 		$this->addDummyValuesToTable('uid', $oldData);
 		$this->invokePrivate($this->accountManager, 'updateExistingUser', [$user, $newData]);
@@ -445,13 +387,14 @@ class AccountManagerTest extends TestCase {
 	public function testInsertNewUser() {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$uid = 'uid';
-		$data = ['key' => ['value' => 'value']];
+		$data = ['key' => ['value' => 'value', 'name' => 'name']];
 
 		$user->expects($this->atLeastOnce())->method('getUID')->willReturn($uid);
 		$this->assertNull($this->getDataFromTable($uid));
 		$this->invokePrivate($this->accountManager, 'insertNewUser', [$user, $data]);
 
 		$dataFromDb = $this->getDataFromTable($uid);
+		$dataFromDb['key']['name'] = 'name'; // from transformation
 		$this->assertEquals($data, $dataFromDb);
 	}
 
@@ -462,8 +405,8 @@ class AccountManagerTest extends TestCase {
 		];
 
 		$expected = [
-			'key1' => ['value' => 'value1', 'verified' => '0'],
-			'key2' => ['value' => 'value1', 'verified' => '0'],
+			'key1' => ['value' => 'value1', 'verified' => '0', 'name' => 'key1'],
+			'key2' => ['value' => 'value1', 'verified' => '0', 'name' => 'key2'],
 			'additional_mail' => []
 		];
 

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -108,32 +108,32 @@ class AccountManagerTest extends TestCase {
 			[
 				'user' => $this->makeUser('j.doe', 'Jane Doe', 'jane.doe@acme.com'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => [
+					[
 						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
 						'value' => 'Jane Doe',
 						'scope' => IAccountManager::SCOPE_PUBLISHED
 					],
-					IAccountManager::PROPERTY_EMAIL => [
+					[
 						'name' => IAccountManager::PROPERTY_EMAIL,
 						'value' => 'jane.doe@acme.com',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_TWITTER => [
+					[
 						'name' => IAccountManager::PROPERTY_TWITTER,
 						'value' => '@sometwitter',
 						'scope' => IAccountManager::SCOPE_PUBLISHED
 					],
-					IAccountManager::PROPERTY_PHONE => [
+					[
 						'name' => IAccountManager::PROPERTY_PHONE,
 						'value' => '+491601231212',
 						'scope' => IAccountManager::SCOPE_FEDERATED
 					],
-					IAccountManager::PROPERTY_ADDRESS => [
+					[
 						'name' => IAccountManager::PROPERTY_ADDRESS,
 						'value' => 'some street',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_WEBSITE => [
+					[
 						'name' => IAccountManager::PROPERTY_WEBSITE,
 						'value' => 'https://acme.com',
 						'scope' => IAccountManager::SCOPE_PRIVATE
@@ -143,32 +143,32 @@ class AccountManagerTest extends TestCase {
 			[
 				'user' => $this->makeUser('a.allison', 'Alice Allison', 'a.allison@example.org'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => [
+					[
 						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
 						'value' => 'Alice Allison',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_EMAIL => [
+					[
 						'name' => IAccountManager::PROPERTY_EMAIL,
 						'value' => 'a.allison@example.org',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_TWITTER => [
+					[
 						'name' => IAccountManager::PROPERTY_TWITTER,
 						'value' => '@a_alice',
 						'scope' => IAccountManager::SCOPE_FEDERATED
 					],
-					IAccountManager::PROPERTY_PHONE => [
+					[
 						'name' => IAccountManager::PROPERTY_PHONE,
 						'value' => '+491602312121',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_ADDRESS => [
+					[
 						'name' => IAccountManager::PROPERTY_ADDRESS,
 						'value' => 'Dundee Road 45',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_WEBSITE => [
+					[
 						'name' => IAccountManager::PROPERTY_WEBSITE,
 						'value' => 'https://example.org',
 						'scope' => IAccountManager::SCOPE_LOCAL
@@ -178,66 +178,112 @@ class AccountManagerTest extends TestCase {
 			[
 				'user' => $this->makeUser('b32c5a5b-1084-4380-8856-e5223b16de9f', 'Armel Oliseh', 'oliseh@example.com'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'Armel Oliseh', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'oliseh@example.com', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+491603121212', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'Sunflower Blvd. 77', 'scope' => IAccountManager::SCOPE_PUBLISHED],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://example.com', 'scope' => IAccountManager::SCOPE_PUBLISHED],
+					[
+						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
+						'value' => 'Armel Oliseh',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_EMAIL,
+						'value' => 'oliseh@example.com',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_TWITTER,
+						'value' => '',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					[
+						'name' => IAccountManager::PROPERTY_PHONE,
+						'value' => '+491603121212',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_ADDRESS,
+						'value' => 'Sunflower Blvd. 77',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_WEBSITE,
+						'value' => 'https://example.com',
+						'scope' => IAccountManager::SCOPE_PUBLISHED
+					],
 				],
 			],
 			[
 				'user' => $this->makeUser('31b5316a-9b57-4b17-970a-315a4cbe73eb', 'K. Cheng', 'cheng@emca.com'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'K. Cheng', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_EMAIL => ['value' => 'cheng@emca.com', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::PROPERTY_TWITTER => ['value' => '', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_PHONE => ['value' => '+71601212123', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_ADDRESS => ['value' => 'Pinapple Street 22', 'scope' => IAccountManager::SCOPE_LOCAL],
-					IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://emca.com', 'scope' => IAccountManager::SCOPE_FEDERATED],
-					IAccountManager::COLLECTION_EMAIL => [
-						[
-							'name' => IAccountManager::COLLECTION_EMAIL,
-							'value' => 'k.cheng@emca.com',
-							'scope' => IAccountManager::SCOPE_LOCAL
-						],
-						[
-							'name' => IAccountManager::COLLECTION_EMAIL,
-							'value' => 'kai.cheng@emca.com',
-							'scope' => IAccountManager::SCOPE_LOCAL
-						],
+					[
+						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
+						'value' => 'K. Cheng',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_EMAIL,
+						'value' => 'cheng@emca.com',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					[
+						'name' => IAccountManager::PROPERTY_TWITTER,
+						'value' => '', '
+						scope' => IAccountManager::SCOPE_LOCAL
+					],
+					[
+						'name' => IAccountManager::PROPERTY_PHONE,
+						'value' => '+71601212123',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					[
+						'name' => IAccountManager::PROPERTY_ADDRESS,
+						'value' => 'Pinapple Street 22',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					[
+						'name' => IAccountManager::PROPERTY_WEBSITE,
+						'value' => 'https://emca.com',
+						'scope' => IAccountManager::SCOPE_FEDERATED
+					],
+					[
+						'name' => IAccountManager::COLLECTION_EMAIL,
+						'value' => 'k.cheng@emca.com',
+						'scope' => IAccountManager::SCOPE_LOCAL
+					],
+					[
+						'name' => IAccountManager::COLLECTION_EMAIL,
+						'value' => 'kai.cheng@emca.com',
+						'scope' => IAccountManager::SCOPE_LOCAL
 					],
 				],
 			],
 			[
 				'user' => $this->makeUser('goodpal@elpmaxe.org', 'Goodpal, Kim', 'goodpal@elpmaxe.org'),
 				'data' => [
-					IAccountManager::PROPERTY_DISPLAYNAME => [
+					[
 						'name' => IAccountManager::PROPERTY_DISPLAYNAME,
 						'value' => 'Goodpal, Kim',
 						'scope' => IAccountManager::SCOPE_PUBLISHED
 					],
-					IAccountManager::PROPERTY_EMAIL => [
+					[
 						'name' => IAccountManager::PROPERTY_EMAIL,
 						'value' => 'goodpal@elpmaxe.org',
 						'scope' => IAccountManager::SCOPE_PUBLISHED
 					],
-					IAccountManager::PROPERTY_TWITTER => [
+					[
 						'name' => IAccountManager::PROPERTY_TWITTER,
 						'value' => '',
 						'scope' => IAccountManager::SCOPE_LOCAL
 					],
-					IAccountManager::PROPERTY_PHONE => [
+					[
 						'name' => IAccountManager::PROPERTY_PHONE,
 						'value' => '+71602121231',
 						'scope' => IAccountManager::SCOPE_FEDERATED
 					],
-					IAccountManager::PROPERTY_ADDRESS => [
+					[
 						'name' => IAccountManager::PROPERTY_ADDRESS,
 						'value' => 'Octopus Ave 17',
 						'scope' => IAccountManager::SCOPE_FEDERATED
 					],
-					IAccountManager::PROPERTY_WEBSITE => [
+					[
 						'name' => IAccountManager::PROPERTY_WEBSITE,
 						'value' => 'https://elpmaxe.org',
 						'scope' => IAccountManager::SCOPE_PUBLISHED
@@ -324,82 +370,15 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestGetUser
-	 *
-	 * @param string $setUser
-	 * @param array $setData
-	 * @param IUser $askUser
-	 * @param array $expectedData
-	 * @param bool $userAlreadyExists
-	 */
-	public function testGetUser($setUser, $setData, $askUser, $expectedData, $userAlreadyExists) {
-		$accountManager = $this->getInstance(['buildDefaultUserRecord', 'insertNewUser', 'addMissingDefaultValues']);
-		if (!$userAlreadyExists) {
-			$accountManager->expects($this->once())->method('buildDefaultUserRecord')
-				->with($askUser)->willReturn($expectedData);
-			$accountManager->expects($this->once())->method('insertNewUser')
-				->with($askUser, $expectedData);
-		}
-
-		if (empty($expectedData)) {
-			$accountManager->expects($this->never())->method('addMissingDefaultValues');
-		} else {
-			$accountManager->expects($this->once())->method('addMissingDefaultValues')->with($expectedData)
-				->willReturn($expectedData);
-		}
-
-		$this->addDummyValuesToTable($setUser, $setData);
-		$this->assertEquals($expectedData, $this->invokePrivate($accountManager, 'getUser', [$askUser]));
-	}
-
-	public function dataTestGetUser() {
-		$user1 = $this->getMockBuilder(IUser::class)->getMock();
-		$user1->expects($this->any())->method('getUID')->willReturn('user1');
-		$user2 = $this->getMockBuilder(IUser::class)->getMock();
-		$user2->expects($this->any())->method('getUID')->willReturn('user2');
-		return [
-			['user1', ['key' => 'value'], $user1, ['key' => 'value'], true],
-			['user1', ['key' => 'value'], $user2, [], false],
-		];
-	}
-
-	public function testUpdateExistingUser() {
-		$user = $this->getMockBuilder(IUser::class)->getMock();
-		$user->expects($this->atLeastOnce())->method('getUID')->willReturn('uid');
-		$oldData = ['key' => ['value' => 'value', 'name' => 'name']];
-		$newData = ['newKey' => ['value' => 'newValue', 'name' => 'name']];
-
-		$this->addDummyValuesToTable('uid', $oldData);
-		$this->invokePrivate($this->accountManager, 'updateExistingUser', [$user, $newData]);
-		$newDataFromTable = $this->getDataFromTable('uid');
-		$this->assertEquals($newData, $newDataFromTable);
-	}
-
-	public function testInsertNewUser() {
-		$user = $this->getMockBuilder(IUser::class)->getMock();
-		$uid = 'uid';
-		$data = ['key' => ['value' => 'value', 'name' => 'name']];
-
-		$user->expects($this->atLeastOnce())->method('getUID')->willReturn($uid);
-		$this->assertNull($this->getDataFromTable($uid));
-		$this->invokePrivate($this->accountManager, 'insertNewUser', [$user, $data]);
-
-		$dataFromDb = $this->getDataFromTable($uid);
-		$dataFromDb['key']['name'] = 'name'; // from transformation
-		$this->assertEquals($data, $dataFromDb);
-	}
-
 	public function testAddMissingDefaultValues() {
 		$input = [
-			'key1' => ['value' => 'value1', 'verified' => '0'],
-			'key2' => ['value' => 'value1'],
+			['value' => 'value1', 'verified' => '0', 'name' => 'key1'],
+			['value' => 'value1', 'name' => 'key2'],
 		];
 
 		$expected = [
-			'key1' => ['value' => 'value1', 'verified' => '0', 'name' => 'key1'],
-			'key2' => ['value' => 'value1', 'verified' => '0', 'name' => 'key2'],
-			'additional_mail' => []
+			['value' => 'value1', 'verified' => '0', 'name' => 'key1'],
+			['value' => 'value1', 'name' => 'key2', 'verified' => '0'],
 		];
 
 		$result = $this->invokePrivate($this->accountManager, 'addMissingDefaultValues', [$input]);
@@ -419,46 +398,30 @@ class AccountManagerTest extends TestCase {
 			->execute();
 	}
 
-	private function getDataFromTable($uid) {
-		$query = $this->connection->getQueryBuilder();
-		$query->select('data')->from($this->table)
-			->where($query->expr()->eq('uid', $query->createParameter('uid')))
-			->setParameter('uid', $uid);
-		$query->execute();
-
-		$qResult = $query->execute();
-		$result = $qResult->fetchAll();
-		$qResult->closeCursor();
-
-		if (!empty($result)) {
-			return json_decode($result[0]['data'], true);
-		}
-	}
-
 	public function testGetAccount() {
 		$accountManager = $this->getInstance(['getUser']);
 		/** @var IUser $user */
 		$user = $this->createMock(IUser::class);
 
 		$data = [
-			IAccountManager::PROPERTY_TWITTER =>
-				[
-					'value' => '@twitterhandle',
-					'scope' => IAccountManager::SCOPE_LOCAL,
-					'verified' => IAccountManager::NOT_VERIFIED,
-				],
-			IAccountManager::PROPERTY_EMAIL =>
-				[
-					'value' => 'test@example.com',
-					'scope' => IAccountManager::SCOPE_PUBLISHED,
-					'verified' => IAccountManager::VERIFICATION_IN_PROGRESS,
-				],
-			IAccountManager::PROPERTY_WEBSITE =>
-				[
-					'value' => 'https://example.com',
-					'scope' => IAccountManager::SCOPE_FEDERATED,
-					'verified' => IAccountManager::VERIFIED,
-				],
+			[
+				'value' => '@twitterhandle',
+				'scope' => IAccountManager::SCOPE_LOCAL,
+				'verified' => IAccountManager::NOT_VERIFIED,
+				'name' => IAccountManager::PROPERTY_TWITTER,
+			],
+			[
+				'value' => 'test@example.com',
+				'scope' => IAccountManager::SCOPE_PUBLISHED,
+				'verified' => IAccountManager::VERIFICATION_IN_PROGRESS,
+				'name' => IAccountManager::PROPERTY_EMAIL,
+			],
+			[
+				'value' => 'https://example.com',
+				'scope' => IAccountManager::SCOPE_FEDERATED,
+				'verified' => IAccountManager::VERIFIED,
+				'name' => IAccountManager::PROPERTY_WEBSITE,
+			],
 		];
 		$expected = new Account($user);
 		$expected->setProperty(IAccountManager::PROPERTY_TWITTER, '@twitterhandle', IAccountManager::SCOPE_LOCAL, IAccountManager::NOT_VERIFIED);


### PR DESCRIPTION
This extends the provisioning API as following

## getUser

endpoint: `ocs/v2.php/cloud/users/2d42e983-a7a8-40b1-8e4a-b8afeb5244240b`

### Original response

```xml
<?xml version="1.0"?>
<ocs>
 <meta>…</meta>
 <data>
  …
  <email>person_11@example.org</email>
  <displayname>Isabel, Morgan (person_11)</displayname>
  …
 </data>
</ocs>
```

### New, with no additional mail set

```xml
…
  <email>person_11@example.org</email>
  <additional_mail/>
  <displayname>Isabel, Morgan (person_11)</displayname>
…
```

### New, with one or more additional mail set

```xml
…
  <email>person_11@example.org</email>
  <additional_mail>
   <element>test1@example.org</element>
   <element>test2@example.org</element>
   <element>test3@example.org</element>
  </additional_mail>
  <displayname>Isabel, Morgan (person_11)</displayname>
…
```

## getEditableFields(ForUser)

endpoint: `ocs/v2.php/cloud/user/fields/e8a7e882-5c5e-4f61-b6bb-bc5fd9b3cb4b`

one entry added unconditionally

```xml
<?xml version="1.0"?>
<ocs>
 <meta>… </meta>
 <data>
  …
  <element>additional_mail</element>
  …
 </data>
</ocs>

```

## editUser

endpoint: `ocs/v2.php/cloud/users/2d42e983-a7a8-40b1-8e4a-b8afeb5244240b`
method: `PUT` 

- To add an additional email, just use 'additional_mail' as key.

- Deleting and setting scope is not possible with this endpoint as we need the value as reference.

## editUserMultiValue

endpoint: `ocs/v2.php/cloud/users/2d42e983-a7a8-40b1-8e4a-b8afeb5244240b/{collectionName}`
method: `PUT` 

- To remove a value, assign the email to the `key` parameter and leave the value empty. Future properties may implement renaming by using `key` as old value and `value` as new value.
- To set the scope, append the `Scope` suffix to the collectionName. `key` is the mail address, `value` the scope value.

---

contributes to #26866 