### PR TITLE
Implementation of Target_Blank option to open External links in a new tab (link with External module Issue #74)

### DIFF
--- a/core/src/components/MainMenu.js
+++ b/core/src/components/MainMenu.js
@@ -72,7 +72,7 @@ export const setUp = () => {
 		if (!$app.is('a')) {
 			$app = $app.closest('a')
 		}
-		if (event.which === 1 && !event.ctrlKey && !event.metaKey) {
+		if (event.which === 1 && !event.ctrlKey && !event.metaKey && $app.attr('target') !== '_blank') {
 			$app.find('svg').remove()
 			$app.find('div').remove() // prevent odd double-clicks
 			// no need for theming, loader is already inverted on dark mode
@@ -100,7 +100,7 @@ export const setUp = () => {
 			$app = $app.closest('a')
 		}
 
-		if (event.which === 1 && !event.ctrlKey && !event.metaKey && $app.parent('#more-apps').length === 0) {
+		if (event.which === 1 && !event.ctrlKey && !event.metaKey && $app.parent('#more-apps').length === 0 && $app.attr('target') !== '_blank') {
 			$app.find('svg').remove()
 			$app.find('div').remove() // prevent odd double-clicks
 			$app.prepend($('<div/>').addClass(

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -55,6 +55,7 @@
 					<?php foreach ($_['navigation'] as $entry): ?>
 						<li data-id="<?php p($entry['id']); ?>" class="hidden" tabindex="-1">
 							<a href="<?php print_unescaped($entry['href']); ?>"
+								<?php if ($entry['target']): ?> target="_blank"<?php endif; ?>
 								<?php if ($entry['active']): ?> class="active"<?php endif; ?>
 								aria-label="<?php p($entry['name']); ?>">
 									<svg width="24" height="20" viewBox="0 0 24 20" alt=""<?php if ($entry['unread'] !== 0) { ?> class="has-unread"<?php } ?>>
@@ -91,6 +92,7 @@
 								<?php foreach ($_['navigation'] as $entry): ?>
 									<li data-id="<?php p($entry['id']); ?>">
 									<a href="<?php print_unescaped($entry['href']); ?>"
+										<?php if ($entry['target']): ?> target="_blank"<?php endif; ?>
 										<?php if ($entry['active']): ?> class="active"<?php endif; ?>
 										aria-label="<?php p($entry['name']); ?>">
 										<svg width="20" height="20" viewBox="0 0 20 20" alt=""<?php if ($entry['unread'] !== 0) { ?> class="has-unread"<?php } ?>>


### PR DESCRIPTION
Fix https://github.com/nextcloud/external/issues/79
** External module Issue : #74 "Open in new tab" **
** External module pull request : "Implementation of Target_Blank option to open External links in a new tab #268" **

Hi !

We are a team that contributes to the improvement and production of free software for the general public. Moreover, being a NextCloud user, we wanted to improve it and especially the External module.

Thus, we wanted to respond to Issue #74 which requires the opening of external links to a new tab.
We have therefore improved the source code of the External module by modifying the following:

On External front-end, we added the possibility to check the "New Tab" option.
We have modified the files "admin.js", "site.handlebars" and "style.css" in the External module where we added a "target" option.
**But we needed to modify some Nextcloud files too : "layout.user.php" and "MainMenu.js". So we also made a contribution on NextCloud Server in order for the implementation to be done properly.**

For setting up the data option in the database and link the front-end to back-end, we had to modify the following files in External module :
"Application.php", "APIController.php", "SitesManager.php", "Personnal.php", "BeforeTemplateRenderedListener.php" and " Capabilites.php".
In all of this files, we added the "target" option which allows us to follow the activation of the front-end option to the back-end and the database.

**If you have any questions about the implementation of the option, please do not hesitate to contact us by email at the following address: contact@fcclvandoeuvre.fr or christophecanovas66@gmail.com.**

Regards.