### PR TITLE
Fix setting up 2FA providers when 2FA is enforced and bc are generated

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -92,7 +92,7 @@ class TwoFactorMiddleware extends Middleware {
 			&& !$this->reflector->hasAnnotation('TwoFactorSetUpDoneRequired')) {
 			$providers = $this->twoFactorManager->getProviderSet($this->userSession->getUser());
 
-			if (!($providers->getProviders() === [] && !$providers->isProviderMissing())) {
+			if (!($providers->getPrimaryProviders() === [] && !$providers->isProviderMissing())) {
 				throw new TwoFactorAuthRequiredException();
 			}
 		}


### PR DESCRIPTION
When a user has backup codes generated and got their 2FA enforced then
they should be able to set up TOTP and similar providers during the
login.

Currently the user is redirected to the backup codes page because that's the only available provider. Going back to the 2FA setup page is not possible.

~~Will give this some more testing, just to be sure :)~~ done

Steps to test
1. Install a 2FA app, like https://apps.nextcloud.com/apps/twofactor_totp
2. Create a user that you'll use for testing
  * Log in and generate 2FA backup codes
  * Do *not* set up TOTP yet
3. Enforce 2FA as admin
4. Log out from the test user
5. Log in with the test user again

### Expected behavior (here)

You are told that 2FA is enforced but not set up. You can pick TOTP for the setup, configure it and then you're logged in and set up.

### Actual behavior (on master)

You are redirected to the backup codes page, there is nothing you can do except fill in a backup code.