### PR TITLE
Fix #20913: Check image resource before attempting to preserve alpha

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -562,9 +562,13 @@ class OC_Image implements \OCP\IImage {
 			case IMAGETYPE_GIF:
 				if (imagetypes() & IMG_GIF) {
 					$this->resource = imagecreatefromgif($imagePath);
-					// Preserve transparency
-					imagealphablending($this->resource, true);
-					imagesavealpha($this->resource, true);
+					if ($this->resource) {
+						// Preserve transparency
+						imagealphablending($this->resource, true);
+						imagesavealpha($this->resource, true);
+					} else {
+						$this->logger->debug('OC_Image->loadFromFile, GIF image not valid: ' . $imagePath, ['app' => 'core']);
+					}
 				} else {
 					$this->logger->debug('OC_Image->loadFromFile, GIF images not supported: ' . $imagePath, ['app' => 'core']);
 				}
@@ -583,9 +587,13 @@ class OC_Image implements \OCP\IImage {
 			case IMAGETYPE_PNG:
 				if (imagetypes() & IMG_PNG) {
 					$this->resource = @imagecreatefrompng($imagePath);
-					// Preserve transparency
-					imagealphablending($this->resource, true);
-					imagesavealpha($this->resource, true);
+					if ($this->resource) {
+						// Preserve transparency
+						imagealphablending($this->resource, true);
+						imagesavealpha($this->resource, true);
+					} else {
+						$this->logger->debug('OC_Image->loadFromFile, PNG image not valid: ' . $imagePath, ['app' => 'core']);
+					}
 				} else {
 					$this->logger->debug('OC_Image->loadFromFile, PNG images not supported: ' . $imagePath, ['app' => 'core']);
 				}


### PR DESCRIPTION
This fixes #20913 by first checking if an image resource has been properly created before attempting to set alpha/transparency. This is implemented for both GIF and PNG images.