### PR TITLE
autotest.sh: Add PHPUNIT_EXE environment variable

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -29,7 +29,10 @@ if [ -z "$PHP_EXE" ]; then
 	PHP_EXE=php
 fi
 PHP=$(which "$PHP_EXE")
-PHPUNIT=$(which phpunit)
+if [ -z "$PHPUNIT_EXE" ]; then
+    PHPUNIT_EXE=phpunit
+fi
+PHPUNIT=$(which "$PHPUNIT_EXE")
 
 set -e
 


### PR DESCRIPTION
Adds the `PHPUNIT_EXE` environment variable to `autotest.sh`, allowing developers to overwrite the `phpunit` executable to use (just like `PHP_EXE`).