### PR TITLE
Add storage info to `user:info` command

### DIFF
--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -26,6 +26,7 @@ namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
 use OCP\IGroupManager;
+use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -80,11 +81,29 @@ class Info extends Base {
 			'enabled' => $user->isEnabled(),
 			'groups' => $groups,
 			'quota' => $user->getQuota(),
+			'storage' => $this->getStorageInfo($user),
 			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];
 		$this->writeArrayInOutputFormat($input, $output, $data);
 		return 0;
+	}
+
+	/**
+	 * @param IUser $user
+	 * @return array
+	 */
+	protected function getStorageInfo(IUser $user): array {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($user->getUID());
+		$storage = \OC_Helper::getStorageInfo('/');
+		return [
+			'free' => $storage['free'],
+			'used' => $storage['used'],
+			'total' => $storage['total'],
+			'relative' => $storage['relative'],
+			'quota' => $storage['quota'],
+		];
 	}
 }


### PR DESCRIPTION
```yml
  - user_id: admin
  - display_name: admin
  - email: admin@cloud.domain.com
  - cloud_id: admin@domain.com
  - enabled: true
  - groups:
    - admin
  - quota: 50 GB
  - storage:
    - free: 29401589073
    - used: 24285502127
    - total: 53687091200
    - relative: 45.24
    - quota: 53687091200
  - last_seen: 2021-08-16T14:18:00+00:00
  - user_directory: /var/www/nextcloud/data/admin
  - backend: Database

```