### PR TITLE
Fix for #26526 

### DIFF
--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -63,7 +63,7 @@ class SupportedDatabase {
 			case MySQL57Platform::class: # extends MySQLPlatform
 			case MariaDb1027Platform::class: # extends MySQLPlatform
 			case MySQLPlatform::class:
-				$result = $this->connection->prepare('SHOW VARIABLES LIKE "version";');
+				$result = $this->connection->prepare("SHOW VARIABLES LIKE 'version';");
 				$result->execute();
 				$row = $result->fetch();
 				$version = strtolower($row['Value']);


### PR DESCRIPTION
Fix #26526
fix for sql query
replaced double quotes with single quotes.
Query should now also work for dbs with sql_mode including "ANSI" and "ANSI_QUOTES"