### PR TITLE
NMC-552 Move filename/size out of the download button

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -71,6 +71,7 @@ thead {
 	display: inline-block;
 	margin-left: auto;
 	margin-right: auto;
+	margin-top: 16px;
 }
 
 .download-size {

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -82,20 +82,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 									<?php p($l->t('Download'))?>
 								</a>
 							</div>							
-						<?php } ?>					
-					<?php if(isset($_['mimetype'])){ ?>
-						 <?php	if (strpos($_['mimetype'], 'image') === 0) { ?>
-							<div class="directDownload">
-								<div>
-									<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
-								</div>
-								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
-									<span class="icon icon-download"></span>
-									<?php p($l->t('Download'))?>
-								</a>
-							</div>							
-						 <?php 	} ?>						
-					<?php } ?>					
+						<?php } ?>									
 				<?php endif; ?>
 				<?php if ($_['previewURL'] === $_['downloadURL'] && !$_['hideDownload']): ?>
 					<div class="directDownload">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -72,6 +72,17 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php else: ?>
 					<!-- Preview frame is filled via JS to support SVG images for modern browsers -->
 					<div id="imgframe"></div>
+						<?php if (isset($_['mimetype']) && strpos($_['mimetype'], 'image') === 0) { ?>
+							<div class="directDownload">
+								<div class="video-file-details">
+									<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
+								</div>
+								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
+									<span class="icon icon-download"></span>
+									<?php p($l->t('Download'))?>
+								</a>
+							</div>							
+						<?php } ?>					
 					<?php if(isset($_['mimetype'])){ ?>
 						 <?php	if (strpos($_['mimetype'], 'image') === 0) { ?>
 							<div class="directDownload">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -72,6 +72,19 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php else: ?>
 					<!-- Preview frame is filled via JS to support SVG images for modern browsers -->
 					<div id="imgframe"></div>
+					<?php if(isset($_['mimetype'])){ ?>
+						 <?php	if (strpos($_['mimetype'], 'image') === 0) { ?>
+							<div class="directDownload">
+								<div class="video-file-details">
+									<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
+								</div>
+								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
+									<span class="icon icon-download"></span>
+									<?php p($l->t('Download'))?>
+								</a>
+							</div>							
+						 <?php 	} ?>						
+					<?php } ?>					
 				<?php endif; ?>
 				<?php if ($_['previewURL'] === $_['downloadURL'] && !$_['hideDownload']): ?>
 					<div class="directDownload">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -74,7 +74,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<div id="imgframe"></div>
 						<?php if (isset($_['mimetype']) && strpos($_['mimetype'], 'image') === 0) { ?>
 							<div class="directDownload">
-								<div class="video-file-details">
+								<div>
 									<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
 								</div>
 								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
@@ -86,7 +86,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 					<?php if(isset($_['mimetype'])){ ?>
 						 <?php	if (strpos($_['mimetype'], 'image') === 0) { ?>
 							<div class="directDownload">
-								<div class="video-file-details">
+								<div>
 									<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
 								</div>
 								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -75,9 +75,12 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 				<?php endif; ?>
 				<?php if ($_['previewURL'] === $_['downloadURL'] && !$_['hideDownload']): ?>
 					<div class="directDownload">
+						<div>
+							<?php p($l->t('%s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
+						</div>
 						<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
 							<span class="icon icon-download"></span>
-							<?php p($l->t('Download %s', [$_['filename']]))?> (<?php p($_['fileSize']) ?>)
+							<?php p($l->t('Download'))?>
 						</a>
 					</div>
 				<?php endif; ?>


### PR DESCRIPTION
Guest view below changes done

1. For Video separated download button form file name and size
2. For Image separated download button form file name and size