### PR TITLE
Fix bug introduced on drag and drop external files

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -776,6 +776,10 @@ OC.Uploader.prototype = _.extend({
 				// no list to check against
 				return true;
 			}
+			if (upload.getTargetFolder() !== fileList.getCurrentDirectory()) {
+				// not uploading to the current folder
+				return true;
+			}
 			var fileInfo = fileList.findFile(file.name);
 			if (fileInfo) {
 				conflicts.push([
@@ -997,7 +1001,8 @@ OC.Uploader.prototype = _.extend({
 						freeSpace = $('#free_space').val()
 					} else if (upload.getTargetFolder().indexOf(self.fileList.getCurrentDirectory()) === 0) {
 						// Check subdirectory free space if file is uploaded there
-						var targetSubdir = upload._targetFolder.replace(self.fileList.getCurrentDirectory(), '')
+						// Retrieve the folder destination name
+						var targetSubdir = upload._targetFolder.split('/').pop()
 						freeSpace = parseInt(upload.uploader.fileList.getModelForFile(targetSubdir).get('quotaAvailableBytes'))
 					}
 					if (freeSpace >= 0 && selection.totalBytes > freeSpace) {

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -75,6 +75,7 @@ describe('OC.Upload tests', function() {
 				files: [file],
 				jqXHR: jqXHR,
 				response: sinon.stub().returns(jqXHR),
+				targetDir: "/",
 				submit: sinon.stub(),
 				abort: sinon.stub()
 			};


### PR DESCRIPTION
Drag and drop of external (OS filesystem) to subdirectories in the browser would fail on specific cases, mainly when the subdirectory was no longer off the root folder.
This seemed to have been an issue introduced with the subdirectory free space calculation [here](https://github.com/nextcloud/server/commit/f9536b08096ed1c80391af36d33a18198be1fced) and it seems to fail for any subdirectory that doesn't belong to the root folder.

Bug reports:
- https://help.nextcloud.com/t/drag-drop-into-subfolders/120731
- https://github.com/nextcloud/server/issues/24720

I couldn't find any reference on scenarios or quota management that would suggest when a subdirectory's free space would be different to the parent's free space, other than when on the root folder, where subdirectories can be external mounts.

As such, if my understanding is correct (please let me know if it isn't), this calculation can - and should - be made by getting the free space from the first subdirectory in the total path, which caters for all subdirectory scenarios.

Please advise, happy to help improve this.