### PR TITLE
Add nextcloud host to capabilities response

### DIFF
--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -102,6 +102,8 @@ class OCSController extends \OCP\AppFramework\OCSController {
 			'extendedSupport' => \OCP\Util::hasExtendedSupport()
 		];
 
+		$result['host'] = $this->request->getServerHost();
+
 		if ($this->userSession->isLoggedIn()) {
 			$result['capabilities'] = $this->capabilitiesManager->getCapabilities();
 		} else {

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -88,6 +88,10 @@ class OCSControllerTest extends TestCase {
 		$this->userSession->expects($this->once())
 			->method('isLoggedIn')
 			->willReturn(true);
+		$this->request
+			->method('getServerHost')
+			->willReturn('awesomehost.io');
+
 		[$major, $minor, $micro] = \OCP\Util::getVersion();
 
 		$result = [];
@@ -99,6 +103,8 @@ class OCSControllerTest extends TestCase {
 			'edition' => '',
 			'extendedSupport' => false
 		];
+
+		$result['host'] = 'awesomehost.io';
 
 		$capabilities = [
 			'foo' => 'bar',
@@ -121,6 +127,10 @@ class OCSControllerTest extends TestCase {
 		$this->userSession->expects($this->once())
 			->method('isLoggedIn')
 			->willReturn(false);
+		$this->request
+			->method('getServerHost')
+			->willReturn('awesomehost.io');
+
 		[$major, $minor, $micro] = \OCP\Util::getVersion();
 
 		$result = [];
@@ -132,6 +142,8 @@ class OCSControllerTest extends TestCase {
 			'edition' => '',
 			'extendedSupport' => false
 		];
+
+		$result['host'] = 'awesomehost.io';
 
 		$capabilities = [
 			'foo' => 'bar',

--- a/tests/Core/Controller/OCSControllerTest.php
+++ b/tests/Core/Controller/OCSControllerTest.php
@@ -68,12 +68,12 @@ class OCSControllerTest extends TestCase {
 
 	public function testGetConfig() {
 		$this->request->method('getServerHost')
-			->willReturn('awesomehost.io');
+			->willReturn('example.tld');
 
 		$data = [
 			'version' => '1.7',
 			'website' => 'Nextcloud',
-			'host' => 'awesomehost.io',
+			'host' => 'example.tld',
 			'contact' => '',
 			'ssl' => 'false',
 		];
@@ -90,7 +90,7 @@ class OCSControllerTest extends TestCase {
 			->willReturn(true);
 		$this->request
 			->method('getServerHost')
-			->willReturn('awesomehost.io');
+			->willReturn('example.tld');
 
 		[$major, $minor, $micro] = \OCP\Util::getVersion();
 
@@ -104,7 +104,7 @@ class OCSControllerTest extends TestCase {
 			'extendedSupport' => false
 		];
 
-		$result['host'] = 'awesomehost.io';
+		$result['host'] = 'example.tld';
 
 		$capabilities = [
 			'foo' => 'bar',
@@ -129,7 +129,7 @@ class OCSControllerTest extends TestCase {
 			->willReturn(false);
 		$this->request
 			->method('getServerHost')
-			->willReturn('awesomehost.io');
+			->willReturn('example.tld');
 
 		[$major, $minor, $micro] = \OCP\Util::getVersion();
 
@@ -143,7 +143,7 @@ class OCSControllerTest extends TestCase {
 			'extendedSupport' => false
 		];
 
-		$result['host'] = 'awesomehost.io';
+		$result['host'] = 'example.tld';
 
 		$capabilities = [
 			'foo' => 'bar',


### PR DESCRIPTION
We have a report (https://github.com/nextcloud/server/issues/15688) that some requests by the desktop client trigger fail2ban. 
The reason seems a htaccess rule/redirect: https://github.com/nextcloud/server/issues/15688#issuecomment-707973799.

It seems the desktop client needs this information for the copy internal link feature: https://github.com/nextcloud/server/issues/15688#issuecomment-724101752 / https://github.com/nextcloud/desktop/pull/2619.

Desktop client does the request for capabilities and ocs config in parallel. I guess it makes sense to provide the host information also within the capabilities request to avoid the second request.
