### PR TITLE
Fix in locking cache check

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -95,7 +95,7 @@ class Factory implements ICacheFactory {
 				'{class}' => $distributedCacheClass, '{use}' => 'distributed'
 			]), $missingCacheHint);
 		}
-		if (!($lockingCacheClass && class_exists($distributedCacheClass) && $lockingCacheClass::isAvailable())) {
+		if (!($lockingCacheClass && class_exists($lockingCacheClass) && $lockingCacheClass::isAvailable())) {
 			// don't fallback since the fallback might not be suitable for storing lock
 			$lockingCacheClass = self::NULL_CACHE;
 		}


### PR DESCRIPTION
The intention obviously was to check whether $lockingCacheClass is defined, and existing class, and available. It was however checked whether the $distributedCacheClass is an existing class, which, if not, would have caused an exception in the previous distributed cache check already.