### PR TITLE
Allow upgrade from 22.1

### DIFF
--- a/version.php
+++ b/version.php
@@ -39,6 +39,7 @@ $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
 		'21.0' => true,
 		'22.0' => true,
+		'22.1' => true,
 	],
 	'owncloud' => [
 		'10.5' => true,


### PR DESCRIPTION
Otherwise upgrading from 22.1.x.x to another 22.2.x.x will fail.

> Exception: Updates between multiple major versions and downgrades are unsupported.
> Update failed

The check failing is in https://github.com/nextcloud/server/blob/stable22/lib/private/Updater.php#L208-L210
