### PR TITLE
Add connection check in autotest.sh for pgsql docker

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -309,8 +309,10 @@ function execute_tests {
 
 			echo "Waiting for Postgres initialisation ..."
 
-			# grep exits on the first match and then the script continues
-			docker logs -f "$DOCKER_CONTAINER_ID" 2>&1 | grep -q "database system is ready to accept connections"
+			if ! apps/files_external/tests/env/wait-for-connection $DATABASEHOST 5432 60; then
+				echo "[ERROR] Waited 60 seconds for $DATABASEHOST, no response" >&2
+				exit 1
+			fi
 
 			echo "Postgres is up."
 		else


### PR DESCRIPTION
When using pgsql docker for testing locally with autotest, make sure to
properly wait for the port to be available.

How to test:
```
USEDOCKER=1 ./autotest.sh pgsql ../apps/files_sharing/tests/External/ManagerTest.php
```

Before this fix, the unit test run would start right away and fail with connection refused.

After this fix it waits a bit longer, but the tests can succeed.
