### PR TITLE
Align checksum dav property with desktop client parsing

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ChecksumList.php
+++ b/apps/dav/lib/Connector/Sabre/ChecksumList.php
@@ -38,7 +38,7 @@ class ChecksumList implements XmlSerializable {
 	private array $checksums;
 
 	public function __construct(string $checksum) {
-		$this->checksums = explode(',', $checksum);
+		$this->checksums = explode(' ', $checksum);
 	}
 
 	/**

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -256,7 +256,10 @@ interface FileInfo {
 	public function getOwner();
 
 	/**
-	 * Get the stored checksum for this file
+	 * Get the stored checksum(s) for this file
+	 *
+	 * Checksums are stored in the format TYPE:CHECKSUM, here may be multiple checksums separated by a single space
+	 * e.g. MD5:d3b07384d113edec49eaa6238ad5ff00 SHA1:f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 	 *
 	 * @return string
 	 * @since 9.0.0


### PR DESCRIPTION
The checksum field was ment to also possibly contain multiple values. The content should actually only contain one these days, but considering possible migrations from other platforms or extension of the usage of that field, it would make sense to have a proper response format.

Currently the desktop client seems to be the only client using this, though there might be a fix that would be required upfront as mentioned in https://github.com/nextcloud/desktop/pull/3400#discussion_r674807520