### PR TITLE
Proper opacity on multiselect actions in files

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -464,7 +464,7 @@ td.avatar {
 	}
 }
 
-tr .action:not(.permanent), .selectedActions a {
+tr .action:not(.permanent), .selectedActions > a {
 	opacity: 0;
 }
 
@@ -476,8 +476,11 @@ tr {
 	}
 }
 
-.selectedActions a {
+.selectedActions > a {
 	opacity: .5;
+	&:hover, &:focus {
+		opacity: 1;
+	}
 }
 
 tr .action {


### PR DESCRIPTION
While the files app related code in core should rather be removed than adjusted this addresses the opacity issue mentioned in #24918

Before:
![image](https://user-images.githubusercontent.com/3404133/122969130-98f4e300-d38c-11eb-9020-48137467290d.png)


After:
![image](https://user-images.githubusercontent.com/3404133/122968987-6c40cb80-d38c-11eb-9d7d-185661ce528a.png)
