### PR TITLE
add event for when a share is mounted

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -37,6 +37,7 @@ return array(
     'OCA\\Files_Sharing\\Controller\\ShareesAPIController' => $baseDir . '/../lib/Controller/ShareesAPIController.php',
     'OCA\\Files_Sharing\\DeleteOrphanedSharesJob' => $baseDir . '/../lib/DeleteOrphanedSharesJob.php',
     'OCA\\Files_Sharing\\Event\\BeforeTemplateRenderedEvent' => $baseDir . '/../lib/Event/BeforeTemplateRenderedEvent.php',
+    'OCA\\Files_Sharing\\Event\\ShareMountedEvent' => $baseDir . '/../lib/Event/ShareMountedEvent.php',
     'OCA\\Files_Sharing\\Exceptions\\BrokenPath' => $baseDir . '/../lib/Exceptions/BrokenPath.php',
     'OCA\\Files_Sharing\\Exceptions\\S2SException' => $baseDir . '/../lib/Exceptions/S2SException.php',
     'OCA\\Files_Sharing\\Exceptions\\SharingRightsException' => $baseDir . '/../lib/Exceptions/SharingRightsException.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -52,6 +52,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Controller\\ShareesAPIController' => __DIR__ . '/..' . '/../lib/Controller/ShareesAPIController.php',
         'OCA\\Files_Sharing\\DeleteOrphanedSharesJob' => __DIR__ . '/..' . '/../lib/DeleteOrphanedSharesJob.php',
         'OCA\\Files_Sharing\\Event\\BeforeTemplateRenderedEvent' => __DIR__ . '/..' . '/../lib/Event/BeforeTemplateRenderedEvent.php',
+        'OCA\\Files_Sharing\\Event\\ShareMountedEvent' => __DIR__ . '/..' . '/../lib/Event/ShareMountedEvent.php',
         'OCA\\Files_Sharing\\Exceptions\\BrokenPath' => __DIR__ . '/..' . '/../lib/Exceptions/BrokenPath.php',
         'OCA\\Files_Sharing\\Exceptions\\S2SException' => __DIR__ . '/..' . '/../lib/Exceptions/S2SException.php',
         'OCA\\Files_Sharing\\Exceptions\\SharingRightsException' => __DIR__ . '/..' . '/../lib/Exceptions/SharingRightsException.php',

--- a/apps/files_sharing/lib/Event/ShareMountedEvent.php
+++ b/apps/files_sharing/lib/Event/ShareMountedEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\Event;
+
+use OCA\Files_Sharing\SharedMount;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Mount\IMountPoint;
+
+class ShareMountedEvent extends Event {
+	/** @var SharedMount */
+	private $mount;
+
+	/** @var IMountPoint[] */
+	private $additionalMounts = [];
+
+	public function __construct(SharedMount $mount) {
+		parent::__construct();
+		$this->mount = $mount;
+	}
+
+	public function getMount(): SharedMount {
+		return $this->mount;
+	}
+
+	public function addAdditionalMount(IMountPoint $mountPoint): void {
+		$this->additionalMounts[] = $mountPoint;
+	}
+
+	/**
+	 * @return IMountPoint[]
+	 */
+	public function getAdditionalMounts(): array {
+		return $this->additionalMounts;
+	}
+}

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -30,6 +30,8 @@ namespace OCA\Files_Sharing;
 
 use OC\Cache\CappedMemoryCache;
 use OC\Files\View;
+use OCA\Files_Sharing\Event\ShareMountedEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
@@ -54,15 +56,24 @@ class MountProvider implements IMountProvider {
 	 */
 	protected $logger;
 
+	/** @var IEventDispatcher */
+	protected $eventDispatcher;
+
 	/**
 	 * @param \OCP\IConfig $config
 	 * @param IManager $shareManager
 	 * @param ILogger $logger
 	 */
-	public function __construct(IConfig $config, IManager $shareManager, ILogger $logger) {
+	public function __construct(
+		IConfig $config,
+		IManager $shareManager,
+		ILogger $logger,
+		IEventDispatcher $eventDispatcher
+	) {
 		$this->config = $config;
 		$this->shareManager = $shareManager;
 		$this->logger = $logger;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 
@@ -125,7 +136,14 @@ class MountProvider implements IMountProvider {
 					$view,
 					$foldersExistCache
 				);
+
+				$event = new ShareMountedEvent($mount);
+				$this->eventDispatcher->dispatchTyped($event);
+
 				$mounts[$mount->getMountPoint()] = $mount;
+				foreach ($event->getAdditionalMounts() as $additionalMount) {
+					$mounts[$additionalMount->getMountPoint()] = $additionalMount;
+				}
 			} catch (\Exception $e) {
 				$this->logger->logException($e);
 				$this->logger->error('Error while trying to create shared mount');

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -30,6 +30,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\MountProvider;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
@@ -70,8 +71,9 @@ class MountProviderTest extends \Test\TestCase {
 		$this->loader = $this->getMockBuilder('OCP\Files\Storage\IStorageFactory')->getMock();
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
 
-		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger);
+		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher);
 	}
 
 	private function makeMockShare($id, $nodeId, $owner = 'user2', $target = null, $permissions = 31) {


### PR DESCRIPTION
When a share is mounted, an event is emitted that allows listeners to setup additional mounts.

This allows apps to setup specialized mount/storage types where child mounts are automatically mounted when shared. Selectively bypassing the restriction that shares do not include any mount inside the shared folder.