### PR TITLE
Do not setup a session when not required on API requests

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -175,6 +175,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
+	 * @UseSession
 	 *
 	 * @param string $dir
 	 * @param string $view

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -42,6 +42,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -362,7 +363,7 @@ class Manager {
 					$this->session->set(self::SESSION_UID_DONE, $user->getUID());
 					return false;
 				}
-			} catch (InvalidTokenException $e) {
+			} catch (InvalidTokenException|SessionNotAvailableException $e) {
 			}
 		}
 


### PR DESCRIPTION
This would resolve https://github.com/nextcloud/server/issues/7628 as currently every API request to webdav/OCS that is using HTTP auth is generating a PHP session even though it is never used afterwards as any follow-up request is sending the auth headers again and therefore just creating another session. This reduces the amount of sessions being created and that would need to be kept by the php session handler which might otherwise grow extensively on large setups with logs of API calls happening.

As we already use a wrapper for the session returning early in the session setup will just result in the memory session implementation being used as a fallback https://github.com/nextcloud/server/blob/7179002600ccde6d6757c068c9388430ed71a2f1/lib/private/Server.php#L516

Ideally the check would be performed when the request is handled and the login checks are performed is handled, but the risk of breaking something when setting up the session that late in the execution flow seems much higher.

Fix https://github.com/nextcloud/server/issues/27603

- [x] Double check if authtokens get still created and shown in the security settings
- [x] Get rid of config flag and make it the default behaviour
- [ ] Smoke testing with pyocclient 
- [x] Still attempt to initiate a session if a session cookie is present during the request, this could happen on public share links if the browser sends both the existing session cookie as well as basic auth for the share link token/password