### PR TITLE
Fix filter declaration in settings appinfo.xml

### DIFF
--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -47,9 +47,9 @@
 			<setting>OCA\Settings\Activity\SecuritySetting</setting>
 			<setting>OCA\Settings\Activity\Setting</setting>
 		</settings>
-		<filter>
+		<filters>
 			<filter>OCA\Settings\Activity\SecurityFilter</filter>
-		</filter>
+		</filters>
 		<providers>
 			<provider>OCA\Settings\Activity\GroupProvider</provider>
 			<provider>OCA\Settings\Activity\Provider</provider>


### PR DESCRIPTION
It's probably just a small typo introduced in 2020. Found by using the
app-info-shipped.xsd file.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>