### PR TITLE
Keep pw based auth tokens valid when pw-less login happens

### DIFF
--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -48,6 +48,11 @@ class UserLoggedInListener implements IEventListener {
 			return;
 		}
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($event->getPassword() === '') {
+			return;
+		}
+
 		// If this is already a token login there is nothing to do
 		if ($event->isTokenLogin()) {
 			return;

--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -48,6 +48,11 @@ class UserLoggedInListener implements IEventListener {
 			return;
 		}
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($event->getPassword()==='') {
+			return;
+		}
+
 		// If this is already a token login there is nothing to do
 		if ($event->isTokenLogin()) {
 			return;

--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -49,7 +49,7 @@ class UserLoggedInListener implements IEventListener {
 		}
 
 		// prevent setting an empty pw as result of pw-less-login
-		if ($event->getPassword()==='') {
+		if ($event->getPassword() === '') {
 			return;
 		}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -413,6 +413,11 @@ class PublicKeyTokenProvider implements IProvider {
 	public function updatePasswords(string $uid, string $password) {
 		$this->cache->clear();
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($password === '') {
+			return;
+		}
+
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
 		foreach ($tokens as $t) {

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -414,6 +414,11 @@ class PublicKeyTokenProvider implements IProvider {
 	public function updatePasswords(string $uid, string $password) {
 		$this->cache->clear();
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($password==='') {
+			return;
+		}
+
 		if (!$this->mapper->hasExpiredTokens($uid)) {
 			// Nothing to do here
 			return;

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -415,7 +415,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		// prevent setting an empty pw as result of pw-less-login
-		if ($password==='') {
+		if ($password === '') {
 			return;
 		}
 


### PR DESCRIPTION
Hi,

after publishing the eID-Login app for Nextcloud users reported about the problem, that after doing a passwordless login with an eID, all already existing password based authn tokens (browser sessions and app passwords) become invalidated. See eid-login/eid-login-nextcloud#2

When investigating the issue, I found the same happens when doing a WebAuthn (password ) login. The empty password from the login is used to update existing authn tokens, which invalidates them. They get removed on the next run of https://github.com/nextcloud/server/blob/c2f62ee0b8c779808992d053494a845daa3d33b7/lib/private/User/Session.php#L729

To keep the existing authn tokens valid, this pull requests prevents the updating of the tokens, if the given password is an empty string.

Please note: This are the two places I found where token passwords are updated on an login attempt. I am not sure why this must happen twice? There may be more? I don`t know.

Also there is a little inconsistency in the function signatures for setting token passwords. When creating a session token a 'null' value as password can be set, which is also set it as 'null' in the database: 
https://github.com/nextcloud/server/blob/c2f62ee0b8c779808992d053494a845daa3d33b7/lib/private/User/Session.php#L679
This is resulting in different handling of the token later on:
https://github.com/nextcloud/server/blob/c4159e37ed594030b5be630139426c05a07c158e/lib/private/Authentication/Token/DefaultTokenProvider.php#L224-L230
https://github.com/nextcloud/server/blob/c2f62ee0b8c779808992d053494a845daa3d33b7/lib/private/User/Session.php#L740-L748


In these functions 'null' is not allowed but an empty string must be used:
https://github.com/nextcloud/server/blob/c4159e37ed594030b5be630139426c05a07c158e/lib/private/Authentication/Token/DefaultTokenProvider.php#L86
https://github.com/nextcloud/server/blob/c4159e37ed594030b5be630139426c05a07c158e/lib/private/Authentication/Token/DefaultTokenProvider.php#L242

Maybe this APIs can be changed to handle the 'null' value more consistently?

TIA for looking into this and feedback about the issue!

Greetings!
