### PR TITLE
Correctly skip suppressed errors in PHP 8.0

### DIFF
--- a/lib/private/Log/ErrorHandler.php
+++ b/lib/private/Log/ErrorHandler.php
@@ -85,7 +85,7 @@ class ErrorHandler {
 
 	//Recoverable errors handler
 	public static function onError($number, $message, $file, $line) {
-		if (error_reporting() === 0) {
+		if (!(error_reporting() & $number)) {
 			return;
 		}
 		$msg = $message . ' at ' . $file . '#' . $line;


### PR DESCRIPTION
Applies the suggested transformation mentioned in
https://www.php.net/manual/en/migration80.incompatible.php,

> The @ operator will no longer silence fatal errors (E_ERROR,
> E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR,
> E_PARSE). Error handlers that expect error_reporting to be 0 when
> @ is used, should be adjusted to use a mask check instead

The new code still works on PHP 7, as error_reporting() already
returns 0 when diagnostics are suppressed.

This fixes https://github.com/nextcloud/server/issues/25807 in PHP 8.0.
For PHP 7.x, https://github.com/nextcloud/server/pull/22243 suppresses
the E_NOTICE message from the second session_start() call with the error
suppression operator @, and thus those E_NOTICE messages are still
logged in PHP 8.0.

See also https://github.com/nextcloud/server/issues/25806

Signed-off-by: Chih-Hsuan Yen <yan12125@gmail.com>