### PR TITLE
Remove error suppression

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -73,14 +73,14 @@ class AssemblyStream implements \Icewind\Streams\File {
 		$this->loadContext('assembly');
 
 		$nodes = $this->nodes;
-		// https://stackoverflow.com/a/10985500
-		@usort($nodes, function (IFile $a, IFile $b) {
+		usort($nodes, function (IFile $a, IFile $b) {
 			return strnatcmp($a->getName(), $b->getName());
 		});
 		$this->nodes = array_values($nodes);
 		$this->size = array_reduce($this->nodes, function ($size, IFile $file) {
 			return $size + $file->getSize();
 		}, 0);
+
 		return true;
 	}
 


### PR DESCRIPTION
This seems no longer needed as per https://bugs.php.net/bug.php?id=50688 (PHP>7 not affected)