### PR TITLE
Fix TypeError on large folder downloads

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -40,7 +40,7 @@ use ZipStreamer\ZipStreamer;
 
 class Streamer {
 	// array of regexp. Matching user agents will get tar instead of zip
-	private $preferTarFor = [ '/macintosh|mac os x/i' ];
+	private $preferTarFor = [ '/macintosh|mac os x|linux/i' ];
 
 	// streamer instance
 	private $streamerInstance;


### PR DESCRIPTION
As requested in #15117, here a PR for discussion.

Additionally, I propose to add Linux to the `preferTarFor` user agent matches.

Please note the `TODO`: I would not consider this PR ready to be merged until that is fixed.
