### PR TITLE
Fix Psalm code scanning alerts

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -28,7 +28,6 @@ namespace OCA\Theming;
 
 use Imagick;
 use ImagickPixel;
-use OCP\App\AppPathNotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 
 class IconBuilder {
@@ -202,8 +201,8 @@ class IconBuilder {
 		$innerHeight = ($appIconFile->getImageHeight() - $border_h * 2);
 		$appIconFile->adaptiveResizeImage($innerWidth, $innerHeight);
 		// center icon
-		$offset_w = 512 / 2 - $innerWidth / 2;
-		$offset_h = 512 / 2 - $innerHeight / 2;
+		$offset_w = (int)(512 / 2 - $innerWidth / 2);
+		$offset_h = (int)(512 / 2 - $innerHeight / 2);
 
 		$finalIconFile = new Imagick();
 		$finalIconFile->setBackgroundColor(new ImagickPixel('transparent'));
@@ -223,10 +222,14 @@ class IconBuilder {
 		return $finalIconFile;
 	}
 
+	/**
+	 * @param $app string app name
+	 * @param $image string relative path to svg file in app directory
+	 * @return string|false content of a colorized svg file
+	 */
 	public function colorSvg($app, $image) {
-		try {
-			$imageFile = $this->util->getAppImage($app, $image);
-		} catch (AppPathNotFoundException $e) {
+		$imageFile = $this->util->getAppImage($app, $image);
+		if ($imageFile === false || $imageFile === "") {
 			return false;
 		}
 		$svg = file_get_contents($imageFile);


### PR DESCRIPTION
I recognised these now breaking CI checks in at least two unrelated PRs. They so far seem all no bugs but more standardisation and failsafe code quality.

~This is WIP~ but I opened the PR already to verify those have the desired effect on Psalm checks.

- InvalidScalarArgument (apps/theming/lib/IconBuilder.php#L213): https://github.com/nextcloud/server/security/code-scanning/6691
- InvalidScalarArgument (apps/theming/lib/IconBuilder.php#L213): https://github.com/nextcloud/server/security/code-scanning/6692
- MissingReturnType (apps/theming/lib/IconBuilder.php#L226): https://github.com/nextcloud/server/security/code-scanning/6693
- MissingParamType (apps/theming/lib/IconBuilder.php#L226): https://github.com/nextcloud/server/security/code-scanning/6694
- MissingParamType (apps/theming/lib/IconBuilder.php#L226): https://github.com/nextcloud/server/security/code-scanning/6695
- PossiblyFalseArgument (apps/theming/lib/IconBuilder.php#L232): https://github.com/nextcloud/server/security/code-scanning/6696

#### EDIT
Lol, I see I misinterpreted the check's results: https://github.com/nextcloud/server/pull/27281/checks?check_run_id=3041016482
It states that these 71 errors have been fixed. But actually they are not and, while probably impossible to trigger or handled gracefully, valid concerns, as far as I see. But the check states instead 71 (as well) new errors, all "Incompatible types found for T", looks like one for each `registerEventListener()` call. So not sure why Psalm sees completely unrelated PRs "solving" exactly 71 unsolved errors while seeing exactly 71 `registerEventListener()` calls as error now? 😄
To satisfy CI, the latter needs to be addressed, which I am not able to. But I'll leave this one open as well as addressing other minor Psalm alerts isn't a bad idea either?