### PR TITLE
Emit an error log when the app token login name does not match

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -788,9 +788,14 @@ class Session implements IUserSession, Emitter {
 
 		// Check if login names match
 		if (!is_null($user) && $dbToken->getLoginName() !== $user) {
-			// TODO: this makes it imposssible to use different login names on browser and client
+			// TODO: this makes it impossible to use different login names on browser and client
 			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
 			//      allow to use the client token with the login name 'user'.
+			$this->logger->error('App token login name does not match', [
+				'tokenLoginName' => $dbToken->getLoginName(),
+				'sessionLoginName' => $user,
+			]);
+
 			return false;
 		}
 


### PR DESCRIPTION
This is a weird limitation and unfortunately popping up recently due to a little bug in the desktop client. Let's make this error more debuggable.