### PR TITLE
Throttle on public DAV endpoint

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -41,7 +41,8 @@ OC_Util::obEnd();
 $authBackend = new OCA\DAV\Connector\PublicAuth(
 	\OC::$server->getRequest(),
 	\OC::$server->getShareManager(),
-	\OC::$server->getSession()
+	\OC::$server->getSession(),
+	\OC::$server->getBruteForceThrottler()
 );
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 

--- a/apps/dav/tests/unit/Connector/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/PublicAuthTest.php
@@ -68,7 +68,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->shareManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->shareManager = $this->getMockBuilder(Throttler::class)
+		$this->throttler = $this->getMockBuilder(Throttler::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/dav/tests/unit/Connector/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/PublicAuthTest.php
@@ -26,6 +26,7 @@
  */
 namespace OCA\DAV\Tests\unit\Connector;
 
+use OC\Security\Bruteforce\Throttler;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -49,6 +50,8 @@ class PublicAuthTest extends \Test\TestCase {
 	private $shareManager;
 	/** @var \OCA\DAV\Connector\PublicAuth */
 	private $auth;
+	/** @var Throttler|\PHPUnit\Framework\MockObject\MockObject */
+	private $throttler;
 
 	/** @var string */
 	private $oldUser;
@@ -65,11 +68,15 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->shareManager = $this->getMockBuilder(IManager::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$this->shareManager = $this->getMockBuilder(Throttler::class)
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->auth = new \OCA\DAV\Connector\PublicAuth(
 			$this->request,
 			$this->shareManager,
-			$this->session
+			$this->session,
+			$this->throttler
 		);
 
 		// Store current user


### PR DESCRIPTION
We should throttle whenever an invalid request is sent to the public WebDAV endpoint.

To test the throttling:

```
curl -u "RANDOM1:RANDOM2" -X PROPFIND http://localhost:8081/public.php/webdav
```
