### PR TITLE
20.0.12

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 12, 0];
+$OC_Version = [20, 0, 12, 1];
 
 // The human readable string
-$OC_VersionString = '20.0.12 RC1';
+$OC_VersionString = '20.0.12';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #27224 Bump vue-router from 3.4.3 to 3.4.9
* #27232 Bump v-click-outside from 3.1.1 to 3.1.2
* #27236 Bump url-search-params-polyfill from 8.1.0 to 8.1.1
* #27646 Bump debounce from 1.2.0 to 1.2.1
* #27701 Bump vue and vue-template-compiler
* #27745 Design fixes to app-settings button
* #27754 Reset checksum when writing files to object store
* #27804 Run s3 tests again
* #27829 Fix in locking cache check
* #27836 Bump dompurify from 2.2.8 to 2.2.9
* #27858 Make search popup usable on mobile, too
* #27863 Cache images on browser
* #27895 Fix dark theme on public link shares
* #27897 Make user status usable on mobile
* #27913 Do not escape display name in dashboard welcome text
* #27924 Bump moment-timezone from 0.5.31 to 0.5.33
* #27941 Fix newfileMenu on public page
* #27955 Fix svg icons disapearing in app navigation when text overflows
* #27965 Bump bootstrap from 4.5.2 to 4.5.3
* #27970 Show registered breadcrumb detail views in breadcrumb menu
* #27976 Fix regression in file sidebar
* #27984 Bump exports-loader from 1.1.0 to 1.1.1
* #27985 Bump @nextcloud/capabilities from 1.0.2 to 1.0.4
* #27988 Bump @nextcloud/vue-dashboard from 1.0.0 to 1.0.1
* #28006 Improve notcreatable permissions hint
* #28018 Update CRL due to revoked twofactor_nextcloud_notification.crt
* #28032 Bump sass-loader from 10.0.2 to 10.0.5
* #28045 Increase footer height for longer menus
* #28054 Mask password for Redis and RedisCluster on connection failure
* #28065 Fix missing theming for login button
* #28072 Fix overlapping of elements in certain views
* #28081 Disable HEIC image preview provider for performance concerns
* #28087 Improve provider check
* #28091 Sanitize more functions from the encryption app
* #28096 Hide download button for public preview of audio files
* #28107 L10n: HTTP in capital letters
* #28111 Fix dark theme in file exists dialog
* #28125 Let memory limit set in tests fit the used amount
* #28172 User management - Add icon to user groups
* #28187 Bump marked from 1.1.1 to 1.1.2
* #28191 Fix variable override in file view
* #28207 Bump regenerator-runtime from 0.13.7 to 0.13.9
* #28208 Bump url-loader from 4.1.0 to 4.1.1
* #28224 Fix Files breadcrumbs being hidden even if there is enough space
* #28241 Dont apply jail search filter is on the root
* [activity#603](https://github.com/nextcloud/activity/pull/603) Fix preference name when generating notifications
* [activity#607](https://github.com/nextcloud/activity/pull/607) Fix monochrome icon detection for correct dark mode invert
* [activity#613](https://github.com/nextcloud/activity/pull/613) Fix "Enable notification emails"
* [activity#616](https://github.com/nextcloud/activity/pull/616) Show add, del and restored files within by and self filter
* [activity#625](https://github.com/nextcloud/activity/pull/625) Link from app-navigation-settings to personal settings
* [files_pdfviewer#446](https://github.com/nextcloud/files_pdfviewer/pull/446) Fix pdfviewer design
* [firstrunwizard#570](https://github.com/nextcloud/firstrunwizard/pull/570) Include version number in firstrunwizard
* [notifications#1040](https://github.com/nextcloud/notifications/pull/1040) Use notification main link if no parameter has a link
* [text#1360](https://github.com/nextcloud/text/pull/1360) Bump sass-loader from 10.1.0 to 10.1.1
* [text#1548](https://github.com/nextcloud/text/pull/1548) Bump @babel/plugin-transform-runtime from 7.13.9 to 7.13.15
* [text#1550](https://github.com/nextcloud/text/pull/1550) Bump @babel/preset-env from 7.13.9 to 7.13.15
* [text#1592](https://github.com/nextcloud/text/pull/1592) Bump vue-loader from 15.9.6 to 15.9.7
* [text#1719](https://github.com/nextcloud/text/pull/1719) Unify error responses and add logging where appropriate
* [viewer#978](https://github.com/nextcloud/viewer/pull/978) Disable header timeout on mobile


Pending PRs:

* [ ] #26409
* [ ] #26630
* [ ] #27207
* [ ] #27407 
* [ ] #27989 @skjnldsv
* [ ] #27991 @goyome
* [ ] #28186
* [ ] #28248 @kesselb
* [ ] #28289