### PR TITLE
Allow to get a local cloud id without going through the contacts manager

### DIFF
--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -32,6 +32,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCP\Contacts\IManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 
 class AddressHandlerTest extends \Test\TestCase {
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
@@ -59,7 +60,7 @@ class AddressHandlerTest extends \Test\TestCase {
 
 		$this->contactsManager = $this->createMock(IManager::class);
 
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->urlGenerator, $this->createMock(IUserManager::class));
 
 		$this->addressHandler = new AddressHandler($this->urlGenerator, $this->il10n, $this->cloudIdManager);
 	}

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -41,6 +41,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IManager;
@@ -106,7 +107,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		$this->userSession = $this->getMockBuilder(IUserSession::class)->disableOriginalConstructor()->getMock();
 		$this->clientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->disableOriginalConstructor()->getMock();
 		$this->contactsManager = $this->createMock(IContactsManager::class);
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->userManager);
 
 		$this->controller = new MountPublicLinkController(
 			'federatedfilesharing', $this->request,

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -46,6 +46,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -115,7 +116,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		//$this->addressHandler = new AddressHandler(\OC::$server->getURLGenerator(), $this->l);
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')->disableOriginalConstructor()->getMock();
 		$this->contactsManager = $this->createMock(IContactsManager::class);
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->userManager);
 		$this->gsConfig = $this->createMock(\OCP\GlobalScale\IConfig::class);
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -31,6 +31,8 @@ use OC\Federation\CloudIdManager;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Contacts\IManager;
 use OCP\Federation\ICloudIdManager;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
 
 /**
  * Class Cache
@@ -66,7 +68,7 @@ class CacheTest extends TestCase {
 
 		$this->contactsManager = $this->createMock(IManager::class);
 
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->createMock(IUserManager::class));
 		$this->remoteUser = $this->getUniqueID('remoteuser');
 
 		$this->storage = $this->getMockBuilder('\OCA\Files_Sharing\External\Storage')

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -42,6 +42,7 @@ use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IGroupManager;
+use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Share\IShare;
 use Test\Traits\UserTrait;
@@ -131,7 +132,7 @@ class ManagerTest extends TestCase {
 
 		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function () {
 			return $this->manager;
-		}, new CloudIdManager($this->contactsManager));
+		}, new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->userManager));
 	}
 
 	private function setupMounts() {

--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -33,13 +33,21 @@ namespace OC\Federation;
 use OCP\Contacts\IManager;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
 
 class CloudIdManager implements ICloudIdManager {
 	/** @var IManager */
 	private $contactsManager;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+	/** @var IUserManager */
+	private $userManager;
 
-	public function __construct(IManager $contactsManager) {
+	public function __construct(IManager $contactsManager, IURLGenerator $urlGenerator, IUserManager $userManager) {
 		$this->contactsManager = $contactsManager;
+		$this->urlGenerator = $urlGenerator;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -103,22 +111,37 @@ class CloudIdManager implements ICloudIdManager {
 
 	/**
 	 * @param string $user
-	 * @param string $remote
+	 * @param string|null $remote
 	 * @return CloudId
 	 */
-	public function getCloudId(string $user, string $remote): ICloudId {
-		// TODO check what the correct url is for remote (asking the remote)
-		$fixedRemote = $this->fixRemoteURL($remote);
-		if (strpos($fixedRemote, 'http://') === 0) {
-			$host = substr($fixedRemote, strlen('http://'));
-		} elseif (strpos($fixedRemote, 'https://') === 0) {
-			$host = substr($fixedRemote, strlen('https://'));
+	public function getCloudId(string $user, ?string $remote): ICloudId {
+		if ($remote === null) {
+			$remote = rtrim($this->removeProtocolFromUrl($this->urlGenerator->getAbsoluteURL('/')), '/');
+			$fixedRemote = $this->fixRemoteURL($remote);
+			$localUser = $this->userManager->get($user);
+			$displayName = !is_null($localUser) ? $localUser->getDisplayName() : '';
 		} else {
-			$host = $fixedRemote;
+			// TODO check what the correct url is for remote (asking the remote)
+			$fixedRemote = $this->fixRemoteURL($remote);
+			$host = $this->removeProtocolFromUrl($fixedRemote);
+			$displayName = $this->getDisplayNameFromContact($user . '@' . $host);
 		}
 		$id = $user . '@' . $remote;
-		$displayName = $this->getDisplayNameFromContact($user . '@' . $host);
 		return new CloudId($id, $user, $fixedRemote, $displayName);
+	}
+
+	/**
+	 * @param string $url
+	 * @return string
+	 */
+	private function removeProtocolFromUrl($url) {
+		if (strpos($url, 'https://') === 0) {
+			return substr($url, strlen('https://'));
+		} elseif (strpos($url, 'http://') === 0) {
+			return substr($url, strlen('http://'));
+		}
+
+		return $url;
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1286,7 +1286,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 
 		$this->registerService(ICloudIdManager::class, function (ContainerInterface $c) {
-			return new CloudIdManager($c->get(\OCP\Contacts\IManager::class));
+			return new CloudIdManager($c->get(\OCP\Contacts\IManager::class), $c->get(IURLGenerator::class), $c->get(IUserManager::class));
 		});
 
 		$this->registerAlias(\OCP\GlobalScale\IConfig::class, \OC\GlobalScale\Config::class);

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -466,7 +466,7 @@ class User implements IUser {
 		$uid = $this->getUID();
 		$server = $this->urlGenerator->getAbsoluteURL('/');
 		$server = rtrim($this->removeProtocolFromUrl($server), '/');
-		return \OC::$server->getCloudIdManager()->getCloudId($uid, $server)->getId();
+		return $uid . '@' . $server;
 	}
 
 	/**

--- a/lib/public/Federation/ICloudIdManager.php
+++ b/lib/public/Federation/ICloudIdManager.php
@@ -46,12 +46,12 @@ interface ICloudIdManager {
 	 * Get the cloud id for a remote user
 	 *
 	 * @param string $user
-	 * @param string $remote
+	 * @param string|null $remote (optional since 23.0.0 for local users)
 	 * @return ICloudId
 	 *
 	 * @since 12.0.0
 	 */
-	public function getCloudId(string $user, string $remote): ICloudId;
+	public function getCloudId(string $user, ?string $remote): ICloudId;
 
 	/**
 	 * Check if the input is a correctly formatted cloud id

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -32,7 +32,9 @@ use OCP\Contacts\IManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IShare;
 use Test\TestCase;
@@ -70,7 +72,7 @@ class MailPluginTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->createMock(IUserManager::class));
 
 		$this->searchResult = new SearchResult();
 	}

--- a/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
@@ -30,6 +30,7 @@ use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\Contacts\IManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -62,7 +63,7 @@ class RemotePluginTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->contactsManager = $this->createMock(IManager::class);
-		$this->cloudIdManager = new CloudIdManager($this->contactsManager);
+		$this->cloudIdManager = new CloudIdManager($this->contactsManager, $this->createMock(IURLGenerator::class), $this->createMock(IUserManager::class));
 		$this->searchResult = new SearchResult();
 	}
 


### PR DESCRIPTION
As from https://github.com/nextcloud/activity/pull/617, [getCloudId can be expensive](https://github.com/nextcloud/server/blob/master/lib/private/Federation/CloudIdManager.php#L84-L120), especially on large instances since curently the contacts manager is called to search for the cloud id which may lead to slow queries as it searches the oc_card_properties table with a LIKE with wildcards on every file action:

```
SELECT DISTINCT `cp`.`cardid` FROM `oc_cards_properties` `cp` WHERE (`cp`.`addressbookid` = N) AND (`cp`.`name` = N) AND (`cp`.`value`  COLLATE utfNmbN_general_ci LIKE '%cloud@exmaple.com%');
```

For local users this PR allows to omit the remote parameter when getting the cloud id for a local user. The display name will then be fetched from the user manager instead and the remote URL will be constructed as it was done before in the User class.