### PR TITLE
Deprecate OCP\Remote

### DIFF
--- a/lib/public/Remote/Api/IApiCollection.php
+++ b/lib/public/Remote/Api/IApiCollection.php
@@ -26,12 +26,14 @@ namespace OCP\Remote\Api;
  * Provides access to the various apis of a remote instance
  *
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IApiCollection {
 	/**
 	 * @return IUserApi
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUserApi();
 
@@ -39,6 +41,7 @@ interface IApiCollection {
 	 * @return ICapabilitiesApi
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getCapabilitiesApi();
 }

--- a/lib/public/Remote/Api/IApiFactory.php
+++ b/lib/public/Remote/Api/IApiFactory.php
@@ -27,6 +27,7 @@ use OCP\Remote\IInstance;
 
 /**
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IApiFactory {
 	/**
@@ -35,6 +36,7 @@ interface IApiFactory {
 	 * @return IApiCollection
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getApiCollection(IInstance $instance, ICredentials $credentials);
 }

--- a/lib/public/Remote/Api/ICapabilitiesApi.php
+++ b/lib/public/Remote/Api/ICapabilitiesApi.php
@@ -24,12 +24,14 @@ namespace OCP\Remote\Api;
 
 /**
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface ICapabilitiesApi {
 	/**
 	 * @return array The capabilities in the form of [$appId => [$capability => $value]]
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getCapabilities();
 }

--- a/lib/public/Remote/Api/IUserApi.php
+++ b/lib/public/Remote/Api/IUserApi.php
@@ -26,6 +26,7 @@ use OCP\Remote\IUser;
 
 /**
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IUserApi {
 	/**
@@ -33,6 +34,7 @@ interface IUserApi {
 	 * @return IUser
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUser($userId);
 }

--- a/lib/public/Remote/ICredentials.php
+++ b/lib/public/Remote/ICredentials.php
@@ -26,12 +26,14 @@ namespace OCP\Remote;
  * The credentials for a remote user
  *
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface ICredentials {
 	/**
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUsername();
 
@@ -39,6 +41,7 @@ interface ICredentials {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getPassword();
 }

--- a/lib/public/Remote/IInstance.php
+++ b/lib/public/Remote/IInstance.php
@@ -26,12 +26,14 @@ namespace OCP\Remote;
  * Provides some basic info about a remote Nextcloud instance
  *
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IInstance {
 	/**
 	 * @return string The url of the remote server without protocol
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUrl();
 
@@ -39,6 +41,7 @@ interface IInstance {
 	 * @return string The of of the remote server with protocol
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getFullUrl();
 
@@ -46,6 +49,7 @@ interface IInstance {
 	 * @return string The full version string in '13.1.2.3' format
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getVersion();
 
@@ -53,6 +57,7 @@ interface IInstance {
 	 * @return string 'http' or 'https'
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getProtocol();
 
@@ -60,6 +65,7 @@ interface IInstance {
 	 * Check that the remote server is installed and not in maintenance mode
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 *
 	 * @return bool
 	 */

--- a/lib/public/Remote/IInstanceFactory.php
+++ b/lib/public/Remote/IInstanceFactory.php
@@ -24,6 +24,7 @@ namespace OCP\Remote;
 
 /**
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IInstanceFactory {
 	/**
@@ -31,6 +32,7 @@ interface IInstanceFactory {
 	 * @return IInstance
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getInstance($url);
 }

--- a/lib/public/Remote/IUser.php
+++ b/lib/public/Remote/IUser.php
@@ -26,12 +26,14 @@ namespace OCP\Remote;
  * User info for a remote user
  *
  * @since 13.0.0
+ * @deprecated 23.0.0
  */
 interface IUser {
 	/**
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUserId();
 
@@ -39,6 +41,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getEmail();
 
@@ -46,6 +49,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getDisplayName();
 
@@ -53,6 +57,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getPhone();
 
@@ -60,6 +65,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getAddress();
 
@@ -67,6 +73,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getWebsite();
 
@@ -74,6 +81,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getTwitter();
 
@@ -81,6 +89,7 @@ interface IUser {
 	 * @return string[]
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getGroups();
 
@@ -88,6 +97,7 @@ interface IUser {
 	 * @return string
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getLanguage();
 
@@ -95,6 +105,7 @@ interface IUser {
 	 * @return int
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getUsedSpace();
 
@@ -102,6 +113,7 @@ interface IUser {
 	 * @return int
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getFreeSpace();
 
@@ -109,6 +121,7 @@ interface IUser {
 	 * @return int
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getTotalSpace();
 
@@ -116,6 +129,7 @@ interface IUser {
 	 * @return int
 	 *
 	 * @since 13.0.0
+	 * @deprecated 23.0.0
 	 */
 	public function getQuota();
 }


### PR DESCRIPTION
This is unused.

Fixes https://github.com/nextcloud/server/issues/25780

