### PR TITLE
Manually search for displayname by iterating over group members

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -443,21 +443,17 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 		if (!empty($search)) {
 			// only user backends have the capability to do a complex search for users
-			$searchOffset = 0;
-			$searchLimit = $limit * 100;
-			if ($limit === -1) {
-				$searchLimit = 500;
-			}
-
+			$chunkOffset = 0;
+			$chunkLimit = 500;
 			do {
-				$filteredUsers = $this->userManager->searchDisplayName($search, $searchLimit, $searchOffset);
-				foreach ($filteredUsers as $filteredUser) {
-					if ($group->inGroup($filteredUser)) {
-						$groupUsers[] = $filteredUser;
+				$userChunk = $group->searchUsers('', $chunkLimit, $chunkOffset);
+				foreach ($userChunk as $user) {
+					if (mb_stripos($user->getDisplayName(), $search) > -1) {
+						$groupUsers[] = $user;
 					}
 				}
-				$searchOffset += $searchLimit;
-			} while (count($groupUsers) < $searchLimit + $offset && count($filteredUsers) >= $searchLimit);
+				$chunkOffset += $chunkLimit;
+			} while (count($userChunk) !== 0);
 
 			if ($limit === -1) {
 				$groupUsers = array_slice($groupUsers, $offset);


### PR DESCRIPTION
I encountered that searching for displaynames within a group is quite bad performance wise as the it basically performs inGroup check for all users. A possible alternative would be to manually get the group users and do the filtering on the displayname manually. In my understanding this should give the same results at least as the database backend which just does an ILIKE '%search%' wich no placeholder support in the search term itself. @blizzz Do you see any issues with that for LDAP for example or in general?

Especially with large user directories and groupfolders with multiple groups assigned this could bring quite a performance boost, compared to the previous one when searching for those users (see example comparison for the groupfolder user search https://blackfire.io/profiles/compare/1baf5c45-af1f-42c1-99c2-0c8be6eb777e/graph)