### PR TITLE
Add `riotchat` to rootUrlApps

### DIFF
--- a/lib/private/AppFramework/Routing/RouteConfig.php
+++ b/lib/private/AppFramework/Routing/RouteConfig.php
@@ -58,6 +58,7 @@ class RouteConfig {
 		'core',
 		'files_sharing',
 		'files',
+		'riotchat',
 		'settings',
 		'spreed',
 	];


### PR DESCRIPTION
@sorunome is working on a Matrix integration for Nextcloud but it requires root url routes for some of the Matrix routes so this PR adds `riotchat` to the allowed root url apps.

https://github.com/gary-kim/riotchat/pull/369