### PR TITLE
Remove Internet Explorer support

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -262,7 +262,6 @@ class FilesPlugin extends ServerPlugin {
 			$filename = $node->getName();
 			if ($this->request->isUserAgent(
 				[
-					Request::USER_AGENT_IE,
 					Request::USER_AGENT_ANDROID_MOBILE_CHROME,
 					Request::USER_AGENT_FREEBOX,
 				])) {

--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -61,7 +61,6 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 			return false;
 		}
 		return $request->isUserAgent([
-			Request::USER_AGENT_IE,
 			Request::USER_AGENT_MS_EDGE,
 			Request::USER_AGENT_CHROME,
 			Request::USER_AGENT_FIREFOX,

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -313,7 +313,6 @@ class ViewController extends Controller {
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
 		$params['showgridview'] = $this->config->getUserValue($user, 'files', 'show_grid', false);
-		$params['isIE'] = \OC_Util::isIe();
 		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', false);
 		$params['showHiddenFiles'] = $showHidden ? 1 : 0;
 		$cropImagePreviews = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'crop_image_previews', true);

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -32,12 +32,11 @@ $shareManager = \OC::$server->get(IManager::class);
 $publicUploadEnabled = $shareManager->shareApiLinkAllowPublicUpload() ? 'yes' : 'no';;
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = OC_Util::isIe();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'list', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 $tmpl->assign('publicUploadEnabled', $publicUploadEnabled);
 $tmpl->printPage();

--- a/apps/files/recentlist.php
+++ b/apps/files/recentlist.php
@@ -29,11 +29,10 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files', 'recentlist', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 
 $tmpl->printPage();

--- a/apps/files/simplelist.php
+++ b/apps/files/simplelist.php
@@ -26,11 +26,10 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = OC_Util::isIe();
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'simplelist', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 $tmpl->printPage();

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -2,13 +2,11 @@
 <?php $_['appNavigation']->printPage(); ?>
 <div id="app-content">
 
-	<?php if (!$_['isIE']) { ?>
-		<input type="checkbox" class="hidden-visually" id="showgridview"
-			aria-label="<?php p($l->t('Toggle grid view'))?>"
-			<?php if ($_['showgridview']) { ?>checked="checked" <?php } ?>/>
-		<label id="view-toggle" for="showgridview" class="button <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>"
-			title="<?php p($l->t('Toggle grid view'))?>"></label>
-	<?php } ?>
+	<input type="checkbox" class="hidden-visually" id="showgridview"
+		aria-label="<?php p($l->t('Toggle grid view'))?>"
+		<?php if ($_['showgridview']) { ?>checked="checked" <?php } ?>/>
+	<label id="view-toggle" for="showgridview" class="button <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>"
+		title="<?php p($l->t('Toggle grid view'))?>"></label>
 
 	<?php foreach ($_['appContents'] as $content) { ?>
 	<div id="app-content-<?php p($content['id']) ?>" class="hidden viewcontainer">

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -408,7 +408,6 @@ class ViewControllerTest extends TestCase {
 				],
 				'hiddenFields' => [],
 				'showgridview' => false,
-				'isIE' => false,
 			]
 		);
 		$policy = new Http\ContentSecurityPolicy();

--- a/apps/files_external/list.php
+++ b/apps/files_external/list.php
@@ -29,12 +29,11 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', true);
-$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_external', 'list', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 
 /* Load Status Manager */
 \OCP\Util::addStyle('files_external', 'external');

--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -37,12 +37,11 @@ $legacyEventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher = \OC::$server->get(OCP\EventDispatcher\IEventDispatcher::class);
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_sharing', 'list', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 
 // fire script events
 $legacyEventDispatcher->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts', new GenericEvent());

--- a/apps/files_trashbin/list.php
+++ b/apps/files_trashbin/list.php
@@ -31,11 +31,10 @@ $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
-$isIE = OC_Util::isIe();
 
 $tmpl = new OCP\Template('files_trashbin', 'index', '');
 
 // gridview not available for ie
-$tmpl->assign('showgridview', $showgridview && !$isIE);
+$tmpl->assign('showgridview', $showgridview);
 OCP\Util::addScript('files_trashbin', 'files_trashbin');
 $tmpl->printPage();

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -71,7 +71,6 @@ class Plugin extends ServerPlugin {
 
 		if ($this->request->isUserAgent(
 			[
-				Request::USER_AGENT_IE,
 				Request::USER_AGENT_ANDROID_MOBILE_CHROME,
 				Request::USER_AGENT_FREEBOX,
 			])) {

--- a/apps/settings/src/components/AuthToken.vue
+++ b/apps/settings/src/components/AuthToken.vue
@@ -93,7 +93,6 @@ import {
 
 // When using capture groups the following parts are extracted the first is used as the version number, the second as the OS
 const userAgentMap = {
-	ie: /(?:MSIE|Trident|Trident\/7.0; rv)[ :](\d+)/,
 	// Microsoft Edge User Agent from https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx
 	edge: /^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Chrome\/[0-9.]+ (?:Mobile Safari|Safari)\/[0-9.]+ Edge\/[0-9.]+$/,
 	// Firefox User Agent from https://developer.mozilla.org/en-US/docs/Web/HTTP/Gecko_user_agent_string_reference
@@ -118,7 +117,6 @@ const userAgentMap = {
 	sailfishBrowser: /(Sailfish).*SailfishBrowser\/(\d+)/,
 }
 const nameMap = {
-	ie: t('setting', 'Internet Explorer'),
 	edge: t('setting', 'Edge'),
 	firefox: t('setting', 'Firefox'),
 	chrome: t('setting', 'Google Chrome'),
@@ -135,7 +133,6 @@ const nameMap = {
 	sailfishBrowser: 'SailfishBrowser',
 }
 const iconMap = {
-	ie: 'icon-desktop',
 	edge: 'icon-desktop',
 	firefox: 'icon-desktop',
 	chrome: 'icon-desktop',

--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -304,20 +304,12 @@ const Dialogs = {
 				multiselect = false
 			}
 
-			// No grid for IE!
-			if (OC.Util.isIE()) {
-				self.$filePicker.find('#picker-view-toggle').remove()
-				self.$filePicker.find('#picker-filestable').removeClass('view-grid')
-			}
-
 			$('body').append(self.$filePicker)
 
 			self.$showGridView = $('input#picker-showgridview')
 			self.$showGridView.on('change', _.bind(self._onGridviewChange, self))
 
-			if (!OC.Util.isIE()) {
-				self._getGridSettings()
-			}
+			self._getGridSettings()
 
 			var newButton = self.$filePicker.find('.actions.creatable .button-add')
 			if (type === self.FILEPICKER_TYPE_CHOOSE && !options.allowDirectoryChooser) {

--- a/core/src/OC/util.js
+++ b/core/src/OC/util.js
@@ -21,7 +21,6 @@
  *
  */
 
-import $ from 'jquery'
 import moment from 'moment'
 
 import History from './util-history'

--- a/core/src/OC/util.js
+++ b/core/src/OC/util.js
@@ -142,15 +142,6 @@ export default {
 	},
 
 	/**
-	 * Returns whether this is IE
-	 *
-	 * @returns {bool} true if this is IE, false otherwise
-	 */
-	isIE() {
-		return $('html').hasClass('ie')
-	},
-
-	/**
 	 * Returns the width of a generic browser scrollbar
 	 *
 	 * @returns {int} width of scrollbar

--- a/core/src/init.js
+++ b/core/src/init.js
@@ -113,20 +113,15 @@ moment.locale(OC.getLocale())
  */
 export const initCore = () => {
 	const userAgent = window.navigator.userAgent
-	const msie = userAgent.indexOf('MSIE ')
-	const trident = userAgent.indexOf('Trident/')
 	const edge = userAgent.indexOf('Edge/')
 
-	if (msie > 0 || trident > 0) {
-		// (IE 10 or older) || IE 11
-		$('html').addClass('ie')
-	} else if (edge > 0) {
+	if (edge > 0) {
 		// for edge
 		$('html').addClass('edge')
 	}
 
-	// css variables fallback for IE
-	if (msie > 0 || trident > 0 || edge > 0) {
+	// css variables fallback for Edge
+	if (edge > 0) {
 		console.info('Legacy browser detected, applying css vars polyfill')
 		cssVars({
 			watch: true,

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -63,7 +63,6 @@ use OCP\Security\ISecureRandom;
  * @property mixed[] server
  */
 class Request implements \ArrayAccess, \Countable, IRequest {
-	public const USER_AGENT_IE = '/(MSIE)|(Trident)/';
 	// Microsoft Edge User Agent from https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx
 	public const USER_AGENT_MS_EDGE = '/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Chrome\/[0-9.]+ (Mobile Safari|Safari)\/[0-9.]+ Edge\/[0-9.]+$/';
 	// Firefox User Agent from https://developer.mozilla.org/en-US/docs/Web/HTTP/Gecko_user_agent_string_reference

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -80,10 +80,6 @@ class TemplateLayout extends \OC_Template {
 		/** @var IInitialStateService */
 		$this->initialState = \OC::$server->get(IInitialStateService::class);
 
-		if (\OC_Util::isIe()) {
-			Util::addStyle('ie');
-		}
-
 		// Decide which page we show
 		if ($renderAs === TemplateResponse::RENDER_AS_USER) {
 			/** @var INavigationManager */

--- a/lib/private/legacy/OC_Response.php
+++ b/lib/private/legacy/OC_Response.php
@@ -36,7 +36,6 @@ class OC_Response {
 	public static function setContentDispositionHeader($filename, $type = 'attachment') {
 		if (\OC::$server->getRequest()->isUserAgent(
 			[
-				\OC\AppFramework\Http\Request::USER_AGENT_IE,
 				\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME,
 				\OC\AppFramework\Http\Request::USER_AGENT_FREEBOX,
 			])) {

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -120,11 +120,6 @@ class OC_Template extends \OC\Template\Base {
 			}
 			OC_Util::addScript('core', 'dist/main', true);
 
-			if (\OC::$server->getRequest()->isUserAgent([\OC\AppFramework\Http\Request::USER_AGENT_IE])) {
-				// shim for the davclient.js library
-				\OCP\Util::addScript('dist/files_iedavclient');
-			}
-
 			self::$initTemplateEngineFirstRun = false;
 		}
 	}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1463,17 +1463,4 @@ class OC_Util {
 			return false;
 		}
 	}
-
-	/**
-	 * is this Internet explorer ?
-	 *
-	 * @return boolean
-	 */
-	public static function isIe() {
-		if (!isset($_SERVER['HTTP_USER_AGENT'])) {
-			return false;
-		}
-
-		return preg_match(Request::USER_AGENT_IE, $_SERVER['HTTP_USER_AGENT']) === 1;
-	}
 }

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -933,20 +933,6 @@ class RequestTest extends \Test\TestCase {
 	public function userAgentProvider() {
 		return [
 			[
-				'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)',
-				[
-					Request::USER_AGENT_IE
-				],
-				true,
-			],
-			[
-				'Mozilla/5.0 (X11; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0',
-				[
-					Request::USER_AGENT_IE
-				],
-				false,
-			],
-			[
 				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36',
 				[
 					Request::USER_AGENT_CHROME
@@ -968,24 +954,8 @@ class RequestTest extends \Test\TestCase {
 				true,
 			],
 			[
-				'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)',
-				[
-					Request::USER_AGENT_ANDROID_MOBILE_CHROME
-				],
-				false,
-			],
-			[
-				'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)',
-				[
-					Request::USER_AGENT_IE,
-					Request::USER_AGENT_ANDROID_MOBILE_CHROME,
-				],
-				true,
-			],
-			[
 				'Mozilla/5.0 (Linux; Android 4.4; Nexus 4 Build/KRT16S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36',
 				[
-					Request::USER_AGENT_IE,
 					Request::USER_AGENT_ANDROID_MOBILE_CHROME,
 				],
 				true,


### PR DESCRIPTION
Removes IE detection and workarounds.
Also removes public symbols for IE detection.

This might break apps that are relying on the USER_AGENT_IE constant.