### PR TITLE
Remove allmost all deprecation from the files_version app

### DIFF
--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -43,9 +43,14 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\ILogger;
+use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Share\IManager as IShareManager;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'files_versions';
@@ -67,14 +72,14 @@ class Application extends App implements IBootstrap {
 			/** @var IServerContainer $server */
 			$server = $c->get(IServerContainer::class);
 			return new Principal(
-				$server->getUserManager(),
-				$server->getGroupManager(),
-				$server->getShareManager(),
-				$server->getUserSession(),
-				$server->getAppManager(),
+				$server->get(IUserManager::class),
+				$server->get(IGroupManager::class),
+				$server->get(IShareManager::class),
+				$server->get(IUserSession::class),
+				$server->get(IAppManager::class),
 				$server->get(ProxyMapper::class),
 				$server->get(KnownUserService::class),
-				$server->getConfig()
+				$server->get(IConfig::class)
 			);
 		});
 
@@ -98,7 +103,7 @@ class Application extends App implements IBootstrap {
 		Hooks::connectHooks();
 	}
 
-	public function registerVersionBackends(ContainerInterface $container, IAppManager $appManager, ILogger $logger) {
+	public function registerVersionBackends(ContainerInterface $container, IAppManager $appManager, LoggerInterface $logger): void {
 		foreach ($appManager->getInstalledApps() as $app) {
 			$appInfo = $appManager->getAppInfo($app);
 			if (isset($appInfo['versions'])) {
@@ -116,7 +121,7 @@ class Application extends App implements IBootstrap {
 		}
 	}
 
-	private function loadBackend(array $backend, ContainerInterface $container, ILogger $logger) {
+	private function loadBackend(array $backend, ContainerInterface $container, LoggerInterface $logger): void {
 		/** @var IVersionManager $versionManager */
 		$versionManager = $container->get(IVersionManager::class);
 		$class = $backend['@value'];
@@ -125,7 +130,7 @@ class Application extends App implements IBootstrap {
 			$backendObject = $container->get($class);
 			$versionManager->registerBackend($for, $backendObject);
 		} catch (\Exception $e) {
-			$logger->logException($e);
+			$logger->error($e->getMessage(), ['exception' => $e]);
 		}
 	}
 }

--- a/apps/files_versions/lib/Command/Expire.php
+++ b/apps/files_versions/lib/Command/Expire.php
@@ -27,7 +27,8 @@ use OC\Command\FileAccess;
 use OCA\Files_Versions\Storage;
 use OCP\Command\ICommand;
 use OCP\Files\StorageNotAvailableException;
-use OCP\ILogger;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 
 class Expire implements ICommand {
 	use FileAccess;
@@ -42,18 +43,14 @@ class Expire implements ICommand {
 	 */
 	private $user;
 
-	/**
-	 * @param string $user
-	 * @param string $fileName
-	 */
-	public function __construct($user, $fileName) {
+	public function __construct(string $user, string $fileName) {
 		$this->user = $user;
 		$this->fileName = $fileName;
 	}
 
-
 	public function handle() {
-		$userManager = \OC::$server->getUserManager();
+		/** @var IUserManager $userManager */
+		$userManager = \OC::$server->get(IUserManager::class);
 		if (!$userManager->userExists($this->user)) {
 			// User has been deleted already
 			return;
@@ -65,11 +62,10 @@ class Expire implements ICommand {
 			// In case of external storage and session credentials, the expiration
 			// fails because the command does not have those credentials
 
-			/** @var ILogger $logger */
-			$logger = \OC::$server->get(ILogger::class);
-
-			$logger->logException($e, [
-				'level' => ILogger::WARN,
+			/** @var LoggerInterface */
+			$logger = \OC::$server->get(LoggerInterface::class);
+			$logger->warning($e->getMessage(), [
+				'exception' => $e,
 				'uid' => $this->user,
 				'fileName' => $this->fileName,
 			]);

--- a/apps/files_versions/lib/Controller/PreviewController.php
+++ b/apps/files_versions/lib/Controller/PreviewController.php
@@ -29,7 +29,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
-use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IPreview;
@@ -44,9 +43,6 @@ class PreviewController extends Controller {
 	/** @var IUserSession */
 	private $userSession;
 
-	/** @var IMimeTypeDetector */
-	private $mimeTypeDetector;
-
 	/** @var IVersionManager */
 	private $versionManager;
 
@@ -54,11 +50,10 @@ class PreviewController extends Controller {
 	private $previewManager;
 
 	public function __construct(
-		$appName,
+		string $appName,
 		IRequest $request,
 		IRootFolder $rootFolder,
 		IUserSession $userSession,
-		IMimeTypeDetector $mimeTypeDetector,
 		IVersionManager $versionManager,
 		IPreview $previewManager
 	) {
@@ -66,7 +61,6 @@ class PreviewController extends Controller {
 
 		$this->rootFolder = $rootFolder;
 		$this->userSession = $userSession;
-		$this->mimeTypeDetector = $mimeTypeDetector;
 		$this->versionManager = $versionManager;
 		$this->previewManager = $previewManager;
 	}
@@ -82,10 +76,10 @@ class PreviewController extends Controller {
 	 * @return DataResponse|FileDisplayResponse
 	 */
 	public function getPreview(
-		$file = '',
-		$x = 44,
-		$y = 44,
-		$version = ''
+		string $file = '',
+		int $x = 44,
+		int $y = 44,
+		string $version = ''
 	) {
 		if ($file === '' || $version === '' || $x === 0 || $y === 0) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);

--- a/apps/files_versions/lib/Events/CreateVersionEvent.php
+++ b/apps/files_versions/lib/Events/CreateVersionEvent.php
@@ -58,14 +58,14 @@ class CreateVersionEvent extends Event {
 	 *
 	 * @return Node
 	 */
-	public function getNode() {
+	public function getNode(): Node {
 		return $this->node;
 	}
 
 	/**
 	 * disable versions for this file
 	 */
-	public function disableVersions() {
+	public function disableVersions(): void {
 		$this->createVersion = false;
 	}
 
@@ -74,7 +74,7 @@ class CreateVersionEvent extends Event {
 	 *
 	 * @return bool
 	 */
-	public function shouldCreateVersion() {
+	public function shouldCreateVersion(): bool {
 		return $this->createVersion;
 	}
 }

--- a/apps/files_versions/lib/Expiration.php
+++ b/apps/files_versions/lib/Expiration.php
@@ -26,6 +26,7 @@ namespace OCA\Files_Versions;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 
 class Expiration {
 
@@ -47,8 +48,12 @@ class Expiration {
 	/** @var bool */
 	private $canPurgeToSaveSpace;
 
-	public function __construct(IConfig $config,ITimeFactory $timeFactory) {
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(IConfig $config, ITimeFactory $timeFactory, LoggerInterface $logger) {
 		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
 		$this->retentionObligation = $config->getSystemValue('versions_retention_obligation', 'auto');
 
 		if ($this->retentionObligation !== 'disabled') {
@@ -60,14 +65,14 @@ class Expiration {
 	 * Is versions expiration enabled
 	 * @return bool
 	 */
-	public function isEnabled() {
+	public function isEnabled(): bool {
 		return $this->retentionObligation !== 'disabled';
 	}
 
 	/**
 	 * Is default expiration active
 	 */
-	public function shouldAutoExpire() {
+	public function shouldAutoExpire(): bool {
 		return $this->minAge === self::NO_OBLIGATION
 				|| $this->maxAge === self::NO_OBLIGATION;
 	}
@@ -78,7 +83,7 @@ class Expiration {
 	 * @param bool $quotaExceeded
 	 * @return bool
 	 */
-	public function isExpired($timestamp, $quotaExceeded = false) {
+	public function isExpired(int $timestamp, bool $quotaExceeded = false): bool {
 		// No expiration if disabled
 		if (!$this->isEnabled()) {
 			return false;
@@ -117,7 +122,8 @@ class Expiration {
 
 	/**
 	 * Get maximal retention obligation as a timestamp
-	 * @return int
+	 *
+	 * @return int|false
 	 */
 	public function getMaxAgeAsTimestamp() {
 		$maxAge = false;
@@ -132,7 +138,7 @@ class Expiration {
 	 * Read versions_retention_obligation, validate it
 	 * and set private members accordingly
 	 */
-	private function parseRetentionObligation() {
+	private function parseRetentionObligation(): void {
 		$splitValues = explode(',', $this->retentionObligation);
 		if (!isset($splitValues[0])) {
 			$minValue = 'auto';
@@ -150,7 +156,7 @@ class Expiration {
 		// Validate
 		if (!ctype_digit($minValue) && $minValue !== 'auto') {
 			$isValid = false;
-			\OC::$server->getLogger()->warning(
+			$this->logger->warning(
 					$minValue . ' is not a valid value for minimal versions retention obligation. Check versions_retention_obligation in your config.php. Falling back to auto.',
 					['app' => 'files_versions']
 			);
@@ -158,7 +164,7 @@ class Expiration {
 
 		if (!ctype_digit($maxValue) && $maxValue !== 'auto') {
 			$isValid = false;
-			\OC::$server->getLogger()->warning(
+			$this->logger->warning(
 					$maxValue . ' is not a valid value for maximal versions retention obligation. Check versions_retention_obligation in your config.php. Falling back to auto.',
 					['app' => 'files_versions']
 			);

--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -50,7 +50,7 @@ class Hooks {
 	/**
 	 * listen to write event.
 	 */
-	public static function write_hook($params) {
+	public static function write_hook(array $params): void {
 		$path = $params[Filesystem::signal_param_path];
 		if ($path !== '') {
 			Storage::store($path);
@@ -65,7 +65,7 @@ class Hooks {
 	 * This function is connected to the delete signal of OC_Filesystem
 	 * cleanup the versions directory if the actual file gets deleted
 	 */
-	public static function remove_hook($params) {
+	public static function remove_hook(array $params): void {
 		$path = $params[Filesystem::signal_param_path];
 		if ($path !== '') {
 			Storage::delete($path);
@@ -76,7 +76,7 @@ class Hooks {
 	 * mark file as "deleted" so that we can clean up the versions if the file is gone
 	 * @param array $params
 	 */
-	public static function pre_remove_hook($params) {
+	public static function pre_remove_hook(array $params): void {
 		$path = $params[Filesystem::signal_param_path];
 		if ($path !== '') {
 			Storage::markDeletedFile($path);
@@ -90,7 +90,7 @@ class Hooks {
 	 * This function is connected to the rename signal of OC_Filesystem and adjust the name and location
 	 * of the stored versions along the actual file
 	 */
-	public static function rename_hook($params) {
+	public static function rename_hook(array $params): void {
 		$oldpath = $params['oldpath'];
 		$newpath = $params['newpath'];
 		if ($oldpath !== '' && $newpath !== '') {
@@ -105,7 +105,7 @@ class Hooks {
 	 * This function is connected to the copy signal of OC_Filesystem and copies the
 	 * the stored versions to the new location
 	 */
-	public static function copy_hook($params) {
+	public static function copy_hook(array $params): void {
 		$oldpath = $params['oldpath'];
 		$newpath = $params['newpath'];
 		if ($oldpath !== '' && $newpath !== '') {
@@ -121,7 +121,7 @@ class Hooks {
 	 * @param array $params array with oldpath and newpath
 	 *
 	 */
-	public static function pre_renameOrCopy_hook($params) {
+	public static function pre_renameOrCopy_hook(array $params): void {
 		// if we rename a movable mount point, then the versions don't have
 		// to be renamed
 		$absOldPath = Filesystem::normalizePath('/' . \OC_User::getUser() . '/files' . $params['oldpath']);

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -53,7 +53,7 @@ class Plugin extends ServerPlugin {
 
 	public function afterGet(RequestInterface $request, ResponseInterface $response) {
 		$path = $request->getPath();
-		if (strpos($path, 'versions') !== 0) {
+		if (!str_starts_with($path, 'versions')) {
 			return;
 		}
 

--- a/apps/files_versions/lib/Sabre/RootCollection.php
+++ b/apps/files_versions/lib/Sabre/RootCollection.php
@@ -27,6 +27,7 @@ use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use Sabre\DAV\INode;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 use Sabre\DAVACL\PrincipalBackend;
@@ -42,18 +43,23 @@ class RootCollection extends AbstractPrincipalCollection {
 	/** @var IVersionManager */
 	private $versionManager;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	public function __construct(
 		PrincipalBackend\BackendInterface $principalBackend,
 		IRootFolder $rootFolder,
 		IConfig $config,
 		IUserManager $userManager,
-		IVersionManager $versionManager
+		IVersionManager $versionManager,
+		IUserSession $userSession
 	) {
 		parent::__construct($principalBackend, 'principals/users');
 
 		$this->rootFolder = $rootFolder;
 		$this->userManager = $userManager;
 		$this->versionManager = $versionManager;
+		$this->userSession = $userSession;
 
 		$this->disableListing = !$config->getSystemValue('debug', false);
 	}
@@ -70,7 +76,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 */
 	public function getChildForPrincipal(array $principalInfo) {
 		[, $name] = \Sabre\Uri\split($principalInfo['uri']);
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = $this->userSession->getUser();
 		if (is_null($user) || $name !== $user->getUID()) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}

--- a/apps/files_versions/lib/Sabre/VersionCollection.php
+++ b/apps/files_versions/lib/Sabre/VersionCollection.php
@@ -29,15 +29,12 @@ namespace OCA\Files_Versions\Sabre;
 use OCA\Files_Versions\Versions\IVersion;
 use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 
 class VersionCollection implements ICollection {
-	/** @var Folder */
-	private $userFolder;
 
 	/** @var File */
 	private $file;
@@ -48,8 +45,7 @@ class VersionCollection implements ICollection {
 	/** @var IVersionManager */
 	private $versionManager;
 
-	public function __construct(Folder $userFolder, File $file, IUser $user, IVersionManager $versionManager) {
-		$this->userFolder = $userFolder;
+	public function __construct(File $file, IUser $user, IVersionManager $versionManager) {
 		$this->file = $file;
 		$this->user = $user;
 		$this->versionManager = $versionManager;

--- a/apps/files_versions/lib/Sabre/VersionRoot.php
+++ b/apps/files_versions/lib/Sabre/VersionRoot.php
@@ -87,7 +87,7 @@ class VersionRoot implements ICollection {
 			throw new NotFound();
 		}
 
-		return new VersionCollection($userFolder, $node, $this->user, $this->versionManager);
+		return new VersionCollection($node, $this->user, $this->versionManager);
 	}
 
 	public function getChildren(): array {


### PR DESCRIPTION
The remaining deprecations are related to Utils::hooks and I will take a
look at how EventDispatcher works before working on them.

Aside from the deprecations, this patch also does a few minor
improvements around type hinting.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>