### PR TITLE
add psalm return type to SimpleContainer::get using templates

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -52,6 +52,11 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 		$this->container = new Container();
 	}
 
+	/**
+	 * @template T
+	 * @psalm-param class-string<T> $id
+	 * @psalm-return T
+	 */
 	public function get(string $id) {
 		return $this->query($id);
 	}


### PR DESCRIPTION
this way psalm (and phpstorm) know what `\OC::$server->get(...)` returns

Signed-off-by: Robin Appelman <robin@icewind.nl>