### PR TITLE
Make integrity commands verbose

### DIFF
--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -72,8 +72,10 @@ class CheckApp extends Base {
 		$result = $this->checker->verifyAppSignature($appid, $path, true);
 		$this->writeArrayInOutputFormat($input, $output, $result);
 		if (count($result) > 0) {
+			$output->writeln('<error>' . count($result) . ' errors found</error>', OutputInterface::VERBOSITY_VERBOSE);
 			return 1;
 		}
+		$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
 		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -68,8 +68,10 @@ class CheckCore extends Base {
 		$result = $this->checker->verifyCoreSignature();
 		$this->writeArrayInOutputFormat($input, $output, $result);
 		if (count($result) > 0) {
+			$output->writeln('<error>' . count($result) . ' errors found</error>', OutputInterface::VERBOSITY_VERBOSE);
 			return 1;
 		}
+		$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
 		return 0;
 	}
 }


### PR DESCRIPTION
### With success before

```
$ occ  integrity:check-core 
$ occ  integrity:check-core -v
$
```

### With success after

```
$ occ  integrity:check-core 
$ occ  integrity:check-core -v
No errors found
$
```