### PR TITLE
Validate reshare permissions against actual path that the user tries to share

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -510,8 +510,9 @@ class ApiTest extends TestCase {
 			->setPermissions(19);
 		$share1 = $this->shareManager->createShare($share1);
 
+		$node2 = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER2)->get($this->filename);
 		$share2 = $this->shareManager->newShare();
-		$share2->setNode($node)
+		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
 			->setShareType(IShare::TYPE_USER)
@@ -633,7 +634,7 @@ class ApiTest extends TestCase {
 		$share1->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share1);
 
-		$node2 = $this->userFolder->get($this->folder.'/'.$this->filename);
+		$node2 = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER2)->get($this->folder.'/'.$this->filename);
 		$share2 = $this->shareManager->newShare();
 		$share2->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
@@ -643,7 +644,7 @@ class ApiTest extends TestCase {
 		$share2->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share2);
 
-		$node3 = $this->userFolder->get($this->folder.'/'.$this->subfolder.'/'.$this->filename);
+		$node3 = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER2)->get($this->folder.'/'.$this->subfolder.'/'.$this->filename);
 		$share3 = $this->shareManager->newShare();
 		$share3->setNode($node3)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
@@ -824,8 +825,9 @@ class ApiTest extends TestCase {
 		$share2->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share2);
 
+		$node2 = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER2)->get($this->folder . $this->subfolder);
 		$share3 = $this->shareManager->newShare();
-		$share3->setNode($node1)
+		$share3->setNode($node2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
 			->setShareType(IShare::TYPE_LINK)
 			->setPermissions(1);

--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -472,6 +472,36 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "200"
 
+  Scenario: do allow to create links on a shared folder with two mountpoints
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And group "group1" exists
+    And user "user1" belongs to group "group1"
+    And user "user0" created a folder "/TMP"
+    And user "user0" created a folder "/TMP/SUB"
+    And As an "user0"
+    And creating a share with
+      | path | TMP |
+      | shareType | 1 |
+      | shareWith | group1 |
+      | permissions | 15  |
+    When As an "user1"
+    And accepting last share
+    And As an "user0"
+    And creating a share with
+      | path | TMP/SUB |
+      | shareType | 0 |
+      | shareWith | user1 |
+      | permissions | 31  |
+    When As an "user1"
+    And accepting last share
+    And creating a share with
+      | path | TMP/SUB |
+      | shareType | 3 |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+
   Scenario: deleting file out of a share as recipient creates a backup for the owner
     Given As an "admin"
     And user "user0" exists

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -52,6 +52,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Node;
+use OCP\Files\NotFoundException;
 use OCP\HintException;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -292,10 +293,18 @@ class Manager implements IManager {
 		$permissions = 0;
 
 		if (!$isFederatedShare && $share->getNode()->getOwner() && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
-			$userMounts = array_filter($userFolder->getById($share->getNode()->getId()), function ($mount) use ($share) {
+			try {
+				$targetNode = $share->getTarget() ? $userFolder->get($share->getTarget()) : null;
+			} catch (NotFoundException $e) {
+				$targetNode = null;
+			}
+			$userMounts = array_filter($userFolder->getById($share->getNode()->getId()), function ($mount) use ($share, $targetNode) {
 				// We need to filter since there might be other mountpoints that contain the file
 				// e.g. if the user has access to the same external storage that the file is originating from
-				return $mount->getStorage()->instanceOfStorage(ISharedStorage::class) && $mount->getPath() === $share->getNode()->getPath();
+				return $mount->getStorage()->instanceOfStorage(ISharedStorage::class) && (
+					$targetNode ? $targetNode->getPath() === $mount->getPath() :
+						$mount->getPath() === $share->getNode()->getPath()
+				);
 			});
 			$userMount = array_shift($userMounts);
 			if ($userMount === null) {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -292,10 +292,10 @@ class Manager implements IManager {
 		$permissions = 0;
 
 		if (!$isFederatedShare && $share->getNode()->getOwner() && $share->getNode()->getOwner()->getUID() !== $share->getSharedBy()) {
-			$userMounts = array_filter($userFolder->getById($share->getNode()->getId()), function ($mount) {
+			$userMounts = array_filter($userFolder->getById($share->getNode()->getId()), function ($mount) use ($share) {
 				// We need to filter since there might be other mountpoints that contain the file
 				// e.g. if the user has access to the same external storage that the file is originating from
-				return $mount->getStorage()->instanceOfStorage(ISharedStorage::class);
+				return $mount->getStorage()->instanceOfStorage(ISharedStorage::class) && $mount->getPath() === $share->getNode()->getPath();
 			});
 			$userMount = array_shift($userMounts);
 			if ($userMount === null) {


### PR DESCRIPTION
Otherwise this could lead to taking the wrong user mount in case there
are multiple ones with different permissions that the user could use to
reshare

Possible reproduction:
- A creates a folder and shares it with group without reshare permissions
- A creates a subfolder inside of the share and shares it to B with reshare permisions
- B is member of group
- B Tries to create a share link of the subfolder

Before:
:boom: Cannot increase permissions

After:
The proper source user mount is taken for permission comparison where the user has reshare permissions and the share link creation passes.