### PR TITLE
Fix sort function of files multiple selection actions

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1506,7 +1506,7 @@
 				return;
 			}
 			this.fileMultiSelectMenu = new OCA.Files.FileMultiSelectMenu(this.multiSelectMenuItems.sort(function(a, b) {
-				return a.order > b.order
+				return a.order - b.order
 			}));
 			this.fileMultiSelectMenu.render();
 			this.$el.find('.selectedActions .filesSelectMenu').remove();


### PR DESCRIPTION
Javascript array sort function must return -1, 0 or 1 :grin:.

This can be backported to stable22 only.