### PR TITLE
Change reviewers of Psalm baseline update

### DIFF
--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -44,4 +44,4 @@ jobs:
             Auto-generated update psalm-baseline.xml with fixed psalm warnings
           labels: |
             automated pr
-          reviewers: rullzer, morrisjobke, kesselb
+          reviewers: juliushaertl, artonge, kesselb


### PR DESCRIPTION
Change reviewers from Roeland and Me to Julius and Louis

I hope that's okay @juliushaertl and @artonge?

Those are the PRs like https://github.com/nextcloud/server/pull/27517 that just need a +1 and a check that the Psalm run works.



