### PR TITLE
Downstream encryption:fix-encrypted-version for repairing "bad signature" errors

### DIFF
--- a/apps/encryption/appinfo/info.xml
+++ b/apps/encryption/appinfo/info.xml
@@ -45,6 +45,7 @@
 		<command>OCA\Encryption\Command\DisableMasterKey</command>
 		<command>OCA\Encryption\Command\RecoverUser</command>
 		<command>OCA\Encryption\Command\ScanLegacyFormat</command>
+		<command>OCA\Encryption\Command\FixEncryptedVersion</command>
 	</commands>
 
 	<settings>

--- a/apps/encryption/composer/composer/autoload_classmap.php
+++ b/apps/encryption/composer/composer/autoload_classmap.php
@@ -10,6 +10,7 @@ return array(
     'OCA\\Encryption\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\Encryption\\Command\\DisableMasterKey' => $baseDir . '/../lib/Command/DisableMasterKey.php',
     'OCA\\Encryption\\Command\\EnableMasterKey' => $baseDir . '/../lib/Command/EnableMasterKey.php',
+    'OCA\\Encryption\\Command\\FixEncryptedVersion' => $baseDir . '/../lib/Command/FixEncryptedVersion.php',
     'OCA\\Encryption\\Command\\RecoverUser' => $baseDir . '/../lib/Command/RecoverUser.php',
     'OCA\\Encryption\\Command\\ScanLegacyFormat' => $baseDir . '/../lib/Command/ScanLegacyFormat.php',
     'OCA\\Encryption\\Controller\\RecoveryController' => $baseDir . '/../lib/Controller/RecoveryController.php',

--- a/apps/encryption/composer/composer/autoload_static.php
+++ b/apps/encryption/composer/composer/autoload_static.php
@@ -25,6 +25,7 @@ class ComposerStaticInitEncryption
         'OCA\\Encryption\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\Encryption\\Command\\DisableMasterKey' => __DIR__ . '/..' . '/../lib/Command/DisableMasterKey.php',
         'OCA\\Encryption\\Command\\EnableMasterKey' => __DIR__ . '/..' . '/../lib/Command/EnableMasterKey.php',
+        'OCA\\Encryption\\Command\\FixEncryptedVersion' => __DIR__ . '/..' . '/../lib/Command/FixEncryptedVersion.php',
         'OCA\\Encryption\\Command\\RecoverUser' => __DIR__ . '/..' . '/../lib/Command/RecoverUser.php',
         'OCA\\Encryption\\Command\\ScanLegacyFormat' => __DIR__ . '/..' . '/../lib/Command/ScanLegacyFormat.php',
         'OCA\\Encryption\\Controller\\RecoveryController' => __DIR__ . '/..' . '/../lib/Controller/RecoveryController.php',

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ * @author Ilja Neumann <ineumann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Command;
+
+use OC\Files\View;
+use OC\HintException;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixEncryptedVersion extends Command {
+	/** @var IRootFolder  */
+	private $rootFolder;
+
+	/** @var IUserManager  */
+	private $userManager;
+
+	/** @var View  */
+	private $view;
+
+	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->view = $view;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('encryption:fix-encrypted-version')
+			->setDescription('Fix the encrypted version if the encrypted file(s) are not downloadable.')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'The id of the user whose files need fixing'
+			)->addOption(
+				'path',
+				'p',
+				InputArgument::OPTIONAL,
+				'Limit files to fix with path, e.g., --path="/Music/Artist". If path indicates a directory, all the files inside directory will be fixed.'
+			);
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$user = $input->getArgument('user');
+		$pathToWalk = "/$user/files";
+
+		/**
+		 * trim() returns an empty string when the argument is an unset/null
+		 */
+		$pathOption = \trim($input->getOption('path'), '/');
+		if ($pathOption !== "") {
+			$pathToWalk = "$pathToWalk/$pathOption";
+		}
+
+		if ($user === null) {
+			$output->writeln("<error>No user id provided.</error>\n");
+			return 1;
+		}
+
+		if ($this->userManager->get($user) === null) {
+			$output->writeln("<error>User id $user does not exist. Please provide a valid user id</error>");
+			return 1;
+		}
+		return $this->walkPathOfUser($user, $pathToWalk, $output);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @param OutputInterface $output
+	 * @return int 0 for success, 1 for error
+	 */
+	private function walkPathOfUser($user, $path, OutputInterface $output) {
+		$this->setupUserFs($user);
+		if (!$this->view->file_exists($path)) {
+			$output->writeln("<error>Path $path does not exist. Please provide a valid path.</error>");
+			return 1;
+		}
+
+		if ($this->view->is_file($path)) {
+			$output->writeln("Verifying the content of file $path");
+			$this->verifyFileContent($path, $output);
+			return 0;
+		}
+		$directories = [];
+		$directories[] = $path;
+		while ($root = \array_pop($directories)) {
+			$directoryContent = $this->view->getDirectoryContent($root);
+			foreach ($directoryContent as $file) {
+				$path = $root . '/' . $file['name'];
+				if ($this->view->is_dir($path)) {
+					$directories[] = $path;
+				} else {
+					$output->writeln("Verifying the content of file $path");
+					$this->verifyFileContent($path, $output);
+				}
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 * @param bool $ignoreCorrectEncVersionCall, setting this variable to false avoids recursion
+	 */
+	private function verifyFileContent($path, OutputInterface $output, $ignoreCorrectEncVersionCall = true) {
+		try {
+			/**
+			 * In encryption, the files are read in a block size of 8192 bytes
+			 * Read block size of 8192 and a bit more (808 bytes)
+			 * If there is any problem, the first block should throw the signature
+			 * mismatch error. Which as of now, is enough to proceed ahead to
+			 * correct the encrypted version.
+			 */
+			$handle = $this->view->fopen($path, 'rb');
+
+			if (\fread($handle, 9001) !== false) {
+				$output->writeln("<info>The file $path is: OK</info>");
+			}
+
+			\fclose($handle);
+
+			return true;
+		} catch (HintException $e) {
+			\OC::$server->getLogger()->warning("Issue: " . $e->getMessage());
+			//If allowOnce is set to false, this becomes recursive.
+			if ($ignoreCorrectEncVersionCall === true) {
+				//Lets rectify the file by correcting encrypted version
+				$output->writeln("<info>Attempting to fix the path: $path</info>");
+				return $this->correctEncryptedVersion($path, $output);
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * @param string $path
+	 * @param OutputInterface $output
+	 * @return bool
+	 */
+	private function correctEncryptedVersion($path, OutputInterface $output) {
+		$fileInfo = $this->view->getFileInfo($path);
+		$fileId = $fileInfo->getId();
+		$encryptedVersion = $fileInfo->getEncryptedVersion();
+		$wrongEncryptedVersion = $encryptedVersion;
+
+		$storage = $fileInfo->getStorage();
+
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileId);
+
+		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+			$output->writeln("<info>The file: $path is a share. Hence kindly fix this by running the script for the owner of share</info>");
+			return true;
+		}
+
+		// Save original encrypted version so we can restore it if decryption fails with all version
+		$originalEncryptedVersion = $encryptedVersion;
+		if ($encryptedVersion >= 0) {
+			//test by decrementing the value till 1 and if nothing works try incrementing
+			$encryptedVersion--;
+			while ($encryptedVersion > 0) {
+				$cacheInfo = ['encryptedVersion' => $encryptedVersion, 'encrypted' => $encryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Decrement the encrypted version to $encryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file: $path with version " . $encryptedVersion . "</info>");
+					return true;
+				}
+				$encryptedVersion--;
+			}
+
+			//So decrementing did not work. Now lets increment. Max increment is till 5
+			$increment = 1;
+			while ($increment <= 5) {
+				/**
+				 * The wrongEncryptedVersion would not be incremented so nothing to worry about here.
+				 * Only the newEncryptedVersion is incremented.
+				 * For example if the wrong encrypted version is 4 then
+				 * cycle1 -> newEncryptedVersion = 5 ( 4 + 1)
+				 * cycle2 -> newEncryptedVersion = 6 ( 4 + 2)
+				 * cycle3 -> newEncryptedVersion = 7 ( 4 + 3)
+				 */
+				$newEncryptedVersion = $wrongEncryptedVersion + $increment;
+
+				$cacheInfo = ['encryptedVersion' => $newEncryptedVersion, 'encrypted' => $newEncryptedVersion];
+				$cache->put($fileCache->getPath(), $cacheInfo);
+				$output->writeln("<info>Increment the encrypted version to $newEncryptedVersion</info>");
+				if ($this->verifyFileContent($path, $output, false) === true) {
+					$output->writeln("<info>Fixed the file: $path with version " . $newEncryptedVersion . "</info>");
+					return true;
+				}
+				$increment++;
+			}
+		}
+
+		$cacheInfo = ['encryptedVersion' => $originalEncryptedVersion, 'encrypted' => $originalEncryptedVersion];
+		$cache->put($fileCache->getPath(), $cacheInfo);
+		$output->writeln("<info>No fix found for $path, restored version to original: $originalEncryptedVersion</info>");
+
+		return false;
+	}
+
+	/**
+	 * Setup user file system
+	 * @param string $uid
+	 */
+	private function setupUserFs($uid) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($uid);
+	}
+}

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -24,6 +24,7 @@ namespace OCA\Encryption\Command;
 
 use OC\Files\View;
 use OC\HintException;
+use OCA\Encryption\Util;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -46,14 +47,25 @@ class FixEncryptedVersion extends Command {
 	/** @var IUserManager  */
 	private $userManager;
 
+	/** @var Util */
+	private $util;
+
 	/** @var View  */
 	private $view;
 
-	public function __construct(IConfig $config, ILogger $logger, IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+	public function __construct(
+		IConfig $config,
+		ILogger $logger,
+		IRootFolder $rootFolder,
+		IUserManager $userManager,
+		Util $util,
+		View $view
+	) {
 		$this->config = $config;
 		$this->logger = $logger;
 		$this->rootFolder = $rootFolder;
 		$this->userManager = $userManager;
+		$this->util = $util;
 		$this->view = $view;
 		parent::__construct();
 	}
@@ -86,6 +98,11 @@ class FixEncryptedVersion extends Command {
 
 		if ($skipSignatureCheck) {
 			$output->writeln("<error>Repairing is not possible when \"encryption_skip_signature_check\" is set. Please disable this flag in the configuration.</error>\n");
+			return 1;
+		}
+
+		if (!$this->util->isMasterKeyEnabled()) {
+			$output->writeln("<error>Repairing only works with master key encryption.</error>\n");
 			return 1;
 		}
 

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -25,6 +25,7 @@ namespace OCA\Encryption\Command;
 use OC\Files\View;
 use OC\HintException;
 use OCP\Files\IRootFolder;
+use OCP\IConfig;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,6 +33,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FixEncryptedVersion extends Command {
+	/** @var IConfig */
+	private $config;
+
 	/** @var IRootFolder  */
 	private $rootFolder;
 
@@ -41,7 +45,8 @@ class FixEncryptedVersion extends Command {
 	/** @var View  */
 	private $view;
 
-	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+	public function __construct(IConfig $config, IRootFolder $rootFolder, IUserManager $userManager, View $view) {
+		$this->config = $config;
 		$this->rootFolder = $rootFolder;
 		$this->userManager = $userManager;
 		$this->view = $view;
@@ -72,6 +77,13 @@ class FixEncryptedVersion extends Command {
 	 * @return int
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+
+		if ($skipSignatureCheck) {
+			$output->writeln("<error>Repairing is not possible when \"encryption_skip_signature_check\" is set. Please disable this flag in the configuration.</error>\n");
+			return 1;
+		}
+
 		$user = $input->getArgument('user');
 		$pathToWalk = "/$user/files";
 

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -121,12 +121,12 @@ class FixEncryptedVersion extends Command {
 	private function walkPathOfUser($user, $path, OutputInterface $output): int {
 		$this->setupUserFs($user);
 		if (!$this->view->file_exists($path)) {
-			$output->writeln("<error>Path $path does not exist. Please provide a valid path.</error>");
+			$output->writeln("<error>Path \"$path\" does not exist. Please provide a valid path.</error>");
 			return 1;
 		}
 
 		if ($this->view->is_file($path)) {
-			$output->writeln("Verifying the content of file $path");
+			$output->writeln("Verifying the content of file \"$path\"");
 			$this->verifyFileContent($path, $output);
 			return 0;
 		}
@@ -139,7 +139,7 @@ class FixEncryptedVersion extends Command {
 				if ($this->view->is_dir($path)) {
 					$directories[] = $path;
 				} else {
-					$output->writeln("Verifying the content of file $path");
+					$output->writeln("Verifying the content of file \"$path\"");
 					$this->verifyFileContent($path, $output);
 				}
 			}
@@ -164,7 +164,7 @@ class FixEncryptedVersion extends Command {
 			$handle = $this->view->fopen($path, 'rb');
 
 			if (\fread($handle, 9001) !== false) {
-				$output->writeln("<info>The file $path is: OK</info>");
+				$output->writeln("<info>The file \"$path\" is: OK</info>");
 			}
 
 			\fclose($handle);
@@ -175,7 +175,7 @@ class FixEncryptedVersion extends Command {
 			//If allowOnce is set to false, this becomes recursive.
 			if ($ignoreCorrectEncVersionCall === true) {
 				//Lets rectify the file by correcting encrypted version
-				$output->writeln("<info>Attempting to fix the path: $path</info>");
+				$output->writeln("<info>Attempting to fix the path: \"$path\"</info>");
 				return $this->correctEncryptedVersion($path, $output);
 			}
 			return false;

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -1,0 +1,373 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Encryption\Tests\Command;
+
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OCA\Encryption\Command\FixEncryptedVersion;
+use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Session;
+use OCA\Encryption\Util;
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use OCA\Encryption\Users\Setup;
+use Test\TestCase;
+
+/**
+ * Class FixEncryptedVersionTest
+ *
+ * @group DB
+ * @package OCA\Encryption\Tests\Command
+ */
+class FixEncryptedVersionTest extends TestCase {
+	public const TEST_ENCRYPTION_VERSION_AFFECTED_USER = 'test_enc_version_affected_user1';
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var View */
+	private $view;
+
+	/** @var FixEncryptedVersion */
+	private $fixEncryptedVersion;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		//Enable encryption
+		\OC::$server->getConfig()->setAppValue('core', 'encryption_enabled', 'yes');
+		//Enable Masterkey
+		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
+		$crypt = new Crypt(\OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getL10N('encryption'));
+		$encryptionSession = new Session(\OC::$server->getSession());
+		$view = new View("/");
+		$encryptionUtil = new Util($view, $crypt, \OC::$server->getLogger(), \OC::$server->getUserSession(), \OC::$server->getConfig(), \OC::$server->getUserManager());
+		$keyManager = new KeyManager(
+			\OC::$server->getEncryptionKeyStorage(),
+			$crypt,
+			\OC::$server->getConfig(),
+			\OC::$server->getUserSession(),
+			$encryptionSession,
+			\OC::$server->getLogger(),
+			$encryptionUtil
+		);
+		$userSetup = new Setup(\OC::$server->getLogger(), \OC::$server->getUserSession(), $crypt, $keyManager);
+		$userSetup->setupSystem();
+		\OC::$server->getUserManager()->createUser(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+	}
+
+	public static function tearDownAfterClass(): void {
+		parent::tearDownAfterClass();
+		\OC\Files\Filesystem::clearMounts();
+		$user = \OC::$server->getUserManager()->get(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER);
+		if ($user !== null) {
+			$user->delete();
+		}
+		\OC::$server->getConfig()->deleteAppValue('core', 'encryption_enabled');
+		\OC::$server->getConfig()->deleteAppValue('core', 'default_encryption_module');
+		\OC::$server->getConfig()->deleteAppValues('encryption');
+		Filesystem::getLoader()->removeStorageWrapper("oc_encryption");
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->rootFolder = \OC::$server->getRootFolder();
+		$this->userManager = \OC::$server->getUserManager();
+		$this->view = new View("/");
+		$this->fixEncryptedVersion = new FixEncryptedVersion($this->rootFolder, $this->userManager, $this->view);
+		$this->commandTester = new CommandTester($this->fixEncryptedVersion);
+	}
+
+	/**
+	 * In this test the encrypted version is set to zero whereas it should have been
+	 * set to a positive non zero number.
+	 */
+	public function testEncryptedVersionIsNotZero() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('world.txt', 'a test string for world');
+
+		$fileInfo = $view->getFileInfo('hello.txt');
+
+		$storage = $fileInfo->getStorage();
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileInfo->getId());
+
+		//Now change the encrypted version to zero
+		$cacheInfo = ['encryptedVersion' => 0, 'encrypted' => 0];
+		$cache->put($fileCache->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Increment the encrypted version to 1
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 1", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
+	}
+
+	/**
+	 * In this test the encrypted version of the file is less than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionLessThanOriginalValue() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Yet another value');
+		$view->file_put_contents('hello.txt', 'Lets modify again1');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to two
+		$cacheInfo = ['encryptedVersion' => 2, 'encrypted' => 2];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 1, 'encrypted' => 1];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 1
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+Increment the encrypted version to 6
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 6", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Increment the encrypted version to 2
+Increment the encrypted version to 3
+Increment the encrypted version to 4
+Increment the encrypted version to 5
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 5", $output);
+	}
+
+	/**
+	 * In this test the encrypted version of the file is greater than the original value
+	 * but greater than zero
+	 */
+	public function testEncryptedVersionGreaterThanOriginalValue() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('hello.txt');
+		$view->touch('world.txt');
+		$view->touch('foo.txt');
+		$view->file_put_contents('hello.txt', 'a test string for hello');
+		$view->file_put_contents('hello.txt', 'Lets modify again2');
+		$view->file_put_contents('hello.txt', 'Lets modify again3');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('world.txt', 'a test string for world');
+		$view->file_put_contents('foo.txt', 'a foo test');
+
+		$fileInfo1 = $view->getFileInfo('hello.txt');
+
+		$storage1 = $fileInfo1->getStorage();
+		$cache1 = $storage1->getCache();
+		$fileCache1 = $cache1->get($fileInfo1->getId());
+
+		//Now change the encrypted version to fifteen
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache1->put($fileCache1->getPath(), $cacheInfo);
+
+		$fileInfo2 = $view->getFileInfo('world.txt');
+		$storage2 = $fileInfo2->getStorage();
+		$cache2 = $storage2->getCache();
+		$filecache2 = $cache2->get($fileInfo2->getId());
+
+		//Now change the encrypted version to 1
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache2->put($filecache2->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/hello.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/hello.txt is: OK
+Fixed the file: /test_enc_version_affected_user1/files/hello.txt with version 9", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+Attempting to fix the path: /test_enc_version_affected_user1/files/world.txt
+Decrement the encrypted version to 14
+Decrement the encrypted version to 13
+Decrement the encrypted version to 12
+Decrement the encrypted version to 11
+Decrement the encrypted version to 10
+Decrement the encrypted version to 9
+The file /test_enc_version_affected_user1/files/world.txt is: OK
+Fixed the file: /test_enc_version_affected_user1/files/world.txt with version 9", $output);
+	}
+
+	public function testVersionIsRestoredToOriginalIfNoFixIsFound() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+		$view = new View("/" . self::TEST_ENCRYPTION_VERSION_AFFECTED_USER . "/files");
+
+		$view->touch('bar.txt');
+		for ($i = 0; $i < 40; $i++) {
+			$view->file_put_contents('bar.txt', 'a test string for hello ' . $i);
+		}
+
+		$fileInfo = $view->getFileInfo('bar.txt');
+
+		$storage = $fileInfo->getStorage();
+		$cache = $storage->getCache();
+		$fileCache = $cache->get($fileInfo->getId());
+
+		$cacheInfo = ['encryptedVersion' => 15, 'encrypted' => 15];
+		$cache->put($fileCache->getPath(), $cacheInfo);
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER
+		]);
+
+		$cacheInfo = $cache->get($fileInfo->getId());
+		$encryptedVersion = $cacheInfo["encryptedVersion"];
+
+		$this->assertEquals(15, $encryptedVersion);
+	}
+
+	/**
+	 * Test commands with a file path
+	 */
+	public function testExecuteWithFilePathOption() {
+		\OC::$server->getUserSession()->login(self::TEST_ENCRYPTION_VERSION_AFFECTED_USER, 'foo');
+
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER,
+			'--path' => "/hello.txt"
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+The file /test_enc_version_affected_user1/files/hello.txt is: OK", $output);
+	}
+
+	/**
+	 * Test commands with a directory path
+	 */
+	public function testExecuteWithDirectoryPathOption() {
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER,
+			'--path' => "/"
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/hello.txt
+The file /test_enc_version_affected_user1/files/hello.txt is: OK", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/world.txt
+The file /test_enc_version_affected_user1/files/world.txt is: OK", $output);
+		$this->assertStringContainsString("Verifying the content of file /test_enc_version_affected_user1/files/foo.txt
+The file /test_enc_version_affected_user1/files/foo.txt is: OK", $output);
+	}
+
+	/**
+	 * Test commands with a directory path
+	 */
+	public function testExecuteWithNoUser() {
+		$this->commandTester->execute([
+			'user' => null,
+			'--path' => "/"
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("No user id provided.", $output);
+	}
+
+	/**
+	 * Test commands with a directory path
+	 */
+	public function testExecuteWithNonExistentPath() {
+		$this->commandTester->execute([
+			'user' => self::TEST_ENCRYPTION_VERSION_AFFECTED_USER,
+			'--path' => "/non-exist"
+		]);
+
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString("Please provide a valid path.", $output);
+	}
+}


### PR DESCRIPTION
For fixing "Bad signature" errors.

Imported from https://github.com/owncloud/encryption/blob/c8d67f5/lib/Command/FixEncryptedVersion.php (master from that time).
No changes were made in the initial import.

### Tests

To test, upload a file and then manually change its "encrypted" value to either value - 1 or value + 1 then run `occ encryption:fix-encrypted-version`

#### User-key encryption

- ~~recovering all files for user~~ not supported
- ~~recovering by path for user~~ not supported

#### Master-key encryption

- [x] recovering all files for user
- [x] recovering by path for user

#### Other

- [x] does it repair when "encryption_skip_signature_check" is set ? :no_entry_sign: see below
- [x] group folders ??? => not supported
