### PR TITLE
Use proper "Share to Diaspora" URL

### DIFF
--- a/apps/federatedfilesharing/templates/settings-personal.php
+++ b/apps/federatedfilesharing/templates/settings-personal.php
@@ -31,7 +31,7 @@ style('federatedfilesharing', 'settings-personal');
 			Twitter
 		</button>
 		<button class="social-diaspora pop-up"
-				data-url='https://sharetodiaspora.github.io/?title=<?php p($_['message_without_URL']); ?>&url=<?php p(urlencode($_['reference'])); ?>'>
+				data-url='https://share.diasporafoundation.org/?title=<?php p($_['message_without_URL']); ?>&url=<?php p(urlencode($_['reference'])); ?>'>
 			Diaspora
 		</button>
 		<button id="oca-files-sharing-add-to-your-website">


### PR DESCRIPTION
The previous URL leads to an outdated GitHub page that links to websites
which are already available to sale.

This uses the somewhat more official https://share.diasporafoundation.org/

FWIW: I'd personally also be completely fine with removing this share dialogue as I don't believe Diaspora has any reasonable traction to advertise it. But keeping it is probably less controversial 🤷 