### PR TITLE
Set alias for result of cast column function 

### DIFF
--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -155,7 +155,8 @@ class Manager implements IManager {
 	public function getAllConfiguredEvents() {
 		$query = $this->connection->getQueryBuilder();
 
-		$query->select('class', 'entity', $query->expr()->castColumn('events', IQueryBuilder::PARAM_STR))
+		$query->select('class', 'entity')
+			->selectAlias($query->expr()->castColumn('events', IQueryBuilder::PARAM_STR), 'events')
 			->from('flow_operations')
 			->where($query->expr()->neq('events', $query->createNamedParameter('[]'), IQueryBuilder::PARAM_STR))
 			->groupBy('class', 'entity', $query->expr()->castColumn('events', IQueryBuilder::PARAM_STR));


### PR DESCRIPTION
On OCI an expression like to_char(events) end up as $row['to_char(events)'] in the query result.

**Main**
```
Array
(
    [class] => OCA\WorkflowScript\Operation
    [entity] => OCA\WorkflowEngine\Entity\File
    [TO_CHAR("EVENTS")] => ["\\OCP\\Files::postCreate","\\OCP\\Files::postWrite","\\OCP\\Files::postRename","\\OCP\\Files::postDelete","\\OCP\\Files::postTouch","\\OCP\\Files::postCopy","OCP\\SystemTag\\ISystemTagObjectMapper::assignTags"]
)
```

**This PR**
```
Array
(
    [class] => OCA\WorkflowScript\Operation
    [entity] => OCA\WorkflowEngine\Entity\File
    [events] => ["\\OCP\\Files::postCreate","\\OCP\\Files::postWrite","\\OCP\\Files::postRename","\\OCP\\Files::postDelete","\\OCP\\Files::postTouch","\\OCP\\Files::postCopy","OCP\\SystemTag\\ISystemTagObjectMapper::assignTags"]
)
```


