### PR TITLE
A session had already been started - ignoring at /home/mydomain/public/lib/private/Session/Internal.php#208

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -103,7 +103,9 @@ class Internal extends Session {
 	public function clear() {
 		$this->invoke('session_unset');
 		$this->regenerateId();
-		$this->startSession(true);
+		if(!isset($_SESSION)){
+			$this->startSession(true);
+		}
 		$_SESSION = [];
 	}
 


### PR DESCRIPTION
I have an error in the nextcloud.log after log out every time. 

session_start(): A session had already been started - ignoring at /home/mydomain/public/lib/private/Session/Internal.php#208