### PR TITLE
Do not retain VerifyUserData job when lookup server is not available

### DIFF
--- a/apps/settings/lib/BackgroundJobs/VerifyUserData.php
+++ b/apps/settings/lib/BackgroundJobs/VerifyUserData.php
@@ -172,7 +172,7 @@ class VerifyUserData extends Job {
 		if (empty($this->lookupServerUrl) ||
 			$this->config->getAppValue('files_sharing', 'lookupServerUploadEnabled', 'yes') !== 'yes' ||
 			$this->config->getSystemValue('has_internet_connection', true) === false) {
-			return false;
+			return true;
 		}
 
 		$user = $this->userManager->get($argument['uid']);


### PR DESCRIPTION
If the lookup server is disabled there is no need to retain a VerifyUserData job since any of the 24 attempts to verify will never succeed if the server is configured like that.

This will save some unnecessary load on the cron job execution as well as making the oc_jobs table stay in lower numbers during mass user creation.