### PR TITLE
Reset checksum when writing files to object store

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -465,6 +465,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 		$stat['mimetype'] = $mimetype;
 		$stat['etag'] = $this->getETag($path);
+		$stat['checksum'] = '';
 
 		$exists = $this->getCache()->inCache($path);
 		$uploadPath = $exists ? $path : $path . '.part';


### PR DESCRIPTION
With a local storage the checksum will be reset when scanning the file after writing to it:

https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Files/Cache/Scanner.php#L222

This does not work for object store storage backends as those use a NoopScanner so the checksum was never reset for those.

Fixes https://github.com/nextcloud/server/issues/27563