### PR TITLE
Add missing order attribute to tag multiselect action

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -116,7 +116,8 @@
 						{
 							name: 'tags',
 							displayName:  'Tags',
-							iconClass: 'icon-tag'
+							iconClass: 'icon-tag',
+							order: 100,
 						},
 					],
 					sorting: {


### PR DESCRIPTION
It actually messes with the sorting.