### PR TITLE
Mask password for Redis and RedisCluster on connection failure

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -112,6 +112,12 @@ class ExceptionSerializer {
 		Key::class => [
 			'__construct'
 		],
+		\Redis::class => [
+			'auth'
+		],
+		\RedisCluster::class => [
+			'__construct'
+		]
 	];
 
 	private function editTrace(array &$sensitiveValues, array $traceLine): array {


### PR DESCRIPTION
If redis is password protected and the password is incorrect something like below will end up in the logs. The same error is thrown if the connection is interrupted. This patch will replace the actual password with `*** sensitive parameters replaced ***`.

```
{
  "reqId": "rIZRf0kETxwygW3M0rfc",
  "level": 3,
  "time": "2021-07-19T17:47:37+00:00",
  "remoteAddr": "192.168.208.1",
  "user": "--",
  "app": "core",
  "method": "GET",
  "url": "/favicon.ico",
  "message": "WRONGPASS invalid username-password pair or user is disabled.",
  "userAgent": "super client",
  "version": "23.0.0.0",
  "exception": {
    "Exception": "RedisException",
    "Message": "WRONGPASS invalid username-password pair or user is disabled.",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/lib/private/RedisFactory.php",
        "line": 93,
        "function": "auth",
        "class": "Redis",
        "type": "->",
        "args": [
          "blubblub"
        ]
      },
      {
        "file": "/var/www/html/lib/private/RedisFactory.php",
        "line": 107,
        "function": "create",
        "class": "OC\\RedisFactory",
        "type": "->",
        "args": []
      },
      ........
    ],
    "File": "/var/www/html/lib/private/RedisFactory.php",
    "Line": 93,
    "CustomMessage": "--"
  }
}

```