### PR TITLE
Fixes recursion count incrementation

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -46,7 +46,7 @@ class DnsPinMiddleware {
 			return [];
 		}
 
-		$recursionCount = $recursionCount++;
+		$recursionCount++;
 		$targetIps = [];
 
 		$soaDnsEntry = dns_get_record($target, DNS_SOA);


### PR DESCRIPTION
Due to [operator precedence](https://www.php.net/manual/en/language.operators.precedence.php) the counter is never incremented.

This could block the upgrade process, see #27821
Fix #27821