### PR TITLE
22.0.0 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 0, 0, 9];
+$OC_Version = [22, 0, 0, 10];
 
 // The human readable string
-$OC_VersionString = '22.0.0 RC1';
+$OC_VersionString = '22.0.0 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
changes relative to RC1

* #27649 Fix branch selection in stable22
* #27669 Unshift crash reports when they are loaded, to break the recusion
* #27678 Validate the theming color also on CLI
* #27682 Harden bootstrap context registrations when apps are missing
* #27702 LDAP: determine shares of offline users only when needed
* #27716 Revert "First attempt to check against core routes before loading all app routes"
* #27719 Make Provisioning API aware of multiple mails
* #27726 Downstream encryption:fix-encrypted-version for repairing "bad signature" errors
* #27736 Fix LDAPProviderFactory not found
* [activity#596](https://github.com/nextcloud/activity/pull/596) Update stable22 target versions
* [circles#638](https://github.com/nextcloud/circles/pull/638) Update stable22 target versions
* [circles#652](https://github.com/nextcloud/circles/pull/652) Cleaner version of config check for memberships
* [circles#653](https://github.com/nextcloud/circles/pull/653) Allow an admin account to manage Circles using ocs
* [circles#655](https://github.com/nextcloud/circles/pull/655) Keeping an illusion of consistency
* [circles#656](https://github.com/nextcloud/circles/pull/656) Removing deprecated code
* [circles#657](https://github.com/nextcloud/circles/pull/657) Maintenance management and federatedEvent retries
* [circles#658](https://github.com/nextcloud/circles/pull/658) Log on ocs exception
* [circles#659](https://github.com/nextcloud/circles/pull/659) Filter personal on canBeVisitor
* [circles#660](https://github.com/nextcloud/circles/pull/660) 22.0.0-beta.4
* [circles#662](https://github.com/nextcloud/circles/pull/662) Bypass initiator from 'membership' using direct 'member'
* [files_pdfviewer#435](https://github.com/nextcloud/files_pdfviewer/pull/435) Update stable22 target versions
* [firstrunwizard#553](https://github.com/nextcloud/firstrunwizard/pull/553) Update stable22 target versions
* [logreader#539](https://github.com/nextcloud/logreader/pull/539) Update stable22 target versions
* [nextcloud_announcements#80](https://github.com/nextcloud/nextcloud_announcements/pull/80) Update stable22 target versions
* [nextcloud_announcements#83](https://github.com/nextcloud/nextcloud_announcements/pull/83) Bye travis
* [notifications#1031](https://github.com/nextcloud/notifications/pull/1031) Update stable22 target versions
* [password_policy#221](https://github.com/nextcloud/password_policy/pull/221) Update stable22 target versions
* [photos#814](https://github.com/nextcloud/photos/pull/814) Update stable22 target versions
* [serverinfo#322](https://github.com/nextcloud/serverinfo/pull/322) Update stable22 target versions
* [survey_client#117](https://github.com/nextcloud/survey_client/pull/117) Update stable22 target versions
* [text#1678](https://github.com/nextcloud/text/pull/1678) Update stable22 target versions
* [text#1690](https://github.com/nextcloud/text/pull/1690) Use text/plain as content type for fetching the document
* [text#1696](https://github.com/nextcloud/text/pull/1696) Log exceptions that happen on unknown exception and return generic messages

Pending PRs:

* [ ] #26716 Fix share creation insert and get @skjnldsv
* [x] #27743 Design fixes to app-settings button 
* [x] [notifications#1037](https://github.com/nextcloud/notifications/pull/1037) Increase the icon size to 20px
