### PR TITLE
Make security warning stand out more

### DIFF
--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -36,8 +36,8 @@ $urlGenerator = $_['urlGenerator'];
 		])) ?>
 	</p>
 
-	<p class="info">
-		<?php print_unescaped($l->t('If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
+	<p class="warning">
+		<?php print_unescaped($l->t('<strong>Security warning:</strong> If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
 	</p>
 
 	<br/>

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -36,9 +36,12 @@ $urlGenerator = $_['urlGenerator'];
 		])) ?>
 	</p>
 
-	<p class="warning">
-		<?php print_unescaped($l->t('<strong>Security warning:</strong> If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
-	</p>
+	<span class="warning">
+		<h3><?php p('Security warning') ?></h3>
+		<p>
+			<?php p($l->t('If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
+		</p>
+	</span>
 
 	<br/>
 

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -35,8 +35,8 @@ $urlGenerator = $_['urlGenerator'];
 		])) ?>
 	</p>
 
-	<p class="info">
-		<?php print_unescaped($l->t('If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
+	<p class="warning">
+		<?php print_unescaped($l->t('<strong>Security warning:</strong> If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
 	</p>
 
 	<br/>

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -35,9 +35,12 @@ $urlGenerator = $_['urlGenerator'];
 		])) ?>
 	</p>
 
-	<p class="warning">
-		<?php print_unescaped($l->t('<strong>Security warning:</strong> If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
-	</p>
+	<span class="warning">
+		<h3><?php p('Security warning') ?></h3>
+		<p>
+			<?php p($l->t('If you are not trying to set up a new device or app, someone is trying to trick you into granting them access to your data. In this case do not proceed and instead contact your system administrator.')) ?>
+		</p>
+	</span>
 
 	<br/>
 


### PR DESCRIPTION
The security warning is currently being ignored by too many users as it's part of the text and not visually distinct.

Before:
<img width="964" alt="Screenshot 2021-06-22 at 19 19 37" src="https://user-images.githubusercontent.com/878997/122971644-8c25be80-d38f-11eb-9f78-3fbc28cbd9d5.png">

After:
<img width="846" alt="Screenshot 2021-06-22 at 19 20 24" src="https://user-images.githubusercontent.com/878997/122971631-892ace00-d38f-11eb-930c-80a2eda4c6c5.png">

Fixes https://github.com/nextcloud/server/issues/26943
