### PR TITLE
[stable20] Activate constraint check for oracle / pqsql also for 20

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -31,6 +31,7 @@ namespace OC\DB\QueryBuilder;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Query\QueryException;
 use OC\DB\OracleConnection;
 use OC\DB\QueryBuilder\ExpressionBuilder\ExpressionBuilder;
 use OC\DB\QueryBuilder\ExpressionBuilder\MySqlExpressionBuilder;
@@ -214,7 +215,6 @@ class QueryBuilder implements IQueryBuilder {
 			}
 		}
 
-		return $this->queryBuilder->execute();
 		$numberOfParameters = 0;
 		$hasTooLargeArrayParameter = false;
 		foreach ($this->getParameters() as $parameter) {
@@ -244,6 +244,8 @@ class QueryBuilder implements IQueryBuilder {
 				'app' => 'core',
 			]);
 		}
+
+		return $this->queryBuilder->execute();
 	}
 
 	/**


### PR DESCRIPTION
Looks like something went wrong during the backport. For Nextcloud 20 the query is executed before the check for the oracle / pqsql constraints.

I guess there are still some places not using chunked queries. Unsure if enabling the constraint checks for Nextcloud 20 with the next patch release is a good idea. 

