### PR TITLE
Only recommand for php-sodium on >= PHP 7.4

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -627,7 +627,11 @@ Raw output
 			}
 		}
 
-		if (!defined('PASSWORD_ARGON2I')) {
+		if (!defined('PASSWORD_ARGON2I') && PHP_VERSION_ID >= 70400) {
+			// Installing php-sodium on >=php7.4 will provide PASSWORD_ARGON2I
+			// on previous version argon2 wasn't part of the "standard" extension
+			// and RedHat disabled it so even installing php-sodium won't provide argon2i
+			// support in password_hash/password_verify.
 			$recommendedPHPModules[] = 'sodium';
 		}
 


### PR DESCRIPTION
This is because php-sodium will solve the missing PASSWORD_ARGON2I
constant problem only on >= php 7.4, previously argon2 wasn't part of
the standard extension and was disabled on Centos/RHEL.

So installing php-sodium on php 7.2 for example wouldn't hide the
message. Tested on Fedora with php 7.4, Centos 7 with php 7.2,
Centos 8 with php 7.2 and openSUSE with php 7.4.

Link for more info: https://lists.fedoraproject.org/archives/list/php-devel@lists.fedoraproject.org/message/DPUS5BTCJD6IXREHJKMRK7JEFNSHKFSR/

Signed-off-by: Carl Schwan <carl@carlschwan.eu>