### PR TITLE
Improve limit for single s3 put uploads

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -62,6 +62,9 @@ trait S3ConnectionTrait {
 	/** @var int */
 	protected $uploadPartSize;
 
+	/** @var int */
+	private $putSizeLimit;
+
 	protected $test;
 
 	protected function parseParams($params) {
@@ -76,6 +79,7 @@ trait S3ConnectionTrait {
 		$this->proxy = $params['proxy'] ?? false;
 		$this->timeout = $params['timeout'] ?? 15;
 		$this->uploadPartSize = $params['uploadPartSize'] ?? 524288000;
+		$this->putSizeLimit = $params['putSizeLimit'] ?? 104857600;
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];
 		$params['hostname'] = empty($params['hostname']) ? 's3.' . $params['region'] . '.amazonaws.com' : $params['hostname'];
 		if (!isset($params['port']) || $params['port'] === '') {

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -144,9 +144,9 @@ trait S3ObjectTrait {
 		// ($psrStream->isSeekable() && $psrStream->getSize() !== null) evaluates to true for a On-Seekable stream
 		// so the optimisation does not apply
 		$buffer = new Psr7\Stream(fopen("php://memory", 'rwb+'));
-		Utils::copyToStream($psrStream, $buffer, MultipartUploader::PART_MIN_SIZE);
+		Utils::copyToStream($psrStream, $buffer, $this->uploadPartSize);
 		$buffer->seek(0);
-		if ($buffer->getSize() < MultipartUploader::PART_MIN_SIZE) {
+		if ($buffer->getSize() < $this->putSizeLimit) {
 			// buffer is fully seekable, so use it directly for the small upload
 			$this->writeSingle($urn, $buffer, $mimetype);
 		} else {


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/27877 to further address the comments from @kesselb 

> Could we use a higher value for single put operations? Like 25 or 50 MB. I understand the buffer uses the memory hence we should not pick a value to high. However most pictures have more than 5 MB nowadays.

100 MB was picked as the default, as per AWS S3 recommendation to make use of multipart upload for files larger than that:

> In general, when your object size reaches 100 MB, you should consider using multipart uploads instead of uploading the object in a single operation. 

https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html

Memory overhead is the actual file size which would fit our recommended php memory limit of 512 MB still fairly easy.
