### PR TITLE
Add h2 to personal info page, fixing accessibility issue

### DIFF
--- a/apps/settings/templates/settings/personal/personal.info.php
+++ b/apps/settings/templates/settings/personal/personal.info.php
@@ -36,7 +36,8 @@ script('settings', [
 ?>
 
 <div id="personal-settings" data-lookup-server-upload-enabled="<?php p($_['lookupServerUploadEnabled'] ? 'true' : 'false') ?>">
-<div id="personal-settings-avatar-container" class="personal-settings-container">
+	<h2 class="hidden-visually"><?php p($l->t('Personal info')); ?></h2>
+	<div id="personal-settings-avatar-container" class="personal-settings-container">
 		<div>
 			<form id="avatarform" class="section" method="post" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.avatar.postAvatar')); ?>">
 				<h3>


### PR DESCRIPTION
Last thing reported by Lighthouse on the personal settings page – there were h3 elements but no h2. Fixed by inserting a hidden-visually h2.

Please review @nextcloud/accessibility 

Proposing backport to 20–22 as well since the string already exists in the navigation and should not require further translations, right?