### PR TITLE
Check that php was compiled with argon2 support or that the php-sodium extensions is installed

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -627,6 +627,10 @@ Raw output
 			}
 		}
 
+		if (!defined('PASSWORD_ARGON2I')) {
+			$recommendedPHPModules[] = 'sodium';
+		}
+
 		return $recommendedPHPModules;
 	}
 


### PR DESCRIPTION
This is the case on rhel7 there PHP is not compiled with argon2 support and php-sodium is a weak dependency and not installed by default. On other distributions and rhel8, php-sodium or argon2 is already installed so there is less risk of it breaking.

Related to https://github.com/nextcloud/server/issues/21100

Signed-off-by: Carl Schwan <carl@carlschwan.eu>