### PR TITLE
cron: exit 1 on exception

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -20,6 +20,7 @@
  * @author Steffen Lindner <mail@steffen-lindner.de>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Stephen Michel <git@smichel.me>
  *
  * @license AGPL-3.0
  *
@@ -158,6 +159,8 @@ try {
 	exit();
 } catch (Exception $ex) {
 	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	exit(1);
 } catch (Error $ex) {
 	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	exit(1);
 }


### PR DESCRIPTION
Allows the caller to more easily respond to cron failures.

Signed-off-by: Stephen Michel <git@smichel.me>

Fixes #28038

`CONTRIBUTING.md` mentions adding tests for all PRs. I'm happy to add them, but am not sure where; if you'd like that, please point me to the right place :)