### PR TITLE
properly handle cases where cache wrappers block access

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3509,9 +3509,6 @@
       <code>string</code>
       <code>string</code>
     </InvalidReturnType>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;view-&gt;hash($type, $this-&gt;path, $raw)</code>
-    </NullableReturnStatement>
     <UndefinedThisPropertyAssignment occurrences="1">
       <code>$this-&gt;exists</code>
     </UndefinedThisPropertyAssignment>

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -328,7 +328,7 @@ class CacheJail extends CacheWrapper {
 		if ($rawEntry) {
 			$jailedPath = $this->getJailedPath($rawEntry->getPath());
 			if ($jailedPath !== null) {
-				return $this->formatCacheEntry(clone $rawEntry);
+				return $this->formatCacheEntry(clone $rawEntry) ?: null;
 			}
 		}
 

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -60,7 +60,7 @@ class CacheWrapper extends Cache {
 	 * Make it easy for wrappers to modify every returned cache entry
 	 *
 	 * @param ICacheEntry $entry
-	 * @return ICacheEntry
+	 * @return ICacheEntry|false
 	 */
 	protected function formatCacheEntry($entry) {
 		return $entry;
@@ -311,7 +311,8 @@ class CacheWrapper extends Cache {
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {
 		$rawEntry = $this->getCache()->getCacheEntryFromSearchResult($rawEntry);
 		if ($rawEntry) {
-			return $this->formatCacheEntry(clone $rawEntry);
+			$entry = $this->formatCacheEntry(clone $rawEntry);
+			return $entry ?: null;
 		}
 
 		return null;


### PR DESCRIPTION
`CacheWrapper::formatCacheEntry` can return false for files that should be filtered out

Fixes https://github.com/nextcloud/groupfolders/issues/1621