### PR TITLE
Filepicker - hide empty create action box if creation is not allowed

### DIFF
--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -787,7 +787,6 @@ code {
 		max-height: 36px;
 		max-width: 36px;
 		background-color: var(--color-background-dark);
-		border: 1px solid var(--color-border-dark);
 		border-radius: var(--border-radius-pill);
 		position: relative;
 		left: 15px;
@@ -797,8 +796,8 @@ code {
 		.icon.icon-add{
 			background-image: var(--icon-add-000);
 			background-size: 16px 16px;
-			width: 34px;
-			height: 34px;
+			width: 36px;
+			height: 36px;
 			margin: 0px;
 			opacity: 0.5;
 		}

--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -321,7 +321,7 @@ const Dialogs = {
 
 			var newButton = self.$filePicker.find('.actions.creatable .button-add')
 			if (type === self.FILEPICKER_TYPE_CHOOSE && !options.allowDirectoryChooser) {
-				newButton.hide()
+				self.$filePicker.find('.actions.creatable').hide()
 			}
 			newButton.on('focus', function() {
 				self.$filePicker.ocdialog('setEnterCallback', function() {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/15966
Signed-off-by: szaimen <szaimen@e.mail.de>