### PR TITLE
Update stubs for php to v2021.1

### DIFF
--- a/build/stubs/IntlChar.php
+++ b/build/stubs/IntlChar.php
@@ -1,12 +1,14 @@
 <?php
 
+use JetBrains\PhpStorm\Pure;
+
 /**
  * <p>IntlChar provides access to a number of utility methods that can be used to access information about Unicode characters.</p>
  * <p>The methods and constants adhere closely to the names and behavior used by the underlying ICU library.</p>
  * @since 7.0
  */
 class IntlChar {
-    const UNICODE_VERSION = 6.3;
+    const UNICODE_VERSION = 13.0;
     const CODEPOINT_MIN = 0;
     const CODEPOINT_MAX = 1114111;
     const FOLD_CASE_DEFAULT = 0;
@@ -69,7 +71,7 @@ class IntlChar {
     const PROPERTY_CHANGES_WHEN_CASEFOLDED = 54;
     const PROPERTY_CHANGES_WHEN_CASEMAPPED = 55;
     const PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED = 56;
-    const PROPERTY_BINARY_LIMIT = 57;
+    const PROPERTY_BINARY_LIMIT = 65;
     const PROPERTY_BIDI_CLASS = 4096;
     const PROPERTY_INT_START = 4096;
     const PROPERTY_BLOCK = 4097;
@@ -93,7 +95,7 @@ class IntlChar {
     const PROPERTY_SENTENCE_BREAK = 4115;
     const PROPERTY_WORD_BREAK = 4116;
     const PROPERTY_BIDI_PAIRED_BRACKET_TYPE = 4117;
-    const PROPERTY_INT_LIMIT = 4118;
+    const PROPERTY_INT_LIMIT = 4121;
     const PROPERTY_GENERAL_CATEGORY_MASK = 8192;
     const PROPERTY_MASK_START = 8192;
     const PROPERTY_MASK_LIMIT = 8193;
@@ -431,7 +433,7 @@ class IntlChar {
     const BLOCK_CODE_SUPPLEMENTAL_ARROWS_C = 250;
     const BLOCK_CODE_TIRHUTA = 251;
     const BLOCK_CODE_WARANG_CITI = 252;
-    const BLOCK_CODE_COUNT = 263;
+    const BLOCK_CODE_COUNT = 309;
     const BLOCK_CODE_INVALID_CODE = -1;
     const BPT_NONE = 0;
     const BPT_OPEN = 1;
@@ -565,7 +567,7 @@ class IntlChar {
     const JG_MANICHAEAN_YODH = 83;
     const JG_MANICHAEAN_ZAYIN = 84;
     const JG_STRAIGHT_WAW = 85;
-    const JG_COUNT = 86;
+    const JG_COUNT = 102;
     const GCB_OTHER = 0;
     const GCB_CONTROL = 1;
     const GCB_CR = 2;
@@ -579,7 +581,7 @@ class IntlChar {
     const GCB_SPACING_MARK = 10;
     const GCB_PREPEND = 11;
     const GCB_REGIONAL_INDICATOR = 12;
-    const GCB_COUNT = 13;
+    const GCB_COUNT = 18;
     const WB_OTHER = 0;
     const WB_ALETTER = 1;
     const WB_FORMAT = 2;
@@ -597,7 +599,7 @@ class IntlChar {
     const WB_HEBREW_LETTER = 14;
     const WB_SINGLE_QUOTE = 15;
     const WB_DOUBLE_QUOTE = 16;
-    const WB_COUNT = 17;
+    const WB_COUNT = 23;
     const SB_OTHER = 0;
     const SB_ATERM = 1;
     const SB_CLOSE = 2;
@@ -655,7 +657,7 @@ class IntlChar {
     const LB_CONDITIONAL_JAPANESE_STARTER = 37;
     const LB_HEBREW_LETTER = 38;
     const LB_REGIONAL_INDICATOR = 39;
-    const LB_COUNT = 40;
+    const LB_COUNT = 43;
     const NT_NONE = 0;
     const NT_DECIMAL = 1;
     const NT_DIGIT = 2;
@@ -668,10 +670,11 @@ class IntlChar {
     const HST_LV_SYLLABLE = 4;
     const HST_LVT_SYLLABLE = 5;
     const HST_COUNT = 6;
+    const NO_NUMERIC_VALUE = -123456789;
 
     /**
      * Check a binary Unicode property for a code point
-     * @link https://php.net/manual/ru/intlchar.hasbinaryproperty.php
+     * @link https://php.net/manual/en/intlchar.hasbinaryproperty.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @param int $property The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * @return bool|null Returns TRUE or FALSE according to the binary Unicode property value for codepoint.
@@ -679,10 +682,11 @@ class IntlChar {
      * Or NULL if <em>codepoint</em> is out of bounds.
      * @since 7.0
      */
+    #[Pure]
     static public function hasBinaryProperty($codepoint, $property){}
 
     /**
-     * @link https://php.net/manual/ru/intlchar.charage.php
+     * @link https://php.net/manual/en/intlchar.charage.php
      * Get the "age" of the code point
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return array|null The Unicode version number, as an array. For example, version 1.3.31.2 would be represented as [1, 3, 31, 2].
@@ -692,7 +696,7 @@ class IntlChar {
     public static function charAge($codepoint) {}
 
     /**
-     * @link https://php.net/manual/ru/intlchar.chardigitvalue.php
+     * @link https://php.net/manual/en/intlchar.chardigitvalue.php
      * Get the decimal digit value of a decimal digit character
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|null The decimal digit value of codepoint, or -1 if it is not a decimal digit character.
@@ -703,7 +707,7 @@ class IntlChar {
 
     /**
      * Get bidirectional category value for a code point
-     * @link https://php.net/manual/ru/intlchar.chardirection.php
+     * @link https://php.net/manual/en/intlchar.chardirection.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")</p>
      * @return int|null <p>The bidirectional category value; one of the following constants:
      * </p>
@@ -741,8 +745,8 @@ class IntlChar {
     /**
      * @link https://php.net/manual/en/intlchar.charfromname.php
      * Find Unicode character by name and return its code point value
-     * @param string $characterName <p>Full name of the Unicode character.</p>
-     * @param int $nameChoice [optional] <p>
+     * @param string $name <p>Full name of the Unicode character.</p>
+     * @param int $type [optional] <p>
      * Which set of names to use for the lookup. Can be any of these constants:
      * </p><ul>
      * <li><b> IntlChar::UNICODE_CHAR_NAME </b> (default)</li>
@@ -754,10 +758,10 @@ class IntlChar {
      * @return int|null The Unicode value of the code point with the given name (as an integer), or NULL if there is no such code point.
      * @since 7.0
      */
-    public static function charFromName($characterName, $nameChoice = IntlChar::UNICODE_CHAR_NAME) {}
+    public static function charFromName($name, $type = IntlChar::UNICODE_CHAR_NAME) {}
 
     /**
-     * @link https://php.net/manual/ru/intlchar.charmirror.php
+     * @link https://php.net/manual/en/intlchar.charmirror.php
      * Get the "mirror-image" character for a code point
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|string|null Returns another Unicode code point that may serve as a mirror-image substitute, or codepoint itself if there is no such mapping or codepoint does not have the Bidi_Mirrored property.
@@ -768,9 +772,9 @@ class IntlChar {
 
     /**
      * Retrieve the name of a Unicode character
-     * @link https://php.net/manual/ru/intlchar.charname.php
+     * @link https://php.net/manual/en/intlchar.charname.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
-     * @param int $nameChoice [optional] Which set of names to use for the lookup. Can be any of these constants: </p>
+     * @param int $type [optional] Which set of names to use for the lookup. Can be any of these constants:
      * <ul>
      * <li><b> IntlChar::UNICODE_CHAR_NAME </b> (default)</li>
      * <li><b> IntlChar::UNICODE_10_CHAR_NAME </b></li>
@@ -781,11 +785,11 @@ class IntlChar {
      * @return string|null The corresponding name, or an empty string if there is no name for this character, or NULL if <em>codepoint</em> is out of bounds.
      * @since 7.0
      */
-    public static function charName($codepoint, $nameChoice = IntlChar::UNICODE_CHAR_NAME) {}
+    public static function charName($codepoint, $type = IntlChar::UNICODE_CHAR_NAME) {}
 
     /**
      * Get the general category value for a code point
-     * @link https://php.net/manual/ru/intlchar.chartype.php
+     * @link https://php.net/manual/en/intlchar.chartype.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|null Returns the general category type, which may be one of the following constants:
      * </p><ul>
@@ -830,7 +834,7 @@ class IntlChar {
 
     /**
      * Return Unicode character by code point value
-     * @link https://php.net/manual/ru/intlchar.chr.php
+     * @link https://php.net/manual/en/intlchar.chr.php
      * @param mixed $codepoint <p>The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")</p>
      * @return string|null A string containing the single character specified by the Unicode code point value.
      * Or NULL if <em>codepoint</em> is out of bound.
@@ -843,29 +847,29 @@ class IntlChar {
 
     /**
      * Get the decimal digit value of a code point for a given radix
-     * @link https://php.net/manual/ru/intlchar.digit.php
+     * @link https://php.net/manual/en/intlchar.digit.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. <em>0x2603</em> for <em>U+2603 SNOWMAN</em>), or the character encoded as a UTF-8 string (e.g. <em>"\u{2603}"</em>)</p>
-     * @param int $radix <p>The radix (defaults to 10).</p>
+     * @param int $base <p>The radix (defaults to 10).</p>
      * @return int|false|null Returns the numeric value represented by the character in the specified radix,
      * or <b>FALSE</b> if there is no value or if the value exceeds the radix,
      * or <b>NULL</b> if <em>codepoint</em> is out of bound.
      * @since 7.0
      */
-    public static function digit ($codepoint,$radix = 10 ) {}
+    public static function digit ($codepoint, $base = 10 ) {}
 
     /**
      * Enumerate all assigned Unicode characters within a range
-     * @link https://php.net/manual/ru/intlchar.enumcharnames.php
+     * @link https://php.net/manual/en/intlchar.enumcharnames.php
      * @param int|string $start The first code point in the enumeration range.
-     * @param int|string $limit One more than the last code point in the enumeration range (the first one after the range).
+     * @param int|string $end One more than the last code point in the enumeration range (the first one after the range).
      * @param callable $callback<p>
      * The function that is to be called for each character name.  The following three arguments will be passed into it:
      * </p><ul>
-     * <li>integer</a> <em>$codepoint</em> - The numeric code point value</li>
+     * <li>integer <em>$codepoint</em> - The numeric code point value</li>
      * <li>integer <em>$nameChoice</em> - The same value as the <b>nameChoice</b> parameter below</li>
      * <li>string <em>$name</em> - The name of the character</li>
      * </ul>
-     * @param int $nameChoice [optional]  <p>
+     * @param int $type [optional]  <p>
      * Selector for which kind of names to enumerate.  Can be any of these constants:
      * </p><ul>
      * <li><b>IntlChar::UNICODE_CHAR_NAME</b> (default)</li>
@@ -876,12 +880,12 @@ class IntlChar {
      * </ul>
      * @since 7.0
      */
-    public static function enumCharNames ($start, $limit, $callback, $nameChoice = IntlChar::UNICODE_CHAR_NAME) {}
+    public static function enumCharNames ($start, $end, $callback, $type = IntlChar::UNICODE_CHAR_NAME) {}
 
     /**
      * Enumerate all code points with their Unicode general categories
-     * @link https://php.net/manual/ru/intlchar.enumchartypes.php
-     * @param callable $callable <p>
+     * @link https://php.net/manual/en/intlchar.enumchartypes.php
+     * @param callable $callback <p>
      * The function that is to be called for each contiguous range of code points with the same general category.
      * The following three arguments will be passed into it:
      * </p><ul>
@@ -891,7 +895,7 @@ class IntlChar {
      * </ul>
      * @since 7.0
      */
-    public static function enumCharTypes ($callable) {}
+    public static function enumCharTypes ($callback) {}
 
     /**
      * Perform case folding on a code point
@@ -906,17 +910,17 @@ class IntlChar {
 
     /**
      * Get character representation for a given digit and radix
-     * @link https://php.net/manual/ru/intlchar.fordigit.php
+     * @link https://php.net/manual/en/intlchar.fordigit.php
      * @param int $digit <p>The number to convert to a character.</p>
-     * @param int $radix [optional] <p>The radix (defaults to 10).</p>
+     * @param int $base [optional] <p>The radix (defaults to 10).</p>
      * @return int The character representation (as a string) of the specified digit in the specified radix.
      * @since 7.0
      */
-    public static function forDigit ($digit, $radix = 10) {}
+    public static function forDigit ($digit, $base = 10) {}
 
     /**
      * Get the paired bracket character for a code point
-     * @link https://php.net/manual/ru/intlchar.getbidipairedbracket.php
+     * @link https://php.net/manual/en/intlchar.getbidipairedbracket.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")</p>
      * @return int|string|null  Returns the paired bracket code point, or <em>codepoint</em> itself if there is no such mapping.
      * The return type will be integer unless the code point was passed as a UTF-8 string, in which case a string will be returned.
@@ -927,7 +931,7 @@ class IntlChar {
 
     /**
      * Get the Unicode allocation block containing a code point
-     * @link https://php.net/manual/ru/intlchar.getblockcode.php
+     * @link https://php.net/manual/en/intlchar.getblockcode.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|null Returns the block value for <em>codepoint</em>, or NULL if <em>codepoint</em> is out of bound.
      * See the <em>IntlChar::BLOCK_CODE_*</em> constants for possible return values.
@@ -937,7 +941,7 @@ class IntlChar {
 
     /**
      * Get the combining class of a code point
-     * @link https://php.net/manual/ru/intlchar.getcombiningclass.php
+     * @link https://php.net/manual/en/intlchar.getcombiningclass.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|null Returns the combining class of the character.
      * Or NULL if <em>codepoint</em> is out of bound.
@@ -947,7 +951,7 @@ class IntlChar {
 
     /**
      * Get the FC_NFKC_Closure property for a code point
-     * @link https://php.net/manual/ru/intlchar.getfc-nfkc-closure.php
+     * @link https://php.net/manual/en/intlchar.getfc-nfkc-closure.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return string|false|null Returns the FC_NFKC_Closure property string for the codepoint, or an empty string if there is none,
      * or NULL if <em>codepoint</em> is out of bound,
@@ -958,7 +962,7 @@ class IntlChar {
 
     /**
      * Get the max value for a Unicode property
-     * @link https://php.net/manual/ru/intlchar.getintpropertymaxvalue.php
+     * @link https://php.net/manual/en/intlchar.getintpropertymaxvalue.php
      * @param int $property The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * @return int The maximum value returned by {@see IntlChar::getIntPropertyValue()} for a Unicode property. <=0 if the property selector is out of range.
      * @since 7.0
@@ -967,7 +971,7 @@ class IntlChar {
 
     /**
      * Get the min value for a Unicode property
-     * @link https://php.net/manual/ru/intlchar.getintpropertyminvalue.php
+     * @link https://php.net/manual/en/intlchar.getintpropertyminvalue.php
      * @param int $property The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * @return int The minimum value returned by {@see IntlChar::getIntPropertyValue()} for a Unicode property. 0 if the property selector is out of range.
      * @since 7.0
@@ -976,7 +980,7 @@ class IntlChar {
 
     /**
      * Get the value for a Unicode property for a code point
-     * @link https://php.net/manual/ru/intlchar.getintpropertyvalue.php
+     * @link https://php.net/manual/en/intlchar.getintpropertyvalue.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @param int $property The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * @return int|null <p>
@@ -1002,7 +1006,7 @@ class IntlChar {
 
     /**
      * Get the numeric value for a Unicode code point
-     * @link https://php.net/manual/ru/intlchar.getnumericvalue.php
+     * @link https://php.net/manual/en/intlchar.getnumericvalue.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return float|null Numeric value of codepoint, or float(-123456789) if none is defined, or NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1011,7 +1015,7 @@ class IntlChar {
 
     /**
      * Get the property constant value for a given property name
-     * @link https://php.net/manual/ru/intlchar.getpropertyenum.php
+     * @link https://php.net/manual/en/intlchar.getpropertyenum.php
      * @param string $alias The property name to be matched. The name is compared using "loose matching" as described in PropertyAliases.txt.
      * @return int Returns an IntlChar::PROPERTY_ constant value, or <b>IntlChar::PROPERTY_INVALID_CODE</b> if the given name does not match any property.
      * @since 7.0
@@ -1020,10 +1024,10 @@ class IntlChar {
 
     /**
      * Get the Unicode name for a property
-     * @link https://php.net/manual/ru/intlchar.getpropertyname.php
+     * @link https://php.net/manual/en/intlchar.getpropertyname.php
      * @param int $property <p>The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).</p>
      * <p><b>IntlChar::PROPERTY_INVALID_CODE</b> should not be used. Also, if property is out of range, FALSE is returned.</p>
-     * @param int $nameChoice <p> Selector for which name to get. If out of range, FALSE is returned.</p>
+     * @param int $type <p> Selector for which name to get. If out of range, FALSE is returned.</p>
      * <p>All properties have a long name. Most have a short name, but some do not. Unicode allows for additional names; if present these will be returned by adding 1, 2, etc. to <b>IntlChar::LONG_PROPERTY_NAME</b>.</p>
      * @return string|false <p>
      * Returns the name, or <b>FALSE</b> if either the <em>property</em> or the <em>nameChoice</em>
@@ -1037,11 +1041,11 @@ class IntlChar {
      * </p>
      * @since 7.0
      */
-    public static function getPropertyName ($property, $nameChoice = IntlChar::LONG_PROPERTY_NAME) {}
+    public static function getPropertyName ($property, $type = IntlChar::LONG_PROPERTY_NAME) {}
 
     /**
      * Get the property value for a given value name
-     * @link https://php.net/manual/ru/intlchar.getpropertyvalueenum.php
+     * @link https://php.net/manual/en/intlchar.getpropertyvalueenum.php
      * @param int $property <p>The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * If out of range, or this method doesn't work with the given value, IntlChar::PROPERTY_INVALID_CODE is returned</p>
      * @param string $name <p> The value name to be matched. The name is compared using "loose matching" as described in PropertyValueAliases.txt.</p>
@@ -1052,7 +1056,7 @@ class IntlChar {
 
     /**
      * Get the Unicode name for a property value
-     * @link https://php.net/manual/ru/intlchar.getpropertyvaluename.php
+     * @link https://php.net/manual/en/intlchar.getpropertyvaluename.php
      * @param int $property <p>
      * The Unicode property to lookup (see the IntlChar::PROPERTY_* constants).
      * If out of range, or this method doesn't work with the given value, FALSE is returned.
@@ -1070,7 +1074,7 @@ class IntlChar {
      * <b>IntlChar::PROPERTY_CANONICAL_COMBINING_CLASS</b> values are not contiguous and range from 0..240.
      * </li>
      * </ul>
-     * @param int $nameChoice [optional] <p>
+     * @param int $type [optional] <p>
      * Selector for which name to get. If out of range, FALSE is returned.
      * All values have a long name. Most have a short name, but some do not. Unicode allows for additional names; if present these will be returned by adding 1, 2, etc. to IntlChar::LONG_PROPERTY_NAME.
      * </p>
@@ -1078,11 +1082,11 @@ class IntlChar {
      * If a given nameChoice returns FALSE, then all larger values of nameChoice will return FALSE, with one exception: if FALSE is returned for IntlChar::SHORT_PROPERTY_NAME, then IntlChar::LONG_PROPERTY_NAME (and higher) may still return a non-FALSE value.
      * @since 7.0
      */
-    public static function getPropertyValueName ($property, $value, $nameChoice = IntlChar::LONG_PROPERTY_NAME) {}
+    public static function getPropertyValueName ($property, $value, $type = IntlChar::LONG_PROPERTY_NAME) {}
 
     /**
      * Get the Unicode version
-     * @link https://php.net/manual/ru/intlchar.getunicodeversion.php
+     * @link https://php.net/manual/en/intlchar.getunicodeversion.php
      * @return array An array containing the Unicode version number.
      * @since 7.0
      */
@@ -1090,7 +1094,7 @@ class IntlChar {
 
     /**
      * Check if code point is an alphanumeric character
-     * @link https://php.net/manual/ru/intlchar.isalnum.php
+     * @link https://php.net/manual/en/intlchar.isalnum.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is an alphanumeric character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1099,7 +1103,7 @@ class IntlChar {
 
     /**
      * Check if code point is a letter character
-     * @link https://php.net/manual/ru/intlchar.isalpha.php
+     * @link https://php.net/manual/en/intlchar.isalpha.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a letter character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1107,7 +1111,7 @@ class IntlChar {
     public static function isalpha ($codepoint) {}
     /**
      * Check if code point is a base character
-     * @link https://php.net/manual/ru/intlchar.isbase.php
+     * @link https://php.net/manual/en/intlchar.isbase.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a base character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1115,7 +1119,7 @@ class IntlChar {
     public static function isbase ($codepoint ){}
     /**
      * Check if code point is a "blank" or "horizontal space" character
-     * @link https://php.net/manual/ru/intlchar.isblank.php
+     * @link https://php.net/manual/en/intlchar.isblank.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is either a "blank" or "horizontal space" character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1124,7 +1128,7 @@ class IntlChar {
 
     /**
      * Check if code point is a control character
-     * @link https://php.net/manual/ru/intlchar.iscntrl.php
+     * @link https://php.net/manual/en/intlchar.iscntrl.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a control character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1133,7 +1137,7 @@ class IntlChar {
 
     /**
      * Check whether the code point is defined
-     * @link https://php.net/manual/ru/intlchar.isdefined.php
+     * @link https://php.net/manual/en/intlchar.isdefined.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a defined character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1142,7 +1146,7 @@ class IntlChar {
 
     /**
      * Check if code point is a digit character
-     * @link https://php.net/manual/ru/intlchar.isdigit.php
+     * @link https://php.net/manual/en/intlchar.isdigit.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a digit character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1150,7 +1154,7 @@ class IntlChar {
     public static function isdigit ($codepoint) {}
     /**
      * Check if code point is a graphic character
-     * @link https://php.net/manual/ru/intlchar.isgraph.php
+     * @link https://php.net/manual/en/intlchar.isgraph.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a "graphic" character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1158,7 +1162,7 @@ class IntlChar {
     public static function isgraph ($codepoint ) {}
     /**
      * Check if code point is an ignorable character
-     * @link https://php.net/manual/ru/intlchar.isidignorable.php
+     * @link https://php.net/manual/en/intlchar.isidignorable.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is ignorable in identifiers, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1166,7 +1170,7 @@ class IntlChar {
     public static function isIDIgnorable ($codepoint ) {}
     /**
      * Check if code point is permissible in an identifier
-     * @link https://php.net/manual/ru/intlchar.isidpart.php
+     * @link https://php.net/manual/en/intlchar.isidpart.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is the code point may occur in an identifier, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1175,7 +1179,7 @@ class IntlChar {
 
     /**
      * Check if code point is permissible as the first character in an identifier
-     * @link https://php.net/manual/ru/intlchar.isidstart.php
+     * @link https://php.net/manual/en/intlchar.isidstart.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint may start an identifier, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1183,7 +1187,7 @@ class IntlChar {
     public static function isIDStart ($codepoint ) {}
     /**
      * Check if code point is an ISO control code
-     * @link https://php.net/manual/ru/intlchar.isisocontrol.php
+     * @link https://php.net/manual/en/intlchar.isisocontrol.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is an ISO control code, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1191,7 +1195,7 @@ class IntlChar {
     public static function isISOControl ($codepoint ) {}
     /**
      * Check if code point is permissible in a Java identifier
-     * @link https://php.net/manual/ru/intlchar.isjavaidpart.php
+     * @link https://php.net/manual/en/intlchar.isjavaidpart.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint may occur in a Java identifier, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1199,7 +1203,7 @@ class IntlChar {
     public static function isJavaIDPart ($codepoint ) {}
     /**
      * Check if code point is permissible as the first character in a Java identifier
-     * @link https://php.net/manual/ru/intlchar.isjavaidstart.php
+     * @link https://php.net/manual/en/intlchar.isjavaidstart.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint may start a Java identifier, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1207,7 +1211,7 @@ class IntlChar {
     public static function isJavaIDStart ($codepoint ) {}
     /**
      * Check if code point is a space character according to Java
-     * @link https://php.net/manual/ru/intlchar.isjavaspacechar.php
+     * @link https://php.net/manual/en/intlchar.isjavaspacechar.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a space character according to Java, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1216,7 +1220,7 @@ class IntlChar {
 
     /**
      * Check if code point is a lowercase letter
-     * @link https://php.net/manual/ru/intlchar.islower.php
+     * @link https://php.net/manual/en/intlchar.islower.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN),
      * or the character encoded as a UTF-8 string (e.g. "\u{2603}")</p>
      * @return bool|null Returns TRUE if codepoint is an Ll lowercase letter, FALSE if not, NULL if <em>codepoint</em> is out of bound.
@@ -1225,7 +1229,7 @@ class IntlChar {
     public static function islower ($codepoint ) {}
     /**
      * Check if code point has the Bidi_Mirrored property
-     * @link https://php.net/manual/ru/intlchar.ismirrored.php
+     * @link https://php.net/manual/en/intlchar.ismirrored.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. <em>0x2603</em> for <em>U+2603 SNOWMAN</em>), or the character encoded as a UTF-8 string (e.g. <em>"\u{2603}"</em>)</p>
      * @return bool|null Returns TRUE if codepoint has the Bidi_Mirrored property, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1234,7 +1238,7 @@ class IntlChar {
 
     /**
      * Check if code point is a printable character
-     * @link https://php.net/manual/ru/intlchar.isprint.php
+     * @link https://php.net/manual/en/intlchar.isprint.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. <em>0x2603</em> for <em>U+2603 SNOWMAN</em>), or the character encoded as a UTF-8 string (e.g. <em>"\u{2603}"</em>)</p>
      * @return bool|null Returns TRUE if codepoint is a printable character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1243,7 +1247,7 @@ class IntlChar {
 
     /**
      * Check if code point is punctuation character
-     * @link https://php.net/manual/ru/intlchar.ispunct.php
+     * @link https://php.net/manual/en/intlchar.ispunct.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. <em>0x2603</em> for <em>U+2603 SNOWMAN</em>),
      * or the character encoded as a UTF-8 string (e.g. <em>"\u{2603}"</em>)</p>
      * @return bool|null Returns TRUE if codepoint is a punctuation character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
@@ -1252,7 +1256,7 @@ class IntlChar {
     public static function ispunct ($codepoint ) {}
     /**
      * Check if code point is a space character
-     * @link https://php.net/manual/ru/intlchar.isspace.php
+     * @link https://php.net/manual/en/intlchar.isspace.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a space character, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1260,7 +1264,7 @@ class IntlChar {
     public static function isspace ($codepoint ) {}
     /**
      * Check if code point is a titlecase letter
-     * @link https://php.net/manual/ru/intlchar.istitle.php
+     * @link https://php.net/manual/en/intlchar.istitle.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a titlecase letter, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1269,7 +1273,7 @@ class IntlChar {
 
     /**
      * Check if code point has the Alphabetic Unicode property
-     * @link https://php.net/manual/ru/intlchar.isualphabetic.php
+     * @link https://php.net/manual/en/intlchar.isualphabetic.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint has the Alphabetic Unicode property, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1277,7 +1281,7 @@ class IntlChar {
     public static function isUAlphabetic ($codepoint ) {}
     /**
      * Check if code point has the Lowercase Unicode property
-     * @link https://php.net/manual/ru/intlchar.isulowercase.php
+     * @link https://php.net/manual/en/intlchar.isulowercase.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint has the Lowercase Unicode property, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1285,7 +1289,7 @@ class IntlChar {
     public static function isULowercase ($codepoint ) {}
     /**
      * Check if code point has the general category "Lu" (uppercase letter)
-     * @link https://php.net/manual/ru/intlchar.isupper.php
+     * @link https://php.net/manual/en/intlchar.isupper.php
      * @param int|string $codepoint <p>The integer codepoint value (e.g. <em>0x2603</em> for <em>U+2603 SNOWMAN</em>),
      * or the character encoded as a UTF-8 string (e.g. <em>"\u{2603}"</em>)</p>
      * @return bool|null Returns TRUE if codepoint is an Lu uppercase letter, FALSE if not, NULL if <em>codepoint</em> is out of bound.
@@ -1294,7 +1298,7 @@ class IntlChar {
     public static function isupper ($codepoint) {}
     /**
      * Check if code point has the Uppercase Unicode property
-     * @link https://php.net/manual/ru/intlchar.isuuppercase.php
+     * @link https://php.net/manual/en/intlchar.isuuppercase.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint has the Uppercase Unicode property, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1302,7 +1306,7 @@ class IntlChar {
     public static function isUUppercase ($codepoint) {}
     /**
      * Check if code point has the White_Space Unicode property
-     * @link https://php.net/manual/ru/intlchar.isuwhitespace.php
+     * @link https://php.net/manual/en/intlchar.isuwhitespace.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint has the White_Space Unicode property, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1310,7 +1314,7 @@ class IntlChar {
     public static function isUWhiteSpace ($codepoint ) {}
     /**
      * Check if code point is a whitespace character according to ICU
-     * @link https://php.net/manual/ru/intlchar.iswhitespace.php
+     * @link https://php.net/manual/en/intlchar.iswhitespace.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return bool|null Returns TRUE if codepoint is a whitespace character according to ICU, FALSE if not, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1327,7 +1331,7 @@ class IntlChar {
 
     /**
      * Return Unicode code point value of character
-     * @link https://php.net/manual/ru/intlchar.ord.php
+     * @link https://php.net/manual/en/intlchar.ord.php
      * @param int|string $character <p>A Unicode character.</p>
      * @return int|null Returns the Unicode code point value as an integer, NULL if <em>codepoint</em> is out of bound.
      * @since 7.0
@@ -1346,7 +1350,7 @@ class IntlChar {
     public static function tolower($codepoint) {}
     /**
      * Make Unicode character titlecase
-     * @link https://php.net/manual/ru/intlchar.totitle.php
+     * @link https://php.net/manual/en/intlchar.totitle.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|string|null  Returns the Simple_Titlecase_Mapping of the code point, if any; otherwise the code point itself.
      * The return type will be integer unless the code point was passed as a UTF-8 string, in which case a string will be returned.
@@ -1357,7 +1361,7 @@ class IntlChar {
 
     /**
      * Make Unicode character uppercase
-     * @link https://php.net/manual/ru/intlchar.toupper.php
+     * @link https://php.net/manual/en/intlchar.toupper.php
      * @param int|string $codepoint The integer codepoint value (e.g. 0x2603 for U+2603 SNOWMAN), or the character encoded as a UTF-8 string (e.g. "\u{2603}")
      * @return int|string|null Returns the Simple_Uppercase_Mapping of the code point, if any; otherwise the code point itself.
      * The return type will be integer unless the code point was passed as a UTF-8 string, in which case a string will be returned.

--- a/build/stubs/apcu.php
+++ b/build/stubs/apcu.php
@@ -23,7 +23,7 @@ define('APC_BIN_VERIFY_CRC32', 2);
  * system cache (cached files) will be returned.
  * @param bool $limited If limited is TRUE, the return value will exclude the individual list
  * of cache entries. This is useful when trying to optimize calls for statistics gathering.
- * @return array|bool Array of cached data (and meta-data) or FALSE on failure.
+ * @return array|false Array of cached data (and meta-data) or FALSE on failure.
  */
 function apc_cache_info($type = '', $limited = false){}
 
@@ -41,7 +41,7 @@ function apc_clear_cache($cache_type = ''){}
  * @link https://php.net/manual/en/function.apc-sma-info.php
  * @param bool $limited When set to FALSE (default) apc_sma_info() will
  * return a detailed information about each segment.
- * @return array|bool Array of Shared Memory Allocation data; FALSE on failure.
+ * @return array|false Array of Shared Memory Allocation data; FALSE on failure.
  */
 function apc_sma_info($limited = false){}
 
@@ -65,8 +65,8 @@ function apc_store($key, $var, $ttl = 0){}
  * @link https://php.net/manual/en/function.apc-fetch.php
  * @param string|string[] $key The key used to store the value (with apc_store()).
  * If an array is passed then each element is fetched and returned.
- * @param bool $success Set to TRUE in success and FALSE in failure.
- * @return mixed The stored variable or array of variables on success; FALSE on failure.
+ * @param bool|null &$success Set to TRUE in success and FALSE in failure.
+ * @return mixed|false The stored variable or array of variables on success; FALSE on failure.
  */
 function apc_fetch($key, &$success = null){}
 
@@ -139,7 +139,7 @@ function apc_load_constants($key, $case_sensitive = true){}
 /**
  * Checks if APC key exists
  * @link https://php.net/manual/en/function.apc-exists.php
- * @param bool|string[] $keys A string, or an array of strings, that contain keys.
+ * @param string|string[] $keys A string, or an array of strings, that contain keys.
  * @return bool|string[] Returns TRUE if the key exists, otherwise FALSE
  * Or if an array was passed to keys, then an array is returned that
  * contains all existing keys, or an empty array if none exist.
@@ -163,8 +163,8 @@ function apc_delete_file($keys){}
  * @link https://php.net/manual/en/function.apc-inc.php
  * @param string $key The key of the value being increased.
  * @param int $step The step, or value to increase.
- * @param bool $success Optionally pass the success or fail boolean value to this referenced variable.
- * @return int|bool Returns the current value of key's value on success, or FALSE on failure.
+ * @param bool|null &$success Optionally pass the success or fail boolean value to this referenced variable.
+ * @return int|false Returns the current value of key's value on success, or FALSE on failure.
  */
 function apc_inc($key, $step = 1, &$success = null){}
 
@@ -173,12 +173,13 @@ function apc_inc($key, $step = 1, &$success = null){}
  * @link https://php.net/manual/en/function.apc-dec.php
  * @param string $key The key of the value being decreased.
  * @param int $step The step, or value to decrease.
- * @param bool $success Optionally pass the success or fail boolean value to this referenced variable.
- * @return int|bool Returns the current value of key's value on success, or FALSE on failure.
+ * @param bool|null &$success Optionally pass the success or fail boolean value to this referenced variable.
+ * @return int|false Returns the current value of key's value on success, or FALSE on failure.
  */
 function apc_dec($key, $step = 1, &$success = null){}
 
 /**
+ * Updates an old value with a new value
  * @link https://php.net/manual/en/function.apc-cas.php
  * @param string $key
  * @param int $old
@@ -195,7 +196,7 @@ function apc_cas($key, $old, $new){}
  * @link https://php.net/manual/en/function.apc-bin-dump.php
  * @param string[]|null $files The files. Passing in NULL signals a dump of every entry, while passing in array() will dump nothing.
  * @param string[]|null $user_vars The user vars. Passing in NULL signals a dump of every entry, while passing in array() will dump nothing.
- * @return string|bool|null Returns a binary dump of the given files and user variables from the APC cache, FALSE if APC is not enabled, or NULL if an unknown error is encountered.
+ * @return string|false|null Returns a binary dump of the given files and user variables from the APC cache, FALSE if APC is not enabled, or NULL if an unknown error is encountered.
  */
 function apc_bin_dump($files = null, $user_vars = null){}
 
@@ -207,7 +208,7 @@ function apc_bin_dump($files = null, $user_vars = null){}
  * @param string $filename The filename where the dump is being saved.
  * @param int $flags Flags passed to the filename stream. See the file_put_contents() documentation for details.
  * @param resource $context The context passed to the filename stream. See the file_put_contents() documentation for details.
- * @return int|bool The number of bytes written to the file, otherwise FALSE if APC
+ * @return int|false The number of bytes written to the file, otherwise FALSE if APC
  * is not enabled, filename is an invalid file name, filename can't be opened,
  * the file dump can't be completed (e.g., the hard drive is out of disk space),
  * or an unknown error was encountered.
@@ -278,14 +279,14 @@ class APCIterator implements Iterator
     /**
      * Gets the current item from the APCIterator stack
      * @link https://php.net/manual/en/apciterator.current.php
-     * @return mixed Returns the current item on success, or FALSE if no more items or exist, or on failure.
+     * @return mixed|false Returns the current item on success, or FALSE if no more items or exist, or on failure.
      */
     public function current(){}
 
     /**
      * Gets the current iterator key
      * @link https://php.net/manual/en/apciterator.key.php
-     * @return string|int|bool Returns the key on success, or FALSE upon failure.
+     * @return string|int|false Returns the key on success, or FALSE upon failure.
      */
     public function key(){}
 
@@ -299,7 +300,7 @@ class APCIterator implements Iterator
     /**
      * Gets the total number of cache hits
      * @link https://php.net/manual/en/apciterator.gettotalhits.php
-     * @return int|bool The number of hits on success, or FALSE on failure.
+     * @return int|false The number of hits on success, or FALSE on failure.
      */
     public function getTotalHits(){}
 
@@ -421,7 +422,7 @@ function apcu_sma_info($limited = false){}
 /**
  * Cache a variable in the data store
  * @link https://php.net/manual/en/function.apcu-store.php
- * @param string|array $key String: Store the variable using this name. Keys are cache-unique,
+ * @param string|string[] $key String: Store the variable using this name. Keys are cache-unique,
  * so storing a second value with the same key will overwrite the original value.
  * Array: Names in key, variables in value.
  * @param mixed $var [optional] The variable to store
@@ -438,15 +439,15 @@ function apcu_store($key, $var, $ttl = 0){}
  * @link https://php.net/manual/en/function.apcu-fetch.php
  * @param string|string[] $key The key used to store the value (with apcu_store()).
  * If an array is passed then each element is fetched and returned.
- * @param bool $success Set to TRUE in success and FALSE in failure.
- * @return mixed The stored variable or array of variables on success; FALSE on failure.
+ * @param bool|null &$success Set to TRUE in success and FALSE in failure.
+ * @return mixed|false The stored variable or array of variables on success; FALSE on failure.
  */
 function apcu_fetch($key, &$success = null){}
 
 /**
  * Removes a stored variable from the cache
  * @link https://php.net/manual/en/function.apcu-delete.php
- * @param string|string[]|APCuIterator $key The key used to store the value (with apcu_store()).
+ * @param string|string[]|APCUIterator $key The key used to store the value (with apcu_store()).
  * @return bool|string[] Returns TRUE on success or FALSE on failure. For array of keys returns list of failed keys.
  */
 function apcu_delete($key){}
@@ -488,7 +489,7 @@ function apcu_exists($keys){}
  * the stored variable will be expunged from the cache (on the next request). If no ttl is supplied
  * (or if the ttl is 0), the value will persist until it is removed from the cache manually,
  * or otherwise fails to exist in the cache (clear, restart, etc.).
- * @param bool $success Optionally pass the success or fail boolean value to this referenced variable.
+ * @param bool|null &$success Optionally pass the success or fail boolean value to this referenced variable.
  * @return int|false Returns the current value of key's value on success, or FALSE on failure.
  */
 function apcu_inc($key, $step = 1, &$success = null, $ttl = 0){}
@@ -502,7 +503,7 @@ function apcu_inc($key, $step = 1, &$success = null, $ttl = 0){}
  * the stored variable will be expunged from the cache (on the next request). If no ttl is supplied
  * (or if the ttl is 0), the value will persist until it is removed from the cache manually,
  * or otherwise fails to exist in the cache (clear, restart, etc.).
- * @param bool $success Optionally pass the success or fail boolean value to this referenced variable.
+ * @param bool|null &$success Optionally pass the success or fail boolean value to this referenced variable.
  * @return int|false Returns the current value of key's value on success, or FALSE on failure.
  */
 function apcu_dec($key, $step = 1, &$success = null, $ttl = 0){}
@@ -573,13 +574,14 @@ function apcu_enabled(){}
 
 /**
  * @param string $key
+ * @return array|null
  */
 function apcu_key_info($key){}
 
 /**
- * The APCuIterator class
+ * The APCUIterator class
  *
- * The APCuIterator class makes it easier to iterate over large APCu caches.
+ * The APCUIterator class makes it easier to iterate over large APCu caches.
  * This is helpful as it allows iterating over large caches in steps, while grabbing a defined number
  * of entries per lock instance, so it frees the cache locks for other activities rather than hold up
  * the entire cache to grab 100 (the default) entries. Also, using regular expression matching is more
@@ -588,10 +590,10 @@ function apcu_key_info($key){}
  * @link https://php.net/manual/en/class.apcuiterator.php
  * @since APCu 5.0.0
  */
-class APCuIterator implements Iterator
+class APCUIterator implements Iterator
 {
 	/**
-	 * Constructs an APCuIterator iterator object
+	 * Constructs an APCUIterator iterator object
 	 * @link https://php.net/manual/en/apcuiterator.construct.php
 	 * @param string|string[]|null $search A PCRE regular expression that matches against APCu key names,
 	 * either as a string for a single regular expression, or as an array of regular expressions.
@@ -616,9 +618,9 @@ class APCuIterator implements Iterator
 	public function valid(){}
 
 	/**
-	 * Gets the current item from the APCuIterator stack
+	 * Gets the current item from the APCUIterator stack
 	 * @link https://php.net/manual/en/apcuiterator.current.php
-	 * @return mixed Returns the current item on success, or FALSE if no more items or exist, or on failure.
+	 * @return mixed|false Returns the current item on success, or FALSE if no more items or exist, or on failure.
 	 */
 	public function current(){}
 

--- a/build/stubs/gd.php
+++ b/build/stubs/gd.php
@@ -1,10 +1,12 @@
 <?php
 
+use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\Pure;
+
 /**
  * Retrieve information about the currently installed GD library
  * @link https://php.net/manual/en/function.gd-info.php
  * @return array an associative array.
- * </p>
  * <p>
  * <table>
  * Elements of array returned by <b>gd_info</b>
@@ -77,17 +79,19 @@
  * <p>
  * Previous to PHP 5.3.0, the JPEG Support attribute was named
  * JPG Support.
+ * </p>
  */
-function gd_info () {}
+#[Pure]
+function gd_info (): array {}
 
 /**
  * Draws an arc
  * @link https://php.net/manual/en/function.imagearc.php
- * @param resource $image
- * @param int $cx <p>
+ * @param resource|GdImage $image
+ * @param int $center_x <p>
  * x-coordinate of the center.
  * </p>
- * @param int $cy <p>
+ * @param int $center_y <p>
  * y-coordinate of the center.
  * </p>
  * @param int $width <p>
@@ -96,10 +100,10 @@ function gd_info () {}
  * @param int $height <p>
  * The arc height.
  * </p>
- * @param int $start <p>
+ * @param int $start_angle <p>
  * The arc start angle, in degrees.
  * </p>
- * @param int $end <p>
+ * @param int $end_angle <p>
  * The arc end angle, in degrees.
  * 0° is located at the three-o'clock position, and the arc is drawn
  * clockwise.
@@ -110,16 +114,16 @@ function gd_info () {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function imagearc ($image, $cx, $cy, $width, $height, $start, $end, $color) {}
+function imagearc (GdImage $image, int $center_x, int $center_y, int $width, int $height, int $start_angle, int $end_angle, int $color): bool {}
 
 /**
  * Draw an ellipse
  * @link https://php.net/manual/en/function.imageellipse.php
- * @param resource $image
- * @param int $cx <p>
+ * @param resource|GdImage $image
+ * @param int $center_x <p>
  * x-coordinate of the center.
  * </p>
- * @param int $cy <p>
+ * @param int $center_y <p>
  * y-coordinate of the center.
  * </p>
  * @param int $width <p>
@@ -134,12 +138,12 @@ function imagearc ($image, $cx, $cy, $width, $height, $start, $end, $color) {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
+function imageellipse (GdImage $image, int $center_x, int $center_y, int $width, int $height, int $color): bool {}
 
 /**
  * Draw a character horizontally
  * @link https://php.net/manual/en/function.imagechar.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $font
  * @param int $x <p>
  * x-coordinate of the start.
@@ -147,7 +151,7 @@ function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
  * @param int $y <p>
  * y-coordinate of the start.
  * </p>
- * @param string $c <p>
+ * @param string $char <p>
  * The character to draw.
  * </p>
  * @param int $color <p>
@@ -156,12 +160,12 @@ function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function imagechar ($image, $font, $x, $y, $c, $color) {}
+function imagechar (GdImage $image, int $font, int $x, int $y, string $char, int $color): bool {}
 
 /**
  * Draw a character vertically
  * @link https://php.net/manual/en/function.imagecharup.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $font
  * @param int $x <p>
  * x-coordinate of the start.
@@ -169,7 +173,7 @@ function imagechar ($image, $font, $x, $y, $c, $color) {}
  * @param int $y <p>
  * y-coordinate of the start.
  * </p>
- * @param string $c <p>
+ * @param string $char <p>
  * The character to draw.
  * </p>
  * @param int $color <p>
@@ -178,12 +182,12 @@ function imagechar ($image, $font, $x, $y, $c, $color) {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function imagecharup ($image, $font, $x, $y, $c, $color) {}
+function imagecharup (GdImage $image, int $font, int $x, int $y, string $char, int $color): bool {}
 
 /**
  * Get the index of the color of a pixel
  * @link https://php.net/manual/en/function.imagecolorat.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x <p>
  * x-coordinate of the point.
  * </p>
@@ -192,107 +196,113 @@ function imagecharup ($image, $font, $x, $y, $c, $color) {}
  * </p>
  * @return int|false the index of the color or <b>FALSE</b> on failure
  */
-function imagecolorat ($image, $x, $y) {}
+#[Pure]
+function imagecolorat (GdImage $image, int $x, int $y): int|false {}
 
 /**
  * Allocate a color for an image
  * @link https://php.net/manual/en/function.imagecolorallocate.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>Value of red component.</p>
  * @param int $green <p>Value of green component.</p>
  * @param int $blue <p>Value of blue component.</p>
  * @return int|false A color identifier or <b>FALSE</b> if the allocation failed.
  */
-function imagecolorallocate ($image, $red, $green, $blue) {}
+function imagecolorallocate (GdImage $image, int $red, int $green, int $blue): int|false {}
 
 /**
  * Copy the palette from one image to another
  * @link https://php.net/manual/en/function.imagepalettecopy.php
- * @param resource $destination <p>
+ * @param resource|GdImage $dst <p>
  * The destination image resource.
  * </p>
- * @param resource $source <p>
+ * @param resource|GdImage $src <p>
  * The source image resource.
  * </p>
  * @return void No value is returned.
  */
-function imagepalettecopy ($destination, $source) {}
+function imagepalettecopy (GdImage $dst, GdImage $src): void {}
 
 /**
  * Create a new image from the image stream in the string
  * @link https://php.net/manual/en/function.imagecreatefromstring.php
- * @param string $image <p>
+ * @param string $data <p>
  * A string containing the image data.
  * </p>
- * @return resource|false An image resource will be returned on success. <b>FALSE</b> is returned if
+ * @return resource|GdImage|false An image resource will be returned on success. <b>FALSE</b> is returned if
  * the image type is unsupported, the data is not in a recognised format,
  * or the image is corrupt and cannot be loaded.
  */
-function imagecreatefromstring ($image) {}
+#[Pure]
+function imagecreatefromstring (string $data): GdImage|false {}
 
 /**
  * Get the index of the closest color to the specified color
  * @link https://php.net/manual/en/function.imagecolorclosest.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>Value of red component.</p>
  * @param int $green <p>Value of green component.</p>
  * @param int $blue <p>Value of blue component.</p>
  * @return int|false the index of the closest color, in the palette of the image, to
  * the specified one or <b>FALSE</b> on failure
  */
-function imagecolorclosest ($image, $red, $green, $blue) {}
+#[Pure]
+function imagecolorclosest (GdImage $image, int $red, int $green, int $blue): int|false {}
 
 /**
  * Get the index of the color which has the hue, white and blackness
  * @link https://php.net/manual/en/function.imagecolorclosesthwb.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>Value of red component.</p>
  * @param int $green <p>Value of green component.</p>
  * @param int $blue <p>Value of blue component.</p>
  * @return int|false an integer with the index of the color which has
  * the hue, white and blackness nearest the given color or <b>FALSE</b> on failure
  */
-function imagecolorclosesthwb ($image, $red, $green, $blue) {}
+#[Pure]
+function imagecolorclosesthwb (GdImage $image, int $red, int $green, int $blue): int|false {}
 
 /**
  * De-allocate a color for an image
  * @link https://php.net/manual/en/function.imagecolordeallocate.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $color <p>
  * The color identifier.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function imagecolordeallocate ($image, $color) {}
+function imagecolordeallocate (GdImage $image, int $color): bool {}
 
 /**
  * Get the index of the specified color or its closest possible alternative
  * @link https://php.net/manual/en/function.imagecolorresolve.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>Value of red component.</p>
  * @param int $green <p>Value of green component.</p>
  * @param int $blue <p>Value of blue component.</p>
  * @return int|false a color index or <b>FALSE</b> on failure
  */
-function imagecolorresolve ($image, $red, $green, $blue) {}
+#[Pure]
+function imagecolorresolve (GdImage $image, int $red, int $green, int $blue): int|false {}
 
 /**
  * Get the index of the specified color
  * @link https://php.net/manual/en/function.imagecolorexact.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>Value of red component.</p>
  * @param int $green <p>Value of green component.</p>
  * @param int $blue <p>Value of blue component.</p>
  * @return int|false the index of the specified color in the palette, -1 if the
  * color does not exist, or <b>FALSE</b> on failure
  */
-function imagecolorexact ($image, $red, $green, $blue) {}
+#[Pure]
+function imagecolorexact (GdImage $image, int $red, int $green, int $blue): int|false {}
 
 /**
  * Set the color for the specified palette index
  * @link https://php.net/manual/en/function.imagecolorset.php
- * @param resource $image
- * @param int $index <p>
+ * @param resource|GdImage $image
+ * @param int $color <p>
  * An index in the palette.
  * </p>
  * @param int $red <p>Value of red component.</p>
@@ -301,56 +311,58 @@ function imagecolorexact ($image, $red, $green, $blue) {}
  * @param int $alpha [optional] <p>
  * Value of alpha component.
  * </p>
- * @return void No value is returned.
+ * @return bool|null
  */
-function imagecolorset ($image, $index, $red, $green, $blue, $alpha = 0) {}
+function imagecolorset (GdImage $image, int $color, int $red, int $green, int $blue, int $alpha = 0): ?bool {}
 
 /**
  * Define a color as transparent
  * @link https://php.net/manual/en/function.imagecolortransparent.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $color [optional] <p>
  * A color identifier created with
  * <b>imagecolorallocate</b>.
  * </p>
- * @return int|false The identifier of the new (or current, if none is specified)
+ * @return int|null The identifier of the new (or current, if none is specified)
  * transparent color is returned. If <i>color</i>
  * is not specified, and the image has no transparent color, the
- * returned identifier will be -1. If an error occurs, <b>FALSE</b> is returned.
+ * returned identifier will be -1.
  */
-function imagecolortransparent ($image, $color = null) {}
+function imagecolortransparent (GdImage $image, ?int $color = null): ?int {}
 
 /**
  * Find out the number of colors in an image's palette
  * @link https://php.net/manual/en/function.imagecolorstotal.php
- * @param resource $image <p>
+ * @param resource|GdImage $image <p>
  * An image resource, returned by one of the image creation functions, such
  * as <b>imagecreatefromgif</b>.
  * </p>
  * @return int|false the number of colors in the specified image's palette, 0 for
  * truecolor images, or <b>FALSE</b> on failure
  */
-function imagecolorstotal ($image) {}
+#[Pure]
+function imagecolorstotal (GdImage $image): int {}
 
 /**
  * Get the colors for an index
  * @link https://php.net/manual/en/function.imagecolorsforindex.php
- * @param resource $image
- * @param int $index <p>
+ * @param resource|GdImage $image
+ * @param int $color <p>
  * The color index.
  * </p>
  * @return array|false an associative array with red, green, blue and alpha keys that
  * contain the appropriate values for the specified color index or <b>FALSE</b> on failure
  */
-function imagecolorsforindex ($image, $index) {}
+#[Pure]
+function imagecolorsforindex (GdImage $image, int $color): array|false {}
 
 /**
  * Copy part of an image
  * @link https://php.net/manual/en/function.imagecopy.php
- * @param resource $dst_im <p>
+ * @param resource|GdImage $dst_image <p>
  * Destination image link resource.
  * </p>
- * @param resource $src_im <p>
+ * @param resource|GdImage $src_image <p>
  * Source image link resource.
  * </p>
  * @param int $dst_x <p>
@@ -365,23 +377,23 @@ function imagecolorsforindex ($image, $index) {}
  * @param int $src_y <p>
  * y-coordinate of source point.
  * </p>
- * @param int $src_w <p>
+ * @param int $src_width <p>
  * Source width.
  * </p>
- * @param int $src_h <p>
+ * @param int $src_height <p>
  * Source height.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h) {}
+function imagecopy (GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height): bool {}
 
 /**
  * Copy and merge part of an image
  * @link https://php.net/manual/en/function.imagecopymerge.php
- * @param resource $dst_im <p>
+ * @param resource|GdImage $dst_image <p>
  * Destination image link resource.
  * </p>
- * @param resource $src_im <p>
+ * @param resource|GdImage $src_image <p>
  * Source image link resource.
  * </p>
  * @param int $dst_x <p>
@@ -396,10 +408,10 @@ function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $s
  * @param int $src_y <p>
  * y-coordinate of source point.
  * </p>
- * @param int $src_w <p>
+ * @param int $src_width <p>
  * Source width.
  * </p>
- * @param int $src_h <p>
+ * @param int $src_height <p>
  * Source height.
  * </p>
  * @param int $pct <p>
@@ -411,15 +423,15 @@ function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $s
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
+function imagecopymerge (GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height, int $pct): bool {}
 
 /**
  * Copy and merge part of an image with gray scale
  * @link https://php.net/manual/en/function.imagecopymergegray.php
- * @param resource $dst_im <p>
+ * @param resource|GdImage $dst_image <p>
  * Destination image link resource.
  * </p>
- * @param resource $src_im <p>
+ * @param resource|GdImage $src_image <p>
  * Source image link resource.
  * </p>
  * @param int $dst_x <p>
@@ -434,10 +446,10 @@ function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_
  * @param int $src_y <p>
  * y-coordinate of source point.
  * </p>
- * @param int $src_w <p>
+ * @param int $src_width <p>
  * Source width.
  * </p>
- * @param int $src_h <p>
+ * @param int $src_height <p>
  * Source height.
  * </p>
  * @param int $pct <p>
@@ -449,13 +461,13 @@ function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecopymergegray ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
+function imagecopymergegray (GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height, int $pct): bool {}
 
 /**
  * Copy and resize part of an image
  * @link https://php.net/manual/en/function.imagecopyresized.php
- * @param resource $dst_image
- * @param resource $src_image
+ * @param resource|GdImage $dst_image
+ * @param resource|GdImage $src_image
  * @param int $dst_x <p>
  * x-coordinate of destination point.
  * </p>
@@ -468,21 +480,21 @@ function imagecopymergegray ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $
  * @param int $src_y <p>
  * y-coordinate of source point.
  * </p>
- * @param int $dst_w <p>
+ * @param int $dst_width <p>
  * Destination width.
  * </p>
- * @param int $dst_h <p>
+ * @param int $dst_height <p>
  * Destination height.
  * </p>
- * @param int $src_w <p>
+ * @param int $src_width <p>
  * Source width.
  * </p>
- * @param int $src_h <p>
+ * @param int $src_height <p>
  * Source height.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecopyresized ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
+function imagecopyresized (GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $dst_width, int $dst_height, int $src_width, int $src_height): bool {}
 
 /**
  * Create a new palette based image
@@ -493,9 +505,10 @@ function imagecopyresized ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_
  * @param int $height <p>
  * The image height.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreate ($width, $height) {}
+#[Pure]
+function imagecreate (int $width, int $height): GdImage|false {}
 
 /**
  * Create a new true color image
@@ -506,54 +519,56 @@ function imagecreate ($width, $height) {}
  * @param int $height <p>
  * Image height.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatetruecolor ($width, $height) {}
+#[Pure]
+function imagecreatetruecolor (int $width, int $height): GdImage|false {}
 
 /**
  * Finds whether an image is a truecolor image
  * @link https://php.net/manual/en/function.imageistruecolor.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @return bool true if the image is truecolor, false
  * otherwise.
  */
-function imageistruecolor ($image) {}
+#[Pure]
+function imageistruecolor (GdImage $image): bool {}
 
 /**
  * Convert a true color image to a palette image
  * @link https://php.net/manual/en/function.imagetruecolortopalette.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param bool $dither <p>
  * Indicates if the image should be dithered - if it is true then
  * dithering will be used which will result in a more speckled image but
  * with better color approximation.
  * </p>
- * @param int $ncolors <p>
+ * @param int $num_colors <p>
  * Sets the maximum number of colors that should be retained in the palette.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagetruecolortopalette ($image, $dither, $ncolors) {}
+function imagetruecolortopalette (GdImage $image, bool $dither, int $num_colors): bool {}
 
 /**
  * Set the thickness for line drawing
  * @link https://php.net/manual/en/function.imagesetthickness.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $thickness <p>
  * Thickness, in pixels.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesetthickness ($image, $thickness) {}
+function imagesetthickness (GdImage $image, int $thickness): bool {}
 
 /**
  * Draw a partial arc and fill it
  * @link https://php.net/manual/en/function.imagefilledarc.php
- * @param resource $image
- * @param int $cx <p>
+ * @param resource|GdImage $image
+ * @param int $center_x <p>
  * x-coordinate of the center.
  * </p>
- * @param int $cy <p>
+ * @param int $center_y <p>
  * y-coordinate of the center.
  * </p>
  * @param int $width <p>
@@ -562,10 +577,10 @@ function imagesetthickness ($image, $thickness) {}
  * @param int $height <p>
  * The arc height.
  * </p>
- * @param int $start <p>
+ * @param int $start_angle <p>
  * The arc start angle, in degrees.
  * </p>
- * @param int $end <p>
+ * @param int $end_angle <p>
  * The arc end angle, in degrees.
  * 0&deg; is located at the three-o'clock position, and the arc is drawn
  * clockwise.
@@ -576,19 +591,19 @@ function imagesetthickness ($image, $thickness) {}
  * </p>
  * @param int $style <p>
  * A bitwise OR of the following possibilities:
- * IMG_ARC_PIE
+ * IMG_ARC_PIE</p>
  * @return bool true on success or false on failure.
  */
-function imagefilledarc ($image, $cx, $cy, $width, $height, $start, $end, $color, $style) {}
+function imagefilledarc (GdImage $image, int $center_x, int $center_y, int $width, int $height, int $start_angle, int $end_angle, int $color, int $style): bool {}
 
 /**
  * Draw a filled ellipse
  * @link https://php.net/manual/en/function.imagefilledellipse.php
- * @param resource $image
- * @param int $cx <p>
+ * @param resource|GdImage $image
+ * @param int $center_x <p>
  * x-coordinate of the center.
  * </p>
- * @param int $cy <p>
+ * @param int $center_y <p>
  * y-coordinate of the center.
  * </p>
  * @param int $width <p>
@@ -603,35 +618,35 @@ function imagefilledarc ($image, $cx, $cy, $width, $height, $start, $end, $color
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagefilledellipse ($image, $cx, $cy, $width, $height, $color) {}
+function imagefilledellipse (GdImage $image, int $center_x, int $center_y, int $width, int $height, int $color): bool {}
 
 /**
  * Set the blending mode for an image
  * @link https://php.net/manual/en/function.imagealphablending.php
- * @param resource $image
- * @param bool $blendmode <p>
+ * @param resource|GdImage $image
+ * @param bool $enable <p>
  * Whether to enable the blending mode or not. On true color images
  * the default value is true otherwise the default value is false
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagealphablending ($image, $blendmode) {}
+function imagealphablending (GdImage $image, bool $enable): bool {}
 
 /**
  * Set the flag to save full alpha channel information (as opposed to single-color transparency) when saving PNG images
  * @link https://php.net/manual/en/function.imagesavealpha.php
- * @param resource $image
- * @param bool $saveflag <p>
+ * @param resource|GdImage $image
+ * @param bool $enable <p>
  * Whether to save the alpha channel or not. Default to false.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesavealpha ($image, $saveflag) {}
+function imagesavealpha (GdImage $image, bool $enable): bool {}
 
 /**
  * Allocate a color for an image
  * @link https://php.net/manual/en/function.imagecolorallocatealpha.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>
  * Value of red component.
  * </p>
@@ -648,12 +663,12 @@ function imagesavealpha ($image, $saveflag) {}
  * </p>
  * @return int|false A color identifier or false if the allocation failed.
  */
-function imagecolorallocatealpha ($image, $red, $green, $blue, $alpha) {}
+function imagecolorallocatealpha (GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
 /**
  * Get the index of the specified color + alpha or its closest possible alternative
  * @link https://php.net/manual/en/function.imagecolorresolvealpha.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>
  * Value of red component.
  * </p>
@@ -670,12 +685,13 @@ function imagecolorallocatealpha ($image, $red, $green, $blue, $alpha) {}
  * </p>
  * @return int|false a color index or <b>FALSE</b> on failure
  */
-function imagecolorresolvealpha ($image, $red, $green, $blue, $alpha) {}
+#[Pure]
+function imagecolorresolvealpha (GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
 /**
  * Get the index of the closest color to the specified color + alpha
  * @link https://php.net/manual/en/function.imagecolorclosestalpha.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>
  * Value of red component.
  * </p>
@@ -693,12 +709,13 @@ function imagecolorresolvealpha ($image, $red, $green, $blue, $alpha) {}
  * @return int|false the index of the closest color in the palette or
  * <b>FALSE</b> on failure
  */
-function imagecolorclosestalpha ($image, $red, $green, $blue, $alpha) {}
+#[Pure]
+function imagecolorclosestalpha (GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
 /**
  * Get the index of the specified color + alpha
  * @link https://php.net/manual/en/function.imagecolorexactalpha.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $red <p>
  * Value of red component.
  * </p>
@@ -717,13 +734,14 @@ function imagecolorclosestalpha ($image, $red, $green, $blue, $alpha) {}
  * image, -1 if the color does not exist in the image's palette, or <b>FALSE</b>
  * on failure
  */
-function imagecolorexactalpha ($image, $red, $green, $blue, $alpha) {}
+#[Pure]
+function imagecolorexactalpha (GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
 /**
  * Copy and resize part of an image with resampling
  * @link https://php.net/manual/en/function.imagecopyresampled.php
- * @param resource $dst_image
- * @param resource $src_image
+ * @param resource|GdImage $dst_image
+ * @param resource|GdImage $src_image
  * @param int $dst_x <p>
  * x-coordinate of destination point.
  * </p>
@@ -736,85 +754,85 @@ function imagecolorexactalpha ($image, $red, $green, $blue, $alpha) {}
  * @param int $src_y <p>
  * y-coordinate of source point.
  * </p>
- * @param int $dst_w <p>
+ * @param int $dst_width <p>
  * Destination width.
  * </p>
- * @param int $dst_h <p>
+ * @param int $dst_height <p>
  * Destination height.
  * </p>
- * @param int $src_w <p>
+ * @param int $src_width <p>
  * Source width.
  * </p>
- * @param int $src_h <p>
+ * @param int $src_height <p>
  * Source height.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecopyresampled ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
+function imagecopyresampled (GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $dst_width, int $dst_height, int $src_width, int $src_height): bool {}
 
 /**
  * Rotate an image with a given angle
  * @link https://php.net/manual/en/function.imagerotate.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param float $angle <p>
  * Rotation angle, in degrees.
  * </p>
- * @param int $bgd_color <p>
+ * @param int $background_color <p>
  * Specifies the color of the uncovered zone after the rotation
  * </p>
- * @param int $ignore_transparent [optional] <p>
+ * @param bool $ignore_transparent [optional] <p>
  * If set and non-zero, transparent colors are ignored (otherwise kept).
  * </p>
- * @return resource|false the rotated image or <b>FALSE</b> on failure
+ * @return resource|GdImage|false the rotated image or <b>FALSE</b> on failure
  */
-function imagerotate ($image, $angle, $bgd_color, $ignore_transparent = null) {}
+function imagerotate (GdImage $image, float $angle, int $background_color, bool $ignore_transparent = false): GdImage|false {}
 
 /**
  * Should antialias functions be used or not. <br/>
  * Before 7.2.0 it's only available if PHP iscompiled with the bundled version of the GD library.
  * @link https://php.net/manual/en/function.imageantialias.php
- * @param resource $image
- * @param bool $enabled <p>
+ * @param resource|GdImage $image
+ * @param bool $enable <p>
  * Whether to enable antialiasing or not.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imageantialias ($image, $enabled) {}
+function imageantialias (GdImage $image, bool $enable): bool {}
 
 /**
  * Set the tile image for filling
  * @link https://php.net/manual/en/function.imagesettile.php
- * @param resource $image
- * @param resource $tile <p>
+ * @param resource|GdImage $image
+ * @param resource|GdImage $tile <p>
  * The image resource to be used as a tile.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesettile ($image, $tile) {}
+function imagesettile (GdImage $image, GdImage $tile): bool {}
 
 /**
  * Set the brush image for line drawing
  * @link https://php.net/manual/en/function.imagesetbrush.php
- * @param resource $image
- * @param resource $brush <p>
+ * @param resource|GdImage $image
+ * @param resource|GdImage $brush <p>
  * An image resource.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesetbrush ($image, $brush) {}
+function imagesetbrush (GdImage $image, GdImage $brush): bool {}
 
 /**
  * Set the style for line drawing
  * @link https://php.net/manual/en/function.imagesetstyle.php
- * @param resource $image
- * @param array $style <p>
+ * @param resource|GdImage $image
+ * @param int[] $style <p>
  * An array of pixel colors. You can use the
  * IMG_COLOR_TRANSPARENT constant to add a
  * transparent pixel.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesetstyle ($image, array $style) {}
+function imagesetstyle (GdImage $image, array $style): bool {}
 
 /**
  * Create a new image from file or URL
@@ -822,9 +840,9 @@ function imagesetstyle ($image, array $style) {}
  * @param string $filename <p>
  * Path to the PNG image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefrompng ($filename) {}
+function imagecreatefrompng (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -832,9 +850,9 @@ function imagecreatefrompng ($filename) {}
  * @param string $filename <p>
  * Path to the GIF image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromgif ($filename) {}
+function imagecreatefromgif (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -842,9 +860,9 @@ function imagecreatefromgif ($filename) {}
  * @param string $filename <p>
  * Path to the JPEG image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromjpeg ($filename) {}
+function imagecreatefromjpeg (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -852,9 +870,9 @@ function imagecreatefromjpeg ($filename) {}
  * @param string $filename <p>
  * Path to the WBMP image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromwbmp ($filename) {}
+function imagecreatefromwbmp (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -862,10 +880,10 @@ function imagecreatefromwbmp ($filename) {}
  * @param string $filename <p>
  * Path to the WebP image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  * @since 5.4
  */
-function imagecreatefromwebp ($filename) {}
+function imagecreatefromwebp (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -873,9 +891,9 @@ function imagecreatefromwebp ($filename) {}
  * @param string $filename <p>
  * Path to the XBM image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromxbm ($filename) {}
+function imagecreatefromxbm (string $filename): GdImage|false {}
 
 /**
  * Create a new image from file or URL
@@ -883,9 +901,9 @@ function imagecreatefromxbm ($filename) {}
  * @param string $filename <p>
  * Path to the XPM image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromxpm ($filename) {}
+function imagecreatefromxpm (string $filename): GdImage|false {}
 
 /**
  * Create a new image from GD file or URL
@@ -893,9 +911,9 @@ function imagecreatefromxpm ($filename) {}
  * @param string $filename <p>
  * Path to the GD file.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromgd ($filename) {}
+function imagecreatefromgd (string $filename): GdImage|false {}
 
 /**
  * Create a new image from GD2 file or URL
@@ -903,9 +921,9 @@ function imagecreatefromgd ($filename) {}
  * @param string $filename <p>
  * Path to the GD2 image.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromgd2 ($filename) {}
+function imagecreatefromgd2 (string $filename): GdImage|false {}
 
 /**
  * Create a new image from a given part of GD2 file or URL
@@ -913,10 +931,10 @@ function imagecreatefromgd2 ($filename) {}
  * @param string $filename <p>
  * Path to the GD2 image.
  * </p>
- * @param int $srcX <p>
+ * @param int $x <p>
  * x-coordinate of source point.
  * </p>
- * @param int $srcY <p>
+ * @param int $y <p>
  * y-coordinate of source point.
  * </p>
  * @param int $width <p>
@@ -925,20 +943,20 @@ function imagecreatefromgd2 ($filename) {}
  * @param int $height <p>
  * Source height.
  * </p>
- * @return resource|false an image resource identifier on success, false on errors.
+ * @return resource|GdImage|false an image resource identifier on success, false on errors.
  */
-function imagecreatefromgd2part ($filename, $srcX, $srcY, $width, $height) {}
+function imagecreatefromgd2part (string $filename, int $x, int $y, int $width, int $height): GdImage|false {}
 
 /**
  * Output a PNG image to either the browser or a file
  * @link https://php.net/manual/en/function.imagepng.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string $file [optional] <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * <p>
- * &null; is invalid if the quality and
+ * null is invalid if the quality and
  * filters arguments are not used.
  * </p>
  * @param int $quality [optional] <p>
@@ -953,14 +971,14 @@ function imagecreatefromgd2part ($filename, $srcX, $srcY, $width, $height) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagepng ($image, $filename = null, $quality = null, $filters = null) {}
+function imagepng (GdImage $image, $file = null, int $quality = -1, int $filters = -1): bool {}
 
 /**
  * Output a WebP image to browser or file
  * @link https://php.net/manual/en/function.imagewebp.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param string $to [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * @param int $quality [optional] <p>
@@ -969,31 +987,31 @@ function imagepng ($image, $filename = null, $quality = null, $filters = null) {
  * @return bool true on success or false on failure.
  * @since 5.4
  */
-function imagewebp ($image, $to = null, $quality = 80) {}
+function imagewebp ($image, $to = null, $quality = 80): bool {}
 
 /**
  * Output image to browser or file
  * @link https://php.net/manual/en/function.imagegif.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string $file [optional] <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagegif ($image, $filename = null) {}
+function imagegif (GdImage $image, $file = null): bool {}
 
 /**
  * Output image to browser or file
  * @link https://php.net/manual/en/function.imagejpeg.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * <p>
  * To skip this argument in order to provide the
- * quality parameter, use &null;.
+ * quality parameter, use null.
  * </p>
  * @param int $quality [optional] <p>
  * quality is optional, and ranges from 0 (worst
@@ -1002,84 +1020,84 @@ function imagegif ($image, $filename = null) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagejpeg ($image, $filename = null, $quality = null) {}
+function imagejpeg ($image, $filename = null, $quality = null): bool {}
 
 /**
  * Output image to browser or file
  * @link https://php.net/manual/en/function.imagewbmp.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string $file [optional] <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
- * @param int $foreground [optional] <p>
+ * @param int $foreground_color [optional] <p>
  * You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagewbmp ($image, $filename = null, $foreground = null) {}
+function imagewbmp (GdImage $image, $file = null, ?int $foreground_color = null): bool {}
 
 /**
  * Output GD image to browser or file. <br/>
  * Since 7.2.0 allows to output truecolor images.
  * @link https://php.net/manual/en/function.imagegd.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string $file [optional] <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagegd ($image, $filename = null) {}
+function imagegd (GdImage $image, string $file = null): bool {}
 
 /**
  * Output GD2 image to browser or file
  * @link https://php.net/manual/en/function.imagegd2.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string $file [optional] <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
  * @param int $chunk_size [optional] <p>
  * Chunk size.
  * </p>
- * @param int $type [optional] <p>
+ * @param int $mode [optional] <p>
  * Either IMG_GD2_RAW or
  * IMG_GD2_COMPRESSED. Default is
  * IMG_GD2_RAW.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagegd2 ($image, $filename = null, $chunk_size = null, $type = null) {}
+function imagegd2 (GdImage $image, string $file = null, int $chunk_size = null, int $mode = null): bool {}
 
 /**
  * Destroy an image
  * @link https://php.net/manual/en/function.imagedestroy.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @return bool true on success or false on failure.
  */
-function imagedestroy ($image) {}
+function imagedestroy (GdImage $image): bool {}
 
 /**
  * Apply a gamma correction to a GD image
  * @link https://php.net/manual/en/function.imagegammacorrect.php
- * @param resource $image
- * @param float $inputgamma <p>
+ * @param resource|GdImage $image
+ * @param float $input_gamma <p>
  * The input gamma.
  * </p>
- * @param float $outputgamma <p>
+ * @param float $output_gamma <p>
  * The output gamma.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagegammacorrect ($image, $inputgamma, $outputgamma) {}
+function imagegammacorrect (GdImage $image, float $input_gamma, float $output_gamma): bool {}
 
 /**
  * Flood fill
  * @link https://php.net/manual/en/function.imagefill.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x <p>
  * x-coordinate of start point.
  * </p>
@@ -1092,31 +1110,31 @@ function imagegammacorrect ($image, $inputgamma, $outputgamma) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagefill ($image, $x, $y, $color) {}
+function imagefill (GdImage $image, int $x, int $y, int $color): bool {}
 
 /**
  * Draw a filled polygon
  * @link https://php.net/manual/en/function.imagefilledpolygon.php
- * @param resource $image
- * @param array $points <p>
+ * @param resource|GdImage $image
+ * @param int[] $points <p>
  * An array containing the x and y
  * coordinates of the polygons vertices consecutively.
  * </p>
- * @param int $num_points [optional] <p>
+ * @param int $num_points_or_color <p>
  * Total number of vertices, which must be at least 3.
  * </p>
- * @param int $color <p>
+ * @param int|null $color <p>
  * A color identifier created with
  * imagecolorallocate.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagefilledpolygon ($image, array $points, $num_points, $color) {}
+function imagefilledpolygon (GdImage $image, array $points, int $num_points_or_color, ?int $color = null): bool {}
 
 /**
  * Draw a filled rectangle
  * @link https://php.net/manual/en/function.imagefilledrectangle.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x1 <p>
  * x-coordinate for point 1.
  * </p>
@@ -1135,19 +1153,19 @@ function imagefilledpolygon ($image, array $points, $num_points, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagefilledrectangle ($image, $x1, $y1, $x2, $y2, $color) {}
+function imagefilledrectangle (GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
 /**
  * Flood fill to specific color
  * @link https://php.net/manual/en/function.imagefilltoborder.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x <p>
  * x-coordinate of start.
  * </p>
  * @param int $y <p>
  * y-coordinate of start.
  * </p>
- * @param int $border <p>
+ * @param int $border_color <p>
  * The border color. A color identifier created with
  * imagecolorallocate.
  * </p>
@@ -1157,7 +1175,7 @@ function imagefilledrectangle ($image, $x1, $y1, $x2, $y2, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagefilltoborder ($image, $x, $y, $border, $color) {}
+function imagefilltoborder (GdImage $image, int $x, int $y, int $border_color, int $color): bool {}
 
 /**
  * Get font width
@@ -1165,7 +1183,8 @@ function imagefilltoborder ($image, $x, $y, $border, $color) {}
  * @param int $font
  * @return int the width of the pixel
  */
-function imagefontwidth ($font) {}
+#[Pure]
+function imagefontwidth (int $font): int {}
 
 /**
  * Get font height
@@ -1173,25 +1192,26 @@ function imagefontwidth ($font) {}
  * @param int $font
  * @return int the height of the pixel.
  */
-function imagefontheight ($font) {}
+#[Pure]
+function imagefontheight (int $font): int {}
 
 /**
  * Enable or disable interlace
  * @link https://php.net/manual/en/function.imageinterlace.php
- * @param resource $image
- * @param int $interlace [optional] <p>
+ * @param resource|GdImage $image
+ * @param bool|null $enable [optional] <p>
  * If non-zero, the image will be interlaced, else the interlace bit is
  * turned off.
  * </p>
- * @return int|false 1 if the interlace bit is set for the image,
- * 0 if it is not, or <b>FALSE</b> on failure
+ * @return int|null 1 if the interlace bit is set for the image,
+ * 0 if it is not
  */
-function imageinterlace ($image, $interlace = null) {}
+function imageinterlace (GdImage $image, ?bool $enable = null): ?int {}
 
 /**
  * Draw a line
  * @link https://php.net/manual/en/function.imageline.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x1 <p>
  * x-coordinate for first point.
  * </p>
@@ -1210,12 +1230,12 @@ function imageinterlace ($image, $interlace = null) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imageline ($image, $x1, $y1, $x2, $y2, $color) {}
+function imageline (GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
 /**
  * Load a new font
  * @link https://php.net/manual/en/function.imageloadfont.php
- * @param string $file <p>
+ * @param string $filename <p>
  * The font file format is currently binary and architecture
  * dependent. This means you should generate the font files on the
  * same type of CPU as the machine you are running PHP on.
@@ -1263,13 +1283,13 @@ function imageline ($image, $x1, $y1, $x2, $y2, $color) {}
  * @return int|false The font identifier which is always bigger than 5 to avoid conflicts with
  * built-in fonts or false on errors.
  */
-function imageloadfont ($file) {}
+function imageloadfont (string $filename): int|false {}
 
 /**
  * Draws a polygon
  * @link https://php.net/manual/en/function.imagepolygon.php
- * @param resource $image
- * @param array $points <p>
+ * @param resource|GdImage $image
+ * @param int[] $points <p>
  * An array containing the polygon's vertices, e.g.:
  * <tr valign="top">
  * <td>points[0]</td>
@@ -1288,21 +1308,21 @@ function imageloadfont ($file) {}
  * <td>= y1</td>
  * </tr>
  * </p>
- * @param int $num_points [optional] <p>
+ * @param int $num_points_or_color <p>
  * Total number of points (vertices).
  * </p>
- * @param int $color <p>
+ * @param int|null $color <p>
  * A color identifier created with
  * imagecolorallocate.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagepolygon ($image, array $points, $num_points, $color) {}
+function imagepolygon (GdImage $image, array $points, int $num_points_or_color, ?int $color = null): bool {}
 
 /**
  * Draw a rectangle
  * @link https://php.net/manual/en/function.imagerectangle.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x1 <p>
  * Upper left x coordinate.
  * </p>
@@ -1322,12 +1342,12 @@ function imagepolygon ($image, array $points, $num_points, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagerectangle ($image, $x1, $y1, $x2, $y2, $color) {}
+function imagerectangle (GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
 /**
  * Set a single pixel
  * @link https://php.net/manual/en/function.imagesetpixel.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x <p>
  * x-coordinate.
  * </p>
@@ -1340,12 +1360,12 @@ function imagerectangle ($image, $x1, $y1, $x2, $y2, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagesetpixel ($image, $x, $y, $color) {}
+function imagesetpixel (GdImage $image, int $x, int $y, int $color): bool {}
 
 /**
  * Draw a string horizontally
  * @link https://php.net/manual/en/function.imagestring.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $font
  * @param int $x <p>
  * x-coordinate of the upper left corner.
@@ -1362,12 +1382,12 @@ function imagesetpixel ($image, $x, $y, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagestring ($image, $font, $x, $y, $string, $color) {}
+function imagestring (GdImage $image, int $font, int $x, int $y, string $string, int $color): bool {}
 
 /**
  * Draw a string vertically
  * @link https://php.net/manual/en/function.imagestringup.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $font
  * @param int $x <p>
  * x-coordinate of the upper left corner.
@@ -1384,30 +1404,32 @@ function imagestring ($image, $font, $x, $y, $string, $color) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagestringup ($image, $font, $x, $y, $string, $color) {}
+function imagestringup (GdImage $image, int $font, int $x, int $y, string $string, int $color): bool {}
 
 /**
  * Get image width
  * @link https://php.net/manual/en/function.imagesx.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @return int|false Return the width of the image or false on
  * errors.
  */
-function imagesx ($image) {}
+#[Pure]
+function imagesx (GdImage $image): int {}
 
 /**
  * Get image height
  * @link https://php.net/manual/en/function.imagesy.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @return int|false Return the height of the image or false on
  * errors.
  */
-function imagesy ($image) {}
+#[Pure]
+function imagesy (GdImage $image): int {}
 
 /**
  * Draw a dashed line
  * @link https://php.net/manual/en/function.imagedashedline.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $x1 <p>
  * Upper left x coordinate.
  * </p>
@@ -1425,9 +1447,11 @@ function imagesy ($image) {}
  * imagecolorallocate.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @deprecated Use combination of imagesetstyle() and imageline() instead
+ * @see imagesetstyle()
+ * @see imageline()
  */
-function imagedashedline ($image, $x1, $y1, $x2, $y2, $color) {}
+#[Deprecated("Use combination of imagesetstyle() and imageline() instead")]
+function imagedashedline (GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
 /**
  * Give the bounding box of a text using TrueType fonts
@@ -1493,12 +1517,13 @@ function imagedashedline ($image, $x1, $y1, $x2, $y2, $color) {}
  * angle, so "upper left" means in the top left-hand
  * corner seeing the text horizontally.
  */
+#[Pure]
 function imagettfbbox ($size, $angle, $fontfile, $text) {}
 
 /**
  * Write text to the image using TrueType fonts
  * @link https://php.net/manual/en/function.imagettftext.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param float $size <p>
  * The font size. Depending on your version of GD, this should be
  * specified as the pixel size (GD1) or point size (GD2).
@@ -1664,12 +1689,13 @@ function imagettftext ($image, $size, $angle, $x, $y, $color, $fontfile, $text) 
  * corner seeing the text horizontally.
  * Returns false on error.
  */
+#[Pure]
 function imageftbbox ($size, $angle, $fontfile, $text, $extrainfo = null ) {}
 
 /**
  * Write text to the image using fonts using FreeType 2
  * @link https://php.net/manual/en/function.imagefttext.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param float $size <p>
  * The font size to use in points.
  * </p>
@@ -1790,7 +1816,7 @@ function imagefttext ($image, $size, $angle, $x, $y, $color, $fontfile, $text, $
  * @param string $filename <p>
  * Path to the Postscript font file.
  * </p>
- * @return resource|false In the case everything went right, a valid font index will be returned and
+ * @return resource|GdImage|false In the case everything went right, a valid font index will be returned and
  * can be used for further purposes. Otherwise the function returns false.
  * @removed 7.0 This function was REMOVED in PHP 7.0.0.
  */
@@ -1799,7 +1825,7 @@ function imagepsloadfont ($filename) {}
 /**
  * Free memory used by a PostScript Type 1 font
  * @link https://php.net/manual/en/function.imagepsfreefont.php
- * @param resource $font_index <p>
+ * @param resource|GdImage $font_index <p>
  * A font resource, returned by imagepsloadfont.
  * </p>
  * @return bool true on success or false on failure.
@@ -1810,7 +1836,7 @@ function imagepsfreefont ($font_index) {}
 /**
  * Change the character encoding vector of a font
  * @link https://php.net/manual/en/function.imagepsencodefont.php
- * @param resource $font_index <p>
+ * @param resource|GdImage $font_index <p>
  * A font resource, returned by imagepsloadfont.
  * </p>
  * @param string $encodingfile <p>
@@ -1827,7 +1853,7 @@ function imagepsencodefont ($font_index, $encodingfile) {}
 /**
  * Extend or condense a font
  * @link https://php.net/manual/en/function.imagepsextendfont.php
- * @param resource $font_index <p>
+ * @param resource|GdImage $font_index <p>
  * A font resource, returned by imagepsloadfont.
  * </p>
  * @param float $extend <p>
@@ -1841,7 +1867,7 @@ function imagepsextendfont ($font_index, $extend) {}
 /**
  * Slant a font
  * @link https://php.net/manual/en/function.imagepsslantfont.php
- * @param resource $font_index <p>
+ * @param resource|GdImage $font_index <p>
  * A font resource, returned by imagepsloadfont.
  * </p>
  * @param float $slant <p>
@@ -1855,11 +1881,11 @@ function imagepsslantfont ($font_index, $slant) {}
 /**
  * Draws a text over an image using PostScript Type1 fonts
  * @link https://php.net/manual/en/function.imagepstext.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param string $text <p>
  * The text to be written.
  * </p>
- * @param resource $font_index <p>
+ * @param resource|GdImage $font_index <p>
  * A font resource, returned by imagepsloadfont.
  * </p>
  * @param int $size <p>
@@ -1931,7 +1957,7 @@ function imagepstext ($image, $text, $font_index, $size, $foreground, $backgroun
  * @param string $text <p>
  * The text to be written.
  * </p>
- * @param resource $font
+ * @param resource|GdImage $font
  * @param int $size <p>
  * size is expressed in pixels.
  * </p>
@@ -1964,7 +1990,8 @@ function imagepsbbox ($text, $font, $size) {}
  * version of GD linked into PHP. The following bits are returned,
  * IMG_BMP | IMG_GIF | IMG_JPG | IMG_PNG | IMG_WBMP | IMG_XPM | IMG_WEBP
  */
-function imagetypes () {}
+#[Pure]
+function imagetypes (): int {}
 
 /**
  * Convert JPEG image file to WBMP image file
@@ -1985,9 +2012,10 @@ function imagetypes () {}
  * Threshold value, between 0 and 8 (inclusive).
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated 7.2 Use imagecreatefromjpeg() and imagewbmp() instead
  * @removed 8.0
+ * @see imagecreatefromjpeg()
  */
+#[Deprecated(reason: "Use imagecreatefromjpeg() and imagewbmp() instead", since: "7.2")]
 function jpeg2wbmp ($jpegname, $wbmpname, $dest_height, $dest_width, $threshold) {}
 
 /**
@@ -2009,15 +2037,17 @@ function jpeg2wbmp ($jpegname, $wbmpname, $dest_height, $dest_width, $threshold)
  * Threshold value, between 0 and 8 (inclusive).
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated 7.2 Use imagecreatefrompng() and imagewbmp() instead
  * @removed 8.0
+ * @see imagecreatefrompng()
+ * @see imagewbmp()
  */
+#[Deprecated("Use imagecreatefrompng() and imagewbmp() instead", since: "7.2")]
 function png2wbmp ($pngname, $wbmpname, $dest_height, $dest_width, $threshold) {}
 
 /**
  * Output image to browser or file
  * @link https://php.net/manual/en/function.image2wbmp.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param string $filename [optional] <p>
  * Path to the saved file. If not given, the raw image stream will be
  * outputted directly.
@@ -2026,85 +2056,77 @@ function png2wbmp ($pngname, $wbmpname, $dest_height, $dest_width, $threshold) {
  * Threshold value, between 0 and 255 (inclusive).
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated 7.3 Use imagewbmp() instead
  * @removed 8.0
+ * @see imagewbmp()
  */
+#[Deprecated(replacement: "imagewbmp(%parametersList%)", since: "7.3")]
 function image2wbmp ($image, $filename = null, $threshold = null) {}
 
 /**
  * Set the alpha blending flag to use the bundled libgd layering effects
  * @link https://php.net/manual/en/function.imagelayereffect.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param int $effect <p>
  * One of the following constants:
  * IMG_EFFECT_REPLACE
  * Use pixel replacement (equivalent of passing true to
- * imagealphablending)
+ * imagealphablending)</p>
  * @return bool true on success or false on failure.
  */
-function imagelayereffect ($image, $effect) {}
+function imagelayereffect (GdImage $image, int $effect): bool {}
 
 /**
  * Makes the colors of the palette version of an image more closely match the true color version
  * @link https://php.net/manual/en/function.imagecolormatch.php
- * @param $image1 resource <p>
+ * @param resource|GdImage $image1 <p>
  * A truecolor image link resource.
  * </p>
- * @param $image2 resource <p>
+ * @param resource|GdImage $image2 <p>
  * A palette image link resource pointing to an image that has the same
  * size as image1.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagecolormatch ($image1, $image2) {}
+function imagecolormatch (GdImage $image1, GdImage $image2): bool {}
 
 /**
  * Output XBM image to browser or file
  * @link https://php.net/manual/en/function.imagexbm.php
- * @param resource $image
- * @param string $filename <p>
- * The path to save the file to. If not set or &null;, the raw image stream
+ * @param resource|GdImage $image
+ * @param string|null $filename <p>
+ * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
- * @param int $foreground [optional] <p>
+ * @param int|null $foreground_color [optional] <p>
  * You can set the foreground color with this parameter by setting an
  * identifier obtained from imagecolorallocate.
  * The default foreground color is black.
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagexbm ($image, $filename, $foreground = null) {}
+function imagexbm (GdImage $image, ?string $filename, ?int $foreground_color = null): bool {}
 
 /**
  * Applies a filter to an image
  * @link https://php.net/manual/en/function.imagefilter.php
- * @param resource $image
- * @param int $filtertype <p>
+ * @param resource|GdImage $image
+ * @param int $filter <p>
  * filtertype can be one of the following:
  * IMG_FILTER_NEGATE: Reverses all colors of
- * the image.
- * @param int $arg1 [optional] <p>
- * IMG_FILTER_BRIGHTNESS: Brightness level.
- * @param int $arg2 [optional] <p>
- * IMG_FILTER_COLORIZE: Value of green component.
- * @param int $arg3 [optional] <p>
- * IMG_FILTER_COLORIZE: Value of blue component.
- * @param int $arg4 [optional] <p>
- * IMG_FILTER_COLORIZE: Alpha channel, A value
- * between 0 and 127. 0 indicates completely opaque while 127 indicates
- * completely transparent.
+ * the image.</p>
+ * @param int ...$args
  * @return bool true on success or false on failure.
  */
-function imagefilter ($image, $filtertype, $arg1 = null, $arg2 = null, $arg3 = null, $arg4 = null) {}
+function imagefilter (GdImage $image, int $filter, ...$args): bool {}
 
 /**
  * Apply a 3x3 convolution matrix, using coefficient and offset
  * @link https://php.net/manual/en/function.imageconvolution.php
- * @param resource $image
+ * @param resource|GdImage $image
  * @param array $matrix <p>
  * A 3x3 matrix: an array of three arrays of three floats.
  * </p>
- * @param float $div <p>
+ * @param float $divisor <p>
  * The divisor of the result of the convolution, used for normalization.
  * </p>
  * @param float $offset <p>
@@ -2112,22 +2134,22 @@ function imagefilter ($image, $filtertype, $arg1 = null, $arg2 = null, $arg3 = n
  * </p>
  * @return bool true on success or false on failure.
  */
-function imageconvolution ($image, array $matrix, $div, $offset) {}
+function imageconvolution (GdImage $image, array $matrix, float $divisor, float $offset): bool {}
 
 /**
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param int $res_x [optional] The horizontal resolution in DPI.
- * @param int $res_y [optional] The vertical resolution in DPI.
+ * @param resource|GdImage $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
+ * @param int|null $resolution_x [optional] The horizontal resolution in DPI.
+ * @param int|null $resolution_y [optional] The vertical resolution in DPI.
  * @return array|bool When used as getter (that is without the optional parameters), it returns <b>TRUE</b> on success, or <b>FALSE</b> on failure. When used as setter (that is with one or both optional parameters given), it returns an indexed array of the horizontal and vertical resolution on success, or <b>FALSE</b> on failure.
  * @link https://php.net/manual/en/function.imageresolution.php
  * @since 7.2
  */
-function imageresolution ($im, $res_x = 96, $res_y = 96) {}
+function imageresolution (GdImage $image, ?int $resolution_x = 96, ?int $resolution_y = 96): array|bool {}
 
 
 /**
  * <b>imagesetclip()</b> sets the current clipping rectangle, i.e. the area beyond which no pixels will be drawn.
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
+ * @param resource|GdImage $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
  * @param int $x1 The x-coordinate of the upper left corner.
  * @param int $y1 The y-coordinate of the upper left corner.
  * @param int $x2 The x-coordinate of the lower right corner.
@@ -2137,11 +2159,11 @@ function imageresolution ($im, $res_x = 96, $res_y = 96) {}
  * @see imagegetclip()
  * @since 7.2
  */
-function imagesetclip ($im, $x1, $y1, $x2, $y2) {}
+function imagesetclip (GdImage $image, int $x1, int $y1, int $x2, int $y2): bool {}
 
 /**
  * <b>imagegetclip()</b> retrieves the current clipping rectangle, i.e. the area beyond which no pixels will be drawn.
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}
+ * @param resource|GdImage $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}
  * @return array|false an indexed array with the coordinates of the clipping rectangle which has the following entries:
  * <ul>
  * <li>x-coordinate of the upper left corner</li>
@@ -2154,41 +2176,41 @@ function imagesetclip ($im, $x1, $y1, $x2, $y2) {}
  * @see imagesetclip()
  * @since 7.2
  */
-function imagegetclip ($im) {}
+function imagegetclip (GdImage $image): array {}
 
 /**
  * <b>imageopenpolygon()</b> draws an open polygon on the given <b>image.</b> Contrary to {@see imagepolygon()}, no line is drawn between the last and the first point.
- * @param resource $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param array $points An array containing the polygon's vertices, e.g.:
+ * @param resource|GdImage $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
+ * @param int[] $points An array containing the polygon's vertices, e.g.:
  * <pre>
  * points[0]	= x0
  * points[1]	= y0
  * points[2]	= x1
  * points[3]	= y1
  * </pre>
- * @param int $num_points [optional] Total number of points (vertices).
- * @param int $color A color identifier created with {@see imagecolorallocate()}.
+ * @param int $num_points_or_color Total number of points (vertices).
+ * @param int|null $color A color identifier created with {@see imagecolorallocate()}.
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @link https://php.net/manual/en/function.imageopenpolygon.php
  * @since 7.2
  * @see imageplygon()
  */
-function imageopenpolygon ($image , $points, $num_points, $color) {}
+function imageopenpolygon (GdImage $image , array $points, int $num_points_or_color, ?int $color = null): bool {}
 
 /**
  * <b>imagecreatefrombmp()</b> returns an image identifier representing the image obtained from the given filename.
  * <b>TIP</b> A URL can be used as a filename with this function if the fopen wrappers have been enabled. See {@see fopen()} for more details on how to specify the filename. See the Supported Protocols and Wrappers for links to information about what abilities the various wrappers have, notes on their usage, and information on any predefined variables they may provide.
  * @param string $filename Path to the BMP image.
- * @return resource|false Returns an image resource identifier on success, <b>FALSE</b> on errors.
+ * @return resource|GdImage|false Returns an image resource identifier on success, <b>FALSE</b> on errors.
  * @link https://php.net/manual/en/function.imagecreatefrombmp.php
  * @since 7.2
  */
-function imagecreatefrombmp($filename){}
+function imagecreatefrombmp(string $filename): GdImage|false {}
 
 /**
  * Outputs or saves a BMP version of the given <b>image</b>.
- * @param resource $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param mixed $to The path or an open stream resource (which is automatically being closed after this function returns) to save the file to. If not set or <b>NULL</b>, the raw image stream will be outputted directly.
+ * @param resource|GdImage $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
+ * @param mixed $file The path or an open stream resource (which is automatically being closed after this function returns) to save the file to. If not set or <b>NULL</b>, the raw image stream will be outputted directly.
  * <br />
  * <b>Note:</b> <b>NULL</b> is invalid if the <b>compressed</b> arguments is not used.
  * @param bool $compressed Whether the BMP should be compressed with run-length encoding (RLE), or not.
@@ -2198,21 +2220,22 @@ function imagecreatefrombmp($filename){}
  * @link https://php.net/manual/en/function.imagebmp.php
  * @since 7.2
  */
-function imagebmp ($image, $to = null, $compressed = true) {}
+function imagebmp (GdImage $image, $file = null, bool $compressed = true): bool {}
 
 /**
  * @param string $filename
- * @return resource|false
+ * @return resource|GdImage|false
  */
-function imagecreatefromtga($filename) {}
+function imagecreatefromtga(string $filename): GdImage|false {}
 
 /**
  * Captures the whole screen
  *
  * https://www.php.net/manual/en/function.imagegrabscreen.php
  *
- * @return resource|false
+ * @return resource|GdImage|false
  */
+#[Pure]
 function imagegrabscreen() {}
 
 /**
@@ -2222,9 +2245,21 @@ function imagegrabscreen() {}
  *
  * @param int $handle
  * @param int|null $client_area
- * @return resource|false
+ * @return resource|GdImage|false
  */
+#[Pure]
 function imagegrabwindow($handle, $client_area = null) {}
+
+/**
+ * Gets the currently set interpolation method of the image.
+ *
+ * @link https://www.php.net/manual/en/function.imagegetinterpolation.php
+ *
+ * @param GdImage $image
+ * @return int
+ */
+#[Pure]
+function imagegetinterpolation (GdImage $image): int {}
 
 /**
  * Used as a return value by {@see imagetypes()}
@@ -2805,53 +2840,52 @@ define('IMG_TGA', 128);
 
 /**
  * Return an image containing the affine tramsformed src image, using an optional clipping area
- * @link https://www.php.net/manual/en/function.imageaffine.php
- * @param resource $image <p>An image resource, returned by one of the image creation functions,
- * such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.</p>
+ * @link https://secure.php.net/manual/en/function.imageaffine.php
+ * @param resource|GdImage $image <p>An image resource, returned by one of the image creation functions,
+ * such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.</p>
  * @param array $affine <p>Array with keys 0 to 5.</p>
- * @param array $clip [optional] <p>Array with keys "x", "y", "width" and "height".</p>
- * @return resource|bool Return affined image resource on success or FALSE on failure.
+ * @param array|null $clip [optional] <p>Array with keys "x", "y", "width" and "height".</p>
+ * @return resource|GdImage|false Return affined image resource on success or FALSE on failure.
  */
-function imageaffine($image, $affine, $clip = null) {}
+function imageaffine(GdImage $image, array $affine, ?array $clip = null): GdImage|false {}
 
 /**
  * Concat two matrices (as in doing many ops in one go)
- * @link https://www.php.net/manual/en/function.imageaffinematrixconcat.php
- * @param array $m1 <p>Array with keys 0 to 5.</p>
- * @param array $m2 <p>Array with keys 0 to 5.</p>
- * @return array|bool Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
+ * @link https://secure.php.net/manual/en/function.imageaffinematrixconcat.php
+ * @param array $matrix1 <p>Array with keys 0 to 5.</p>
+ * @param array $matrix2 <p>Array with keys 0 to 5.</p>
+ * @return float[]|false Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function imageaffinematrixconcat(array $m1, array $m2) {}
+function imageaffinematrixconcat(array $matrix1, array $matrix2): array|false {}
 
 /**
  * Return an image containing the affine tramsformed src image, using an optional clipping area
- * @link https://www.php.net/manual/en/function.imageaffinematrixget.php
- * @param int $type <p> One of <b>IMG_AFFINE_*</b> constants.
+ * @link https://secure.php.net/manual/en/function.imageaffinematrixget.php
+ * @param int $type <p> One of <b>IMG_AFFINE_*</b> constants.</p>
  * @param mixed $options [optional]
- * @return array|bool Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
+ * @return float[]|false Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
  * @since 5.5
  */
-
-function imageaffinematrixget ($type, $options = null) {}
+function imageaffinematrixget (int $type, $options = null): array|false {}
 
 /**
  * Crop an image using the given coordinates and size, x, y, width and height
- * @link https://www.php.net/manual/en/function.imagecrop.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * @link https://secure.php.net/manual/en/function.imagecrop.php
+ * @param resource|GdImage $image <p>
+ * An image resource, returned by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
  * </p>
- * @param array $rect <p>Array with keys "x", "y", "width" and "height".</p>
- * @return resource|bool Return cropped image resource on success or FALSE on failure.
+ * @param array $rectangle <p>Array with keys "x", "y", "width" and "height".</p>
+ * @return resource|GdImage|false Return cropped image resource on success or FALSE on failure.
  * @since 5.5
  */
-function imagecrop ($image, $rect) {}
+function imagecrop (GdImage $image, array $rectangle): GdImage|false {}
 
 /**
  * Crop an image automatically using one of the available modes
- * @link https://www.php.net/manual/en/function.imagecropauto.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * @link https://secure.php.net/manual/en/function.imagecropauto.php
+ * @param resource|GdImage $image <p>
+ * An image resource, returned by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
  * </p>
  * @param int $mode [optional] <p>
  * One of <b>IMG_CROP_*</b> constants.
@@ -2863,16 +2897,16 @@ function imagecrop ($image, $rect) {}
  * <p>
  * Used in <b>IMG_CROP_THRESHOLD</b> mode.
  * </p>
- * @return resource|bool Return cropped image resource on success or <b>FALSE</b> on failure.
+ * @return resource|GdImage|false Return cropped image resource on success or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function imagecropauto ($image, $mode = IMG_CROP_DEFAULT, $threshold = .5, $color = -1) {}
+function imagecropauto (GdImage $image, int $mode = IMG_CROP_DEFAULT, float $threshold = .5, int $color = -1): GdImage|false {}
 
 /**
  * Flips an image using a given mode
- * @link https://www.php.net/manual/en/function.imageflip.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * @link https://secure.php.net/manual/en/function.imageflip.php
+ * @param resource|GdImage $image <p>
+ * An image resource, returned by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
  * </p>
  * @param int $mode <p>
  * Flip mode, this can be one of the <b>IMG_FLIP_*</b> constants:
@@ -2884,6 +2918,7 @@ function imagecropauto ($image, $mode = IMG_CROP_DEFAULT, $threshold = .5, $colo
  * <th>Meaning</th>
  * </tr>
  * </thead>
+ * <tbody>
  * <tr>
  * <td><b>IMG_FLIP_HORIZONTAL</b></td>
  * <td>
@@ -2907,39 +2942,38 @@ function imagecropauto ($image, $mode = IMG_CROP_DEFAULT, $threshold = .5, $colo
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function imageflip ($image, $mode) {}
+function imageflip (GdImage $image, int $mode): bool {}
 
 /**
  * Converts a palette based image to true color
- * @link https://www.php.net/manual/en/function.imagepalettetotruecolor.php
- * @param resource $image <p>
- * An image resource, returnd by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * @link https://secure.php.net/manual/en/function.imagepalettetotruecolor.php
+ * @param resource|GdImage $image <p>
+ * An image resource, returnd by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
  * </p>
  * @return bool Returns <b>TRUE</b> if the convertion was complete, or if the source image already is a true color image, otherwise <b>FALSE</b> is returned.
  * @since 5.5
  */
-function imagepalettetotruecolor ($image) {}
+function imagepalettetotruecolor (GdImage $image): bool {}
 
 /**
+ * @param resource|GdImage $image <p>
+ * An image resource, returnd by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * </p>
+ * @param int $width
+ * @param int $height [optional]
+ * @param int $mode [optional] One of <b>IMG_NEAREST_NEIGHBOUR</b>, <b>IMG_BILINEAR_FIXED</b>, <b>IMG_BICUBIC</b>, <b>IMG_BICUBIC_FIXED</b> or anything else (will use two pass).
+ * @return resource|GdImage|false Return scaled image resource on success or <b>FALSE</b> on failure.
+ *@link https://secure.php.net/manual/en/function.imagescale.php
  * @since 5.5
  * Scale an image using the given new width and height
- * @link https://www.php.net/manual/en/function.imagescale.php
- * @param resource $image <p>
- * An image resource, returnd by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param int $new_width
- * @param int $new_height [optional]
- * @param int $mode [optional] One of <b>IMG_NEAREST_NEIGHBOUR</b>, <b>IMG_BILINEAR_FIXED</b>, <b>IMG_BICUBIC</b>, <b>IMG_BICUBIC_FIXED</b> or anything else (will use two pass).
- * @return resource|bool Return scaled image resource on success or <b>FALSE</b> on failure.
  */
-
-function imagescale ($image, $new_width, $new_height = -1, $mode = IMG_BILINEAR_FIXED) {}
+function imagescale (GdImage $image, int $width, int $height = -1, int $mode = IMG_BILINEAR_FIXED): GdImage|false {}
 
 /**
  * Set the interpolation method
- * @link https://www.php.net/manual/en/function.imagesetinterpolation.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
+ * @link https://secure.php.net/manual/en/function.imagesetinterpolation.php
+ * @param resource|GdImage $image <p>
+ * An image resource, returned by one of the image creation functions, such as {@link https://secure.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
  * </p>
  * @param int $method <p>
  * The interpolation method, which can be one of the following:
@@ -3012,4 +3046,15 @@ function imagescale ($image, $new_width, $new_height = -1, $mode = IMG_BILINEAR_
  * @return bool Returns TRUE on success or FALSE on failure.
  * @since 5.5
  */
-function imagesetinterpolation ($image, $method = IMG_BILINEAR_FIXED) {}
+function imagesetinterpolation (GdImage $image, int $method = IMG_BILINEAR_FIXED): bool {}
+
+/**
+ * @since 8.0
+ */
+final class GdImage{
+    /**
+     * You cannot initialize a GdImage object except through helper functions.
+     */
+    private function __construct(){}
+    private function __clone(){}
+}

--- a/build/stubs/imagick.php
+++ b/build/stubs/imagick.php
@@ -2,6 +2,10 @@
 
 // Start of imagick v.3.4.3
 
+use JetBrains\PhpStorm\ArrayShape;
+use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\Pure;
+
 class ImagickException extends Exception  {
 }
 
@@ -12,6 +16,9 @@ class ImagickPixelIteratorException extends Exception  {
 }
 
 class ImagickPixelException extends Exception  {
+}
+
+class ImagickKernelException extends Exception  {
 }
 
 /**
@@ -580,6 +587,7 @@ class Imagick implements Iterator, Countable {
 	 * Removes repeated portions of images to optimize
 	 * @link https://php.net/manual/en/imagick.optimizeimagelayers.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function optimizeImageLayers () {}
 
@@ -591,6 +599,7 @@ class Imagick implements Iterator, Countable {
 	 * One of the layer method constants.
 	 * </p>
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function compareImageLayers ($method) {}
 
@@ -602,6 +611,7 @@ class Imagick implements Iterator, Countable {
 	 * A string containing the image.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function pingImageBlob ($image) {}
 
@@ -616,6 +626,7 @@ class Imagick implements Iterator, Countable {
 	 * Optional filename for this image.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function pingImageFile ($filehandle, $fileName = null) {}
 
@@ -624,6 +635,7 @@ class Imagick implements Iterator, Countable {
 	 * Creates a vertical mirror image
 	 * @link https://php.net/manual/en/imagick.transposeimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function transposeImage () {}
 
@@ -632,6 +644,7 @@ class Imagick implements Iterator, Countable {
 	 * Creates a horizontal mirror image
 	 * @link https://php.net/manual/en/imagick.transverseimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function transverseImage () {}
 
@@ -647,6 +660,7 @@ class Imagick implements Iterator, Countable {
 	 * on the quantum range.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function trimImage ($fuzz) {}
 
@@ -661,6 +675,7 @@ class Imagick implements Iterator, Countable {
 	 * The length of the wave.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function waveImage ($amplitude, $length) {}
 
@@ -681,6 +696,7 @@ class Imagick implements Iterator, Countable {
 	 * Y offset of the ellipse
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function vignetteImage ($blackPoint, $whitePoint, $x, $y) {}
 
@@ -689,6 +705,7 @@ class Imagick implements Iterator, Countable {
 	 * Discards all but one of any pixel color
 	 * @link https://php.net/manual/en/imagick.uniqueimagecolors.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function uniqueImageColors () {}
 
@@ -697,7 +714,10 @@ class Imagick implements Iterator, Countable {
 	 * Return if the image has a matte channel
 	 * @link https://php.net/manual/en/imagick.getimagematte.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
+	#[Pure]
 	public function getImageMatte () {}
 
 	/**
@@ -708,6 +728,7 @@ class Imagick implements Iterator, Countable {
 	 * True activates the matte channel and false disables it.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageMatte ($matte) {}
 
@@ -745,6 +766,7 @@ class Imagick implements Iterator, Countable {
 	 * Apply the effect along this angle.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sketchImage ($radius, $sigma, $angle) {}
 
@@ -762,6 +784,7 @@ class Imagick implements Iterator, Countable {
 	 * Defines the light source direction.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function shadeImage ($gray, $azimuth, $elevation) {}
 
@@ -770,7 +793,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the size offset
 	 * @link https://php.net/manual/en/imagick.getsizeoffset.php
 	 * @return int the size offset associated with the Imagick object.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getSizeOffset () {}
 
 	/**
@@ -787,6 +812,7 @@ class Imagick implements Iterator, Countable {
 	 * The image offset.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setSizeOffset ($columns, $rows, $offset) {}
 
@@ -805,6 +831,7 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function adaptiveBlurImage ($radius, $sigma, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -825,6 +852,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function contrastStretchImage ($black_point, $white_point, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -842,6 +870,7 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function adaptiveSharpenImage ($radius, $sigma, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -862,6 +891,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function randomThresholdImage ($low, $high, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -871,12 +901,14 @@ class Imagick implements Iterator, Countable {
 	 * @param $strokeWidth [optional]
 	 * @param $displace [optional]
 	 * @param $sizeCorrection [optional]
+	 * @throws ImagickException on error.
 	 */
 	public function roundCornersImage ($xRounding, $yRounding, $strokeWidth, $displace, $sizeCorrection) {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Rounds image corners
+	 * Alias to {@see Imagick::roundCornersImage}
 	 * @link https://php.net/manual/en/imagick.roundcorners.php
 	 * @param float $x_rounding <p>
 	 * x rounding
@@ -894,7 +926,9 @@ class Imagick implements Iterator, Countable {
 	 * size correction
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated(replacement: "%class%->roundCornersImage(%parametersList%)")]
 	public function roundCorners ($x_rounding, $y_rounding, $stroke_width = 10.0, $displace = 5.0, $size_correction = -6.0) {}
 
 	/**
@@ -905,6 +939,7 @@ class Imagick implements Iterator, Countable {
 	 * The position to set the iterator to
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setIteratorIndex ($index) {}
 
@@ -914,6 +949,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getiteratorindex.php
 	 * @return int an integer containing the index of the image in the stack.
 	 */
+	#[Pure]
 	public function getIteratorIndex () {}
 
 	/**
@@ -927,6 +963,7 @@ class Imagick implements Iterator, Countable {
 	 * An image geometry string. This geometry defines the final size of the image.
 	 * </p>
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function transformImage ($crop, $geometry) {}
 
@@ -939,6 +976,7 @@ class Imagick implements Iterator, Countable {
 	 * transparent.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageOpacity ($opacity) {}
 
@@ -956,6 +994,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function orderedPosterizeImage ($threshold_map, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -970,6 +1009,7 @@ class Imagick implements Iterator, Countable {
 	 * The polaroid angle
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function polaroidImage (ImagickDraw $properties, $angle) {}
 
@@ -982,7 +1022,9 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @return string|false a string containing the image property, false if a
 	 * property with the given name does not exist.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageProperty ($name) {}
 
 	/**
@@ -992,6 +1034,7 @@ class Imagick implements Iterator, Countable {
 	 * @param string $name
 	 * @param string $value
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageProperty ($name, $value) {}
 
@@ -1003,6 +1046,7 @@ class Imagick implements Iterator, Countable {
 	 * The method is one of the <b>Imagick::INTERPOLATE_*</b> constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageInterpolateMethod ($method) {}
 
@@ -1011,7 +1055,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the interpolation method
 	 * @link https://php.net/manual/en/imagick.getimageinterpolatemethod.php
 	 * @return int the interpolate method on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageInterpolateMethod () {}
 
 	/**
@@ -1025,6 +1071,7 @@ class Imagick implements Iterator, Countable {
 	 * The image white point
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function linearStretchImage ($blackPoint, $whitePoint) {}
 
@@ -1033,7 +1080,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image length in bytes
 	 * @link https://php.net/manual/en/imagick.getimagelength.php
 	 * @return int an int containing the current image size.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageLength () {}
 
 	/**
@@ -1053,6 +1102,7 @@ class Imagick implements Iterator, Countable {
 	 * Y position for the new size
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function extentImage ($width, $height, $x, $y) {}
 
@@ -1061,7 +1111,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image orientation
 	 * @link https://php.net/manual/en/imagick.getimageorientation.php
 	 * @return int an int on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageOrientation () {}
 
 	/**
@@ -1072,6 +1124,7 @@ class Imagick implements Iterator, Countable {
 	 * One of the orientation constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageOrientation ($orientation) {}
 
@@ -1100,7 +1153,9 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function paintFloodfillImage ($fill, $fuzz, $bordercolor, $x, $y, $channel = Imagick::CHANNEL_ALL) {}
 
 	/**
@@ -1115,6 +1170,7 @@ class Imagick implements Iterator, Countable {
 	 * constant. When not supplied, default channels are replaced.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 * @since 2.0.0
 	 */
 	public function clutImage (Imagick $lookup_table, $channel = Imagick::CHANNEL_DEFAULT) {}
@@ -1130,7 +1186,9 @@ class Imagick implements Iterator, Countable {
 	 * Whether to return only property names. If <b>FALSE</b> then also the values are returned
 	 * </p>
 	 * @return array an array containing the image properties or property names.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageProperties ($pattern = "*", $only_names = true) {}
 
 	/**
@@ -1144,7 +1202,9 @@ class Imagick implements Iterator, Countable {
 	 * Whether to return only profile names. If <b>FALSE</b> then only profile names will be returned.
 	 * </p>
 	 * @return array an array containing the image profiles or profile names.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageProfiles ($pattern = "*", $include_values = true) {}
 
 	/**
@@ -1161,6 +1221,7 @@ class Imagick implements Iterator, Countable {
 	 * Attempt to resize destination to fit distorted source
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function distortImage ($method, array $arguments, $bestfit) {}
 
@@ -1172,6 +1233,7 @@ class Imagick implements Iterator, Countable {
 	 * Filehandle where to write the image
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function writeImageFile ($filehandle) {}
 
@@ -1183,6 +1245,7 @@ class Imagick implements Iterator, Countable {
 	 * Filehandle where to write the images
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function writeImagesFile ($filehandle) {}
 
@@ -1194,6 +1257,7 @@ class Imagick implements Iterator, Countable {
 	 * The page definition. For example 7168x5147+0+0
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function resetImagePage ($page) {}
 
@@ -1213,7 +1277,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets image clip mask
 	 * @link https://php.net/manual/en/imagick.getimageclipmask.php
 	 * @return Imagick an Imagick object containing the clip mask.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageClipMask () {}
 
 	/**
@@ -1224,6 +1290,7 @@ class Imagick implements Iterator, Countable {
 	 * X server address
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function animateImages ($x_server) {}
 
@@ -1235,7 +1302,9 @@ class Imagick implements Iterator, Countable {
 	 * The matrix containing the color values
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function recolorImage (array $matrix) {}
 
 	/**
@@ -1246,6 +1315,7 @@ class Imagick implements Iterator, Countable {
 	 * Font name or a filename
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setFont ($font) {}
 
@@ -1255,6 +1325,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getfont.php
 	 * @return string|false the string containing the font name or <b>FALSE</b> if not font is set.
 	 */
+	#[Pure]
 	public function getFont () {}
 
 	/**
@@ -1265,6 +1336,7 @@ class Imagick implements Iterator, Countable {
 	 * Point size
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setPointSize ($point_size) {}
 
@@ -1274,6 +1346,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getpointsize.php
 	 * @return float a float containing the point size.
 	 */
+	#[Pure]
 	public function getPointSize () {}
 
 	/**
@@ -1296,6 +1369,7 @@ class Imagick implements Iterator, Countable {
 	 * One of the <b>Imagick::ALPHACHANNEL_*</b> constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageAlphaChannel ($mode) {}
 
@@ -1325,6 +1399,7 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function floodFillPaintImage ($fill, $fuzz, $target, $x, $y, $invert, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -1348,6 +1423,7 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function opaquePaintImage ($target, $fill, $fuzz, $invert, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -1368,6 +1444,7 @@ class Imagick implements Iterator, Countable {
 	 * If <b>TRUE</b> paints any pixel that does not match the target color.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function transparentPaintImage ($target, $alpha, $fuzz, $invert) {}
 
@@ -1390,6 +1467,7 @@ class Imagick implements Iterator, Countable {
 	 * typically 0.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function liquidRescaleImage ($width, $height, $delta_x, $rigidity) {}
 
@@ -1401,6 +1479,7 @@ class Imagick implements Iterator, Countable {
 	 * The passphrase
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function encipherImage ($passphrase) {}
 
@@ -1412,6 +1491,7 @@ class Imagick implements Iterator, Countable {
 	 * The passphrase
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function decipherImage ($passphrase) {}
 
@@ -1424,6 +1504,7 @@ class Imagick implements Iterator, Countable {
 	 * gravity constants.
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickException on error.
 	 */
 	public function setGravity ($gravity) {}
 
@@ -1434,6 +1515,7 @@ class Imagick implements Iterator, Countable {
 	 * @return int the gravity property. Refer to the list of
 	 * gravity constants.
 	 */
+	#[Pure]
 	public function getGravity () {}
 
 	/**
@@ -1443,8 +1525,14 @@ class Imagick implements Iterator, Countable {
 	 * @param int $channel <p>
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
-	 * @return array an array containing minima and maxima values of the channel(s).
+	 * @return float[] an array containing minima and maxima values of the channel(s).
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "minima" => "float",
+        "maxima" => "float"
+    ])]
+	#[Pure]
 	public function getImageChannelRange ($channel) {}
 
 	/**
@@ -1453,7 +1541,9 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getimagealphachannel.php
 	 * @return int a constant defining the current alpha channel value. Refer to this
 	 * list of alpha channel constants.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageAlphaChannel () {}
 
 	/**
@@ -1469,8 +1559,10 @@ class Imagick implements Iterator, Countable {
 	 * @param int $channel [optional] <p>
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
-	 * @return float a double describing the channel distortion.
+	 * @return float a float describing the channel distortion.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageChannelDistortions (Imagick $reference, $metric, $channel = Imagick::CHANNEL_DEFAULT) {}
 
 	/**
@@ -1482,6 +1574,7 @@ class Imagick implements Iterator, Countable {
 	 * gravity constants.
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageGravity ($gravity) {}
 
@@ -1491,7 +1584,9 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getimagegravity.php
 	 * @return int the images gravity property. Refer to the list of
 	 * gravity constants.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageGravity () {}
 
 	/**
@@ -1523,6 +1618,7 @@ class Imagick implements Iterator, Countable {
 	 * The array of pixels
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function importImagePixels ($x, $y, $width, $height, $map, $storage, array $pixels) {}
 
@@ -1534,6 +1630,7 @@ class Imagick implements Iterator, Countable {
 	 * Deskew threshold
 	 * </p>
 	 * @return bool
+	 * @throws ImagickException on error.
 	 */
 	public function deskewImage ($threshold) {}
 
@@ -1555,6 +1652,7 @@ class Imagick implements Iterator, Countable {
 	 * Whether to output detailed information about recognised classes.
 	 * </p>
 	 * @return bool
+	 * @throws ImagickException on error.
 	 */
 	public function segmentImage ($COLORSPACE, $cluster_threshold, $smooth_threshold, $verbose = false) {}
 
@@ -1571,6 +1669,7 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sparseColorImage ($SPARSE_METHOD, array $arguments, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -1585,6 +1684,7 @@ class Imagick implements Iterator, Countable {
 	 * Refer to this list of dither method constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function remapImage (Imagick $replacement, $DITHER) {}
 
@@ -1611,7 +1711,8 @@ class Imagick implements Iterator, Countable {
 	 * @param int $STORAGE <p>
 	 * Refer to this list of pixel type constants
 	 * </p>
-	 * @return array an array containing the pixels values.
+	 * @return int[] an array containing the pixels values.
+	 * @throws ImagickException on error.
 	 */
 	public function exportImagePixels ($x, $y, $width, $height, $map, $STORAGE) {}
 
@@ -1622,9 +1723,15 @@ class Imagick implements Iterator, Countable {
 	 * @param int $channel [optional] <p>
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
-	 * @return array an array with kurtosis and skewness
+	 * @return float[] an array with kurtosis and skewness
 	 * members.
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "kurtosis" => "float",
+        "skewness" => "float"
+    ])]
+	#[Pure]
 	public function getImageChannelKurtosis ($channel = Imagick::CHANNEL_DEFAULT) {}
 
 	/**
@@ -1639,11 +1746,15 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function functionImage ($function, array $arguments, $channel = Imagick::CHANNEL_DEFAULT) {}
 
 	/**
+	 * Transform image colorspace
 	 * @param $COLORSPACE
+	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function transformImageColorspace ($COLORSPACE) {}
 
@@ -1658,16 +1769,23 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function haldClutImage (Imagick $clut, $channel = Imagick::CHANNEL_DEFAULT) {}
 
 	/**
+	 * Adjusts the levels of a particular image channel by scaling the minimum and maximum values to the full quantum range.
 	 * @param $CHANNEL [optional]
+	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function autoLevelImage ($CHANNEL) {}
 
 	/**
-	 * @param $factor [optional]
+	 * @link https://www.php.net/manual/en/imagick.blueshiftimage.php
+	 * @param float $factor [optional]
+	 * @return bool
+	 * @throws ImagickException on error.
 	 */
 	public function blueShiftImage ($factor) {}
 
@@ -1679,7 +1797,9 @@ class Imagick implements Iterator, Countable {
 	 * The name of the artifact
 	 * </p>
 	 * @return string the artifact value on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageArtifact ($artifact) {}
 
 	/**
@@ -1693,6 +1813,7 @@ class Imagick implements Iterator, Countable {
 	 * The value of the artifact
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageArtifact ($artifact, $value) {}
 
@@ -1704,6 +1825,7 @@ class Imagick implements Iterator, Countable {
 	 * The name of the artifact to delete
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function deleteImageArtifact ($artifact) {}
 
@@ -1713,6 +1835,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getcolorspace.php
 	 * @return int an integer which can be compared against COLORSPACE constants.
 	 */
+	#[Pure]
 	public function getColorspace () {}
 
 	/**
@@ -1728,12 +1851,15 @@ class Imagick implements Iterator, Countable {
 
 	/**
 	 * @param $CHANNEL [optional]
+	 * @throws ImagickException on error.
 	 */
 	public function clampImage ($CHANNEL) {}
 
 	/**
-	 * @param $stack
-	 * @param $offset
+	 * @param bool $stack
+	 * @param int $offset
+	 * @return Imagick
+	 * @throws ImagickException on error.
 	 */
 	public function smushImages ($stack, $offset) {}
 
@@ -1761,7 +1887,10 @@ class Imagick implements Iterator, Countable {
 	 * Returns a MagickPixelIterator
 	 * @link https://php.net/manual/en/imagick.getpixeliterator.php
 	 * @return ImagickPixelIterator an ImagickPixelIterator on success.
+	 * @throws ImagickException on error.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
+	#[Pure]
 	public function getPixelIterator () {}
 
 	/**
@@ -1781,7 +1910,10 @@ class Imagick implements Iterator, Countable {
 	 * The height of the region.
 	 * </p>
 	 * @return ImagickPixelIterator an ImagickPixelIterator for an image section.
+	 * @throws ImagickException on error.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
+	#[Pure]
 	public function getPixelRegionIterator ($x, $y, $columns, $rows) {}
 
 	/**
@@ -1820,6 +1952,7 @@ class Imagick implements Iterator, Countable {
 	 * depends on the ImageMagick installation.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageFormat ($format) {}
 
@@ -1849,6 +1982,7 @@ class Imagick implements Iterator, Countable {
 	 * for example "jpg:test.png".
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function writeImage ($filename = null) {}
 
@@ -1859,6 +1993,7 @@ class Imagick implements Iterator, Countable {
 	 * @param string $filename
 	 * @param bool $adjoin
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function writeImages ($filename, $adjoin) {}
 
@@ -1877,6 +2012,7 @@ class Imagick implements Iterator, Countable {
 	 * constant. When not supplied, all channels are blurred.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function blurImage ($radius, $sigma, $channel = null) {}
 
@@ -1900,6 +2036,7 @@ class Imagick implements Iterator, Countable {
 	 * @param bool $fill [optional]
 	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 * @since 2.0.0
 	 */
 	public function thumbnailImage ($columns, $rows, $bestfit = false, $fill = false, $legacy = false) {}
@@ -1923,7 +2060,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the filename of a particular image in a sequence
 	 * @link https://php.net/manual/en/imagick.getimagefilename.php
 	 * @return string a string with the filename of the image.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageFilename () {}
 
 	/**
@@ -1932,6 +2071,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagefilename.php
 	 * @param string $filename
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageFilename ($filename) {}
 
@@ -1940,13 +2080,17 @@ class Imagick implements Iterator, Countable {
 	 * Returns the format of a particular image in a sequence
 	 * @link https://php.net/manual/en/imagick.getimageformat.php
 	 * @return string a string containing the image format on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageFormat () {}
 
 	/**
-	 * @link https://www.php.net/manual/en/imagick.getimagemimetype.php
+	 * @link https://secure.php.net/manual/en/imagick.getimagemimetype.php
 	 * @return string Returns the image mime-type.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageMimeType () {}
 
 	/**
@@ -1954,6 +2098,7 @@ class Imagick implements Iterator, Countable {
 	 * Removes an image from the image list
 	 * @link https://php.net/manual/en/imagick.removeimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function removeImage () {}
 
@@ -1978,8 +2123,10 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image length in bytes
 	 * @link https://php.net/manual/en/imagick.getimagesize.php
 	 * @return int an int containing the current image size.
-	 * @deprecated use {@see Imagick::getImageLength()} instead
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated(replacement: "%class%->getImageLength()")]
+	#[Pure]
 	public function getImageSize () {}
 
 	/**
@@ -1987,7 +2134,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image sequence as a blob
 	 * @link https://php.net/manual/en/imagick.getimageblob.php
 	 * @return string a string containing the image.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageBlob () {}
 
 	/**
@@ -1997,6 +2146,7 @@ class Imagick implements Iterator, Countable {
 	 * @return string a string containing the images. On failure, throws ImagickException on failure
 	 * @throws ImagickException on failure
 	 */
+	#[Pure]
 	public function getImagesBlob () {}
 
 	/**
@@ -2059,7 +2209,9 @@ class Imagick implements Iterator, Countable {
 	 * The position to set the iterator to
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function setImageIndex ($index) {}
 
 	/**
@@ -2068,6 +2220,8 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getimageindex.php
 	 * @return int an integer containing the index of the image in the stack.
 	 */
+	#[Deprecated]
+	#[Pure]
 	public function getImageIndex () {}
 
 	/**
@@ -2078,6 +2232,7 @@ class Imagick implements Iterator, Countable {
 	 * The comment to add
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function commentImage ($comment) {}
 
@@ -2098,6 +2253,7 @@ class Imagick implements Iterator, Countable {
 	 * The Y coordinate of the cropped region's top left corner
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function cropImage ($width, $height, $x, $y) {}
 
@@ -2109,6 +2265,7 @@ class Imagick implements Iterator, Countable {
 	 * The label to add
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function labelImage ($label) {}
 
@@ -2116,8 +2273,14 @@ class Imagick implements Iterator, Countable {
 	 * (PECL imagick 2.0.0)<br/>
 	 * Gets the width and height as an associative array
 	 * @link https://php.net/manual/en/imagick.getimagegeometry.php
-	 * @return array an array with the width/height of the image.
+	 * @return int[] an array with the width/height of the image.
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "width" => "int",
+        "height" => "int"
+    ])]
+	#[Pure]
 	public function getImageGeometry () {}
 
 	/**
@@ -2128,6 +2291,7 @@ class Imagick implements Iterator, Countable {
 	 * The drawing operations to render on the image.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function drawImage (ImagickDraw $draw) {}
 
@@ -2139,6 +2303,7 @@ class Imagick implements Iterator, Countable {
 	 * The image compression quality as an integer
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageCompressionQuality ($quality) {}
 
@@ -2148,6 +2313,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getimagecompressionquality.php
 	 * @return int integer describing the images compression quality
 	 */
+	#[Pure]
 	public function getImageCompressionQuality () {}
 
 	/**
@@ -2170,6 +2336,7 @@ class Imagick implements Iterator, Countable {
 	 * The string to draw
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function annotateImage (ImagickDraw $draw_settings, $x, $y, $angle, $text) {}
 
@@ -2193,6 +2360,7 @@ class Imagick implements Iterator, Countable {
 	 * bitwise operators. Refer to this list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function compositeImage (Imagick $composite_object, $composite, $x, $y, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -2204,6 +2372,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $saturation
 	 * @param float $hue
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function modulateImage ($brightness, $saturation, $hue) {}
 
@@ -2212,7 +2381,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the number of unique colors in the image
 	 * @link https://php.net/manual/en/imagick.getimagecolors.php
 	 * @return int <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageColors () {}
 
 	/**
@@ -2227,7 +2398,7 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @param string $thumbnail_geometry <p>
 	 * Preferred image size and border size of each thumbnail
-	 * (e.g. 120x120+4+3>).
+	 * (e.g. 120x120+4+3&#x3E;).
 	 * </p>
 	 * @param int $mode <p>
 	 * Thumbnail framing mode, see Montage Mode constants.
@@ -2237,6 +2408,7 @@ class Imagick implements Iterator, Countable {
 	 * frame color is that of the thumbnail's matte color.
 	 * </p>
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function montageImage (ImagickDraw $draw, $tile_geometry, $thumbnail_geometry, $mode, $frame) {}
 
@@ -2247,6 +2419,7 @@ class Imagick implements Iterator, Countable {
 	 * @param bool $appendRawOutput [optional]
 	 * @return array Identifies an image and returns the attributes. Attributes include
 	 * the image width, height, size, and others.
+	 * @throws ImagickException on error.
 	 */
 	public function identifyImage ($appendRawOutput = false) {}
 
@@ -2257,6 +2430,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $threshold
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function thresholdImage ($threshold, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -2274,6 +2448,7 @@ class Imagick implements Iterator, Countable {
 	 * The mean offset
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function adaptiveThresholdImage ($width, $height, $offset) {}
 
@@ -2285,6 +2460,7 @@ class Imagick implements Iterator, Countable {
 	 * The threshold below which everything turns black
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function blackThresholdImage ($threshold) {}
 
@@ -2294,6 +2470,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.whitethresholdimage.php
 	 * @param mixed $threshold
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function whiteThresholdImage ($threshold) {}
 
@@ -2307,6 +2484,7 @@ class Imagick implements Iterator, Countable {
 	 * If <i>stack</i> is <b>TRUE</b>, images are stacked top-to-bottom.
 	 * </p>
 	 * @return Imagick Imagick instance on success.
+	 * @throws ImagickException on error.
 	 */
 	public function appendImages ($stack = false) {}
 
@@ -2321,6 +2499,7 @@ class Imagick implements Iterator, Countable {
 	 * The standard deviation of the Gaussian, in pixels
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function charcoalImage ($radius, $sigma) {}
 
@@ -2335,6 +2514,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function normalizeImage ($channel = Imagick::CHANNEL_ALL) {}
 
@@ -2346,6 +2526,7 @@ class Imagick implements Iterator, Countable {
 	 * The radius of the circular neighborhood.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function oilPaintImage ($radius) {}
 
@@ -2356,6 +2537,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $levels
 	 * @param bool $dither
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function posterizeImage ($levels, $dither) {}
 
@@ -2366,6 +2548,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $angle
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function radialBlurImage ($angle, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -2379,6 +2562,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $y
 	 * @param bool $raise
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function raiseImage ($width, $height, $x, $y, $raise) {}
 
@@ -2391,6 +2575,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $filter
 	 * @param float $blur
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function resampleImage ($x_resolution, $y_resolution, $filter, $blur) {}
 
@@ -2409,6 +2594,7 @@ class Imagick implements Iterator, Countable {
 	 * @param bool $bestfit [optional] Added since 2.1.0. Added optional fit parameter. This method now supports proportional scaling. Pass zero as either parameter for proportional scaling
 	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
 	 * @return bool TRUE on success
+	 * @throws ImagickException on error.
 	 * @since 2.0.0
 	 */
 	public function resizeImage ($columns, $rows, $filter, $blur, $bestfit = false, $legacy = false) {}
@@ -2424,6 +2610,7 @@ class Imagick implements Iterator, Countable {
 	 * The Y offset.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function rollImage ($x, $y) {}
 
@@ -2438,6 +2625,7 @@ class Imagick implements Iterator, Countable {
 	 * The number of degrees to rotate the image
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function rotateImage ($background, $degrees) {}
 
@@ -2448,6 +2636,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $columns
 	 * @param int $rows
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sampleImage ($columns, $rows) {}
 
@@ -2457,6 +2646,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.solarizeimage.php
 	 * @param int $threshold
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function solarizeImage ($threshold) {}
 
@@ -2469,13 +2659,17 @@ class Imagick implements Iterator, Countable {
 	 * @param int $x
 	 * @param int $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function shadowImage ($opacity, $sigma, $x, $y) {}
 
 	/**
-	 * @param $key
-	 * @param $value
+	 * @param string $key
+	 * @param string $value
+	 * @return bool
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function setImageAttribute ($key, $value) {}
 
 	/**
@@ -2484,6 +2678,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagebackgroundcolor.php
 	 * @param mixed $background
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageBackgroundColor ($background) {}
 
@@ -2493,6 +2688,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagecompose.php
 	 * @param int $compose
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageCompose ($compose) {}
 
@@ -2504,6 +2700,7 @@ class Imagick implements Iterator, Countable {
 	 * One of the <b>COMPRESSION</b> constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageCompression ($compression) {}
 
@@ -2517,6 +2714,7 @@ class Imagick implements Iterator, Countable {
 	 * value of 20 would be 20/100 of a second aka 1/5th of a second.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageDelay ($delay) {}
 
@@ -2526,6 +2724,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagedepth.php
 	 * @param int $depth
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageDepth ($depth) {}
 
@@ -2535,6 +2734,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagegamma.php
 	 * @param float $gamma
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageGamma ($gamma) {}
 
@@ -2547,6 +2747,7 @@ class Imagick implements Iterator, Countable {
 	 * continuously.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageIterations ($iterations) {}
 
@@ -2556,6 +2757,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagemattecolor.php
 	 * @param mixed $matte
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageMatteColor ($matte) {}
 
@@ -2568,11 +2770,13 @@ class Imagick implements Iterator, Countable {
 	 * @param int $x
 	 * @param int $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImagePage ($width, $height, $x, $y) {}
 
 	/**
 	 * @param $filename
+	 * @throws ImagickException on error.
 	 */
 	public function setImageProgressMonitor ($filename) {}
 
@@ -2583,6 +2787,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $x_resolution
 	 * @param float $y_resolution
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageResolution ($x_resolution, $y_resolution) {}
 
@@ -2592,6 +2797,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagescene.php
 	 * @param int $scene
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageScene ($scene) {}
 
@@ -2604,6 +2810,7 @@ class Imagick implements Iterator, Countable {
 	 * per second.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageTicksPerSecond ($ticks_per_second) {}
 
@@ -2613,6 +2820,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagetype.php
 	 * @param int $image_type
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageType ($image_type) {}
 
@@ -2622,6 +2830,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimageunits.php
 	 * @param int $units
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageUnits ($units) {}
 
@@ -2633,6 +2842,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $sigma
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sharpenImage ($radius, $sigma, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -2643,6 +2853,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $columns
 	 * @param int $rows
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function shaveImage ($columns, $rows) {}
 
@@ -2660,6 +2871,7 @@ class Imagick implements Iterator, Countable {
 	 * The number of degrees to shear on the y axis
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function shearImage ($background, $x_shear, $y_shear) {}
 
@@ -2672,6 +2884,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $x
 	 * @param int $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function spliceImage ($width, $height, $x, $y) {}
 
@@ -2683,6 +2896,7 @@ class Imagick implements Iterator, Countable {
 	 * The filename to read the information from.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function pingImage ($filename) {}
 
@@ -2693,6 +2907,7 @@ class Imagick implements Iterator, Countable {
 	 * @param resource $filehandle
 	 * @param string $fileName [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function readImageFile ($filehandle, $fileName = null) {}
 
@@ -2704,6 +2919,7 @@ class Imagick implements Iterator, Countable {
 	 * The X server name
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function displayImage ($servername) {}
 
@@ -2715,6 +2931,7 @@ class Imagick implements Iterator, Countable {
 	 * The X server name
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function displayImages ($servername) {}
 
@@ -2724,6 +2941,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.spreadimage.php
 	 * @param float $radius
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function spreadImage ($radius) {}
 
@@ -2733,6 +2951,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.swirlimage.php
 	 * @param float $degrees
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function swirlImage ($degrees) {}
 
@@ -2741,6 +2960,7 @@ class Imagick implements Iterator, Countable {
 	 * Strips an image of all profiles and comments
 	 * @link https://php.net/manual/en/imagick.stripimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function stripImage () {}
 
@@ -2778,6 +2998,7 @@ class Imagick implements Iterator, Countable {
 	 * Multiline parameter. If left empty it is autodetected
 	 * </p>
 	 * @return array a multi-dimensional array representing the font metrics.
+	 * @throws ImagickException on error.
 	 */
 	public function queryFontMetrics (ImagickDraw $properties, $text, $multiline = null) {}
 
@@ -2788,6 +3009,7 @@ class Imagick implements Iterator, Countable {
 	 * @param Imagick $watermark_wand
 	 * @param int $offset
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function steganoImage (Imagick $watermark_wand, $offset) {}
 
@@ -2803,6 +3025,7 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function addNoiseImage ($noise_type, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -2828,6 +3051,7 @@ class Imagick implements Iterator, Countable {
 	 * 6.4.4 or greater.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function motionBlurImage ($radius, $sigma, $angle, $channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -2836,7 +3060,9 @@ class Imagick implements Iterator, Countable {
 	 * Forms a mosaic from images
 	 * @link https://php.net/manual/en/imagick.mosaicimages.php
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function mosaicImages () {}
 
 	/**
@@ -2849,6 +3075,7 @@ class Imagick implements Iterator, Countable {
 	 * @return Imagick This method returns a new Imagick object on success.
 	 * Throw an <b>ImagickException</b> on error.
 	 * @throws ImagickException on error
+	 * @throws ImagickException on error.
 	 */
 	public function morphImages ($number_frames) {}
 
@@ -2857,6 +3084,7 @@ class Imagick implements Iterator, Countable {
 	 * Scales an image proportionally to half its size
 	 * @link https://php.net/manual/en/imagick.minifyimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function minifyImage () {}
 
@@ -2868,6 +3096,7 @@ class Imagick implements Iterator, Countable {
 	 * The affine matrix
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function affineTransformImage (ImagickDraw $matrix) {}
 
@@ -2876,7 +3105,9 @@ class Imagick implements Iterator, Countable {
 	 * Average a set of images
 	 * @link https://php.net/manual/en/imagick.averageimages.php
 	 * @return Imagick a new Imagick object on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function averageImages () {}
 
 	/**
@@ -2893,6 +3124,7 @@ class Imagick implements Iterator, Countable {
 	 * Border height
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function borderImage ($bordercolor, $width, $height) {}
 
@@ -2913,6 +3145,7 @@ class Imagick implements Iterator, Countable {
 	 * Y origo of the chopped area
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function chopImage ($width, $height, $x, $y) {}
 
@@ -2921,6 +3154,7 @@ class Imagick implements Iterator, Countable {
 	 * Clips along the first path from the 8BIM profile
 	 * @link https://php.net/manual/en/imagick.clipimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function clipImage () {}
 
@@ -2936,12 +3170,15 @@ class Imagick implements Iterator, Countable {
 	 * Otherwise later operations take effect outside clipping path.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function clipPathImage ($pathname, $inside) {}
 
 	/**
-	 * @param $pathname
-	 * @param $inside
+	 * Alias to {@see Imagick::clipPathImage}
+	 * @param string $pathname
+	 * @param string $inside
+	 * @throws ImagickException on error.
 	 */
 	public function clipImagePath ($pathname, $inside) {}
 
@@ -2950,6 +3187,7 @@ class Imagick implements Iterator, Countable {
 	 * Composites a set of images
 	 * @link https://php.net/manual/en/imagick.coalesceimages.php
 	 * @return Imagick a new Imagick object on success.
+	 * @throws ImagickException on error.
 	 */
 	public function coalesceImages () {}
 
@@ -2975,7 +3213,9 @@ class Imagick implements Iterator, Countable {
 	 * Y start position of the floodfill
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function colorFloodfillImage ($fill, $fuzz, $bordercolor, $x, $y) {}
 
 	/**
@@ -3014,6 +3254,7 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @return array Array consisting of new_wand and
 	 * distortion.
+	 * @throws ImagickException on error.
 	 */
 	public function compareImageChannels (Imagick $image, $channelType, $metricType) {}
 
@@ -3029,7 +3270,7 @@ class Imagick implements Iterator, Countable {
 	 * list of metric constants.
 	 * </p>
 	 * @return array Array consisting of an Imagick object of the
-	 * reconstructed image and a double representing the difference.
+	 * reconstructed image and a float representing the difference.
 	 * @throws ImagickException Throws ImagickException on error.
 	 */
 	public function compareImages (Imagick $compare, $metric) {}
@@ -3042,6 +3283,7 @@ class Imagick implements Iterator, Countable {
 	 * The sharpen value
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function contrastImage ($sharpen) {}
 
@@ -3056,6 +3298,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function combineImages ($channelType) {}
 
@@ -3073,6 +3316,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function convolveImage (array $kernel, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3084,6 +3328,7 @@ class Imagick implements Iterator, Countable {
 	 * The amount to displace the colormap.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function cycleColormapImage ($displace) {}
 
@@ -3092,6 +3337,7 @@ class Imagick implements Iterator, Countable {
 	 * Returns certain pixel differences between images
 	 * @link https://php.net/manual/en/imagick.deconstructimages.php
 	 * @return Imagick a new Imagick object on success.
+	 * @throws ImagickException on error.
 	 */
 	public function deconstructImages () {}
 
@@ -3100,6 +3346,7 @@ class Imagick implements Iterator, Countable {
 	 * Reduces the speckle noise in an image
 	 * @link https://php.net/manual/en/imagick.despeckleimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function despeckleImage () {}
 
@@ -3111,6 +3358,7 @@ class Imagick implements Iterator, Countable {
 	 * The radius of the operation.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function edgeImage ($radius) {}
 
@@ -3125,6 +3373,7 @@ class Imagick implements Iterator, Countable {
 	 * The sigma of the effect
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function embossImage ($radius, $sigma) {}
 
@@ -3133,6 +3382,7 @@ class Imagick implements Iterator, Countable {
 	 * Improves the quality of a noisy image
 	 * @link https://php.net/manual/en/imagick.enhanceimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function enhanceImage () {}
 
@@ -3141,6 +3391,7 @@ class Imagick implements Iterator, Countable {
 	 * Equalizes the image histogram
 	 * @link https://php.net/manual/en/imagick.equalizeimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function equalizeImage () {}
 
@@ -3161,6 +3412,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function evaluateImage ($op, $constant, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3175,6 +3427,7 @@ class Imagick implements Iterator, Countable {
 	 * @throws ImagickException Throws ImagickException on error.
 	 * @since 2.0.0
 	 */
+	#[Deprecated]
 	public function flattenImages () {}
 
 	/**
@@ -3182,6 +3435,7 @@ class Imagick implements Iterator, Countable {
 	 * Creates a vertical mirror image
 	 * @link https://php.net/manual/en/imagick.flipimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function flipImage () {}
 
@@ -3190,6 +3444,7 @@ class Imagick implements Iterator, Countable {
 	 * Creates a horizontal mirror image
 	 * @link https://php.net/manual/en/imagick.flopimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function flopImage () {}
 
@@ -3213,6 +3468,7 @@ class Imagick implements Iterator, Countable {
 	 * The outer bevel width
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function frameImage ($matte_color, $width, $height, $inner_bevel, $outer_bevel) {}
 
@@ -3230,6 +3486,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return Imagick <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function fxImage ($expression, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3247,6 +3504,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function gammaImage ($gamma, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3267,12 +3525,17 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function gaussianBlurImage ($radius, $sigma, $channel = Imagick::CHANNEL_ALL) {}
 
 	/**
-	 * @param $key
+     * @link https://www.php.net/manual/en/imagick.getimageattribute.php
+	 * @param string $key <p>The key of the attribute to get.</p>
+     * @return string
 	 */
+	#[Deprecated]
+	#[Pure]
 	public function getImageAttribute ($key) {}
 
 	/**
@@ -3280,15 +3543,23 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image background color
 	 * @link https://php.net/manual/en/imagick.getimagebackgroundcolor.php
 	 * @return ImagickPixel an ImagickPixel set to the background color of the image.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageBackgroundColor () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the chromaticy blue primary point
 	 * @link https://php.net/manual/en/imagick.getimageblueprimary.php
-	 * @return array Array consisting of "x" and "y" coordinates of point.
+	 * @return float[] Array consisting of "x" and "y" coordinates of point.
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "x" => "float",
+        "y" => "float"
+    ])]
+	#[Pure]
 	public function getImageBluePrimary () {}
 
 	/**
@@ -3296,7 +3567,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image border color
 	 * @link https://php.net/manual/en/imagick.getimagebordercolor.php
 	 * @return ImagickPixel <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageBorderColor () {}
 
 	/**
@@ -3307,7 +3580,9 @@ class Imagick implements Iterator, Countable {
 	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
 	 * </p>
 	 * @return int <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageChannelDepth ($channel) {}
 
 	/**
@@ -3327,7 +3602,9 @@ class Imagick implements Iterator, Countable {
 	 * One of the metric type constants.
 	 * </p>
 	 * @return float <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageChannelDistortion (Imagick $reference, $channel, $metric) {}
 
 	/**
@@ -3340,8 +3617,15 @@ class Imagick implements Iterator, Countable {
 	 * bitwise operators. Refer to this
 	 * list of channel constants.
 	 * </p>
-	 * @return array <b>TRUE</b> on success.
+	 * @return int[]
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "minima" => "int",
+        "maxima" => "int"
+    ])]
+	#[Deprecated]
+	#[Pure]
 	public function getImageChannelExtrema ($channel) {}
 
 	/**
@@ -3354,16 +3638,24 @@ class Imagick implements Iterator, Countable {
 	 * bitwise operators. Refer to this
 	 * list of channel constants.
 	 * </p>
-	 * @return array <b>TRUE</b> on success.
+	 * @return float[]
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "mean" => "float",
+        "standardDeviation" => "float"
+    ])]
+	#[Pure]
 	public function getImageChannelMean ($channel) {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns statistics for each channel in the image
 	 * @link https://php.net/manual/en/imagick.getimagechannelstatistics.php
-	 * @return array <b>TRUE</b> on success.
+	 * @return array
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageChannelStatistics () {}
 
 	/**
@@ -3374,7 +3666,9 @@ class Imagick implements Iterator, Countable {
 	 * The offset into the image colormap.
 	 * </p>
 	 * @return ImagickPixel <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageColormapColor ($index) {}
 
 	/**
@@ -3382,7 +3676,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image colorspace
 	 * @link https://php.net/manual/en/imagick.getimagecolorspace.php
 	 * @return int <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageColorspace () {}
 
 	/**
@@ -3390,7 +3686,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the composite operator associated with the image
 	 * @link https://php.net/manual/en/imagick.getimagecompose.php
 	 * @return int <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageCompose () {}
 
 	/**
@@ -3398,7 +3696,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image delay
 	 * @link https://php.net/manual/en/imagick.getimagedelay.php
 	 * @return int the image delay.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageDelay () {}
 
 	/**
@@ -3406,7 +3706,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image depth
 	 * @link https://php.net/manual/en/imagick.getimagedepth.php
 	 * @return int The image depth.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageDepth () {}
 
 	/**
@@ -3421,15 +3723,24 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @return float the distortion metric used on the image (or the best guess
 	 * thereof).
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageDistortion (Imagick $reference, $metric) {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Gets the extrema for the image
 	 * @link https://php.net/manual/en/imagick.getimageextrema.php
-	 * @return array an associative array with the keys "min" and "max".
+	 * @return int[] an associative array with the keys "min" and "max".
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "min" => "int",
+        "max" => "int"
+    ])]
+	#[Deprecated]
+	#[Pure]
 	public function getImageExtrema () {}
 
 	/**
@@ -3437,7 +3748,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image disposal method
 	 * @link https://php.net/manual/en/imagick.getimagedispose.php
 	 * @return int the dispose method on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageDispose () {}
 
 	/**
@@ -3445,16 +3758,24 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image gamma
 	 * @link https://php.net/manual/en/imagick.getimagegamma.php
 	 * @return float the image gamma on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageGamma () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the chromaticy green primary point
 	 * @link https://php.net/manual/en/imagick.getimagegreenprimary.php
-	 * @return array an array with the keys "x" and "y" on success, throws an ImagickException on failure.
+	 * @return float[] an array with the keys "x" and "y" on success, throws an ImagickException on failure.
 	 * @throws ImagickException on failure
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "x" => "float",
+        "y" => "float"
+    ])]
+	#[Pure]
 	public function getImageGreenPrimary () {}
 
 	/**
@@ -3462,7 +3783,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image height
 	 * @link https://php.net/manual/en/imagick.getimageheight.php
 	 * @return int the image height in pixels.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageHeight () {}
 
 	/**
@@ -3470,7 +3793,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image histogram
 	 * @link https://php.net/manual/en/imagick.getimagehistogram.php
 	 * @return array the image histogram as an array of ImagickPixel objects.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageHistogram () {}
 
 	/**
@@ -3481,6 +3806,8 @@ class Imagick implements Iterator, Countable {
 	 * Trhow an <b>ImagickException</b> on error.
 	 * @throws ImagickException on error
 	 */
+	#[Deprecated]
+	#[Pure]
 	public function getImageInterlaceScheme () {}
 
 	/**
@@ -3488,7 +3815,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image iterations
 	 * @link https://php.net/manual/en/imagick.getimageiterations.php
 	 * @return int the image iterations as an integer.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageIterations () {}
 
 	/**
@@ -3496,16 +3825,26 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image matte color
 	 * @link https://php.net/manual/en/imagick.getimagemattecolor.php
 	 * @return ImagickPixel ImagickPixel object on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageMatteColor () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the page geometry
 	 * @link https://php.net/manual/en/imagick.getimagepage.php
-	 * @return array the page geometry associated with the image in an array with the
+	 * @return int[] the page geometry associated with the image in an array with the
 	 * keys "width", "height", "x", and "y".
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "width" => "int",
+        "height" => "int",
+        "x" => "int",
+        "y" => "int"
+    ])]
+	#[Pure]
 	public function getImagePage () {}
 
 	/**
@@ -3519,7 +3858,9 @@ class Imagick implements Iterator, Countable {
 	 * The y-coordinate of the pixel
 	 * </p>
 	 * @return ImagickPixel an ImagickPixel instance for the color at the coordinates given.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImagePixelColor ($x, $y) {}
 
 	/**
@@ -3530,18 +3871,25 @@ class Imagick implements Iterator, Countable {
 	 * The name of the profile to return.
 	 * </p>
 	 * @return string a string containing the image profile.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageProfile ($name) {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the chromaticity red primary point
 	 * @link https://php.net/manual/en/imagick.getimageredprimary.php
-	 * @return array the chromaticity red primary point as an array with the keys "x"
+	 * @return float[] the chromaticity red primary point as an array with the keys "x"
 	 * and "y".
 	 * Throw an <b>ImagickException</b> on error.
 	 * @throws ImagickException on error
 	 */
+    #[ArrayShape([
+        "x" => "float",
+        "y" => "float"
+    ])]
+	#[Pure]
 	public function getImageRedPrimary () {}
 
 	/**
@@ -3549,15 +3897,23 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image rendering intent
 	 * @link https://php.net/manual/en/imagick.getimagerenderingintent.php
 	 * @return int the image rendering intent.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageRenderingIntent () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Gets the image X and Y resolution
 	 * @link https://php.net/manual/en/imagick.getimageresolution.php
-	 * @return array the resolution as an array.
+	 * @return float[] the resolution as an array.
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "x" => "float",
+        "y" => "float"
+    ])]
+	#[Pure]
 	public function getImageResolution () {}
 
 	/**
@@ -3565,7 +3921,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image scene
 	 * @link https://php.net/manual/en/imagick.getimagescene.php
 	 * @return int the image scene.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageScene () {}
 
 	/**
@@ -3573,7 +3931,9 @@ class Imagick implements Iterator, Countable {
 	 * Generates an SHA-256 message digest
 	 * @link https://php.net/manual/en/imagick.getimagesignature.php
 	 * @return string a string containing the SHA-256 hash of the file.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageSignature () {}
 
 	/**
@@ -3581,7 +3941,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image ticks-per-second
 	 * @link https://php.net/manual/en/imagick.getimagetickspersecond.php
 	 * @return int the image ticks-per-second.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageTicksPerSecond () {}
 
 	/**
@@ -3600,7 +3962,9 @@ class Imagick implements Iterator, Countable {
 	 * <b>imagick::IMGTYPE_COLORSEPARATION</b>
 	 * <b>imagick::IMGTYPE_COLORSEPARATIONMATTE</b>
 	 * <b>imagick::IMGTYPE_OPTIMIZE</b>
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageType () {}
 
 	/**
@@ -3608,7 +3972,9 @@ class Imagick implements Iterator, Countable {
 	 * Gets the image units of resolution
 	 * @link https://php.net/manual/en/imagick.getimageunits.php
 	 * @return int the image units of resolution.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageUnits () {}
 
 	/**
@@ -3616,16 +3982,24 @@ class Imagick implements Iterator, Countable {
 	 * Returns the virtual pixel method
 	 * @link https://php.net/manual/en/imagick.getimagevirtualpixelmethod.php
 	 * @return int the virtual pixel method on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageVirtualPixelMethod () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the chromaticity white point
 	 * @link https://php.net/manual/en/imagick.getimagewhitepoint.php
-	 * @return array the chromaticity white point as an associative array with the keys
+	 * @return float[] the chromaticity white point as an associative array with the keys
 	 * "x" and "y".
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "x" => "float",
+        "y" => "float"
+    ])]
+	#[Pure]
 	public function getImageWhitePoint () {}
 
 	/**
@@ -3633,7 +4007,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns the image width
 	 * @link https://php.net/manual/en/imagick.getimagewidth.php
 	 * @return int the image width.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageWidth () {}
 
 	/**
@@ -3642,6 +4018,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getnumberimages.php
 	 * @return int the number of images associated with Imagick object.
 	 */
+	#[Pure]
 	public function getNumberImages () {}
 
 	/**
@@ -3651,7 +4028,9 @@ class Imagick implements Iterator, Countable {
 	 * @return float the image total ink density of the image.
 	 * Throw an <b>ImagickException</b> on error.
 	 * @throws ImagickException on error
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageTotalInkDensity () {}
 
 	/**
@@ -3671,7 +4050,9 @@ class Imagick implements Iterator, Countable {
 	 * Y-coordinate of the top-left corner of the extracted region.
 	 * </p>
 	 * @return Imagick Extracts a region of the image and returns it as a new wand.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImageRegion ($width, $height, $x, $y) {}
 
 	/**
@@ -3682,6 +4063,7 @@ class Imagick implements Iterator, Countable {
 	 * The radius of the implode
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function implodeImage ($radius) {}
 
@@ -3705,6 +4087,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function levelImage ($blackPoint, $gamma, $whitePoint, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3713,6 +4096,7 @@ class Imagick implements Iterator, Countable {
 	 * Scales an image proportionally 2x
 	 * @link https://php.net/manual/en/imagick.magnifyimage.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function magnifyImage () {}
 
@@ -3723,7 +4107,9 @@ class Imagick implements Iterator, Countable {
 	 * @param Imagick $map
 	 * @param bool $dither
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function mapImage (Imagick $map, $dither) {}
 
 	/**
@@ -3748,7 +4134,9 @@ class Imagick implements Iterator, Countable {
 	 * The starting y coordinate of the operation.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function matteFloodfillImage ($alpha, $fuzz, $bordercolor, $x, $y) {}
 
 	/**
@@ -3759,7 +4147,9 @@ class Imagick implements Iterator, Countable {
 	 * The radius of the pixel neighborhood.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function medianFilterImage ($radius) {}
 
 	/**
@@ -3776,6 +4166,7 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function negateImage ($gray, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -3801,7 +4192,9 @@ class Imagick implements Iterator, Countable {
 	 * list of channel constants.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function paintOpaqueImage ($target, $fill, $fuzz, $channel = Imagick::CHANNEL_ALL) {}
 
 	/**
@@ -3820,7 +4213,9 @@ class Imagick implements Iterator, Countable {
 	 * consider two colors as the same.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function paintTransparentImage ($target, $alpha, $fuzz) {}
 
 	/**
@@ -3831,6 +4226,7 @@ class Imagick implements Iterator, Countable {
 	 * Preview type. See Preview type constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function previewImages ($preview) {}
 
@@ -3841,6 +4237,7 @@ class Imagick implements Iterator, Countable {
 	 * @param string $name
 	 * @param string $profile
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function profileImage ($name, $profile) {}
 
@@ -3854,6 +4251,7 @@ class Imagick implements Iterator, Countable {
 	 * @param bool $dither
 	 * @param bool $measureError
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function quantizeImage ($numberColors, $colorspace, $treedepth, $dither, $measureError) {}
 
@@ -3867,6 +4265,7 @@ class Imagick implements Iterator, Countable {
 	 * @param bool $dither
 	 * @param bool $measureError
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function quantizeImages ($numberColors, $colorspace, $treedepth, $dither, $measureError) {}
 
@@ -3876,7 +4275,9 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.reducenoiseimage.php
 	 * @param float $radius
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
+	#[Deprecated]
 	public function reduceNoiseImage ($radius) {}
 
 	/**
@@ -3885,6 +4286,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.removeimageprofile.php
 	 * @param string $name
 	 * @return string a string containing the profile of the image.
+	 * @throws ImagickException on error.
 	 */
 	public function removeImageProfile ($name) {}
 
@@ -3894,6 +4296,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.separateimagechannel.php
 	 * @param int $channel
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function separateImageChannel ($channel) {}
 
@@ -3903,6 +4306,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.sepiatoneimage.php
 	 * @param float $threshold
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sepiaToneImage ($threshold) {}
 
@@ -3922,6 +4326,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $x
 	 * @param float $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageBluePrimary ($x, $y) {}
 
@@ -3933,6 +4338,7 @@ class Imagick implements Iterator, Countable {
 	 * The border color
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageBorderColor ($border) {}
 
@@ -3943,6 +4349,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $channel
 	 * @param int $depth
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageChannelDepth ($channel, $depth) {}
 
@@ -3953,6 +4360,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $index
 	 * @param ImagickPixel $color
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageColormapColor ($index, ImagickPixel $color) {}
 
@@ -3964,6 +4372,7 @@ class Imagick implements Iterator, Countable {
 	 * One of the COLORSPACE constants
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageColorspace ($colorspace) {}
 
@@ -3973,6 +4382,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagedispose.php
 	 * @param int $dispose
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageDispose ($dispose) {}
 
@@ -3983,6 +4393,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $columns
 	 * @param int $rows
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageExtent ($columns, $rows) {}
 
@@ -3993,6 +4404,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $x
 	 * @param float $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageGreenPrimary ($x, $y) {}
 
@@ -4002,6 +4414,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimageinterlacescheme.php
 	 * @param int $interlace_scheme
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageInterlaceScheme ($interlace_scheme) {}
 
@@ -4012,6 +4425,7 @@ class Imagick implements Iterator, Countable {
 	 * @param string $name
 	 * @param string $profile
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageProfile ($name, $profile) {}
 
@@ -4022,6 +4436,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $x
 	 * @param float $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageRedPrimary ($x, $y) {}
 
@@ -4031,6 +4446,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagerenderingintent.php
 	 * @param int $rendering_intent
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageRenderingIntent ($rendering_intent) {}
 
@@ -4040,6 +4456,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setimagevirtualpixelmethod.php
 	 * @param int $method
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageVirtualPixelMethod ($method) {}
 
@@ -4050,6 +4467,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $x
 	 * @param float $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImageWhitePoint ($x, $y) {}
 
@@ -4062,6 +4480,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $beta
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function sigmoidalContrastImage ($sharpen, $alpha, $beta, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -4071,6 +4490,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.stereoimage.php
 	 * @param Imagick $offset_wand
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function stereoImage (Imagick $offset_wand) {}
 
@@ -4080,6 +4500,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.textureimage.php
 	 * @param Imagick $texture_wand
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function textureImage (Imagick $texture_wand) {}
 
@@ -4106,6 +4527,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $threshold
 	 * @param int $channel [optional]
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function unsharpMaskImage ($radius, $sigma, $amount, $threshold, $channel = Imagick::CHANNEL_ALL) {}
 
@@ -4114,7 +4536,9 @@ class Imagick implements Iterator, Countable {
 	 * Returns a new Imagick object
 	 * @link https://php.net/manual/en/imagick.getimage.php
 	 * @return Imagick a new Imagick object with the current image sequence.
+	 * @throws ImagickException on error.
 	 */
+	#[Pure]
 	public function getImage () {}
 
 	/**
@@ -4125,6 +4549,7 @@ class Imagick implements Iterator, Countable {
 	 * The source Imagick object
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function addImage (Imagick $source) {}
 
@@ -4136,6 +4561,7 @@ class Imagick implements Iterator, Countable {
 	 * The replace Imagick object
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setImage (Imagick $replace) {}
 
@@ -4156,6 +4582,7 @@ class Imagick implements Iterator, Countable {
 	 * Image format. This parameter was added in Imagick version 2.0.1.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function newImage ($cols, $rows, $background, $format = null) {}
 
@@ -4173,6 +4600,7 @@ class Imagick implements Iterator, Countable {
 	 * string containing pseudo image definition.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function newPseudoImage ($columns, $rows, $pseudoString) {}
 
@@ -4182,6 +4610,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getcompression.php
 	 * @return int the compression constant
 	 */
+	#[Pure]
 	public function getCompression () {}
 
 	/**
@@ -4190,6 +4619,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getcompressionquality.php
 	 * @return int integer describing the compression quality
 	 */
+	#[Pure]
 	public function getCompressionQuality () {}
 
 	/**
@@ -4207,6 +4637,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getfilename.php
 	 * @return string a string on success.
 	 */
+	#[Pure]
 	public function getFilename () {}
 
 	/**
@@ -4215,6 +4646,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getformat.php
 	 * @return string the format of the image.
 	 */
+	#[Pure]
 	public function getFormat () {}
 
 	/**
@@ -4232,6 +4664,7 @@ class Imagick implements Iterator, Countable {
 	 * @return int Gets the wand interlace
 	 * scheme.
 	 */
+	#[Pure]
 	public function getInterlaceScheme () {}
 
 	/**
@@ -4243,6 +4676,7 @@ class Imagick implements Iterator, Countable {
 	 * </p>
 	 * @return string a value associated with a wand and the specified key.
 	 */
+	#[Pure]
 	public function getOption ($key) {}
 
 	/**
@@ -4257,11 +4691,19 @@ class Imagick implements Iterator, Countable {
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the page geometry
 	 * @link https://php.net/manual/en/imagick.getpage.php
-	 * @return array the page geometry associated with the Imagick object in
+	 * @return int[] the page geometry associated with the Imagick object in
 	 * an associative array with the keys "width", "height", "x", and "y",
 	 * throwing ImagickException on error.
 	 * @throws ImagickException on error
 	 */
+	//width:int, height:int, x:int, y:int
+    #[ArrayShape([
+        "width" => "int",
+        "height" => "int",
+        "x" => "int",
+        "y" => "int"
+    ])]
+	#[Pure]
 	public function getPage () {}
 
 	/**
@@ -4270,6 +4712,11 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getquantumdepth.php
 	 * @return array the Imagick quantum depth as a string.
 	 */
+	// quantumDepthLong:int, quantumDepthString:string
+    #[ArrayShape([
+        "quantumDepthLong" => "int",
+        "quantumDepthString" => "string",
+    ])]
 	public static function getQuantumDepth () {}
 
 	/**
@@ -4278,6 +4725,10 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getquantumrange.php
 	 * @return array the Imagick quantum range as a string.
 	 */
+    #[ArrayShape([
+        "quantumDepthLong" => "int",
+        "quantumDepthString" => "string",
+    ])]
 	public static function getQuantumRange () {}
 
 	/**
@@ -4317,15 +4768,22 @@ class Imagick implements Iterator, Countable {
 	 * @return array an associative array with the horizontal and vertical sampling
 	 * factors of the image.
 	 */
+	#[Pure]
 	public function getSamplingFactors () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the size associated with the Imagick object
 	 * @link https://php.net/manual/en/imagick.getsize.php
-	 * @return array the size associated with the Imagick object as an array with the
+	 * @return int[] the size associated with the Imagick object as an array with the
 	 * keys "columns" and "rows".
+	 * @throws ImagickException on error.
 	 */
+    #[ArrayShape([
+        "columns" => "int",
+        "rows" => "int"
+    ])]
+	#[Pure]
 	public function getSize () {}
 
 	/**
@@ -4334,6 +4792,10 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getversion.php
 	 * @return array the ImageMagick API version as a string and as a number.
 	 */
+    #[ArrayShape([
+        "versionNumber" => "int",
+        "versionString" => "string",
+    ])]
 	public static function getVersion () {}
 
 	/**
@@ -4342,6 +4804,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setbackgroundcolor.php
 	 * @param mixed $background
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setBackgroundColor ($background) {}
 
@@ -4351,6 +4814,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setcompression.php
 	 * @param int $compression
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setCompression ($compression) {}
 
@@ -4360,6 +4824,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setcompressionquality.php
 	 * @param int $quality
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setCompressionQuality ($quality) {}
 
@@ -4369,6 +4834,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setfilename.php
 	 * @param string $filename
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setFilename ($filename) {}
 
@@ -4378,6 +4844,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setformat.php
 	 * @param string $format
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setFormat ($format) {}
 
@@ -4387,6 +4854,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setinterlacescheme.php
 	 * @param int $interlace_scheme
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setInterlaceScheme ($interlace_scheme) {}
 
@@ -4397,6 +4865,7 @@ class Imagick implements Iterator, Countable {
 	 * @param string $key
 	 * @param string $value
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setOption ($key, $value) {}
 
@@ -4409,6 +4878,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $x
 	 * @param int $y
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setPage ($width, $height, $x, $y) {}
 
@@ -4423,6 +4893,7 @@ class Imagick implements Iterator, Countable {
 	 * The resource limit. The unit depends on the type of the resource being limited.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public static function setResourceLimit ($type, $limit) {}
 
@@ -4437,6 +4908,7 @@ class Imagick implements Iterator, Countable {
 	 * The vertical resolution.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setResolution ($x_resolution, $y_resolution) {}
 
@@ -4446,6 +4918,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.setsamplingfactors.php
 	 * @param array $factors
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setSamplingFactors (array $factors) {}
 
@@ -4456,6 +4929,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $columns
 	 * @param int $rows
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setSize ($columns, $rows) {}
 
@@ -4465,6 +4939,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.settype.php
 	 * @param int $image_type
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function setType ($image_type) {}
 
@@ -4479,6 +4954,7 @@ class Imagick implements Iterator, Countable {
 	 * Checks if the current item is valid
 	 * @link https://php.net/manual/en/imagick.valid.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function valid () {}
 
@@ -4493,10 +4969,11 @@ class Imagick implements Iterator, Countable {
 	/**
 	 * Change the brightness and/or contrast of an image. It converts the brightness and contrast parameters into slope and intercept and calls a polynomical function to apply to the image.
 	 * @link https://php.net/manual/en/imagick.brightnesscontrastimage.php
-	 * @param string $brightness
-	 * @param string $contrast
+	 * @param float $brightness
+	 * @param float $contrast
 	 * @param int $CHANNEL [optional]
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function brightnessContrastImage ($brightness, $contrast, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
@@ -4509,6 +4986,8 @@ class Imagick implements Iterator, Countable {
 	 * @param ImagickKernel $ImagickKernel
 	 * @param int $CHANNEL [optional]
 	 * @return void
+	 * @throws ImagickException on error.
+	 * @throws ImagickKernelException on error.
 	 * @since 3.3.0
 	 */
 	public function morphology ($morphologyMethod, $iterations, ImagickKernel $ImagickKernel, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
@@ -4519,6 +4998,7 @@ class Imagick implements Iterator, Countable {
 	 * @param ImagickKernel $ImagickKernel An instance of ImagickKernel that represents either a single kernel or a linked series of kernels.
 	 * @param int $CHANNEL [optional] Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to Imagick::CHANNEL_DEFAULT. Refer to this list of channel constants
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function filter (ImagickKernel $ImagickKernel , $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
@@ -4527,8 +5007,9 @@ class Imagick implements Iterator, Countable {
 	 * Apply color transformation to an image. The method permits saturation changes, hue rotation, luminance to alpha, and various other effects. Although variable-sized transformation matrices can be used, typically one uses a 5x5 matrix for an RGBA image and a 6x6 for CMYKA (or RGBA with offsets).
 	 * The matrix is similar to those used by Adobe Flash except offsets are in column 6 rather than 5 (in support of CMYKA images) and offsets are normalized (divide Flash offset by 255)
 	 * @link https://php.net/manual/en/imagick.colormatriximage.php
-	 * @param string $color_matrix
+	 * @param array $color_matrix
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function colorMatrixImage ($color_matrix = Imagick::CHANNEL_DEFAULT) { }
@@ -4538,6 +5019,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.deleteimageproperty.php
 	 * @param string $name The name of the property to delete.
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function deleteImageProperty ($name) { }
@@ -4547,6 +5029,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.forwardfouriertransformimage.php
 	 * @param bool $magnitude If true, return as magnitude / phase pair otherwise a real / imaginary image pair.
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function forwardFourierTransformimage ($magnitude) { }
@@ -4557,6 +5040,7 @@ class Imagick implements Iterator, Countable {
 	 * @return int
 	 * @since 3.3.0
 	 */
+	#[Pure]
 	public function getImageCompression () { }
 
 	/**
@@ -4564,7 +5048,7 @@ class Imagick implements Iterator, Countable {
 	 * @link https://php.net/manual/en/imagick.getregistry.php
 	 * @param string $key
 	 * @return string|false
-	 * @throws Exception Since version >=3.4.3. Throws an exception if the key does not exist, rather than terminating the program.
+	 * @throws ImagickException Since version >= 3.4.3. Throws an exception if the key does not exist, rather than terminating the program.
 	 * @since 3.3.0
 	 */
 	public static function getRegistry ($key) { }
@@ -4583,6 +5067,7 @@ class Imagick implements Iterator, Countable {
 	 * @see https://www.imagemagick.org/script/escape.php
 	 * @param string $embedText A string containing formatting sequences e.g. "Trim box: %@ number of unique colors: %k".
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function identifyFormat ($embedText) { }
@@ -4593,6 +5078,7 @@ class Imagick implements Iterator, Countable {
 	 * @param Imagick $complement The second image to combine with this one to form either the magnitude / phase or real / imaginary image pair.
 	 * @param bool $magnitude If true, combine as magnitude / phase pair otherwise a real / imaginary image pair.
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function inverseFourierTransformImage ($complement, $magnitude) { }
@@ -4608,9 +5094,10 @@ class Imagick implements Iterator, Countable {
 	/**
 	 * Rotational blurs an image.
 	 * @link https://php.net/manual/en/imagick.rotationalblurimage.php
-	 * @param string $angle
-	 * @param string $CHANNEL
+	 * @param float $angle
+	 * @param int $CHANNEL
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function rotationalBlurImage ($angle, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
@@ -4623,6 +5110,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $threshold
 	 * @param int $CHANNEL Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to Imagick::CHANNEL_DEFAULT. Refer to this list of channel constants
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function selectiveBlurImage ($radius, $sigma, $threshold, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
@@ -4631,6 +5119,7 @@ class Imagick implements Iterator, Countable {
 	 * Set whether antialiasing should be used for operations. On by default.
 	 * @param bool $antialias
 	 * @return int
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function setAntiAlias ($antialias) { }
@@ -4652,6 +5141,7 @@ class Imagick implements Iterator, Countable {
 	 * <b>Caution</b>
 	 * The values passed to the callback function are not consistent. In particular the span parameter can increase during image processing. Because of this calculating the percentage complete of an image operation is not trivial.
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function setProgressMonitor ($callback) { }
@@ -4674,6 +5164,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $height
 	 * @param int $channel [optional]
 	 * @return void
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function statisticImage ($type, $width, $height, $channel = Imagick::CHANNEL_DEFAULT ) { }
@@ -4687,11 +5178,12 @@ class Imagick implements Iterator, Countable {
 	 *
 	 * @link https://php.net/manual/en/imagick.subimagematch.php
 	 * @param Imagick $imagick
-	 * @param array $bestMatch [optional]
-	 * @param float $similarity [optional] A new image that displays the amount of similarity at each pixel.
+	 * @param array &$bestMatch [optional]
+	 * @param float &$similarity [optional] A new image that displays the amount of similarity at each pixel.
 	 * @param float $similarity_threshold [optional] Only used if compiled with ImageMagick (library) > 7
 	 * @param int $metric [optional] Only used if compiled with ImageMagick (library) > 7
 	 * @return Imagick
+	 * @throws ImagickException on error.
 	 * @since 3.3.0
 	 */
 	public function subImageMatch (Imagick $imagick, array &$bestMatch, &$similarity, $similarity_threshold, $metric) { }
@@ -4700,11 +5192,12 @@ class Imagick implements Iterator, Countable {
 	 * Is an alias of Imagick::subImageMatch
 	 *
 	 * @param Imagick $imagick
-	 * @param array $bestMatch [optional]
-	 * @param float $similarity [optional] A new image that displays the amount of similarity at each pixel.
+	 * @param array &$bestMatch [optional]
+	 * @param float &$similarity [optional] A new image that displays the amount of similarity at each pixel.
 	 * @param float $similarity_threshold [optional]
 	 * @param int $metric [optional]
 	 * @return Imagick
+	 * @throws ImagickException on error.
 	 * @see Imagick::subImageMatch() This function is an alias of subImageMatch()
 	 * @since 3.4.0
 	 */
@@ -4715,6 +5208,7 @@ class Imagick implements Iterator, Countable {
 	 * @return string
 	 * @since 3.4.0
 	 */
+	#[Pure]
 	public function getConfigureOptions () { }
 
 	/**
@@ -4722,18 +5216,21 @@ class Imagick implements Iterator, Countable {
 	 * @return string
 	 * @since 3.4.0
 	 */
+	#[Pure]
 	public function getFeatures () { }
 
 	/**
 	 * @return int
 	 * @since 3.4.0
 	 */
+	#[Pure]
 	public function getHDRIEnabled () { }
 
 	/**
 	 * Sets the image channel mask. Returns the previous set channel mask.
-	 * Only works with Imagick >=7
+	 * Only works with Imagick >= 7
 	 * @param int $channel
+	 * @throws ImagickException on error.
 	 * @since 3.4.0
 	 */
 	public function setImageChannelMask ($channel) {}
@@ -4743,6 +5240,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $EVALUATE_CONSTANT
 	 * @return bool
 	 * @see https://www.imagemagick.org/Usage/layers/#evaluate-sequence
+	 * @throws ImagickException on error.
 	 * @since 3.4.0
 	 */
 	public function evaluateImages ($EVALUATE_CONSTANT) { }
@@ -4751,6 +5249,7 @@ class Imagick implements Iterator, Countable {
 	 * Extracts the 'mean' from the image and adjust the image to try make set its gamma appropriately.
 	 * @param int $channel [optional] Default value Imagick::CHANNEL_ALL
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function autoGammaImage ($channel = Imagick::CHANNEL_ALL) { }
@@ -4758,6 +5257,7 @@ class Imagick implements Iterator, Countable {
 	/**
 	 * Adjusts an image so that its orientation is suitable $ for viewing (i.e. top-left orientation).
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function autoOrient () { }
@@ -4769,6 +5269,7 @@ class Imagick implements Iterator, Countable {
 	 * @param int $COMPOSITE_CONSTANT
 	 * @param int $GRAVITY_CONSTANT
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function compositeImageGravity(Imagick $imagick, $COMPOSITE_CONSTANT, $GRAVITY_CONSTANT) { }
@@ -4779,6 +5280,7 @@ class Imagick implements Iterator, Countable {
 	 * @param float $radius
 	 * @param float $strength
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function localContrastImage($radius, $strength) { }
@@ -4786,6 +5288,7 @@ class Imagick implements Iterator, Countable {
 	/**
 	 * Identifies the potential image type, returns one of the Imagick::IMGTYPE_* constants
 	 * @return int
+	 * @throws ImagickException on error.
 	 * @since 3.4.3
 	 */
 	public function identifyImageType() { }
@@ -4795,6 +5298,7 @@ class Imagick implements Iterator, Countable {
 	 *
 	 * @param float $alpha
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.3
 	 */
 	public function setImageAlpha($alpha) { }
@@ -4808,13 +5312,15 @@ class ImagickDraw  {
 
 	public function resetVectorGraphics () {}
 
+	#[Pure]
 	public function getTextKerning () {}
 
 	/**
-	 * @param $kerning
+	 * @param float $kerning
 	 */
 	public function setTextKerning ($kerning) {}
 
+	#[Pure]
 	public function getTextInterWordSpacing () {}
 
 	/**
@@ -4822,6 +5328,7 @@ class ImagickDraw  {
 	 */
 	public function setTextInterWordSpacing ($spacing) {}
 
+	#[Pure]
 	public function getTextInterLineSpacing () {}
 
 	/**
@@ -4844,6 +5351,7 @@ class ImagickDraw  {
 	 * ImagickPixel to use to set the color
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function setFillColor (ImagickPixel $fill_pixel) {}
 
@@ -4856,11 +5364,15 @@ class ImagickDraw  {
 	 * </p>
 	 * @return bool No value is returned.
 	 */
+	#[Deprecated]
 	public function setFillAlpha ($opacity) {}
 
 	/**
-	 * @param $x_resolution
-	 * @param $y_resolution
+     * Sets the image resolution
+	 * @param float $x_resolution <p>The horizontal resolution.</p>
+	 * @param float $y_resolution <p>The vertical resolution.</p>
+	 * @return bool
+	 * @throws ImagickDrawException on error.
 	 */
 	public function setResolution ($x_resolution, $y_resolution) {}
 
@@ -4872,6 +5384,7 @@ class ImagickDraw  {
 	 * the stroke color
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function setStrokeColor (ImagickPixel $stroke_pixel) {}
 
@@ -4884,6 +5397,7 @@ class ImagickDraw  {
 	 * </p>
 	 * @return bool No value is returned.
 	 */
+	#[Deprecated]
 	public function setStrokeAlpha ($opacity) {}
 
 	/**
@@ -4939,6 +5453,7 @@ class ImagickDraw  {
 	 * The text to draw on the image
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function annotation ($x, $y, $text) {}
 
@@ -4968,6 +5483,8 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.setfont.php
 	 * @param string $font_name
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickDrawException on error.
+	 * @throws ImagickException on error.
 	 */
 	public function setFont ($font_name) {}
 
@@ -4979,6 +5496,8 @@ class ImagickDraw  {
 	 * the font family
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickDrawException on error.
+	 * @throws ImagickException on error.
 	 */
 	public function setFontFamily ($font_family) {}
 
@@ -5010,6 +5529,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.setfontweight.php
 	 * @param int $font_weight
 	 * @return bool
+	 * @throws ImagickDrawException on error.
 	 */
 	public function setFontWeight ($font_weight) {}
 
@@ -5019,6 +5539,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfont.php
 	 * @return string|false a string on success and false if no font is set.
 	 */
+	#[Pure]
 	public function getFont () {}
 
 	/**
@@ -5027,6 +5548,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfontfamily.php
 	 * @return string|false the font family currently selected or false if font family is not set.
 	 */
+	#[Pure]
 	public function getFontFamily () {}
 
 	/**
@@ -5035,6 +5557,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfontsize.php
 	 * @return float the font size associated with the current ImagickDraw object.
 	 */
+	#[Pure]
 	public function getFontSize () {}
 
 	/**
@@ -5044,6 +5567,7 @@ class ImagickDraw  {
 	 * @return int the font style constant (STYLE_) associated with the ImagickDraw object
 	 * or 0 if no style is set.
 	 */
+	#[Pure]
 	public function getFontStyle () {}
 
 	/**
@@ -5052,6 +5576,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfontweight.php
 	 * @return int an int on success and 0 if no weight is set.
 	 */
+	#[Pure]
 	public function getFontWeight () {}
 
 	/**
@@ -5229,6 +5754,7 @@ class ImagickDraw  {
 	 * multidimensional array like array( array( 'x' => 3, 'y' => 4 ), array( 'x' => 2, 'y' => 6 ) );
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function polygon (array $coordinates) {}
 
@@ -5253,6 +5779,7 @@ class ImagickDraw  {
 	 * @return int one of the DECORATION_ constants
 	 * and 0 if no decoration is set.
 	 */
+	#[Pure]
 	public function getTextDecoration () {}
 
 	/**
@@ -5262,8 +5789,10 @@ class ImagickDraw  {
 	 * @return string a string specifying the code set
 	 * or false if text encoding is not set.
 	 */
+	#[Pure]
 	public function getTextEncoding () {}
 
+	#[Pure]
 	public function getFontStretch () {}
 
 	/**
@@ -5318,6 +5847,7 @@ class ImagickDraw  {
 	 * the under color
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function setTextUnderColor (ImagickPixel $under_color) {}
 
@@ -5349,6 +5879,7 @@ class ImagickDraw  {
 	 * Affine matrix parameters
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function affine (array $affine) {}
 
@@ -5361,6 +5892,7 @@ class ImagickDraw  {
 	 * array( 'x' => 3, 'y' => 4 ) )
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function bezier (array $coordinates) {}
 
@@ -5387,6 +5919,7 @@ class ImagickDraw  {
 	 * the Imagick object where composition image is taken from
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickException on error.
 	 */
 	public function composite ($compose, $x, $y, $width, $height, Imagick $compositeWand) {}
 
@@ -5424,6 +5957,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getclippath.php
 	 * @return string|false a string containing the clip path ID or false if no clip path exists.
 	 */
+	#[Pure]
 	public function getClipPath () {}
 
 	/**
@@ -5432,6 +5966,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getcliprule.php
 	 * @return int one of the FILLRULE_ constants.
 	 */
+	#[Pure]
 	public function getClipRule () {}
 
 	/**
@@ -5440,6 +5975,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getclipunits.php
 	 * @return int an int on success.
 	 */
+	#[Pure]
 	public function getClipUnits () {}
 
 	/**
@@ -5448,6 +5984,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfillcolor.php
 	 * @return ImagickPixel an ImagickPixel object.
 	 */
+	#[Pure]
 	public function getFillColor () {}
 
 	/**
@@ -5456,6 +5993,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfillopacity.php
 	 * @return float The opacity.
 	 */
+	#[Pure]
 	public function getFillOpacity () {}
 
 	/**
@@ -5464,6 +6002,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getfillrule.php
 	 * @return int a FILLRULE_ constant
 	 */
+	#[Pure]
 	public function getFillRule () {}
 
 	/**
@@ -5472,6 +6011,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getgravity.php
 	 * @return int a GRAVITY_ constant on success and 0 if no gravity is set.
 	 */
+	#[Pure]
 	public function getGravity () {}
 
 	/**
@@ -5480,6 +6020,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokeantialias.php
 	 * @return bool <b>TRUE</b> if antialiasing is on and false if it is off.
 	 */
+	#[Pure]
 	public function getStrokeAntialias () {}
 
 	/**
@@ -5488,6 +6029,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokecolor.php
 	 * @return ImagickPixel an ImagickPixel object which describes the color.
 	 */
+	#[Pure]
 	public function getStrokeColor () {}
 
 	/**
@@ -5496,6 +6038,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokedasharray.php
 	 * @return array an array on success and empty array if not set.
 	 */
+	#[Pure]
 	public function getStrokeDashArray () {}
 
 	/**
@@ -5504,6 +6047,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokedashoffset.php
 	 * @return float a float representing the offset and 0 if it's not set.
 	 */
+	#[Pure]
 	public function getStrokeDashOffset () {}
 
 	/**
@@ -5512,6 +6056,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokelinecap.php
 	 * @return int one of the LINECAP_ constants or 0 if stroke linecap is not set.
 	 */
+	#[Pure]
 	public function getStrokeLineCap () {}
 
 	/**
@@ -5520,6 +6065,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getstrokelinejoin.php
 	 * @return int one of the LINEJOIN_ constants or 0 if stroke line join is not set.
 	 */
+	#[Pure]
 	public function getStrokeLineJoin () {}
 
 	/**
@@ -5529,22 +6075,25 @@ class ImagickDraw  {
 	 * @return int an int describing the miter limit
 	 * and 0 if no miter limit is set.
 	 */
+	#[Pure]
 	public function getStrokeMiterLimit () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the opacity of stroked object outlines
 	 * @link https://php.net/manual/en/imagickdraw.getstrokeopacity.php
-	 * @return float a double describing the opacity.
+	 * @return float a float describing the opacity.
 	 */
+	#[Pure]
 	public function getStrokeOpacity () {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the width of the stroke used to draw object outlines
 	 * @link https://php.net/manual/en/imagickdraw.getstrokewidth.php
-	 * @return float a double describing the stroke width.
+	 * @return float a float describing the stroke width.
 	 */
+	#[Pure]
 	public function getStrokeWidth () {}
 
 	/**
@@ -5553,6 +6102,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.gettextalignment.php
 	 * @return int one of the ALIGN_ constants and 0 if no align is set.
 	 */
+	#[Pure]
 	public function getTextAlignment () {}
 
 	/**
@@ -5561,6 +6111,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.gettextantialias.php
 	 * @return bool <b>TRUE</b> if text is antialiased and false if not.
 	 */
+	#[Pure]
 	public function getTextAntialias () {}
 
 	/**
@@ -5569,6 +6120,7 @@ class ImagickDraw  {
 	 * @link https://php.net/manual/en/imagickdraw.getvectorgraphics.php
 	 * @return string a string containing the vector graphics.
 	 */
+	#[Pure]
 	public function getVectorGraphics () {}
 
 	/**
@@ -5576,7 +6128,9 @@ class ImagickDraw  {
 	 * Returns the text under color
 	 * @link https://php.net/manual/en/imagickdraw.gettextundercolor.php
 	 * @return ImagickPixel an ImagickPixel object describing the color.
+	 * @throws ImagickDrawException on error.
 	 */
+	#[Pure]
 	public function getTextUnderColor () {}
 
 	/**
@@ -5929,6 +6483,7 @@ class ImagickDraw  {
 	 * array of x and y coordinates: array( array( 'x' => 4, 'y' => 6 ), array( 'x' => 8, 'y' => 10 ) )
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickDrawException on error.
 	 */
 	public function polyline (array $coordinates) {}
 
@@ -5953,6 +6508,7 @@ class ImagickDraw  {
 	 * Terminates a pattern definition
 	 * @link https://php.net/manual/en/imagickdraw.poppattern.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 * @throws ImagickException on error.
 	 */
 	public function popPattern () {}
 
@@ -6003,6 +6559,7 @@ class ImagickDraw  {
 	 * Renders all preceding drawing commands onto the image
 	 * @link https://php.net/manual/en/imagickdraw.render.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 * @throws ImagickException on error.
 	 */
 	public function render () {}
 
@@ -6039,6 +6596,7 @@ class ImagickDraw  {
 	 * the clipping path name
 	 * </p>
 	 * @return bool No value is returned.
+	 * @throws ImagickException on error.
 	 */
 	public function setClipPath ($clip_mask) {}
 
@@ -6083,6 +6641,7 @@ class ImagickDraw  {
 	 * URL to use to obtain fill pattern.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 * @throws ImagickException on error.
 	 */
 	public function setFillPatternURL ($fill_url) {}
 
@@ -6116,6 +6675,7 @@ class ImagickDraw  {
 	 * stroke URL
 	 * </p>
 	 * @return bool imagick.imagickdraw.return.success;
+	 * @throws ImagickException on error.
 	 */
 	public function setStrokePatternURL ($stroke_url) {}
 
@@ -6190,6 +6750,7 @@ class ImagickDraw  {
 	 * Destroys the current ImagickDraw in the stack, and returns to the previously pushed ImagickDraw
 	 * @link https://php.net/manual/en/imagickdraw.pop.php
 	 * @return bool <b>TRUE</b> on success and false on failure.
+	 * @throws ImagickException on error.
 	 */
 	public function pop () {}
 
@@ -6198,6 +6759,7 @@ class ImagickDraw  {
 	 * Clones the current ImagickDraw and pushes it to the stack
 	 * @link https://php.net/manual/en/imagickdraw.push.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+	 * @throws ImagickException on error.
 	 */
 	public function push () {}
 
@@ -6227,6 +6789,7 @@ class ImagickDraw  {
 	 * @return float
 	 * @since 3.4.1
 	 */
+	#[Pure]
 	public function getOpacity() { }
 
 	/**
@@ -6235,6 +6798,7 @@ class ImagickDraw  {
 	 * @param float $x
 	 * @param float $y
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function setFontResolution($x, $y) { }
@@ -6243,8 +6807,10 @@ class ImagickDraw  {
 	 * Gets the image X and Y resolution.
 	 *
 	 * @return array
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
+	#[Pure]
 	public function getFontResolution() { }
 
 	/**
@@ -6252,6 +6818,7 @@ class ImagickDraw  {
 	 * @return bool
 	 * @since 3.4.1
 	 */
+	#[Pure]
 	public function getTextDirection() { }
 
 	/**
@@ -6269,12 +6836,14 @@ class ImagickDraw  {
 	 * @return ImagickPixel
 	 * @since 3.4.1
 	 */
+	#[Pure]
 	public function getBorderColor() { }
 
 	/**
 	 * Sets the border color to be used for drawing bordered objects.
 	 * @param ImagickPixel $color
 	 * @return bool
+	 * @throws ImagickDrawException on error.
 	 * @since 3.4.1
 	 */
 	public function setBorderColor(ImagickPixel $color) { }
@@ -6285,12 +6854,14 @@ class ImagickDraw  {
 	 * @return string|null
 	 * @since 3.4.1
 	 */
+	#[Pure]
 	public function getDensity() { }
 
 	/**
 	 * Sets the vertical and horizontal resolution.
 	 * @param string $density_string
 	 * @return bool
+	 * @throws ImagickException on error.
 	 * @since 3.4.1
 	 */
 	public function setDensity($density_string) { }
@@ -6306,6 +6877,8 @@ class ImagickPixelIterator implements Iterator {
 	 * The ImagickPixelIterator constructor
 	 * @link https://php.net/manual/en/imagickpixeliterator.construct.php
 	 * @param Imagick $wand
+	 * @throws ImagickPixelIteratorException on error.
+	 * @throws ImagickException on error.
 	 */
 	public function __construct (Imagick $wand) {}
 
@@ -6316,7 +6889,9 @@ class ImagickPixelIterator implements Iterator {
 	 * @param Imagick $wand
 	 * @return bool <b>TRUE</b> on success. Throwing ImagickPixelIteratorException.
 	 * @throws ImagickPixelIteratorException
+	 * @throws ImagickException
 	 */
+	#[Deprecated(replacement: "%class%->getPixelIterator(%parametersList%)")]
 	public function newPixelIterator (Imagick $wand) {}
 
 	/**
@@ -6330,7 +6905,9 @@ class ImagickPixelIterator implements Iterator {
 	 * @param int $rows
 	 * @return bool a new ImagickPixelIterator on success; on failure, throws ImagickPixelIteratorException
 	 * @throws ImagickPixelIteratorException
+	 * @throws ImagickException
 	 */
+	#[Deprecated(replacement: "%class%->getPixelRegionIterator(%parametersList%)")]
 	public function newPixelRegionIterator (Imagick $wand, $x, $y, $columns, $rows) {}
 
 	/**
@@ -6340,6 +6917,7 @@ class ImagickPixelIterator implements Iterator {
 	 * @return int the integer offset of the row, throwing ImagickPixelIteratorException on error.
 	 * @throws ImagickPixelIteratorException on error
 	 */
+	#[Pure]
 	public function getIteratorRow () {}
 
 	/**
@@ -6348,6 +6926,7 @@ class ImagickPixelIterator implements Iterator {
 	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorrow.php
 	 * @param int $row
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function setIteratorRow ($row) {}
 
@@ -6356,6 +6935,7 @@ class ImagickPixelIterator implements Iterator {
 	 * Sets the pixel iterator to the first pixel row
 	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorfirstrow.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function setIteratorFirstRow () {}
 
@@ -6364,6 +6944,7 @@ class ImagickPixelIterator implements Iterator {
 	 * Sets the pixel iterator to the last pixel row
 	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorlastrow.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function setIteratorLastRow () {}
 
@@ -6375,6 +6956,7 @@ class ImagickPixelIterator implements Iterator {
 	 * ImagickPixelIterator, throwing ImagickPixelIteratorException on error.
 	 * @throws ImagickPixelIteratorException on error
 	 */
+	#[Pure]
 	public function getPreviousIteratorRow () {}
 
 	/**
@@ -6382,7 +6964,9 @@ class ImagickPixelIterator implements Iterator {
 	 * Returns the current row of ImagickPixel objects
 	 * @link https://php.net/manual/en/imagickpixeliterator.getcurrentiteratorrow.php
 	 * @return array a row as an array of ImagickPixel objects that can themselves be iterated.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
+	#[Pure]
 	public function getCurrentIteratorRow () {}
 
 	/**
@@ -6393,6 +6977,7 @@ class ImagickPixelIterator implements Iterator {
 	 * ImagickPixelIteratorException on error.
 	 * @throws ImagickPixelIteratorException on error
 	 */
+	#[Pure]
 	public function getNextIteratorRow () {}
 
 	/**
@@ -6400,6 +6985,7 @@ class ImagickPixelIterator implements Iterator {
 	 * Resets the pixel iterator
 	 * @link https://php.net/manual/en/imagickpixeliterator.resetiterator.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function resetIterator () {}
 
@@ -6408,6 +6994,7 @@ class ImagickPixelIterator implements Iterator {
 	 * Syncs the pixel iterator
 	 * @link https://php.net/manual/en/imagickpixeliterator.synciterator.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function syncIterator () {}
 
@@ -6416,6 +7003,7 @@ class ImagickPixelIterator implements Iterator {
 	 * Deallocates resources associated with a PixelIterator
 	 * @link https://php.net/manual/en/imagickpixeliterator.destroy.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function destroy () {}
 
@@ -6424,11 +7012,14 @@ class ImagickPixelIterator implements Iterator {
 	 * Clear resources associated with a PixelIterator
 	 * @link https://php.net/manual/en/imagickpixeliterator.clear.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelIteratorException on error.
 	 */
 	public function clear () {}
 
 	/**
 	 * @param Imagick $Imagick
+	 * @throws ImagickPixelIteratorException on error.
+	 * @throws ImagickException on error.
 	 */
 	public static function getpixeliterator (Imagick $Imagick) {}
 
@@ -6438,17 +7029,34 @@ class ImagickPixelIterator implements Iterator {
 	 * @param $y
 	 * @param $columns
 	 * @param $rows
+	 * @throws ImagickPixelIteratorException on error.
+	 * @throws ImagickException on error.
 	 */
 	public static function getpixelregioniterator (Imagick $Imagick, $x, $y, $columns, $rows) {}
 
+	/**
+	 * @throws ImagickPixelIteratorException on error.
+	 */
 	public function key () {}
 
+	/**
+	 * @throws ImagickPixelIteratorException on error.
+	 */
 	public function next () {}
 
+	/**
+	 * @throws ImagickPixelIteratorException on error.
+	 */
 	public function rewind () {}
 
+	/**
+	 * @throws ImagickPixelIteratorException on error.
+	 */
 	public function current () {}
 
+	/**
+	 * @throws ImagickPixelIteratorException on error.
+	 */
 	public function valid () {}
 
 }
@@ -6463,10 +7071,16 @@ class ImagickPixel  {
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the normalized HSL color of the ImagickPixel object
 	 * @link https://php.net/manual/en/imagickpixel.gethsl.php
-	 * @return array the HSL value in an array with the keys "hue",
+	 * @return float[] the HSL value in an array with the keys "hue",
 	 * "saturation", and "luminosity". Throws ImagickPixelException on failure.
 	 * @throws ImagickPixelException on failure
 	 */
+    #[ArrayShape([
+        "hue" => "float",
+        "saturation" => "float",
+        "luminosity" => "float"
+    ])]
+	#[Pure]
 	public function getHSL () {}
 
 	/**
@@ -6486,20 +7100,32 @@ class ImagickPixel  {
 	 * 0 to white at 1, with the full HS value at 0.5 luminosity.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setHSL ($hue, $saturation, $luminosity) {}
 
+	/**
+	 * @throws ImagickPixelException on failure
+	 */
+	#[Pure]
 	public function getColorValueQuantum () {}
 
 	/**
 	 * @param $color_value
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setColorValueQuantum ($color_value) {}
 
+    /**
+     * Gets the colormap index of the pixel wand.
+	 * @throws ImagickPixelException on failure
+     */
+	#[Pure]
 	public function getIndex () {}
 
 	/**
-	 * @param $index
+	 * @param int $index
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setIndex ($index) {}
 
@@ -6510,6 +7136,7 @@ class ImagickPixel  {
 	 * @param string $color [optional] <p>
 	 * The optional color string to use as the initial value of this object.
 	 * </p>
+	 * @throws ImagickPixelException on failure
 	 */
 	public function __construct ($color = null) {}
 
@@ -6522,6 +7149,7 @@ class ImagickPixel  {
 	 * ImagickPixel object.
 	 * </p>
 	 * @return bool <b>TRUE</b> if the specified color was set, <b>FALSE</b> otherwise.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setColor ($color) {}
 
@@ -6536,6 +7164,7 @@ class ImagickPixel  {
 	 * The value to set this channel to, ranging from 0 to 1.
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setColorValue ($color, $value) {}
 
@@ -6552,6 +7181,7 @@ class ImagickPixel  {
 	 * ImagickPixelException on error.
 	 * @throws ImagickPixelException on error
 	 */
+	#[Pure]
 	public function getColorValue ($color) {}
 
 	/**
@@ -6559,6 +7189,7 @@ class ImagickPixel  {
 	 * Clears resources associated with this object
 	 * @link https://php.net/manual/en/imagickpixel.clear.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function clear () {}
 
@@ -6567,6 +7198,7 @@ class ImagickPixel  {
 	 * Deallocates resources associated with this object
 	 * @link https://php.net/manual/en/imagickpixel.destroy.php
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function destroy () {}
 
@@ -6583,6 +7215,7 @@ class ImagickPixel  {
 	 * (1.732).
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function isSimilar (ImagickPixel $color, $fuzz) {}
 
@@ -6599,6 +7232,7 @@ class ImagickPixel  {
 	 * (1.732).
 	 * </p>
 	 * @return bool <b>TRUE</b> on success.
+	 * @throws ImagickPixelException on failure
 	 */
 	public function isPixelSimilar (ImagickPixel $color, $fuzz) {}
 
@@ -6606,21 +7240,30 @@ class ImagickPixel  {
 	 * (PECL imagick 2.0.0)<br/>
 	 * Returns the color
 	 * @link https://php.net/manual/en/imagickpixel.getcolor.php
-	 * @param bool $normalized [optional] <p>
+	 * @param int $normalized [optional] <p>
 	 * Normalize the color values
 	 * </p>
 	 * @return array An array of channel values, each normalized if <b>TRUE</b> is given as param. Throws
 	 * ImagickPixelException on error.
 	 * @throws ImagickPixelException on error.
 	 */
-	public function getColor ($normalized = false) {}
+    #[ArrayShape([
+        "r" => "int|float",
+        "g" => "int|float",
+        "b" => "int|float",
+        "a" => "int|float"
+    ])]
+	#[Pure]
+	public function getColor ($normalized = 0) {}
 
 	/**
 	 * (PECL imagick 2.1.0)<br/>
 	 * Returns the color as a string
 	 * @link https://php.net/manual/en/imagickpixel.getcolorasstring.php
 	 * @return string the color of the ImagickPixel object as a string.
+	 * @throws ImagickPixelException on failure
 	 */
+	#[Pure]
 	public function getColorAsString () {}
 
 	/**
@@ -6631,10 +7274,12 @@ class ImagickPixel  {
 	 * ImagickPixelException on failure.
 	 * @throws ImagickPixelException on failure.
 	 */
+	#[Pure]
 	public function getColorCount () {}
 
 	/**
-	 * @param $colorCount
+	 * @param int $colorCount
+	 * @throws ImagickPixelException on failure
 	 */
 	public function setColorCount ($colorCount) {}
 
@@ -6643,9 +7288,10 @@ class ImagickPixel  {
 	 * Returns true if the distance between two colors is less than the specified distance. The fuzz value should be in the range 0-QuantumRange.<br>
 	 * The maximum value represents the longest possible distance in the colorspace. e.g. from RGB(0, 0, 0) to RGB(255, 255, 255) for the RGB colorspace
 	 * @link https://php.net/manual/en/imagickpixel.ispixelsimilarquantum.php
-	 * @param string $pixel
+	 * @param string $color
 	 * @param string $fuzz
 	 * @return bool
+	 * @throws ImagickPixelException on failure
 	 * @since 3.3.0
 	 */
 	public function isPixelSimilarQuantum($color, $fuzz) { }
@@ -6654,8 +7300,10 @@ class ImagickPixel  {
 	 * Returns the color of the pixel in an array as Quantum values. If ImageMagick was compiled as HDRI these will be floats, otherwise they will be integers.
 	 * @link https://php.net/manual/en/imagickpixel.getcolorquantum.php
 	 * @return mixed The quantum value of the color element. Float if ImageMagick was compiled with HDRI, otherwise an int.
+	 * @throws ImagickPixelException on failure
 	 * @since 3.3.0
 	 */
+	#[Pure]
 	public function getColorQuantum() { }
 
 	/**
@@ -6663,6 +7311,7 @@ class ImagickPixel  {
 	 *
 	 * @param ImagickPixel $srcPixel
 	 * @return bool
+	 * @throws ImagickPixelException on failure
 	 * @since 3.4.1
 	 */
 	public function setColorFromPixel(ImagickPixel $srcPixel) { }
@@ -6680,6 +7329,7 @@ class ImagickKernel {
 	 * @link https://php.net/manual/en/imagickkernel.addkernel.php
 	 * @param ImagickKernel $imagickKernel
 	 * @return void
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
 	public function addKernel(ImagickKernel $imagickKernel) { }
@@ -6688,6 +7338,7 @@ class ImagickKernel {
 	 * Adds a given amount of the 'Unity' Convolution Kernel to the given pre-scaled and normalized Kernel. This in effect adds that amount of the original image into the resulting convolution kernel. The resulting effect is to convert the defined kernels into blended soft-blurs, unsharp kernels or into sharpening kernels.
 	 * @link https://php.net/manual/en/imagickkernel.addunitykernel.php
 	 * @return void
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
 	public function addUnityKernel() { }
@@ -6711,6 +7362,7 @@ class ImagickKernel {
 	 * @param array $matrix A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or FALSE if that element shouldn't be used by the kernel.
 	 * @param array $origin [optional] Which element of the kernel should be used as the origin pixel. e.g. For a 3x3 matrix specifying the origin as [2, 2] would specify that the bottom right element should be the origin pixel.
 	 * @return ImagickKernel
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
 	public static function fromMatrix($matrix, $origin) { }
@@ -6719,8 +7371,10 @@ class ImagickKernel {
 	 * Get the 2d matrix of values used in this kernel. The elements are either float for elements that are used or 'false' if the element should be skipped.
 	 * @link https://php.net/manual/en/imagickkernel.getmatrix.php
 	 * @return array A matrix (2d array) of the values that represent the kernel.
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
+	#[Pure]
 	public function getMatrix() { }
 
 	/**
@@ -6730,6 +7384,7 @@ class ImagickKernel {
 	 * @link https://php.net/manual/en/imagickkernel.scale.php
 	 * @see https://www.imagemagick.org/api/morphology.php#ScaleKernelInfo
 	 * @return void
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
 	public function scale() { }
@@ -6738,6 +7393,7 @@ class ImagickKernel {
 	 * Separates a linked set of kernels and returns an array of ImagickKernels.
 	 * @link https://php.net/manual/en/imagickkernel.separate.php
 	 * @return void
+	 * @throws ImagickKernelException on error
 	 * @since 3.3.0
 	 */
 	public function seperate() { }

--- a/build/stubs/intl.php
+++ b/build/stubs/intl.php
@@ -2,6 +2,9 @@
 
 // Start of intl v.1.1.0
 
+use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\Pure;
+
 class Collator {
     const DEFAULT_VALUE = -1;
     const PRIMARY = 0;
@@ -37,7 +40,7 @@ class Collator {
      * F=ON cote &lt; côte &lt; coté &lt; côté
      * </p>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const FRENCH_COLLATION = 0;
 
@@ -82,7 +85,7 @@ class Collator {
      * S=4, A=S di Silva &lt; diSilva &lt; Di Silva &lt; U.S.A. &lt; USA
      * </p>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const ALTERNATE_HANDLING = 1;
 
@@ -116,7 +119,7 @@ class Collator {
      * C=U "China" &lt; "china" &lt; "Denmark" &lt; "denmark"
      * </p>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const CASE_FIRST = 2;
 
@@ -142,7 +145,7 @@ class Collator {
      * S=1, E=O role = rôle &lt; Role
      * </p>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const CASE_LEVEL = 3;
 
@@ -168,7 +171,7 @@ class Collator {
      * <b>Collator::ON</b>
      * <b>Collator::DEFAULT_VALUE</b>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const NORMALIZATION_MODE = 4;
 
@@ -186,12 +189,12 @@ class Collator {
      * Possible values are:
      * <b>Collator::PRIMARY</b>
      * <b>Collator::SECONDARY</b>
-     * <b>Collator::TERTIARY</b>(<default)
+     * <b>Collator::TERTIARY</b>(default)
      * <b>Collator::QUATERNARY</b>
      * <b>Collator::IDENTICAL</b>
      * <b>Collator::DEFAULT_VALUE</b>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const STRENGTH = 5;
 
@@ -210,7 +213,7 @@ class Collator {
      * <b>Collator::ON</b>
      * <b>Collator::DEFAULT_VALUE</b>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const HIRAGANA_QUATERNARY_MODE = 6;
 
@@ -226,7 +229,7 @@ class Collator {
      * <b>Collator::ON</b>
      * <b>Collator::DEFAULT_VALUE</b>
      * </p>
-     * @link https://php.net/manual/en/intl.collator-constants.php
+     * @link https://php.net/manual/en/class.collator.php#intl.collator-constants
      */
     const NUMERIC_COLLATION = 7;
     const SORT_REGULAR = 0;
@@ -240,6 +243,7 @@ class Collator {
      * @link https://php.net/manual/en/collator.construct.php
      * @param string $locale
      */
+    #[Pure]
     public function __construct($locale) { }
 
     /**
@@ -252,7 +256,7 @@ class Collator {
      * default locale collation rules will be used. If empty string ("") or
      * "root" are passed, UCA rules will be used.
      * </p>
-     * @return Collator Return new instance of <b>Collator</b> object, or <b>NULL</b>
+     * @return Collator|null Return new instance of <b>Collator</b> object, or <b>NULL</b>
      * on error.
      */
     public static function create($locale) { }
@@ -261,10 +265,10 @@ class Collator {
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Compare two Unicode strings
      * @link https://php.net/manual/en/collator.compare.php
-     * @param string $str1 <p>
+     * @param string $string1 <p>
      * The first string to compare.
      * </p>
-     * @param string $str2 <p>
+     * @param string $string2 <p>
      * The second string to compare.
      * </p>
      * @return int Return comparison result:</p>
@@ -286,73 +290,73 @@ class Collator {
      * <b>FALSE</b>
      * is returned.
      */
-    public function compare($str1, $str2) { }
+    #[Pure]
+    public function compare($string1, $string2) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Sort array using specified collator
      * @link https://php.net/manual/en/collator.sort.php
-     * @param array $arr <p>
+     * @param string[] &$array <p>
      * Array of strings to sort.
      * </p>
-     * @param int $sort_flag [optional] <p>
+     * @param int $flags [optional] <p>
      * Optional sorting type, one of the following:
      * </p>
-     * <p>
      * <p>
      * <b>Collator::SORT_REGULAR</b>
      * - compare items normally (don't change types)
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function sort(array &$arr, $sort_flag = null) { }
+    public function sort(array &$array, $flags = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Sort array using specified collator and sort keys
      * @link https://php.net/manual/en/collator.sortwithsortkeys.php
-     * @param array $arr <p>Array of strings to sort</p>
+     * @param string[] &$array <p>Array of strings to sort</p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function sortWithSortKeys(array &$arr) { }
+    public function sortWithSortKeys(array &$array) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Sort array maintaining index association
      * @link https://php.net/manual/en/collator.asort.php
-     * @param array $arr <p>Array of strings to sort.</p>
-     * @param int $sort_flag [optional] <p>
+     * @param string[] &$array <p>Array of strings to sort.</p>
+     * @param int $flags [optional] <p>
      * Optional sorting type, one of the following:
-     * <p>
      * <b>Collator::SORT_REGULAR</b>
      * - compare items normally (don't change types)
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function asort(array &$arr, $sort_flag = null) { }
+    public function asort(array &$array, $flags = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Get collation attribute value
      * @link https://php.net/manual/en/collator.getattribute.php
-     * @param int $attr <p>
+     * @param int $attribute <p>
      * Attribute to get value for.
      * </p>
      * @return int|false Attribute value, or boolean <b>FALSE</b> on error.
      */
-    public function getAttribute($attr) { }
+    #[Pure]
+    public function getAttribute($attribute) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Set collation attribute
      * @link https://php.net/manual/en/collator.setattribute.php
-     * @param int $attr <p>Attribute.</p>
-     * @param int $val <p>
+     * @param int $attribute <p>Attribute.</p>
+     * @param int $value <p>
      * Attribute value.
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setAttribute($attr, $val) { }
+    public function setAttribute($attribute, $value) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -360,6 +364,7 @@ class Collator {
      * @link https://php.net/manual/en/collator.getstrength.php
      * @return int|false current collation strength, or boolean <b>FALSE</b> on error.
      */
+    #[Pure]
     public function getStrength() { }
 
     /**
@@ -369,7 +374,6 @@ class Collator {
      * @param int $strength <p>Strength to set.</p>
      * <p>
      * Possible values are:
-     * <p>
      * <b>Collator::PRIMARY</b>
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -390,6 +394,7 @@ class Collator {
      * instantiated from rules or an error occurred, returns
      * boolean <b>FALSE</b>.
      */
+    #[Pure]
     public function getLocale($type = null) { }
 
     /**
@@ -398,6 +403,7 @@ class Collator {
      * @link https://php.net/manual/en/collator.geterrorcode.php
      * @return int Error code returned by the last Collator API function call.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -406,109 +412,113 @@ class Collator {
      * @link https://php.net/manual/en/collator.geterrormessage.php
      * @return string Description of an error occurred in the last Collator API function call.
      */
+    #[Pure]
     public function getErrorMessage() { }
 
     /**
      * (No version information available, might only be in SVN)<br/>
      * Get sorting key for a string
      * @link https://php.net/manual/en/collator.getsortkey.php
-     * @param string $str <p>
+     * @param string $string <p>
      * The string to produce the key from.
      * </p>
      * @return string the collation key for the string. Collation keys can be compared directly instead of strings.
      */
-    public function getSortKey($str) { }
+    #[Pure]
+    public function getSortKey($string) { }
 }
 
 class NumberFormatter {
 
+    const CURRENCY_ACCOUNTING = 12;
+
     /**
      * Decimal format defined by pattern
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PATTERN_DECIMAL = 0;
 
     /**
      * Decimal format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DECIMAL = 1;
 
     /**
      * Currency format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const CURRENCY = 2;
 
     /**
      * Percent format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PERCENT = 3;
 
     /**
      * Scientific format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const SCIENTIFIC = 4;
 
     /**
      * Spellout rule-based format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const SPELLOUT = 5;
 
     /**
      * Ordinal rule-based format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ORDINAL = 6;
 
     /**
      * Duration rule-based format
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DURATION = 7;
 
     /**
      * Rule-based format defined by pattern
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PATTERN_RULEBASED = 9;
 
     /**
      * Alias for PATTERN_DECIMAL
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const IGNORE = 0;
 
     /**
      * Default format for the locale
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DEFAULT_STYLE = 1;
 
     /**
      * Rounding mode to round towards positive infinity.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_CEILING = 0;
 
     /**
      * Rounding mode to round towards negative infinity.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_FLOOR = 1;
 
     /**
      * Rounding mode to round towards zero.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_DOWN = 2;
 
     /**
      * Rounding mode to round away from zero.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_UP = 3;
 
@@ -516,209 +526,209 @@ class NumberFormatter {
      * Rounding mode to round towards the "nearest neighbor" unless both
      * neighbors are equidistant, in which case, round towards the even
      * neighbor.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_HALFEVEN = 4;
 
     /**
      * Rounding mode to round towards "nearest neighbor" unless both neighbors
      * are equidistant, in which case round down.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_HALFDOWN = 5;
 
     /**
      * Rounding mode to round towards "nearest neighbor" unless both neighbors
      * are equidistant, in which case round up.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUND_HALFUP = 6;
 
     /**
      * Pad characters inserted before the prefix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PAD_BEFORE_PREFIX = 0;
 
     /**
      * Pad characters inserted after the prefix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PAD_AFTER_PREFIX = 1;
 
     /**
      * Pad characters inserted before the suffix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PAD_BEFORE_SUFFIX = 2;
 
     /**
      * Pad characters inserted after the suffix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PAD_AFTER_SUFFIX = 3;
 
     /**
      * Parse integers only.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PARSE_INT_ONLY = 0;
 
     /**
      * Use grouping separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const GROUPING_USED = 1;
 
     /**
      * Always show decimal point.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DECIMAL_ALWAYS_SHOWN = 2;
 
     /**
      * Maximum integer digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MAX_INTEGER_DIGITS = 3;
 
     /**
      * Minimum integer digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MIN_INTEGER_DIGITS = 4;
 
     /**
      * Integer digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const INTEGER_DIGITS = 5;
 
     /**
      * Maximum fraction digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MAX_FRACTION_DIGITS = 6;
 
     /**
      * Minimum fraction digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MIN_FRACTION_DIGITS = 7;
 
     /**
      * Fraction digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const FRACTION_DIGITS = 8;
 
     /**
      * Multiplier.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MULTIPLIER = 9;
 
     /**
      * Grouping size.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const GROUPING_SIZE = 10;
 
     /**
      * Rounding Mode.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUNDING_MODE = 11;
 
     /**
      * Rounding increment.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ROUNDING_INCREMENT = 12;
 
     /**
      * The width to which the output of format() is padded.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const FORMAT_WIDTH = 13;
 
     /**
      * The position at which padding will take place. See pad position
      * constants for possible argument values.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PADDING_POSITION = 14;
 
     /**
      * Secondary grouping size.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const SECONDARY_GROUPING_SIZE = 15;
 
     /**
      * Use significant digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const SIGNIFICANT_DIGITS_USED = 16;
 
     /**
      * Minimum significant digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MIN_SIGNIFICANT_DIGITS = 17;
 
     /**
      * Maximum significant digits.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MAX_SIGNIFICANT_DIGITS = 18;
 
     /**
      * Lenient parse mode used by rule-based formats.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const LENIENT_PARSE = 19;
 
     /**
      * Positive prefix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const POSITIVE_PREFIX = 0;
 
     /**
      * Positive suffix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const POSITIVE_SUFFIX = 1;
 
     /**
      * Negative prefix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const NEGATIVE_PREFIX = 2;
 
     /**
      * Negative suffix.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const NEGATIVE_SUFFIX = 3;
 
     /**
      * The character used to pad to the format width.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PADDING_CHARACTER = 4;
 
     /**
      * The ISO currency code.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const CURRENCY_CODE = 5;
 
     /**
      * The default rule set. This is only available with rule-based
      * formatters.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DEFAULT_RULESET = 6;
 
@@ -727,154 +737,156 @@ class NumberFormatter {
      * formatters. This is a read-only attribute. The public rulesets are
      * returned as a single string, with each ruleset name delimited by ';'
      * (semicolon).
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PUBLIC_RULESETS = 7;
 
     /**
      * The decimal separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DECIMAL_SEPARATOR_SYMBOL = 0;
 
     /**
      * The grouping separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const GROUPING_SEPARATOR_SYMBOL = 1;
 
     /**
      * The pattern separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PATTERN_SEPARATOR_SYMBOL = 2;
 
     /**
      * The percent sign.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PERCENT_SYMBOL = 3;
 
     /**
      * Zero.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const ZERO_DIGIT_SYMBOL = 4;
 
     /**
      * Character representing a digit in the pattern.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const DIGIT_SYMBOL = 5;
 
     /**
      * The minus sign.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MINUS_SIGN_SYMBOL = 6;
 
     /**
      * The plus sign.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PLUS_SIGN_SYMBOL = 7;
 
     /**
      * The currency symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const CURRENCY_SYMBOL = 8;
 
     /**
      * The international currency symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const INTL_CURRENCY_SYMBOL = 9;
 
     /**
      * The monetary separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MONETARY_SEPARATOR_SYMBOL = 10;
 
     /**
      * The exponential symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const EXPONENTIAL_SYMBOL = 11;
 
     /**
      * Per mill symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PERMILL_SYMBOL = 12;
 
     /**
      * Escape padding character.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const PAD_ESCAPE_SYMBOL = 13;
 
     /**
      * Infinity symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const INFINITY_SYMBOL = 14;
 
     /**
      * Not-a-number symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const NAN_SYMBOL = 15;
 
     /**
      * Significant digit symbol.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const SIGNIFICANT_DIGIT_SYMBOL = 16;
 
     /**
      * The monetary grouping separator.
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const MONETARY_GROUPING_SEPARATOR_SYMBOL = 17;
 
     /**
      * Derive the type from variable type
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const TYPE_DEFAULT = 0;
 
     /**
      * Format/parse as 32-bit integer
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const TYPE_INT32 = 1;
 
     /**
      * Format/parse as 64-bit integer
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const TYPE_INT64 = 2;
 
     /**
      * Format/parse as floating point value
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const TYPE_DOUBLE = 3;
 
     /**
      * Format/parse as currency value
-     * @link https://php.net/manual/en/intl.numberformatter-constants.php
+     * @link https://php.net/manual/en/class.locale.php#intl.locale-constants
      */
     const TYPE_CURRENCY = 4;
 
 
     /**
-     * @param $locale
-     * @param $style
-     * @param $pattern [optional]
+     * @link https://www.php.net/manual/en/class.numberformatter.php
+     * @param string $locale
+     * @param int $style
+     * @param string $pattern [optional]
      */
+    #[Pure]
     public function __construct($locale, $style, $pattern = null) { }
 
     /**
@@ -907,7 +919,7 @@ class NumberFormatter {
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Format a number
      * @link https://php.net/manual/en/numberformatter.format.php
-     * @param int|float $value <p>
+     * @param int|float $num <p>
      * The value to format. Can be integer or float,
      * other values will be converted to a numeric value.
      * </p>
@@ -917,31 +929,32 @@ class NumberFormatter {
      * </p>
      * @return string|false the string containing formatted value, or <b>FALSE</b> on error.
      */
-    public function format($value, $type = null) { }
+    #[Pure]
+    public function format($num, $type = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Parse a number
      * @link https://php.net/manual/en/numberformatter.parse.php
-     * @param string $value
+     * @param string $string
      * @param int $type [optional] <p>
      * The
      * formatting type to use. By default,
      * <b>NumberFormatter::TYPE_DOUBLE</b> is used.
      * </p>
-     * @param int $position [optional] <p>
+     * @param int &$offset [optional] <p>
      * Offset in the string at which to begin parsing. On return, this value
      * will hold the offset at which parsing ended.
      * </p>
      * @return mixed The value of the parsed number or <b>FALSE</b> on error.
      */
-    public function parse($value, $type = null, &$position = null) { }
+    public function parse($string, $type = NumberFormatter::TYPE_DOUBLE, &$offset = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Format a currency value
      * @link https://php.net/manual/en/numberformatter.formatcurrency.php
-     * @param float $value <p>
+     * @param float $amount <p>
      * The numeric currency value.
      * </p>
      * @param string $currency <p>
@@ -949,30 +962,31 @@ class NumberFormatter {
      * </p>
      * @return string String representing the formatted currency value.
      */
-    public function formatCurrency($value, $currency) { }
+    #[Pure]
+    public function formatCurrency($amount, $currency) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Parse a currency number
      * @link https://php.net/manual/en/numberformatter.parsecurrency.php
-     * @param string $value
-     * @param string $currency <p>
+     * @param string $string
+     * @param string &$currency <p>
      * Parameter to receive the currency name (3-letter ISO 4217 currency
      * code).
      * </p>
-     * @param int $position [optional] <p>
+     * @param int &$offset [optional] <p>
      * Offset in the string at which to begin parsing. On return, this value
      * will hold the offset at which parsing ended.
      * </p>
      * @return float|false The parsed numeric value or <b>FALSE</b> on error.
      */
-    public function parseCurrency($value, &$currency, &$position = null) { }
+    public function parseCurrency($string, &$currency, &$offset = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Set an attribute
      * @link https://php.net/manual/en/numberformatter.setattribute.php
-     * @param int $attr <p>
+     * @param int $attribute <p>
      * Attribute specifier - one of the
      * numeric attribute constants.
      * </p>
@@ -981,25 +995,26 @@ class NumberFormatter {
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setAttribute($attr, $value) { }
+    public function setAttribute($attribute, $value) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Get an attribute
      * @link https://php.net/manual/en/numberformatter.getattribute.php
-     * @param int $attr <p>
+     * @param int $attribute <p>
      * Attribute specifier - one of the
      * numeric attribute constants.
      * </p>
      * @return int|false Return attribute value on success, or <b>FALSE</b> on error.
      */
-    public function getAttribute($attr) { }
+    #[Pure]
+    public function getAttribute($attribute) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Set a text attribute
      * @link https://php.net/manual/en/numberformatter.settextattribute.php
-     * @param int $attr <p>
+     * @param int $attribute <p>
      * Attribute specifier - one of the
      * text attribute
      * constants.
@@ -1009,25 +1024,26 @@ class NumberFormatter {
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setTextAttribute($attr, $value) { }
+    public function setTextAttribute($attribute, $value) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Get a text attribute
      * @link https://php.net/manual/en/numberformatter.gettextattribute.php
-     * @param int $attr <p>
+     * @param int $attribute <p>
      * Attribute specifier - one of the
      * text attribute constants.
      * </p>
      * @return string|false Return attribute value on success, or <b>FALSE</b> on error.
      */
-    public function getTextAttribute($attr) { }
+    #[Pure]
+    public function getTextAttribute($attribute) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Set a symbol value
      * @link https://php.net/manual/en/numberformatter.setsymbol.php
-     * @param int $attr <p>
+     * @param int $symbol <p>
      * Symbol specifier, one of the
      * format symbol constants.
      * </p>
@@ -1036,19 +1052,20 @@ class NumberFormatter {
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setSymbol($attr, $value) { }
+    public function setSymbol($symbol, $value) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Get a symbol value
      * @link https://php.net/manual/en/numberformatter.getsymbol.php
-     * @param int $attr <p>
+     * @param int $symbol <p>
      * Symbol specifier, one of the
      * format symbol constants.
      * </p>
      * @return string|false The symbol string or <b>FALSE</b> on error.
      */
-    public function getSymbol($attr) { }
+    #[Pure]
+    public function getSymbol($symbol) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1069,6 +1086,7 @@ class NumberFormatter {
      * @link https://php.net/manual/en/numberformatter.getpattern.php
      * @return string|false Pattern string that is used by the formatter, or <b>FALSE</b> if an error happens.
      */
+    #[Pure]
     public function getPattern() { }
 
     /**
@@ -1083,6 +1101,7 @@ class NumberFormatter {
      * </p>
      * @return string The locale name used to create the formatter.
      */
+    #[Pure]
     public function getLocale($type = null) { }
 
     /**
@@ -1091,6 +1110,7 @@ class NumberFormatter {
      * @link https://php.net/manual/en/numberformatter.geterrorcode.php
      * @return int error code from last formatter call.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -1099,89 +1119,103 @@ class NumberFormatter {
      * @link https://php.net/manual/en/numberformatter.geterrormessage.php
      * @return string error message from last formatter call.
      */
+    #[Pure]
     public function getErrorMessage() { }
 }
 
 class Normalizer {
 
+    const NFKC_CF = 48;
+
+    const FORM_KC_CF = 48;
+
     /**
      * Default normalization options
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      */
     const OPTION_DEFAULT = "";
 
     /**
      * No decomposition/composition
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      * @removed 8.0
      */
     const NONE = "1";
 
     /**
      * Normalization Form D (NFD) - Canonical Decomposition
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      */
-    const FORM_D = "2";
-    const NFD = 2;
+    const FORM_D = 4;
+    const NFD = 4;
 
     /**
      * Normalization Form KD (NFKD) - Compatibility Decomposition
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      */
-    const FORM_KD = "3";
-    const NFKD = 3;
+    const FORM_KD = 8;
+    const NFKD = 8;
 
     /**
      * Normalization Form C (NFC) - Canonical Decomposition followed by
      * Canonical Composition
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      */
-    const FORM_C = "4";
-    const NFC = 4;
+    const FORM_C = 16;
+    const NFC = 16;
 
     /**
      * Normalization Form KC (NFKC) - Compatibility Decomposition, followed by
      * Canonical Composition
-     * @link https://www.php.net/manual/en/class.normalizer.php
+     * @link https://secure.php.net/manual/en/class.normalizer.php
      */
-    const FORM_KC = "5";
-    const NFKC = 5;
+    const FORM_KC = 32;
+    const NFKC = 32;
 
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Normalizes the input provided and returns the normalized string
      * @link https://php.net/manual/en/normalizer.normalize.php
-     * @param string $input <p>The input string to normalize</p>
-     * @param string $form [optional] <p>One of the normalization forms.</p>
-     * @return string The normalized string or <b>NULL</b> if an error occurred.
+     * @param string $string <p>The input string to normalize</p>
+     * @param int $form [optional] <p>One of the normalization forms.</p>
+     * @return string|false The normalized string or <b>FALSE</b> if an error occurred.
      */
-    public static function normalize($input, $form = Normalizer::FORM_C) { }
+    public static function normalize($string, $form = Normalizer::FORM_C) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Checks if the provided string is already in the specified normalization form.
      * @link https://php.net/manual/en/normalizer.isnormalized.php
-     * @param string $input <p>The input string to normalize</p>
-     * @param string $form [optional] <p>
+     * @param string $string <p>The input string to normalize</p>
+     * @param int $form [optional] <p>
      * One of the normalization forms.
      * </p>
      * @return bool <b>TRUE</b> if normalized, <b>FALSE</b> otherwise or if there an error
      */
-    public static function isNormalized($input, $form = Normalizer::FORM_C) { }
+    public static function isNormalized($string, $form = Normalizer::FORM_C) { }
+
+    /**
+     * @link https://www.php.net/manual/en/normalizer.getrawdecomposition.php
+     * @param string $string <p>The input string to normalize</p>
+     * @param string $form [optional]
+     * @return string|null <p>Returns a string containing the Decomposition_Mapping property, if present in the UCD.
+     * Returns null if there is no Decomposition_Mapping property for the character.</p>
+     */
+    public static function getRawDecomposition(string $string, $form = 16) {}
 }
 
 class Locale {
 
     /**
      * This is locale the data actually comes from.
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const ACTUAL_LOCALE = 0;
 
     /**
      * This is the most specific locale supported by ICU.
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const VALID_LOCALE = 1;
 
@@ -1189,49 +1223,49 @@ class Locale {
      * Used as locale parameter with the methods of the various locale affected classes,
      * such as NumberFormatter. This constant would make the methods to use default
      * locale.
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const DEFAULT_LOCALE = null;
 
     /**
      * Language subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const LANG_TAG = "language";
 
     /**
      * Extended language subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const EXTLANG_TAG = "extlang";
 
     /**
      * Script subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const SCRIPT_TAG = "script";
 
     /**
      * Region subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const REGION_TAG = "region";
 
     /**
      * Variant subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const VARIANT_TAG = "variant";
 
     /**
      * Grandfathered Language subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const GRANDFATHERED_LANG_TAG = "grandfathered";
 
     /**
      * Private subtag
-     * @link https://php.net/manual/en/intl.locale-constants.php
+     * @link https://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants
      */
     const PRIVATE_TAG = "private";
 
@@ -1262,7 +1296,7 @@ class Locale {
      * @param string $locale <p>
      * The locale to extract the primary language code from
      * </p>
-     * @return string The language code associated with the language or <b>NULL</b> in case of error.
+     * @return string|null The language code associated with the language or <b>NULL</b> in case of error.
      */
     public static function getPrimaryLanguage($locale) { }
 
@@ -1273,7 +1307,7 @@ class Locale {
      * @param string $locale <p>
      * The locale to extract the script code from
      * </p>
-     * @return string The script subtag for the locale or <b>NULL</b> if not present
+     * @return string|null The script subtag for the locale or <b>NULL</b> if not present
      */
     public static function getScript($locale) { }
 
@@ -1284,7 +1318,7 @@ class Locale {
      * @param string $locale <p>
      * The locale to extract the region code from
      * </p>
-     * @return string The region subtag for the locale or <b>NULL</b> if not present
+     * @return string|null The region subtag for the locale or <b>NULL</b> if not present
      */
     public static function getRegion($locale) { }
 
@@ -1306,13 +1340,13 @@ class Locale {
      * @param string $locale <p>
      * The locale to return a display script for
      * </p>
-     * @param string $in_locale [optional] <p>
+     * @param string $displayLocale [optional] <p>
      * Optional format locale to use to display the script name
      * </p>
      * @return string Display name of the script for the $locale in the format appropriate for
      * $in_locale.
      */
-    public static function getDisplayScript($locale, $in_locale = null) { }
+    public static function getDisplayScript($locale, $displayLocale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1321,13 +1355,13 @@ class Locale {
      * @param string $locale <p>
      * The locale to return a display region for.
      * </p>
-     * @param string $in_locale [optional] <p>
+     * @param string $displayLocale [optional] <p>
      * Optional format locale to use to display the region name
      * </p>
      * @return string display name of the region for the $locale in the format appropriate for
      * $in_locale.
      */
-    public static function getDisplayRegion($locale, $in_locale = null) { }
+    public static function getDisplayRegion($locale, $displayLocale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1336,10 +1370,10 @@ class Locale {
      * @param string $locale <p>
      * The locale to return a display name for.
      * </p>
-     * @param string $in_locale [optional] <p>optional format locale</p>
+     * @param string $displayLocale [optional] <p>optional format locale</p>
      * @return string Display name of the locale in the format appropriate for $in_locale.
      */
-    public static function getDisplayName($locale, $in_locale = null) { }
+    public static function getDisplayName($locale, $displayLocale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1348,13 +1382,13 @@ class Locale {
      * @param string $locale <p>
      * The locale to return a display language for
      * </p>
-     * @param string $in_locale [optional] <p>
+     * @param string $displayLocale [optional] <p>
      * Optional format locale to use to display the language name
      * </p>
      * @return string display name of the language for the $locale in the format appropriate for
      * $in_locale.
      */
-    public static function getDisplayLanguage($locale, $in_locale = null) { }
+    public static function getDisplayLanguage($locale, $displayLocale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1363,13 +1397,13 @@ class Locale {
      * @param string $locale <p>
      * The locale to return a display variant for
      * </p>
-     * @param string $in_locale [optional] <p>
+     * @param string $displayLocale [optional] <p>
      * Optional format locale to use to display the variant name
      * </p>
      * @return string Display name of the variant for the $locale in the format appropriate for
      * $in_locale.
      */
-    public static function getDisplayVariant($locale, $in_locale = null) { }
+    public static function getDisplayVariant($locale, $displayLocale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1422,7 +1456,7 @@ class Locale {
      * @param string $locale <p>
      * The locale to extract the variants from
      * </p>
-     * @return array The array containing the list of all variants subtag for the locale
+     * @return array|null The array containing the list of all variants subtag for the locale
      * or <b>NULL</b> if not present
      */
     public static function getAllVariants($locale) { }
@@ -1431,7 +1465,7 @@ class Locale {
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Checks if a language tag filter matches with locale
      * @link https://php.net/manual/en/locale.filtermatches.php
-     * @param string $langtag <p>
+     * @param string $languageTag <p>
      * The language tag to check
      * </p>
      * @param string $locale <p>
@@ -1443,13 +1477,13 @@ class Locale {
      * </p>
      * @return bool <b>TRUE</b> if $locale matches $langtag <b>FALSE</b> otherwise.
      */
-    public static function filterMatches($langtag, $locale, $canonicalize = false) { }
+    public static function filterMatches($languageTag, $locale, $canonicalize = false) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Searches the language tag list for the best match to the language
      * @link https://php.net/manual/en/locale.lookup.php
-     * @param array $langtag <p>
+     * @param array $languageTag <p>
      * An array containing a list of language tags to compare to
      * <i>locale</i>. Maximum 100 items allowed.
      * </p>
@@ -1460,12 +1494,12 @@ class Locale {
      * If true, the arguments will be converted to canonical form before
      * matching.
      * </p>
-     * @param string $default [optional] <p>
+     * @param string $defaultLocale [optional] <p>
      * The locale to use if no match is found.
      * </p>
      * @return string The closest matching language tag or default value.
      */
-    public static function lookup(array $langtag, $locale, $canonicalize = false, $default = null) { }
+    public static function lookup(array $languageTag, $locale, $canonicalize = false, $defaultLocale = null) { }
 
     /**
      * @link https://php.net/manual/en/locale.canonicalize.php
@@ -1502,6 +1536,7 @@ class MessageFormatter {
      * before being interpreted.
      * </p>
      */
+    #[Pure]
     public function __construct($locale, $pattern) { }
 
     /**
@@ -1525,12 +1560,13 @@ class MessageFormatter {
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Format the message
      * @link https://php.net/manual/en/messageformatter.format.php
-     * @param array $args <p>
+     * @param array $values <p>
      * Arguments to insert into the format string
      * </p>
      * @return string|false The formatted string, or <b>FALSE</b> if an error occurred
      */
-    public function format(array $args) { }
+    #[Pure]
+    public function format(array $values) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1545,23 +1581,24 @@ class MessageFormatter {
      * umsg_autoQuoteApostrophe
      * before being interpreted.
      * </p>
-     * @param array $args <p>
+     * @param array $values <p>
      * The array of values to insert into the format string
      * </p>
      * @return string|false The formatted pattern string or <b>FALSE</b> if an error occurred
      */
-    public static function formatMessage($locale, $pattern, array $args) { }
+    public static function formatMessage($locale, $pattern, array $values) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Parse input string according to pattern
      * @link https://php.net/manual/en/messageformatter.parse.php
-     * @param string $value <p>
+     * @param string $string <p>
      * The string to parse
      * </p>
      * @return array|false An array containing the items extracted, or <b>FALSE</b> on error
      */
-    public function parse($value) { }
+    #[Pure]
+    public function parse($string) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1573,12 +1610,12 @@ class MessageFormatter {
      * @param string $pattern <p>
      * The pattern with which to parse the <i>value</i>.
      * </p>
-     * @param string $source <p>
+     * @param string $message <p>
      * The string to parse, conforming to the <i>pattern</i>.
      * </p>
      * @return array|false An array containing items extracted, or <b>FALSE</b> on error
      */
-    public static function parseMessage($locale, $pattern, $source) { }
+    public static function parseMessage($locale, $pattern, $message) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1600,6 +1637,7 @@ class MessageFormatter {
      * @link https://php.net/manual/en/messageformatter.getpattern.php
      * @return string The pattern string for this message formatter
      */
+    #[Pure]
     public function getPattern() { }
 
     /**
@@ -1608,6 +1646,7 @@ class MessageFormatter {
      * @link https://php.net/manual/en/messageformatter.getlocale.php
      * @return string The locale name
      */
+    #[Pure]
     public function getLocale() { }
 
     /**
@@ -1616,6 +1655,7 @@ class MessageFormatter {
      * @link https://php.net/manual/en/messageformatter.geterrorcode.php
      * @return int The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -1624,6 +1664,7 @@ class MessageFormatter {
      * @link https://php.net/manual/en/messageformatter.geterrormessage.php
      * @return string Description of the last error.
      */
+    #[Pure]
     public function getErrorMessage() { }
 }
 
@@ -1671,21 +1712,22 @@ class IntlDateFormatter {
      */
     const TRADITIONAL = 0;
 
-    const RELATIVE_FULL = 0;
-    const RELATIVE_LONG = 1;
-    const RELATIVE_MEDIUM = 2;
-    const RELATIVE_SHORT = 3;
+    const RELATIVE_FULL = 128;
+    const RELATIVE_LONG = 129;
+    const RELATIVE_MEDIUM = 130;
+    const RELATIVE_SHORT = 131;
 
 
     /**
      * @param string|null $locale
-     * @param int $datetype
-     * @param int $timetype
+     * @param int $dateType
+     * @param int $timeType
      * @param mixed|null $timezone [optional]
      * @param mixed|null $calendar [optional]
      * @param string $pattern [optional]
      */
-    public function __construct($locale, $datetype, $timetype, $timezone = null, $calendar = null, $pattern = '') { }
+    #[Pure]
+    public function __construct($locale, $dateType, $timeType, $timezone = null, $calendar = null, $pattern = '') { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1694,14 +1736,14 @@ class IntlDateFormatter {
      * @param string $locale <p>
      * Locale to use when formatting or parsing; default is specified in the ini setting intl.default_locale.
      * </p>
-     * @param int $datetype <p>
+     * @param int $dateType <p>
      * Date type to use (<b>none</b>,
      * <b>short</b>, <b>medium</b>,
      * <b>long</b>, <b>full</b>).
      * This is one of the
      * IntlDateFormatter constants.
      * </p>
-     * @param int $timetype <p>
+     * @param int $timeType <p>
      * Time type to use (<b>none</b>,
      * <b>short</b>, <b>medium</b>,
      * <b>long</b>, <b>full</b>).
@@ -1722,7 +1764,7 @@ class IntlDateFormatter {
      * </p>
      * @return IntlDateFormatter
      */
-    public static function create($locale, $datetype, $timetype, $timezone = null, $calendar = null, $pattern = '') { }
+    public static function create($locale, $dateType, $timeType, $timezone = null, $calendar = null, $pattern = '') { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1730,6 +1772,7 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.getdatetype.php
      * @return int The current date type value of the formatter.
      */
+    #[Pure]
     public function getDateType() { }
 
     /**
@@ -1738,6 +1781,7 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.gettimetype.php
      * @return int The current date type value of the formatter.
      */
+    #[Pure]
     public function getTimeType() { }
 
     /**
@@ -1746,19 +1790,20 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.getcalendar.php
      * @return int The calendar being used by the formatter.
      */
+    #[Pure]
     public function getCalendar() { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * sets the calendar used to the appropriate calendar, which must be
      * @link https://php.net/manual/en/intldateformatter.setcalendar.php
-     * @param int $which <p>
+     * @param int $calendar <p>
      * The calendar to use.
      * Default is <b>IntlDateFormatter::GREGORIAN</b>.
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setCalendar($which) { }
+    public function setCalendar($calendar) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1766,22 +1811,25 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.gettimezoneid.php
      * @return string ID string for the time zone used by this formatter.
      */
+    #[Pure]
     public function getTimeZoneId() { }
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
      * Get copy of formatter's calendar object
-     * @link https://www.php.net/manual/en/intldateformatter.getcalendarobject.php
+     * @link https://secure.php.net/manual/en/intldateformatter.getcalendarobject.php
      * @return IntlCalendar A copy of the internal calendar object used by this formatter.
      */
+    #[Pure]
     public function getCalendarObject() { }
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
      *  Get formatter's timezone
-     * @link https://www.php.net/manual/en/intldateformatter.gettimezone.php
+     * @link https://secure.php.net/manual/en/intldateformatter.gettimezone.php
      * @return IntlTimeZone|false The associated IntlTimeZone object or FALSE on failure.
      */
+    #[Pure]
     public function getTimeZone() { }
 
     /**
@@ -1793,42 +1841,43 @@ class IntlDateFormatter {
      * If <b>NULL</b> or the empty string, the default time zone for the runtime is used.
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-     * @deprecated 5.5 https://www.php.net/manual/en/migration55.deprecated.php
      * @removed 7.0
+     * @see IntlDateFormatter::setTimeZone()
      */
+    #[Deprecated(replacement: "%class%->setTimeZone(%parametersList%)" ,since: "5.5")]
     public function setTimeZoneId($zone) { }
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
      * Sets formatter's timezone
      * @link https://php.net/manual/en/intldateformatter.settimezone.php
-     * @param mixed $zone <p>
+     * @param mixed $timezone <p>
      * The timezone to use for this formatter. This can be specified in the
      * following forms:
      * <ul>
      * <li>
      * <p>
      * <b>NULL</b>, in which case the default timezone will be used, as specified in
-     * the ini setting {@link "https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone" date.timezone} or
-     * through the function  {@link "https://www.php.net/manual/en/function.date-default-timezone-set.php" date_default_timezone_set()} and as
-     * returned by {@link "https://www.php.net/manual/en/function.date-default-timezone-get.php" date_default_timezone_get()}.
+     * the ini setting {@link "https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone" date.timezone} or
+     * through the function  {@link "https://secure.php.net/manual/en/function.date-default-timezone-set.php" date_default_timezone_set()} and as
+     * returned by {@link "https://secure.php.net/manual/en/function.date-default-timezone-get.php" date_default_timezone_get()}.
      * </p>
      * </li>
      * <li>
      * <p>
-     * An {@link "https://www.php.net/manual/en/class.intltimezone.php" IntlTimeZone}, which will be used directly.
+     * An {@link "https://secure.php.net/manual/en/class.intltimezone.php" IntlTimeZone}, which will be used directly.
      * </p>
      * </li>
      * <li>
      * <p>
-     * A {@link "https://www.php.net/manual/en/class.datetimezone.php" DateTimeZone}. Its identifier will be extracted
+     * A {@link "https://secure.php.net/manual/en/class.datetimezone.php" DateTimeZone}. Its identifier will be extracted
      * and an ICU timezone object will be created; the timezone will be backed
      * by ICU's database, not PHP's.
      * </p>
      * </li>
-     *<li>
+     * <li>
      * <p>
-     * A {@link "https://www.php.net/manual/en/language.types.string.php" string}, which should be a valid ICU timezone identifier.
+     * A {@link "https://secure.php.net/manual/en/language.types.string.php" string}, which should be a valid ICU timezone identifier.
      * See <b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw offsets such as <em>"GMT+08:30"</em> are also accepted.
      * </p>
      * </li>
@@ -1836,7 +1885,7 @@ class IntlDateFormatter {
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function setTimeZone($zone) { }
+    public function setTimeZone($timezone) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1857,16 +1906,18 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.getpattern.php
      * @return string The pattern string being used to format/parse.
      */
+    #[Pure]
     public function getPattern() { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Get the locale used by formatter
      * @link https://php.net/manual/en/intldateformatter.getlocale.php
-     * @param int $which [optional]
+     * @param int $type [optional]
      * @return string|false the locale of this formatter or 'false' if error
      */
-    public function getLocale($which = null) { }
+    #[Pure]
+    public function getLocale($type = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1885,13 +1936,14 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.islenient.php
      * @return bool <b>TRUE</b> if parser is lenient, <b>FALSE</b> if parser is strict. By default the parser is lenient.
      */
+    #[Pure]
     public function isLenient() { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Format the date/time value as a string
      * @link https://php.net/manual/en/intldateformatter.format.php
-     * @param mixed $value <p>
+     * @param mixed $datetime <p>
      * Value to format. This may be a <b>DateTime</b> object,
      * an integer representing a Unix timestamp value (seconds
      * since epoch, UTC) or an array in the format output by
@@ -1899,17 +1951,17 @@ class IntlDateFormatter {
      * </p>
      * @return string|false The formatted string or, if an error occurred, <b>FALSE</b>.
      */
-    public function format($value) { }
+    public function format($datetime) { }
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
      * Formats an object
-     * @link https://www.php.net/manual/en/intldateformatter.formatobject.php
-     * @param object $object <p>
-     * An object of type {@link "https://www.php.net/manual/en/class.intlcalendar.php" IntlCalendar} or {@link "https://www.php.net/manual/en/class.datetime.php" DateTime}. The timezone information in the object will be used.
+     * @link https://secure.php.net/manual/en/intldateformatter.formatobject.php
+     * @param object $datetime <p>
+     * An object of type {@link "https://secure.php.net/manual/en/class.intlcalendar.php" IntlCalendar} or {@link "https://secure.php.net/manual/en/class.datetime.php" DateTime}. The timezone information in the object will be used.
      * </p>
      * @param mixed $format [optional] <p>
-     * How to format the date/time. This can either be an {@link "https://www.php.net/manual/en/language.types.array.php" array} with
+     * How to format the date/time. This can either be an {@link "https://secure.php.net/manual/en/language.types.array.php" array} with
      * two elements (first the date style, then the time style, these being one
      * of the constants <b>IntlDateFormatter::NONE</b>,
      * <b>IntlDateFormatter::SHORT</b>,
@@ -1917,24 +1969,24 @@ class IntlDateFormatter {
      * <b>IntlDateFormatter::LONG</b>,
      * <b>IntlDateFormatter::FULL</b>), a long with
      * the value of one of these constants (in which case it will be used both
-     * for the time and the date) or a {@link "https://www.php.net/manual/en/language.types.string.php" string} with the format
+     * for the time and the date) or a {@link "https://secure.php.net/manual/en/language.types.string.php" string} with the format
      * described in {@link "http://www.icu-project.org/apiref/icu4c/classSimpleDateFormat.html#details" the ICU documentation}.
-     * If <br>NULL</br>, the default style will be used.
+     * If <b>NULL</b>, the default style will be used.
      * </p>
-     * @param string $locale [optional] <p>
-     * The locale to use, or <b>NULL</b> to use the {@link "https://www.php.net/manual/en/intl.configuration.php#ini.intl.default-locale"default one}.</p>
+     * @param string|null $locale [optional] <p>
+     * The locale to use, or <b>NULL</b> to use the {@link "https://secure.php.net/manual/en/intl.configuration.php#ini.intl.default-locale" default one}.</p>
      * @return string|false A string with result or <b>FALSE</b> on failure.
      */
-    public static function formatObject($object, $format = null, $locale = null) { }
+    public static function formatObject($datetime, $format = null, $locale = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Parse string to a timestamp value
      * @link https://php.net/manual/en/intldateformatter.parse.php
-     * @param string $value <p>
+     * @param string $string <p>
      * string to convert to a time
      * </p>
-     * @param int $position [optional] <p>
+     * @param int &$offset [optional] <p>
      * Position at which to start the parsing in $value (zero-based).
      * If no error occurs before $value is consumed, $parse_pos will contain -1
      * otherwise it will contain the position at which parsing ended (and the error occurred).
@@ -1943,16 +1995,16 @@ class IntlDateFormatter {
      * </p>
      * @return int timestamp parsed value
      */
-    public function parse($value, &$position = null) { }
+    public function parse($string, &$offset = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Parse string to a field-based time value
      * @link https://php.net/manual/en/intldateformatter.localtime.php
-     * @param string $value <p>
+     * @param string $string <p>
      * string to convert to a time
      * </p>
-     * @param int $position [optional] <p>
+     * @param int &$offset [optional] <p>
      * Position at which to start the parsing in $value (zero-based).
      * If no error occurs before $value is consumed, $parse_pos will contain -1
      * otherwise it will contain the position at which parsing ended .
@@ -1960,7 +2012,7 @@ class IntlDateFormatter {
      * </p>
      * @return array Localtime compatible array of integers : contains 24 hour clock value in tm_hour field
      */
-    public function localtime($value, &$position = null) { }
+    public function localtime($string, &$offset = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1968,6 +2020,7 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.geterrorcode.php
      * @return int The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -1976,17 +2029,20 @@ class IntlDateFormatter {
      * @link https://php.net/manual/en/intldateformatter.geterrormessage.php
      * @return string Description of the last error.
      */
+    #[Pure]
     public function getErrorMessage() { }
 }
 
-class ResourceBundle implements IteratorAggregate {
+class ResourceBundle implements IteratorAggregate, Countable {
 
     /**
-     * @param $locale
-     * @param $bundlename
-     * @param $fallback [optional]
+     * @link https://www.php.net/manual/en/resourcebundle.create.php
+     * @param string $locale <p>Locale for which the resources should be loaded (locale name, e.g. en_CA).</p>
+     * @param string $bundle <p>The directory where the data is stored or the name of the .dat file.</p>
+     * @param bool $fallback [optional] <p>Whether locale should match exactly or fallback to parent locale is allowed.</p>
      */
-    public function __construct($locale, $bundlename, $fallback) { }
+    #[Pure]
+    public function __construct($locale, $bundle, $fallback = true) { }
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -1995,7 +2051,7 @@ class ResourceBundle implements IteratorAggregate {
      * @param string $locale <p>
      * Locale for which the resources should be loaded (locale name, e.g. en_CA).
      * </p>
-     * @param string $bundlename <p>
+     * @param string $bundle <p>
      * The directory where the data is stored or the name of the .dat file.
      * </p>
      * @param bool $fallback [optional] <p>
@@ -2003,7 +2059,7 @@ class ResourceBundle implements IteratorAggregate {
      * </p>
      * @return ResourceBundle|false <b>ResourceBundle</b> object or <b>FALSE</b> on error.
      */
-    public static function create($locale, $bundlename, $fallback = null) { }
+    public static function create($locale, $bundle, $fallback = true) { }
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2012,11 +2068,13 @@ class ResourceBundle implements IteratorAggregate {
      * @param string|int $index <p>
      * Data index, must be string or integer.
      * </p>
+     * @param bool $fallback
      * @return mixed the data located at the index or <b>NULL</b> on error. Strings, integers and binary data strings
      * are returned as corresponding PHP types, integer array is returned as PHP array. Complex types are
      * returned as <b>ResourceBundle</b> object.
      */
-    public function get($index) { }
+    #[Pure]
+    public function get($index, $fallback = true) { }
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2024,19 +2082,20 @@ class ResourceBundle implements IteratorAggregate {
      * @link https://php.net/manual/en/resourcebundle.count.php
      * @return int number of elements in the bundle.
      */
+    #[Pure]
     public function count() { }
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
      * Get supported locales
      * @link https://php.net/manual/en/resourcebundle.locales.php
-     * @param string $bundlename <p>
+     * @param string $bundle <p>
      * Path of ResourceBundle for which to get available locales, or
      * empty string for default locales list.
      * </p>
      * @return array the list of locales supported by the bundle.
      */
-    public static function getLocales($bundlename) { }
+    public static function getLocales($bundle) { }
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2044,6 +2103,7 @@ class ResourceBundle implements IteratorAggregate {
      * @link https://php.net/manual/en/resourcebundle.geterrorcode.php
      * @return int error code from last bundle object call.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -2052,11 +2112,14 @@ class ResourceBundle implements IteratorAggregate {
      * @link https://php.net/manual/en/resourcebundle.geterrormessage.php
      * @return string error message from last bundle object's call.
      */
+    #[Pure]
     public function getErrorMessage() { }
 
     /**
      * @since 8.0
+     * @return Traversable
      */
+    #[Pure]
     public function getIterator(){}
 }
 
@@ -2086,11 +2149,11 @@ class Transliterator {
      * </p>
      * @param int $direction [optional] <p>
      * The direction, defaults to
-     * >Transliterator::FORWARD.
+     * Transliterator::FORWARD.
      * May also be set to
      * Transliterator::REVERSE.
      * </p>
-     * @return Transliterator a <b>Transliterator</b> object on success,
+     * @return Transliterator|null a <b>Transliterator</b> object on success,
      * or <b>NULL</b> on failure.
      */
     public static function create($id, $direction = null) { }
@@ -2102,13 +2165,13 @@ class Transliterator {
      * @param string $rules <p>
      * The rules.
      * </p>
-     * @param string $direction [optional] <p>
+     * @param int $direction [optional] <p>
      * The direction, defaults to
-     * >Transliterator::FORWARD.
+     * {@see Transliterator::FORWARD}.
      * May also be set to
-     * Transliterator::REVERSE.
+     * {@see Transliterator::REVERSE}.
      * </p>
-     * @return Transliterator a <b>Transliterator</b> object on success,
+     * @return Transliterator|null a <b>Transliterator</b> object on success,
      * or <b>NULL</b> on failure.
      */
     public static function createFromRules($rules, $direction = null) { }
@@ -2117,9 +2180,10 @@ class Transliterator {
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Create an inverse transliterator
      * @link https://php.net/manual/en/transliterator.createinverse.php
-     * @return Transliterator a <b>Transliterator</b> object on success,
+     * @return Transliterator|null a <b>Transliterator</b> object on success,
      * or <b>NULL</b> on failure
      */
+    #[Pure]
     public function createInverse() { }
 
     /**
@@ -2135,7 +2199,7 @@ class Transliterator {
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Transliterate a string
      * @link https://php.net/manual/en/transliterator.transliterate.php
-     * @param string $subject <p>
+     * @param string $string <p>
      * The string to be transformed.
      * </p>
      * @param int $start [optional] <p>
@@ -2150,24 +2214,27 @@ class Transliterator {
      * </p>
      * @return string|false The transfomed string on success, or <b>FALSE</b> on failure.
      */
-    public function transliterate($subject, $start = null, $end = null) { }
+    #[Pure]
+    public function transliterate($string, $start = null, $end = -1) { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Get last error code
      * @link https://php.net/manual/en/transliterator.geterrorcode.php
-     * @return int The error code on success,
+     * @return int|false The error code on success,
      * or <b>FALSE</b> if none exists, or on failure.
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Get last error message
      * @link https://php.net/manual/en/transliterator.geterrormessage.php
-     * @return string The error code on success,
+     * @return string|false The error code on success,
      * or <b>FALSE</b> if none exists, or on failure.
      */
+    #[Pure]
     public function getErrorMessage() { }
 }
 
@@ -2182,66 +2249,86 @@ class Spoofchecker {
     const SINGLE_SCRIPT = 16;
     const INVISIBLE = 32;
     const CHAR_LIMIT = 64;
-
+    const ASCII = 268435456;
+    const HIGHLY_RESTRICTIVE = 805306368;
+    const MODERATELY_RESTRICTIVE = 1073741824;
+    const MINIMALLY_RESTRICTIVE = 1342177280;
+    const UNRESTRICTIVE = 1610612736;
+    const SINGLE_SCRIPT_RESTRICTIVE = 536870912;
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Constructor
      * @link https://php.net/manual/en/spoofchecker.construct.php
      */
+    #[Pure]
     public function __construct() { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Checks if a given text contains any suspicious characters
      * @link https://php.net/manual/en/spoofchecker.issuspicious.php
-     * @param string $text <p>
+     * @param string $string <p>
      * </p>
-     * @param string $error [optional] <p>
+     * @param string &$errorCode [optional] <p>
      * </p>
      * @return bool
      */
-    public function isSuspicious($text, &$error = null) { }
+    public function isSuspicious($string, &$errorCode = null) { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Checks if a given text contains any confusable characters
      * @link https://php.net/manual/en/spoofchecker.areconfusable.php
-     * @param string $s1 <p>
+     * @param string $string1 <p>
      * </p>
-     * @param string $s2 <p>
+     * @param string $string2 <p>
      * </p>
-     * @param string $error [optional] <p>
+     * @param string &$errorCode [optional] <p>
      * </p>
      * @return bool
      */
-    public function areConfusable($s1, $s2, &$error = null) { }
+    public function areConfusable($string1, $string2, &$errorCode = null) { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Locales to use when running checks
      * @link https://php.net/manual/en/spoofchecker.setallowedlocales.php
-     * @param string $locale_list <p>
+     * @param string $locales <p>
      * </p>
      * @return void
      */
-    public function setAllowedLocales($locale_list) { }
+    public function setAllowedLocales($locales) { }
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
      * Set the checks to run
      * @link https://php.net/manual/en/spoofchecker.setchecks.php
-     * @param string $checks <p>
+     * @param int $checks <p>
      * </p>
      * @return void
      */
     public function setChecks($checks) { }
+
+    public function setRestrictionLevel(int $level) {}
 }
 
 /**
  * @since 5.5
  */
 class IntlGregorianCalendar extends IntlCalendar {
+
+    /**
+     * @link https://www.php.net/manual/en/intlgregoriancalendar.construct
+     * @param int $timezoneOrYear [optional]
+     * @param int $localeOrMonth [optional]
+     * @param int $day [optional]
+     * @param int $hour [optional]
+     * @param int $minute [optional]
+     * @param int $second [optional]
+     */
+    public function __construct($timezoneOrYear , $localeOrMonth , $day , $hour , $minute , $second) {}
+
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * @param mixed $timeZone
@@ -2251,20 +2338,22 @@ class IntlGregorianCalendar extends IntlCalendar {
     public static function createInstance($timeZone = null, $locale = null) { }
 
     /**
-     * @param double $change
+     * @param float $timestamp
      *
      */
-    public function setGregorianChange($change) { }
+    public function setGregorianChange($timestamp) { }
 
     /**
-     * @return double $change
+     * @return float
      */
+    #[Pure]
     public function getGregorianChange() { }
 
     /**
      * @param int $year
      * @return bool
      */
+    #[Pure]
     public function isLeapYear($year) { }
 }
 
@@ -2318,51 +2407,52 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Add a (signed) amount of time to a field
-     * @link https://www.php.net/manual/en/intlcalendar.add.php
+     * @link https://secure.php.net/manual/en/intlcalendar.add.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
      * These are integer values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
-     * @param int $amount <p>The signed amount to add to the current field. If the amount is positive, the instant will be moved forward; if it is negative, the instant wil be moved into the past. The unit is implicit to the field type.
+     * @param int $value <p>The signed amount to add to the current field. If the amount is positive, the instant will be moved forward; if it is negative, the instant wil be moved into the past. The unit is implicit to the field type.
      * For instance, hours for <b>IntlCalendar::FIELD_HOUR_OF_DAY</b>.</p>
      * @return bool Returns TRUE on success or FALSE on failure.
      */
-    public function add($field, $amount) { }
+    public function add($field, $value) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether this object's time is after that of the passed object
-     * https://www.php.net/manual/en/intlcalendar.after.php
-     * @param IntlCalendar $calendar <p>The calendar whose time will be checked against this object's time.</p>
+     * https://secure.php.net/manual/en/intlcalendar.after.php
+     * @param IntlCalendar $other <p>The calendar whose time will be checked against this object's time.</p>
      * @return bool
      * Returns <b>TRUE</b> if this object's current time is after that of the
      * <em>calendar</em> argument's time. Returns <b>FALSE</b> otherwise.
-     * Also returns <b>FALSE</b> on failure. You can use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
-     * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
+     * Also returns <b>FALSE</b> on failure. You can use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
+     * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
      */
-    public function after(IntlCalendar $calendar) { }
+    #[Pure]
+    public function after(IntlCalendar $other) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether this object's time is before that of the passed object
-     * @link https://www.php.net/manual/en/intlcalendar.before.php
-     * @param IntlCalendar $calendar <p> The calendar whose time will be checked against this object's time.</p>
+     * @link https://secure.php.net/manual/en/intlcalendar.before.php
+     * @param IntlCalendar $other <p> The calendar whose time will be checked against this object's time.</p>
      * @return bool
      * Returns <b>TRUE</B> if this object's current time is before that of the
      * <em>calendar</em> argument's time. Returns <b>FALSE</b> otherwise.
-     * Also returns <b>FALSE</b> on failure. You can use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
-     * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
-     * </p>
+     * Also returns <b>FALSE</b> on failure. You can use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
+     * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
      */
-    public function before(IntlCalendar $calendar) { }
+    #[Pure]
+    public function before(IntlCalendar $other) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Clear a field or all fields
-     * @link https://www.php.net/manual/en/intlcalendar.clear.php
+     * @link https://secure.php.net/manual/en/intlcalendar.clear.php
      * @param int $field [optional] <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
@@ -2373,7 +2463,7 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Private constructor for disallowing instantiation
-     * @link https://www.php.net/manual/en/intlcalendar.construct.php
+     * @link https://secure.php.net/manual/en/intlcalendar.construct.php
      *
      */
     private function __construct() { }
@@ -2382,8 +2472,8 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Create a new IntlCalendar
-     * @link https://www.php.net/manual/en/intlcalendar.createinstance.php
-     * @param mixed $timeZone [optional] <p> <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.createinstance.php
+     * @param mixed $timezone [optional] <p> <p>
      * The timezone to use.
      * </p>
      *
@@ -2391,61 +2481,62 @@ class IntlCalendar {
      * <li>
      * <p>
      * <b>NULL</b>, in which case the default timezone will be used, as specified in
-     * the ini setting {@link https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
-     * through the function  {@link https://www.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
-     * returned by {@link https://www.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
+     * the ini setting {@link https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
+     * through the function  {@link https://secure.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
+     * returned by {@link https://secure.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
      * </p>
      * </li>
      * <li>
      * <p>
-     * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
+     * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
      * </p>
      * </li>
      * <li>
      * <p>
-     * A {@link https://www.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
+     * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
      * and an ICU timezone object will be created; the timezone will be backed
      * by ICU's database, not PHP's.
      * </p>
      * </li>
      * <li>
      * <p>
-     * A {@link https://www.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
+     * A {@link https://secure.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
      * See  <b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw
      * offsets such as <em>"GMT+08:30"</em> are also accepted.
      * </p>
      * </li>
      * </ul>
      * </p>
-     * @param string $locale [optional] <p>
-     * A locale to use or <b>NULL</b> to use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.default-locale the default locale}.
+     * @param string|null $locale [optional] <p>
+     * A locale to use or <b>NULL</b> to use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.default-locale the default locale}.
      * </p>
-     * @return IntlCalendar
-     * The created {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} instance or <b>NULL</b> on
+     * @return IntlCalendar|null
+     * The created {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} instance or <b>NULL</b> on
      * failure.
      */
-    public static function createInstance($timeZone = null, $locale = null) { }
+    public static function createInstance($timezone = null, $locale = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Compare time of two IntlCalendar objects for equality
-     * @link https://www.php.net/manual/en/intlcalendar.equals.php
-     * @param IntlCalendar $calendar
+     * @link https://secure.php.net/manual/en/intlcalendar.equals.php
+     * @param IntlCalendar $other
      * @return bool <p>
      * Returns <b>TRUE</b> if the current time of both this and the passed in
-     * {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} object are the same, or <b>FALSE</b>
+     * {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} object are the same, or <b>FALSE</b>
      * otherwise. The value <b>FALSE</b> can also be returned on failure. This can only
      * happen if bad arguments are passed in. In any case, the two cases can be
-     * distinguished by calling  {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()}.
+     * distinguished by calling  {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()}.
      * </p>
      */
-    public function equals($calendar) { }
+    #[Pure]
+    public function equals($other) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Calculate difference between given time and this object's time
-     * @link https://www.php.net/manual/en/intlcalendar.fielddifference.php
-     * @param float $when <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.fielddifference.php
+     * @param float $timestamp <p>
      * The time against which to compare the quantity represented by the
      * <em>field</em>. For the result to be positive, the time
      * given for this parameter must be ahead of the time of the object the
@@ -2456,7 +2547,7 @@ class IntlCalendar {
      * </p>
      *
      * <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
@@ -2464,73 +2555,77 @@ class IntlCalendar {
      * specified field or <b>FALSE</b> on failure.
      *
      */
-    public function fieldDifference($when, $field) { }
+    #[Pure]
+    public function fieldDifference($timestamp, $field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
      * Create an IntlCalendar from a DateTime object or string
-     * @link https://www.php.net/manual/en/intlcalendar.fromdatetime.php
-     * @param mixed $dateTime <p>
-     * A {@link https://www.php.net/manual/en/class.datetime.php DateTime} object or a {@link https://www.php.net/manual/en/language.types.string.php string} that
-     * can be passed to  {@link https://www.php.net/manual/en/datetime.construct.php DateTime::__construct()}.
+     * @link https://secure.php.net/manual/en/intlcalendar.fromdatetime.php
+     * @param mixed $datetime <p>
+     * A {@link https://secure.php.net/manual/en/class.datetime.php DateTime} object or a {@link https://secure.php.net/manual/en/language.types.string.php string} that
+     * can be passed to  {@link https://secure.php.net/manual/en/datetime.construct.php DateTime::__construct()}.
      * </p>
-     * @return IntlCalendar
-     * The created {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} object or <b>NULL</b> in case of
-     * failure. If a {@link https://www.php.net/manual/en/language.types.string.php string} is passed, any exception that occurs
-     * inside the {@link https://www.php.net/manual/en/class.datetime.php DateTime} constructor is propagated.
+     * @param $locale [optional]
+     * @return IntlCalendar|null
+     * The created {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} object or <b>NULL</b> in case of
+     * failure. If a {@link https://secure.php.net/manual/en/language.types.string.php string} is passed, any exception that occurs
+     * inside the {@link https://secure.php.net/manual/en/class.datetime.php DateTime} constructor is propagated.
      */
-    public static function fromDateTime($dateTime) { }
+    public static function fromDateTime($datetime, $locale) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the value for a field
-     * @link https://www.php.net/manual/en/intlcalendar.get.php
+     * @link https://secure.php.net/manual/en/intlcalendar.get.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
      * @return int An integer with the value of the time field.
      */
+    #[Pure]
     public function get($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * The maximum value for a field, considering the object's current time
-     * @link https://www.php.net/manual/en/intlcalendar.getactualmaximum.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getactualmaximum.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
      * @return int
-     * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing the maximum value in the units associated
+     * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing the maximum value in the units associated
      * with the given <em>field</em> or <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function getActualMaximum($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * The minimum value for a field, considering the object's current time
-     * @link https://www.php.net/manual/en/intlcalendar.getactualminimum.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getactualminimum.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
      * These are integer values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
      * @return int
-     * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing the minimum value in the field's
+     * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing the minimum value in the field's
      * unit or <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function getActualMinimum($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get array of locales for which there is data
-     * @link https://www.php.net/manual/en/intlcalendar.getavailablelocales.php
-     * @return array An array of strings, one for which locale.
+     * @link https://secure.php.net/manual/en/intlcalendar.getavailablelocales.php
+     * @return string[] An array of strings, one for which locale.
      */
-
     public static function getAvailableLocales() { }
 
     /**
@@ -2549,90 +2644,95 @@ class IntlCalendar {
      * <b>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</b> or <b>FALSE</b> on failure.
      *
      */
+    #[Pure]
     public function getDayOfWeekType($dayOfWeek) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get last error code on the object
-     * @link https://www.php.net/manual/en/intlcalendar.geterrorcode.php
+     * @link https://secure.php.net/manual/en/intlcalendar.geterrorcode.php
      * @return int An ICU error code indicating either success, failure or a warning.
      *
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get last error message on the object
-     * @link https://www.php.net/manual/en/intlcalendar.geterrormessage.php
+     * @link https://secure.php.net/manual/en/intlcalendar.geterrormessage.php
      * @return string The error message associated with last error that occurred in a function call on this object, or a string indicating the non-existance of an error.
      */
+    #[Pure]
     public function getErrorMessage() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the first day of the week for the calendar's locale
-     * @link https://www.php.net/manual/en/intlcalendar.getfirstdayofweek.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getfirstdayofweek.php
      * @return int
      * One of the constants <b>IntlCalendar::DOW_SUNDAY</b>,
      * <b>IntlCalendar::DOW_MONDAY</b>, ...,
      * <b>IntlCalendar::DOW_SATURDAY</b> or <b>FALSE</b> on failure.
      *
      */
+    #[Pure]
     public function getFirstDayOfWeek() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the largest local minimum value for a field
-     * @link https://www.php.net/manual/en/intlcalendar.getgreatestminimum.php
-     * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * @link https://secure.php.net/manual/en/intlcalendar.getgreatestminimum.php
+     * @param int $field
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * @return int
-     * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
+     * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
      * unit, or <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function getGreatestMinimum($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get set of locale keyword values
-     * @param string $key <p>
+     * @param string $keyword <p>
      * The locale keyword for which relevant values are to be queried. Only
      * <em>'calendar'</em> is supported.
      * </p>
      * @param string $locale <p>
      * The locale onto which the keyword/value pair are to be appended.
      * </p>
-     * @param bool $commonlyUsed
+     * @param bool $onlyCommon
      * <p>
      * Whether to show only the values commonly used for the specified locale.
      * </p>
      * @return Iterator|false An iterator that yields strings with the locale keyword values or <b>FALSE</b> on failure.
      */
-    public static function getKeywordValuesForLocale($key, $locale, $commonlyUsed) { }
+    public static function getKeywordValuesForLocale($keyword, $locale, $onlyCommon) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the smallest local maximum for a field
-     * @link https://www.php.net/manual/en/intlcalendar.getleastmaximum.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getleastmaximum.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
      * @return int
-     * An {@link https://www.php.net/manual/en/language.types.integer.ph int} representing a field value in the field's
+     * An {@link https://secure.php.net/manual/en/language.types.integer.ph int} representing a field value in the field's
      * unit or <b>FALSE</b> on failure.
-     * </p>
      */
+    #[Pure]
     public function getLeastMaximum($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the locale associated with the object
-     * @link https://www.php.net/manual/en/intlcalendar.getlocale.php
-     * @param int $localeType <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.getlocale.php
+     * @param int $type <p>
      * Whether to fetch the actual locale (the locale from which the calendar
      * data originates, with <b>Locale::ACTUAL_LOCALE</b>) or the
      * valid locale, i.e., the most specific locale supported by ICU relatively
@@ -2641,46 +2741,48 @@ class IntlCalendar {
      * this fashion – actual locale, valid locale, requested locale.
      * </p>
      * @return string
-     * A locale string or <b>FALSE</b> on failure.
      *
      */
-    public function getLocale($localeType) { }
+    #[Pure]
+    public function getLocale($type) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the global maximum value for a field
-     * @link https://www.php.net/manual/en/intlcalendar.getmaximum.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getmaximum.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
-     * @return string
-     * A locale string or <b>FALSE</b> on failure.
+     * @return int
      */
+    #[Pure]
     public function getMaximum($field) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get minimal number of days the first week in a year or month can have
-     * @link https://www.php.net/manual/en/intlcalendar.getminimaldaysinfirstweek.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getminimaldaysinfirstweek.php
      * @return int
-     * An {@link https://www.php.net/manual/en/language.types.integer.php  int} representing a number of days or <b>FALSE</b> on failure.
+     * An {@link https://secure.php.net/manual/en/language.types.integer.php  int} representing a number of days or <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function getMinimalDaysInFirstWeek() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the global minimum value for a field
-     * @link https://www.php.net/manual/en/intlcalendar.getminimum.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getminimum.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
      * @return int
      * An int representing a value for the given field in the field's unit or FALSE on failure.
      */
+    #[Pure]
     public function getMinimum($field) { }
 
     /**
@@ -2693,58 +2795,63 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get behavior for handling repeating wall time
-     * @link https://www.php.net/manual/en/intlcalendar.getrepeatedwalltimeoption.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getrepeatedwalltimeoption.php
      * @return int
      * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b> or
      * <b>IntlCalendar::WALLTIME_LAST</b>.
      *
      */
+    #[Pure]
     public function getRepeatedWallTimeOption() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get behavior for handling skipped wall time
-     * @link https://www.php.net/manual/en/intlcalendar.getskippedwalltimeoption.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getskippedwalltimeoption.php
      * @return int
      * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b>,
      * <b>IntlCalendar::WALLTIME_LAST</b> or
      * <b>IntlCalendar::WALLTIME_NEXT_VALID</b>.
      */
+    #[Pure]
     public function getSkippedWallTimeOption() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get time currently represented by the object
      * @return float
-     * A {@link https://www.php.net/manual/en/language.types.float.php float} representing the number of milliseconds elapsed since the
+     * A {@link https://secure.php.net/manual/en/language.types.float.php float} representing the number of milliseconds elapsed since the
      * reference time (1 Jan 1970 00:00:00 UTC).
      */
+    #[Pure]
     public function getTime() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the object's timezone
-     * @link https://www.php.net/manual/en/intlcalendar.gettimezone.php
+     * @link https://secure.php.net/manual/en/intlcalendar.gettimezone.php
      * @return IntlTimeZone
-     * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone} object corresponding to the one used
+     * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone} object corresponding to the one used
      * internally in this object.
      */
+    #[Pure]
     public function getTimeZone() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the calendar type
-     * @link https://www.php.net/manual/en/intlcalendar.gettype.php
+     * @link https://secure.php.net/manual/en/intlcalendar.gettype.php
      * @return string
-     * A {@link https://www.php.net/manual/en/language.types.string.php string} representing the calendar type, such as
+     * A {@link https://secure.php.net/manual/en/language.types.string.php string} representing the calendar type, such as
      * <em>'gregorian'</em>, <em>'islamic'</em>, etc.
      */
+    #[Pure]
     public function getType() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get time of the day at which weekend begins or ends
-     * @link https://www.php.net/manual/en/intlcalendar.getweekendtransition.php
+     * @link https://secure.php.net/manual/en/intlcalendar.getweekendtransition.php
      * @param string $dayOfWeek <p>
      * One of the constants <b>IntlCalendar::DOW_SUNDAY</b>,
      * <b>IntlCalendar::DOW_MONDAY</b>, ...,
@@ -2754,86 +2861,91 @@ class IntlCalendar {
      * The number of milliseconds into the day at which the the weekend begins or
      * ends or <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function getWeekendTransition($dayOfWeek) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether the object's time is in Daylight Savings Time
-     * @link https://www.php.net/manual/en/intlcalendar.indaylighttime.php
+     * @link https://secure.php.net/manual/en/intlcalendar.indaylighttime.php
      * @return bool
      * Returns <b>TRUE</b> if the date is in Daylight Savings Time, <b>FALSE</b> otherwise.
      * The value <b>FALSE</b> may also be returned on failure, for instance after
-     * specifying invalid field values on non-lenient mode; use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
-     * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.
+     * specifying invalid field values on non-lenient mode; use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
+     * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.
      */
+    #[Pure]
     public function inDaylightTime() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether another calendar is equal but for a different time
-     * @link https://www.php.net/manual/en/intlcalendar.isequivalentto.php
-     * @param IntlCalendar $calendar The other calendar against which the comparison is to be made.
+     * @link https://secure.php.net/manual/en/intlcalendar.isequivalentto.php
+     * @param IntlCalendar $other The other calendar against which the comparison is to be made.
      * @return bool
      * Assuming there are no argument errors, returns <b>TRUE</b> iif the calendars are equivalent except possibly for their set time.
      */
-    public function isEquivalentTo(IntlCalendar $calendar) { }
+    #[Pure]
+    public function isEquivalentTo(IntlCalendar $other) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether date/time interpretation is in lenient mode
-     * @link https://www.php.net/manual/en/intlcalendar.islenient.php
+     * @link https://secure.php.net/manual/en/intlcalendar.islenient.php
      * @return bool
-     * A {@link https://www.php.net/manual/en/language.types.boolean.php bool} representing whether the calendar is set to lenient mode.
+     * A {@link https://secure.php.net/manual/en/language.types.boolean.php bool} representing whether the calendar is set to lenient mode.
      */
+    #[Pure]
     public function isLenient() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether a certain date/time is in the weekend
-     * @link https://www.php.net/manual/en/intlcalendar.isweekend.php
-     * @param float|null $date [optional] <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.isweekend.php
+     * @param float|null $timestamp [optional] <p>
      * An optional timestamp representing the number of milliseconds since the
      * epoch, excluding leap seconds. If <b>NULL</b>, this object's current time is
      * used instead.
      * </p>
      * @return bool
-     * <p> A {@link https://www.php.net/manual/en/language.types.boolean.php bool} indicating whether the given or this object's time occurs
+     * <p> A {@link https://secure.php.net/manual/en/language.types.boolean.php bool} indicating whether the given or this object's time occurs
      * in a weekend.
      * </p>
      * <p>
      * The value <b>FALSE</b> may also be returned on failure, for instance after giving
-     * a date out of bounds on non-lenient mode; use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
-     * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.</p>
+     * a date out of bounds on non-lenient mode; use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
+     * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.</p>
      */
-    public function isWeekend($date = null) { }
+    #[Pure]
+    public function isWeekend($timestamp = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Add value to field without carrying into more significant fields
-     * @link https://www.php.net/manual/en/intlcalendar.roll.php
+     * @link https://secure.php.net/manual/en/intlcalendar.roll.php
      * @param int $field
-     * <p>One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
-     * {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * <p>One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
+     * {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
-     * @param mixed $amountOrUpOrDown <p>
+     * @param mixed $value <p>
      * The (signed) amount to add to the field, <b>TRUE</b> for rolling up (adding
      * <em>1</em>), or <b>FALSE</b> for rolling down (subtracting
      * <em>1</em>).
      * </p>
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function roll($field, $amountOrUpOrDown) { }
+    public function roll($field, $value) { }
 
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Whether a field is set
-     * @link https://www.php.net/manual/en/intlcalendar.isset.php
+     * @link https://secure.php.net/manual/en/intlcalendar.isset.php
      * @param int $field <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
-     * {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
+     * {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
      * These are integer values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
@@ -2844,9 +2956,9 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set a time field or several common fields at once
-     * @link https://www.php.net/manual/en/intlcalendar.set.php
+     * @link https://secure.php.net/manual/en/intlcalendar.set.php
      * @param int $year <p>
-     * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+     * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
      * values between <em>0</em> and
      * <b>IntlCalendar::FIELD_COUNT</b>.
      * </p>
@@ -2869,15 +2981,15 @@ class IntlCalendar {
      * </p>
      * @param int $second [optional] <p>
      * The new value for <b>IntlCalendar::FIELD_SECOND</b>.
-     *</p>
+     * </p>
      * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
      */
     public function set($year, $month, $dayOfMonth = null, $hour = null, $minute = null, $second = null) { }
 
     /**
-     * (PHP 5 >=5.5.0 PECL intl >= 3.0.0a1)<br/>
+     * (PHP 5 >= 5.5.0 PECL intl >= 3.0.0a1)<br/>
      * Set a time field or several common fields at once
-     * @link https://www.php.net/manual/en/intlcalendar.set.php
+     * @link https://secure.php.net/manual/en/intlcalendar.set.php
      * @param int $field One of the IntlCalendar date/time field constants. These are integer values between 0 and IntlCalendar::FIELD_COUNT.
      * @param int $value The new value of the given field.
      * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
@@ -2888,7 +3000,7 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set the day on which the week is deemed to start
-     * @link https://www.php.net/manual/en/intlcalendar.setfirstdayofweek.php
+     * @link https://secure.php.net/manual/en/intlcalendar.setfirstdayofweek.php
      * @param int $dayOfWeek <p>
      * One of the constants <b>IntlCalendar::DOW_SUNDAY</b>,
      * <b>IntlCalendar::DOW_MONDAY</b>, ...,
@@ -2901,19 +3013,19 @@ class IntlCalendar {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set whether date/time interpretation is to be lenient
-     * @link https://www.php.net/manual/en/intlcalendar.setlenient.php
-     * @param string $isLenient <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.setlenient.php
+     * @param bool $lenient <p>
      * Use <b>TRUE</b> to activate the lenient mode; <b>FALSE</b> otherwise.
      * </p>
      * @return bool Returns <b>TRUE</b> on success. Failure can only happen due to invalid parameters.
      */
-    public function setLenient($isLenient) { }
+    public function setLenient($lenient) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set behavior for handling repeating wall times at negative timezone offset transitions
-     * @link https://www.php.net/manual/en/intlcalendar.setrepeatedwalltimeoption.php
-     * @param int $wallTimeOption <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.setrepeatedwalltimeoption.php
+     * @param int $option <p>
      * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b> or
      * <b>IntlCalendar::WALLTIME_LAST</b>.
      * </p>
@@ -2921,13 +3033,13 @@ class IntlCalendar {
      * Returns <b>TRUE</b> on success. Failure can only happen due to invalid parameters.
      *
      */
-    public function setRepeatedWallTimeOption($wallTimeOption) { }
+    public function setRepeatedWallTimeOption($option) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set behavior for handling skipped wall times at positive timezone offset transitions
-     * @link https://www.php.net/manual/en/intlcalendar.setskippedwalltimeoption.php
-     * @param int $wallTimeOption <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.setskippedwalltimeoption.php
+     * @param int $option <p>
      * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b>,
      * <b>IntlCalendar::WALLTIME_LAST</b> or
      * <b>IntlCalendar::WALLTIME_NEXT_VALID</b>.
@@ -2937,26 +3049,26 @@ class IntlCalendar {
      * Returns <b>TRUE</b> on success. Failure can only happen due to invalid parameters.
      * </p>
      */
-    public function setSkippedWallTimeOption($wallTimeOption) { }
+    public function setSkippedWallTimeOption($option) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set the calendar time in milliseconds since the epoch
-     * @link https://www.php.net/manual/en/intlcalendar.settime.php
-     * @param float $date <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.settime.php
+     * @param float $timestamp <p>
      * An instant represented by the number of number of milliseconds between
      * such instant and the epoch, ignoring leap seconds.
      * </p>
      * @return bool
      * Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
      */
-    public function setTime($date) { }
+    public function setTime($timestamp) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Set the timezone used by this calendar
-     * @link https://www.php.net/manual/en/intlcalendar.settimezone.php
-     * @param mixed $timeZone <p>
+     * @link https://secure.php.net/manual/en/intlcalendar.settimezone.php
+     * @param mixed $timezone <p>
      * The new timezone to be used by this calendar. It can be specified in the
      * following ways:
      *
@@ -2964,26 +3076,26 @@ class IntlCalendar {
      * <li>
      * <p>
      * <b>NULL</b>, in which case the default timezone will be used, as specified in
-     * the ini setting {@link https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
-     * through the function  {@link https://www.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
-     * returned by  {@link https://www.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
+     * the ini setting {@link https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
+     * through the function  {@link https://secure.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
+     * returned by  {@link https://secure.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
      * </p>
      * </li>
      * <li>
      * <p>
-     * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
+     * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
      * </p>
      * </li>
      * <li>
      * <p>
-     * A {@link https://www.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
+     * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
      * and an ICU timezone object will be created; the timezone will be backed
      * by ICU's database, not PHP's.
      * </p>
      * </li>
      * <li>
      * <p>
-     * A {@link https://www.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
+     * A {@link https://secure.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
      * See  b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw
      * offsets such as <em>"GMT+08:30"</em> are also accepted.
      * </p>
@@ -2991,19 +3103,27 @@ class IntlCalendar {
      * </ul>
      * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
      */
-    public function setTimeZone($timeZone) { }
+    public function setTimeZone($timezone) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
      * Convert an IntlCalendar into a DateTime object
-     * @link https://www.php.net/manual/en/intlcalendar.todatetime.php
+     * @link https://secure.php.net/manual/en/intlcalendar.todatetime.php
      * @return DateTime|false
-     * A {@link https://www.php.net/manual/en/class.datetime.php DateTime} object with the same timezone as this
+     * A {@link https://secure.php.net/manual/en/class.datetime.php DateTime} object with the same timezone as this
      * object (though using PHP's database instead of ICU's) and the same time,
      * except for the smaller precision (second precision instead of millisecond).
      * Returns <b>FALSE</b> on failure.
      */
+    #[Pure]
     public function toDateTime() { }
+
+    /**
+     * @link https://www.php.net/manual/en/intlcalendar.setminimaldaysinfirstweek.php
+     * @param int $days
+     * @return bool
+     */
+    public function setMinimalDaysInFirstWeek($days) {}
 }
 
 /**
@@ -3036,22 +3156,33 @@ class IntlTimeZone {
     /* Constants */
     const  DISPLAY_SHORT = 1;
     const  DISPLAY_LONG = 2;
+    const DISPLAY_SHORT_GENERIC = 3;
+    const DISPLAY_LONG_GENERIC = 4;
+    const DISPLAY_SHORT_GMT = 5;
+    const DISPLAY_LONG_GMT = 6;
+    const DISPLAY_SHORT_COMMONLY_USED = 7;
+    const DISPLAY_GENERIC_LOCATION = 8;
+    const TYPE_ANY = 0;
+    const TYPE_CANONICAL = 1;
+    const TYPE_CANONICAL_LOCATION = 2;
 
     /* Methods */
+
+    private function __construct() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the number of IDs in the equivalency group that includes the given ID
-     * @link https://www.php.net/manual/en/intltimezone.countequivalentids.php
-     * @param string $zoneId
+     * @link https://secure.php.net/manual/en/intltimezone.countequivalentids.php
+     * @param string $timezoneId
      * @return int|false number of IDs or <b>FALSE</b> on failure
      */
-    public static function countEquivalentIDs($zoneId) { }
+    public static function countEquivalentIDs($timezoneId) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Create a new copy of the default timezone for this host
-     * @link https://www.php.net/manual/en/intltimezone.createdefault.php
+     * @link https://secure.php.net/manual/en/intltimezone.createdefault.php
      * @return IntlTimeZone
      */
     public static function createDefault() { }
@@ -3059,7 +3190,7 @@ class IntlTimeZone {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get an enumeration over time zone IDs associated with the given country or offset
-     * @link https://www.php.net/manual/en/intltimezone.createenumeration.php
+     * @link https://secure.php.net/manual/en/intltimezone.createenumeration.php
      * @param mixed $countryOrRawOffset [optional]
      * @return IntlIterator|false an iterator or <b>FALSE</b> on failure
      */
@@ -3068,90 +3199,94 @@ class IntlTimeZone {
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Create a timezone object for the given ID
-     * @link https://www.php.net/manual/en/intltimezone.createtimezone.php
-     * @param string $zoneId
+     * @link https://secure.php.net/manual/en/intltimezone.createtimezone.php
+     * @param string $timezoneId
      * @return IntlTimeZone|null a timezone object or <b>NULL</b> on failure
      */
-    public static function createTimeZone($zoneId) { }
+    public static function createTimeZone($timezoneId) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get an enumeration over system time zone IDs with the given filter conditions
-     * @link https://www.php.net/manual/en/intltimezone.createtimezoneidenumeration.php
-     * @param int $zoneType
+     * @link https://secure.php.net/manual/en/intltimezone.createtimezoneidenumeration.php
+     * @param int $type
      * @param string|null $region [optional]
      * @param int $rawOffset [optional]
      * @return IntlIterator|false an iterator or <b>FALSE</b> on failure
      */
-    public static function createTimeZoneIDEnumeration($zoneType, $region = null, $rawOffset = 0) { }
+    public static function createTimeZoneIDEnumeration($type, $region = null, $rawOffset = 0) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Create a timezone object from DateTimeZone
-     * @link https://www.php.net/manual/en/intltimezone.fromdatetimezone.php
-     * @param DateTimeZone $zoneId
+     * @link https://secure.php.net/manual/en/intltimezone.fromdatetimezone.php
+     * @param DateTimeZone $timezone
      * @return IntlTimeZone|null a timezone object or <b>NULL</b> on failure
      */
-    public static function  fromDateTimeZone($zoneId) { }
+    public static function  fromDateTimeZone($timezone) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the canonical system timezone ID or the normalized custom time zone ID for the given time zone ID
-     * @link https://www.php.net/manual/en/intltimezone.getcanonicalid.php
-     * @param string $zoneId
-     * @param bool $isSystemID [optional]
+     * @link https://secure.php.net/manual/en/intltimezone.getcanonicalid.php
+     * @param string $timezoneId
+     * @param bool &$isSystemId [optional]
      * @return string|false the timezone ID or <b>FALSE</b> on failure
      */
-    public static function getCanonicalID($zoneId, &$isSystemID) { }
+    public static function getCanonicalID($timezoneId, &$isSystemId) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get a name of this time zone suitable for presentation to the user
-     * @param bool $isDaylight [optional]
+     * @param bool $dst [optional]
      * @param int $style [optional]
      * @param string $locale [optional]
      * @return string|false the timezone name or <b>FALSE</b> on failure
      */
-    public function getDisplayName($isDaylight, $style, $locale) { }
+    #[Pure]
+    public function getDisplayName($dst = false, $style = 2, $locale) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the amount of time to be added to local standard time to get local wall clock time
-     * @link https://www.php.net/manual/en/intltimezone.getequivalentid.php
+     * @link https://secure.php.net/manual/en/intltimezone.getequivalentid.php
      * @return int
      */
+    #[Pure]
     public function  getDSTSavings() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get an ID in the equivalency group that includes the given ID
-     * @link https://www.php.net/manual/en/intltimezone.getequivalentid.php
-     * @param string $zoneId
-     * @param int $index
+     * @link https://secure.php.net/manual/en/intltimezone.getequivalentid.php
+     * @param string $timezoneId
+     * @param int $offset
      * @return string|false the time zone ID or <b>FALSE</b> on failure
      */
-    public static function getEquivalentID($zoneId, $index) { }
+    public static function getEquivalentID($timezoneId, $offset) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get last error code on the object
-     * @link https://www.php.net/manual/en/intltimezone.geterrorcode.php
+     * @link https://secure.php.net/manual/en/intltimezone.geterrorcode.php
      * @return int
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get last error message on the object
-     * @link https://www.php.net/manual/en/intltimezone.geterrormessage.php
+     * @link https://secure.php.net/manual/en/intltimezone.geterrormessage.php
      * @return string
      */
+    #[Pure]
     public function getErrorMessage() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Create GMT (UTC) timezone
-     * @link https://www.php.net/manual/en/intltimezone.getgmt.php
+     * @link https://secure.php.net/manual/en/intltimezone.getgmt.php
      * @return IntlTimeZone
      */
     public static function getGMT() { }
@@ -3161,13 +3296,14 @@ class IntlTimeZone {
      * Get timezone ID
      * @return string
      */
+    #[Pure]
     public function getID() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the time zone raw and GMT offset for the given moment in time
-     * @link https://www.php.net/manual/en/intltimezone.getoffset.php
-     * @param float $date
+     * @link https://secure.php.net/manual/en/intltimezone.getoffset.php
+     * @param float $timestamp
      *   moment in time for which to return offsets, in units of milliseconds from
      *   January 1, 1970 0:00 GMT, either GMT time or local wall time, depending on
      *   `local'.
@@ -3183,29 +3319,30 @@ class IntlTimeZone {
      *   typically one hour.
      * @return bool boolean indication of success
      */
-    public function getOffset($date, $local, &$rawOffset, &$dstOffset) { }
+    public function getOffset($timestamp, $local, &$rawOffset, &$dstOffset) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the raw GMT offset (before taking daylight savings time into account
-     * @link https://www.php.net/manual/en/intltimezone.getrawoffset.php
+     * @link https://secure.php.net/manual/en/intltimezone.getrawoffset.php
      * @return int
      */
+    #[Pure]
     public function  getRawOffset() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get the region code associated with the given system time zone ID
-     * @link https://www.php.net/manual/en/intltimezone.getregion.php
-     * @param string $zoneId
+     * @link https://secure.php.net/manual/en/intltimezone.getregion.php
+     * @param string $timezoneId
      * @return string|false region or <b>FALSE</b> on failure
      */
-    public static function getRegion($zoneId) { }
+    public static function getRegion($timezoneId) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Get the timezone data version currently used by ICU
-     * @link https://www.php.net/manual/en/intltimezone.gettzdataversion.php
+     * @link https://secure.php.net/manual/en/intltimezone.gettzdataversion.php
      * @return string
      */
     public static function getTZDataVersion() { }
@@ -3213,7 +3350,7 @@ class IntlTimeZone {
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get the "unknown" time zone
-     * @link https://www.php.net/manual/en/intltimezone.getunknown.php
+     * @link https://secure.php.net/manual/en/intltimezone.getunknown.php
      * @return IntlTimeZone
      */
     public static function getUnknown() { }
@@ -3222,34 +3359,45 @@ class IntlTimeZone {
      * (PHP 7 &gt;=7.1.0)<br/>
      * Translates a system timezone (e.g. "America/Los_Angeles") into a Windows
      * timezone (e.g. "Pacific Standard Time").
-     * @link https://www.php.net/manual/en/intltimezone.getwindowsid.php
-     * @param string $timezone
+     * @link https://secure.php.net/manual/en/intltimezone.getwindowsid.php
+     * @param string $timezoneId
      * @return string|false the Windows timezone or <b>FALSE</b> on failure
      * @since 7.1
      */
-    public static function getWindowsID($timezone) { }
+    public static function getWindowsID(string $timezoneId) { }
+
+    /**
+     * @link https://www.php.net/manual/en/intltimezone.getidforwindowsid.php
+     * @param string $timezoneId
+     * @param string|null $region
+     * @return string|false the Windows timezone or <b>FALSE</b> on failure
+     * @since 7.1
+     */
+    public static function getIDForWindowsID(string $timezoneId , ?string $region = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Check if this zone has the same rules and offset as another zone
-     * @link https://www.php.net/manual/en/intltimezone.hassamerules.php
-     * @param IntlTimeZone $otherTimeZone
+     * @link https://secure.php.net/manual/en/intltimezone.hassamerules.php
+     * @param IntlTimeZone $other
      * @return bool
      */
-    public function hasSameRules(IntlTimeZone $otherTimeZone) { }
+    #[Pure]
+    public function hasSameRules(IntlTimeZone $other) { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Convert to DateTimeZone object
-     * @link https://www.php.net/manual/ru/intltimezone.todatetimezone.php
+     * @link https://secure.php.net/manual/en/intltimezone.todatetimezone.php
      * @return DateTimeZone|false the DateTimeZone object or <b>FALSE</b> on failure
      */
+    #[Pure]
     public function toDateTimeZone() { }
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
      * Check if this time zone uses daylight savings time
-     * @link https://www.php.net/manual/ru/intltimezone.usedaylighttime.php
+     * @link https://secure.php.net/manual/en/intltimezone.usedaylighttime.php
      * @return bool
      */
     public function useDaylightTime() { }
@@ -3265,67 +3413,70 @@ class IntlTimeZone {
  * default locale collation rules will be used. If empty string ("") or
  * "root" are passed, UCA rules will be used.
  * </p>
- * @return Collator Return new instance of <b>Collator</b> object, or <b>NULL</b>
+ * @return Collator|null Return new instance of <b>Collator</b> object, or <b>NULL</b>
  * on error.
  */
-function collator_create($locale) { }
+#[Pure]
+function collator_create(string $locale): ?Collator { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Compare two Unicode strings
  * @link https://php.net/manual/en/collator.compare.php
  * @param Collator $object
- * @param string $str1 <p>
+ * @param string $string1 <p>
  * The first string to compare.
  * </p>
- * @param string $str2 <p>
+ * @param string $string2 <p>
  * The second string to compare.
  * </p>
- * @return int Return comparison result:</p>
+ * @return int|false Return comparison result:</p>
  * <p>
  * <p>
- * 1 if <i>str1</i> is greater than
- * <i>str2</i> ;
+ * 1 if <i>string1</i> is greater than
+ * <i>string2</i> ;
  * </p>
  * <p>
- * 0 if <i>str1</i> is equal to
- * <i>str2</i>;
+ * 0 if <i>string1</i> is equal to
+ * <i>string2</i>;
  * </p>
  * <p>
- * -1 if <i>str1</i> is less than
- * <i>str2</i> .
+ * -1 if <i>string1</i> is less than
+ * <i>string2</i> .
  * </p>
  * On error
  * boolean
  * <b>FALSE</b>
  * is returned.
  */
-function collator_compare(Collator $object, $str1, $str2) { }
+#[Pure]
+function collator_compare(Collator $object, string $string1, string $string2): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get collation attribute value
  * @link https://php.net/manual/en/collator.getattribute.php
  * @param Collator $object
- * @param int $attr <p>
+ * @param int $attribute <p>
  * Attribute to get value for.
  * </p>
  * @return int|false Attribute value, or boolean <b>FALSE</b> on error.
  */
-function collator_get_attribute(Collator $object, $attr) { }
+#[Pure]
+function collator_get_attribute(Collator $object, int $attribute): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set collation attribute
  * @link https://php.net/manual/en/collator.setattribute.php
  * @param Collator $object
- * @param int $attr <p>Attribute.</p>
- * @param int $val <p>
+ * @param int $attribute <p>Attribute.</p>
+ * @param int $value <p>
  * Attribute value.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function collator_set_attribute(Collator $object, $attr, $val) { }
+function collator_set_attribute(Collator $object, int $attribute, int $value): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3334,7 +3485,8 @@ function collator_set_attribute(Collator $object, $attr, $val) { }
  * @param Collator $object
  * @return int|false current collation strength, or boolean <b>FALSE</b> on error.
  */
-function collator_get_strength(Collator $object) { }
+#[Pure]
+function collator_get_strength(Collator $object): int { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3344,58 +3496,55 @@ function collator_get_strength(Collator $object) { }
  * @param int $strength <p>Strength to set.</p>
  * <p>
  * Possible values are:
- * <p>
  * <b>Collator::PRIMARY</b>
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function collator_set_strength(Collator $object, $strength) { }
+function collator_set_strength(Collator $object, int $strength): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Sort array using specified collator
  * @link https://php.net/manual/en/collator.sort.php
  * @param Collator $object
- * @param array $arr <p>
+ * @param string[] &$array <p>
  * Array of strings to sort.
  * </p>
- * @param int $sort_flag [optional] <p>
+ * @param int $flags [optional] <p>
  * Optional sorting type, one of the following:
  * </p>
- * <p>
  * <p>
  * <b>Collator::SORT_REGULAR</b>
  * - compare items normally (don't change types)
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function collator_sort(Collator $object, array &$arr, $sort_flag = null) { }
+function collator_sort(Collator $object, array &$array, int $flags = null): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Sort array using specified collator and sort keys
  * @link https://php.net/manual/en/collator.sortwithsortkeys.php
  * @param Collator $object
- * @param array $arr <p>Array of strings to sort</p>
+ * @param string[] &$array <p>Array of strings to sort</p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function collator_sort_with_sort_keys(Collator $object, array &$arr) { }
+function collator_sort_with_sort_keys(Collator $object, array &$array): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Sort array maintaining index association
  * @link https://php.net/manual/en/collator.asort.php
  * @param Collator $object
- * @param array $arr <p>Array of strings to sort.</p>
- * @param int $sort_flag [optional] <p>
+ * @param string[] &$array <p>Array of strings to sort.</p>
+ * @param int $flags [optional] <p>
  * Optional sorting type, one of the following:
- * <p>
  * <b>Collator::SORT_REGULAR</b>
  * - compare items normally (don't change types)
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function collator_asort(Collator $object, array &$arr, $sort_flag = null) { }
+function collator_asort(Collator $object, array &$array, int $flags = null): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3408,41 +3557,45 @@ function collator_asort(Collator $object, array &$arr, $sort_flag = null) { }
  * <b>Locale::ACTUAL_LOCALE</b>,
  * respectively). The default is the actual locale.
  * </p>
- * @return string Real locale name from which the collation data comes. If the collator was
+ * @return string|false Real locale name from which the collation data comes. If the collator was
  * instantiated from rules or an error occurred, returns
  * boolean <b>FALSE</b>.
  */
-function collator_get_locale(Collator $object, $type = null) { }
+#[Pure]
+function collator_get_locale(Collator $object, int $type = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get collator's last error code
  * @link https://php.net/manual/en/collator.geterrorcode.php
  * @param Collator $object
- * @return int Error code returned by the last Collator API function call.
+ * @return int|false Error code returned by the last Collator API function call.
  */
-function collator_get_error_code(Collator $object) { }
+#[Pure]
+function collator_get_error_code(Collator $object): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get text for collator's last error code
  * @link https://php.net/manual/en/collator.geterrormessage.php
  * @param Collator $object
- * @return string Description of an error occurred in the last Collator API function call.
+ * @return string|false Description of an error occurred in the last Collator API function call.
  */
-function collator_get_error_message(Collator $object) { }
+#[Pure]
+function collator_get_error_message(Collator $object): string|false { }
 
 /**
- * (No version information available, might only be in SVN)<br/>
+ * (PHP 5 &gt;= 5.3.2, PHP 7, PECL intl &gt;= 1.0.3)<br/>
  * Get sorting key for a string
  * @link https://php.net/manual/en/collator.getsortkey.php
  * @param Collator $object
- * @param string $str <p>
+ * @param string $string <p>
  * The string to produce the key from.
  * </p>
- * @return string the collation key for the string. Collation keys can be compared directly instead of strings.
+ * @return string|false the collation key for the string. Collation keys can be compared directly instead of strings.
  */
-function collator_get_sort_key(Collator $object, $str) { }
+#[Pure]
+function collator_get_sort_key(Collator $object, string $string): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3466,16 +3619,17 @@ function collator_get_sort_key(Collator $object, $str) { }
  * @param string $pattern [optional] <p>
  * Pattern string if the chosen style requires a pattern.
  * </p>
- * @return NumberFormatter|false <b>NumberFormatter</b> object or <b>FALSE</b> on error.
+ * @return NumberFormatter|false|null <b>NumberFormatter</b> object or <b>FALSE</b> on error.
  */
-function numfmt_create($locale, $style, $pattern = null) { }
+#[Pure]
+function numfmt_create(string $locale, int $style, string $pattern = null): ?NumberFormatter { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Format a number
  * @link https://php.net/manual/en/numberformatter.format.php
- * @param NumberFormatter $fmt
- * @param int|float $value <p>
+ * @param NumberFormatter $formatter
+ * @param int|float $num <p>
  * The value to format. Can be integer or float,
  * other values will be converted to a numeric value.
  * </p>
@@ -3485,95 +3639,99 @@ function numfmt_create($locale, $style, $pattern = null) { }
  * </p>
  * @return string|false the string containing formatted value, or <b>FALSE</b> on error.
  */
-function numfmt_format(NumberFormatter $fmt, $value, $type = null) { }
+#[Pure]
+function numfmt_format(NumberFormatter $formatter, int|float $num, int $type = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Parse a number
  * @link https://php.net/manual/en/numberformatter.parse.php
- * @param NumberFormatter $fmt
- * @param string $value
+ * @param NumberFormatter $formatter
+ * @param string $string
  * @param int $type [optional] <p>
  * The
  * formatting type to use. By default,
  * <b>NumberFormatter::TYPE_DOUBLE</b> is used.
  * </p>
- * @param int $position [optional] <p>
+ * @param int &$offset [optional] <p>
  * Offset in the string at which to begin parsing. On return, this value
  * will hold the offset at which parsing ended.
  * </p>
- * @return mixed The value of the parsed number or <b>FALSE</b> on error.
+ * @return int|float|false The value of the parsed number or <b>FALSE</b> on error.
  */
-function numfmt_parse(NumberFormatter $fmt, $value, $type = null, &$position = null) { }
+#[Pure]
+function numfmt_parse(NumberFormatter $formatter, string $string, int $type = NumberFormatter::TYPE_DOUBLE, &$offset = null): int|float|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Format a currency value
  * @link https://php.net/manual/en/numberformatter.formatcurrency.php
- * @param NumberFormatter $fmt
- * @param float $value <p>
+ * @param NumberFormatter $formatter
+ * @param float $amount <p>
  * The numeric currency value.
  * </p>
  * @param string $currency <p>
  * The 3-letter ISO 4217 currency code indicating the currency to use.
  * </p>
- * @return string String representing the formatted currency value.
+ * @return string|false String representing the formatted currency value.
  */
-function numfmt_format_currency(NumberFormatter $fmt, $value, $currency) { }
+#[Pure]
+function numfmt_format_currency(NumberFormatter $formatter, float $amount, string $currency): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Parse a currency number
  * @link https://php.net/manual/en/numberformatter.parsecurrency.php
- * @param NumberFormatter $fmt
- * @param string $value
- * @param string $currency <p>
+ * @param NumberFormatter $formatter
+ * @param string $string
+ * @param string &$currency <p>
  * Parameter to receive the currency name (3-letter ISO 4217 currency
  * code).
  * </p>
- * @param int $position [optional] <p>
+ * @param int &$offset [optional] <p>
  * Offset in the string at which to begin parsing. On return, this value
  * will hold the offset at which parsing ended.
  * </p>
  * @return float|false The parsed numeric value or <b>FALSE</b> on error.
  */
-function numfmt_parse_currency(NumberFormatter $fmt, $value, &$currency, &$position = null) { }
+function numfmt_parse_currency(NumberFormatter $formatter, string $string, &$currency, &$offset = null): float|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set an attribute
  * @link https://php.net/manual/en/numberformatter.setattribute.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $attribute <p>
  * Attribute specifier - one of the
  * numeric attribute constants.
  * </p>
- * @param int $value <p>
+ * @param int|float $value <p>
  * The attribute value.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function numfmt_set_attribute(NumberFormatter $fmt, $attr, $value) { }
+function numfmt_set_attribute(NumberFormatter $formatter, int $attribute, int|float $value): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get an attribute
  * @link https://php.net/manual/en/numberformatter.getattribute.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $attribute <p>
  * Attribute specifier - one of the
  * numeric attribute constants.
  * </p>
- * @return int|false Return attribute value on success, or <b>FALSE</b> on error.
+ * @return int|float|false Return attribute value on success, or <b>FALSE</b> on error.
  */
-function numfmt_get_attribute(NumberFormatter $fmt, $attr) { }
+#[Pure]
+function numfmt_get_attribute(NumberFormatter $formatter, int $attribute): int|float|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set a text attribute
  * @link https://php.net/manual/en/numberformatter.settextattribute.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $attribute <p>
  * Attribute specifier - one of the
  * text attribute
  * constants.
@@ -3583,27 +3741,28 @@ function numfmt_get_attribute(NumberFormatter $fmt, $attr) { }
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function numfmt_set_text_attribute(NumberFormatter $fmt, $attr, $value) { }
+function numfmt_set_text_attribute(NumberFormatter $formatter, int $attribute, string $value): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get a text attribute
  * @link https://php.net/manual/en/numberformatter.gettextattribute.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $attribute <p>
  * Attribute specifier - one of the
  * text attribute constants.
  * </p>
  * @return string|false Return attribute value on success, or <b>FALSE</b> on error.
  */
-function numfmt_get_text_attribute(NumberFormatter $fmt, $attr) { }
+#[Pure]
+function numfmt_get_text_attribute(NumberFormatter $formatter, int $attribute): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set a symbol value
  * @link https://php.net/manual/en/numberformatter.setsymbol.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $symbol <p>
  * Symbol specifier, one of the
  * format symbol constants.
  * </p>
@@ -3612,26 +3771,27 @@ function numfmt_get_text_attribute(NumberFormatter $fmt, $attr) { }
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function numfmt_set_symbol(NumberFormatter $fmt, $attr, $value) { }
+function numfmt_set_symbol(NumberFormatter $formatter, int $symbol, string $value): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get a symbol value
  * @link https://php.net/manual/en/numberformatter.getsymbol.php
- * @param NumberFormatter $fmt
- * @param int $attr <p>
+ * @param NumberFormatter $formatter
+ * @param int $symbol <p>
  * Symbol specifier, one of the
  * format symbol constants.
  * </p>
  * @return string|false The symbol string or <b>FALSE</b> on error.
  */
-function numfmt_get_symbol(NumberFormatter $fmt, $attr) { }
+#[Pure]
+function numfmt_get_symbol(NumberFormatter $formatter, int $symbol): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set formatter pattern
  * @link https://php.net/manual/en/numberformatter.setpattern.php
- * @param NumberFormatter $fmt
+ * @param NumberFormatter $formatter
  * @param string $pattern <p>
  * Pattern in syntax described in
  * ICU DecimalFormat
@@ -3639,94 +3799,98 @@ function numfmt_get_symbol(NumberFormatter $fmt, $attr) { }
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function numfmt_set_pattern(NumberFormatter $fmt, $pattern) { }
+function numfmt_set_pattern(NumberFormatter $formatter, string $pattern): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get formatter pattern
  * @link https://php.net/manual/en/numberformatter.getpattern.php
- * @param NumberFormatter $fmt
- * @param $nf
+ * @param NumberFormatter $formatter
  * @return string|false Pattern string that is used by the formatter, or <b>FALSE</b> if an error happens.
  */
-function numfmt_get_pattern(NumberFormatter $fmt, $nf) { }
+#[Pure]
+function numfmt_get_pattern(NumberFormatter $formatter): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get formatter locale
  * @link https://php.net/manual/en/numberformatter.getlocale.php
- * @param NumberFormatter $fmt
+ * @param NumberFormatter $formatter
  * @param int $type [optional] <p>
  * You can choose between valid and actual locale (
  * <b>Locale::VALID_LOCALE</b>,
  * <b>Locale::ACTUAL_LOCALE</b>,
  * respectively). The default is the actual locale.
  * </p>
- * @return string The locale name used to create the formatter.
+ * @return string|false The locale name used to create the formatter.
  */
-function numfmt_get_locale(NumberFormatter $fmt, $type = null) { }
+#[Pure]
+function numfmt_get_locale(NumberFormatter $formatter, int $type = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get formatter's last error code.
  * @link https://php.net/manual/en/numberformatter.geterrorcode.php
- * @param NumberFormatter $fmt
- * @param $nf
+ * @param NumberFormatter $formatter
  * @return int error code from last formatter call.
  */
-function numfmt_get_error_code(NumberFormatter $fmt, $nf) { }
+#[Pure]
+function numfmt_get_error_code(NumberFormatter $formatter): int { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get formatter's last error message.
  * @link https://php.net/manual/en/numberformatter.geterrormessage.php
- * @param NumberFormatter $fmt
- * @param $nf
+ * @param NumberFormatter $formatter
  * @return string error message from last formatter call.
  */
-function numfmt_get_error_message(NumberFormatter $fmt, $nf) { }
+#[Pure]
+function numfmt_get_error_message(NumberFormatter $formatter): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Normalizes the input provided and returns the normalized string
  * @link https://php.net/manual/en/normalizer.normalize.php
- * @param string $input <p>The input string to normalize</p>
- * @param string $form [optional] <p>One of the normalization forms.</p>
- * @return string The normalized string or <b>NULL</b> if an error occurred.
+ * @param string $string <p>The input string to normalize</p>
+ * @param int $form [optional] <p>One of the normalization forms.</p>
+ * @return string|false The normalized string or <b>FALSE</b> if an error occurred.
  */
-function normalizer_normalize($input, $form = Normalizer::FORM_C) { }
+#[Pure]
+function normalizer_normalize(string $string, int $form = Normalizer::FORM_C): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Checks if the provided string is already in the specified normalization
-form.
+* form.
  * @link https://php.net/manual/en/normalizer.isnormalized.php
- * @param string $input <p>The input string to normalize</p>
- * @param string $form [optional] <p>
+ * @param string $string <p>The input string to normalize</p>
+ * @param int $form [optional] <p>
  * One of the normalization forms.
  * </p>
  * @return bool <b>TRUE</b> if normalized, <b>FALSE</b> otherwise or if there an error
  */
-function normalizer_is_normalized($input, $form = Normalizer::FORM_C) { }
+#[Pure]
+function normalizer_is_normalized(string $string, int $form = Normalizer::FORM_C): bool { }
 
 /**
- * Get the default Locale
+ * Gets the default locale value from the intl global 'default_locale'
  * @link https://php.net/manual/en/function.locale-get-default.php
  * @return string a string with the current Locale.
  */
-function locale_get_default() { }
+#[Pure]
+function locale_get_default(): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
- * Set the default Locale
+ * Set the default runtime Locale
  * @link https://php.net/manual/en/function.locale-set-default.php
- * @param string $name <p>
+ * @param string $locale <p>
  * The new Locale name. A comprehensive list of the supported locales is
  * available at .
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function locale_set_default($name) { }
+function locale_set_default(string $locale): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3735,9 +3899,10 @@ function locale_set_default($name) { }
  * @param string $locale <p>
  * The locale to extract the primary language code from
  * </p>
- * @return string The language code associated with the language or <b>NULL</b> in case of error.
+ * @return string|null The language code associated with the language or <b>NULL</b> in case of error.
  */
-function locale_get_primary_language($locale) { }
+#[Pure]
+function locale_get_primary_language(string $locale): ?string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3746,9 +3911,10 @@ function locale_get_primary_language($locale) { }
  * @param string $locale <p>
  * The locale to extract the script code from
  * </p>
- * @return string The script subtag for the locale or <b>NULL</b> if not present
+ * @return string|null The script subtag for the locale or <b>NULL</b> if not present
  */
-function locale_get_script($locale) { }
+#[Pure]
+function locale_get_script(string $locale): ?string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3757,9 +3923,10 @@ function locale_get_script($locale) { }
  * @param string $locale <p>
  * The locale to extract the region code from
  * </p>
- * @return string The region subtag for the locale or <b>NULL</b> if not present
+ * @return string|null The region subtag for the locale or <b>NULL</b> if not present
  */
-function locale_get_region($locale) { }
+#[Pure]
+function locale_get_region(string $locale): ?string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3768,9 +3935,10 @@ function locale_get_region($locale) { }
  * @param string $locale <p>
  * The locale to extract the keywords from
  * </p>
- * @return array Associative array containing the keyword-value pairs for this locale
+ * @return array|false|null Associative array containing the keyword-value pairs for this locale
  */
-function locale_get_keywords($locale) { }
+#[Pure]
+function locale_get_keywords(string $locale): array|false|null { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3779,13 +3947,14 @@ function locale_get_keywords($locale) { }
  * @param string $locale <p>
  * The locale to return a display script for
  * </p>
- * @param string $in_locale [optional] <p>
+ * @param string|null $displayLocale [optional] <p>
  * Optional format locale to use to display the script name
  * </p>
- * @return string Display name of the script for the $locale in the format appropriate for
+ * @return string|false Display name of the script for the $locale in the format appropriate for
  * $in_locale.
  */
-function locale_get_display_script($locale, $in_locale = null) { }
+#[Pure]
+function locale_get_display_script(string $locale, ?string $displayLocale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3794,13 +3963,14 @@ function locale_get_display_script($locale, $in_locale = null) { }
  * @param string $locale <p>
  * The locale to return a display region for.
  * </p>
- * @param string $in_locale [optional] <p>
+ * @param string|null $displayLocale [optional] <p>
  * Optional format locale to use to display the region name
  * </p>
- * @return string display name of the region for the $locale in the format appropriate for
+ * @return string|false display name of the region for the $locale in the format appropriate for
  * $in_locale.
  */
-function locale_get_display_region($locale, $in_locale = null) { }
+#[Pure]
+function locale_get_display_region(string $locale, ?string $displayLocale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3809,10 +3979,11 @@ function locale_get_display_region($locale, $in_locale = null) { }
  * @param string $locale <p>
  * The locale to return a display name for.
  * </p>
- * @param string $in_locale [optional] <p>optional format locale</p>
- * @return string Display name of the locale in the format appropriate for $in_locale.
+ * @param string|null $displayLocale [optional] <p>optional format locale</p>
+ * @return string|false Display name of the locale in the format appropriate for $in_locale.
  */
-function locale_get_display_name($locale, $in_locale = null) { }
+#[Pure]
+function locale_get_display_name(string $locale, ?string $displayLocale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3821,13 +3992,14 @@ function locale_get_display_name($locale, $in_locale = null) { }
  * @param string $locale <p>
  * The locale to return a display language for
  * </p>
- * @param string $in_locale [optional] <p>
+ * @param string|null $displayLocale [optional] <p>
  * Optional format locale to use to display the language name
  * </p>
- * @return string display name of the language for the $locale in the format appropriate for
+ * @return string|false display name of the language for the $locale in the format appropriate for
  * $in_locale.
  */
-function locale_get_display_language($locale, $in_locale = null) { }
+#[Pure]
+function locale_get_display_language(string $locale, ?string $displayLocale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3836,19 +4008,20 @@ function locale_get_display_language($locale, $in_locale = null) { }
  * @param string $locale <p>
  * The locale to return a display variant for
  * </p>
- * @param string $in_locale [optional] <p>
+ * @param string|null $displayLocale [optional] <p>
  * Optional format locale to use to display the variant name
  * </p>
- * @return string Display name of the variant for the $locale in the format appropriate for
+ * @return string|false Display name of the variant for the $locale in the format appropriate for
  * $in_locale.
  */
-function locale_get_display_variant($locale, $in_locale = null) { }
+#[Pure]
+function locale_get_display_variant(string $locale, ?string $displayLocale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Returns a correctly ordered and delimited locale ID
  * @link https://php.net/manual/en/locale.composelocale.php
- * @param array $subtags <p>
+ * @param string[] $subtags <p>
  * an array containing a list of key-value pairs, where the keys identify
  * the particular locale ID subtags, and the values are the associated
  * subtag values.
@@ -3866,9 +4039,10 @@ function locale_get_display_variant($locale, $in_locale = null) { }
  * (e.g. 'variant0', 'variant1', etc.).
  * </p>
  * </p>
- * @return string The corresponding locale identifier.
+ * @return string|false The corresponding locale identifier.
  */
-function locale_compose(array $subtags) { }
+#[Pure]
+function locale_compose(array $subtags): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3879,14 +4053,15 @@ function locale_compose(array $subtags) { }
  * 'private' subtags can take maximum 15 values whereas 'extlang' can take
  * maximum 3 values.
  * </p>
- * @return array an array containing a list of key-value pairs, where the keys
+ * @return string[]|null an array containing a list of key-value pairs, where the keys
  * identify the particular locale ID subtags, and the values are the
  * associated subtag values. The array will be ordered as the locale id
  * subtags e.g. in the locale id if variants are '-varX-varY-varZ' then the
  * returned array will have variant0=&gt;varX , variant1=&gt;varY ,
  * variant2=&gt;varZ
  */
-function locale_parse($locale) { }
+#[Pure]
+function locale_parse(string $locale): ?array { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3895,16 +4070,17 @@ function locale_parse($locale) { }
  * @param string $locale <p>
  * The locale to extract the variants from
  * </p>
- * @return array The array containing the list of all variants subtag for the locale
+ * @return array|null The array containing the list of all variants subtag for the locale
  * or <b>NULL</b> if not present
  */
-function locale_get_all_variants($locale) { }
+#[Pure]
+function locale_get_all_variants(string $locale): ?array { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Checks if a language tag filter matches with locale
  * @link https://php.net/manual/en/locale.filtermatches.php
- * @param string $langtag <p>
+ * @param string $languageTag <p>
  * The language tag to check
  * </p>
  * @param string $locale <p>
@@ -3914,20 +4090,25 @@ function locale_get_all_variants($locale) { }
  * If true, the arguments will be converted to canonical form before
  * matching.
  * </p>
- * @return bool <b>TRUE</b> if $locale matches $langtag <b>FALSE</b> otherwise.
+ * @return bool|null <b>TRUE</b> if $locale matches $langtag <b>FALSE</b> otherwise.
  */
-function locale_filter_matches($langtag, $locale, $canonicalize = false) { }
+#[Pure]
+function locale_filter_matches(string $languageTag, string $locale, bool $canonicalize = false): ?bool { }
 
 /**
- * @param $arg1
+ * Canonicalize the locale string
+ * @param string $locale
+ *
+ * @return null|string
  */
-function locale_canonicalize($arg1) { }
+#[Pure]
+function locale_canonicalize(string $locale): ?string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Searches the language tag list for the best match to the language
  * @link https://php.net/manual/en/locale.lookup.php
- * @param array $langtag <p>
+ * @param string[] $languageTag <p>
  * An array containing a list of language tags to compare to
  * <i>locale</i>. Maximum 100 items allowed.
  * </p>
@@ -3938,12 +4119,13 @@ function locale_canonicalize($arg1) { }
  * If true, the arguments will be converted to canonical form before
  * matching.
  * </p>
- * @param string $default [optional] <p>
+ * @param string|null $defaultLocale [optional] <p>
  * The locale to use if no match is found.
  * </p>
- * @return string The closest matching language tag or default value.
+ * @return string|null The closest matching language tag or default value.
  */
-function locale_lookup(array $langtag, $locale, $canonicalize = false, $default = null) { }
+#[Pure]
+function locale_lookup(array $languageTag, string $locale, bool $canonicalize = false, ?string $defaultLocale = null): ?string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3952,27 +4134,32 @@ function locale_lookup(array $langtag, $locale, $canonicalize = false, $default 
  * @param string $header <p>
  * The string containing the "Accept-Language" header according to format in RFC 2616.
  * </p>
- * @return string The corresponding locale identifier.
+ * @return string|false The corresponding locale identifier.
  */
-function locale_accept_from_http($header) { }
+#[Pure]
+function locale_accept_from_http(string $header): string|false { }
 
 /**
- * @param $locale
- * @param $pattern
+ * Constructs a new message formatter
+ * @param string $locale
+ * @param string $pattern
+ * @return MessageFormatter|null
  */
-function msgfmt_create($locale, $pattern) { }
+#[Pure]
+function msgfmt_create(string $locale, string $pattern): ?MessageFormatter { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Format the message
  * @link https://php.net/manual/en/messageformatter.format.php
- * @param MessageFormatter $fmt
- * @param array $args <p>
+ * @param MessageFormatter $formatter
+ * @param array $values <p>
  * Arguments to insert into the format string
  * </p>
  * @return string|false The formatted string, or <b>FALSE</b> if an error occurred
  */
-function msgfmt_format(MessageFormatter $fmt, array $args) { }
+#[Pure]
+function msgfmt_format(MessageFormatter $formatter, array $values): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -3987,48 +4174,50 @@ function msgfmt_format(MessageFormatter $fmt, array $args) { }
  * umsg_autoQuoteApostrophe
  * before being interpreted.
  * </p>
- * @param array $args <p>
+ * @param array $values <p>
  * The array of values to insert into the format string
  * </p>
  * @return string|false The formatted pattern string or <b>FALSE</b> if an error occurred
  */
-function msgfmt_format_message(string $locale, string $pattern, array $args) { }
+#[Pure]
+function msgfmt_format_message(string $locale, string $pattern, array $values): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Parse input string according to pattern
  * @link https://php.net/manual/en/messageformatter.parse.php
- * @param MessageFormatter $fmt
- * @param string $value <p>
+ * @param MessageFormatter $formatter
+ * @param string $string <p>
  * The string to parse
  * </p>
  * @return array|false An array containing the items extracted, or <b>FALSE</b> on error
  */
-function msgfmt_parse(MessageFormatter $fmt, $value) { }
+#[Pure]
+function msgfmt_parse(MessageFormatter $formatter, string $string): array|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Quick parse input string
  * @link https://php.net/manual/en/messageformatter.parsemessage.php
- * @param MessageFormatter $fmt
  * @param string $locale <p>
  * The locale to use for parsing locale-dependent parts
  * </p>
  * @param string $pattern <p>
  * The pattern with which to parse the <i>value</i>.
  * </p>
- * @param string $source <p>
+ * @param string $message <p>
  * The string to parse, conforming to the <i>pattern</i>.
  * </p>
  * @return array|false An array containing items extracted, or <b>FALSE</b> on error
  */
-function msgfmt_parse_message(MessageFormatter $fmt, $locale, $pattern, $source) { }
+#[Pure]
+function msgfmt_parse_message(string $locale, string $pattern, string $message): array|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set the pattern used by the formatter
  * @link https://php.net/manual/en/messageformatter.setpattern.php
- * @param MessageFormatter $fmt
+ * @param MessageFormatter $formatter
  * @param string $pattern <p>
  * The pattern string to use in this message formatter.
  * The pattern uses an 'apostrophe-friendly' syntax; it is run through
@@ -4037,47 +4226,47 @@ function msgfmt_parse_message(MessageFormatter $fmt, $locale, $pattern, $source)
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function msgfmt_set_pattern(MessageFormatter $fmt, $pattern) { }
+function msgfmt_set_pattern(MessageFormatter $formatter, string $pattern): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the pattern used by the formatter
  * @link https://php.net/manual/en/messageformatter.getpattern.php
- * @param MessageFormatter $fmt
- * @param $mf
- * @return string The pattern string for this message formatter
+ * @param MessageFormatter $formatter
+ * @return string|false The pattern string for this message formatter
  */
-function msgfmt_get_pattern(MessageFormatter $fmt, $mf) { }
+#[Pure]
+function msgfmt_get_pattern(MessageFormatter $formatter): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the locale for which the formatter was created.
  * @link https://php.net/manual/en/messageformatter.getlocale.php
- * @param MessageFormatter $fmt
- * @param $mf
+ * @param MessageFormatter $formatter
  * @return string The locale name
  */
-function msgfmt_get_locale(MessageFormatter $fmt, $mf) { }
+#[Pure]
+function msgfmt_get_locale(MessageFormatter $formatter): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the error code from last operation
  * @link https://php.net/manual/en/messageformatter.geterrorcode.php
- * @param MessageFormatter $fmt
- * @param $nf
+ * @param MessageFormatter $formatter
  * @return int The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR.
  */
-function msgfmt_get_error_code(MessageFormatter $fmt, $nf) { }
+#[Pure]
+function msgfmt_get_error_code(MessageFormatter $formatter): int { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the error text from the last operation
  * @link https://php.net/manual/en/messageformatter.geterrormessage.php
- * @param MessageFormatter $fmt
- * @param $coll
+ * @param MessageFormatter $formatter
  * @return string Description of the last error.
  */
-function msgfmt_get_error_message(MessageFormatter $fmt, $coll) { }
+#[Pure]
+function msgfmt_get_error_message(MessageFormatter $formatter): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4086,14 +4275,14 @@ function msgfmt_get_error_message(MessageFormatter $fmt, $coll) { }
  * @param string|null $locale <p>
  * Locale to use when formatting or parsing.
  * </p>
- * @param int $datetype <p>
+ * @param int $dateType <p>
  * Date type to use (<b>none</b>,
  * <b>short</b>, <b>medium</b>,
  * <b>long</b>, <b>full</b>).
  * This is one of the
  * IntlDateFormatter constants.
  * </p>
- * @param int $timetype <p>
+ * @param int $timeType <p>
  * Time type to use (<b>none</b>,
  * <b>short</b>, <b>medium</b>,
  * <b>long</b>, <b>full</b>).
@@ -4103,7 +4292,7 @@ function msgfmt_get_error_message(MessageFormatter $fmt, $coll) { }
  * @param string|null $timezone [optional] <p>
  * Time zone ID, default is system default.
  * </p>
- * @param int|null $calendar [optional] <p>
+ * @param IntlCalendar|int|null $calendar [optional] <p>
  * Calendar to use for formatting or parsing; default is Gregorian.
  * This is one of the
  * IntlDateFormatter calendar constants.
@@ -4112,84 +4301,94 @@ function msgfmt_get_error_message(MessageFormatter $fmt, $coll) { }
  * Optional pattern to use when formatting or parsing.
  * Possible patterns are documented at http://userguide.icu-project.org/formatparse/datetime.
  * </p>
- * @return IntlDateFormatter
+ * @return IntlDateFormatter|null
  */
-function datefmt_create($locale, $datetype, $timetype, $timezone = null, $calendar = null, $pattern = '') { }
+#[Pure]
+function datefmt_create(?string $locale, int $dateType, int $timeType, $timezone = null, IntlCalendar|int|null $calendar = null, string $pattern = ''): ?IntlDateFormatter { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the datetype used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.getdatetype.php
- * @param $mf
- * @return int The current date type value of the formatter.
+ * @param IntlDateFormatter $formatter
+ * @return int|false The current date type value of the formatter.
  */
-function datefmt_get_datetype(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_datetype(IntlDateFormatter $formatter): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the timetype used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.gettimetype.php
- * @param $mf
- * @return int The current date type value of the formatter.
+ * @param IntlDateFormatter $formatter
+ * @return int|false The current date type value of the formatter.
  */
-function datefmt_get_timetype(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_timetype(IntlDateFormatter $formatter): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
- * Get the calendar used for the IntlDateFormatter
+ * Get the calendar type used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.getcalendar.php
- * @param $mf
- * @return int The calendar being used by the formatter.
+ * @param IntlDateFormatter $formatter
+ * @return int|false The calendar being used by the formatter.
  */
-function datefmt_get_calendar(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_calendar(IntlDateFormatter $formatter): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * sets the calendar used to the appropriate calendar, which must be
  * @link https://php.net/manual/en/intldateformatter.setcalendar.php
- * @param MessageFormatter $mf
- * @param int $which <p>
+ * @param IntlDateFormatter $formatter $mf
+ * @param IntlCalendar|int|null $calendar <p>
  * The calendar to use.
  * Default is <b>IntlDateFormatter::GREGORIAN</b>.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function datefmt_set_calendar(MessageFormatter $mf, $which) { }
+function datefmt_set_calendar(IntlDateFormatter $formatter, IntlCalendar|int|null $calendar): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the locale used by formatter
  * @link https://php.net/manual/en/intldateformatter.getlocale.php
- * @param MessageFormatter $mf
- * @param int $which [optional]
+ * @param IntlDateFormatter $formatter
+ * @param int $type [optional]
  * @return string|false the locale of this formatter or 'false' if error
  */
-function datefmt_get_locale(MessageFormatter $mf, $which = null) { }
+#[Pure]
+function datefmt_get_locale(IntlDateFormatter $formatter, int $type = ULOC_ACTUAL_LOCALE): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the timezone-id used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.gettimezoneid.php
- * @param $mf
- * @return string ID string for the time zone used by this formatter.
+ * @param IntlDateFormatter $formatter
+ * @return string|false ID string for the time zone used by this formatter.
  */
-function datefmt_get_timezone_id(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_timezone_id(IntlDateFormatter $formatter): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 3.0.0)<br/>
  * Get copy of formatter's calendar object
- * @link https://www.php.net/manual/en/intldateformatter.getcalendarobject.php
- * @return IntlCalendar A copy of the internal calendar object used by this formatter.
+ * @link https://secure.php.net/manual/en/intldateformatter.getcalendarobject.php
+ * @param IntlDateFormatter $formatter
+ * @return IntlCalendar|false|null A copy of the internal calendar object used by this formatter.
  */
-function datefmt_get_calendar_object() { }
+#[Pure]
+function datefmt_get_calendar_object(IntlDateFormatter $formatter): IntlCalendar|false|null { }
 
 /**
  * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
  *  Get formatter's timezone
- * @link https://www.php.net/manual/en/intldateformatter.gettimezone.php
+ * @link https://secure.php.net/manual/en/intldateformatter.gettimezone.php
+ * @param IntlDateFormatter $formatter
  * @return IntlTimeZone|false The associated IntlTimeZone object or FALSE on failure.
  */
-function datefmt_get_timezone() { }
+#[Pure]
+function datefmt_get_timezone(IntlDateFormatter $formatter): IntlTimeZone|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4201,66 +4400,68 @@ function datefmt_get_timezone() { }
  * If <b>NULL</b> or the empty string, the default time zone for the runtime is used.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @deprecated 5.5 https://www.php.net/manual/en/migration55.deprecated.php
  * @removed 7.0
+ * @see datefmt_set_timezone()
  */
+#[Deprecated(replacement: "datefmt_set_timezone(%parametersList%)", since: "5.5")]
 function datefmt_set_timezone_id(MessageFormatter $mf, $zone) { }
 
 /**
  * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
  * Sets formatter's timezone
  * @link https://php.net/manual/en/intldateformatter.settimezone.php
- * @param MessageFormatter $mf
- * @param mixed $zone <p>
+ * @param IntlDateFormatter $formatter
+ * @param IntlTimeZone|DateTimeZone|string|null $timezone <p>
  * The timezone to use for this formatter. This can be specified in the
  * following forms:
  * <ul>
  * <li>
  * <p>
  * <b>NULL</b>, in which case the default timezone will be used, as specified in
- * the ini setting {@link "https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone" date.timezone} or
- * through the function  {@link "https://www.php.net/manual/en/function.date-default-timezone-set.php" date_default_timezone_set()} and as
- * returned by {@link "https://www.php.net/manual/en/function.date-default-timezone-get.php" date_default_timezone_get()}.
+ * the ini setting {@link "https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone" date.timezone} or
+ * through the function  {@link "https://secure.php.net/manual/en/function.date-default-timezone-set.php" date_default_timezone_set()} and as
+ * returned by {@link "https://secure.php.net/manual/en/function.date-default-timezone-get.php" date_default_timezone_get()}.
  * </p>
  * </li>
  * <li>
  * <p>
- * An {@link "https://www.php.net/manual/en/class.intltimezone.php" IntlTimeZone}, which will be used directly.
+ * An {@link "https://secure.php.net/manual/en/class.intltimezone.php" IntlTimeZone}, which will be used directly.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link "https://www.php.net/manual/en/class.datetimezone.php" DateTimeZone}. Its identifier will be extracted
+ * A {@link "https://secure.php.net/manual/en/class.datetimezone.php" DateTimeZone}. Its identifier will be extracted
  * and an ICU timezone object will be created; the timezone will be backed
  * by ICU's database, not PHP's.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link "https://www.php.net/manual/en/language.types.string.php" string}, which should be a valid ICU timezone identifier.
+ * A {@link "https://secure.php.net/manual/en/language.types.string.php" string}, which should be a valid ICU timezone identifier.
  * See <b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw offsets such as <em>"GMT+08:30"</em> are also accepted.
  * </p>
  * </li>
  * </ul>
  * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+ * @return bool|null <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function datefmt_set_timezone(MessageFormatter $mf, $zone) { }
+function datefmt_set_timezone(IntlDateFormatter $formatter, $timezone): ?bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the pattern used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.getpattern.php
- * @param $mf
- * @return string The pattern string being used to format/parse.
+ * @param IntlDateFormatter $formatter
+ * @return string|false The pattern string being used to format/parse.
  */
-function datefmt_get_pattern(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_pattern(IntlDateFormatter $formatter): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set the pattern used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.setpattern.php
- * @param MessageFormatter $mf
+ * @param IntlDateFormatter $formatter
  * @param string $pattern <p>
  * New pattern string to use.
  * Possible patterns are documented at http://userguide.icu-project.org/formatparse/datetime.
@@ -4268,35 +4469,36 @@ function datefmt_get_pattern(MessageFormatter $mf) { }
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * Bad formatstrings are usually the cause of the failure.
  */
-function datefmt_set_pattern(MessageFormatter $mf, $pattern) { }
+function datefmt_set_pattern(IntlDateFormatter $formatter, string $pattern): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the lenient used for the IntlDateFormatter
  * @link https://php.net/manual/en/intldateformatter.islenient.php
- * @param $mf
+ * @param IntlDateFormatter $formatter
  * @return bool <b>TRUE</b> if parser is lenient, <b>FALSE</b> if parser is strict. By default the parser is lenient.
  */
-function datefmt_is_lenient(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_is_lenient(IntlDateFormatter $formatter): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Set the leniency of the parser
  * @link https://php.net/manual/en/intldateformatter.setlenient.php
- * @param MessageFormatter $mf
+ * @param IntlDateFormatter $formatter
  * @param bool $lenient <p>
  * Sets whether the parser is lenient or not, default is <b>TRUE</b> (lenient).
  * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+ * @return void
  */
-function datefmt_set_lenient(MessageFormatter $mf, $lenient) { }
+function datefmt_set_lenient(IntlDateFormatter $formatter, bool $lenient): void { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Format the date/time value as a string
  * @link https://php.net/manual/en/intldateformatter.format.php
- * @param MessageFormatter $mf
- * @param mixed $value <p>
+ * @param IntlDateFormatter $formatter
+ * @param object|array|string|int|float $datetime <p>
  * Value to format. This may be a <b>DateTime</b> object,
  * an integer representing a Unix timestamp value (seconds
  * since epoch, UTC) or an array in the format output by
@@ -4304,17 +4506,18 @@ function datefmt_set_lenient(MessageFormatter $mf, $lenient) { }
  * </p>
  * @return string|false The formatted string or, if an error occurred, <b>FALSE</b>.
  */
-function datefmt_format(MessageFormatter $mf, $value) { }
+#[Pure]
+function datefmt_format(IntlDateFormatter $formatter, $datetime): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
  * Formats an object
- * @link https://www.php.net/manual/en/intldateformatter.formatobject.php
- * @param object $object <p>
+ * @link https://secure.php.net/manual/en/intldateformatter.formatobject.php
+ * @param IntlCalendar|DateTimeInterface $datetime <p>
  * An object of type IntlCalendar or DateTime. The timezone information in the object will be used.
  * </p>
- * @param mixed $format [optional] <p>
- * How to format the date/time. This can either be an {https://www.php.net/manual/en/language.types.array.php array}  with
+ * @param array|int|string|null $format [optional] <p>
+ * How to format the date/time. This can either be an {https://secure.php.net/manual/en/language.types.array.php array}  with
  * two elements (first the date style, then the time style, these being one
  * of the constants <b>IntlDateFormatter::NONE</b>,
  * <b>IntlDateFormatter::SHORT</b>,
@@ -4322,7 +4525,7 @@ function datefmt_format(MessageFormatter $mf, $value) { }
  * <b>IntlDateFormatter::LONG</b>,
  * <b>IntlDateFormatter::FULL</b>), a long with
  * the value of one of these constants (in which case it will be used both
- * for the time and the date) or a {@link https://www.php.net/manual/en/language.types.string.php} with the format
+ * for the time and the date) or a {@link https://secure.php.net/manual/en/language.types.string.php} with the format
  * described in {@link http://www.icu-project.org/apiref/icu4c/classSimpleDateFormat.html#details the ICU documentation}
  * documentation. If <b>NULL</b>, the default style will be used.
  * </p>
@@ -4330,74 +4533,77 @@ function datefmt_format(MessageFormatter $mf, $value) { }
  * The locale to use, or NULL to use the default one.</p>
  * @return string|false The formatted string or, if an error occurred, <b>FALSE</b>.
  */
-function datefmt_format_object($object, $format = null, $locale = null) { }
+#[Pure]
+function datefmt_format_object($datetime, $format = null, ?string $locale = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Parse string to a timestamp value
  * @link https://php.net/manual/en/intldateformatter.parse.php
- * @param MessageFormatter $mf
- * @param string $value <p>
+ * @param IntlDateFormatter $formatter
+ * @param string $string <p>
  * string to convert to a time
  * </p>
- * @param int $position [optional] <p>
+ * @param int &$offset [optional] <p>
  * Position at which to start the parsing in $value (zero-based).
  * If no error occurs before $value is consumed, $parse_pos will contain -1
  * otherwise it will contain the position at which parsing ended (and the error occurred).
  * This variable will contain the end position if the parse fails.
  * If $parse_pos > strlen($value), the parse fails immediately.
  * </p>
- * @return int timestamp parsed value
+ * @return int|float|false timestamp parsed value
  */
-function datefmt_parse(MessageFormatter $mf, $value, &$position = null) { }
+function datefmt_parse(IntlDateFormatter $formatter, string $string, &$offset = null): int|float|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Parse string to a field-based time value
  * @link https://php.net/manual/en/intldateformatter.localtime.php
- * @param MessageFormatter $mf
- * @param string $value <p>
+ * @param IntlDateFormatter $formatter
+ * @param string $string <p>
  * string to convert to a time
  * </p>
- * @param int $position [optional] <p>
+ * @param int &$offset [optional] <p>
  * Position at which to start the parsing in $value (zero-based).
  * If no error occurs before $value is consumed, $parse_pos will contain -1
  * otherwise it will contain the position at which parsing ended .
  * If $parse_pos > strlen($value), the parse fails immediately.
  * </p>
- * @return array Localtime compatible array of integers : contains 24 hour clock value in tm_hour field
+ * @return array|false Localtime compatible array of integers : contains 24 hour clock value in tm_hour field
  */
-function datefmt_localtime(MessageFormatter $mf, $value, &$position = null) { }
+function datefmt_localtime(IntlDateFormatter $formatter, string $string, &$offset = null): array|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the error code from last operation
  * @link https://php.net/manual/en/intldateformatter.geterrorcode.php
- * @param MessageFormatter $mf
+ * @param IntlDateFormatter $formatter
  * @return int The error code, one of UErrorCode values. Initial value is U_ZERO_ERROR.
  */
-function datefmt_get_error_code(MessageFormatter $mf) { }
+#[Pure]
+function datefmt_get_error_code(IntlDateFormatter $formatter): int { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get the error text from the last operation.
  * @link https://php.net/manual/en/intldateformatter.geterrormessage.php
- * @param MessageFormatter $mf
- * @param $coll
+ * @param IntlDateFormatter $formatter
  * @return string Description of the last error.
  */
-function datefmt_get_error_message(MessageFormatter $mf, $coll) { }
+#[Pure]
+function datefmt_get_error_message(IntlDateFormatter $formatter): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get string length in grapheme units
  * @link https://php.net/manual/en/function.grapheme-strlen.php
- * @param string $input <p>
+ * @param string $string <p>
  * The string being measured for length. It must be a valid UTF-8 string.
  * </p>
  * @return int|false|null The length of the string on success, and 0 if the string is empty.
  */
-function grapheme_strlen($input) { }
+#[Pure]
+function grapheme_strlen(string $string): int|false|null { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4417,7 +4623,8 @@ function grapheme_strlen($input) { }
  * </p>
  * @return int|false the position as an integer. If needle is not found, strpos() will return boolean FALSE.
  */
-function grapheme_strpos($haystack, $needle, $offset = 0) { }
+#[Pure]
+function grapheme_strpos(string $haystack, string $needle, int $offset = 0): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4437,7 +4644,8 @@ function grapheme_strpos($haystack, $needle, $offset = 0) { }
  * </p>
  * @return int|false the position as an integer. If needle is not found, grapheme_stripos() will return boolean FALSE.
  */
-function grapheme_stripos($haystack, $needle, $offset = 0) { }
+#[Pure]
+function grapheme_stripos(string $haystack, string $needle, int $offset = 0): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4457,7 +4665,8 @@ function grapheme_stripos($haystack, $needle, $offset = 0) { }
  * </p>
  * @return int|false the position as an integer. If needle is not found, grapheme_strrpos() will return boolean FALSE.
  */
-function grapheme_strrpos($haystack, $needle, $offset = 0) { }
+#[Pure]
+function grapheme_strrpos(string $haystack, string $needle, int $offset = 0): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4477,7 +4686,8 @@ function grapheme_strrpos($haystack, $needle, $offset = 0) { }
  * </p>
  * @return int|false the position as an integer. If needle is not found, grapheme_strripos() will return boolean FALSE.
  */
-function grapheme_strripos($haystack, $needle, $offset = 0) { }
+#[Pure]
+function grapheme_strripos(string $haystack, string $needle, int $offset = 0): int|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4486,7 +4696,7 @@ function grapheme_strripos($haystack, $needle, $offset = 0) { }
  * @param string $string <p>
  * The input string. Must be valid UTF-8.
  * </p>
- * @param int $start <p>
+ * @param int $offset <p>
  * Start position in default grapheme units.
  * If $start is non-negative, the returned string will start at the
  * $start'th position in $string, counting from zero. If $start is negative,
@@ -4503,10 +4713,11 @@ function grapheme_strripos($haystack, $needle, $offset = 0) { }
  * denotes a position beyond this truncation, <b>FALSE</b> will be returned.
  * </p>
  * @return string|false <p>the extracted part of $string,<br />
-                        or <strong>FALSE</strong> if $length is negative and $start denotes a position beyond truncation $length,<br />
-                        or also <strong>FALSE</strong> if $start denotes a position beyond $string length</p>
+                        * or <strong>FALSE</strong> if $length is negative and $start denotes a position beyond truncation $length,<br />
+                        * or also <strong>FALSE</strong> if $start denotes a position beyond $string length</p>
  */
-function grapheme_substr($string, $start, $length = null) { }
+#[Pure]
+function grapheme_substr(string $string, int $offset, ?int $length = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4518,13 +4729,14 @@ function grapheme_substr($string, $start, $length = null) { }
  * @param string $needle <p>
  * The string to look for. Must be valid UTF-8.
  * </p>
- * @param bool $before_needle [optional] <p>
+ * @param bool $beforeNeedle [optional] <p>
  * If <b>TRUE</b>, grapheme_strstr() returns the part of the
  * haystack before the first occurrence of the needle (excluding the needle).
  * </p>
  * @return string|false the portion of string, or FALSE if needle is not found.
  */
-function grapheme_strstr($haystack, $needle, $before_needle = false) { }
+#[Pure]
+function grapheme_strstr(string $haystack, string $needle, bool $beforeNeedle = false): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4536,13 +4748,14 @@ function grapheme_strstr($haystack, $needle, $before_needle = false) { }
  * @param string $needle <p>
  * The string to look for. Must be valid UTF-8.
  * </p>
- * @param bool $before_needle [optional] <p>
+ * @param bool $beforeNeedle [optional] <p>
  * If <b>TRUE</b>, grapheme_strstr() returns the part of the
  * haystack before the first occurrence of the needle (excluding needle).
  * </p>
  * @return string|false the portion of $haystack, or FALSE if $needle is not found.
  */
-function grapheme_stristr($haystack, $needle, $before_needle = false) { }
+#[Pure]
+function grapheme_stristr(string $haystack, string $needle, bool $beforeNeedle = false): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -4554,7 +4767,7 @@ function grapheme_stristr($haystack, $needle, $before_needle = false) { }
  * @param int $size <p>
  * Maximum number items - based on the $extract_type - to return.
  * </p>
- * @param int $extract_type [optional] <p>
+ * @param int $type [optional] <p>
  * Defines the type of units referred to by the $size parameter:
  * </p>
  * <p>
@@ -4565,20 +4778,20 @@ function grapheme_stristr($haystack, $needle, $before_needle = false) { }
  * GRAPHEME_EXTR_MAXCHARS - $size is the maximum number of UTF-8
  * characters returned.
  * </p>
- * @param int $start [optional] <p>
+ * @param int $offset [optional] <p>
  * Starting position in $haystack in bytes - if given, it must be zero or a
  * positive value that is less than or equal to the length of $haystack in
  * bytes. If $start does not point to the first byte of a UTF-8
  * character, the start position is moved to the next character boundary.
  * </p>
- * @param int $next [optional] <p>
+ * @param int &$next [optional] <p>
  * Reference to a value that will be set to the next starting position.
  * When the call returns, this may point to the first byte position past the end of the string.
  * </p>
  * @return string|false A string starting at offset $start and ending on a default grapheme cluster
  * boundary that conforms to the $size and $extract_type specified.
  */
-function grapheme_extract($haystack, $size, $extract_type = null, $start = 0, &$next = null) { }
+function grapheme_extract(string $haystack, int $size, int $type = null, int $offset = 0, &$next = null): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.2, PHP 7, PECL idn &gt;= 0.1)<br/>
@@ -4590,13 +4803,13 @@ function grapheme_extract($haystack, $size, $extract_type = null, $start = 0, &$
  * passed it will be converted into an ACE encoded "xn--" string.
  * It will not be the one you expected though!
  * </p>
- * @param int $options [optional] <p>
+ * @param int $flags [optional] <p>
  * Conversion options - combination of IDNA_* constants (except IDNA_ERROR_* constants).
  * </p>
  * @param int $variant [optional] <p>
  * Either INTL_IDNA_VARIANT_2003 for IDNA 2003 or INTL_IDNA_VARIANT_UTS46 for UTS #46.
  * </p>
- * @param array $idna_info [optional] <p>
+ * @param array &$idna_info [optional] <p>
  * This parameter can be used only if INTL_IDNA_VARIANT_UTS46 was used for variant.
  * In that case, it will be filled with an array with the keys 'result',
  * the possibly illegal result of the transformation, 'isTransitionalDifferent',
@@ -4606,7 +4819,7 @@ function grapheme_extract($haystack, $size, $extract_type = null, $start = 0, &$
  * </p>
  * @return string|false The ACE encoded version of the domain name or <b>FALSE</b> on failure.
  */
-function idn_to_ascii($domain, $options = 0, $variant = INTL_IDNA_VARIANT_2003, array &$idna_info = null) { }
+function idn_to_ascii(string $domain, int $flags = 0, int $variant = INTL_IDNA_VARIANT_UTS46, &$idna_info): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PHP 7, PECL intl &gt;= 1.0.2, PHP 7, PECL idn &gt;= 0.1)<br/>
@@ -4616,13 +4829,13 @@ function idn_to_ascii($domain, $options = 0, $variant = INTL_IDNA_VARIANT_2003, 
  * Domain to convert in IDNA ASCII-compatible format.
  * The ASCII encoded domain name. Looks like "xn--..." if the it originally contained non-ASCII characters.
  * </p>
- * @param int $options [optional] <p>
+ * @param int $flags [optional] <p>
  * Conversion options - combination of IDNA_* constants (except IDNA_ERROR_* constants).
  * </p>
  * @param int $variant [optional] <p>
  * Either INTL_IDNA_VARIANT_2003 for IDNA 2003 or INTL_IDNA_VARIANT_UTS46 for UTS #46.
  * </p>
- * @param int &$idna_info [optional] <p>
+ * @param array &$idna_info [optional] <p>
  * This parameter can be used only if INTL_IDNA_VARIANT_UTS46 was used for variant.
  * In that case, it will be filled with an array with the keys 'result',
  * the possibly illegal result of the transformation, 'isTransitionalDifferent',
@@ -4634,13 +4847,13 @@ function idn_to_ascii($domain, $options = 0, $variant = INTL_IDNA_VARIANT_2003, 
  * RFC 3490 4.2 states though "ToUnicode never fails. If any step fails, then the original input
  * sequence is returned immediately in that step."
  */
-function idn_to_utf8($domain, $options = 0, $variant = INTL_IDNA_VARIANT_2003, array &$idna_info) { }
+function idn_to_utf8(string $domain, int $flags = 0, int $variant = INTL_IDNA_VARIANT_UTS46, &$idna_info): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Create a new IntlCalendar
- * @link https://www.php.net/manual/en/intlcalendar.createinstance.php
- * @param mixed $timeZone [optional] <p> <p>
+ * @link https://secure.php.net/manual/en/intlcalendar.createinstance.php
+ * @param IntlTimeZone|DateTimeZone|string|null $timezone [optional] <p> <p>
  * The timezone to use.
  * </p>
  *
@@ -4648,95 +4861,99 @@ function idn_to_utf8($domain, $options = 0, $variant = INTL_IDNA_VARIANT_2003, a
  * <li>
  * <p>
  * <b>NULL</b>, in which case the default timezone will be used, as specified in
- * the ini setting {@link https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
- * through the function  {@link https://www.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
- * returned by {@link https://www.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
+ * the ini setting {@link https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
+ * through the function  {@link https://secure.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
+ * returned by {@link https://secure.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
  * </p>
  * </li>
  * <li>
  * <p>
- * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
+ * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link https://www.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
+ * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
  * and an ICU timezone object will be created; the timezone will be backed
  * by ICU's database, not PHP's.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link https://www.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
+ * A {@link https://secure.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
  * See  <b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw
  * offsets such as <em>"GMT+08:30"</em> are also accepted.
  * </p>
  * </li>
  * </ul>
  * </p>
- * @param string $locale [optional] <p>
- * A locale to use or <b>NULL</b> to use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.default-locale the default locale}.
+ * @param string|null $locale [optional] <p>
+ * A locale to use or <b>NULL</b> to use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.default-locale the default locale}.
  * </p>
- * @return IntlCalendar
- * The created {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} instance or <b>NULL</b> on
+ * @return IntlCalendar|null
+ * The created {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} instance or <b>NULL</b> on
  * failure.
  * @since 5.5
  */
-function intlcal_create_instance($timeZone = null, $locale = null) { }
+#[Pure]
+function intlcal_create_instance($timezone = null, ?string $locale = null): ?IntlCalendar { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get set of locale keyword values
- * @param string $key <p>
+ * @param string $keyword <p>
  * The locale keyword for which relevant values are to be queried. Only
  * <em>'calendar'</em> is supported.
  * </p>
  * @param string $locale <p>
  * The locale onto which the keyword/value pair are to be appended.
  * </p>
- * @param bool $commonlyUsed
+ * @param bool $onlyCommon
  * <p>
  * Whether to show only the values commonly used for the specified locale.
  * </p>
- * @return Iterator|false An iterator that yields strings with the locale keyword values or <b>FALSE</b> on failure.
+ * @return IntlIterator|false An iterator that yields strings with the locale keyword values or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_keyword_values_for_locale($key, $locale, $commonlyUsed) { }
+#[Pure]
+function intlcal_get_keyword_values_for_locale(string $keyword, string $locale, bool $onlyCommon): IntlIterator|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get number representing the current time
- * @link https://www.php.net/manual/en/intlcalendar.getnow.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getnow.php
  * @return float A float representing a number of milliseconds since the epoch, not counting leap seconds.
  * @since 5.5
  */
-function intlcal_get_now() { }
+#[Pure]
+function intlcal_get_now(): float { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get array of locales for which there is data
- * @link https://www.php.net/manual/en/intlcalendar.getavailablelocales.php
- * @return array An array of strings, one for which locale.
+ * @link https://secure.php.net/manual/en/intlcalendar.getavailablelocales.php
+ * @return string[] An array of strings, one for which locale.
  * @since 5.5
  */
-
-function intlcal_get_available_locales() { }
+#[Pure]
+function intlcal_get_available_locales(): array { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the value for a field
- * @link https://www.php.net/manual/en/intlcalendar.get.php
+ * @link https://secure.php.net/manual/en/intlcalendar.get.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return int An integer with the value of the time field.
  * @since 5.5
  */
+#[Pure]
 function intl_get($calendar, $field) { }
 
 /**
@@ -4744,17 +4961,21 @@ function intl_get($calendar, $field) { }
  * Get time currently represented by the object
  * @param IntlCalendar $calendar <p>The calendar whose time will be checked against this object's time.</p>
  * @return float
- * A {@link https://www.php.net/manual/en/language.types.float.php float} representing the number of milliseconds elapsed since the
+ * A {@link https://secure.php.net/manual/en/language.types.float.php float} representing the number of milliseconds elapsed since the
  * reference time (1 Jan 1970 00:00:00 UTC).
  * @since 5.5
  */
-function intlcal_get_time($calendar) { }
+#[Pure]
+function intlcal_get_time(IntlCalendar $calendar): float { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set the calendar time in milliseconds since the epoch
- * @link https://www.php.net/manual/en/intlcalendar.settime.php
- * @param float $date <p>
+ * @link https://secure.php.net/manual/en/intlcalendar.settime.php
+ * @param IntlCalendar $calendar <p>
+ * The IntlCalendar resource.
+ * </p>
+ * @param float $timestamp <p>
  * An instant represented by the number of number of milliseconds between
  * such instant and the epoch, ignoring leap seconds.
  * </p>
@@ -4762,35 +4983,35 @@ function intlcal_get_time($calendar) { }
  * Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_set_time($date) { }
+function intlcal_set_time(IntlCalendar $calendar, float $timestamp): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Add a (signed) amount of time to a field
- * @link https://www.php.net/manual/en/intlcalendar.add.php
+ * @link https://secure.php.net/manual/en/intlcalendar.add.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
  * These are integer values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
- * @param int $amount <p>The signed amount to add to the current field. If the amount is positive, the instant will be moved forward; if it is negative, the instant wil be moved into the past. The unit is implicit to the field type.
+ * @param int $value <p>The signed amount to add to the current field. If the amount is positive, the instant will be moved forward; if it is negative, the instant wil be moved into the past. The unit is implicit to the field type.
  * For instance, hours for IntlCalendar::FIELD_HOUR_OF_DAY.</p>
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_add($calendar, $field, $amount) { }
+function intlcal_add(IntlCalendar $calendar, int $field, int $value): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set the timezone used by this calendar
- * @link https://www.php.net/manual/en/intlcalendar.settimezone.php
+ * @link https://secure.php.net/manual/en/intlcalendar.settimezone.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param mixed $timeZone <p>
+ * @param IntlTimeZone|DateTimeZone|string|null $timezone <p>
  * The new timezone to be used by this calendar. It can be specified in the
  * following ways:
  *
@@ -4798,26 +5019,26 @@ function intlcal_add($calendar, $field, $amount) { }
  * <li>
  * <p>
  * <b>NULL</b>, in which case the default timezone will be used, as specified in
- * the ini setting {@link https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
- * through the function  {@link https://www.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
- * returned by  {@link https://www.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
+ * the ini setting {@link https://secure.php.net/manual/en/datetime.configuration.php#ini.date.timezone date.timezone} or
+ * through the function  {@link https://secure.php.net/manual/en/function.date-default-timezone-set.php date_default_timezone_set()} and as
+ * returned by  {@link https://secure.php.net/manual/en/function.date-default-timezone-get.php date_default_timezone_get()}.
  * </p>
  * </li>
  * <li>
  * <p>
- * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
+ * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone}, which will be used directly.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link https://www.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
+ * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone}. Its identifier will be extracted
  * and an ICU timezone object will be created; the timezone will be backed
  * by ICU's database, not PHP's.
  * </p>
  * </li>
  * <li>
  * <p>
- * A {@link https://www.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
+ * A {@link https://secure.php.net/manual/en/language.types.string.php string}, which should be a valid ICU timezone identifier.
  * See  <b>IntlTimeZone::createTimeZoneIDEnumeration()</b>. Raw
  * offsets such as <em>"GMT+08:30"</em> are also accepted.
  * </p>
@@ -4826,53 +5047,56 @@ function intlcal_add($calendar, $field, $amount) { }
  * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_set_time_zone($calendar, $timeZone) { }
+function intlcal_set_time_zone(IntlCalendar $calendar, $timezone): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether this object's time is after that of the passed object
- * https://www.php.net/manual/en/intlcalendar.after.php
- * @param IntlCalendar $calendarObject <p>
+ * https://secure.php.net/manual/en/intlcalendar.after.php
+ * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param IntlCalendar $calendar <p>The calendar whose time will be checked against this object's time.</p>
+ * @param IntlCalendar $other <p>The calendar whose time will be checked against this object's time.</p>
  * @return bool
  * Returns <b>TRUE</b> if this object's current time is after that of the
  * <em>calendar</em> argument's time. Returns <b>FALSE</b> otherwise.
- * Also returns <b>FALSE</b> on failure. You can use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
- * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
+ * Also returns <b>FALSE</b> on failure. You can use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
+ * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
  * @since 5.5
  */
-function intlcal_after(IntlCalendar $calendarObject, IntlCalendar $calendar) { }
+#[Pure]
+function intlcal_after(IntlCalendar $calendar, IntlCalendar $other): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether this object's time is before that of the passed object
- * @link https://www.php.net/manual/en/intlcalendar.before.php
- * @param IntlCalendar $calendarObject <p>
+ * @link https://secure.php.net/manual/en/intlcalendar.before.php
+ * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param IntlCalendar $calendar <p> The calendar whose time will be checked against this object's time.</p>
+ * @param IntlCalendar $other <p> The calendar whose time will be checked against this object's time.</p>
  * @return bool
+ * <p>
  * Returns <b>TRUE</B> if this object's current time is before that of the
  * <em>calendar</em> argument's time. Returns <b>FALSE</b> otherwise.
- * Also returns <b>FALSE</b> on failure. You can use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
- * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
+ * Also returns <b>FALSE</b> on failure. You can use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or
+ * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to detect error conditions.
  * </p>
  * @since 5.5
  */
-function intlcal_before(IntlCalendar $calendarObject, IntlCalendar $calendar) { }
+#[Pure]
+function intlcal_before(IntlCalendar $calendar, IntlCalendar $other): bool { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set a time field or several common fields at once
- * @link https://www.php.net/manual/en/intlcalendar.set.php
+ * @link https://secure.php.net/manual/en/intlcalendar.set.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $year <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
@@ -4895,26 +5119,26 @@ function intlcal_before(IntlCalendar $calendarObject, IntlCalendar $calendar) { 
  * </p>
  * @param int $second [optional] <p>
  * The new value for <b>IntlCalendar::FIELD_SECOND</b>.
- *</p>
+ * </p>
  * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_set($calendar, $year, $month, $dayOfMonth = null, $hour = null, $minute = null, $second = null) { }
+function intlcal_set(IntlCalendar $calendar, int $year, int $month, int $dayOfMonth = null, int $hour = null, int $minute = null, int $second = null): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Add value to field without carrying into more significant fields
- * @link https://www.php.net/manual/en/intlcalendar.roll.php
+ * @link https://secure.php.net/manual/en/intlcalendar.roll.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>One of the
- * {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
- * {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+ * {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time
+ * {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
  * These are integer values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
- * @param mixed $amountOrUpOrDown <p>
+ * @param int|bool $value <p>
  * The (signed) amount to add to the field, <b>TRUE</b> for rolling up (adding
  * <em>1</em>), or <b>FALSE</b> for rolling down (subtracting
  * <em>1</em>).
@@ -4922,33 +5146,33 @@ function intlcal_set($calendar, $year, $month, $dayOfMonth = null, $hour = null,
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_roll($calendar, $field, $amountOrUpOrDown) { }
+function intlcal_roll(IntlCalendar $calendar, int $field, $value): bool{ }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Clear a field or all fields
- * @link https://www.php.net/manual/en/intlcalendar.clear.php
+ * @link https://secure.php.net/manual/en/intlcalendar.clear.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param int $field [optional] <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * @param int|null $field [optional] <p>
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure. Failure can only occur is invalid arguments are provided.
  * @since 5.5
  */
-function intlcal_clear($calendar, $field = null) { }
+function intlcal_clear(IntlCalendar $calendar, ?int $field = null): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Calculate difference between given time and this object's time
- * @link https://www.php.net/manual/en/intlcalendar.fielddifference.php
+ * @link https://secure.php.net/manual/en/intlcalendar.fielddifference.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param float $when <p>
+ * @param float $timestamp <p>
  * The time against which to compare the quantity represented by the
  * <em>field</em>. For the result to be positive, the time
  * given for this parameter must be ahead of the time of the object the
@@ -4959,7 +5183,7 @@ function intlcal_clear($calendar, $field = null) { }
  * </p>
  *
  * <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
@@ -4967,50 +5191,53 @@ function intlcal_clear($calendar, $field = null) { }
  * specified field or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_field_difference($calendar, $when, $field) { }
+#[Pure]
+function intlcal_field_difference(IntlCalendar $calendar, float $timestamp, int $field): int { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * The maximum value for a field, considering the object's current time
- * @link https://www.php.net/manual/en/intlcalendar.getactualmaximum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getactualmaximum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing the maximum value in the units associated
+ * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing the maximum value in the units associated
  * with the given <em>field</em> or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_actual_maximum($calendar, $field) { }
+#[Pure]
+function intlcal_get_actual_maximum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * The minimum value for a field, considering the object's current time
- * @link https://www.php.net/manual/en/intlcalendar.getactualminimum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getactualminimum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}.
  * These are integer values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing the minimum value in the field's
+ * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing the minimum value in the field's
  * unit or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_actual_minimum($calendar, $field) { }
+#[Pure]
+function intlcal_get_actual_minimum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @link https://www.php.net/manual/en/intlcalendar.getdayofweektype.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getdayofweektype.php
  * Tell whether a day is a weekday, weekend or a day that has a transition between the two
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
@@ -5028,12 +5255,13 @@ function intlcal_get_actual_minimum($calendar, $field) { }
  * <b>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</b> or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_day_of_week_type($calendar, $dayOfWeek) { }
+#[Pure]
+function intlcal_get_day_of_week_type(IntlCalendar $calendar, int $dayOfWeek): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the first day of the week for the calendar's locale
- * @link https://www.php.net/manual/en/intlcalendar.getfirstdayofweek.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getfirstdayofweek.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
@@ -5043,88 +5271,91 @@ function intlcal_get_day_of_week_type($calendar, $dayOfWeek) { }
  * <b>IntlCalendar::DOW_SATURDAY</b> or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_first_day_of_week($calendar) { }
+#[Pure]
+function intlcal_get_first_day_of_week(IntlCalendar $calendar): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the largest local minimum value for a field
- * @link https://www.php.net/manual/en/intlcalendar.getgreatestminimum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getgreatestminimum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
- * <b>IntlCalendar::FIELD_COUNT</b>.
+ * <b>IntlCalendar::FIELD_COUNT</b>.</p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
+ * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
  * unit, or <b>FALSE</b> on failure.
  * @since 5.5
  */
+#[Pure]
 function intlcal_greates_minimum($calendar, $field) { }
 
 /**
- * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
- * Get data from the bundle
- * @link https://php.net/manual/en/resourcebundle.get.php
+ * (PHP &gt;= 5.5.0, PECL intl &gt;= 3.0.0a1)<br/>
+ * Gets the value for a specific field.
+ * @link https://www.php.net/manual/en/intlcalendar.get.php
  * @param IntlCalendar $calendar <p>
- * The calendar object, on the procedural style interface.
+ * The IntlCalendar resource.
  * </p>
- * @param string|int $index <p>
- * Data index, must be string or integer.
+ * @param int $field <p>
+ * One of the IntlCalendar date/time field constants. These are integer values between 0 and IntlCalendar::FIELD_COUNT.
  * </p>
- * @return mixed the data located at the index or <b>NULL</b> on error. Strings, integers and binary data strings
- * are returned as corresponding PHP types, integer array is returned as PHP array. Complex types are
- * returned as <b>ResourceBundle</b> object.
+ * @return int An integer with the value of the time field.
  */
-function intlcal_get($calendar, $index) { }
+#[Pure]
+function intlcal_get(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the smallest local maximum for a field
- * @link https://www.php.net/manual/en/intlcalendar.getleastmaximum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getleastmaximum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.ph int} representing a field value in the field's
+ * <p>An {@link https://secure.php.net/manual/en/language.types.integer.ph int} representing a field value in the field's
  * unit or <b>FALSE</b> on failure.
  * </p>
  * @since 5.5
  */
-function intlcal_get_least_maximum($calendar, $field) { }
+#[Pure]
+function intlcal_get_least_maximum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the largest local minimum value for a field
- * @link https://www.php.net/manual/en/intlcalendar.getgreatestminimum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getgreatestminimum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
- * <b>IntlCalendar::FIELD_COUNT</b>.
+ * <b>IntlCalendar::FIELD_COUNT</b>.</p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
+ * An {@link https://secure.php.net/manual/en/language.types.integer.php int} representing a field value, in the field's
  * unit, or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_greatest_minimum($calendar, $field) { }
+#[Pure]
+function intlcal_get_greatest_minimum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the locale associated with the object
- * @link https://www.php.net/manual/en/intlcalendar.getlocale.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getlocale.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param int $localeType <p>
+ * @param int $type <p>
  * Whether to fetch the actual locale (the locale from which the calendar
  * data originates, with <b>Locale::ACTUAL_LOCALE</b>) or the
  * valid locale, i.e., the most specific locale supported by ICU relatively
@@ -5136,49 +5367,51 @@ function intlcal_get_greatest_minimum($calendar, $field) { }
  * A locale string or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_locale($calendar, $localeType) { }
+#[Pure]
+function intlcal_get_locale(IntlCalendar $calendar, int $type): string { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the global maximum value for a field
- * @link https://www.php.net/manual/en/intlcalendar.getmaximum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getmaximum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
- * @return string
- * A locale string or <b>FALSE</b> on failure.
+ * @return int|false
  * @since 5.5
  */
+#[Pure]
 function intcal_get_maximum($calendar, $field) { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @link https://www.php.net/manual/en/intlcalendar.getminimaldaysinfirstweek.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getminimaldaysinfirstweek.php
  * Get minimal number of days the first week in a year or month can have
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @return int
- * An {@link https://www.php.net/manual/en/language.types.integer.php  int} representing a number of days or <b>FALSE</b> on failure.
+ * An {@link https://secure.php.net/manual/en/language.types.integer.php  int} representing a number of days or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_minimal_days_in_first_week($calendar) { }
+#[Pure]
+function intlcal_get_minimal_days_in_first_week(IntlCalendar $calendar): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the global minimum value for a field
- * @link https://www.php.net/manual/en/intlcalendar.getminimum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getminimum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
@@ -5186,40 +5419,43 @@ function intlcal_get_minimal_days_in_first_week($calendar) { }
  * An int representing a value for the given field in the field's unit or FALSE on failure.
  * @since 5.5
  */
-function intlcal_get_minimum($calendar, $field) { }
+#[Pure]
+function intlcal_get_minimum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the object's timezone
- * @link https://www.php.net/manual/en/intlcalendar.gettimezone.php
+ * @link https://secure.php.net/manual/en/intlcalendar.gettimezone.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @return IntlTimeZone
- * An {@link https://www.php.net/manual/en/class.intltimezone.php IntlTimeZone} object corresponding to the one used
+ * @return IntlTimeZone|false
+ * An {@link https://secure.php.net/manual/en/class.intltimezone.php IntlTimeZone} object corresponding to the one used
  * internally in this object.
  * @since 5.5
  */
-function intlcal_get_time_zone($calendar) { }
+#[Pure]
+function intlcal_get_time_zone(IntlCalendar $calendar): IntlTimeZone|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the calendar type
- * @link https://www.php.net/manual/en/intlcalendar.gettype.php
+ * @link https://secure.php.net/manual/en/intlcalendar.gettype.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @return string
- * A {@link https://www.php.net/manual/en/language.types.string.php string} representing the calendar type, such as
+ * A {@link https://secure.php.net/manual/en/language.types.string.php string} representing the calendar type, such as
  * <em>'gregorian'</em>, <em>'islamic'</em>, etc.
  * @since 5.5
  */
-function intlcal_get_type($calendar) { }
+#[Pure]
+function intlcal_get_type(IntlCalendar $calendar): string { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get time of the day at which weekend begins or ends
- * @link https://www.php.net/manual/en/intlcalendar.getweekendtransition.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getweekendtransition.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
@@ -5233,115 +5469,121 @@ function intlcal_get_type($calendar) { }
  * ends or <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_get_weekend_transition($calendar, $dayOfWeek) { }
+#[Pure]
+function intlcal_get_weekend_transition(IntlCalendar $calendar, int $dayOfWeek): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether the object's time is in Daylight Savings Time
- * @link https://www.php.net/manual/en/intlcalendar.indaylighttime.php
+ * @link https://secure.php.net/manual/en/intlcalendar.indaylighttime.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @return bool
  * Returns <b>TRUE</b> if the date is in Daylight Savings Time, <b>FALSE</b> otherwise.
  * The value <b>FALSE</b> may also be returned on failure, for instance after
- * specifying invalid field values on non-lenient mode; use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
- * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.
+ * specifying invalid field values on non-lenient mode; use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
+ * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.
  * @since 5.5
  */
-function intlcal_in_daylight_time($calendar) { }
+#[Pure]
+function intlcal_in_daylight_time(IntlCalendar $calendar): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether date/time interpretation is in lenient mode
- * @link https://www.php.net/manual/en/intlcalendar.islenient.php
+ * @link https://secure.php.net/manual/en/intlcalendar.islenient.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @return bool
- * A {@link https://www.php.net/manual/en/language.types.boolean.php bool} representing whether the calendar is set to lenient mode.
+ * A {@link https://secure.php.net/manual/en/language.types.boolean.php bool} representing whether the calendar is set to lenient mode.
  * @since 5.5
  */
-function intlcal_is_lenient($calendar) { }
+#[Pure]
+function intlcal_is_lenient(IntlCalendar $calendar): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether a field is set
- * @link https://www.php.net/manual/en/intlcalendar.isset.php
+ * @link https://secure.php.net/manual/en/intlcalendar.isset.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
  * @return bool Assuming there are no argument errors, returns <b>TRUE</b> iif the field is set.
  * @since 5.5
  */
-function intlcal_is_set($calendar, $field) { }
+#[Pure]
+function intlcal_is_set(IntlCalendar $calendar, int $field): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the global maximum value for a field
- * @link https://www.php.net/manual/en/intlcalendar.getmaximum.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getmaximum.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @param int $field <p>
- * One of the {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://www.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
+ * One of the {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} date/time {@link https://secure.php.net/manual/en/class.intlcalendar.php#intlcalendar.constants field constants}. These are integer
  * values between <em>0</em> and
  * <b>IntlCalendar::FIELD_COUNT</b>.
  * </p>
- * @return string
- * A locale string or <b>FALSE</b> on failure.
+ * @return int|false
  * @since 5.5
  */
-function intlcal_get_maximum($calendar, $field) { }
+#[Pure]
+function intlcal_get_maximum(IntlCalendar $calendar, int $field): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether another calendar is equal but for a different time
- * @link https://www.php.net/manual/en/intlcalendar.isequivalentto.php
- * @param IntlCalendar $calendarObject <p>
+ * @link https://secure.php.net/manual/en/intlcalendar.isequivalentto.php
+ * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param IntlCalendar $calendar The other calendar against which the comparison is to be made.
+ * @param IntlCalendar $other The other calendar against which the comparison is to be made.
  * @return bool
  * Assuming there are no argument errors, returns <b>TRUE</b> iif the calendars are equivalent except possibly for their set time.
  * @since 5.5
  */
-function intlcal_is_equivalent_to(IntlCalendar $calendarObject, IntlCalendar $calendar) { }
+#[Pure]
+function intlcal_is_equivalent_to(IntlCalendar $calendar, IntlCalendar $other): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Whether a certain date/time is in the weekend
- * @link https://www.php.net/manual/en/intlcalendar.isweekend.php
+ * @link https://secure.php.net/manual/en/intlcalendar.isweekend.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param float|null $date [optional] <p>
+ * @param float|null $timestamp [optional] <p>
  * An optional timestamp representing the number of milliseconds since the
  * epoch, excluding leap seconds. If <b>NULL</b>, this object's current time is
  * used instead.
  * </p>
  * @return bool
- * <p> A {@link https://www.php.net/manual/en/language.types.boolean.php bool} indicating whether the given or this object's time occurs
+ * <p> A {@link https://secure.php.net/manual/en/language.types.boolean.php bool} indicating whether the given or this object's time occurs
  * in a weekend.
  * </p>
  * <p>
  * The value <b>FALSE</b> may also be returned on failure, for instance after giving
- * a date out of bounds on non-lenient mode; use {@link https://www.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
- * {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.</p>
+ * a date out of bounds on non-lenient mode; use {@link https://secure.php.net/manual/en/intl.configuration.php#ini.intl.use-exceptions exceptions} or query
+ * {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()} to disambiguate.</p>
  * @since 5.5
  */
-function intlcal_is_weekend($calendar, $date = null) { }
+#[Pure]
+function intlcal_is_weekend(IntlCalendar $calendar, ?float $timestamp = null): bool { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set the day on which the week is deemed to start
- * @link https://www.php.net/manual/en/intlcalendar.setfirstdayofweek.php
+ * @link https://secure.php.net/manual/en/intlcalendar.setfirstdayofweek.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
@@ -5353,28 +5595,28 @@ function intlcal_is_weekend($calendar, $date = null) { }
  * @return bool Returns TRUE on success. Failure can only happen due to invalid parameters.
  * @since 5.5
  */
-function intlcal_set_first_day_of_week($calendar, $dayOfWeek) { }
+function intlcal_set_first_day_of_week(IntlCalendar $calendar, int $dayOfWeek): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set whether date/time interpretation is to be lenient
- * @link https://www.php.net/manual/en/intlcalendar.setlenient.php
+ * @link https://secure.php.net/manual/en/intlcalendar.setlenient.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param string $isLenient <p>
+ * @param bool $lenient <p>
  * Use <b>TRUE</b> to activate the lenient mode; <b>FALSE</b> otherwise.
  * </p>
  * @return bool Returns <b>TRUE</b> on success. Failure can only happen due to invalid parameters.
  * @since 5.5
  */
-function intlcal_set_lenient($calendar, $isLenient) { }
+function intlcal_set_lenient(IntlCalendar $calendar, bool $lenient): bool { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get behavior for handling repeating wall time
- * @link https://www.php.net/manual/en/intlcalendar.getrepeatedwalltimeoption.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getrepeatedwalltimeoption.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
@@ -5383,31 +5625,33 @@ function intlcal_set_lenient($calendar, $isLenient) { }
  * <b>IntlCalendar::WALLTIME_LAST</b>.
  * @since 5.5
  */
-function intlcal_get_repeated_wall_time_option($calendar) { }
+#[Pure]
+function intlcal_get_repeated_wall_time_option(IntlCalendar $calendar): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Compare time of two IntlCalendar objects for equality
- * @link https://www.php.net/manual/en/intlcalendar.equals.php
- * @param IntlCalendar $calendarObject <p>
+ * @link https://secure.php.net/manual/en/intlcalendar.equals.php
+ * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param IntlCalendar $calendar
+ * @param IntlCalendar $other
  * @return bool <p>
  * Returns <b>TRUE</b> if the current time of both this and the passed in
- * {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} object are the same, or <b>FALSE</b>
+ * {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} object are the same, or <b>FALSE</b>
  * otherwise. The value <b>FALSE</b> can also be returned on failure. This can only
  * happen if bad arguments are passed in. In any case, the two cases can be
- * distinguished by calling  {@link https://www.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()}.
+ * distinguished by calling  {@link https://secure.php.net/manual/en/function.intl-get-error-code.php intl_get_error_code()}.
  * </p>
  * @since 5.5
  */
-function intlcal_equals($calendarObject, $calendar) { }
+#[Pure]
+function intlcal_equals(IntlCalendar $calendar, IntlCalendar $other): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get behavior for handling skipped wall time
- * @link https://www.php.net/manual/en/intlcalendar.getskippedwalltimeoption.php
+ * @link https://secure.php.net/manual/en/intlcalendar.getskippedwalltimeoption.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
@@ -5417,16 +5661,17 @@ function intlcal_equals($calendarObject, $calendar) { }
  * <b>IntlCalendar::WALLTIME_NEXT_VALID</b>.
  * @since 5.5
  */
-function intlcal_get_skipped_wall_time_option($calendar) { }
+#[Pure]
+function intlcal_get_skipped_wall_time_option(IntlCalendar $calendar): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set behavior for handling repeating wall times at negative timezone offset transitions
- * @link https://www.php.net/manual/en/intlcalendar.setrepeatedwalltimeoption.php
+ * @link https://secure.php.net/manual/en/intlcalendar.setrepeatedwalltimeoption.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param int $wallTimeOption <p>
+ * @param int $option <p>
  * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b> or
  * <b>IntlCalendar::WALLTIME_LAST</b>.
  * </p>
@@ -5434,16 +5679,16 @@ function intlcal_get_skipped_wall_time_option($calendar) { }
  * Returns <b>TRUE</b> on success. Failure can only happen due to invalid parameters.
  * @since 5.5
  */
-function intlcal_set_repeated_wall_time_option($calendar, $wallTimeOption) { }
+function intlcal_set_repeated_wall_time_option(IntlCalendar $calendar, int $option): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Set behavior for handling skipped wall times at positive timezone offset transitions
- * @link https://www.php.net/manual/en/intlcalendar.setskippedwalltimeoption.php
+ * @link https://secure.php.net/manual/en/intlcalendar.setskippedwalltimeoption.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @param int $wallTimeOption <p>
+ * @param int $option <p>
  * One of the constants <b>IntlCalendar::WALLTIME_FIRST</b>,
  * <b>IntlCalendar::WALLTIME_LAST</b> or
  * <b>IntlCalendar::WALLTIME_NEXT_VALID</b>.
@@ -5454,349 +5699,384 @@ function intlcal_set_repeated_wall_time_option($calendar, $wallTimeOption) { }
  * </p>
  * @since 5.5
  */
-function intlcal_set_skipped_wall_time_option($calendar, $wallTimeOption) { }
+function intlcal_set_skipped_wall_time_option(IntlCalendar $calendar, int $option): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
  * Create an IntlCalendar from a DateTime object or string
- * @link https://www.php.net/manual/en/intlcalendar.fromdatetime.php
- * @param mixed $dateTime <p>
- * A {@link https://www.php.net/manual/en/class.datetime.php DateTime} object or a {@link https://www.php.net/manual/en/language.types.string.php string} that
- * can be passed to  {@link https://www.php.net/manual/en/datetime.construct.php DateTime::__construct()}.
+ * @link https://secure.php.net/manual/en/intlcalendar.fromdatetime.php
+ * @param DateTime|string $datetime <p>
+ * A {@link https://secure.php.net/manual/en/class.datetime.php DateTime} object or a {@link https://secure.php.net/manual/en/language.types.string.php string} that
+ * can be passed to  {@link https://secure.php.net/manual/en/datetime.construct.php DateTime::__construct()}.
  * </p>
- * @return IntlCalendar
- * The created {@link https://www.php.net/manual/en/class.intlcalendar.php IntlCalendar} object or <b>NULL</b> in case of
- * failure. If a {@link https://www.php.net/manual/en/language.types.string.php string} is passed, any exception that occurs
- * inside the {@link https://www.php.net/manual/en/class.datetime.php DateTime} constructor is propagated.
+ * @param null|string $locale
+ * @return IntlCalendar|null
+ * The created {@link https://secure.php.net/manual/en/class.intlcalendar.php IntlCalendar} object or <b>NULL</b> in case of
+ * failure. If a {@link https://secure.php.net/manual/en/language.types.string.php string} is passed, any exception that occurs
+ * inside the {@link https://secure.php.net/manual/en/class.datetime.php DateTime} constructor is propagated.
  * @since 5.5
  */
-function intlcal_from_date_time($dateTime) { }
+#[Pure]
+function intlcal_from_date_time(DateTime|string $datetime, ?string $locale = null): ?IntlCalendar { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
  * Convert an IntlCalendar into a DateTime object
- * @link https://www.php.net/manual/en/intlcalendar.todatetime.php
+ * @link https://secure.php.net/manual/en/intlcalendar.todatetime.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
  * @return DateTime|false
- * A {@link https://www.php.net/manual/en/class.datetime.php DateTime} object with the same timezone as this
+ * A {@link https://secure.php.net/manual/en/class.datetime.php DateTime} object with the same timezone as this
  * object (though using PHP's database instead of ICU's) and the same time,
  * except for the smaller precision (second precision instead of millisecond).
  * Returns <b>FALSE</b> on failure.
  * @since 5.5
  */
-function intlcal_to_date_time($calendar) { }
+#[Pure]
+function intlcal_to_date_time(IntlCalendar $calendar): DateTime|false { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get last error code on the object
- * @link https://www.php.net/manual/en/intlcalendar.geterrorcode.php
+ * @link https://secure.php.net/manual/en/intlcalendar.geterrorcode.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @return int An ICU error code indicating either success, failure or a warning.
+ * @return int|false An ICU error code indicating either success, failure or a warning.
  * @since 5.5
  */
-function intlcal_get_error_code($calendar) { }
+#[Pure]
+function intlcal_get_error_code(IntlCalendar $calendar): int|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get last error message on the object
- * @link https://www.php.net/manual/en/intlcalendar.geterrormessage.php
+ * @link https://secure.php.net/manual/en/intlcalendar.geterrormessage.php
  * @param IntlCalendar $calendar <p>
  * The calendar object, on the procedural style interface.
  * </p>
- * @return string The error message associated with last error that occurred in a function call on this object, or a string indicating the non-existance of an error.
+ * @return string|false The error message associated with last error that occurred in a function call on this object, or a string indicating the non-existance of an error.
  * @since 5.5
  */
-function intlcal_get_error_message($calendar) { }
+#[Pure]
+function intlcal_get_error_message(IntlCalendar $calendar): string|false { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the number of IDs in the equivalency group that includes the given ID
- * @link https://www.php.net/manual/en/intltimezone.countequivalentids.php
- * @param string $zoneId
- * @return int
+ * @link https://secure.php.net/manual/en/intltimezone.countequivalentids.php
+ * @param string $timezoneId
+ * @return int|false
  * @since 5.5
  */
-function intltz_count_equivalent_ids($zoneId) { }
+#[Pure]
+function intltz_count_equivalent_ids(string $timezoneId): int|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Create a new copy of the default timezone for this host
- * @link https://www.php.net/manual/en/intltimezone.createdefault.php
+ * @link https://secure.php.net/manual/en/intltimezone.createdefault.php
  * @return IntlTimeZone
  * @since 5.5
  */
+#[Pure]
 function intlz_create_default() { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @link https://www.php.net/manual/en/intltimezone.createenumeration.php
- * @param mixed $countryOrRawOffset [optional]
- * @return IntlIterator
+ * @link https://secure.php.net/manual/en/intltimezone.createenumeration.php
+ * @param IntlTimeZone|string|int|float|null $countryOrRawOffset [optional]
+ * @return IntlIterator|false
  * @since 5.5
  */
+#[Pure]
 function intltz_create_enumeration($countryOrRawOffset) { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @link https://www.php.net/manual/en/intltimezone.createtimezone.php
- * @param string $zoneId
- * @return IntlTimeZone
+ * @link https://secure.php.net/manual/en/intltimezone.createtimezone.php
+ * @param string $timezoneId
+ * @return IntlTimeZone|null
  * @since 5.5
  */
-function intltz_create_time_zone($zoneId) { }
+#[Pure]
+function intltz_create_time_zone(string $timezoneId): ?IntlTimeZone { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @link https://www.php.net/manual/en/intltimezone.fromdatetimezone.php
- * @param DateTimeZone $zoneId
- * @return IntlTimeZone
+ * @link https://secure.php.net/manual/en/intltimezone.fromdatetimezone.php
+ * @param DateTimeZone $timezone
+ * @return IntlTimeZone|null
  * @since 5.5
  */
-function intltz_from_date_time_zone($zoneId) { }
+#[Pure]
+function intltz_from_date_time_zone(DateTimeZone $timezone): ?IntlTimeZone { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the canonical system timezone ID or the normalized custom time zone ID for the given time zone ID
- * @link https://www.php.net/manual/en/intltimezone.getcanonicalid.php
- * @param string $zoneId
- * @param bool $isSystemID [optional]
- * @return string
+ * @link https://secure.php.net/manual/en/intltimezone.getcanonicalid.php
+ * @param string $timezoneId
+ * @param bool &$isSystemId [optional]
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_canonical_id($zoneId, &$isSystemID) { }
+#[Pure]
+function intltz_get_canonical_id(string $timezoneId, &$isSystemId): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get a name of this time zone suitable for presentation to the user
- * @param IntlTimeZone $obj - <p>
+ * @param IntlTimeZone $timezone - <p>
  * The time zone object, on the procedural style interface.
  * </p>
- * @param bool $isDaylight [optional]
+ * @param bool $dst [optional]
  * @param int $style [optional]
- * @param string $locale [optional]
- * @return string
+ * @param string|null $locale [optional]
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_display_name($obj, $isDaylight, $style, $locale) { }
+#[Pure]
+function intltz_get_display_name(IntlTimeZone $timezone, bool $dst = false, int $style = 2, ?string $locale): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the amount of time to be added to local standard time to get local wall clock time
- * @param IntlTimeZone $obj - <p>
+ * @param IntlTimeZone $timezone - <p>
  * The time zone object, on the procedural style interface.
  * </p>
- * @link https://www.php.net/manual/en/intltimezone.getequivalentid.php
  * @return int
+ * @link https://secure.php.net/manual/en/intltimezone.getequivalentid.php
  * @since 5.5
  */
-function intltz_get_dst_savings($obj) { }
+#[Pure]
+function intltz_get_dst_savings(IntlTimeZone $timezone): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get an ID in the equivalency group that includes the given ID
- * @link https://www.php.net/manual/en/intltimezone.getequivalentid.php
- * @param string $zoneId
- * @param int $index
- * @return string
+ * @link https://secure.php.net/manual/en/intltimezone.getequivalentid.php
+ * @param string $timezoneId
+ * @param int $offset
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_equivalent_id($zoneId, $index) { }
+#[Pure]
+function intltz_get_equivalent_id(string $timezoneId, int $offset): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get last error code on the object
- * @link https://www.php.net/manual/en/intltimezone.geterrorcode.php
- * @param IntlTimeZone $obj - <p>
+ * @link https://secure.php.net/manual/en/intltimezone.geterrorcode.php
+ * @param IntlTimeZone $timezone - <p>
  * The time zone object, on the procedural style interface.
  * </p>
- * @return int
+ * @return int|false
  * @since 5.5
  */
-function intltz_get_error_code($obj) { }
+#[Pure]
+function intltz_get_error_code(IntlTimeZone $timezone): int|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get last error message on the object
- * @link https://www.php.net/manual/en/intltimezone.geterrormessage.php
- * @param IntlTimeZone $obj - <p>
+ * @link https://secure.php.net/manual/en/intltimezone.geterrormessage.php
+ * @param IntlTimeZone $timezone - <p>
  * The time zone object, on the procedural style interface.
  * </p>
- * @return string
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_error_message($obj) { }
+#[Pure]
+function intltz_get_error_message(IntlTimeZone $timezone): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Create GMT (UTC) timezone
- * @link https://www.php.net/manual/en/intltimezone.getgmt.php
+ * @link https://secure.php.net/manual/en/intltimezone.getgmt.php
  * @return IntlTimeZone
  * @since 5.5
  */
-function intltz_getGMT() { }
+#[Pure]
+function intltz_getGMT(): IntlTimeZone { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get timezone ID
- * @link https://www.php.net/manual/en/intltimezone.getid.php
- * @param IntlTimeZone $obj
- * @return string
+ * @link https://secure.php.net/manual/en/intltimezone.getid.php
+ * @param IntlTimeZone $timezone
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_id($obj) { }
+#[Pure]
+function intltz_get_id(IntlTimeZone $timezone): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the time zone raw and GMT offset for the given moment in time
- * @link https://www.php.net/manual/en/intltimezone.getoffset.php
- * @param IntlTimeZone $obj
- * @param float $date
+ * @link https://secure.php.net/manual/en/intltimezone.getoffset.php
+ * @param IntlTimeZone $timezone
+ * @param float $timestamp
  * @param bool $local
- * @param int $rawOffset
- * @param int $dstOffset
- * @return int
+ * @param int &$rawOffset
+ * @param int &$dstOffset
+ * @return bool
  * @since 5.5
  */
-function intltz_get_offset($obj, $date, $local, &$rawOffset, &$dstOffset) { }
+#[Pure]
+function intltz_get_offset(IntlTimeZone $timezone, float $timestamp, bool $local, &$rawOffset, &$dstOffset): bool { }
 
 /**
  * Get the raw GMT offset (before taking daylight savings time into account
- * @link https://www.php.net/manual/en/intltimezone.getrawoffset.php
- * @param IntlTimeZone $obj
+ * @link https://secure.php.net/manual/en/intltimezone.getrawoffset.php
+ * @param IntlTimeZone $timezone
  * @return int
  */
-function intltz_get_raw_offset($obj) { }
+#[Pure]
+function intltz_get_raw_offset(IntlTimeZone $timezone): int { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Get the timezone data version currently used by ICU
- * @link https://www.php.net/manual/en/intltimezone.gettzdataversion.php
- * @param IntlTimeZone $obj
- * @return string
+ * @link https://secure.php.net/manual/en/intltimezone.gettzdataversion.php
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_tz_data_version($obj) { }
+#[Pure]
+function intltz_get_tz_data_version(): string|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Check if this zone has the same rules and offset as another zone
- * @link https://www.php.net/manual/en/intltimezone.hassamerules.php
- * @param IntlTimeZone $obj
- * @param IntlTimeZone $otherTimeZone
+ * @link https://secure.php.net/manual/en/intltimezone.hassamerules.php
+ * @param IntlTimeZone $timezone
+ * @param IntlTimeZone $other
  * @return bool
  * @since 5.5
  */
-function intltz_has_same_rules($obj, $otherTimeZone) { }
+#[Pure]
+function intltz_has_same_rules(IntlTimeZone $timezone, IntlTimeZone $other): bool { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Convert to DateTimeZone object
- * @link https://www.php.net/manual/ru/intltimezone.todatetimezone.php
- * @param $obj
- * @return DateTimeZone
+ * @link https://secure.php.net/manual/en/intltimezone.todatetimezone.php
+ * @param IntlTimeZone $timezone
+ * @return DateTimeZone|false
  * @since 5.5
  */
-function intltz_to_date_time_zone($obj) { }
+#[Pure]
+function intltz_to_date_time_zone(IntlTimeZone $timezone): DateTimeZone|false { }
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
  * Check if this time zone uses daylight savings time
- * @link https://www.php.net/manual/ru/intltimezone.usedaylighttime.php
- * @param $obj
+ * @link https://secure.php.net/manual/en/intltimezone.usedaylighttime.php
+ * @param IntlTimeZone $timezone
  * @return bool
  * @since 5.5
  */
-function intltz_use_daylight_time($obj) { }
+#[Pure]
+function intltz_use_daylight_time(IntlTimeZone $timezone): bool { }
 
 
 /**
  * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
- * @param mixed $timeZone
- * @param string $locale
- * @return IntlGregorianCalendar
+ * @param DateTimeZone|IntlTimeZone|string|int|null $timezoneOrYear
+ * @param string|null $localeOrMonth
+ * @param int $day
+ * @param int $hour
+ * @param int $minute
+ * @param int $second
+ * @return IntlGregorianCalendar|null
  * @since 5.5
  */
-function intlgregcal_create_instance($timeZone = null, $locale = null) { }
+#[Pure]
+function intlgregcal_create_instance($timezoneOrYear = null, $localeOrMonth = null, $day = null, $hour = null, $minute = null, $second = null): ?IntlGregorianCalendar { }
 
 /**
- * @param IntlGregorianCalendar $obj
- * @param double $change
- *
+ * @param IntlGregorianCalendar $calendar
+ * @param float $timestamp
+ * @return bool
  */
-function intlgregcal_set_gregorian_change($obj, $change) { }
+function intlgregcal_set_gregorian_change(IntlGregorianCalendar $calendar, float $timestamp): bool { }
 
 /**
- * @param IntlGregorianCalendar $obj
- * @return double $change
+ * @param IntlGregorianCalendar $calendar
+ * @return float
  */
-function intlgregcal_get_gregorian_change($obj) { }
+#[Pure]
+function intlgregcal_get_gregorian_change(IntlGregorianCalendar $calendar): float { }
 
 /**
+ * @param IntlGregorianCalendar $calendar
  * @param int $year
  * @return bool
  */
-function intlgregcal_is_leap_year($year) { }
+#[Pure]
+function intlgregcal_is_leap_year(IntlGregorianCalendar $calendar, int $year): bool { }
 
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
  * Create a resource bundle
  * @link https://php.net/manual/en/resourcebundle.create.php
- * @param string $locale <p>
+ * @param string|null $locale <p>
  * Locale for which the resources should be loaded (locale name, e.g. en_CA).
  * </p>
- * @param string $bundlename <p>
+ * @param string|null $bundle <p>
  * The directory where the data is stored or the name of the .dat file.
  * </p>
  * @param bool $fallback [optional] <p>
  * Whether locale should match exactly or fallback to parent locale is allowed.
  * </p>
- * @return ResourceBundle|false <b>ResourceBundle</b> object or <b>FALSE</b> on error.
+ * @return ResourceBundle|false|null <b>ResourceBundle</b> object or <b>FALSE</b> on error.
  */
-function resourcebundle_create($locale, $bundlename, $fallback = null) { }
+#[Pure]
+function resourcebundle_create(?string $locale, ?string $bundle, bool $fallback = true): ?ResourceBundle { }
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
  * Get data from the bundle
  * @link https://php.net/manual/en/resourcebundle.get.php
- * @param ResourceBundle $r
+ * @param ResourceBundle $bundle
  * @param string|int $index <p>
  * Data index, must be string or integer.
  * </p>
+ * @param bool $fallback
  * @return mixed the data located at the index or <b>NULL</b> on error. Strings, integers and binary data strings
  * are returned as corresponding PHP types, integer array is returned as PHP array. Complex types are
  * returned as <b>ResourceBundle</b> object.
  */
-function resourcebundle_get(ResourceBundle $r, $index) { }
+#[Pure]
+function resourcebundle_get(ResourceBundle $bundle, $index, bool $fallback = true) { }
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
  * Get number of elements in the bundle
  * @link https://php.net/manual/en/resourcebundle.count.php
- * @param ResourceBundle $r
- * @param $bundle
+ * @param ResourceBundle $bundle
  * @return int number of elements in the bundle.
  */
-function resourcebundle_count(ResourceBundle $r, $bundle) { }
+#[Pure]
+function resourcebundle_count(ResourceBundle $bundle): int { }
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
  * Get supported locales
  * @link https://php.net/manual/en/resourcebundle.locales.php
- * @param string $bundlename <p>
+ * @param string $bundle <p>
  * Path of ResourceBundle for which to get available locales, or
  * empty string for default locales list.
  * </p>
- * @return array the list of locales supported by the bundle.
+ * @return array|false the list of locales supported by the bundle.
  */
-function resourcebundle_locales($bundlename) { }
+#[Pure]
+function resourcebundle_locales(string $bundle): array|false { }
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -5805,7 +6085,8 @@ function resourcebundle_locales($bundlename) { }
  * @param $bundle
  * @return int error code from last bundle object call.
  */
-function resourcebundle_get_error_code(ResourceBundle $bundle) { }
+#[Pure]
+function resourcebundle_get_error_code(ResourceBundle $bundle): int { }
 
 /**
  * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -5814,7 +6095,8 @@ function resourcebundle_get_error_code(ResourceBundle $bundle) { }
  * @param $bundle
  * @return string error message from last bundle object's call.
  */
-function resourcebundle_get_error_message(ResourceBundle $bundle) { }
+#[Pure]
+function resourcebundle_get_error_message(ResourceBundle $bundle): string { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -5825,7 +6107,7 @@ function resourcebundle_get_error_message(ResourceBundle $bundle) { }
  * </p>
  * @param int $direction [optional] <p>
  * The direction, defaults to
- * >Transliterator::FORWARD.
+ * Transliterator::FORWARD.
  * May also be set to
  * Transliterator::REVERSE.
  * </p>
@@ -5833,7 +6115,8 @@ function resourcebundle_get_error_message(ResourceBundle $bundle) { }
  * or <b>NULL</b> on failure.
  * @since 5.4
  */
-function transliterator_create($id, $direction = null) { }
+#[Pure]
+function transliterator_create(string $id, int $direction = null): ?Transliterator { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -5842,45 +6125,48 @@ function transliterator_create($id, $direction = null) { }
  * @param string $rules <p>
  * The rules.
  * </p>
- * @param string $direction [optional] <p>
+ * @param int $direction [optional] <p>
  * The direction, defaults to
- * >Transliterator::FORWARD.
+ * Transliterator::FORWARD.
  * May also be set to
  * Transliterator::REVERSE.
  * </p>
- * @return Transliterator a <b>Transliterator</b> object on success,
+ * @return Transliterator|null a <b>Transliterator</b> object on success,
  * or <b>NULL</b> on failure.
  * @since 5.4
  */
-function transliterator_create_from_rules($rules, $direction = null) { }
+#[Pure]
+function transliterator_create_from_rules(string $rules, int $direction = null): ?Transliterator { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
  * Get transliterator IDs
  * @link https://php.net/manual/en/transliterator.listids.php
- * @return array An array of registered transliterator IDs on success,
+ * @return string[]|false An array of registered transliterator IDs on success,
  * or <b>FALSE</b> on failure.
  * @since 5.4
  */
-function transliterator_list_ids() { }
+#[Pure]
+function transliterator_list_ids(): array|false { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
  * Create an inverse transliterator
  * @link https://php.net/manual/en/transliterator.createinverse.php
- * @param Transliterator $orig_trans
- * @return Transliterator a <b>Transliterator</b> object on success,
+ * @param Transliterator $transliterator
+ * @return Transliterator|null a <b>Transliterator</b> object on success,
  * or <b>NULL</b> on failure
  * @since 5.4
  */
-function transliterator_create_inverse(Transliterator $orig_trans) { }
+#[Pure]
+function transliterator_create_inverse(Transliterator $transliterator): ?Transliterator { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
  * Transliterate a string
  * @link https://php.net/manual/en/transliterator.transliterate.php
  * @param Transliterator|string $transliterator
- * @param string $subject <p>
+ * @param string $string <p>
  * The string to be transformed.
  * </p>
  * @param int $start [optional] <p>
@@ -5896,29 +6182,32 @@ function transliterator_create_inverse(Transliterator $orig_trans) { }
  * @return string|false The transfomed string on success, or <b>FALSE</b> on failure.
  * @since 5.4
  */
-function transliterator_transliterate($transliterator, $subject, $start = null, $end = null) { }
+#[Pure]
+function transliterator_transliterate(Transliterator|string $transliterator, string $string, int $start = null, int $end = -1): string|false { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
  * Get last error code
  * @link https://php.net/manual/en/transliterator.geterrorcode.php
- * @param Transliterator $trans
- * @return int The error code on success,
+ * @param Transliterator $transliterator
+ * @return int|false The error code on success,
  * or <b>FALSE</b> if none exists, or on failure.
  * @since 5.4
  */
-function transliterator_get_error_code(Transliterator $trans) { }
+#[Pure]
+function transliterator_get_error_code(Transliterator $transliterator): int|false { }
 
 /**
  * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
  * Get last error message
  * @link https://php.net/manual/en/transliterator.geterrormessage.php
- * @param Transliterator $trans
- * @return string The error code on success,
+ * @param Transliterator $transliterator
+ * @return string|false The error code on success,
  * or <b>FALSE</b> if none exists, or on failure.
  * @since 5.4
  */
-function transliterator_get_error_message(Transliterator $trans) { }
+#[Pure]
+function transliterator_get_error_message(Transliterator $transliterator): string|false { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -5926,7 +6215,8 @@ function transliterator_get_error_message(Transliterator $trans) { }
  * @link https://php.net/manual/en/function.intl-get-error-code.php
  * @return int Error code returned by the last API function call.
  */
-function intl_get_error_code() { }
+#[Pure]
+function intl_get_error_code(): int { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -5934,13 +6224,14 @@ function intl_get_error_code() { }
  * @link https://php.net/manual/en/function.intl-get-error-message.php
  * @return string Description of an error occurred in the last API function call.
  */
-function intl_get_error_message() { }
+#[Pure]
+function intl_get_error_message(): string { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Check whether the given error code indicates failure
  * @link https://php.net/manual/en/function.intl-is-failure.php
- * @param int $error_code <p>
+ * @param int $errorCode <p>
  * is a value that returned by functions:
  * <b>intl_get_error_code</b>,
  * <b>collator_get_error_code</b> .
@@ -5948,56 +6239,74 @@ function intl_get_error_message() { }
  * @return bool <b>TRUE</b> if it the code indicates some failure, and <b>FALSE</b>
  * in case of success or a warning.
  */
-function intl_is_failure($error_code) { }
+#[Pure]
+function intl_is_failure(int $errorCode): bool { }
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
  * Get symbolic name for a given error code
  * @link https://php.net/manual/en/function.intl-error-name.php
- * @param int $error_code <p>
+ * @param int $errorCode <p>
  * ICU error code.
  * </p>
  * @return string The returned string will be the same as the name of the error code
  * constant.
  */
-function intl_error_name($error_code) { }
+#[Pure]
+function intl_error_name(int $errorCode): string { }
 
 /**
  * Gets the Decomposition_Mapping property for the given UTF-8 encoded code point
  *
  * @link https://www.php.net/manual/en/normalizer.getrawdecomposition.php
  *
- * @param string $input
+ * @param string $string
+ * @param int $form
  * @return string|null
  *
  * @since 7.3
  */
-function normalizer_get_raw_decomposition($input) { }
+#[Pure]
+function normalizer_get_raw_decomposition(string $string, int $form = Normalizer::FORM_C): ?string { }
 
 /**
+ * @return IntlTimeZone
  * @since 5.5
  */
-function intltz_create_default() { }
+#[Pure]
+function intltz_create_default(): IntlTimeZone { }
 
 /**
+ * @return IntlTimeZone
  * @since 5.5
  */
-function intltz_get_gmt() { }
+#[Pure]
+function intltz_get_gmt(): IntlTimeZone { }
 
 /**
+ * @return IntlTimeZone
  * @since 5.5
  */
-function intltz_get_unknown() { }
+#[Pure]
+function intltz_get_unknown(): IntlTimeZone { }
 
 /**
+ * @param int $type
+ * @param null|string $region
+ * @param null|int $rawOffset
+ * @return IntlIterator|false
  * @since 5.5
  */
-function intltz_create_time_zone_id_enumeration($zoneType, $region = null, $rawOffset = null) { }
+#[Pure]
+function intltz_create_time_zone_id_enumeration(int $type, ?string $region = null, ?int $rawOffset = null): IntlIterator|false { }
 
 /**
+ * @param string $timezoneId
+ * @return string|false
  * @since 5.5
  */
-function intltz_get_region($zoneId) { }
+#[Pure]
+function intltz_get_region(string $timezoneId): string|false { }
 
 /**
  * Set minimal number of days the first week in a year or month can have
@@ -6005,21 +6314,25 @@ function intltz_get_region($zoneId) { }
  * @link https://www.php.net/manual/en/intlcalendar.setminimaldaysinfirstweek.php
  *
  * @param IntlCalendar $calendar
- * @param int $numberOfDays
+ * @param int $days
  * @return bool
  *
  * @since 5.5.1
  */
-function intlcal_set_minimal_days_in_first_week(IntlCalendar $calendar, $numberOfDays) { }
+function intlcal_set_minimal_days_in_first_week(IntlCalendar $calendar, int $days): bool { }
+
+function intltz_get_windows_id(string $timezoneId): string|false {}
+
+function intltz_get_id_for_windows_id(string $timezoneId, ?string $region = null): string|false {}
 
 /**
  * Limit on locale length, set to 80 in PHP code. Locale names longer
  * than this limit will not be accepted.
  * @link https://php.net/manual/en/intl.constants.php
  */
-define ('INTL_MAX_LOCALE_LEN', 80);
-define ('INTL_ICU_VERSION', "4.8.1.1");
-define ('INTL_ICU_DATA_VERSION', "4.8.1");
+define ('INTL_MAX_LOCALE_LEN', 156);
+define ('INTL_ICU_VERSION', "67.1");
+define ('INTL_ICU_DATA_VERSION', "67.1");
 define ('ULOC_ACTUAL_LOCALE', 0);
 define ('ULOC_VALID_LOCALE', 1);
 define ('GRAPHEME_EXTR_COUNT', 0);
@@ -6118,7 +6431,7 @@ define ('U_ILLEGAL_PAD_POSITION', 65800);
 define ('U_UNMATCHED_BRACES', 65801);
 define ('U_UNSUPPORTED_PROPERTY', 65802);
 define ('U_UNSUPPORTED_ATTRIBUTE', 65803);
-define ('U_FMT_PARSE_ERROR_LIMIT', 65810);
+define ('U_FMT_PARSE_ERROR_LIMIT', 65812);
 define ('U_BRK_INTERNAL_ERROR', 66048);
 define ('U_BRK_ERROR_START', 66048);
 define ('U_BRK_HEX_DIGITS_EXPECTED', 66049);
@@ -6150,7 +6463,7 @@ define ('U_REGEX_INVALID_BACK_REF', 66314);
 define ('U_REGEX_INVALID_FLAG', 66315);
 define ('U_REGEX_LOOK_BEHIND_LIMIT', 66316);
 define ('U_REGEX_SET_CONTAINS_STRING', 66317);
-define ('U_REGEX_ERROR_LIMIT', 66324);
+define ('U_REGEX_ERROR_LIMIT', 66326);
 define ('U_IDNA_PROHIBITED_ERROR', 66560);
 define ('U_IDNA_ERROR_START', 66560);
 define ('U_IDNA_UNASSIGNED_ERROR', 66561);
@@ -6240,62 +6553,62 @@ define ('INTL_IDNA_VARIANT_UTS46', 1);
  */
 define ('IDNA_ERROR_EMPTY_LABEL', 1);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_LABEL_TOO_LONG', 2);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_DOMAIN_NAME_TOO_LONG', 4);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_LEADING_HYPHEN', 8);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_TRAILING_HYPHEN', 16);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_HYPHEN_3_4', 32);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_LEADING_COMBINING_MARK', 64);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_DISALLOWED', 128);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_PUNYCODE', 256);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_LABEL_HAS_DOT', 512);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_INVALID_ACE_LABEL', 1024);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_BIDI', 2048);
 /**
- * @link https://www.php.net/manual/en/migration54.global-constants.php
+ * @link https://secure.php.net/manual/en/migration54.global-constants.php
  * @since 5.4
  */
 define ('IDNA_ERROR_CONTEXTJ', 4096);
@@ -6336,7 +6649,7 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for boundaries of combining character sequences
-     * @link https://www.php.net/manual/en/intlbreakiterator.createcharacterinstance.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createcharacterinstance.php
      * @param string $locale
      * @return IntlBreakIterator
      */
@@ -6345,7 +6658,7 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for boundaries of code points
-     * @link https://www.php.net/manual/en/intlbreakiterator.createcodepointinstance.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createcodepointinstance.php
      * @return IntlBreakIterator
      */
     public static function createCodePointInstance() { }
@@ -6353,8 +6666,8 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for logically possible line breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createlineinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createlineinstance.php
+     * @param string $locale [optional]
      * @return IntlBreakIterator
      */
     public static function createLineInstance($locale) { }
@@ -6362,8 +6675,8 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for sentence breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createsentenceinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createsentenceinstance.php
+     * @param string $locale [optional]
      * @return IntlBreakIterator
      */
     public static function createSentenceInstance($locale) { }
@@ -6371,8 +6684,8 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for title-casing breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createtitleinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createtitleinstance.php
+     * @param string $locale [optional]
      * @return IntlBreakIterator
      */
     public static function createTitleInstance($locale) { }
@@ -6380,8 +6693,8 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for word breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createwordinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createwordinstance.php
+     * @param string $locale [optional]
      * @return IntlBreakIterator
      */
     public static function createWordInstance($locale) { }
@@ -6389,22 +6702,23 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get index of current position
-     * @link https://www.php.net/manual/en/intlbreakiterator.current.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.current.php
      * @return int
      */
+    #[Pure]
     public function current() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Set position to the first character in the text
-     * @link https://www.php.net/manual/en/intlbreakiterator.first.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.first.php
      */
     public function first() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Advance the iterator to the first boundary following specified offset
-     * @link https://www.php.net/manual/en/intlbreakiterator.following.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.following.php
      * @param int $offset
      */
     public function following($offset) { }
@@ -6412,70 +6726,92 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get last error code on the object
-     * @link https://www.php.net/manual/en/intlbreakiterator.geterrorcode.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.geterrorcode.php
      * @return int
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get last error message on the object
-     * @link https://www.php.net/manual/en/intlbreakiterator.geterrormessage.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.geterrormessage.php
      * @return string
      */
+    #[Pure]
     public function getErrorMessage() { }
 
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get the locale associated with the object
-     * @link https://www.php.net/manual/en/intlbreakiterator.getlocale.php
-     * @param string $locale_type
+     * @link https://secure.php.net/manual/en/intlbreakiterator.getlocale.php
+     * @param string $type
      */
-    public function getLocale($locale_type) { }
+    #[Pure]
+    public function getLocale($type) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create iterator for navigating fragments between boundaries
-     * @link https://www.php.net/manual/en/intlbreakiterator.getpartsiterator.php
-     * @param string $key_type [optional]
+     * @link https://secure.php.net/manual/en/intlbreakiterator.getpartsiterator.php
+     * @param int $type [optional]
+     * <p>
+     * Optional key type. Possible values are:
+     * </p><ul>
+     * <li>
+     * {@see IntlPartsIterator::KEY_SEQUENTIAL}
+     * - The default. Sequentially increasing integers used as key.
+     * </li>
+     * <li>
+     * {@see IntlPartsIterator::KEY_LEFT}
+     * - Byte offset left of current part used as key.
+     * </li>
+     * <li>
+     * {@see IntlPartsIterator::KEY_RIGHT}
+     * - Byte offset right of current part used as key.
+     * </li>
+     * </ul>
      */
-    public function getPartsIterator($key_type = IntlPartsIterator::KEY_SEQUENTIAL) { }
+    #[Pure]
+    public function getPartsIterator($type = IntlPartsIterator::KEY_SEQUENTIAL) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get the text being scanned
-     * @link https://www.php.net/manual/en/intlbreakiterator.gettext.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.gettext.php
      */
+    #[Pure]
     public function getText() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Tell whether an offset is a boundary's offset
-     * @link https://www.php.net/manual/en/intlbreakiterator.isboundary.php
-     * @param string $offset
+     * @link https://secure.php.net/manual/en/intlbreakiterator.isboundary.php
+     * @param int $offset
      */
+    #[Pure]
     public function isBoundary($offset) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Set the iterator position to index beyond the last character
-     * @link https://www.php.net/manual/en/intlbreakiterator.last.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.last.php
      * @return int
      */
     public function last() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlbreakiterator.next.php
-     * @param string $offset [optional]
+     * @link https://secure.php.net/manual/en/intlbreakiterator.next.php
+     * @param int $offset [optional]
      * @return int
      */
     public function next($offset = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlbreakiterator.preceding.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.preceding.php
      * @param int $offset
      */
     public function preceding($offset) { }
@@ -6483,7 +6819,7 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Set the iterator position to the boundary immediately before the current
-     * @link https://www.php.net/manual/en/intlbreakiterator.previous.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.previous.php
      * @return int
      */
     public function previous() { }
@@ -6491,11 +6827,15 @@ class IntlBreakIterator implements IteratorAggregate
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Set the text being scanned
-     * @link https://www.php.net/manual/en/intlbreakiterator.settext.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.settext.php
      * @param string $text
      */
     public function setText($text) { }
 
+    /**
+     * @return Traversable
+     */
+    #[Pure]
     public function getIterator(){}
 }
 
@@ -6504,25 +6844,26 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
     /* Methods */
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlbreakiterator.construct.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.construct.php
      * @param string $rules
-     * @param string $areCompiled [optional]
+     * @param string $compiled [optional]
      */
-    public function __construct($rules, $areCompiled) { }
+    #[Pure]
+    public function __construct($rules, $compiled = false) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for boundaries of combining character sequences
-     * @link https://www.php.net/manual/en/intlbreakiterator.createcharacterinstance.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createcharacterinstance.php
      * @param string $locale
      * @return IntlRuleBasedBreakIterator
      */
     public static function  createCharacterInstance($locale) { }
 
-    /*
+    /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for boundaries of code points
-     * @link https://www.php.net/manual/en/intlbreakiterator.createcodepointinstance.php
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createcodepointinstance.php
      * @return IntlRuleBasedBreakIterator
      */
     public static function createCodePointInstance() { }
@@ -6530,8 +6871,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for logically possible line breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createlineinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createlineinstance.php
+     * @param string $locale [optional]
      * @return IntlRuleBasedBreakIterator
      */
     public static function createLineInstance($locale) { }
@@ -6539,8 +6880,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for sentence breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createsentenceinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createsentenceinstance.php
+     * @param string $locale [optional]
      * @return IntlRuleBasedBreakIterator
      */
     public static function createSentenceInstance($locale) { }
@@ -6548,8 +6889,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for title-casing breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createtitleinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createtitleinstance.php
+     * @param string $locale [optional]
      * @return IntlRuleBasedBreakIterator
      */
     public static function createTitleInstance($locale) { }
@@ -6557,42 +6898,46 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Create break iterator for word breaks
-     * @link https://www.php.net/manual/en/intlbreakiterator.createwordinstance.php
-     * @param string $locale
+     * @link https://secure.php.net/manual/en/intlbreakiterator.createwordinstance.php
+     * @param string $locale [optional]
      * @return IntlRuleBasedBreakIterator
      */
     public static function createWordInstance($locale) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlrulebasedbreakiterator.getbinaryrules.php
+     * @link https://secure.php.net/manual/en/intlrulebasedbreakiterator.getbinaryrules.php
      * Get the binary form of compiled rules
      * @return string
      */
+    #[Pure]
     public function getBinaryRules() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlrulebasedbreakiterator.getrules.php
+     * @link https://secure.php.net/manual/en/intlrulebasedbreakiterator.getrules.php
      * Get the rule set used to create this object
      * @return string
      */
+    #[Pure]
     public function getRules() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlrulebasedbreakiterator.getrulesstatus.php
+     * @link https://secure.php.net/manual/en/intlrulebasedbreakiterator.getrulesstatus.php
      * Get the largest status value from the break rules that determined the current break position
      * @return int
      */
+    #[Pure]
     public function getRuleStatus() { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
-     * @link https://www.php.net/manual/en/intlrulebasedbreakiterator.getrulestatusvec.php
+     * @link https://secure.php.net/manual/en/intlrulebasedbreakiterator.getrulestatusvec.php
      * Get the status values from the break rules that determined the current break position
      * @return array
      */
+    #[Pure]
     public function getRuleStatusVec() { }
 }
 
@@ -6609,6 +6954,7 @@ class IntlPartsIterator extends IntlIterator implements Iterator {
     /**
      * @return IntlBreakIterator
      */
+    #[Pure]
     public function getBreakIterator() { }
 }
 
@@ -6618,9 +6964,10 @@ class IntlCodePointBreakIterator extends IntlBreakIterator implements Traversabl
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
      * Get last code point passed over after advancing or receding the iterator
-     * @link https://www.php.net/manual/en/intlcodepointbreakiterator.getlastcodepoint.php
+     * @link https://secure.php.net/manual/en/intlcodepointbreakiterator.getlastcodepoint.php
      * @return int
      */
+    #[Pure]
     public function getLastCodePoint() { }
 }
 
@@ -6677,6 +7024,7 @@ class UConverter {
      * @param string $destination_encoding
      * @param string $source_encoding
      */
+    #[Pure]
     public function __construct($destination_encoding = null, $source_encoding = null) { }
 
     /**
@@ -6684,10 +7032,11 @@ class UConverter {
      * Convert string from one charset to anothe
      * @link https://php.net/manual/en/uconverter.convert.php
      * @param string $str
-     * @param bool $reverse
+     * @param bool $reverse [optional]
      * @return string
      */
-    public function convert($str, $reverse) { }
+    #[Pure]
+    public function convert($str, $reverse = false) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -6696,7 +7045,7 @@ class UConverter {
      * @param int $reason
      * @param string $source
      * @param string $codePoint
-     * @param int $error
+     * @param int &$error
      * @return mixed
      */
     public function fromUCallback($reason, $source, $codePoint, &$error) { }
@@ -6724,6 +7073,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getdestinationencoding.php
      * @return string
      */
+    #[Pure]
     public function getDestinationEncoding() { }
 
     /**
@@ -6732,6 +7082,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getdestinationtype.php
      * @return int
      */
+    #[Pure]
     public function getDestinationType() { }
 
     /**
@@ -6740,6 +7091,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.geterrorcode.php
      * @return int
      */
+    #[Pure]
     public function getErrorCode() { }
 
     /**
@@ -6748,6 +7100,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.geterrormessage.php
      * @return string
      */
+    #[Pure]
     public function getErrorMessage() { }
 
     /**
@@ -6756,6 +7109,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getsourceencoding.php
      * @return string
      */
+    #[Pure]
     public function getSourceEncoding() { }
 
     /**
@@ -6764,6 +7118,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getsourcetype.php
      * @return int
      */
+    #[Pure]
     public function getSourceType() { }
 
     /**
@@ -6772,6 +7127,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getstandards.php
      * @return array
      */
+    #[Pure]
     public static function getStandards() { }
 
     /**
@@ -6780,6 +7136,7 @@ class UConverter {
      * @link https://php.net/manual/en/uconverter.getsubstchars.php
      * @return string
      */
+    #[Pure]
     public function getSubstChars() { }
 
     /**
@@ -6789,6 +7146,7 @@ class UConverter {
      * @param int $reason
      * @return string
      */
+    #[Pure]
     public static function reasonText($reason) { }
 
     /**
@@ -6825,7 +7183,7 @@ class UConverter {
      * @param int $reason
      * @param string $source
      * @param string $codeUnits
-     * @param int $error
+     * @param int &$error
      * @return mixed
      */
     public function toUCallback($reason, $source, $codeUnits, &$error) { }

--- a/build/stubs/ldap.php
+++ b/build/stubs/ldap.php
@@ -1,65 +1,72 @@
 <?php
 
 // Start of ldap v.
+use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 /**
  * PASSWD extended operation helper
  * @link https://www.php.net/manual/en/function.ldap-exop-passwd.php
- * @param resource $link An LDAP link identifier, returned by ldap_connect().
+ * @param resource $ldap An LDAP link identifier, returned by ldap_connect().
  * @param string $user [optional] dn of the user to change the password of.
- * @param string $oldpw [optional] The old password of this user. May be omitted depending of server configuration.
- * @param string $newpw [optional] The new password for this user. May be omitted or empty to have a generated password.
- * @param array $serverctrls [optional] If provided, a password policy request control is send with the request and this is filled with an array of LDAP Controls returned with the request.
- * @return mixed Returns the generated password if newpw is empty or omitted. Otherwise returns TRUE on success and FALSE on failure.
+ * @param string $old_password [optional] The old password of this user. May be omitted depending of server configuration.
+ * @param string $new_password [optional] The new password for this user. May be omitted or empty to have a generated password.
+ * @param array &$controls [optional] If provided, a password policy request control is send with the request and this is filled with an array of LDAP Controls returned with the request.
+ * @return string|bool Returns the generated password if newpw is empty or omitted. Otherwise returns TRUE on success and FALSE on failure.
  * @since 7.2
  */
-function ldap_exop_passwd ($link , $user = "" , $oldpw = "" , $newpw = "" , array &$serverctrls = []) {}
+function ldap_exop_passwd ($ldap , string $user = "" , string $old_password = "" , string $new_password = "" , &$controls = []): string|bool
+{}
 
 /**
  * Refresh extended operation helper
  * @link https://www.php.net/manual/en/function.ldap-exop-refresh.php
- * @param resource $link An LDAP link identifier, returned by ldap_connect().
+ * @param resource $ldap An LDAP link identifier, returned by ldap_connect().
  * @param string $dn dn of the entry to refresh.
  * @param int $ttl $ttl Time in seconds (between 1 and 31557600) that the client requests that the entry exists in the directory before being automatically removed.
- * @return mixed From RFC: The responseTtl field is the time in seconds which the server chooses to have as the time-to-live field for that entry. It must not be any smaller than that which the client requested, and it may be larger. However, to allow servers to maintain a relatively accurate directory, and to prevent clients from abusing the dynamic extensions, servers are permitted to shorten a client-requested time-to-live value, down to a minimum of 86400 seconds (one day). FALSE will be returned on error.
+ * @return int|false From RFC: The responseTtl field is the time in seconds which the server chooses to have as the time-to-live field for that entry. It must not be any smaller than that which the client requested, and it may be larger. However, to allow servers to maintain a relatively accurate directory, and to prevent clients from abusing the dynamic extensions, servers are permitted to shorten a client-requested time-to-live value, down to a minimum of 86400 seconds (one day). FALSE will be returned on error.
  * @since 7.3
  */
-function ldap_exop_refresh ($link, $dn ,$ttl) {}
+function ldap_exop_refresh ($ldap, string $dn, int $ttl): int|false
+{}
 
 /**
  * WHOAMI extended operation helper
  * @link https://www.php.net/manual/en/function.ldap-exop-whoami.php
- * @param resource $link An LDAP link identifier, returned by ldap_connect().
- * @return mixed The data returned by the server, or FALSE on error.
+ * @param resource $ldap An LDAP link identifier, returned by ldap_connect().
+ * @return string|false The data returned by the server, or FALSE on error.
  * @since 7.2
  */
-function ldap_exop_whoami ($link) {}
+function ldap_exop_whoami ($ldap): string|false
+{}
 
 /**
  * Performs an extended operation on the specified link with reqoid the OID of the operation and reqdata the data.
  * @link https://www.php.net/manual/en/function.ldap-exop.php
- * @param resource $link An LDAP link identifier, returned by ldap_connect().
- * @param string $reqoid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
- * @param string $reqdata [optional] The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
- * @param array $serverctrls [optional] If provided, a password policy request control is send with the request and this is filled with an array of LDAP Controls returned with the request.
- * @param string $retdata [optional] Will be filled with the extended operation response data if provided. If not provided you may use ldap_parse_exop on the result object later to get this data.
- * @param string $retoid [optional] Will be filled with the response OID if provided, usually equal to the request OID.
- * @return mixed When used with retdata, returns TRUE on success or FALSE on error. When used without retdata, returns a result identifier or FALSE on error.
+ * @param resource $ldap An LDAP link identifier, returned by ldap_connect().
+ * @param string $request_oid The extended operation request OID. You may use one of LDAP_EXOP_START_TLS, LDAP_EXOP_MODIFY_PASSWD, LDAP_EXOP_REFRESH, LDAP_EXOP_WHO_AM_I, LDAP_EXOP_TURN, or a string with the OID of the operation you want to send.
+ * @param string|null $request_data [optional] The extended operation request data. May be NULL for some operations like LDAP_EXOP_WHO_AM_I, may also need to be BER encoded.
+ * @param array|null $controls [optional] If provided, a password policy request control is send with the request and this is filled with an array of LDAP Controls returned with the request.
+ * @param string &$response_data [optional] Will be filled with the extended operation response data if provided. If not provided you may use ldap_parse_exop on the result object later to get this data.
+ * @param string &$response_oid [optional] Will be filled with the response OID if provided, usually equal to the request OID.
+ * @return resource|bool When used with retdata, returns TRUE on success or FALSE on error. When used without retdata, returns a result identifier or FALSE on error.
  * @since 7.2
  */
-function ldap_exop ($link , $reqoid , $reqdata = null , $serverctrls = [], &$retdata, &$retoid) {}
+function ldap_exop ($ldap , string $request_oid , ?string $request_data , #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [], &$response_data, &$response_oid)
+{}
 
 /**
  * Parse LDAP extended operation data from result object result
  * @link https://www.php.net/manual/en/function.ldap-parse-exop.php
- * @param resource $link An LDAP link identifier, returned by ldap_connect().
+ * @param resource $ldap An LDAP link identifier, returned by ldap_connect().
  * @param resource $result An LDAP result resource, returned by ldap_exop().
- * @param string $retdata [optional] Will be filled by the response data.
- * @param string $retoid [optional] Will be filled by the response OID.
+ * @param string &$response_data [optional] Will be filled by the response data.
+ * @param string &$response_oid [optional] Will be filled by the response OID.
  * @return bool Returns TRUE on success or FALSE on failure.
  * @since 7.2
  */
-function ldap_parse_exop ($link , $result, &$retdata, &$retoid) {}
+function ldap_parse_exop ($ldap , $result, &$response_data, &$response_oid): bool
+{}
 
 /**
  * Translate 8859 characters to t61 characters
@@ -67,7 +74,8 @@ function ldap_parse_exop ($link , $result, &$retdata, &$retoid) {}
  * @param string $value
  * @return string
  */
-function ldap_8859_to_t61($value) {}
+function ldap_8859_to_t61(string $value): string
+{}
 
 /**
  * Translate t61 characters to 8859 characters
@@ -75,12 +83,13 @@ function ldap_8859_to_t61($value) {}
  * @param string $value
  * @return string
  */
-function ldap_t61_to_8859($value) {}
+function ldap_t61_to_8859(string $value): string
+{}
 
 /**
  * Connect to an LDAP server
  * @link https://php.net/manual/en/function.ldap-connect.php
- * @param string $hostname [optional] <p>
+ * @param string|null $uri [optional] <p>
  * If you are using OpenLDAP 2.x.x you can specify a URL instead of the
  * hostname. To use LDAP with SSL, compile OpenLDAP 2.x.x with SSL
  * support, configure PHP with SSL, and set this parameter as
@@ -100,47 +109,51 @@ function ldap_t61_to_8859($value) {}
  * If no arguments are specified then the link identifier of the already
  * opened link will be returned.
  */
-function ldap_connect ($hostname = null, $port = 389) {}
+function ldap_connect (?string $uri, int $port = 389)
+{}
 
 /**
  * Alias of <b>ldap_unbind</b>
  * @link https://php.net/manual/en/function.ldap-close.php
- * @param $link_identifier
+ * @param resource $ldap
+ * @return bool
  */
-function ldap_close ($link_identifier) {}
+function ldap_close ($ldap): bool {}
 
 /**
  * Bind to LDAP directory
  * @link https://php.net/manual/en/function.ldap-bind.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param string $bind_rdn [optional]
- * @param string $bind_password [optional]
+ * @param string|null $dn [optional]
+ * @param string|null $password [optional]
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_bind ($link_identifier, $bind_rdn = null, $bind_password = null) {}
+function ldap_bind ($ldap, ?string $dn, ?string $password): bool
+{}
 
 /**
  * Bind to LDAP directory
  * Does the same thing as ldap_bind() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-bind.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param string $bind_rdn [optional]
- * @param string $bind_password [optional]
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param string|null $dn [optional]
+ * @param string|null $password [optional]
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
  * @since 7.3
  */
-function ldap_bind_ext ($link_identifier, $bind_rdn = null, $bind_password = null, $serverctrls = []) {}
+function ldap_bind_ext ($ldap, ?string $dn, ?string $password, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 
 /**
  * Bind to LDAP directory using SASL
  * @link https://php.net/manual/en/function.ldap-sasl-bind.php
- * @param resource $link
+ * @param resource $ldap
  * @param string $binddn [optional]
  * @param string $password [optional]
  * @param string $sasl_mech [optional]
@@ -150,28 +163,30 @@ function ldap_bind_ext ($link_identifier, $bind_rdn = null, $bind_password = nul
  * @param string $props [optional]
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_sasl_bind ($link, $binddn = null, $password = null, $sasl_mech = null, $sasl_realm = null, $sasl_authc_id = null, $sasl_authz_id = null, $props = null) {}
+function ldap_sasl_bind ($ldap, $binddn = null, $password = null, $sasl_mech = null, $sasl_realm = null, $sasl_authc_id = null, $sasl_authz_id = null, $props = null): bool
+{}
 
 /**
  * Unbind from LDAP directory
  * @link https://php.net/manual/en/function.ldap-unbind.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_unbind ($link_identifier) {}
+function ldap_unbind ($ldap): bool
+{}
 
 /**
  * Read an entry
  * @link https://php.net/manual/en/function.ldap-read.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param string $base_dn <p>
+ * @param array|array|string $base <p>
  * The base DN for the directory.
  * </p>
- * @param string $filter <p>
+ * @param array|string $filter <p>
  * An empty filter is not allowed. If you want to retrieve absolutely all
  * information for this entry, use a filter of
  * objectClass=*. If you know which entry types are
@@ -189,7 +204,7 @@ function ldap_unbind ($link_identifier) {}
  * The use of this parameter should therefore be considered good
  * practice.
  * </p>
- * @param int $attrsonly [optional] <p>
+ * @param int $attributes_only [optional] <p>
  * Should be set to 1 if only attribute types are wanted. If set to 0
  * both attributes types and attribute values are fetched which is the
  * default behaviour.
@@ -220,22 +235,23 @@ function ldap_unbind ($link_identifier) {}
  * Specifies how aliases should be handled during the search. It can be
  * one of the following:
  * <b>LDAP_DEREF_NEVER</b> - (default) aliases are never
- * dereferenced.
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * dereferenced.</p>
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false a search result identifier or <b>FALSE</b> on error.
  */
-function ldap_read ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null, $serverctrls = []) {}
+function ldap_read ($ldap, array|string $base, array|string $filter, array $attributes, int $attributes_only, int $sizelimit = -1, int $timelimit = -1, int $deref, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Single-level search
  * @link https://php.net/manual/en/function.ldap-list.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param string $base_dn <p>
+ * @param array|array|string $base <p>
  * The base DN for the directory.
  * </p>
- * @param string $filter
+ * @param array|string $filter
  * @param array $attributes [optional] <p>
  * An array of the required attributes, e.g. array("mail", "sn", "cn").
  * Note that the "dn" is always returned irrespective of which attributes
@@ -247,7 +263,7 @@ function ldap_read ($link_identifier, $base_dn, $filter, array $attributes = nul
  * The use of this parameter should therefore be considered good
  * practice.
  * </p>
- * @param int $attrsonly [optional] <p>
+ * @param int $attributes_only [optional] <p>
  * Should be set to 1 if only attribute types are wanted. If set to 0
  * both attributes types and attribute values are fetched which is the
  * default behaviour.
@@ -278,22 +294,23 @@ function ldap_read ($link_identifier, $base_dn, $filter, array $attributes = nul
  * Specifies how aliases should be handled during the search. It can be
  * one of the following:
  * <b>LDAP_DEREF_NEVER</b> - (default) aliases are never
- * dereferenced.
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * dereferenced.</p>
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false a search result identifier or <b>FALSE</b> on error.
  */
-function ldap_list ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null, $serverctrls = []) {}
+function ldap_list ($ldap, array|string $base, array|string $filter, array $attributes, int $attributes_only, int $sizelimit = -1, int $timelimit = -1, int $deref, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Search LDAP tree
  * @link https://php.net/manual/en/function.ldap-search.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param string $base_dn <p>
+ * @param array|string $base <p>
  * The base DN for the directory.
  * </p>
- * @param string $filter <p>
+ * @param array|string $filter <p>
  * The search filter can be simple or advanced, using boolean operators in
  * the format described in the LDAP documentation (see the Netscape Directory SDK for full
  * information on filters).
@@ -309,7 +326,7 @@ function ldap_list ($link_identifier, $base_dn, $filter, array $attributes = nul
  * The use of this parameter should therefore be considered good
  * practice.
  * </p>
- * @param int $attrsonly [optional] <p>
+ * @param int $attributes_only [optional] <p>
  * Should be set to 1 if only attribute types are wanted. If set to 0
  * both attributes types and attribute values are fetched which is the
  * default behaviour.
@@ -340,66 +357,72 @@ function ldap_list ($link_identifier, $base_dn, $filter, array $attributes = nul
  * Specifies how aliases should be handled during the search. It can be
  * one of the following:
  * <b>LDAP_DEREF_NEVER</b> - (default) aliases are never
- * dereferenced.
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * dereferenced.</p>
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false a search result identifier or <b>FALSE</b> on error.
  */
-function ldap_search ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null, $serverctrls = []) {}
+function ldap_search ($ldap, array|string $base, array|string $filter, array $attributes, int $attributes_only, int $sizelimit = -1, int $timelimit = -1, int $deref, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Free result memory
  * @link https://php.net/manual/en/function.ldap-free-result.php
- * @param resource $result_identifier
+ * @param resource $ldap
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_free_result ($result_identifier) {}
+function ldap_free_result ($ldap): bool
+{}
 
 /**
  * Count the number of entries in a search
  * @link https://php.net/manual/en/function.ldap-count-entries.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_identifier <p>
+ * @param resource $result <p>
  * The internal LDAP result.
  * </p>
  * @return int|false number of entries in the result or <b>FALSE</b> on error.
  */
-function ldap_count_entries ($link_identifier, $result_identifier) {}
+#[LanguageLevelTypeAware(["8.0" => "int"], default: "int|false")]
+function ldap_count_entries ($ldap, $result)
+{}
 
 /**
  * Return first result id
  * @link https://php.net/manual/en/function.ldap-first-entry.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_identifier
+ * @param resource $result
  * @return resource|false the result entry identifier for the first entry on success and
  * <b>FALSE</b> on error.
  */
-function ldap_first_entry ($link_identifier, $result_identifier) {}
+function ldap_first_entry ($ldap, $result)
+{}
 
 /**
  * Get next result entry
  * @link https://php.net/manual/en/function.ldap-next-entry.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
+ * @param resource $result
  * @return resource|false entry identifier for the next entry in the result whose entries
  * are being read starting with <b>ldap_first_entry</b>. If
  * there are no more entries in the result then it returns <b>FALSE</b>.
  */
-function ldap_next_entry ($link_identifier, $result_entry_identifier) {}
+function ldap_next_entry ($ldap, $result)
+{}
 
 /**
  * Get all result entries
  * @link https://php.net/manual/en/function.ldap-get-entries.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_identifier
- * @return array a complete result information in a multi-dimensional array on
+ * @param resource $result
+ * @return array|false a complete result information in a multi-dimensional array on
  * success and <b>FALSE</b> on error.
  * </p>
  * <p>
@@ -418,53 +441,55 @@ function ldap_next_entry ($link_identifier, $result_entry_identifier) {}
  * return_value[i]["attribute"][j] = jth value of attribute in ith entry
  * </pre>
  */
-function ldap_get_entries ($link_identifier, $result_identifier) {}
+function ldap_get_entries ($ldap, $result): array|false
+{}
 
 /**
  * Return first attribute
  * @link https://php.net/manual/en/function.ldap-first-attribute.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
- * @param int $dummy_ber [optional] is the identifier to internal memory location pointer. This parameter is no longer used as this is now handled automatically by PHP. For backwards compatibility PHP will not throw an error if this parameter is passed.
+ * @param resource $entry
  * @return string|false the first attribute in the entry on success and <b>FALSE</b> on
  * error.
  */
-function ldap_first_attribute ($link_identifier, $result_entry_identifier, $dummy_ber = null) {}
+function ldap_first_attribute ($ldap, $entry): string|false
+{}
 
 /**
  * Get the next attribute in result
  * @link https://php.net/manual/en/function.ldap-next-attribute.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
- * @param int $dummy_ber [optional] The internal state of the pointer is maintained by this parameter. This parameter is no longer used as this is now handled automatically by PHP. For backwards compatibility PHP will not throw an error if this parameter is passed.
+ * @param resource $entry
  * @return string|false the next attribute in an entry on success and <b>FALSE</b> on
  * error.
  */
-function ldap_next_attribute ($link_identifier, $result_entry_identifier, $dummy_ber) {}
+function ldap_next_attribute ($ldap, $entry): string|false
+{}
 
 /**
  * Get attributes from a search result entry
  * @link https://php.net/manual/en/function.ldap-get-attributes.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
+ * @param resource $entry
  * @return array a complete entry information in a multi-dimensional array
  * on success and <b>FALSE</b> on error.
  */
-function ldap_get_attributes ($link_identifier, $result_entry_identifier) {}
+function ldap_get_attributes ($ldap, $entry): array
+{}
 
 /**
  * Get all values from a result entry
  * @link https://php.net/manual/en/function.ldap-get-values.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
+ * @param resource $entry
  * @param string $attribute
  * @return array|false an array of values for the attribute on success and <b>FALSE</b> on
  * error. The number of values can be found by indexing "count" in the
@@ -479,33 +504,36 @@ function ldap_get_attributes ($link_identifier, $result_entry_identifier) {}
  * return_value[0] = first value of attribute
  * return_value[i] = ith value of attribute
  */
-function ldap_get_values ($link_identifier, $result_entry_identifier, $attribute) {}
+function ldap_get_values ($ldap, $entry, string $attribute): array|false
+{}
 
 /**
  * Get all binary values from a result entry
  * @link https://php.net/manual/en/function.ldap-get-values-len.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
+ * @param resource $entry
  * @param string $attribute
  * @return array|false an array of values for the attribute on success and <b>FALSE</b> on
  * error. Individual values are accessed by integer index in the array. The
  * first index is 0. The number of values can be found by indexing "count"
  * in the resultant array.
  */
-function ldap_get_values_len ($link_identifier, $result_entry_identifier, $attribute) {}
+function ldap_get_values_len ($ldap, $entry, string $attribute): array|false
+{}
 
 /**
  * Get the DN of a result entry
  * @link https://php.net/manual/en/function.ldap-get-dn.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
- * @param resource $result_entry_identifier
+ * @param resource $entry
  * @return string|false the DN of the result entry and <b>FALSE</b> on error.
  */
-function ldap_get_dn ($link_identifier, $result_entry_identifier) {}
+function ldap_get_dn ($ldap, $entry): string|false
+{}
 
 /**
  * Splits DN into its component parts
@@ -519,12 +547,13 @@ function ldap_get_dn ($link_identifier, $result_entry_identifier) {}
  * attribute=value format) set <i>with_attrib</i> to 0
  * and to get only values set it to 1.
  * </p>
- * @return array an array of all DN components.
+ * @return array|false an array of all DN components.
  * The first element in this array has count key and
  * represents the number of returned values, next elements are numerically
  * indexed DN components.
  */
-function ldap_explode_dn ($dn, $with_attrib) {}
+function ldap_explode_dn (string $dn, int $with_attrib): array|false
+{}
 
 /**
  * Convert DN to User Friendly Naming format
@@ -532,14 +561,15 @@ function ldap_explode_dn ($dn, $with_attrib) {}
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
- * @return string the user friendly name.
+ * @return string|false the user friendly name.
  */
-function ldap_dn2ufn ($dn) {}
+function ldap_dn2ufn (string $dn): string|false
+{}
 
 /**
  * Add entries to LDAP directory
  * @link https://php.net/manual/en/function.ldap-add.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
@@ -556,16 +586,17 @@ function ldap_dn2ufn ($dn) {}
  * $entree["attribut2"][1] = "value2";
  * </code>
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_add ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_add ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Add entries to LDAP directory
  * Does the same thing as ldap_add() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://www.php.net/manual/en/function.ldap-add-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
@@ -582,164 +613,176 @@ function ldap_add ($link_identifier, $dn, array $entry, $serverctrls = []) {}
  * $entree["attribut2"][1] = "value2";
  * </code>
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
- * @since 7.4
+ * @since 7.3
  */
-function ldap_add_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_add_ext ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Delete an entry from a directory
  * @link https://php.net/manual/en/function.ldap-delete.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_delete ($link_identifier, $dn, $serverctrls = []) {}
+function ldap_delete ($ldap, string $dn, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Delete an entry from a directory
  * Does the same thing as ldap_delete() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-delete-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
  * @since 7.3
  */
-function ldap_delete_ext ($link_identifier, $dn, $serverctrls = []) {}
+function ldap_delete_ext ($ldap, string $dn, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * This function is an alias of: ldap_mod_replace().
  * Replace attribute values with new ones
  * @link https://php.net/manual/en/function.ldap-mod-replace.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 7.0
  */
-function ldap_modify ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_modify ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Add attribute values to current attributes
  * @link https://php.net/manual/en/function.ldap-mod-add.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_mod_add ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_add ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Add attribute values to current attributes
  * Does the same thing as ldap_mod_add() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-mod-add-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
+ * @since 7.3
  */
-function ldap_mod_add_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_add_ext ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Replace attribute values with new ones
  * @link https://php.net/manual/en/function.ldap-mod-replace.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_mod_replace ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_replace ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Replace attribute values with new ones
  * Does the same thing as ldap_mod_replace() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-mod-replace-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
  * @since 7.3
  */
-function ldap_mod_replace_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_replace_ext ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Delete attribute values from current attributes
  * @link https://php.net/manual/en/function.ldap-mod-del.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_mod_del ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_del ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Delete attribute values from current attributes
  * Does the same thing as ldap_mod_del() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-mod-del-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $entry
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
  * @since 7.3
  */
-function ldap_mod_del_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
+function ldap_mod_del_ext ($ldap, string $dn, array $entry, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Return the LDAP error number of the last LDAP command
  * @link https://php.net/manual/en/function.ldap-errno.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @return int Return the LDAP error number of the last LDAP command for this
  * link.
  */
-function ldap_errno ($link_identifier) {}
+function ldap_errno ($ldap): int
+{}
 
 /**
  * Convert LDAP error number into string error message
@@ -749,22 +792,24 @@ function ldap_errno ($link_identifier) {}
  * </p>
  * @return string the error message, as a string.
  */
-function ldap_err2str ($errno) {}
+function ldap_err2str (int $errno): string
+{}
 
 /**
  * Return the LDAP error message of the last LDAP command
  * @link https://php.net/manual/en/function.ldap-error.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @return string string error message.
  */
-function ldap_error ($link_identifier) {}
+function ldap_error ($ldap): string
+{}
 
 /**
  * Compare value of attribute found in entry specified with DN
  * @link https://php.net/manual/en/function.ldap-compare.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
@@ -776,16 +821,17 @@ function ldap_error ($link_identifier) {}
  * @param string $value <p>
  * The compared value.
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return mixed <b>TRUE</b> if <i>value</i> matches otherwise returns
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
+ * @return int|bool <b>TRUE</b> if <i>value</i> matches otherwise returns
  * <b>FALSE</b>. Returns -1 on error.
  */
-function ldap_compare ($link_identifier, $dn, $attribute, $value, $serverctrls = []) {}
+function ldap_compare ($ldap, string $dn, string $attribute, string $value, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): int|bool
+{}
 
 /**
  * Sort LDAP result entries
  * @link https://php.net/manual/en/function.ldap-sort.php
- * @param resource $link <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param resource $result <p>
@@ -795,66 +841,69 @@ function ldap_compare ($link_identifier, $dn, $attribute, $value, $serverctrls =
  * @param string $sortfilter <p>
  * The attribute to use as a key in the sort.
  * </p>
- * @deprecated 7.0
  * @removed 8.0
  * @return bool
  */
-function ldap_sort ($link, $result, $sortfilter) {}
+#[Deprecated(since: "7.0")]
+function ldap_sort ($ldap, $result, string $sortfilter): bool
+{}
 
 /**
  * Modify the name of an entry
  * @link https://php.net/manual/en/function.ldap-rename.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
- * @param string $newrdn <p>
+ * @param string $new_rdn <p>
  * The new RDN.
  * </p>
- * @param string $newparent <p>
+ * @param string $new_parent <p>
  * The new parent/superior entry.
  * </p>
- * @param bool $deleteoldrdn <p>
+ * @param bool $delete_old_rdn <p>
  * If <b>TRUE</b> the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_rename ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn, $serverctrls = []) {}
+function ldap_rename ($ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
  * Modify the name of an entry
  * Does the same thing as ldap_rename() but returns the LDAP result resource to be parsed with ldap_parse_result().
  * @link https://php.net/manual/en/function.ldap-rename-ext.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param string $dn <p>
  * The distinguished name of an LDAP entity.
  * </p>
- * @param string $newrdn <p>
+ * @param string $new_rdn <p>
  * The new RDN.
  * </p>
- * @param string $newparent <p>
+ * @param string $new_parent <p>
  * The new parent/superior entry.
  * </p>
- * @param bool $deleteoldrdn <p>
+ * @param bool $delete_old_rdn <p>
  * If <b>TRUE</b> the old RDN value(s) is removed, else the old RDN value(s)
  * is retained as non-distinguished values of the entry.
  * </p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return resource|false
  * @since 7.3
  */
-function ldap_rename_ext ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn, $serverctrls = []) {}
+function ldap_rename_ext ($ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = [])
+{}
 
 /**
  * Get the current value for given option
  * @link https://php.net/manual/en/function.ldap-get-option.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param int $option <p>
@@ -916,17 +965,18 @@ function ldap_rename_ext ($link_identifier, $dn, $newrdn, $newparent, $deleteold
  * <td>array</td>
  * </tr>
  * </p>
- * @param mixed $retval <p>
+ * @param mixed &$value <p>
  * This will be set to the option value.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_get_option ($link_identifier, $option, &$retval) {}
+function ldap_get_option ($ldap, int $option, &$value = null): bool
+{}
 
 /**
  * Set the value of the given option
  * @link https://php.net/manual/en/function.ldap-set-option.php
- * @param resource $link_identifier <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param int $option <p>
@@ -1017,76 +1067,81 @@ function ldap_get_option ($link_identifier, $option, &$retval) {}
  * if not supplied. See draft-ietf-ldapext-ldap-c-api-xx.txt
  * for details. See also the second example below.
  * </p>
- * @param mixed $newval <p>
+ * @param mixed $value <p>
  * The new value for the specified <i>option</i>.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_set_option ($link_identifier, $option, $newval) {}
+function ldap_set_option ($ldap, int $option, $value): bool
+{}
 
 /**
  * Return first reference
  * @link https://php.net/manual/en/function.ldap-first-reference.php
- * @param resource $link
+ * @param resource $ldap
  * @param resource $result
  * @return resource
  */
-function ldap_first_reference ($link, $result) {}
+function ldap_first_reference ($ldap, $result) {}
 
 /**
  * Get next reference
  * @link https://php.net/manual/en/function.ldap-next-reference.php
- * @param resource $link
+ * @param resource $ldap
  * @param resource $entry
  * @return resource
  */
-function ldap_next_reference ($link, $entry) {}
+function ldap_next_reference ($ldap, $entry) {}
 
 /**
  * Extract information from reference entry
  * @link https://php.net/manual/en/function.ldap-parse-reference.php
- * @param resource $link
+ * @param resource $ldap
  * @param resource $entry
- * @param array $referrals
+ * @param array &$referrals
  * @return bool
  */
-function ldap_parse_reference ($link, $entry, array &$referrals) {}
+function ldap_parse_reference ($ldap, $entry, &$referrals): bool
+{}
 
 /**
  * Extract information from result
  * @link https://php.net/manual/en/function.ldap-parse-result.php
- * @param resource $link
+ * @param resource $ldap
  * @param resource $result
- * @param int $errcode
- * @param string $matcheddn [optional]
- * @param string $errmsg [optional]
- * @param array $referrals [optional]
- * @param array $serverctrls [optional] An array of LDAP Controls which have been sent with the response.
+ * @param int &$error_code
+ * @param string &$matched_dn [optional]
+ * @param string &$error_message [optional]
+ * @param array &$referrals [optional]
+ * @param array &$controls [optional] An array of LDAP Controls which have been sent with the response.
  * @return bool
  */
-function ldap_parse_result ($link, $result, &$errcode, &$matcheddn = null, &$errmsg = null, array &$referrals = null, &$serverctrls = []) {}
+function ldap_parse_result ($ldap, $result, &$error_code, &$matched_dn, &$error_message, &$referrals, &$controls = []): bool
+{}
 
 /**
  * Start TLS
  * @link https://php.net/manual/en/function.ldap-start-tls.php
- * @param resource $link
+ * @param resource $ldap
  * @return bool
  */
-function ldap_start_tls ($link) {}
+function ldap_start_tls ($ldap): bool
+{}
 
 /**
  * Set a callback function to do re-binds on referral chasing
  * @link https://php.net/manual/en/function.ldap-set-rebind-proc.php
- * @param resource $link
- * @param callable $callback
+ * @param resource $ldap
+ * @param callable|null $callback
  * @return bool
  */
-function ldap_set_rebind_proc ($link, callable $callback) {}
+function ldap_set_rebind_proc ($ldap, ?callable $callback): bool
+{}
 
 /**
  * Send LDAP pagination control
  * @link https://php.net/manual/en/function.ldap-control-paged-result.php
- * @param resource $link <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param int $pagesize <p>
@@ -1103,28 +1158,32 @@ function ldap_set_rebind_proc ($link, callable $callback) {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.4
- * @deprecated 7.4
+ * @removed 8.0
  */
-function ldap_control_paged_result ($link, $pagesize, $iscritical = false, $cookie = "") {}
+#[Deprecated(since: "7.4")]
+function ldap_control_paged_result ($ldap, int $pagesize, $iscritical = false, $cookie = ""): bool
+{}
 
 /**
  * Retrieve the LDAP pagination cookie
  * @link https://php.net/manual/en/function.ldap-control-paged-result-response.php
- * @param resource $link <p>
+ * @param resource $ldap <p>
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param resource $result
- * @param string $cookie [optional] <p>
+ * @param string &$cookie [optional] <p>
  * An opaque structure sent by the server.
  * </p>
- * @param int $estimated [optional] <p>
+ * @param int &$estimated [optional] <p>
  * The estimated number of entries to retrieve.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.4
- * @deprecated 7.4
+ * @removed 8.0
  */
-function ldap_control_paged_result_response ($link, $result, &$cookie = null, &$estimated = null) {}
+#[Deprecated(since: "7.4")]
+function ldap_control_paged_result_response ($ldap, $result, &$cookie = null, &$estimated = null): bool
+{}
 
 /**
  * Escape a string for use in an LDAP filter or DN
@@ -1134,19 +1193,19 @@ function ldap_control_paged_result_response ($link, $result, &$cookie = null, &$
  * @return string
  * @since 5.6
  */
-
-function ldap_escape ($value, $ignore = "", $flags = 0) {}
+function ldap_escape (string $value, string $ignore = "", int $flags = 0): string
+{}
 
 /**
  * (PHP 5.4 &gt;= 5.4.26, PHP 5.5 &gt;= 5.5.10, PHP 5.6 &gt;= 5.6.0)
  * Batch and execute modifications on an LDAP entry
  * @link https://php.net/manual/en/function.ldap-modify-batch.php
- * @param $link_identifier <p>
+ * @param $ldap <p>
  * An LDAP link identifier, returned by
  * {@see ldap_connect()}.
  * </p>
- * @param $dn <p>The distinguished name of an LDAP entity.</p>
- * @param $entry <p>An array that specifies the modifications to make. Each entry in this
+ * @param  string $dn <p>The distinguished name of an LDAP entity.</p>
+ * @param array $modifications_info <p>An array that specifies the modifications to make. Each entry in this
  * array is an associative array with two or three keys:
  * <em>attrib</em> maps to the name of the attribute to modify,
  * <em>modtype</em> maps to the type of modification to perform,
@@ -1155,14 +1214,12 @@ function ldap_escape ($value, $ignore = "", $flags = 0) {}
  * </p>
  * <p>
  * Possible values for <em>modtype</em> include:
- * </p><dl>
- *
+ * </p>
+ * <dl>
  *
  * <dt>
  * <b>LDAP_MODIFY_BATCH_ADD</b></dt>
- *
  * <dd>
- *
  * <p>
  * Each value specified through <em>values</em> is added (as
  * an additional value) to the attribute named by
@@ -1172,9 +1229,7 @@ function ldap_escape ($value, $ignore = "", $flags = 0) {}
  *
  * <dt>
  * <b>LDAP_MODIFY_BATCH_REMOVE</b></dt>
- *
  * <dd>
- *
  * <p>
  * Each value specified through <em>values</em> is removed
  * from the attribute named by <em>attrib</em>. Any value of
@@ -1182,11 +1237,10 @@ function ldap_escape ($value, $ignore = "", $flags = 0) {}
  * will remain untouched.
  * </p>
  * </dd>
+ *
  * <dt>
  * <b>LDAP_MODIFY_BATCH_REMOVE_ALL</b></dt>
- *
  * <dd>
- *
  * <p>
  * All values are removed from the attribute named by
  * <em>attrib</em>. A <em>values</em> entry must
@@ -1196,35 +1250,36 @@ function ldap_escape ($value, $ignore = "", $flags = 0) {}
  *
  * <dt>
  * <b>LDAP_MODIFY_BATCH_REPLACE</b></dt>
- *
  * <dd>
- *
  * <p>
  * All current values of the attribute named by
  * <em>attrib</em> are replaced with the values specified
  * through <em>values</em>.
  * </p>
  * </dd>
+ *
  * </dl>
  * <p>
  * Note that any value for <em>attrib</em> must be a string, any
  * value for <em>values</em> must be an array of strings, and
  * any value for <em>modtype</em> must be one of the
  * <b>LDAP_MODIFY_BATCH_*</b> constants listed above.
- * </p></p>
- * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
+ * </p>
+ * @param array|null $controls [optional] Array of LDAP Controls to send with the request.
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  * @since 5.4
  */
-function ldap_modify_batch ( $link_identifier , $dn , $entry, $serverctrls = []) {}
+function ldap_modify_batch ($ldap , string $dn , array $modifications_info, #[LanguageLevelTypeAware(["8.0" => "null|array"], default: "array")] $controls = []): bool
+{}
 
 /**
- * @param resource $link_identifier
- * @param resource $result_identifier
+ * @param resource $ldap
+ * @param resource $result
  * @return int returns the number of reference messages in a search result.
  * @since 8.0
  */
-function ldap_count_references($link_identifier, $result_identifier){}
+function ldap_count_references($ldap, $result): int
+{}
 
 define('LDAP_ESCAPE_FILTER', 1);
 define ('LDAP_ESCAPE_DN', 2);

--- a/build/stubs/memcached.php
+++ b/build/stubs/memcached.php
@@ -1,6 +1,7 @@
 <?php
 
 // Start of memcached v.3.1.5
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * Represents a connection to a set of memcached servers.
@@ -513,9 +514,9 @@ class Memcached  {
 	 */
 	const RES_CONNECTION_FAILURE = 3;
 	/**
-	 * <p>MEMCACHED_CONNECTION_BIND_FAILURE: Deprecated since version <0.30(libmemcached).
-	 * We were not able to bind() to the socket.</p>
+	 * MEMCACHED_CONNECTION_BIND_FAILURE: We were not able to bind() to the socket.
 	 */
+	#[Deprecated('Deprecated since version 0.30(libmemcached)')]
 	const RES_CONNECTION_BIND_FAILURE = 4;
 	/**
 	 * <p>MEMCACHED_READ_FAILURE: A read failure has occurred.</p>
@@ -534,9 +535,9 @@ class Memcached  {
 	 */
 	const RES_FAIL_UNIX_SOCKET = 27;
 	/**
-	 * <p>MEMCACHED_NO_KEY_PROVIDED: Deprecated since version <0.30(libmemcached): Use MEMCACHED_BAD_KEY_PROVIDED instead.
 	 * No key was provided.</p>
 	 */
+	#[Deprecated('Deprecated since version 0.30 (libmemcached). Use MEMCACHED_BAD_KEY_PROVIDED instead.')]
 	const RES_NO_KEY_PROVIDED = 29;
 	/**
 	 * <p>MEMCACHED_INVALID_ARGUMENTS: The arguments supplied to the given function were not valid.</p>
@@ -1367,7 +1368,7 @@ class Memcached  {
 	 * Get server pool statistics
 	 * @link https://php.net/manual/en/memcached.getstats.php
 	 * @param string $type <p>items, slabs, sizes ...</p>
-	 * @return array Array of server statistics, one entry per server.
+	 * @return array|false Array of server statistics, one entry per server.
 	 */
 	public function getStats ($type = null) {}
 
@@ -1436,7 +1437,7 @@ class Memcached  {
 	/**
 	 * (PECL memcached &gt;= 2.0.0)<br/>
 	 * Set the credentials to use for authentication
-	 * @link https://www.php.net/manual/en/memcached.setsaslauthdata.php
+	 * @link https://secure.php.net/manual/en/memcached.setsaslauthdata.php
 	 * @param string $username <p>
 	 * The username to use for authentication.
 	 * </p>
@@ -1522,7 +1523,8 @@ class Memcached  {
  * @link https://php.net/manual/en/class.memcachedexception.php
  */
 class MemcachedException extends RuntimeException  {
-	function __construct( $errmsg = "", $errcode  = 0 ) {}
+	#[\JetBrains\PhpStorm\Pure]
+    function __construct($errmsg = "", $errcode  = 0 ) {}
 }
 // End of memcached v.3.1.5
 ?>

--- a/build/stubs/redis.php
+++ b/build/stubs/redis.php
@@ -1,5 +1,7 @@
 <?php
 
+use JetBrains\PhpStorm\Deprecated;
+
 /**
  * Helper autocomplete for php redis extension
  *
@@ -39,6 +41,16 @@ class Redis
     const SCAN_RETRY            = 1;
 
     /**
+     * @since 5.3.0
+     */
+    const SCAN_PREFIX           = 2;
+
+    /**
+     * @since 5.3.0
+     */
+    const SCAN_NOPREFIX         = 3;
+
+    /**
      * Serializers
      */
     const SERIALIZER_NONE       = 0;
@@ -53,6 +65,7 @@ class Redis
     const COMPRESSION_NONE      = 0;
     const COMPRESSION_LZF       = 1;
     const COMPRESSION_ZSTD      = 2;
+    const COMPRESSION_LZ4       = 3;
 
     /**
      * Compression ZSTD levels
@@ -129,10 +142,8 @@ class Redis
      * @param float  $readTimeout   value in seconds (optional, default is 0 meaning unlimited)
      *
      * @return bool TRUE on success, FALSE on error
-     *
-     * @see        connect()
-     * @deprecated use Redis::connect()
      */
+    #[Deprecated(replacement: '%class%->connect(%parametersList%)')]
     public function open(
         $host,
         $port = 6379,
@@ -155,7 +166,7 @@ class Redis
     /**
      * Retrieve our host or unix socket that we're connected to
      *
-     * @return string|bool The host or unix socket we're connected to or FALSE if we're not connected
+     * @return string|false The host or unix socket we're connected to or FALSE if we're not connected
      */
     public function getHost()
     {
@@ -164,7 +175,7 @@ class Redis
     /**
      * Get the port we're connected to
      *
-     * @return int|bool Returns the port we're connected to or FALSE if we're not connected
+     * @return int|false Returns the port we're connected to or FALSE if we're not connected
      */
     public function getPort()
     {
@@ -183,7 +194,7 @@ class Redis
     /**
      * Get the (write) timeout in use for phpredis
      *
-     * @return float|bool The timeout (DOUBLE) specified in our connect call or FALSE if we're not connected
+     * @return float|false The timeout (DOUBLE) specified in our connect call or FALSE if we're not connected
      */
     public function getTimeout()
     {
@@ -279,10 +290,8 @@ class Redis
      * @param float  $readTimeout
      *
      * @return bool
-     *
-     * @deprecated use Redis::pconnect()
-     * @see pconnect()
      */
+    #[Deprecated(replacement: '%class%->pconnect(%parametersList%)')]
     public function popen(
         $host,
         $port = 6379,
@@ -378,14 +387,14 @@ class Redis
     /**
      * Check the current connection status
      *
-     * @param string $message
+     * @param string $message [optional]
      *
      * @return bool|string TRUE if the command is successful or returns message
      * Throws a RedisException object on connectivity error, as described above.
      * @throws RedisException
      * @link    https://redis.io/commands/ping
      */
-    public function ping($message)
+    public function ping($message = null)
     {
     }
 
@@ -407,7 +416,7 @@ class Redis
      *
      * @param string $key
      *
-     * @return string|mixed|bool If key didn't exist, FALSE is returned.
+     * @return string|mixed|false If key didn't exist, FALSE is returned.
      * Otherwise, the value related to this key is returned
      *
      * @link    https://redis.io/commands/get
@@ -545,15 +554,13 @@ class Redis
     }
 
     /**
-     * @see del()
-     * @deprecated use Redis::del()
-     *
      * @param   string|string[] $key1
      * @param   string          $key2
      * @param   string          $key3
      *
      * @return int Number of keys deleted
      */
+    #[Deprecated(replacement: "%class%->del(%parametersList%)")]
     public function delete($key1, $key2 = null, $key3 = null)
     {
     }
@@ -592,7 +599,7 @@ class Redis
      * a Redis::PIPELINE block is simply transmitted faster to the server, but without any guarantee of atomicity.
      * discard cancels a transaction.
      *
-     * @return Redis returns the Redis instance and enters multi-mode.
+     * @return static returns the Redis instance and enters multi-mode.
      * Once in multi-mode, all subsequent method calls return the same object until exec() is called.
      *
      * @link    https://redis.io/commands/multi
@@ -958,9 +965,9 @@ class Redis
      * If the key exists and is not a list, FALSE is returned.
      *
      * @param string $key
-     * @param string|mixed $value1... Variadic list of values to push in key, if dont used serialized, used string
+     * @param string|mixed ...$value1 Variadic list of values to push in key, if dont used serialized, used string
      *
-     * @return int|bool The new length of the list in case of success, FALSE in case of Failure
+     * @return int|false The new length of the list in case of success, FALSE in case of Failure
      *
      * @link https://redis.io/commands/lpush
      * @example
@@ -986,9 +993,9 @@ class Redis
      * If the key exists and is not a list, FALSE is returned.
      *
      * @param string $key
-     * @param string|mixed $value1... Variadic list of values to push in key, if dont used serialized, used string
+     * @param string|mixed ...$value1 Variadic list of values to push in key, if dont used serialized, used string
      *
-     * @return int|bool The new length of the list in case of success, FALSE in case of Failure
+     * @return int|false The new length of the list in case of success, FALSE in case of Failure
      *
      * @link    https://redis.io/commands/rpush
      * @example
@@ -1014,7 +1021,7 @@ class Redis
      * @param string $key
      * @param string|mixed $value String, value to push in key
      *
-     * @return int|bool The new length of the list in case of success, FALSE in case of Failure.
+     * @return int|false The new length of the list in case of success, FALSE in case of Failure.
      *
      * @link    https://redis.io/commands/lpushx
      * @example
@@ -1037,7 +1044,7 @@ class Redis
      * @param string $key
      * @param string|mixed $value String, value to push in key
      *
-     * @return int|bool The new length of the list in case of success, FALSE in case of Failure.
+     * @return int|false The new length of the list in case of success, FALSE in case of Failure.
      *
      * @link    https://redis.io/commands/rpushx
      * @example
@@ -1208,14 +1215,13 @@ class Redis
     }
 
     /**
-     * @see lLen()
      * @link https://redis.io/commands/llen
-     * @deprecated use Redis::lLen()
      *
      * @param string $key
      *
      * @return int The size of the list identified by Key exists
      */
+    #[Deprecated(replacement: '%class%->lLen(%parametersList%)')]
     public function lSize($key)
     {
     }
@@ -1248,14 +1254,13 @@ class Redis
     }
 
     /**
-     * @see lIndex()
      * @link https://redis.io/commands/lindex
-     * @deprecated use Redis::lIndex()
      *
      * @param string $key
      * @param int $index
      * @return mixed|bool the element at this index
      */
+    #[Deprecated(replacement: '%class%->lIndex(%parametersList%)')]
     public function lGet($key, $index)
     {
     }
@@ -1310,15 +1315,14 @@ class Redis
     }
 
     /**
-     * @see lRange()
      * @link https://redis.io/commands/lrange
-     * @deprecated use Redis::lRange()
      *
      * @param string    $key
      * @param int       $start
      * @param int       $end
      * @return array
      */
+    #[Deprecated(replacement: '%class%->lRange(%parametersList%)')]
     public function lGetRange($key, $start, $end)
     {
     }
@@ -1330,7 +1334,7 @@ class Redis
      * @param int    $start
      * @param int    $stop
      *
-     * @return array|bool Bool return FALSE if the key identify a non-list value
+     * @return array|false Bool return FALSE if the key identify a non-list value
      *
      * @link        https://redis.io/commands/ltrim
      * @example
@@ -1348,14 +1352,13 @@ class Redis
     }
 
     /**
-     * @see lTrim()
      * @link  https://redis.io/commands/ltrim
-     * @deprecated use Redis::lTrim()
      *
      * @param string    $key
      * @param int       $start
      * @param int       $stop
      */
+    #[Deprecated(replacement: '%class%->lTrim(%parametersList%)')]
     public function listTrim($key, $start, $stop)
     {
     }
@@ -1391,14 +1394,13 @@ class Redis
     }
 
     /**
-     * @see lRem
      * @link https://redis.io/commands/lremove
-     * @deprecated use Redis::lRem()
      *
      * @param string $key
      * @param string $value
      * @param int $count
      */
+    #[Deprecated(replacement: '%class%->lRem(%parametersList%)')]
     public function lRemove($key, $value, $count)
     {
     }
@@ -1483,13 +1485,12 @@ class Redis
     }
 
     /**
-     * @see sRem()
      * @link    https://redis.io/commands/srem
-     * @deprecated use Redis::sRem()
      *
      * @param   string  $key
      * @param   string|mixed  ...$member1
      */
+    #[Deprecated(replacement: '%class%->sRem(%parametersList%)')]
     public function sRemove($key, ...$member1)
     {
     }
@@ -1544,13 +1545,12 @@ class Redis
     }
 
     /**
-     * @see sIsMember()
      * @link    https://redis.io/commands/sismember
-     * @deprecated use Redis::sIsMember()
      *
      * @param string       $key
      * @param string|mixed $value
      */
+    #[Deprecated(replacement: '%class%->sIsMember(%parametersList%)')]
     public function sContains($key, $value)
     {
     }
@@ -1649,7 +1649,7 @@ class Redis
      * @param string $key1         keys identifying the different sets on which we will apply the intersection.
      * @param string ...$otherKeys variadic list of keys
      *
-     * @return array contain the result of the intersection between those keys
+     * @return array|false contain the result of the intersection between those keys
      * If the intersection between the different sets is empty, the return value will be empty array.
      *
      * @link    https://redis.io/commands/sinter
@@ -1687,7 +1687,7 @@ class Redis
      * @param string $key1         keys identifying the different sets on which we will apply the intersection.
      * @param string ...$otherKeys variadic list of keys
      *
-     * @return int|bool The cardinality of the resulting set, or FALSE in case of a missing key
+     * @return int|false The cardinality of the resulting set, or FALSE in case of a missing key
      *
      * @link    https://redis.io/commands/sinterstore
      * @example
@@ -1839,7 +1839,7 @@ class Redis
      * @param string $key1         first key for diff
      * @param string ...$otherKeys variadic list of keys corresponding to sets in redis
      *
-     * @return int|bool The cardinality of the resulting set, or FALSE in case of a missing key
+     * @return int|false The cardinality of the resulting set, or FALSE in case of a missing key
      *
      * @link    https://redis.io/commands/sdiffstore
      * @example
@@ -1903,13 +1903,12 @@ class Redis
     }
 
     /**
-     * @see sMembers()
      * @link    https://redis.io/commands/smembers
-     * @deprecated use Redis::sMembers()
      *
      * @param  string  $key
      * @return array   An array of elements, the contents of the set
      */
+    #[Deprecated(replacement: '%class%->sMembers(%parametersList%)')]
     public function sGetMembers($key)
     {
     }
@@ -1918,11 +1917,11 @@ class Redis
      * Scan a set for members
      *
      * @param string $key      The set to search.
-     * @param int    $iterator LONG (reference) to the iterator as we go.
+     * @param int    &$iterator LONG (reference) to the iterator as we go.
      * @param string   $pattern  String, optional pattern to match against.
      * @param int    $count    How many members to return at a time (Redis might return a different amount)
      *
-     * @return array|bool PHPRedis will return an array of keys or FALSE when we're done iterating
+     * @return array|false PHPRedis will return an array of keys or FALSE when we're done iterating
      *
      * @link    https://redis.io/commands/sscan
      * @example
@@ -2040,13 +2039,12 @@ class Redis
     }
 
     /**
-     * @see rename()
      * @link    https://redis.io/commands/rename
-     * @deprecated use Redis::rename()
      *
      * @param   string  $srcKey
      * @param   string  $dstKey
      */
+    #[Deprecated(replacement: '%class%->rename(%parametersList%)')]
     public function renameKey($srcKey, $dstKey)
     {
     }
@@ -2118,14 +2116,13 @@ class Redis
     }
 
     /**
-     * @see expire()
      * @link    https://redis.io/commands/expire
-     * @deprecated use Redis::expire()
      *
      * @param   string  $key
      * @param   int     $ttl
      * @return  bool
      */
+    #[Deprecated(replacement: '%class%->expire(%parametersList%)')]
     public function setTimeout($key, $ttl)
     {
     }
@@ -2192,12 +2189,10 @@ class Redis
     }
 
     /**
-     * @see keys()
-     * @deprecated use Redis::keys()
-     *
      * @param string $pattern
      * @link    https://redis.io/commands/keys
      */
+    #[Deprecated(replacement: '%class%->keys(%parametersList%)')]
     public function getKeys($pattern)
     {
     }
@@ -2222,7 +2217,7 @@ class Redis
      * Authenticate the connection using a password.
      * Warning: The password is sent in plain-text over the network.
      *
-     * @param string $password
+     * @param string|string[] $password
      *
      * @return bool TRUE if the connection is authenticated, FALSE otherwise
      *
@@ -2309,7 +2304,7 @@ class Redis
      * @param string $string
      * @param string $key
      *
-     * @return string|int|bool for "encoding", int for "refcount" and "idletime", FALSE if the key doesn't exist.
+     * @return string|int|false for "encoding", int for "refcount" and "idletime", FALSE if the key doesn't exist.
      *
      * @link    https://redis.io/commands/object
      * @example
@@ -2445,11 +2440,11 @@ class Redis
     /**
      * Return a substring of a larger string
      *
-     * @deprecated
      * @param   string  $key
      * @param   int     $start
      * @param   int     $end
      */
+    #[Deprecated]
     public function substr($key, $start, $end)
     {
     }
@@ -2725,7 +2720,7 @@ class Redis
      * - vm_enabled
      * - role
      *
-     * @return string
+     * @return array
      *
      * @link    https://redis.io/commands/info
      * @example
@@ -2843,7 +2838,6 @@ class Redis
      *
      * @return array Array containing the values related to keys in argument
      *
-     * @deprecated use Redis::mGet()
      * @example
      * <pre>
      * $redis->set('key1', 'value1');
@@ -2853,6 +2847,7 @@ class Redis
      * $redis->getMultiple(array('key0', 'key1', 'key5')); // array(`FALSE`, 'value2', `FALSE`);
      * </pre>
      */
+    #[Deprecated(replacement: '%class%->mGet(%parametersList%)')]
     public function getMultiple(array $keys)
     {
     }
@@ -2907,7 +2902,7 @@ class Redis
      * @param string $srcKey
      * @param string $dstKey
      *
-     * @return string|mixed|bool The element that was moved in case of success, FALSE in case of failure.
+     * @return string|mixed|false The element that was moved in case of success, FALSE in case of failure.
      *
      * @link    https://redis.io/commands/rpoplpush
      * @example
@@ -2977,7 +2972,6 @@ class Redis
      * @link    https://redis.io/commands/zadd
      * @example
      * <pre>
-     * <pre>
      * $redis->zAdd('z', 1, 'v1', 2, 'v2', 3, 'v3', 4, 'v4' );  // int(2)
      * $redis->zRem('z', 'v2', 'v3');                           // int(2)
      * $redis->zAdd('z', ['NX'], 5, 'v5');                      // int(1)
@@ -3001,7 +2995,6 @@ class Redis
      * //   ["v4"]=> float(4)
      * //   ["v5"]=> float(5)
      * //   ["v6"]=> float(8)
-     * </pre>
      * </pre>
      */
     public function zAdd($key, $options, $score1, $value1 = null, $score2 = null, $value2 = null, $scoreN = null, $valueN = null)
@@ -3065,9 +3058,7 @@ class Redis
     }
 
     /**
-     * @see zRem()
      * @link https://redis.io/commands/zrem
-     * @deprecated use Redis::zRem()
      *
      * @param string       $key
      * @param string|mixed $member1
@@ -3075,6 +3066,7 @@ class Redis
      *
      * @return int Number of deleted values
      */
+    #[Deprecated(replacement: '%class%->zRem(%parametersList%)')]
     public function zDelete($key, $member1, ...$otherMembers)
     {
     }
@@ -3167,7 +3159,7 @@ class Redis
      * @param int    $offset Optional argument if you wish to start somewhere other than the first element.
      * @param int    $limit  Optional argument if you wish to limit the number of elements returned.
      *
-     * @return array|bool Array containing the values in the specified range.
+     * @return array|false Array containing the values in the specified range.
      *
      * @link    https://redis.io/commands/zrangebylex
      * @example
@@ -3248,13 +3240,11 @@ class Redis
     }
 
     /**
-     * @see zRemRangeByScore()
-     * @deprecated use Redis::zRemRangeByScore()
-     *
      * @param string $key
      * @param float  $start
      * @param float  $end
      */
+    #[Deprecated(replacement: '%class%->zRemRangeByScore(%parametersList%)')]
     public function zDeleteRangeByScore($key, $start, $end)
     {
     }
@@ -3283,14 +3273,13 @@ class Redis
     }
 
     /**
-     * @see zRemRangeByRank()
      * @link    https://redis.io/commands/zremrangebyscore
-     * @deprecated use Redis::zRemRangeByRank()
      *
      * @param string $key
      * @param int    $start
      * @param int    $end
      */
+    #[Deprecated(replacement: '%class%->zRemRangeByRank(%parametersList%)')]
     public function zDeleteRangeByRank($key, $start, $end)
     {
     }
@@ -3316,12 +3305,10 @@ class Redis
     }
 
     /**
-     * @see zCard()
-     * @deprecated use Redis::zCard()
-     *
      * @param string $key
      * @return int
      */
+    #[Deprecated(replacement: '%class%->zCard(%parametersList%)')]
     public function zSize($key)
     {
     }
@@ -3352,7 +3339,7 @@ class Redis
      * @param string       $key
      * @param string|mixed $member
      *
-     * @return int|bool the item's score, or false if key or member is not exists
+     * @return int|false the item's score, or false if key or member is not exists
      *
      * @link    https://redis.io/commands/zrank
      * @example
@@ -3375,7 +3362,7 @@ class Redis
      * @param string       $key
      * @param string|mixed $member
      *
-     * @return int|bool the item's score, false - if key or member is not exists
+     * @return int|false the item's score, false - if key or member is not exists
      *
      * @link   https://redis.io/commands/zrevrank
      */
@@ -3415,7 +3402,7 @@ class Redis
      *
      * @param string $output
      * @param array  $zSetKeys
-     * @param array  $weights
+     * @param null|array $weights
      * @param string $aggregateFunction  Either "SUM", "MIN", or "MAX": defines the behaviour to use on
      * duplicate entries during the zUnionStore
      *
@@ -3444,19 +3431,17 @@ class Redis
      * $redis->zUnionStore('ko3', array('k1', 'k2'), array(5, 1)); // 4, 'ko3' => array('val0', 'val2', 'val3', 'val1')
      * </pre>
      */
-    public function zUnionStore($output, $zSetKeys, array $weights = null, $aggregateFunction = 'SUM')
+    public function zUnionStore($output, $zSetKeys, ?array $weights = null, $aggregateFunction = 'SUM')
     {
     }
 
     /**
-     * @see zUnionStore
-     * @deprecated use Redis::zUnionStore()
-     *
      * @param string     $Output
      * @param array      $ZSetKeys
      * @param array|null $Weights
      * @param string     $aggregateFunction
      */
+    #[Deprecated(replacement: '%class%->zUnionStore(%parametersList%)')]
     public function zUnion($Output, $ZSetKeys, array $Weights = null, $aggregateFunction = 'SUM')
     {
     }
@@ -3471,7 +3456,7 @@ class Redis
      *
      * @param string $output
      * @param array  $zSetKeys
-     * @param array  $weights
+     * @param null|array $weights
      * @param string $aggregateFunction Either "SUM", "MIN", or "MAX":
      * defines the behaviour to use on duplicate entries during the zInterStore.
      *
@@ -3509,14 +3494,12 @@ class Redis
     }
 
     /**
-     * @see zInterStore
-     * @deprecated use Redis::zInterStore()
-     *
      * @param $Output
      * @param $ZSetKeys
      * @param array|null $Weights
      * @param string $aggregateFunction
      */
+    #[Deprecated(replacement: '%class%->zInterStore(%parametersList%)')]
     public function zInter($Output, $ZSetKeys, array $Weights = null, $aggregateFunction = 'SUM')
     {
     }
@@ -3525,11 +3508,11 @@ class Redis
      * Scan a sorted set for members, with optional pattern and count
      *
      * @param string $key      String, the set to scan.
-     * @param int    $iterator Long (reference), initialized to NULL.
+     * @param int    &$iterator Long (reference), initialized to NULL.
      * @param string $pattern  String (optional), the pattern to match.
      * @param int    $count    How many keys to return per iteration (Redis might return a different number).
      *
-     * @return array|bool PHPRedis will return matching keys from Redis, or FALSE when iteration is complete
+     * @return array|false PHPRedis will return matching keys from Redis, or FALSE when iteration is complete
      *
      * @link    https://redis.io/commands/zscan
      * @example
@@ -3691,7 +3674,7 @@ class Redis
      * @param string $key
      * @param string $hashKey
      *
-     * @return string The value, if the command executed successfully BOOL FALSE in case of failure
+     * @return string|false The value, if the command executed successfully BOOL FALSE in case of failure
      *
      * @link    https://redis.io/commands/hget
      */
@@ -3704,7 +3687,7 @@ class Redis
      *
      * @param string $key
      *
-     * @return int|bool the number of items in a hash, FALSE if the key doesn't exist or isn't a hash
+     * @return int|false the number of items in a hash, FALSE if the key doesn't exist or isn't a hash
      *
      * @link    https://redis.io/commands/hlen
      * @example
@@ -3955,7 +3938,7 @@ class Redis
     }
 
     /**
-     * Retirieve the values associated to the specified fields in the hash.
+     * Retrieve the values associated to the specified fields in the hash.
      *
      * @param string $key
      * @param array  $hashKeys
@@ -3980,7 +3963,7 @@ class Redis
      * Scan a HASH value for members, with an optional pattern and count.
      *
      * @param string $key
-     * @param int    $iterator
+     * @param int    &$iterator
      * @param string $pattern    Optional pattern to match against.
      * @param int    $count      How many keys to return in a go (only a sugestion to Redis).
      *
@@ -4029,7 +4012,7 @@ class Redis
      * @return int The number of elements added to the geospatial key
      *
      * @link https://redis.io/commands/geoadd
-     * @since >=3.2
+     * @since >= 3.2
      *
      * @example
      * <pre>
@@ -4056,7 +4039,7 @@ class Redis
      * @return array One or more Redis Geohash encoded strings
      *
      * @link https://redis.io/commands/geohash
-     * @since >=3.2
+     * @since >= 3.2
      *
      * @example
      * <pre>
@@ -4083,7 +4066,7 @@ class Redis
      * @return array One or more longitude/latitude positions
      *
      * @link https://redis.io/commands/geopos
-     * @since >=3.2
+     * @since >= 3.2
      *
      * @example
      * <pre>
@@ -4125,7 +4108,7 @@ class Redis
      * @return float The distance between the two passed members in the units requested (meters by default)
      *
      * @link https://redis.io/commands/geodist
-     * @since >=3.2
+     * @since >= 3.2
      *
      * @example
      * <pre>
@@ -4355,14 +4338,12 @@ class Redis
     }
 
     /**
-     * @see eval()
-     * @deprecated use Redis::eval()
-     *
      * @param   string  $script
      * @param   array   $args
      * @param   int     $numKeys
      * @return  mixed   @see eval()
      */
+    #[Deprecated(replacement: '%class%->eval(%parametersList%)')]
     public function evaluate($script, $args = array(), $numKeys = 0)
     {
     }
@@ -4392,13 +4373,11 @@ class Redis
     }
 
     /**
-     * @see evalSha()
-     * @deprecated use Redis::evalSha()
-     *
      * @param string $scriptSha
      * @param array  $args
      * @param int    $numKeys
      */
+    #[Deprecated(replacement: '%class%->evalSha(%parametersList%)')]
     public function evaluateSha($scriptSha, $args = array(), $numKeys = 0)
     {
     }
@@ -4568,7 +4547,7 @@ class Redis
      * The data that comes out of DUMP is a binary representation of the key as Redis stores it.
      * @param string $key
      *
-     * @return string|bool The Redis encoded value of the key, or FALSE if the key doesn't exist
+     * @return string|false The Redis encoded value of the key, or FALSE if the key doesn't exist
      *
      * @link    https://redis.io/commands/dump
      * @example
@@ -4648,11 +4627,11 @@ class Redis
     /**
      * Scan the keyspace for keys
      *
-     * @param int    $iterator Iterator, initialized to NULL.
+     * @param int    &$iterator Iterator, initialized to NULL.
      * @param string $pattern  Pattern to match.
      * @param int    $count    Count of keys per iteration (only a suggestion to Redis).
      *
-     * @return array|bool This function will return an array of keys or FALSE if there are no more keys.
+     * @return array|false This function will return an array of keys or FALSE if there are no more keys.
      *
      * @link   https://redis.io/commands/scan
      * @example
@@ -4699,6 +4678,7 @@ class Redis
      * $redis->pfAdd('key2', array('elem3', 'elem2'));
      * $redis->pfCount('key1'); // int(2)
      * $redis->pfCount(array('key1', 'key2')); // int(3)
+     * </pre>
      */
     public function pfCount($key)
     {
@@ -4720,6 +4700,7 @@ class Redis
      * $redis->pfAdd('key2', array('elem3', 'elem2'));
      * $redis->pfMerge('key3', array('key1', 'key2'));
      * $redis->pfCount('key3'); // int(3)
+     * </pre>
      */
     public function pfMerge($destKey, array $sourceKeys)
     {
@@ -5078,12 +5059,12 @@ class RedisArray
     /**
      * Constructor
      *
-     * @param string|array $hosts Name of the redis array from redis.ini or array of hosts to construct the array with
-     * @param array        $opts  Array of options
+     * @param string|string[] $hosts Name of the redis array from redis.ini or array of hosts to construct the array with
+     * @param null|array      $opts  Array of options
      *
      * @link    https://github.com/nicolasff/phpredis/blob/master/arrays.markdown
      */
-    public function __construct($hosts, array $opts = null)
+    public function __construct($hosts, ?array $opts = null)
     {
     }
 
@@ -5107,6 +5088,15 @@ class RedisArray
      * @return  string  the host to be used for a certain key
      */
     public function _target($key)
+    {
+    }
+
+    /**
+     * @param string $host The host you want to retrieve the instance for
+     *
+     * @return Redis a redis instance connected to a specific node
+     */
+    public function _instance($host)
     {
     }
 

--- a/build/stubs/redis_cluster.php
+++ b/build/stubs/redis_cluster.php
@@ -38,6 +38,16 @@ class RedisCluster {
     const SCAN_RETRY = 1;
 
     /**
+     * @since 5.3.0
+     */
+    const SCAN_PREFIX = 2;
+
+    /**
+     * @since 5.3.0
+     */
+    const SCAN_NOPREFIX = 3;
+
+    /**
      * Serializers
      */
     const SERIALIZER_NONE = 0;
@@ -1565,7 +1575,7 @@ class RedisCluster {
     public function hSetNx($key, $hashKey, $value) { }
 
     /**
-     * Retirieve the values associated to the specified fields in the hash.
+     * Retrieve the values associated to the specified fields in the hash.
      *
      * @param   string $key
      * @param   array  $hashKeys
@@ -2162,6 +2172,7 @@ class RedisCluster {
      * $redisCluster->pfAdd('key2', array('elem3', 'elem2'));
      * $redisCluster->pfCount('key1'); // int(2)
      * $redisCluster->pfCount(array('key1', 'key2')); // int(3)
+     * </pre>
      */
     public function pfCount($key) { }
 
@@ -2192,6 +2203,7 @@ class RedisCluster {
      * $redisCluster->pfAdd('key2', array('elem3', 'elem2'));
      * $redisCluster->pfMerge('key3', array('key1', 'key2'));
      * $redisCluster->pfCount('key3'); // int(3)
+     * </pre>
      */
     public function pfMerge($destKey, array $sourceKeys) { }
 
@@ -2439,7 +2451,7 @@ class RedisCluster {
      *
      * @param string $Output
      * @param array  $ZSetKeys
-     * @param array  $Weights
+     * @param null|array $Weights
      * @param string $aggregateFunction Either "SUM", "MIN", or "MAX": defines the behaviour to use on
      *                                  duplicate entries during the zUnion.
      *
@@ -2467,14 +2479,14 @@ class RedisCluster {
      * $redisCluster->zUnionStore('ko3', array('k1', 'k2'), array(5, 1)); // 4, 'ko3' => array('val0', 'val2', 'val3','val1')
      * </pre>
      */
-    public function zUnionStore($Output, $ZSetKeys, array $Weights = null, $aggregateFunction = 'SUM') { }
+    public function zUnionStore($Output, $ZSetKeys, ?array $Weights = null, $aggregateFunction = 'SUM') { }
 
     /**
      * Intersect multiple sorted sets and store the resulting sorted set in a new key
      *
      * @param   string $Output
      * @param   array  $ZSetKeys
-     * @param   array  $Weights
+     * @param   null|array $Weights
      * @param   string $aggregateFunction Either "SUM", "MIN", or "MAX":
      *                                    defines the behaviour to use on duplicate entries during the zInterStore.
      *
@@ -2703,7 +2715,7 @@ class RedisCluster {
      * Scan a set for members.
      *
      * @param   string $key      The set to search.
-     * @param   int    $iterator LONG (reference) to the iterator as we go.
+     * @param   int    &$iterator LONG (reference) to the iterator as we go.
      * @param   null   $pattern  String, optional pattern to match against.
      * @param   int    $count    How many members to return at a time (Redis might return a different amount).
      *
@@ -2725,7 +2737,7 @@ class RedisCluster {
      * Scan a sorted set for members, with optional pattern and count.
      *
      * @param   string $key      String, the set to scan.
-     * @param   int    $iterator Long (reference), initialized to NULL.
+     * @param   int    &$iterator Long (reference), initialized to NULL.
      * @param   string $pattern  String (optional), the pattern to match.
      * @param   int    $count    How many keys to return per iteration (Redis might return a different number).
      *
@@ -2747,7 +2759,7 @@ class RedisCluster {
      * Scan a HASH value for members, with an optional pattern and count.
      *
      * @param   string $key
-     * @param   int    $iterator
+     * @param   int    &$iterator
      * @param   string $pattern Optional pattern to match against.
      * @param   int    $count   How many keys to return in a go (only a sugestion to Redis).
      *
@@ -3425,10 +3437,10 @@ class RedisCluster {
     /**
      * Returns members of a geospatial index as standard geohash strings
      *
-     * @param $key     string
-     * @param $member1 string
-     * @param $member2 string
-     * @param $memberN string
+     * @param string $key
+     * @param string $member1
+     * @param string $member2
+     * @param string $memberN
      *
      * @example
      * <pre>
@@ -3442,11 +3454,10 @@ class RedisCluster {
     /**
      * Returns longitude and latitude of members of a geospatial index
      *
-     * @param $key     string
-     * @param $member1 string
-     * @param $member2 string
-     * @param $memberN string
-     *
+     * @param string $key
+     * @param string $member1
+     * @param string $member2
+     * @param string $memberN
      * @example
      * <pre>
      * $redisCluster->geoAdd('Sicily', 15.087269, 37.502669, "Catania"); // int(1)

--- a/build/stubs/redis_sentinel.php
+++ b/build/stubs/redis_sentinel.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Tawana Musewe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * <https://opensource.org/licenses/MIT>.
+ */
+
+/**
+ * Helper autocomplete for phpredis extension
+ *
+ * @author  Tawana Musewe <tawana@aeonis.co.za>
+ * @link    https://github.com/tbtmuse/phpredis-sentinel-phpdoc
+ */
+class RedisSentinel {
+
+	/**
+	 * Creates a Redis Sentinel
+	 *
+	 * @param string      $host          Sentinel IP address or hostname
+	 * @param int         $port          Sentinel Port
+	 * @param float       $timeout       Value in seconds (optional, default is 0 meaning unlimited)
+	 * @param string|null $persistent    Persistent connection id (optional, default is null meaning not persistent)
+	 * @param int         $retryInterval Value in milliseconds (optional, default is 0)
+	 * @param float       $readTimeout   Value in seconds (optional, default is 0 meaning unlimited)
+	 *
+	 * @example
+	 * // 1s timeout, 100ms delay between reconnection attempts.
+	 * $sentinel = new RedisSentinel('127.0.0.1', 26379, 1, null, 100);
+	 */
+	public function __construct(
+		string $host,
+		int $port,
+		float $timeout = 0,
+		?string $persistent = null,
+		int $retryInterval = 0,
+		float $readTimeout = 0
+	) {}
+
+	/**
+	 * Check if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the
+	 * majority needed to authorize the failover. This command should be used in monitoring systems to check if a
+	 * Sentinel deployment is ok.
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return bool True in case of success, False in case of failure.
+	 *
+	 * @example $sentinel->ckquorum('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function ckquorum(string $master): bool {}
+
+	/**
+	 * Force a failover as if the master was not reachable, and without asking for agreement to other Sentinels
+	 * (however a new version of the configuration will be published so that the other Sentinels will update
+	 * their configurations).
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return bool True in case of success, False in case of failure.
+	 *
+	 * @example $sentinel->failover('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function failover(string $master): bool {}
+
+	/**
+	 * Force Sentinel to rewrite its configuration on disk, including the current Sentinel state.
+	 *
+	 * Normally Sentinel rewrites the configuration every time something changes in its state (in the context of the
+	 * subset of the state which is persisted on disk across restart). However sometimes it is possible that the
+	 * configuration file is lost because of operation errors, disk failures, package upgrade scripts or configuration
+	 * managers. In those cases a way to to force Sentinel to rewrite the configuration file is handy.
+	 *
+	 * This command works even if the previous configuration file is completely missing.
+	 *
+	 * @return bool True in case of success, False in case of failure.
+	 *
+	 * @example $sentinel->flushconfig();
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function flushconfig(): bool {}
+
+	/**
+	 * Return the ip and port number of the master with that name. If a failover is in progress or terminated
+	 * successfully for this master it returns the address and port of the promoted replica.
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return array|false ['address', 'port'] in case of success, False in case of failure.
+	 *
+	 * @example $sentinel->getMasterAddrByName('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function getMasterAddrByName(string $master) {}
+
+	/**
+	 * Return the state and info of the specified master
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return array|false Associative array with info in case of success, False in case of failure.
+	 *
+	 * @example $sentinel->master('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function master(string $master) {}
+
+	/**
+	 * Return a list of monitored masters and their state
+	 *
+	 * @return array|false Array of arrays with info for each master in case of success, FALSE in case of failure.
+	 *
+	 * @example $sentinel->masters();
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function masters() {}
+
+	/**
+	 * Ping the sentinel
+	 *
+	 * @return bool True in case of success, False in case of failure
+	 *
+	 * @example $sentinel->ping();
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function ping(): bool {}
+
+	/**
+	 * Reset all the masters with matching name. The pattern argument is a glob-style pattern.
+	 * The reset process clears any previous state in a master (including a failover in progress), and removes every
+	 * replica and sentinel already discovered and associated with the master.
+	 *
+	 * @param string $pattern Glob-style pattern
+	 *
+	 * @return bool True in case of success, False in case of failure
+	 *
+	 * @example $sentinel->reset('*');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function reset(string $pattern): bool {}
+
+	/**
+	 * Return a list of sentinel instances for this master, and their state
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return array|false Array of arrays with info for each sentinel in case of success, False in case of failure
+	 *
+	 * @example $sentinel->sentinels('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function sentinels(string $master) {}
+
+	/**
+	 * Return a list of sentinel instances for this master, and their state
+	 *
+	 * @param string $master Name of master
+	 *
+	 * @return array|false Array of arrays with info for each replica in case of success, False in case of failure
+	 *
+	 * @example $sentinel->slaves('mymaster');
+	 *
+	 * @since   >= 5.2.0
+	 */
+	public function slaves(string $master) {}
+}


### PR DESCRIPTION
Update stubs for php to v2021.1 from https://github.com/JetBrains/phpstorm-stubs

Crap! Updating the stubs is more work nowdays as we have to drop the PHP 8 attributes.