### PR TITLE
[stable21] Revert "Fix constraint violation detection in QB Mapper"

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
 
 namespace OCP\AppFramework\Db;
 
-use OCP\DB\Exception;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -162,11 +162,8 @@ abstract class QBMapper {
 	public function insertOrUpdate(Entity $entity): Entity {
 		try {
 			return $this->insert($entity);
-		} catch (Exception $ex) {
-			if ($ex->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-				return $this->update($entity);
-			}
-			throw $ex;
+		} catch (UniqueConstraintViolationException $ex) {
+			return $this->update($entity);
 		}
 	}
 


### PR DESCRIPTION
Reverts nextcloud/server#26587 because this breaks the *insert or update* logic. `insert` actually still throws the old DBAL exception, not our new own class, hence nothing is caught and the conflicting INSERT causes the process to stop when it should continue to run an UPDATE.