### PR TITLE
Always add header-right container

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -54,12 +54,12 @@
 			</span>
 		</div>
 
+		<div class="header-right">
 		<?php
 		/** @var \OCP\AppFramework\Http\Template\PublicTemplateResponse $template */
 		if (isset($template) && $template->getActionCount() !== 0) {
 			$primary = $template->getPrimaryAction();
 			$others = $template->getOtherActions(); ?>
-		<div class="header-right">
 			<span id="header-primary-action" class="<?php if ($template->getActionCount() === 1) {
 				p($primary->getIcon());
 			} ?>">
@@ -82,9 +82,9 @@
 				</div>
 			</div>
 			<?php } ?>
-		</div>
 		<?php
 		} ?>
+		</div>
 	</header>
 	<div id="content" class="app-<?php p($_['appid']) ?>" role="main">
 		<?php print_unescaped($_['content']); ?>


### PR DESCRIPTION
As suggested by @artonge in https://github.com/nextcloud/richdocuments/pull/1707 it makes sense to have the header-right container always present even if no content is initially rendered on public pages.