### PR TITLE
Pin Psalm version for security analysis

### DIFF
--- a/.github/workflows/psalm-github.yml
+++ b/.github/workflows/psalm-github.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:4.9.3
         continue-on-error: true
         with:
           composer_ignore_platform_reqs: false

--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           submodules: recursive
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:4.9.3
         with:
           security_analysis: true
           composer_ignore_platform_reqs: false


### PR DESCRIPTION
The action will otherwise pull dev-master and this can break easily as
we just experienced.

Ref https://github.com/psalm/psalm-github-actions#specify-psalm-version
Ref https://github.com/nextcloud/server/pull/28692#issuecomment-912398313