### PR TITLE
Fix SQL type error

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -656,7 +656,7 @@ class Manager implements ICommentsManager {
 
 		$unreadComments = array_fill_keys($objectIds, 0);
 		foreach (array_chunk($objectIds, 1000) as $chunk) {
-			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
 			while ($row = $result->fetch()) {


### PR DESCRIPTION
Fixing the following SQL error encountered with PostgreSQL:

    SQLSTATE[42883]: Undefined function: 7 ERROR:
    No operator matches the given name and argument types. You might need to add explicit type casts.

This prevented the Nextcloud apps/files page to show the files and directories. See #27881