### PR TITLE
UnifiedSearchController: strip webroot from URL before finding a route

### DIFF
--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -123,9 +123,17 @@ class UnifiedSearchController extends OCSController {
 
 		if ($url !== '') {
 			$urlParts = parse_url($url);
+			$urlPath = $urlParts['path'];
+
+			// Optionally strip webroot from URL. Required for route matching on setups
+			// with Nextcloud in a webserver subfolder (webroot).
+			$webroot = \OC::$WEBROOT;
+			if ($webroot !== '' && substr($urlPath, 0, strlen($webroot)) === $webroot) {
+				$urlPath = substr($urlPath, strlen($webroot));
+			}
 
 			try {
-				$parameters = $this->router->findMatchingRoute($urlParts['path']);
+				$parameters = $this->router->findMatchingRoute($urlPath);
 
 				// contacts.PageController.index => contacts.Page.index
 				$route = $parameters['caller'];

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Route\IRouter;
 use OCP\Search\ISearchQuery;
@@ -49,15 +50,20 @@ class UnifiedSearchController extends OCSController {
 	/** @var IRouter */
 	private $router;
 
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
 	public function __construct(IRequest $request,
 								IUserSession $userSession,
 								SearchComposer $composer,
-								IRouter $router) {
+								IRouter $router,
+								IURLGenerator $urlGenerator) {
 		parent::__construct('core', $request);
 
 		$this->composer = $composer;
 		$this->userSession = $userSession;
 		$this->router = $router;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -127,7 +133,7 @@ class UnifiedSearchController extends OCSController {
 
 			// Optionally strip webroot from URL. Required for route matching on setups
 			// with Nextcloud in a webserver subfolder (webroot).
-			$webroot = \OC::$WEBROOT;
+			$webroot = $this->urlGenerator->getWebroot();
 			if ($webroot !== '' && substr($urlPath, 0, strlen($webroot)) === $webroot) {
 				$urlPath = substr($urlPath, strlen($webroot));
 			}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -276,4 +276,11 @@ class URLGenerator implements IURLGenerator {
 		}
 		return $this->baseUrl;
 	}
+
+	/**
+	 * @return string webroot part of the base url
+	 */
+	public function getWebroot(): string {
+		return \OC::$WEBROOT;
+	}
 }

--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -102,4 +102,10 @@ interface IURLGenerator {
 	 * @since 13.0.0
 	 */
 	public function getBaseUrl(): string;
+
+	/**
+	 * @return string webroot part of the base url
+	 * @since 23.0.0
+	 */
+	public function getWebroot(): string;
 }

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -179,6 +179,12 @@ class UrlGeneratorTest extends \Test\TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	public function testGetWebroot() {
+		\OC::$WEBROOT = '/nextcloud';
+		$actual = $this->urlGenerator->getWebroot();
+		$this->assertEquals(\OC::$WEBROOT, $actual);
+	}
+
 	/**
 	 * @dataProvider provideOCSRoutes
 	 */


### PR DESCRIPTION
This should fix route matching in UnifiedSearchController on setups with
Nextcloud in a subfolder (webroot).

Fixes: #24144
Signed-off-by: Jonas Meurer <jonas@freesources.org>