### PR TITLE
Align occ status with status.php

### DIFF
--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -24,25 +24,45 @@
  */
 namespace OC\Core\Command;
 
+use OC_Util;
+use OCP\Defaults;
+use OCP\IConfig;
+use OCP\Util;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends Base {
+
+	/** @var IConfig */
+	private $config;
+	/** @var Defaults */
+	private $themingDefaults;
+
+	public function __construct(IConfig $config, Defaults $themingDefaults) {
+		parent::__construct('status');
+
+		$this->config = $config;
+		$this->themingDefaults = $themingDefaults;
+	}
+
 	protected function configure() {
 		parent::configure();
 
 		$this
-			->setName('status')
 			->setDescription('show some status information')
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$values = [
-			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
-			'version' => implode('.', \OCP\Util::getVersion()),
-			'versionstring' => \OC_Util::getVersionString(),
+			'installed' => $this->config->getSystemValueBool('installed', false),
+			'version' => implode('.', Util::getVersion()),
+			'versionstring' => OC_Util::getVersionString(),
 			'edition' => '',
+			'maintenance' => $this->config->getSystemValueBool('maintenance', false),
+			'needsDbUpgrade' => Util::needUpgrade(),
+			'productname' => $this->themingDefaults->getProductName(),
+			'extendedSupport' => Util::hasExtendedSupport()
 		];
 
 		$this->writeArrayInOutputFormat($input, $output, $values);

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -51,7 +51,7 @@ declare(strict_types=1);
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
-$application->add(new OC\Core\Command\Status);
+$application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
 $application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
 $application->add(new OC\Core\Command\App\CheckCode());
 $application->add(new OC\Core\Command\L10n\CreateJs());


### PR DESCRIPTION
Make sure that all fields that are available in status.php are also exposed when running `occ status`. Especially `needsDbUpgrade` might be useful for automated checks.