### PR TITLE
Only trap E_ERROR in session handling

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -181,7 +181,9 @@ class Internal extends Session {
 	 * @throws \ErrorException
 	 */
 	public function trapError(int $errorNumber, string $errorString) {
-		throw new \ErrorException($errorString);
+		if ($errorNumber & E_ERROR) {
+			throw new \ErrorException($errorString);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Otherwise PHP errors with any level would cause an ErrorException that would make the code behave as if the operation failed.

E.g. as reported in https://github.com/nextcloud/server/issues/28463 where the sesison gc failed which then leads to the session cookie being invalidated in https://github.com/nextcloud/server/blob/c1ea6a899c649b1ef4eb3de10f898e912448cc06/lib/private/Session/Internal.php#L55-L59 See https://github.com/nextcloud/server/issues/28463#issuecomment-900106184 for more details.