### PR TITLE
Allow editing files with LibreOffice via WebDav

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -627,6 +627,23 @@
 			});
 
 			this.registerAction({
+				name: 'Edit',
+				displayName: t('files', 'Edit with LibreOffice'),
+				order: -19,
+				mime: 'file',
+				permissions: OC.PERMISSION_UPDATE,
+				iconClass: 'icon-edit',
+				actionHandler: function (filename, context) {
+					var dir = context.dir || context.fileList.getCurrentDirectory();
+					var isDir = context.$file.attr('data-type') === 'dir';
+					var url = context.fileList.getLibreOfficeUrl(filename, dir, isDir);
+					if (url) {
+						OCA.Files.Files.handleDownload(url, null);
+					}
+				}
+			});
+
+			this.registerAction({
 				name: 'Rename',
 				displayName: t('files', 'Rename'),
 				mime: 'all',

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2176,6 +2176,11 @@
 			return OCA.Files.Files.getDownloadUrl(files, dir || this.getCurrentDirectory(), isDir);
 		},
 
+		getLibreOfficeUrl: function(files, dir, isDir) {
+			return "vnd.libreoffice.command:ofe|u|" + window.location.protocol
+				+ "//" + window.location.host + this.getDownloadUrl(files, dir, isDir);
+		},
+
 		getDefaultActionUrl: function(path, id) {
 			return this.linkTo(path) + "&openfile="+id;
 		},


### PR DESCRIPTION
This adds a new context menu item to the Files Dropdown menu "Edit with LibreOffice".
Clicking that item will open the file in LibreOffice via WebDav (the file can then be edited and saved back directly in LibreOffice).

This greatly improves the user experience when working with Office files in the browser. No need to download, edit, reupload. Instead use the "Edit with LibreOffice" item.

Of course this only works when LibreOffice is installed. Might want to put this item behind a config option.