### PR TITLE
hide personal circle from the sharedWithMe

### DIFF
--- a/apps/files_sharing/src/utils/SharedWithMe.js
+++ b/apps/files_sharing/src/utils/SharedWithMe.js
@@ -34,16 +34,28 @@ const shareWithTitle = function(share) {
 			{ escape: false }
 		)
 	} else if (share.type === OC.Share.SHARE_TYPE_CIRCLE) {
-		return t(
-			'files_sharing',
-			'Shared with you and {circle} by {owner}',
-			{
-				circle: share.shareWithDisplayName,
-				owner: share.ownerDisplayName,
-			},
-			undefined,
-			{ escape: false }
-		)
+		if (share.shareWithDisplayName === ' ') {
+			return t(
+				'files_sharing',
+				'Shared with you by {owner}',
+				{
+					owner: share.ownerDisplayName,
+				},
+				undefined,
+				{ escape: false }
+			)
+		} else {
+			return t(
+				'files_sharing',
+				'Shared with you and {circle} by {owner}',
+				{
+					circle: share.shareWithDisplayName,
+					owner: share.ownerDisplayName,
+				},
+				undefined,
+				{ escape: false }
+			)
+		}
 	} else if (share.type === OC.Share.SHARE_TYPE_ROOM) {
 		if (share.shareWithDisplayName) {
 			return t(


### PR DESCRIPTION
Personal Circle are hidden to its own members (but the owner of the Circle).
Because shareWithDisplayName cannot be empty, or it will be replaced by the Id of the share, the work around is that the Circles App will returns a name with a space char.

The idea is that when sharing a file to a personal Circle, the recipient of the share is not aware of the fact that he is in a personal Circle.