### PR TITLE
22.1.1-rc2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 1, 1, 0];
+$OC_Version = [22, 1, 1, 1];
 
 // The human readable string
-$OC_VersionString = '22.1.1 RC1';
+$OC_VersionString = '22.1.1 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28231 Allow to disable group membership change notification
* #28256 Add quota restrictions options
* #28518 Output exception in cron
* #28522 Properly log errors in Movie previews generation
* #28534 Fix folder size contained in S3 buckets
* #28536 Set alias for result of cast column function
* #28545 Do not load versions tab view if the files app is not available
* #28553 Bump webdav from 4.6.0 to 4.6.1
* #28568 Fix UserController tests
* [circles#791](https://github.com/nextcloud/circles/pull/791) Emulate initiator on CircleJoin
* [files_pdfviewer#473](https://github.com/nextcloud/files_pdfviewer/pull/473) Fix download & print view
* [notifications#1062](https://github.com/nextcloud/notifications/pull/1062) Give twofactor nextcloud notifications a high priority
* [notifications#1065](https://github.com/nextcloud/notifications/pull/1065) Always show the dismiss all button
* [notifications#1067](https://github.com/nextcloud/notifications/pull/1067) Fix maria db tests
* [text#1732](https://github.com/nextcloud/text/pull/1732) Bump @babel/plugin-transform-modules-commonjs from 7.14.0 to 7.14.5