### PR TITLE
Strip webroot from URL before trying to find a route (Fixes: #24144)

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -234,6 +234,12 @@ class Router implements IRouter {
 	 * @return array
 	 */
 	public function findMatchingRoute(string $url): array {
+		// Optionally strip webroot from URL
+		$webroot = \OC::$WEBROOT;
+		if ($webroot !== '' && substr($url, 0, strlen($webroot)) === $webroot) {
+			$url = substr($url, strlen($webroot));
+		}
+
 		if (substr($url, 0, 6) === '/apps/') {
 			// empty string / 'apps' / $app / rest of the route
 			[, , $app,] = explode('/', $url, 4);


### PR DESCRIPTION
This should fix `Route\Router->findMatchingRoute()` on setups with Nextcloud in a subfolder (see #24144).

The Nextcloud core routing code is new to me, so at least two reviews from NC developers might be a good idea. But the fix should be simple and straightforward and easy to review :blush: 

Closes: #24144