### PR TITLE
Write upgrade/not-installed notices to stderr

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -142,12 +142,14 @@ class Application {
 					}
 				}
 			} elseif ($input->getArgument('command') !== '_completion' && $input->getArgument('command') !== 'maintenance:install') {
-				$output->writeln("Nextcloud is not installed - only a limited number of commands are available");
+				$errorOutput = $output->getErrorOutput();
+				$errorOutput->writeln("Nextcloud is not installed - only a limited number of commands are available");
 			}
 		} catch (NeedsUpdateException $e) {
 			if ($input->getArgument('command') !== '_completion') {
-				$output->writeln("Nextcloud or one of the apps require upgrade - only a limited number of commands are available");
-				$output->writeln("You may use your browser or the occ upgrade command to do the upgrade");
+				$errorOutput = $output->getErrorOutput();
+				$errorOutput->writeln("Nextcloud or one of the apps require upgrade - only a limited number of commands are available");
+				$errorOutput->writeln("You may use your browser or the occ upgrade command to do the upgrade");
 			}
 		}
 


### PR DESCRIPTION
Generic warnings that are not explicitly related to the command output should be written to stderr instead of stdout as otherwise automatic parsing of command output like `occ status --output=json` becomes harder than needed.

The same approach is already taken for the maintenance mode notice in https://github.com/nextcloud/server/blob/b8b73fa9e43a44daf836275c12a546bf310a71f3/lib/private/Console/Application.php#L183

Fixes #23596