### PR TITLE
Admin Audit - Sharing: createShare - report the full path

### DIFF
--- a/apps/admin_audit/lib/Actions/Sharing.php
+++ b/apps/admin_audit/lib/Actions/Sharing.php
@@ -50,7 +50,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'permissions',
 					'id',
@@ -62,7 +62,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -75,7 +75,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -88,7 +88,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -101,7 +101,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -114,7 +114,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -127,7 +127,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -140,7 +140,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',
@@ -153,7 +153,7 @@ class Sharing extends Action {
 				$params,
 				[
 					'itemType',
-					'itemTarget',
+					'path',
 					'itemSource',
 					'shareWith',
 					'permissions',

--- a/lib/private/Share20/LegacyHooks.php
+++ b/lib/private/Share20/LegacyHooks.php
@@ -170,6 +170,7 @@ class LegacyHooks {
 			'shareWith' => $share->getSharedWith(),
 			'itemTarget' => $share->getTarget(),
 			'fileTarget' => $share->getTarget(),
+			'path' => $share->getNode()->getPath(),
 		];
 
 		\OC_Hook::emit(Share::class, 'post_shared', $postHookData);

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -342,6 +342,7 @@ class LegacyHooksTest extends TestCase {
 			'permissions' => Constants::PERMISSION_ALL,
 			'expiration' => $date,
 			'token' => 'token',
+			'path' => null,
 		];
 
 		$hookListner


### PR DESCRIPTION
As the Admin of a Nextcloud instance, I want to see the full path to a file/folder that is shared in the admin audit log and not the theoretical position where the file/folder might be found after sharing. Beeing able to see the full path is a much more useful information because you can much better see where the file/folder is initialy located.

Signed-off-by: szaimen <szaimen@e.mail.de>