### PR TITLE
use getGetUnjailedRoot to determine if jailed search needs the path filter

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -306,7 +306,7 @@ class CacheJail extends CacheWrapper {
 	}
 
 	public function getQueryFilterForStorage(): ISearchOperator {
-		if ($this->root !== '' && $this->root !== '/') {
+		if ($this->getGetUnjailedRoot() !== '' && $this->getGetUnjailedRoot() !== '/') {
 			return new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND,
 				[
 					$this->getCache()->getQueryFilterForStorage(),


### PR DESCRIPTION
This mostly affects shared cache where `$root` starts as `''`.

Note that the broken logic doesn't actually cause unexpected search results from showing up since the post-processing would filter these out, it does however make the search slower and messes with `limit`/`offset`