### PR TITLE
22.1.1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 1, 1, 1];
+$OC_Version = [22, 1, 1, 2];
 
 // The human readable string
-$OC_VersionString = '22.1.1 RC2';
+$OC_VersionString = '22.1.1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28573 Use case insensitive like when limiting search to jail
* #28576 Log exception message during failed ownership transfer share restore
* #28583 Use getGetUnjailedRoot to determine if jailed search needs the path filter
* [circles#799](https://github.com/nextcloud/circles/pull/799) Owner of NO_OWNER should not have memberships cached
* [circles#800](https://github.com/nextcloud/circles/pull/800) Fix notification when invited to a circle
* [circles#805](https://github.com/nextcloud/circles/pull/805) Exception on non visible circle
* [circles#806](https://github.com/nextcloud/circles/pull/806) Force join_request on old secret circles
* [notifications#1070](https://github.com/nextcloud/notifications/pull/1070) High priority for the PhoneTrack app
