### PR TITLE
Clarify that federated sharing settings may also affect shares between users on the current instanc

### DIFF
--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -15,7 +15,7 @@ style('federatedfilesharing', 'settings-admin');
 	   title="<?php p($l->t('Open documentation'));?>"
 	   href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
 
-	<p class="settings-hint"><?php p($l->t('Adjust how people can share between servers.')); ?></p>
+	<p class="settings-hint"><?php p($l->t('Adjust how people can share between servers. This includes shares between users on this server as well if they are using federated sharing.')); ?></p>
 
 	<p>
 		<input type="checkbox" name="outgoing_server2server_share_enabled" id="outgoingServer2serverShareEnabled" class="checkbox"


### PR DESCRIPTION
Otherwise admins might have the impression that if they disable sharing to other servers, federated sharing on the same server (e.g. with sharing to a user on the same instance or through "Add to your Nextcloud") would still be enabled.