### PR TITLE
Add regex to match Windows 10 calendar user-agent

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
@@ -40,9 +40,12 @@ class Plugin extends ServerPlugin {
 	 * list of regular expressions for calendar user agents,
 	 * that do not support subscriptions on their own
 	 *
+	 * /^MSFT-WIN-3/ - Windows 10 Calendar
 	 * @var string[]
 	 */
-	public const ENABLE_FOR_CLIENTS = [];
+	public const ENABLE_FOR_CLIENTS = [
+		"/^MSFT-WIN-3/"
+	];
 
 	/**
 	 * @var bool

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
@@ -31,7 +31,7 @@ class PluginTest extends \Test\TestCase {
 		$request = $this->createMock(IRequest::class);
 		$request->expects($this->at(0))
 			->method('isUserAgent')
-			->with([])
+			->with(Plugin::ENABLE_FOR_CLIENTS)
 			->willReturn(false);
 
 		$request->expects($this->at(1))
@@ -48,7 +48,7 @@ class PluginTest extends \Test\TestCase {
 		$request = $this->createMock(IRequest::class);
 		$request->expects($this->at(0))
 			->method('isUserAgent')
-			->with([])
+			->with(Plugin::ENABLE_FOR_CLIENTS)
 			->willReturn(false);
 
 		$request->expects($this->at(1))


### PR DESCRIPTION
This pull requests adds Windows 10 calendar to the list of user-agents in WebCalCaching -plugin, and exposes subscribed calendars to Windows 10 calendar client.

Typical user-agent string for Windows 10 Calendar is: `MSFT-WIN-3/10.0.19041`
Included regex matches, the `MSFT-WIN-3` part only.

Considers #17754 

@tcitworld 