### PR TITLE
Remove the CAN_INSTALL file when occ maintenance:install is complete

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -107,6 +107,9 @@ class Install extends Command {
 			$this->printErrors($output, $errors);
 			return 1;
 		}
+		if ($setupHelper->canInstallExists()) {
+			$output->writeln('<warn>Could not remove CAN_INSTALL from the config folder. Please remove this file manually.</warn>');
+		}
 		$output->writeln("Nextcloud was successfully installed");
 		return 0;
 	}

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -107,7 +107,7 @@ class Install extends Command {
 			$this->printErrors($output, $errors);
 			return 1;
 		}
-		if ($setupHelper->canInstallExists()) {
+		if ($setupHelper->shouldRemoveCanInstallFile()) {
 			$output->writeln('<warn>Could not remove CAN_INSTALL from the config folder. Please remove this file manually.</warn>');
 		}
 		$output->writeln("Nextcloud was successfully installed");

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -59,7 +59,7 @@ class SetupController {
 			$post['dbpass'] = $post['dbpassword'];
 		}
 
-		if (!$this->setupHelper->canInstallExists()) {
+		if (!$this->setupHelper->canInstallFileExists()) {
 			$this->displaySetupForbidden();
 			return;
 		}
@@ -107,7 +107,7 @@ class SetupController {
 		}
 		\OC::$server->getIntegrityCodeChecker()->runInstanceVerification();
 
-		if ($this->setupHelper->canInstallExists()) {
+		if ($this->setupHelper->shouldRemoveCanInstallFile()) {
 			\OC_Template::printGuestPage('', 'installation_incomplete');
 		}
 

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -59,7 +59,7 @@ class SetupController {
 			$post['dbpass'] = $post['dbpassword'];
 		}
 
-		if (!is_file(\OC::$configDir.'/CAN_INSTALL')) {
+		if (!$this->setupHelper->canInstallExists()) {
 			$this->displaySetupForbidden();
 			return;
 		}
@@ -107,10 +107,8 @@ class SetupController {
 		}
 		\OC::$server->getIntegrityCodeChecker()->runInstanceVerification();
 
-		if (\OC_Util::getChannel() !== 'git' && is_file(\OC::$configDir.'/CAN_INSTALL')) {
-			if (!unlink(\OC::$configDir.'/CAN_INSTALL')) {
-				\OC_Template::printGuestPage('', 'installation_incomplete');
-			}
+		if ($this->setupHelper->canInstallExists()) {
+			\OC_Template::printGuestPage('', 'installation_incomplete');
 		}
 
 		header('Location: ' . \OC::$server->getURLGenerator()->getAbsoluteURL('index.php/core/apps/recommended'));

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -419,7 +419,7 @@ class Setup {
 
 			//and we are done
 			$config->setSystemValue('installed', true);
-			if (self::canInstallExists()) {
+			if (self::shouldRemoveCanInstallFile()) {
 				unlink(\OC::$configDir.'/CAN_INSTALL');
 			}
 
@@ -603,7 +603,14 @@ class Setup {
 	/**
 	 * @return bool
 	 */
-	public function canInstallExists() {
+	public function shouldRemoveCanInstallFile() {
 		return \OC_Util::getChannel() !== 'git' && is_file(\OC::$configDir.'/CAN_INSTALL');
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function canInstallFileExists() {
+		return is_file(\OC::$configDir.'/CAN_INSTALL');
 	}
 }

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -419,6 +419,9 @@ class Setup {
 
 			//and we are done
 			$config->setSystemValue('installed', true);
+			if (\OC_Util::getChannel() !== 'git' && is_file(\OC::$configDir.'/CAN_INSTALL')) {
+				unlink(\OC::$configDir.'/CAN_INSTALL');
+			}
 
 			$bootstrapCoordinator = \OC::$server->query(\OC\AppFramework\Bootstrap\Coordinator::class);
 			$bootstrapCoordinator->runInitialRegistration();

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -419,7 +419,7 @@ class Setup {
 
 			//and we are done
 			$config->setSystemValue('installed', true);
-			if (\OC_Util::getChannel() !== 'git' && is_file(\OC::$configDir.'/CAN_INSTALL')) {
+			if (self::canInstallExists()) {
 				unlink(\OC::$configDir.'/CAN_INSTALL');
 			}
 
@@ -598,5 +598,12 @@ class Setup {
 			'vendor' => (string)$vendor,
 			'channel' => (string)$OC_Channel,
 		];
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function canInstallExists() {
+		return \OC_Util::getChannel() !== 'git' && is_file(\OC::$configDir.'/CAN_INSTALL');
 	}
 }


### PR DESCRIPTION
When occ maintenance:install is run from the CLI, the CAN_INSTALL in the config directory is left in place when installed is set to true, whereas this file is removed when the web installer is used.  Removing this file in the CLI command maintains consistency between the two.  This allows automation tools an easier way to determine if this process has been completed.

Signed-off-by: Alex Harpin <development@landsofshadow.co.uk>