### PR TITLE
Allow to disable group membership change notification

### DIFF
--- a/apps/settings/lib/Activity/GroupSetting.php
+++ b/apps/settings/lib/Activity/GroupSetting.php
@@ -85,7 +85,7 @@ class GroupSetting implements ISetting {
 	 * @since 11.0.0
 	 */
 	public function canChangeMail(): bool {
-		return false;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
fix https://github.com/nextcloud/activity/issues/626

<img width="485" alt="Screenshot 2021-07-28 at 12 28 08" src="https://user-images.githubusercontent.com/26852655/127310517-aab69c1d-c2fe-4b5b-8e80-b879114be55f.png">


Signed-off-by: Marco Ambrosini <marcoambrosini@pm.me>