### PR TITLE
Revert "Update guzzlehttp/guzzle requirement from 6.5.2 to 7.3.0 in /build/integration"

### DIFF
--- a/build/integration/composer.json
+++ b/build/integration/composer.json
@@ -2,7 +2,7 @@
   "require-dev": {
     "phpunit/phpunit": "~6.5",
     "behat/behat": "~3.8.0",
-    "guzzlehttp/guzzle": "7.3.0",
+    "guzzlehttp/guzzle": "6.5.2",
     "jarnaiz/behat-junit-formatter": "^1.3",
     "sabre/dav": "3.2.3",
     "symfony/event-dispatcher": "~5.3"


### PR DESCRIPTION
Reverts nextcloud/server#27654

As pointed out in https://github.com/nextcloud/server/pull/27654#issuecomment-879620100 the integration tests fail now since guzzle/psr got a major bump and deprecated methods we use were dropped.