### PR TITLE
Fix encrypted version to 0 when finding unencrypted file

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -212,7 +212,7 @@ class Encryption extends Wrapper {
 			} else {
 				$wrapped = fopen($protocol . '://', $mode, false, $context);
 			}
-		} catch (\BadMethodCallException $e) {
+		} catch (\Exception $e) {
 			stream_wrapper_unregister($protocol);
 			throw $e;
 		}


### PR DESCRIPTION
Whenever the command is run and a "legacy cipher" seems to be detected
when the legacy option is disabled, it's highly likely that the file is
actually unencrypted but the database contains a encrypted version
higher than 0 for some reason.

The command now detects this case and automatically sets the encrypted
version to 0 so that the file can be read again.
:warning: This assumes that there are no more legacy encrypted files because the admin has not set the legacy option.

- [x] add unit tests

### Steps to test

1. Setup NC and login as "admin"
2. Upload a picture and rename it to "unencrypted.jpg"
3. Enable encryption with `occ app:enable encryption && occ encryption:enable`
4. Upload another picture and rename it to "encrypted.jpg"
5. Set encrypted flag in database: `update oc_filecache set encrypted=2 where name like '%unencrypted%';`
6. Try downloading the files: "unencrypted.jpg" shows an error
7. Run `occ encryption:fix-encrypted-version admin`
8. Try downloading the files: both can be downloaded properly
