### PR TITLE
Add isDeletable() check to OC\Files\Node::move()

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -5,6 +5,7 @@
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Daniel Rudolf <github.com@daniel-rudolf.de>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Julius Härtl <jus@bitgrid.net>
  * @author Morris Jobke <hey@morrisjobke.de>
@@ -435,6 +436,7 @@ class Node implements \OCP\Files\Node {
 		$targetPath = $this->normalizePath($targetPath);
 		$parent = $this->root->get(dirname($targetPath));
 		if (
+			$this->isDeletable() and
 			$parent instanceof Folder and
 			$this->isValidPath($targetPath) and
 			(

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -702,7 +702,7 @@ abstract class NodeTest extends \Test\TestCase {
 
 
 	public function testMoveParentIsFile() {
-		$this->expectException(\OCP\Files\NotPermittedException::class);
+		$this->expectException(\OCP\Files\NotFoundException::class);
 
 		$this->view->expects($this->never())
 			->method('rename');


### PR DESCRIPTION
Moving a file (or directory) is the same as creating a copy of the file and deleting the original one. This is also enforced on a filesystem level: One can't move 'foo/test' to 'bar/test' unless the user has 'wx' permissions on both 'foo' and 'bar'. In practice this never was an issue because the low-level storage returns 'false' anyway, but it might be in the future.