### PR TITLE
Do not cache file ids in FileSystemTags inside group folders

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -77,6 +77,11 @@
 		<file name="build/stubs/xsl.php"/>
 	</stubs>
 	<issueHandlers>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OCA\GroupFolders\Mount\GroupFolderStorage"/>
+			</errorLevel>
+		</UndefinedClass>
 		<UndefinedFunction>
 			<errorLevel type="suppress">
 				<!-- template functions: https://github.com/nextcloud/server/blob/6e8e34fef920a073118c22111f0f31eb3b3a91dc/lib/private/legacy/template/functions.php -->


### PR DESCRIPTION
The numerical storage id returned by a cache might not be unique because it is passed down the CacheWrapper chain. Multiple caches may return the same numerical id. Additionally, when combined with the CacheJail wrapper multiple files may be mapped to the same numerical id + path combination even if they represent separate entries in the file cache. 

In this case the first inserted file id for the combination of numerical id and path "wins" and blocks any subsequent insertions. This will lead to invalid tags being returned.

## How to reproduce:
1. Install groupfolders and files_accesscontrol.
2. Create a group folder "Groupfolder".
3. Create another group folder nested inside the first one "Groupfolder/folder-1".
4. Create a system tag "AccessDenied".
5. Add a workflow to block access to all files with "AccessDenied" tag.
6. Tag the inner group folder at "Groupfolder/folder-1" with the new tag.
7. Try to access the inner folder at "Groupfolder/folder-1".

**Expected:** The access should be blocked.
**Actual:** You can navigate to "Groupfolder/folder-1" and list its contents.