### PR TITLE
Log exception message during failed ownership transfer share restore

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -349,7 +349,7 @@ class OwnershipTransferService {
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
 			} catch (\Throwable $e) {
-				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
+				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getMessage() . ' : ' . $e->getTraceAsString() . '</error>');
 			}
 			$progress->advance();
 		}


### PR DESCRIPTION
Without this patch you don't know *why* the share can't be restored. You only get a trace that doesn't tell you much.