### PR TITLE
22.1.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 1, 0, 0];
+$OC_Version = [22, 1, 0, 1];
 
 // The human readable string
-$OC_VersionString = '22.1.0 RC1';
+$OC_VersionString = '22.1.0';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #27654 Update guzzlehttp/guzzle requirement from 6.5.2 to 7.3.0 in /build/integration
* #27658 Bump vue and vue-template-compiler
* #27659 Bump vue-router from 3.5.1 to 3.5.2
* #27825 Ignore subdomain for soa queries
* #27826 Fix in locking cache check
* #27848 Fixes recursion count incrementation
* #27856 Make search popup usable on mobile, too
* #27861 Cache images on browser
* #27878 Fix add group button
* #27889 Fix dark theme on public link shares
* #27898 Make user status usable on mobile
* #27925 Check if dns_get_record returns non-false
* #27938 Correctly skip suppressed errors in PHP 8.0
* #27942 Fix newfileMenu on public page
* #27944 Do not escape display name in dashboard welcome text
* #27957 Fix svg icons disapearing in app navigation when text overflows
* #27959 Revert "Update guzzlehttp/guzzle requirement from 6.5.2 to 7.3.0 in /build/integration"
* #27964 Also hide group from direct matches
* #27966 Show registered breadcrumb detail views in breadcrumb menu
* #27974 Fix regression in file sidebar
* #27979 Allow to get a local cloud id without going through the contacts manager
* #28001 Multiple Emails UI and Integration
* #28008 Improve notcreatable permissions hint
* #28011 Some multiselect design fixes
* #28014 Only display supported email scopes
* #28016 Update CRL due to revoked twofactor_nextcloud_notification.crt
* #28043 Increase footer height for longer menus
* #28047 Add titleTooltip to sidebar
* #28053 Mask password for Redis and RedisCluster on connection failure
* #28061 Fix missing theming for login button
* #28071 Improve Emails UX
* #28073 Fix overlapping of elements in certain views
* #28079 Disable HEIC image preview provider for performance concerns
* #28085 Improve provider check
* #28089 Sanitize more functions from the encryption app
* #28093 Hide download button for public preview of audio files
* #28109 Fix dark theme in file exists dialog
* #28112 Support redis user password auth and tls encryption
* #28121 Bump @babel/core from 7.14.3 to 7.14.8
* #28123 Let memory limit set in tests fit the used amount
* #28126 Bump @nextcloud/babel-config from 1.0.0-beta.1 to 1.0.0
* #28131 Allow empty Redis config
* #28135 Add an option to the multiple files selected actions to add and remov…
* #28149 Bump css-vars-ponyfill from 2.4.3 to 2.4.5
* #28152 Make sure that the dav propfind plugins always use the proper user id
* #28167 Admin Audit - Sharing: createShare - report the full path
* #28168 Fix sort function of files multiple selection actions
* #28170 User management - Add icon to user groups
* #28177 Bump @babel/preset-env from 7.14.7 to 7.14.8
* #28179 Bump sass from 1.35.1 to 1.35.2
* #28181 Bump autosize from 4.0.2 to 4.0.4
* #28193 Fix variable override in file view
* #28197 Fix comments file action sidebar opening
* #28215 Set openfile params when following internal links
* #28222 Fix Files breadcrumbs being hidden even if there is enough space
* #28228 Dont apply jail search filter is on the root
* #28244 Fix missing label of Search function
* #28247 Add missing order attribute to tag multiselect action
* #28269 Update guzzlehttp/guzzle requirement from 6.5.2 to 6.5.5 in /build/integration
* #28270 Bump css-loader from 5.2.6 to 5.2.7
* #28272 Bump css-vars-ponyfill from 2.4.5 to 2.4.6
* #28273 Bump regenerator-runtime from 0.13.7 to 0.13.9
* [activity#611](https://github.com/nextcloud/activity/pull/611) Fix "Enable notification emails"
* [activity#614](https://github.com/nextcloud/activity/pull/614) Show add, del and restored files within by and self filter
* [activity#618](https://github.com/nextcloud/activity/pull/618) Only call getCloudId if needed
* [activity#623](https://github.com/nextcloud/activity/pull/623) Link from app-navigation-settings to personal settings
* [circles#688](https://github.com/nextcloud/circles/pull/688) Remove echo
* [circles#698](https://github.com/nextcloud/circles/pull/698) Returns files shared to Personal
* [circles#699](https://github.com/nextcloud/circles/pull/699) Make cs-fix/cs-check
* [circles#700](https://github.com/nextcloud/circles/pull/700) Cs fix
* [circles#708](https://github.com/nextcloud/circles/pull/708) Backport of 704
* [circles#709](https://github.com/nextcloud/circles/pull/709) Avoid timeout on check
* [circles#714](https://github.com/nextcloud/circles/pull/714) Better probe
* [circles#717](https://github.com/nextcloud/circles/pull/717) Removing hidden flag by default
* [circles#719](https://github.com/nextcloud/circles/pull/719) Generate probe if needed
* [circles#721](https://github.com/nextcloud/circles/pull/721) Adding unified search
* [circles#724](https://github.com/nextcloud/circles/pull/724) Detect source of search
* [circles#727](https://github.com/nextcloud/circles/pull/727) Remove root circles from search for new members
* [circles#729](https://github.com/nextcloud/circles/pull/729) Sending mail on new shares
* [circles#732](https://github.com/nextcloud/circles/pull/732) GetDefinition
* [circles#737](https://github.com/nextcloud/circles/pull/737) Cloud_force_base
* [circles#738](https://github.com/nextcloud/circles/pull/738) Fixing notification and mails
* [circles#740](https://github.com/nextcloud/circles/pull/740) Remote inherited and memberships
* [circles#741](https://github.com/nextcloud/circles/pull/741) Sendmail on new fileshare
* [circles#742](https://github.com/nextcloud/circles/pull/742) Fix phpdoc+lint
* [circles#744](https://github.com/nextcloud/circles/pull/744) Better display of mail addresses
* [circles#747](https://github.com/nextcloud/circles/pull/747) Limit non-local circles as members of local circles
* [circles#749](https://github.com/nextcloud/circles/pull/749) Local stays local
* [circles#751](https://github.com/nextcloud/circles/pull/751) Local circles starts local
* [circles#754](https://github.com/nextcloud/circles/pull/754) Throw instead of doing nothing
* [circles#755](https://github.com/nextcloud/circles/pull/755) Send mails to inherited members on GS
* [circles#757](https://github.com/nextcloud/circles/pull/757) Optional details on Link
* [circles#759](https://github.com/nextcloud/circles/pull/759) Include and config path in loopback
* [circles#761](https://github.com/nextcloud/circles/pull/761) Cleaning old code
* [circles#762](https://github.com/nextcloud/circles/pull/762) Migration to 22.1.0 - child shares
* [files_pdfviewer#445](https://github.com/nextcloud/files_pdfviewer/pull/445) Fix pdfviewer design
* [firstrunwizard#568](https://github.com/nextcloud/firstrunwizard/pull/568) Include version number in firstrunwizard
* [notifications#1049](https://github.com/nextcloud/notifications/pull/1049) Remove timeout of browser notifications
* [text#1711](https://github.com/nextcloud/text/pull/1711) Some Design fixes
* [text#1717](https://github.com/nextcloud/text/pull/1717) Unify error responses and add logging where appropriate
* [text#1734](https://github.com/nextcloud/text/pull/1734) Bump eslint-plugin-import from 2.23.3 to 2.23.4
* [text#1739](https://github.com/nextcloud/text/pull/1739) Bump @babel/core from 7.14.3 to 7.14.6
* [text#1769](https://github.com/nextcloud/text/pull/1769) Fix: rich workspaces overlap with new file dropdown
* [text#1775](https://github.com/nextcloud/text/pull/1775) Azul/fix links 1676
* [text#1781](https://github.com/nextcloud/text/pull/1781) Extend mimetypes for direct editing
* [text#1792](https://github.com/nextcloud/text/pull/1792) Bump @vue/test-utils from 1.2.1 to 1.2.2
* [text#1808](https://github.com/nextcloud/text/pull/1808) Fix: cypress icon close selector
* [viewer#977](https://github.com/nextcloud/viewer/pull/977) Disable header timeout on mobile
