### PR TITLE
Already pass size difference to the cache updater to avoid calculation of the folder size to update

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -366,7 +366,8 @@ class File extends Node implements IFile {
 			}
 
 			// since we skipped the view we need to scan and emit the hooks ourselves
-			$storage->getUpdater()->update($internalPath, null, ($writtenByteCount - $previousFileSize));
+			$sizeDifference = isset($previousFileSize, $writtenByteCount) ? ($writtenByteCount - $previousFileSize) : null;
+			$storage->getUpdater()->update($internalPath, null, $sizeDifference);
 
 			try {
 				$this->changeLock(ILockingProvider::LOCK_SHARED);

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -236,6 +236,7 @@ class File extends Node implements IFile {
 				}
 			}
 
+			$previousFileSize = $exists ? $partStorage->filesize($internalPath) : 0;
 			if ($partStorage->instanceOfStorage(Storage\IWriteStreamStorage::class)) {
 				$isEOF = false;
 				$wrappedData = CallbackWrapper::wrap($data, null, null, null, null, function ($stream) use (&$isEOF) {
@@ -365,7 +366,7 @@ class File extends Node implements IFile {
 			}
 
 			// since we skipped the view we need to scan and emit the hooks ourselves
-			$storage->getUpdater()->update($internalPath);
+			$storage->getUpdater()->update($internalPath, null, ($count-$previousFileSize));
 
 			try {
 				$this->changeLock(ILockingProvider::LOCK_SHARED);

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -113,8 +113,9 @@ class Updater implements IUpdater {
 	 *
 	 * @param string $path
 	 * @param int $time
+	 * @param int $sizeDifference
 	 */
-	public function update($path, $time = null) {
+	public function update($path, $time = null, $sizeDifference = null) {
 		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
@@ -129,14 +130,15 @@ class Updater implements IUpdater {
 		) {
 			$sizeDifference = $data['size'] - $data['oldSize'];
 		} else {
-			// scanner didn't provide size info, fallback to full size calculation
-			$sizeDifference = 0;
-			if ($this->cache instanceof Cache) {
+			// scanner didn't provide size info, fallback to full size calculation if the difference was not already passed
+			// otherwise we can update through the propagator
+			if ($this->cache instanceof Cache && $sizeDifference === null) {
 				$this->cache->correctFolderSize($path, $data);
+				$sizeDifference = 0;
 			}
 		}
 		$this->correctParentStorageMtime($path);
-		$this->propagator->propagateChange($path, $time, $sizeDifference);
+		$this->propagator->propagateChange($path, $time, $sizeDifference ?? 0);
 	}
 
 	/**


### PR DESCRIPTION
With S3 the scanner will never return anything so the updater always falls back to a full size calculation. Since we know the transferred filesize during upload, we can pass it as an optional parameter then in order to directly update the parent folder sizes.

Additionally the sizeDifference is also passed in the View when creating directories (which always have a difference of 0) and when calling file_put_contents where we know the size difference from the storage return value.