### PR TITLE
Check datadirectory owner, not config owner.

### DIFF
--- a/console.php
+++ b/console.php
@@ -59,18 +59,20 @@ try {
 
 	set_exception_handler('exceptionHandler');
 
+	$config = \OC::$server->getConfig();
+
 	if (!function_exists('posix_getuid')) {
 		echo "The posix extensions are required - see https://www.php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
 	$user = posix_getuid();
-	$configUser = fileowner(OC::$configDir . 'config.php');
-	if ($user !== $configUser) {
-		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+	$dataDirectoryUser = fileowner($config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data'));
+	if ($user !== $dataDirectoryUser) {
+		echo "Console has to be executed with the user that owns the data directory" . PHP_EOL;
 		echo "Current user id: " . $user . PHP_EOL;
-		echo "Owner id of config.php: " . $configUser . PHP_EOL;
-		echo "Try adding 'sudo -u #" . $configUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
-		echo "If running with 'docker exec' try adding the option '-u " . $configUser . "' to the docker command (without the single quotes)" . PHP_EOL;
+		echo "Owner id of the data directory: " . $dataDirectoryUser . PHP_EOL;
+		echo "Try adding 'sudo -u #" . $dataDirectoryUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
+		echo "If running with 'docker exec' try adding the option '-u " . $dataDirectoryUser . "' to the docker command (without the single quotes)" . PHP_EOL;
 		exit(1);
 	}
 
@@ -90,7 +92,7 @@ try {
 	}
 
 	$application = new Application(
-		\OC::$server->getConfig(),
+		$config,
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getRequest(),
 		\OC::$server->get(\Psr\Log\LoggerInterface::class),

--- a/console.php
+++ b/console.php
@@ -57,23 +57,34 @@ try {
 		exit(1);
 	}
 
-	set_exception_handler('exceptionHandler');
-
 	$config = \OC::$server->getConfig();
+	set_exception_handler('exceptionHandler');
 
 	if (!function_exists('posix_getuid')) {
 		echo "The posix extensions are required - see https://www.php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
-	$user = posix_getuid();
-	$dataDirectoryUser = fileowner($config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data'));
-	if ($user !== $dataDirectoryUser) {
-		echo "Console has to be executed with the user that owns the data directory" . PHP_EOL;
-		echo "Current user id: " . $user . PHP_EOL;
-		echo "Owner id of the data directory: " . $dataDirectoryUser . PHP_EOL;
-		echo "Try adding 'sudo -u #" . $dataDirectoryUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
-		echo "If running with 'docker exec' try adding the option '-u " . $dataDirectoryUser . "' to the docker command (without the single quotes)" . PHP_EOL;
+
+	// Check if the data directory is available and the server is installed
+	$dataDirectory = $config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
+	if ($config->getSystemValueBool('installed', false) && !is_dir($dataDirectory)) {
+		echo "Data directory (" . $dataDirectory . ") not found" . PHP_EOL;
 		exit(1);
+	}
+
+	// Check if the user running the console is the same as the user that owns the data directory
+	// If the data directory does not exist, the server is not setup yet and we can skip.
+	if (is_dir($dataDirectory)) {
+		$user = posix_getuid();
+		$dataDirectoryUser = fileowner($dataDirectory);
+		if ($user !== $dataDirectoryUser) {
+			echo "Console has to be executed with the user that owns the data directory" . PHP_EOL;
+			echo "Current user id: " . $user . PHP_EOL;
+			echo "Owner id of the data directory: " . $dataDirectoryUser . PHP_EOL;
+			echo "Try adding 'sudo -u #" . $dataDirectoryUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
+			echo "If running with 'docker exec' try adding the option '-u " . $dataDirectoryUser . "' to the docker command (without the single quotes)" . PHP_EOL;
+			exit(1);
+		}
 	}
 
 	$oldWorkingDir = getcwd();

--- a/cron.php
+++ b/cron.php
@@ -115,11 +115,11 @@ try {
 		}
 
 		$user = posix_getuid();
-		$configUser = fileowner(OC::$configDir . 'config.php');
-		if ($user !== $configUser) {
-			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+		$dataDirectoryUser = fileowner($config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data'));
+		if ($user !== $dataDirectoryUser) {
+			echo "Console has to be executed with the user that owns the data directory" . PHP_EOL;
 			echo "Current user id: " . $user . PHP_EOL;
-			echo "Owner id of config.php: " . $configUser . PHP_EOL;
+			echo "Owner id of the data directory: " . $dataDirectoryUser . PHP_EOL;
 			exit(1);
 		}
 


### PR DESCRIPTION
Changes permission checks to use datadirectory, rather than config file.
Step 1 towards root-owned configs (#11075).

For root-owned configs, the only thing that needs to be writeable is the data directory. For non-root configs, this check shouldn't make any difference, it's very likely the same user is used for both config and data dir.

Currently, the user shouldn't see any difference in behaviour, as the check here would still disallow a root-owned config:
https://github.com/nextcloud/server/blob/master/lib/base.php#L247
Once the rest of the work to support root-owned configs is complete, then this check should be removed (`|| !$configFileWritable && \OCP\Util::needUpgrade()`).