### PR TITLE
Validate the theming color also on CLI

### DIFF
--- a/apps/theming/lib/Command/UpdateConfig.php
+++ b/apps/theming/lib/Command/UpdateConfig.php
@@ -127,6 +127,11 @@ class UpdateConfig extends Command {
 			$key = $key . 'Mime';
 		}
 
+		if ($key === 'color' && !preg_match('/^\#([0-9a-f]{3}|[0-9a-f]{6})$/i', $value)) {
+			$output->writeln('<error>The given color is invalid: ' . $value . '</error>');
+			return 1;
+		}
+
 		$this->themingDefaults->set($key, $value);
 		$output->writeln('<info>Updated ' . $key . ' to ' . $value . '</info>');
 

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -220,7 +220,11 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @return string
 	 */
 	public function getColorPrimary() {
-		return $this->config->getAppValue('theming', 'color', $this->color);
+		$color = $this->config->getAppValue('theming', 'color', $this->color);
+		if (!preg_match('/^\#([0-9a-f]{3}|[0-9a-f]{6})$/i', $color)) {
+			$color = '#0082c9';
+		}
+		return $color;
 	}
 
 	/**


### PR DESCRIPTION
Vincent and me just wasted 2*2+ hours debugging segfault. Turns out if you have a 7 digit color in the oc_appconfig it breaks. It tries to show an error page, but we theme it and theming errors. So showing the error also errors until it segfaults. Root cause is:
```
expecting color, keyword received: core/css/variables.scss on line 47, at column 1\nCall Stack:\n#0 import core/css/variables.scss (unknown file) on line 1
```

Since you can also f*** up the color code via config:app:set I also added a backup validation on getting the primary color. 