### PR TITLE
Fix usage of DateTime constants

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -390,8 +390,8 @@ class EmailProvider extends AbstractProvider {
 
 		$diff = $dtstartDt->diff($dtendDt);
 
-		$dtstartDt = new \DateTime($dtstartDt->format(\DateTime::ATOM));
-		$dtendDt = new \DateTime($dtendDt->format(\DateTime::ATOM));
+		$dtstartDt = new \DateTime($dtstartDt->format(\DateTimeInterface::ATOM));
+		$dtendDt = new \DateTime($dtendDt->format(\DateTimeInterface::ATOM));
 
 		if ($isAllDay) {
 			// One day event

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -137,10 +137,10 @@ class PushProvider extends AbstractProvider {
 				? ((string) $vevent->LOCATION)
 				: null,
 			'all_day' => $start instanceof Property\ICalendar\Date,
-			'start_atom' => $start->getDateTime()->format(\DateTime::ATOM),
+			'start_atom' => $start->getDateTime()->format(\DateTimeInterface::ATOM),
 			'start_is_floating' => $start->isFloating(),
 			'start_timezone' => $start->getDateTime()->getTimezone()->getName(),
-			'end_atom' => $end->getDateTime()->format(\DateTime::ATOM),
+			'end_atom' => $end->getDateTime()->format(\DateTimeInterface::ATOM),
 			'end_is_floating' => $end->isFloating(),
 			'end_timezone' => $end->getDateTime()->getTimezone()->getName(),
 		];

--- a/apps/dav/lib/CalDAV/Reminder/Notifier.php
+++ b/apps/dav/lib/CalDAV/Reminder/Notifier.php
@@ -144,7 +144,7 @@ class Notifier implements INotifier {
 	private function prepareNotificationSubject(INotification $notification): void {
 		$parameters = $notification->getSubjectParameters();
 
-		$startTime = \DateTime::createFromFormat(\DateTime::ATOM, $parameters['start_atom']);
+		$startTime = \DateTime::createFromFormat(\DateTimeInterface::ATOM, $parameters['start_atom']);
 		$now = $this->timeFactory->getDateTime();
 		$title = $this->getTitleFromParameters($parameters);
 
@@ -221,8 +221,8 @@ class Notifier implements INotifier {
 	 * @throws \Exception
 	 */
 	private function generateDateString(array $parameters):string {
-		$startDateTime = DateTime::createFromFormat(\DateTime::ATOM, $parameters['start_atom']);
-		$endDateTime = DateTime::createFromFormat(\DateTime::ATOM, $parameters['end_atom']);
+		$startDateTime = DateTime::createFromFormat(\DateTimeInterface::ATOM, $parameters['start_atom']);
+		$endDateTime = DateTime::createFromFormat(\DateTimeInterface::ATOM, $parameters['end_atom']);
 
 		// If the event has already ended, dismiss the notification
 		if ($endDateTime < $this->timeFactory->getDateTime()) {

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -441,8 +441,8 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$diff = $dtstartDt->diff($dtendDt);
 
-		$dtstartDt = new \DateTime($dtstartDt->format(\DateTime::ATOM));
-		$dtendDt = new \DateTime($dtendDt->format(\DateTime::ATOM));
+		$dtstartDt = new \DateTime($dtstartDt->format(\DateTimeInterface::ATOM));
+		$dtendDt = new \DateTime($dtendDt->format(\DateTimeInterface::ATOM));
 
 		if ($isAllDay) {
 			// One day event

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -378,7 +378,7 @@ class FileSearchBackend implements ISearchBackend {
 				if (is_numeric($value)) {
 					return max(0, 0 + $value);
 				}
-				$date = \DateTime::createFromFormat(\DateTime::ATOM, $value);
+				$date = \DateTime::createFromFormat(\DateTimeInterface::ATOM, $value);
 				return ($date instanceof \DateTime && $date->getTimestamp() !== false) ? $date->getTimestamp() : 0;
 			default:
 				return $value;

--- a/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
+++ b/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
@@ -76,7 +76,7 @@ class AppleProvisioningNode implements INode, IProperties {
 
 		return [
 			'{DAV:}getcontentlength' => 42,
-			'{DAV:}getlastmodified' => $datetime->format(\DateTime::RFC2822),
+			'{DAV:}getlastmodified' => $datetime->format(\DateTimeInterface::RFC2822),
 		];
 	}
 

--- a/apps/dav/lib/Search/EventsSearchProvider.php
+++ b/apps/dav/lib/Search/EventsSearchProvider.php
@@ -181,8 +181,8 @@ class EventsSearchProvider extends ACalendarSearchProvider {
 		$dtStart = $eventComponent->DTSTART;
 		$dtEnd = $this->getDTEndForEvent($eventComponent);
 		$isAllDayEvent = $dtStart instanceof Property\ICalendar\Date;
-		$startDateTime = new \DateTime($dtStart->getDateTime()->format(\DateTime::ATOM));
-		$endDateTime = new \DateTime($dtEnd->getDateTime()->format(\DateTime::ATOM));
+		$startDateTime = new \DateTime($dtStart->getDateTime()->format(\DateTimeInterface::ATOM));
+		$endDateTime = new \DateTime($dtEnd->getDateTime()->format(\DateTimeInterface::ATOM));
 
 		if ($isAllDayEvent) {
 			$endDateTime->modify('-1 day');

--- a/apps/dav/lib/Search/TasksSearchProvider.php
+++ b/apps/dav/lib/Search/TasksSearchProvider.php
@@ -153,13 +153,13 @@ class TasksSearchProvider extends ACalendarSearchProvider {
 	 */
 	protected function generateSubline(Component $taskComponent): string {
 		if ($taskComponent->COMPLETED) {
-			$completedDateTime = new \DateTime($taskComponent->COMPLETED->getDateTime()->format(\DateTime::ATOM));
+			$completedDateTime = new \DateTime($taskComponent->COMPLETED->getDateTime()->format(\DateTimeInterface::ATOM));
 			$formattedDate = $this->l10n->l('date', $completedDateTime, ['width' => 'medium']);
 			return $this->l10n->t('Completed on %s', [$formattedDate]);
 		}
 
 		if ($taskComponent->DUE) {
-			$dueDateTime = new \DateTime($taskComponent->DUE->getDateTime()->format(\DateTime::ATOM));
+			$dueDateTime = new \DateTime($taskComponent->DUE->getDateTime()->format(\DateTimeInterface::ATOM));
 			$formattedDate = $this->l10n->l('date', $dueDateTime, ['width' => 'medium']);
 
 			if ($taskComponent->DUE->hasTime()) {

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -58,10 +58,10 @@ class ListCertificates extends Base {
 					'name' => $certificate->getName(),
 					'common_name' => $certificate->getCommonName(),
 					'organization' => $certificate->getOrganization(),
-					'expire' => $certificate->getExpireDate()->format(\DateTime::ATOM),
+					'expire' => $certificate->getExpireDate()->format(\DateTimeInterface::ATOM),
 					'issuer' => $certificate->getIssuerName(),
 					'issuer_organization' => $certificate->getIssuerOrganization(),
-					'issue_date' => $certificate->getIssueDate()->format(\DateTime::ATOM)
+					'issue_date' => $certificate->getIssueDate()->format(\DateTimeInterface::ATOM)
 				];
 			}, $this->certificateManager->listCertificates());
 			if ($outputType === self::OUTPUT_FORMAT_JSON) {

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -80,7 +80,7 @@ class Info extends Base {
 			'enabled' => $user->isEnabled(),
 			'groups' => $groups,
 			'quota' => $user->getQuota(),
-			'last_seen' => date(\DateTime::ATOM, $user->getLastLogin()), // ISO-8601
+			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];

--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -109,7 +109,7 @@ class ListCommand extends Base {
 					'enabled' => $user->isEnabled(),
 					'groups' => $groups,
 					'quota' => $user->getQuota(),
-					'last_seen' => date(\DateTime::ATOM, $user->getLastLogin()), // ISO-8601
+					'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 					'user_directory' => $user->getHome(),
 					'backend' => $user->getBackendClassName()
 				];

--- a/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
+++ b/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
@@ -46,7 +46,7 @@ class NotModifiedMiddleware extends Middleware {
 		}
 
 		$modifiedSinceHeader = $this->request->getHeader('IF_MODIFIED_SINCE');
-		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(\DateTime::RFC2822)) {
+		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(\DateTimeInterface::RFC2822)) {
 			$response->setStatus(Http::STATUS_NOT_MODIFIED);
 			return $response;
 		}

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -103,7 +103,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 		$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
 
 		$time = new \DateTime('now', $timeZone);
-		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', \DateTime::ATOM));
+		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', \DateTimeInterface::ATOM));
 
 		return $timestampInfo . ' ' . $this->formatter->format($message);
 	}

--- a/lib/private/Files/ObjectStore/S3Signature.php
+++ b/lib/private/Files/ObjectStore/S3Signature.php
@@ -129,7 +129,7 @@ class S3Signature implements SignatureInterface {
 	) {
 		$modify = [
 			'remove_headers' => ['X-Amz-Date'],
-			'set_headers' => ['Date' => gmdate(\DateTime::RFC2822)]
+			'set_headers' => ['Date' => gmdate(\DateTimeInterface::RFC2822)]
 		];
 
 		// Add the security token header if one is being used by the credentials

--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -37,7 +37,7 @@ abstract class LogDetails {
 
 	public function logDetails(string $app, $message, int $level): array {
 		// default to ISO8601
-		$format = $this->config->getValue('logdateformat', \DateTime::ATOM);
+		$format = $this->config->getValue('logdateformat', \DateTimeInterface::ATOM);
 		$logTimeZone = $this->config->getValue('logtimezone', 'UTC');
 		try {
 			$timezone = new \DateTimeZone($logTimeZone);

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -115,7 +115,7 @@ class Response {
 			$time = \OC::$server->query(ITimeFactory::class);
 			$expires->setTimestamp($time->getTime());
 			$expires->add(new \DateInterval('PT'.$cacheSeconds.'S'));
-			$this->addHeader('Expires', $expires->format(\DateTime::RFC2822));
+			$this->addHeader('Expires', $expires->format(\DateTimeInterface::RFC2822));
 		} else {
 			$this->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
 			unset($this->headers['Expires'], $this->headers['Pragma']);
@@ -244,7 +244,7 @@ class Response {
 
 		if ($this->lastModified) {
 			$mergeWith['Last-Modified'] =
-				$this->lastModified->format(\DateTime::RFC2822);
+				$this->lastModified->format(\DateTimeInterface::RFC2822);
 		}
 
 		$this->headers['Content-Security-Policy'] = $this->getContentSecurityPolicy()->buildPolicy();

--- a/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
@@ -62,11 +62,11 @@ class NotModifiedMiddlewareTest extends \Test\TestCase {
 			['etag', '"etag"', null, '', true],
 
 			[null, '', $now, $now->format(\DateTime::RFC2822), true],
-			[null, '', $now, $now->format(\DateTime::ATOM), false],
+			[null, '', $now, $now->format(\DateTimeInterface::ATOM), false],
 			[null, '', null, $now->format(\DateTime::RFC2822), false],
 			[null, '', $now, '', false],
 
-			['etag', '"etag"', $now, $now->format(\DateTime::ATOM), true],
+			['etag', '"etag"', $now, $now->format(\DateTimeInterface::ATOM), true],
 			['etag', '"etag"', $now, $now->format(\DateTime::RFC2822), true],
 		];
 	}

--- a/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
@@ -61,13 +61,13 @@ class NotModifiedMiddlewareTest extends \Test\TestCase {
 			[null, '"etag"', null, '', false],
 			['etag', '"etag"', null, '', true],
 
-			[null, '', $now, $now->format(\DateTime::RFC2822), true],
+			[null, '', $now, $now->format(\DateTimeInterface::RFC2822), true],
 			[null, '', $now, $now->format(\DateTimeInterface::ATOM), false],
-			[null, '', null, $now->format(\DateTime::RFC2822), false],
+			[null, '', null, $now->format(\DateTimeInterface::RFC2822), false],
 			[null, '', $now, '', false],
 
 			['etag', '"etag"', $now, $now->format(\DateTimeInterface::ATOM), true],
-			['etag', '"etag"', $now, $now->format(\DateTime::RFC2822), true],
+			['etag', '"etag"', $now, $now->format(\DateTimeInterface::RFC2822), true],
 		];
 	}
 


### PR DESCRIPTION
In PHP7.2 those were moved to the interface. The `DateTime` class doesn't actually have them anymore.