### PR TITLE
Fix default product name for old themes

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -121,7 +121,7 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->name = parent::getName();
 		$this->title = parent::getTitle();
 		$this->entity = parent::getEntity();
-		$this->productName = parent::getName();
+		$this->productName = parent::getProductName();
 		$this->url = parent::getBaseUrl();
 		$this->color = parent::getColorPrimary();
 		$this->iTunesAppId = parent::getiTunesAppId();

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -53,6 +53,7 @@ class OC_Defaults {
 	private $defaultSlogan;
 	private $defaultColorPrimary;
 	private $defaultTextColorPrimary;
+	private $defaultProductName;
 
 	public function __construct() {
 		$config = \OC::$server->getConfig();
@@ -69,6 +70,7 @@ class OC_Defaults {
 		$this->defaultDocVersion = \OC_Util::getVersion()[0]; // used to generate doc links
 		$this->defaultColorPrimary = '#0082c9';
 		$this->defaultTextColorPrimary = '#ffffff';
+		$this->defaultProductName = 'Nextcloud';
 
 		$themePath = OC::$SERVERROOT . '/themes/' . OC_Util::getTheme() . '/defaults.php';
 		if (file_exists($themePath)) {
@@ -330,5 +332,12 @@ class OC_Defaults {
 			return $this->theme->getTextColorPrimary();
 		}
 		return $this->defaultTextColorPrimary;
+	}
+
+	public function getProductName() {
+		if ($this->themeExist('getProductName')) {
+			return $this->theme->getProductName();
+		}
+		return $this->defaultProductName;
 	}
 }


### PR DESCRIPTION
Regression from #25950 

Error was: `Call to undefined method OC_Defaults::getProductName()`