### PR TITLE
use case insensitive like when limiting search to jail

### DIFF
--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -39,6 +39,7 @@ use OCP\Files\Search\ISearchOrder;
 class SearchBuilder {
 	protected static $searchOperatorMap = [
 		ISearchComparison::COMPARE_LIKE => 'iLike',
+		ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE => 'like',
 		ISearchComparison::COMPARE_EQUAL => 'eq',
 		ISearchComparison::COMPARE_GREATER_THAN => 'gt',
 		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'gte',
@@ -48,6 +49,7 @@ class SearchBuilder {
 
 	protected static $searchOperatorNegativeMap = [
 		ISearchComparison::COMPARE_LIKE => 'notLike',
+		ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE => 'notLike',
 		ISearchComparison::COMPARE_EQUAL => 'neq',
 		ISearchComparison::COMPARE_GREATER_THAN => 'lte',
 		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'lt',
@@ -186,8 +188,8 @@ class SearchBuilder {
 		$comparisons = [
 			'mimetype' => ['eq', 'like'],
 			'mtime' => ['eq', 'gt', 'lt', 'gte', 'lte'],
-			'name' => ['eq', 'like'],
-			'path' => ['eq', 'like'],
+			'name' => ['eq', 'like', 'clike'],
+			'path' => ['eq', 'like', 'clike'],
 			'size' => ['eq', 'gt', 'lt', 'gte', 'lte'],
 			'tagname' => ['eq', 'like'],
 			'favorite' => ['eq'],

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -313,7 +313,7 @@ class CacheJail extends CacheWrapper {
 					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR,
 						[
 							new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
-							new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', $this->getGetUnjailedRoot() . '/%'),
+							new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', $this->getGetUnjailedRoot() . '/%'),
 						],
 					)
 				]

--- a/lib/public/Files/Search/ISearchComparison.php
+++ b/lib/public/Files/Search/ISearchComparison.php
@@ -33,6 +33,7 @@ interface ISearchComparison extends ISearchOperator {
 	public const COMPARE_LESS_THAN = 'lt';
 	public const COMPARE_LESS_THAN_EQUAL = 'lte';
 	public const COMPARE_LIKE = 'like';
+	public const COMPARE_LIKE_CASE_SENSITIVE = 'clike';
 
 	/**
 	 * Get the type of comparison, one of the ISearchComparison::COMPARE_* constants


### PR DESCRIPTION
The case insensitivity isn't required and making the comparison case sensitive makes things easier for the database especially if we ever get a (partial) index on `path`