### PR TITLE
22.1.1 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 1, 0, 1];
+$OC_Version = [22, 1, 1, 0];
 
 // The human readable string
-$OC_VersionString = '22.1.0';
+$OC_VersionString = '22.1.1 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28252 Add h2 to personal info page, fixing accessibility issue
* #28271 Bump marked from 2.0.6 to 2.0.7
* #28274 Fix CI failures when building settings app
* #28288 Check that php was compiled with argon2 support or that the php-sodium extensions is installed
* #28304 Allow upgrade from 22.1
* #28340 Bump dompurify from 2.2.8 to 2.2.9
* #28341 Bump @babel/preset-env from 7.14.8 to 7.14.9
* #28342 Bump vue-loader from 15.9.7 to 15.9.8
* #28353 Change the concurrent upload limit to less than 10
* #28359 Fix Folder->getById() when a single storage is mounted multiple times
* #28384 Make "name" column nullable for workflows
* #28416 Gracefully handle smb acls for users without a domain
* #28441 Add missing files for Composer v2
* #28446 Improve auto expiration hint for trashbin and file versions
* #28470 Only trap E_ERROR in session handling
* #28479 Disable autofocus of primary Email
* #28489 Emit an error log when the app token login name does not match
* #28494 Hash cache key
* [activity#633](https://github.com/nextcloud/activity/pull/633) Fix activity design
* [circles#776](https://github.com/nextcloud/circles/pull/776) Check if `$knownPath` is set before invoking `rtrim()`
* [circles#779](https://github.com/nextcloud/circles/pull/779) Generate quick members' memberships during migration
* [circles#782](https://github.com/nextcloud/circles/pull/782) Verify shareType in params
* [circles#787](https://github.com/nextcloud/circles/pull/787) Details on non-visible (but open) circles
* [circles#788](https://github.com/nextcloud/circles/pull/788) Fix definition on single circles
* [files_pdfviewer#460](https://github.com/nextcloud/files_pdfviewer/pull/460) Fix hide download and printing
* [files_pdfviewer#463](https://github.com/nextcloud/files_pdfviewer/pull/463) Fix body footer hiding
* [files_pdfviewer#469](https://github.com/nextcloud/files_pdfviewer/pull/469) Disable download for pdf files
* [files_rightclick#119](https://github.com/nextcloud/files_rightclick/pull/119) Fix share option being displayed erroneously
* [text#1813](https://github.com/nextcloud/text/pull/1813) Bump @babel/plugin-transform-classes from 7.14.5 to 7.14.9
* [text#1814](https://github.com/nextcloud/text/pull/1814) Bump vue-loader from 15.9.7 to 15.9.8
* [text#1815](https://github.com/nextcloud/text/pull/1815) Bump @babel/preset-env from 7.14.5 to 7.14.9


Pending PRs:

* [x] #27993  @goyome
* [x] #28209  
* [ ] #28231  
* [ ] #28256  @eneiluj
* [ ] #28373  @PVince81
* [x] #28454  
* [x] #28499  
