### PR TITLE
Allow admins to disable 2FA backup codes via occ

### DIFF
--- a/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
+++ b/apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php
@@ -30,15 +30,15 @@ namespace OCA\TwoFactorBackupCodes\Provider;
 use OC\App\AppManager;
 use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
 use OCA\TwoFactorBackupCodes\Settings\Personal;
+use OCP\Authentication\TwoFactorAuth\IDeactivatableByAdmin;
 use OCP\Authentication\TwoFactorAuth\IPersonalProviderSettings;
-use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IProvidesPersonalSettings;
 use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\Template;
 
-class BackupCodesProvider implements IProvider, IProvidesPersonalSettings {
+class BackupCodesProvider implements IDeactivatableByAdmin, IProvidesPersonalSettings {
 
 	/** @var string */
 	private $appName;
@@ -163,5 +163,9 @@ class BackupCodesProvider implements IProvider, IProvidesPersonalSettings {
 		$state = $this->storage->getBackupCodesState($user);
 		$this->initialStateService->provideInitialState($this->appName, 'state', $state);
 		return new Personal();
+	}
+
+	public function disableFor(IUser $user) {
+		$this->storage->deleteCodes($user);
 	}
 }

--- a/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
+++ b/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
@@ -136,4 +136,8 @@ class BackupCodeStorage {
 		}
 		return false;
 	}
+
+	public function deleteCodes(IUser $user): void {
+		$this->mapper->deleteCodes($user);
+	}
 }

--- a/apps/twofactor_backupcodes/tests/Unit/Provider/BackupCodesProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Provider/BackupCodesProviderTest.php
@@ -159,4 +159,13 @@ class BackupCodesProviderTest extends TestCase {
 
 		$this->assertTrue($this->provider->isActive($user));
 	}
+
+	public function testDisable(): void {
+		$user = $this->getMockBuilder(IUser::class)->getMock();
+		$this->storage->expects(self::once())
+			->method('deleteCodes')
+			->with($user);
+
+		$this->provider->disableFor($user);
+	}
 }

--- a/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Service/BackupCodeStorageTest.php
@@ -236,4 +236,13 @@ class BackupCodeStorageTest extends TestCase {
 
 		$this->assertFalse($this->storage->validateCode($user, 'CHALLENGE'));
 	}
+
+	public function testDeleteCodes(): void {
+		$user = $this->createMock(IUser::class);
+		$this->mapper->expects($this->once())
+			->method('deleteCodes')
+			->with($user);
+
+		$this->storage->deleteCodes($user);
+	}
 }


### PR DESCRIPTION
This help when a user locked themselves out and 2FA is not enforced. Then the admin(s) can disable the providers via CLI, TOTP and U2F support this already. Backup codes couldn't do this before.

### How to test

1) Install another 2FA provider like twofactor_totp and enable the app
2) Open the personal security settings, generate backup codes
3) Run `php occ twofactorauth:state ` -> user has backup codes enabled
4) Run `php occ twofactorauth:disable` -> it works now, showed an error before
5) Run `php occ twofactorauth:state ` again -> user has backup codes disabled