### PR TITLE
Fix truncation of files upon read when using object store and encryption

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -612,7 +612,7 @@ class Encryption extends Wrapper {
 	 * @param int $blockSize Length of requested data block in bytes
 	 * @return string Data fetched from stream.
 	 */
-	private function fread_block($handle, $blockSize): string {
+	private function fread_block($handle, int $blockSize): string {
 		$remaining = $blockSize;
 		$data = '';
 
@@ -623,7 +623,7 @@ class Encryption extends Wrapper {
 			$remaining -= $chunk_len;
 		} while (($remaining > 0) && ($chunk_len > 0));
 
- 	  return $data;
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
When using and object store as primary storage and using the default encryption module at the same time,  any encrypted file would be truncated when read, and a text error message added to the end.

This was caused by a combination of the reliance of the read functions on on knowing the unencrypted file size,  and a bug in the function which calculated the unencrypted file size for a given file.

In order to calculate the unencrypted file size,  the function would first skip the header block, then use `fseek` to skip to the last encrypted block in the file.  Because there was a correspondence between the encrypted and unencrypted blocks, this would also be the last encrypted block.  It would then read the final block and decrypt it to get the unencrypted length of the last block.  With that, the number of blocks, and the unencrypted block size, it could calculate the unencrypted file size.

The trouble was that when using an object store, an `fread` call doesn't always get you the number of bytes you asked for, even if they are available.  To resolve this I adapted the stream_read_block function from `lib/private/Files/Streams/Encryption.php` to work here.  This function wraps the `fread` call in a loop and repeats until it has the entire set of bytes that were requested,  or there are no more to get.  (The same sort of fix as in the PR mentioned later on).

This fixes the immediate bug, and should (with luck) allow people to read their encrypted files now.  (The problem was purely on the decryption side).  In the future it would be nice to do some refactoring here.

I have done some testing of this with image files ranging from 1kb to 10mb using Nextcloud version 22.1.0 (the nextcloud:22.1-apache docker image), with sqlite and a Linode object store as the primary storage.

Does anyone have time to take a look and help nudge this PR into contribution shape?

I think @szaimen has been keeping an eye on the related [issue](https://github.com/nextcloud/server/issues/22077), and @kesselb and @rullzer were involved in a [previous related PR](https://github.com/nextcloud/server/pull/15946/files).