### PR TITLE
Fix scanner mistaking socket files for directories

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -169,7 +169,7 @@ class Local extends \OC\Files\Storage\Common {
 
 		$permissions = Constants::PERMISSION_SHARE;
 		$statPermissions = $stat['mode'];
-		$isDir = ($statPermissions & 0x4000) === 0x4000;
+		$isDir = ($statPermissions & 0x4000) === 0x4000 && !($statPermissions & 0x8000);
 		if ($statPermissions & 0x0100) {
 			$permissions += Constants::PERMISSION_READ;
 		}
@@ -492,7 +492,7 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	private function calculateEtag(string $path, array $stat): string {
-		if ($stat['mode'] & 0x4000) { // is_dir
+		if ($stat['mode'] & 0x4000 && !($stat['mode'] & 0x8000)) { // is_dir & not socket
 			return parent::getETag($path);
 		} else {
 			if ($stat === false) {


### PR DESCRIPTION
We stumbled upon a bug in the scanner:

```
Exception during scan: opendir(/storage/admin/files/apps/xxxx/config/xxx/xxx.sock): failed to open dir: Not a directory
#0 [internal function]: OCA\Files\Command\Scan->exceptionErrorHandler()
#1 /home/appbox/public_html/lib/private/Files/Storage/Local.php(134): opendir()
#2 /home/appbox/public_html/lib/private/Files/Storage/Common.php(878): OC\Files\Storage\Local->opendir()
#3 [internal function]: OC\Files\Storage\Common->getDirectoryContent()
#4 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(409): iterator_to_array()
#5 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(389): OC\Files\Cache\Scanner->handleChildren()
#6 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#7 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#8 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#9 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#10 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#11 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#12 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(392): OC\Files\Cache\Scanner->scanChildren()
#13 /home/appbox/public_html/lib/private/Files/Cache/Scanner.php(341): OC\Files\Cache\Scanner->scanChildren()
#14 /home/appbox/public_html/lib/private/Files/Utils/Scanner.php(260): OC\Files\Cache\Scanner->scan()
#15 /home/appbox/public_html/apps/files/lib/Command/Scan.php(158): OC\Files\Utils\Scanner->scan()
#16 /home/appbox/public_html/apps/files/lib/Command/Scan.php(214): OCA\Files\Command\Scan->scanFiles()
#17 /home/appbox/public_html/3rdparty/symfony/console/Command/Command.php(255): OCA\Files\Command\Scan->execute()
#18 /home/appbox/public_html/core/Command/Base.php(169): Symfony\Component\Console\Command\Command->run()
#19 /home/appbox/public_html/3rdparty/symfony/console/Application.php(1009): OC\Core\Command\Base->run()
#20 /home/appbox/public_html/3rdparty/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#21 /home/appbox/public_html/3rdparty/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun()
#22 /home/appbox/public_html/lib/private/Console/Application.php(215): Symfony\Component\Console\Application->run()
#23 /home/appbox/public_html/console.php(100): OC\Console\Application->run()
#24 {main}
```

According to https://www.php.net/manual/en/function.stat.php sockets `1100000000000000` and directories `0100000000000000` share a bit (`0x4000`), we just make sure that the extra socket bit (`0x8000`) is not set when deciding if it's a directory or not.