### PR TITLE
Output exception in cron

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -159,8 +159,10 @@ try {
 	exit();
 } catch (Exception $ex) {
 	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	echo $ex . PHP_EOL;
 	exit(1);
 } catch (Error $ex) {
 	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	echo $ex . PHP_EOL;
 	exit(1);
 }


### PR DESCRIPTION
When the cron job is failing, there is no output. As this is a command line script, it would be easier to debug what is causing the issue with a more front facing message.