### PR TITLE
Investigate pending size for s3 buckets

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -380,7 +380,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			$stat = [];
 			if ($this->is_dir($path)) {
 				//folders don't really exist
+				// 5. The size default to -1 because it is a folder.
 				$stat['size'] = -1; //unknown
+				// 1. The fact that mtime is always 'now' leads to...
 				$stat['mtime'] = time();
 				$cacheEntry = $this->getCache()->get($path);
 				if ($cacheEntry instanceof CacheEntry && $this->getMountOption('filesystem_check_changes', 1) !== 1) {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -396,6 +396,8 @@ class Scanner extends BasicEmitter implements IScanner {
 			}
 		}
 		if ($this->cacheActive) {
+			// 4. The cached to be updated every time the folder is acceceed.
+			// But this is always called with -1, because ...
 			$this->cache->update($folderId, ['size' => $size]);
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'postScanFolder', [$path, $this->storageId]);

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -329,6 +329,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @return bool
 	 */
 	public function hasUpdated($path, $time) {
+		// 2. This being always true, and ...
 		return $this->filemtime($path) > $time;
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1344,6 +1344,7 @@ class View {
 				$scanner = $storage->getScanner($internalPath);
 				$scanner->scan($internalPath, Cache\Scanner::SCAN_SHALLOW);
 				$data = $cache->get($internalPath);
+				// 3. needsUpdate to be also be always true, and ...
 			} elseif (!Cache\Scanner::isPartialFile($internalPath) && $watcher->needsUpdate($internalPath, $data)) {
 				$this->lockFile($relativePath, ILockingProvider::LOCK_SHARED);
 				$watcher->update($internalPath, $data);


### PR DESCRIPTION
Folders contained in S3 bucket's are displayed with a size of "Pending".

The following command can get the real size to be displayed, but only for one time: `php occ files:scan --path "<S3 bucket path>"`