### PR TITLE
Allow upgrade from 22.1

### DIFF
--- a/version.php
+++ b/version.php
@@ -37,7 +37,7 @@ $OC_VersionString = '23.0.0 alpha';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
-		'22.0' => true,
+		'22.1' => true,
 		'23.0' => true,
 	],
 	'owncloud' => [


### PR DESCRIPTION
Forward-port of https://github.com/nextcloud/server/pull/28304 for avoiding issues during upgrades with upcoming 23.0.x releases.

In theory we could also allow upgrading from 22.0 to 23 but that would need double checking to make sure that we didn't introduce any upgrade step or migration that might be lost otherwise if skipping the 22.1.x releases. 