### PR TITLE
20.0.11

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 11, 0];
+$OC_Version = [20, 0, 11, 1];
 
 // The human readable string
-$OC_VersionString = '20.0.11 RC1';
+$OC_VersionString = '20.0.11';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
changes relative to RC 1

* #27226 Bump p-queue from 6.6.1 to 6.6.2
* #27552 Only allow removing existing shares that would not be allowed due to reshare restrictions
* #27651 Bump eslint-plugin-standard from 4.0.1 to 4.0.2
* #27680 Validate the theming color also on CLI
* #27728 Downstream encryption:fix-encrypted-version for repairing "bad signature" errors
* [photos#813](https://github.com/nextcloud/photos/pull/813) Update File.vue
* [text#1692](https://github.com/nextcloud/text/pull/1692) Use text/plain as content type for fetching the document
* [text#1698](https://github.com/nextcloud/text/pull/1698) Log exceptions that happen on unknown exception and return generic messages

Pending PRs:


* [ ] #26630 Add command to repair broken filesystem trees 
* [x] #27108 Fix return value of getStorageInfo when 'quota_include_external_storage' is enabled 
* [ ] #27207 Better cleanup of filecache when deleting an external storage 
* [ ] #27407 Avoid fread on directories and unencrypted files 

