### PR TITLE
Phase out the controller reflector

### DIFF
--- a/lib/public/AppFramework/Utility/IControllerMethodReflector.php
+++ b/lib/public/AppFramework/Utility/IControllerMethodReflector.php
@@ -33,6 +33,8 @@ namespace OCP\AppFramework\Utility;
  * Reads and parses annotations from doc comments
  *
  * @since 8.0.0
+ * @deprecated 22.0.0 will be obsolete with native attributes in PHP8
+ * @see https://help.nextcloud.com/t/how-should-we-use-php8-attributes/104278
  */
 interface IControllerMethodReflector {
 
@@ -53,12 +55,14 @@ interface IControllerMethodReflector {
 	 * @return string|null type in the type parameters (@param int $something)
 	 * would return int or null if not existing
 	 * @since 8.0.0
+	 * @deprecated 22.0.0 this method is only used internally
 	 */
 	public function getType(string $parameter);
 
 	/**
 	 * @return array the arguments of the method with key => default value
 	 * @since 8.0.0
+	 * @deprecated 22.0.0 this method is only used internally
 	 */
 	public function getParameters(): array;
 
@@ -68,6 +72,8 @@ interface IControllerMethodReflector {
 	 * @param string $name the name of the annotation
 	 * @return bool true if the annotation is found
 	 * @since 8.0.0
+	 * @deprecated 22.0.0 will be obsolete with native attributes in PHP8
+	 * @see https://help.nextcloud.com/t/how-should-we-use-php8-attributes/104278
 	 */
 	public function hasAnnotation(string $name): bool;
 }


### PR DESCRIPTION
1) PHP8 attributes will soon replace phpdoc annotations
2) Most of the class was never meant to be used by an app but internally

THere is no direct replacement yet, but we'll still have three years to build a solid alternative.