### PR TITLE
22.0.0 beta 5

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 7];
+$OC_Version = [22, 0, 0, 8];
 
 // The human readable string
-$OC_VersionString = '22.0.0 beta 4';
+$OC_VersionString = '22.0.0 beta 5';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changelog relative to beta 4:

* #22628 Coalesce RewriteCond lines in .htaccess
* #25950 Add dedicated product name to OCP\Defaults
* #26319 Move files_external to IBootstrap and remove some deprecated stuff in the process
* #26421 OCC command to delete calendars
* #26430 Dashboard API for clients
* #26571 Only allow removing existing shares that would not be allowed due to reshare restrictions
* #26874 Rework search api to allow searching on multiple caches at once
* #27051 Add timestamp tooltip
* #27098 Force 'name' key in array
* #27190 Deduplicate translations and fix double .
* #27459 Bump christophwurst/id3parser from 0.1.1 to 0.1.2
* #27464 Bump guzzlehttp/guzzle from 7.2.0 to 7.3.0
* #27469 [Automated] Update psalm-baseline.xml
* #27470 Bump php-http/guzzle7-adapter from 0.1.1 to 1.0.0
* #27482 Bump @babel/preset-env from 7.14.4 to 7.14.5
* #27483 Bump @testing-library/jest-dom from 5.12.0 to 5.14.1
* #27486 Bump @babel/plugin-proposal-class-properties from 7.13.0 to 7.14.5
* #27497 Bump aws/aws-sdk-php from 3.171.21 to 3.184.2
* #27506 Fix avatar actions
* #27508 Skip deleted calendar objects of deleted calendars
* #27512 Add return type for writeToCache
* #27514 Fix share activity dispatch
* #27515 Add method to read multi-value attributes from ldap
* #27516 Bump postcss from 7.0.35 to 7.0.36
* #27517 [Automated] Update psalm-baseline.xml
* #27520 Change reviewers of Psalm baseline update
* #27529 Fix default product name for old themes
* #27534 [Automated] Update psalm-baseline.xml
* [3rdparty#682](https://github.com/nextcloud/3rdparty/pull/682) Bump php-http/guzzle7-adapter from 0.1.1 to 1.0.0
* [3rdparty#685](https://github.com/nextcloud/3rdparty/pull/685) Bump guzzlehttp/guzzle from 7.2.0 to 7.3.0
* [3rdparty#691](https://github.com/nextcloud/3rdparty/pull/691) Bump aws/aws-sdk-php from 3.171.21 to 3.184.2
* [activity#593](https://github.com/nextcloud/activity/pull/593) Use npm 7
* [files_pdfviewer#414](https://github.com/nextcloud/files_pdfviewer/pull/414) Disable content copy for PDF files that specify it
* [files_pdfviewer#422](https://github.com/nextcloud/files_pdfviewer/pull/422) Bump phpunit/phpunit from 8.5.15 to 8.5.16
* [files_pdfviewer#423](https://github.com/nextcloud/files_pdfviewer/pull/423) Bump @babel/preset-env from 7.14.4 to 7.14.5
* [files_pdfviewer#424](https://github.com/nextcloud/files_pdfviewer/pull/424) Bump vue-template-compiler from 2.6.13 to 2.6.14
* [files_pdfviewer#425](https://github.com/nextcloud/files_pdfviewer/pull/425) Bump eslint-plugin-vue from 7.10.0 to 7.11.0
* [files_pdfviewer#426](https://github.com/nextcloud/files_pdfviewer/pull/426) Bump @babel/eslint-parser from 7.14.4 to 7.14.5
* [files_pdfviewer#427](https://github.com/nextcloud/files_pdfviewer/pull/427) Bump @babel/core from 7.14.3 to 7.14.5
* [files_pdfviewer#428](https://github.com/nextcloud/files_pdfviewer/pull/428) Bump webpack-cli from 4.7.0 to 4.7.2
* [files_pdfviewer#429](https://github.com/nextcloud/files_pdfviewer/pull/429) Bump node and npm version in package.json
* [files_pdfviewer#431](https://github.com/nextcloud/files_pdfviewer/pull/431) Bump postcss from 7.0.32 to 7.0.36
* [files_pdfviewer#432](https://github.com/nextcloud/files_pdfviewer/pull/432) Bump deps and use npm7
* [files_videoplayer#239](https://github.com/nextcloud/files_videoplayer/pull/239) Bump node and npm version in package.json
* [firstrunwizard#540](https://github.com/nextcloud/firstrunwizard/pull/540) Bump vue and vue-template-compiler
* [firstrunwizard#542](https://github.com/nextcloud/firstrunwizard/pull/542) Bump @babel/core from 7.14.3 to 7.14.5
* [firstrunwizard#543](https://github.com/nextcloud/firstrunwizard/pull/543) Bump @babel/preset-env from 7.14.4 to 7.14.5
* [firstrunwizard#544](https://github.com/nextcloud/firstrunwizard/pull/544) Bump acorn from 8.3.0 to 8.4.0
* [firstrunwizard#546](https://github.com/nextcloud/firstrunwizard/pull/546) Bump postcss from 7.0.25 to 7.0.36
* [firstrunwizard#547](https://github.com/nextcloud/firstrunwizard/pull/547) Bump node and npm version in package.json
* [logreader#530](https://github.com/nextcloud/logreader/pull/530) Properly parse new log format with dedicated exception field
* [logreader#531](https://github.com/nextcloud/logreader/pull/531) Update node checks
* [logreader#534](https://github.com/nextcloud/logreader/pull/534) Bump node and npm version in package.json
* [notifications#1000](https://github.com/nextcloud/notifications/pull/1000) Bump webpack-cli from 4.7.0 to 4.7.2
* [notifications#1001](https://github.com/nextcloud/notifications/pull/1001) Bump vue and vue-template-compiler
* [notifications#1002](https://github.com/nextcloud/notifications/pull/1002) Bump @babel/eslint-parser from 7.14.4 to 7.14.5
* [notifications#1004](https://github.com/nextcloud/notifications/pull/1004) Bump @babel/preset-env from 7.14.4 to 7.14.5
* [notifications#1005](https://github.com/nextcloud/notifications/pull/1005) Bump @babel/core from 7.14.3 to 7.14.5
* [notifications#1006](https://github.com/nextcloud/notifications/pull/1006) Bump @nextcloud/vue from 3.10.1 to 4.0.1
* [notifications#1007](https://github.com/nextcloud/notifications/pull/1007) Bump postcss from 7.0.26 to 7.0.36
* [notifications#1008](https://github.com/nextcloud/notifications/pull/1008) Bump node and npm version in package.json
* [notifications#996](https://github.com/nextcloud/notifications/pull/996) Only ask for permissions on HTTPS
* [notifications#999](https://github.com/nextcloud/notifications/pull/999) Bump eslint-plugin-vue from 7.10.0 to 7.11.0
* [password_policy#201](https://github.com/nextcloud/password_policy/pull/201) Bump eslint-plugin-vue from 7.10.0 to 7.11.0
* [password_policy#203](https://github.com/nextcloud/password_policy/pull/203) Bump webpack-cli from 4.7.0 to 4.7.2
* [password_policy#204](https://github.com/nextcloud/password_policy/pull/204) Bump @babel/eslint-parser from 7.14.4 to 7.14.5
* [password_policy#205](https://github.com/nextcloud/password_policy/pull/205) Bump @babel/preset-env from 7.14.4 to 7.14.5
* [password_policy#207](https://github.com/nextcloud/password_policy/pull/207) Bump webpack-merge from 5.7.3 to 5.8.0
* [password_policy#208](https://github.com/nextcloud/password_policy/pull/208) Bump @babel/core from 7.14.3 to 7.14.5
* [password_policy#209](https://github.com/nextcloud/password_policy/pull/209) Bump postcss from 7.0.35 to 7.0.36
* [password_policy#210](https://github.com/nextcloud/password_policy/pull/210) Bump node and npm version in package.json
* [photos#793](https://github.com/nextcloud/photos/pull/793) Bump phpunit/phpunit from 9.5.4 to 9.5.5
* [photos#794](https://github.com/nextcloud/photos/pull/794) Bump @babel/core from 7.14.3 to 7.14.5
* [photos#795](https://github.com/nextcloud/photos/pull/795) Bump eslint-plugin-vue from 7.10.0 to 7.11.0
* [photos#798](https://github.com/nextcloud/photos/pull/798) Bump webpack-merge from 5.7.3 to 5.8.0
* [photos#799](https://github.com/nextcloud/photos/pull/799) Bump @babel/preset-env from 7.14.4 to 7.14.5
* [photos#801](https://github.com/nextcloud/photos/pull/801) Bump deps and use npm7
* [privacy#638](https://github.com/nextcloud/privacy/pull/638) Bump node and npm version in package.json
* [recommendations#411](https://github.com/nextcloud/recommendations/pull/411) Bump postcss from 7.0.17 to 7.0.36
* [recommendations#412](https://github.com/nextcloud/recommendations/pull/412) Bump node and npm version in package.json
* [serverinfo#319](https://github.com/nextcloud/serverinfo/pull/319) Fix Chart.js Syntax
* [text#1613](https://github.com/nextcloud/text/pull/1613) Small changes to README
* [text#1652](https://github.com/nextcloud/text/pull/1652) Bump @babel/preset-env from 7.14.2 to 7.14.5
* [text#1657](https://github.com/nextcloud/text/pull/1657) Bump postcss from 7.0.32 to 7.0.36
* [text#1658](https://github.com/nextcloud/text/pull/1658) Try enabling apcu on cli for cypress
* [text#1663](https://github.com/nextcloud/text/pull/1663) Bump node and npm version in package.json
* [viewer#913](https://github.com/nextcloud/viewer/pull/913) React to sidebar events from nextcloud-bus
* [viewer#945](https://github.com/nextcloud/viewer/pull/945) Build(deps-dev): bump phpunit/phpunit from 8.5.15 to 8.5.16
* [viewer#955](https://github.com/nextcloud/viewer/pull/955) Bump deps and use npm7


Pending PRs:

* [ ] #16708 Replace usage of "addslashes" with prepared statements @tianon
* [ ] #20605 Remove confusing placeholder in Sharing Settings @matthiasbe
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #24318 Use proper methods for display name retrieval @MorrisJobke
* [ ] #24827 Run oci tests against phpunit9/php8 @juliushaertl
* [ ] #25023 Fixes visual bug by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25109 Add command to scan external storages directly @icewind1991
* [ ] #25249 Moving between storages is not a rename @rullzer
* [ ] #25392 Dont return private storage interface from public mount interface @icewind1991
* [ ] #25418 Update variables.scss - Fallback font before Noto Color Emoji @kaktuspalme
* [ ] #25471 Add optional index API @rullzer
* [ ] #25540 ACLs without \ in the username throw exception @anikrooz
* [ ] #25768 Use mimetype from cache for workflow checks @icewind1991
* [ ] #26318 Add typed event for loading additional external storage backends @icewind1991
* [ ] #26320 Cleanup files sidebar navigation manager @icewind1991
* [ ] #26408 Sign in form best practice @kevin147147
* [ ] #26411 Catch node for share not found @skjnldsv
* [ ] #26463 Fix S3 ObjectStore proxy option @maxbes
* [ ] #26585 Drone: drop MariaDB 10.1 (EOL) add MariaDB 10.5 @acsfer
* [ ] #26681 Move HintException to OCP @juliushaertl
* [ ] #26688 Add proper message to created share not found @skjnldsv
* [ ] #26725 Fix federated scope not shown when public addressbook upload is disabled @danxuliu
* [ ] #26939 Let apps toggle an unread counter on app icons @juliushaertl
* [ ] #26982 Add some high level filesystem documention @icewind1991
* [ ] #27119 Fix getTableNamesWithoutPrefix() @daita
* [ ] #27196 Fix setUserValue bool test on testShowHiddenFiles & testCropImagePreviews @skjnldsv
* [ ] #27252 Bump @nextcloud/event-bus from 1.2.0 to 2.0.0 
* [ ] #27254 Bump @nextcloud/files from 1.1.0 to 2.0.0 
* [ ] #27259 Bump autosize from 4.0.2 to 5.0.0 
* [ ] #27261 Prevent supplied resource is not a valid stream resource @liamdemafelix
* [ ] #27378 Add dav plugin to trigger recalculating of checksums @icewind1991
* [ ] #27379 Multiple Emails UI and Integration @Pytal
* [ ] #27390 Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1 
* [ ] #27392 Bump dompurify from 2.2.8 to 2.2.9 
* [ ] #27393 Bump marked from 2.0.6 to 2.0.7 
* [ ] #27474 Make Provisioning API aware of multiple mails @blizzz
* [ ] #27484 Bump core-js from 3.13.1 to 3.14.0 
* [x] #27522 Save a request everytime we send the heartbeat @nickvergessen
* [ ] #27532 Properly cleanup entries of WebAuthn on user deletion @MorrisJobke
* [ ] #27535 Update shipped info.xsd too @nickvergessen
* [ ] #27537 Allow WebAuthn on localhost as well @MorrisJobke
* [ ] [text#1574](https://github.com/nextcloud/text/pull/1574) Fix: rich workspaces overlap with new file dropdown @gary-kim
* [ ] [viewer#936](https://github.com/nextcloud/viewer/pull/936) Remove deprecation on open method @skjnldsv
