### PR TITLE
Check if dns_get_record returns non-false

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -82,7 +82,7 @@ class DnsPinMiddleware {
 
 			$dnsResponses = dns_get_record($target, $dnsType);
 			$canHaveCnameRecord = true;
-			if ($dnsResponses && count($dnsResponses) > 0) {
+			if ($dnsResponses !== false && count($dnsResponses) > 0) {
 				foreach ($dnsResponses as $dnsResponse) {
 					if (isset($dnsResponse['ip'])) {
 						$targetIps[] = $dnsResponse['ip'];

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -82,7 +82,7 @@ class DnsPinMiddleware {
 
 			$dnsResponses = dns_get_record($target, $dnsType);
 			$canHaveCnameRecord = true;
-			if (count($dnsResponses) > 0) {
+			if ($dnsResponses && count($dnsResponses) > 0) {
 				foreach ($dnsResponses as $dnsResponse) {
 					if (isset($dnsResponse['ip'])) {
 						$targetIps[] = $dnsResponse['ip'];


### PR DESCRIPTION
`dns_get_record` can return false which results in exceptions such as the ones shown in https://github.com/nextcloud/server/issues/27870.

Fixes https://github.com/nextcloud/server/issues/27870