### PR TITLE
22.0.0 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 8];
+$OC_Version = [22, 0, 0, 9];
 
 // The human readable string
-$OC_VersionString = '22.0.0 beta 5';
+$OC_VersionString = '22.0.0 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
changes since Beta5:

* #24318 Use proper methods for display name retrieval
* #26323 Use constant for supported formats
* #26344 Return early if path is root
* #26346 Cleaner removePassword regex
* #26939 Let apps toggle an unread counter on app icons
* #27283 L10n: Spelling unification
* #27383 Bump puppeteer from 5.5.0 to 10.0.0 in /build
* #27532 Properly cleanup entries of WebAuthn on user deletion
* #27535 Update shipped info.xsd too
* #27537 Allow WebAuthn on localhost as well
* #27540 Handle case where storage can't be created in getStorageRootId
* #27544 Phase out the controller reflector
* #27548 [Automated] Update psalm-baseline.xml
* #27555 Bump sass from 1.34.1 to 1.35.1
* #27561 Allow setting offset for dav search queries not limited to the users home storage
* #27566 Update Login with device page styles
* #27567 Bump karma from 5.2.3 to 6.3.4 in /build
* #27573 Bump vue-material-design-icons from 4.11.0 to 4.12.1
* #27581 Bump vimeo/psalm from 4.7.2 to 4.8.1
* #27583 Upgrade to GitHub-native Dependabot
* #27585 Bump phpseclib/phpseclib from 2.0.31 to 2.0.32
* #27587 Bump icewind/streams from 0.7.4 to 0.7.5
* #27590 Bump swiftmailer/swiftmailer from 6.2.5 to 6.2.7
* #27593 Bump giggsey/libphonenumber-for-php from 8.12.24 to 8.12.25
* #27595 Mail-template - don't show hyphen if slogan is empty
* #27604 Proper opacity on multiselect actions in files
* #27605 Make security warning stand out more
* #27609 Bump aws/aws-sdk-php from 3.184.2 to 3.184.6
* #27610 Throttle on public DAV endpoint
* #27611 Bump query-string from 5.1.1 to 7.0.1
* #27627 Bump @babel/preset-env from 7.14.5 to 7.14.7
* #27628 Add security.txt
* #27632 Use ISO8601 timestamps for the CalDAV trashbin
* #27635 Fix usage of DateTime constants
* [3rdparty#687](https://github.com/nextcloud/3rdparty/pull/687) Bump swiftmailer/swiftmailer from 6.2.5 to 6.2.7
* [3rdparty#692](https://github.com/nextcloud/3rdparty/pull/692) Bump aws/aws-sdk-php from 3.184.2 to 3.184.6
* [3rdparty#693](https://github.com/nextcloud/3rdparty/pull/693) Bump phpseclib/phpseclib from 2.0.31 to 2.0.32
* [3rdparty#694](https://github.com/nextcloud/3rdparty/pull/694) Bump giggsey/libphonenumber-for-php from 8.12.24 to 8.12.25
* [3rdparty#695](https://github.com/nextcloud/3rdparty/pull/695) Bump icewind/streams from 0.7.4 to 0.7.5
* [activity#595](https://github.com/nextcloud/activity/pull/595) Replace deprecated occ app:check-code with xml linter
* [firstrunwizard#548](https://github.com/nextcloud/firstrunwizard/pull/548) Bump striptags from 3.1.1 to 3.2.0
* [firstrunwizard#549](https://github.com/nextcloud/firstrunwizard/pull/549) Bump @babel/core from 7.14.5 to 7.14.6
* [firstrunwizard#550](https://github.com/nextcloud/firstrunwizard/pull/550) Bump stylelint-webpack-plugin from 2.1.1 to 2.2.0
* [notifications#1009](https://github.com/nextcloud/notifications/pull/1009) Replace deprecated occ app:check-code with xml linter
* [notifications#1013](https://github.com/nextcloud/notifications/pull/1013) Dont load UI on embedded pages
* [notifications#1016](https://github.com/nextcloud/notifications/pull/1016) Fix casting token to int
* [notifications#1017](https://github.com/nextcloud/notifications/pull/1017) Use node 14 and npm7
* [notifications#1018](https://github.com/nextcloud/notifications/pull/1018) Bump node-polyfill-webpack-plugin from 1.1.2 to 1.1.3
* [notifications#1019](https://github.com/nextcloud/notifications/pull/1019) Bump stylelint-webpack-plugin from 2.1.1 to 2.2.0
* [notifications#1020](https://github.com/nextcloud/notifications/pull/1020) Bump @babel/core from 7.14.5 to 7.14.6
* [notifications#1021](https://github.com/nextcloud/notifications/pull/1021) Bump webpack from 5.38.1 to 5.39.1
* [notifications#1023](https://github.com/nextcloud/notifications/pull/1023) Bump eslint from 7.28.0 to 7.29.0
* [notifications#1024](https://github.com/nextcloud/notifications/pull/1024) Bump eslint-plugin-vue from 7.11.0 to 7.11.1
* [notifications#1027](https://github.com/nextcloud/notifications/pull/1027) Fix handling the response of the proxy
* [notifications#1028](https://github.com/nextcloud/notifications/pull/1028) Fix asterix conflict with talk
* [password_policy#213](https://github.com/nextcloud/password_policy/pull/213) Bump striptags from 3.1.1 to 3.2.0
* [password_policy#214](https://github.com/nextcloud/password_policy/pull/214) Bump sass from 1.34.1 to 1.35.1
* [password_policy#215](https://github.com/nextcloud/password_policy/pull/215) Bump eslint-plugin-vue from 7.11.0 to 7.11.1
* [password_policy#216](https://github.com/nextcloud/password_policy/pull/216) Bump stylelint-webpack-plugin from 2.1.1 to 2.2.0
* [password_policy#217](https://github.com/nextcloud/password_policy/pull/217) Bump @babel/core from 7.14.5 to 7.14.6
* [password_policy#218](https://github.com/nextcloud/password_policy/pull/218) Bump webpack from 5.38.1 to 5.39.1
* [password_policy#219](https://github.com/nextcloud/password_policy/pull/219) Bump eslint from 7.28.0 to 7.29.0
* [photos#804](https://github.com/nextcloud/photos/pull/804) Support external storage
* [text#1625](https://github.com/nextcloud/text/pull/1625) Bump psalm/phar from 4.7.1 to 4.7.3
* [text#1653](https://github.com/nextcloud/text/pull/1653) Bump @babel/plugin-transform-classes from 7.14.2 to 7.14.5
* [text#1666](https://github.com/nextcloud/text/pull/1666) Bump node version on github actions
* [text#1669](https://github.com/nextcloud/text/pull/1669) Bump acorn from 8.2.4 to 8.4.0
* [text#1671](https://github.com/nextcloud/text/pull/1671) Bump cypress from 7.4.0 to 7.5.0
* [text#1672](https://github.com/nextcloud/text/pull/1672) Bump @vue/test-utils from 1.2.0 to 1.2.1


Pending PRs:

* [ ] #20605 Remove confusing placeholder in Sharing Settings @matthiasbe
* [ ] #22294 SFTP-Storage: Correctly Sync mtime @msander
* [ ] #22943 Improve handling of files we can't access in the scanner @icewind1991
* [ ] #24185 Properly handle folder deletion on external s3 storage @juliushaertl
* [ ] #25023 Fixes visual bug by making the icon grey only on hover and white otherwise. @RafaOP
* [ ] #25249 Moving between storages is not a rename @rullzer
* [ ] #25392 Dont return private storage interface from public mount interface @icewind1991
* [ ] #25418 Update variables.scss - Fallback font before Noto Color Emoji @kaktuspalme
* [ ] #25471 Add optional index API @rullzer
* [ ] #25540 ACLs without \ in the username throw exception @anikrooz
* [ ] #25768 Use mimetype from cache for workflow checks @icewind1991
* [ ] #26347 Cleaner normalizePath regex @J0WI
* [ ] #26408 Sign in form best practice @kevin147147
* [ ] #26411 Catch node for share not found @skjnldsv
* [ ] #26463 Fix S3 ObjectStore proxy option @maxbes
* [ ] #26585 Drone: drop MariaDB 10.1 (EOL) add MariaDB 10.5 @acsfer
* [ ] #26666 Fix LDAP Dark Theme Issue @andyxheli
* [ ] #26688 Add proper message to created share not found @skjnldsv
* [ ] #26725 Fix federated scope not shown when public addressbook upload is disabled @danxuliu
* [ ] #26982 Add some high level filesystem documention @icewind1991
* [ ] #27075 Using empty file as ZipArchive is deprecated @acsfer
* [ ] #27119 Fix getTableNamesWithoutPrefix() @ArtificialOwl
* [ ] #27196 Fix setUserValue bool test on testShowHiddenFiles & testCropImagePreviews @skjnldsv
* [ ] #27252 Bump @nextcloud/event-bus from 1.2.0 to 2.0.0 
* [ ] #27254 Bump @nextcloud/files from 1.1.0 to 2.0.0 
* [ ] #27259 Bump autosize from 4.0.2 to 5.0.0 
* [ ] #27261 Prevent supplied resource is not a valid stream resource @liamdemafelix
* [ ] #27378 Add dav plugin to trigger recalculating of checksums @icewind1991
* [ ] #27379 Multiple Emails UI and Integration @Pytal
* [ ] #27390 Bump babel-loader-exclude-node-modules-except from 1.1.2 to 1.2.1 
* [ ] #27392 Bump dompurify from 2.2.8 to 2.2.9 
* [ ] #27474 Make Provisioning API aware of multiple mails @blizzz
* [ ] #27484 Bump core-js from 3.13.1 to 3.14.0 
* [ ] #27586 Reset checksum when writing files to object store @juliushaertl
* [ ] #27631 Correctly skip suppressed errors in PHP 8.0 @yan12125
* [ ] #27633 Hide personal circle from the sharedWithMe @ArtificialOwl
* [ ] #27637 Use search to get versions list from cache for expiry @icewind1991
* [ ] #27638 Downstream encryption:fix-encrypted-version for repairing "bad signature" errors @PVince81
* [ ] [text#1574](https://github.com/nextcloud/text/pull/1574) Fix: rich workspaces overlap with new file dropdown @gary-kim
