### PR TITLE
Unshift crash reports when they are loaded, to break the recusion

### DIFF
--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -35,6 +35,7 @@ use OCP\Support\CrashReport\IMessageReporter;
 use OCP\Support\CrashReport\IRegistry;
 use OCP\Support\CrashReport\IReporter;
 use Throwable;
+use function array_shift;
 
 class Registry implements IRegistry {
 
@@ -119,8 +120,7 @@ class Registry implements IRegistry {
 	}
 
 	private function loadLazyProviders(): void {
-		$classes = $this->lazyReporters;
-		foreach ($classes as $class) {
+		while (($class = array_shift($this->lazyReporters)) !== null) {
 			try {
 				/** @var IReporter $reporter */
 				$reporter = $this->serverContainer->query($class);
@@ -151,6 +151,5 @@ class Registry implements IRegistry {
 				]);
 			}
 		}
-		$this->lazyReporters = [];
 	}
 }


### PR DESCRIPTION
If, for whatever reason, during the loading of a crash reporter a new
log entry is generated, then the lazy loading mechanism will be invoked
*again* while it's already executed. This doesn't result in an endless
recursion, but means that the crash reporters will be built and
registered many times. This then means any further log entry will be
logged x times instead of once.

Unshift makes sure to take the class off the registration list right
away, so another invocation of the same method won't try to do the same
job.

Found while trying to bring the Sentry app to 21/22.