### PR TITLE
do not rewrite to top root index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -65,7 +65,7 @@
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
-  RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
+  RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) index.php [QSA,L]
   RewriteRule ^(?:\.(?!well-known)|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 <IfModule mod_mime.c>


### PR DESCRIPTION
The idea is that on a setup of Nextcloud in a subfolder of the website, even with a Redirect from /.well-known/ to /nextcloud/.well-known the current .htaccess will try to reach /index.php instead of looking the local index.php

At the root of the domain:
```
Redirect "/.well-known/" "/nextcloud/.well-known/"
```

Rewrite will not work because the pathInfo is out of Nextcloud, the only way to fix this would be to add
```
	if ($pathInfo === '/.well-known/webfinger') {
		return $pathInfo;
	}
```
in https://github.com/nextcloud/server/blob/master/lib/private/AppFramework/Http/Request.php#L770



