### PR TITLE
21.0.3

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 3, 0];
+$OC_Version = [21, 0, 3, 1];
 
 // The human readable string
-$OC_VersionString = '21.0.3 RC1';
+$OC_VersionString = '21.0.3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changes relative to RC 1

* #27551 Only allow removing existing shares that would not be allowed due to reshare restrictions
* #27670 Unshift crash reports when they are loaded, to break the recusion
* #27679 Validate the theming color also on CLI
* #27703 LDAP: determine shares of offline users only when needed
* #27727 Downstream encryption:fix-encrypted-version for repairing "bad signature" errors
* [text#1691](https://github.com/nextcloud/text/pull/1691) Use text/plain as content type for fetching the document
* [text#1697](https://github.com/nextcloud/text/pull/1697) Log exceptions that happen on unknown exception and return generic messages
* [text#1700](https://github.com/nextcloud/text/pull/1700) Try enabling apcu on cli for cypress


Pending PRs:

Pending PRs:

* [ ] #26650 Files & Core accessibility fixes 
* [ ] #26724 Fix account data visibility after disabling public addressbook upload 
* [x] #27107 Fix return value of getStorageInfo when 'quota_include_external_storage' is enabled 
* [ ] #27203 Fix Oracle query limit compliance in Comments 
* [ ] #27205 Better cleanup of filecache when deleting an external storage 
* [ ] #27406 Avoid fread on directories and unencrypted files 
* [ ] #27681 Harden bootstrap context registrations when apps are missing 
* [x] [nextcloud_announcements#78](https://github.com/nextcloud/nextcloud_announcements/pull/78) Update openssl for PHP 8.0 
* [x] [photos#812](https://github.com/nextcloud/photos/pull/812) Update File.vue 
* [ ] [text#1646](https://github.com/nextcloud/text/pull/1646) ViewerComponent: pass on autofocus to EditorWrapper 

