### PR TITLE
Fix share activity dispatch

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -107,6 +107,8 @@ class Manager implements IManager {
 	private $sharingDisabledForUsersCache;
 	/** @var EventDispatcherInterface */
 	private $legacyDispatcher;
+	/** @var LegacyHooks */
+	private $legacyHooks;
 	/** @var IMailer */
 	private $mailer;
 	/** @var IURLGenerator */
@@ -149,6 +151,9 @@ class Manager implements IManager {
 		$this->rootFolder = $rootFolder;
 		$this->legacyDispatcher = $legacyDispatcher;
 		$this->sharingDisabledForUsersCache = new CappedMemoryCache();
+		// The constructor of LegacyHooks registers the listeners of share events
+		// do not remove if those are not properly migrated
+		$this->legacyHooks = new LegacyHooks($this->legacyDispatcher);
 		$this->mailer = $mailer;
 		$this->urlGenerator = $urlGenerator;
 		$this->defaults = $defaults;


### PR DESCRIPTION
A regression was introduced by #26727. This reverts [one of the changes](https://github.com/nextcloud/server/pull/26727/files#diff-6c825986578290fe355bffe05c5232629a36e554d48f5d889bb2c1ec73645265L169) that causes share creation activities to not be dispatched.

This was caught by https://github.com/nextcloud/activity/pull/593/checks?check_run_id=2822075000.

Another solution would be to update the code to drop legacy API, but I don't want to dive into that without a more informed opinion.

FYI: It is probably due to a linter removing the variable because it is unused. We only need the side-effects from the constructor.

@icewind1991, @juliushaertl or @MorrisJobke ?