### PR TITLE
[stable21] Pin Psalm version for security analysis

### DIFF
--- a/.github/workflows/psalm-security.yml
+++ b/.github/workflows/psalm-security.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: recursive
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions:4.9.3
         with:
           security_analysis: true
           report_file: results.sarif


### PR DESCRIPTION
Manual backport of #28700, required as dedicated `psalm-github.yml` workflow does not yet exist on `stable21`.