### PR TITLE
always allow dav move for movable mount root

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -125,7 +125,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	public function setName($name) {
 
 		// rename is only allowed if the update privilege is granted
-		if (!$this->info->isUpdateable()) {
+		if (!($this->info->isUpdateable() || ($this->info->getMountPoint() instanceof MoveableMount && $this->info->getInternalPath() === ''))) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 


### PR DESCRIPTION
the root of a movable mountpoint can be moved even if it doesn't have update permissions

Signed-off-by: Robin Appelman <robin@icewind.nl>