### PR TITLE
Fix trashbin files view sticky action bar

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -306,7 +306,8 @@ table th.column-last, table td.column-last {
 	max-width: 130px;
 }
 
-#app-content-files thead {
+#app-content-files thead,
+#app-content-trashbin thead {
 	top: 94px;
 }
 


### PR DESCRIPTION
Hi there,

It's a simple quick fix for the action bar of the trashbin view. When you selected some files, the sticky position wasn't activated on scroll and you had to go to the top to have access to the action menu.

Have a nice day.