### PR TITLE
Set a maximum level of encoding nested arguments of exception traces

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -237,11 +237,11 @@ class ExceptionSerializer {
 				];
 			}
 
-			$data = get_object_vars($arg);
-			$data['__class__'] = get_class($arg);
+			$objectInfo = [ '__class__' => get_class($arg) ];
+			$objectVars = get_object_vars($arg);
 			return array_map(function ($arg) use ($nestingLevel) {
 				return $this->encodeArg($arg, $nestingLevel - 1);
-			}, $data);
+			}, array_merge($objectInfo, $objectVars));
 		}
 
 		if (is_array($arg)) {


### PR DESCRIPTION
This will make sure that nested objects or arrays do not cause exceeding the maximum nesting level of functions when parsing arguments of an exception trace. In addition the second commit ensures that the class of an encoded object argument is always listed first in the resulting json object.

Found when debugging issues in #25774 with @marcoambrosini where a faulty scss code caused an exception but the arguments passed in the SCSS library contain a deeply nested tree of the parsed scss.

Example patch to reproduce the exception happening:

```patch
diff --git a/core/css/css-variables.scss b/core/css/css-variables.scss
index 86f80611a6..4b17bff4c9 100644
--- a/core/css/css-variables.scss
+++ b/core/css/css-variables.scss
@@ -13,6 +13,7 @@
        --color-background-hover: #{$color-background-hover};
        --color-background-dark: #{$color-background-dark};
        --color-background-darker: #{$color-background-darker};
+       --color-background-darker: #{$color-background-darker-aaa};
 
        --color-placeholder-light: #{$color-placeholder-light};
        --color-placeholder-dark: #{$color-placeholder-dark};
```

Without this patch an empty page is shown and just a generic error with xdebug or even a core dump without:

```
  Error   PHP   Error: Xdebug has detected a possible infinite loop, and aborted   2021-08-05T09:13:49+00:00  
                your script with a stack depth of '256' frames at                                             
                /var/www/html/lib/private/Log/ExceptionSerializer.php#232
```


With this PR we get a proper error page and trace in the logs:

- ScssPhp\ScssPhp\Exception\CompilerException: Undefined variable $color-background-darker-aaa: core/css/css-variables.scss on line 16, at column 2 Call Stack: #0 import core/css/css-variables.scss (unknown file) on line 1