### PR TITLE
Use storage filter when fetching previews to cleanup

### DIFF
--- a/lib/private/Files/AppData/AppData.php
+++ b/lib/private/Files/AppData/AppData.php
@@ -79,7 +79,7 @@ class AppData implements IAppData {
 		return 'appdata_' . $instanceId;
 	}
 
-	private function getAppDataRootFolder(): Folder {
+	protected function getAppDataRootFolder(): Folder {
 		$name = $this->getAppDataFolderName();
 
 		try {

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -134,6 +134,7 @@ class BackgroundCleanupJob extends TimedJob {
 			))
 			->where(
 				$qb->expr()->andX(
+					$qb->expr()->eq('a.storage', $qb->createNamedParameter($this->previewFolder->getStorageId())),
 					$qb->expr()->isNull('b.fileid'),
 					$qb->expr()->like('a.path', $qb->createNamedParameter($like)),
 					$qb->expr()->eq('a.mimetype', $qb->createNamedParameter($this->mimeTypeLoader->getId('httpd/unix-directory')))

--- a/lib/private/Preview/Storage/Root.php
+++ b/lib/private/Preview/Storage/Root.php
@@ -85,4 +85,8 @@ class Root extends AppData {
 	public static function getInternalFolder(string $name): string {
 		return implode('/', str_split(substr(md5($name), 0, 7))) . '/' . $name;
 	}
+
+	public function getStorageId(): int {
+		return $this->getAppDataRootFolder()->getStorage()->getCache()->getNumericStorageId();
+	}
 }


### PR DESCRIPTION
First attempt to speed up the slow query that is used to cleaning up previews a bit as described in https://github.com/nextcloud/server/issues/28114 in order to at least use the indexed storage column which would always be the root storage where the app data is located

The query is still quite bad with larger amounts of previews, but I don't see any further way to improve that other than basically moving back the preview cleanup to the actual deletion of files which of course would bring back the risk of timing out requests as described in https://github.com/nextcloud/server/commit/3e07c4f73a80bfa7e5de5a9e0074d2c7d35f18cc

I'll put some further ideas into https://github.com/nextcloud/server/issues/28114
