### PR TITLE
Trigger first login flow also with tokens

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -392,7 +392,11 @@ class Session implements IUserSession, Emitter {
 		if ($isToken) {
 			$this->setToken($loginDetails['token']->getId());
 			$this->lockdownManager->setToken($loginDetails['token']);
-			$firstTimeLogin = false;
+
+			$firstTimeLogin = $user->getLastLogin();
+			if ($firstTimeLogin === 0) {
+				$user->updateLastLoginTimestamp();
+			}
 		} else {
 			$this->setToken(null);
 			$firstTimeLogin = $user->updateLastLoginTimestamp();


### PR DESCRIPTION
This makes sure that the user folder is also created in cases where the first login happens through an app token, which is useful for migration scenarios in combination with SSO where the API is accessed with a manually generated app password before the user logs in through SSO for the first time.

There is no additional overhead for regular API requests as the last login time is already fetched from app config before and we just read it here from the user object.

Steps to reproduce:
- Create a user `user1`
- Create an app password through `occ user:add-app-password user1`
- Try to create a new directory for the user with an MKCOL webdav request with the generated app password