### PR TITLE
21.0.4 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 3, 1];
+$OC_Version = [21, 0, 4, 0];
 
 // The human readable string
-$OC_VersionString = '21.0.3';
+$OC_VersionString = '21.0.4 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #26650 Files & Core accessibility fixes
* #27225 Bump @babel/preset-env from 7.12.11 to 7.12.17
* #27228 Bump marked from 1.2.8 to 1.2.9
* #27624 Bump vuex from 3.6.0 to 3.6.2
* #27744 Design fixes to app-settings button
* #27753 Reset checksum when writing files to object store
* #27803 Run s3 tests again
* #27828 Fix in locking cache check
* #27857 Make search popup usable on mobile, too
* #27862 Cache images on browser
* #27896 Fix dark theme on public link shares
* #27899 Make user status usable on mobile
* #27939 Correctly skip suppressed errors in PHP 8.0
* #27940 Fix newfileMenu on public page
* #27943 Do not escape display name in dashboard welcome text
* #27956 Fix svg icons disapearing in app navigation when text overflows
* #27967 Show registered breadcrumb detail views in breadcrumb menu
* #27975 Fix regression in file sidebar
* #28007 Improve notcreatable permissions hint
* #28017 Update CRL due to revoked twofactor_nextcloud_notification.crt
* #28044 Increase footer height for longer menus
* #28048 Add titleTooltip to sidebar
* #28055 Mask password for Redis and RedisCluster on connection failure
* #28064 Fix missing theming for login button
* #28074 Fix overlapping of elements in certain views
* #28080 Disable HEIC image preview provider for performance concerns
* #28086 Improve provider check
* #28090 Sanitize more functions from the encryption app
* #28097 Hide download button for public preview of audio files
* #28110 Fix dark theme in file exists dialog
* #28124 Let memory limit set in tests fit the used amount
* [activity#602](https://github.com/nextcloud/activity/pull/602) Fix preference name when generating notifications
* [activity#606](https://github.com/nextcloud/activity/pull/606) Fix monochrome icon detection for correct dark mode invert
* [activity#612](https://github.com/nextcloud/activity/pull/612) Fix "Enable notification emails"
* [activity#615](https://github.com/nextcloud/activity/pull/615) Show add, del and restored files within by and self filter
* [activity#624](https://github.com/nextcloud/activity/pull/624) Link from app-navigation-settings to personal settings
* [files_pdfviewer#447](https://github.com/nextcloud/files_pdfviewer/pull/447) Fix pdfviewer design
* [firstrunwizard#569](https://github.com/nextcloud/firstrunwizard/pull/569) Include version number in firstrunwizard
* [notifications#1039](https://github.com/nextcloud/notifications/pull/1039) Use notification main link if no parameter has a link
* [text#1646](https://github.com/nextcloud/text/pull/1646) ViewerComponent: pass on autofocus to EditorWrapper
* [text#1718](https://github.com/nextcloud/text/pull/1718) Unify error responses and add logging where appropriate
* [text#1736](https://github.com/nextcloud/text/pull/1736) Bump cypress-image-snapshot from 4.0.0 to 4.0.1
* [text#1743](https://github.com/nextcloud/text/pull/1743) Bump vue-loader from 15.9.6 to 15.9.7
* [text#1744](https://github.com/nextcloud/text/pull/1744) Bump @vue/test-utils from 1.1.2 to 1.1.4
* [text#1749](https://github.com/nextcloud/text/pull/1749) Bump @babel/plugin-proposal-class-properties from 7.12.1 to 7.12.13
* [text#1751](https://github.com/nextcloud/text/pull/1751) Bump @babel/core from 7.12.10 to 7.12.17
* [text#1753](https://github.com/nextcloud/text/pull/1753) Bump @babel/plugin-transform-runtime from 7.12.10 to 7.12.17
* [text#1756](https://github.com/nextcloud/text/pull/1756) Bump @babel/plugin-transform-modules-commonjs from 7.12.1 to 7.12.13
* [viewer#976](https://github.com/nextcloud/viewer/pull/976) Disable header timeout on mobile


Pending PRs:

* [x] #26724 Fix account data visibility after disabling public addressbook upload 
* [ ] #27203 Fix Oracle query limit compliance in Comments 
* [x] #27205 Better cleanup of filecache when deleting an external storage 
* [ ] #27234 Bump @babel/core from 7.12.10 to 7.12.17 
* [ ] #27406 Avoid fread on directories and unencrypted files 
* [ ] #27640 Bump clipboard from 2.0.6 to 2.0.8 
* [ ] #27681 Harden bootstrap context registrations when apps are missing 
* [x] #27729 Revert "Fix constraint violation detection in QB Mapper" @ChristophWurst
* [ ] #27917 Bump css-loader from 5.0.1 to 5.0.2 
* [ ] #27983 Bump vue and vue-template-compiler 
* [x] #27992 Manual backport of "No limit in the number of group shares" #27875 @goyome
* [x] #28145 Bump regenerator-runtime from 0.13.7 to 0.13.9 
* [ ] [text#1770](https://github.com/nextcloud/text/pull/1770) Fix: rich workspaces overlap with new file dropdown @szaimen
* [x] [text#1782](https://github.com/nextcloud/text/pull/1782) Some Design fixes 
