### PR TITLE
Nmc 431-harmonizing of sharing permissions step 2

### DIFF
--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -38,6 +38,27 @@
 				<span>{{ share.status.icon || '' }}</span>
 				<span>{{ share.status.message || '' }}</span>
 			</p>
+
+			<template v-if="share.canEdit">
+				<!-- folder -->
+				<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+					<select
+						:name="randomId"
+						@change="togglePermissions">
+						<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+						<option :value="publicUploadRWValue" :selected="sharePermissions === publicUploadRWValue">{{ t('files_sharing', 'Allow upload and editing') }}</option>
+					</select>
+				</template>
+				<!-- files -->
+				<template v-else>
+					<select
+						:name="randomId"
+						@change="togglePermissions">
+						<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+						<option :value="publicUploadEValue" :selected="sharePermissions === publicUploadEValue">{{ t('files_sharing', 'Editing') }}</option>
+					</select>
+				</template>
+			</template>
 		</component>
 		<Actions
 			menu-align="right"
@@ -263,6 +284,10 @@ export default {
 			return !this.isRemote
 		},
 
+		canHaveExpirationDate() {
+			return !this.isRemoteShare
+		},
+
 		isRemote() {
 			return this.share.type === this.SHARE_TYPES.SHARE_TYPE_REMOTE
 				|| this.share.type === this.SHARE_TYPES.SHARE_TYPE_REMOTE_GROUP
@@ -380,6 +405,15 @@ export default {
 		 */
 		isFolder() {
 			return this.fileInfo.type === 'dir'
+		},
+
+		/**
+		 * Does the current file/folder have create permissions
+		 * TODO: move to a proper FileInfo model?
+		 * @returns {boolean}
+		 */
+		fileHasCreatePermission() {
+			return !!(this.fileInfo.permissions & OC.PERMISSION_CREATE)
 		},
 
 		/**

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -45,53 +45,24 @@
 			@close="onMenuClose">
 			<template v-if="share.canEdit">
 				<!-- folder -->
-				<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
-					<template v-if="isRemoteShare">
-						<!-- edit permission -->
-						<ActionCheckbox
-							ref="canEdit"
-							:checked.sync="canEdit"
-							:value="permissionsEdit"
-							:disabled="saving || !canSetEdit">
-							{{ t('files_sharing', 'Allow editing') }}
-						</ActionCheckbox>
+				<template v-if="isFolder && config.isPublicUploadEnabled">
 
-						<!-- create permission -->
-						<ActionCheckbox
-							ref="canCreate"
-							:checked.sync="canCreate"
-							:value="permissionsCreate"
-							:disabled="saving || !canSetCreate">
-							{{ t('files_sharing', 'Allow creating') }}
-						</ActionCheckbox>
+					<ActionRadio :checked="sharePermissions === publicUploadRValue"
+						:value="publicUploadRValue"
+						:name="randomId"
+						:disabled="saving"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Read only') }}
+					</ActionRadio>
 
-						<!-- delete permission -->
-						<ActionCheckbox
-							ref="canDelete"
-							:checked.sync="canDelete"
-							:value="permissionsDelete"
-							:disabled="saving || !canSetDelete">
-							{{ t('files_sharing', 'Allow deleting') }}
-						</ActionCheckbox>
-					</template>
-					<template v-else>
-						<ActionRadio :checked="sharePermissions === publicUploadRValue"
-							:value="publicUploadRValue"
-							:name="randomId"
-							:disabled="saving"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Read only') }}
-						</ActionRadio>
+					<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+						:value="publicUploadRWValue"
+						:disabled="saving"
+						:name="randomId"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Allow upload and editing') }}
+					</ActionRadio>
 
-						<ActionRadio :checked="sharePermissions === publicUploadRWValue"
-							:value="publicUploadRWValue"
-							:disabled="saving"
-							:name="randomId"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Allow upload and editing') }}
-						</ActionRadio>
-
-					</template>
 				</template>
 				<!-- file -->
 				<template v-else>

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -413,7 +413,7 @@ export default {
 		 * @returns {boolean}
 		 */
 		fileHasCreatePermission() {
-			return !!(this.fileInfo.permissions & OC.PERMISSION_CREATE)
+			return Boolean(this.fileInfo.permissions & OC.PERMISSION_CREATE)
 		},
 
 		/**

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -44,34 +44,73 @@
 			class="sharing-entry__actions"
 			@close="onMenuClose">
 			<template v-if="share.canEdit">
-				<!-- edit permission -->
-				<ActionCheckbox
-					ref="canEdit"
-					:checked.sync="canEdit"
-					:value="permissionsEdit"
-					:disabled="saving || !canSetEdit">
-					{{ t('files_sharing', 'Allow editing') }}
-				</ActionCheckbox>
+				<!-- folder -->
+				<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+					<template v-if="isRemoteShare">
+						<!-- edit permission -->
+						<ActionCheckbox
+							ref="canEdit"
+							:checked.sync="canEdit"
+							:value="permissionsEdit"
+							:disabled="saving || !canSetEdit">
+							{{ t('files_sharing', 'Allow editing') }}
+						</ActionCheckbox>
 
-				<!-- create permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canCreate"
-					:checked.sync="canCreate"
-					:value="permissionsCreate"
-					:disabled="saving || !canSetCreate">
-					{{ t('files_sharing', 'Allow creating') }}
-				</ActionCheckbox>
+						<!-- create permission -->
+						<ActionCheckbox
+							ref="canCreate"
+							:checked.sync="canCreate"
+							:value="permissionsCreate"
+							:disabled="saving || !canSetCreate">
+							{{ t('files_sharing', 'Allow creating') }}
+						</ActionCheckbox>
 
-				<!-- delete permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canDelete"
-					:checked.sync="canDelete"
-					:value="permissionsDelete"
-					:disabled="saving || !canSetDelete">
-					{{ t('files_sharing', 'Allow deleting') }}
-				</ActionCheckbox>
+						<!-- delete permission -->
+						<ActionCheckbox
+							ref="canDelete"
+							:checked.sync="canDelete"
+							:value="permissionsDelete"
+							:disabled="saving || !canSetDelete">
+							{{ t('files_sharing', 'Allow deleting') }}
+						</ActionCheckbox>
+					</template>
+					<template v-else>
+						<ActionRadio :checked="sharePermissions === publicUploadRValue"
+							:value="publicUploadRValue"
+							:name="randomId"
+							:disabled="saving"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Read only') }}
+						</ActionRadio>
+
+						<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+							:value="publicUploadRWValue"
+							:disabled="saving"
+							:name="randomId"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Allow upload and editing') }}
+						</ActionRadio>
+
+					</template>
+				</template>
+				<!-- file -->
+				<template v-else>
+					<ActionRadio :checked="sharePermissions === publicUploadRValue"
+						:value="publicUploadRValue"
+						:name="randomId"
+						:disabled="saving"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Read only') }}
+					</ActionRadio>
+
+					<ActionRadio :checked="sharePermissions === publicUploadEValue"
+						:value="publicUploadEValue"
+						:disabled="saving"
+						:name="randomId"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Editing') }}
+					</ActionRadio>
+				</template>
 
 				<!-- reshare permission -->
 				<ActionCheckbox
@@ -84,7 +123,9 @@
 				</ActionCheckbox>
 
 				<!-- expiration date -->
-				<ActionCheckbox :checked.sync="hasExpirationDate"
+				<ActionCheckbox
+					v-if="canHaveExpirationDate"
+					:checked.sync="hasExpirationDate"
 					:disabled="config.isDefaultInternalExpireDateEnforced || saving"
 					@uncheck="onExpirationDisable">
 					{{ config.isDefaultInternalExpireDateEnforced
@@ -149,6 +190,7 @@
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import ActionRadio from '@nextcloud/vue/dist/Components/ActionRadio'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionTextEditable from '@nextcloud/vue/dist/Components/ActionTextEditable'
@@ -162,6 +204,7 @@ export default {
 	components: {
 		Actions,
 		ActionButton,
+		ActionRadio,
 		ActionCheckbox,
 		ActionInput,
 		ActionTextEditable,
@@ -181,10 +224,34 @@ export default {
 			permissionsDelete: OC.PERMISSION_DELETE,
 			permissionsRead: OC.PERMISSION_READ,
 			permissionsShare: OC.PERMISSION_SHARE,
+
+			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
+			publicUploadRValue: OC.PERMISSION_READ,
+			publicUploadWValue: OC.PERMISSION_CREATE | OC.PERMISSION_READ,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 		}
 	},
 
 	computed: {
+		/**
+		 * Return the current share permissions
+		 * We always ignore the SHARE permission as this is used for the
+		 * federated sharing.
+		 * @returns {number}
+		 */
+		sharePermissions() {
+			return this.share.permissions & ~OC.PERMISSION_SHARE
+		},
+		/**
+		 * Generate a unique random id for this SharingEntryLink only
+		 * This allows ActionRadios to have the same name prop
+		 * but not to impact others SharingEntryLink
+		 * @returns {string}
+		 */
+		randomId() {
+			return Math.random().toString(27).substr(2)
+		},
+
 		title() {
 			let title = this.share.shareWithDisplayName
 			if (this.share.type === this.SHARE_TYPES.SHARE_TYPE_GROUP) {
@@ -394,6 +461,17 @@ export default {
 				| (isEditChecked ? this.permissionsEdit : 0)
 				| (isReshareChecked ? this.permissionsShare : 0)
 
+			this.share.permissions = permissions
+			this.queueUpdate('permissions')
+		},
+
+		/**
+		 * On permissions change
+		 * @param {Event} event js event
+		 */
+		togglePermissions(event) {
+			const permissions = parseInt(event.target.value, 10)
+			| (this.canReshare ? this.permissionsShare : 0)
 			this.share.permissions = permissions
 			this.queueUpdate('permissions')
 		},

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -32,6 +32,31 @@
 			<p v-if="subtitle">
 				{{ subtitle }}
 			</p>
+
+			<template v-if="share">
+				<template v-if="share.canEdit">
+					<!-- folder -->
+					<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+						<select
+							:name="randomId"
+							@change="togglePermissions">
+							<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+							<option :value="publicUploadRWValue" :selected="sharePermissions === publicUploadRWValue">{{ t('files_sharing', 'Allow upload and editing') }}</option>
+							<option :value="publicUploadWValue" :selected="sharePermissions === publicUploadWValue">{{ t('files_sharing', 'File drop (upload only)') }}</option>
+						</select>
+					</template>
+
+					<!-- file -->
+					<template v-else>
+						<select
+							:name="randomId"
+							@change="togglePermissions">
+							<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+							<option :value="publicUploadEValue" :selected="sharePermissions === publicUploadEValue">{{ t('files_sharing', 'Editing') }}</option>
+						</select>
+					</template>
+				</template>
+			</template>
 		</div>
 
 		<!-- clipboard -->
@@ -584,6 +609,18 @@ export default {
 				this.share.permissions = enabled
 					? OC.PERMISSION_READ | OC.PERMISSION_UPDATE
 					: OC.PERMISSION_READ
+			},
+		},
+
+		/**
+		 * Can the sharee edit the shared file ?
+		 */
+		canEdit: {
+			get() {
+				return this.share.hasUpdatePermission
+			},
+			set(checked) {
+				this.updatePermissions({ isEditChecked: checked })
 			},
 		},
 

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -178,12 +178,23 @@
 					</template>
 
 					<!-- file -->
-					<ActionCheckbox v-else
-						:checked.sync="canUpdate"
-						:disabled="saving"
-						@change="queueUpdate('permissions')">
-						{{ t('files_sharing', 'Allow editing') }}
-					</ActionCheckbox>
+					<template v-else>
+						<ActionRadio :checked="sharePermissions === publicUploadRValue"
+							:value="publicUploadRValue"
+							:name="randomId"
+							:disabled="saving"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Read only') }}
+						</ActionRadio>
+
+						<ActionRadio :checked="sharePermissions === publicUploadEValue"
+							:value="publicUploadEValue"
+							:disabled="saving"
+							:name="randomId"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Editing') }}
+						</ActionRadio>
+					</template>
 
 					<ActionCheckbox
 						:checked.sync="share.hideDownload"
@@ -380,6 +391,7 @@ export default {
 			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
 			publicUploadRValue: OC.PERMISSION_READ,
 			publicUploadWValue: OC.PERMISSION_CREATE,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 
 			ExternalLinkActions: OCA.Sharing.ExternalLinkActions.state,
 		}


### PR DESCRIPTION
We added a new dropdown button under the display of the email-address or account name of the recipient

For folders
Internal user - Ready only and Allow upload and editing
External user - Read only, allow upload and editing, file drop
Share link - Read only, allow upload and editing, file drop
For files
Internal user - Read only, editing
External user - Read only ,editing
Share link - Read only ,editing
 Ignored hasStatus which is having message and icon below user name or email address. We are removing this functionality in sharing 4. Also Nextcloud will change something with that function after we added this new button as discussed with Jens.
Also keeping the existing options in hamburger menu, as we will remove those in sharing 3.

Signed-off-by: Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>

Based on https://github.com/nextcloud/server/pull/28635