### PR TITLE
Fix Files breadcrumbs being hidden even if there is enough space

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -327,7 +327,7 @@
 			// Note that the crumbs shown always overflow the parent width
 			// (except, of course, when they all fit in).
 			while (this.$el.find(this.hiddenCrumbSelector).length > 0
-				&& this.getTotalWidth() <= this.$el.parent().width()) {
+				&& Math.round(this.getTotalWidth()) <= Math.round(this.$el.parent().width())) {
 				this._showCrumb();
 			}
 
@@ -343,7 +343,7 @@
 
 			// If container is smaller than content
 			// AND if there are crumbs left to hide
-			while (this.getTotalWidth() > availableWidth
+			while (Math.round(this.getTotalWidth()) > Math.round(availableWidth)
 				&& this.$el.find(this.crumbSelector).length > 0) {
 				// As soon as one of the crumbs is hidden the menu will be
 				// shown. This is needed for proper results in further width


### PR DESCRIPTION
refs #21263

In Files breadcrumb management, we sometimes get floats in width calculations. This can lead to wrong comparison results when sizes are almost the same.

At some point this will be fixed by using the Breadcrumb Vue component. Until then, here is a solution.

Make sure you set `debug` to `true` in `config/config.php` to try these changes.

* Before
![before](https://user-images.githubusercontent.com/11291457/125269322-dce26480-e308-11eb-8649-b16d4046b38d.gif)
* After
![after](https://user-images.githubusercontent.com/11291457/125269317-db18a100-e308-11eb-844b-71aae5198eeb.gif)
* Multiple breadcrumbs still works as expected
![long](https://user-images.githubusercontent.com/11291457/125270168-b1ac4500-e309-11eb-9d98-3585a04aad61.gif)
