### PR TITLE
Fix "never catch" catches in OC_App

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -63,6 +63,7 @@ use OCP\Authentication\IAlternativeLogin;
 use OCP\ILogger;
 use OCP\Settings\IManager as ISettingsManager;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the


### PR DESCRIPTION
Need to check another legacy. Need to explicitly add to use or do not forget add slash `\`