### PR TITLE
Allow to open any app in a standalone window

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -372,9 +372,29 @@ class ThemingController extends Controller {
 	 */
 	public function getManifest($app) {
 		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
+		if ($app === 'core' || $app === 'settings') {
+			$name = $this->themingDefaults->getName();
+			$shortName = $this->themingDefaults->getName();
+			$startUrl = $this->urlGenerator->getBaseUrl();
+			$description = $this->themingDefaults->getSlogan();
+		} else {
+			$info = $this->appManager->getAppInfo($app);
+			$name = $info['name'] . ' - ' . $this->themingDefaults->getName();
+			$shortName = $info['name'];
+			if (strpos($this->request->getRequestUri(), '/index.php/') !== false) {
+				$startUrl = $this->urlGenerator->getBaseUrl() . '/index.php/apps/' . $app . '/';
+			} else {
+				$startUrl = $this->urlGenerator->getBaseUrl() . '/apps/' . $app . '/';
+			}
+			$description = $info['summary'];
+		}
 		$responseJS = [
-			'name' => $this->themingDefaults->getName(),
-			'start_url' => $this->urlGenerator->getBaseUrl(),
+			'name' => $name,
+			'short_name' => $shortName,
+			'start_url' => $startUrl,
+			'theme_color' => $this->themingDefaults->getColorPrimary(),
+			'background_color' => $this->themingDefaults->getColorPrimary(),
+			'description' => $description,
 			'icons' =>
 				[
 					[

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -384,7 +384,7 @@ class ThemingDefaults extends \OC_Defaults {
 				}
 			} catch (AppPathNotFoundException $e) {
 			}
-			$route = $this->urlGenerator->linkToRoute('theming.Theming.getManifest');
+			$route = $this->urlGenerator->linkToRoute('theming.Theming.getManifest', ['app' => $app ]);
 		}
 		if (strpos($image, 'filetypes/') === 0 && file_exists(\OC::$SERVERROOT . '/core/img/' . $image)) {
 			$route = $this->urlGenerator->linkToRoute('theming.Icon.getThemedIcon', ['app' => $app, 'image' => $image]);

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -823,7 +823,11 @@ class ThemingControllerTest extends TestCase {
 						'sizes' => '16x16'
 					]
 				],
-			'display' => 'standalone'
+			'display' => 'standalone',
+			'short_name' => 'Nextcloud',
+			'theme_color' => null,
+			'background_color' => null,
+			'description' => null
 		]);
 		$response->cacheFor(3600);
 		$this->assertEquals($response, $this->themingController->getManifest('core'));


### PR DESCRIPTION
## Description
This change allows to start every app in its own standalone window which is very cool for some apps that you might want to access directly from the startmenu of your OS without needing to open the browser and clicking on a favorite or app inside Nextcloud first. It applies to any app if the theming app is enabled.

## Example: Files app 
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/130442758-3005943d-d2f7-4585-952d-187e99290c1e.png) | ![image](https://user-images.githubusercontent.com/42591237/130487067-5061ccc8-f44f-4d72-bc14-3565e97477f3.png) |
| ![image](https://user-images.githubusercontent.com/42591237/130443132-01b38df6-4688-4f17-a710-3d57652953ff.png) | ![image](https://user-images.githubusercontent.com/42591237/130444233-b6578ce2-efbc-4d9e-afac-aa61d5925d5d.png) |

## Standalone window will afterwards look like this
![image](https://user-images.githubusercontent.com/42591237/130448493-f02cd9f0-5e9d-4ea5-8eeb-e4af20eec264.png)


Signed-off-by: szaimen <szaimen@e.mail.de>

