### PR TITLE
hide download button for public preview of audio files

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -63,7 +63,8 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 			<?php else: ?>
 				<?php if ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'audio'): ?>
 					<div id="imgframe">
-						<audio tabindex="0" controls="" preload="none" style="width: 100%; max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px">
+						<audio tabindex="0" controls="" preload="none" style="width: 100%; max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px"
+							   <?php if ($_['hideDownload']) { ?>controlsList="nodownload" <?php } ?>>
 							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
 						</audio>
 					</div>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -64,7 +64,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php if ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'audio'): ?>
 					<div id="imgframe">
 						<audio tabindex="0" controls="" preload="none" style="width: 100%; max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px"
-							   <?php // See https://github.com/nextcloud/server/pull/27674 ?>
+							   <?php // See https://github.com/nextcloud/server/pull/27674?>
 							   <?php if ($_['hideDownload']) { ?>controlsList="nodownload" <?php } ?>>
 							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
 						</audio>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -64,6 +64,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php if ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'audio'): ?>
 					<div id="imgframe">
 						<audio tabindex="0" controls="" preload="none" style="width: 100%; max-width: <?php p($_['previewMaxX']); ?>px; max-height: <?php p($_['previewMaxY']); ?>px"
+							   <?php // See https://github.com/nextcloud/server/pull/27674 ?>
 							   <?php if ($_['hideDownload']) { ?>controlsList="nodownload" <?php } ?>>
 							<source src="<?php p($_['downloadURL']); ?>" type="<?php p($_['mimetype']); ?>" />
 						</audio>


### PR DESCRIPTION
When the option to hide downloads was selected at public link creation, the download button can be hidden by the audio html attribute controlsList="nodownload"

closes #26086
closes #27872 

code was not tested, due to lack of local php setup