### PR TITLE
LDAP: determine shares of offline users only when needed

### DIFF
--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -146,7 +146,8 @@ class OfflineUser {
 	 */
 	public function getDN() {
 		if ($this->dn === null) {
-			$this->fetchDetails();
+			$dn = $this->mapping->getDNByName($this->ocName);
+			$this->dn = ($dn !== false) ? $dn : '';
 		}
 		return $this->dn;
 	}
@@ -212,7 +213,7 @@ class OfflineUser {
 	 */
 	public function getHasActiveShares() {
 		if ($this->hasActiveShares === null) {
-			$this->fetchDetails();
+			$this->determineShares();
 		}
 		return $this->hasActiveShares;
 	}
@@ -232,11 +233,6 @@ class OfflineUser {
 		foreach ($properties as $property => $app) {
 			$this->$property = $this->config->getUserValue($this->ocName, $app, $property, '');
 		}
-
-		$dn = $this->mapping->getDNByName($this->ocName);
-		$this->dn = ($dn !== false) ? $dn : '';
-
-		$this->determineShares();
 	}
 
 	/**


### PR DESCRIPTION
The story behind is this:

1. On a migration call that loops over all users
2. Also all known LDAP users get into consideration
3. including those that are not found on LDAP anymore (`OfflineUser`)
4. and userExists is run against each user
5. which also causes an existency check against the LDAP server
6. for which the DN is required
7. the getter of the `OfflinerUser` triggered fetching all details
8. including checking whether they are a sharee
9. which depending on the share provider logic might invoke a user existence check

But the only place where we need the information is the `ldap:show-remnants` command.

fixes a segfault on a migration step of accessibility app on upgrade ~~#25761~~ (wrong issue)