### PR TITLE
  Fix folder size contained in S3 buckets

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -385,13 +385,14 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		try {
 			$stat = [];
 			if ($this->is_dir($path)) {
-				//folders don't really exist
-				$stat['size'] = -1; //unknown
-				$stat['mtime'] = time();
 				$cacheEntry = $this->getCache()->get($path);
-				if ($cacheEntry instanceof CacheEntry && $this->getMountOption('filesystem_check_changes', 1) !== 1) {
+				if ($cacheEntry instanceof CacheEntry) {
 					$stat['size'] = $cacheEntry->getSize();
 					$stat['mtime'] = $cacheEntry->getMTime();
+				} else {
+					// Use dummy values
+					$stat['size'] = -1; // Pending
+					$stat['mtime'] = time();
 				}
 			} else {
 				$stat['size'] = $this->getContentLength($path);
@@ -404,6 +405,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			\OC::$server->getLogger()->logException($e, ['app' => 'files_external']);
 			return false;
 		}
+	}
+
+	public function hasUpdated($path, $time) {
+		return $this->getMountOption('filesystem_check_changes', 1) === 1 || parent::hasUpdated($path, $time);
 	}
 
 	/**


### PR DESCRIPTION
Folders contained in S3 bucket's are displayed with a size of "Pending".

The following command can get the real size to be displayed, but only for one refresh: `php occ files:scan --path "<S3 bucket path>"`

Rational (I might be wrong):
1. When running the `stat` method on the S3 folder, the `mtime` is always set to 'now'.
2. This leads to the `hasUpdated` method from `Files/Storage/Common.php` to always returns `true`,
3. And to the `needsUpdate` method in `Files/View.php` to always returns `true` too.
4. So the cache gets updated by `Files/Cache/Scanner.php` every time the folder is acceceed. But it gets updated with a size of `-1` because the size for S3 folders is not getting computed and default to `-1`

Need guidance on how and where we should address this issue :).