### PR TITLE
fixes missing prefix to validate password reset token

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -172,7 +172,8 @@ class LostController extends Controller {
 	 */
 	protected function checkPasswordResetToken(string $token, string $userId): void {
 		try {
-			$this->verificationToken->check($token, $this->userManager->get($userId), 'lostpassword', '', true);
+			$user = $this->userManager->get($userId);
+			$this->verificationToken->check($token, $user, 'lostpassword', $user ? $user->getEMailAddress() : '', true);
 		} catch (InvalidTokenException $e) {
 			$error = $e->getCode() === InvalidTokenException::TOKEN_EXPIRED
 				? $this->l10n->t('Could not reset password because the token is expired')

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -153,7 +153,7 @@ class LostControllerTest extends \Test\TestCase {
 			->willReturn($this->existingUser);
 		$this->verificationToken->expects($this->once())
 			->method('check')
-			->with('12345:MySecretToken', $this->existingUser, 'lostpassword')
+			->with('12345:MySecretToken', $this->existingUser, 'lostpassword', 'test@example.com')
 			->willThrowException(new InvalidTokenException(InvalidTokenException::TOKEN_DECRYPTION_ERROR));
 
 		$response = $this->lostController->resetform('12345:MySecretToken', 'ValidTokenUser');
@@ -174,7 +174,7 @@ class LostControllerTest extends \Test\TestCase {
 			->willReturn($this->existingUser);
 		$this->verificationToken->expects($this->once())
 			->method('check')
-			->with('MySecretToken', $this->existingUser, 'lostpassword');
+			->with('MySecretToken', $this->existingUser, 'lostpassword', 'test@example.com');
 
 		$response = $this->lostController->resetform('MySecretToken', 'ValidTokenUser');
 		$expectedResponse = new TemplateResponse('core',
@@ -513,6 +513,9 @@ class LostControllerTest extends \Test\TestCase {
 			->willReturn(false);
 		$user->expects($this->never())
 			->method('setPassword');
+		$user->expects($this->any())
+			->method('getEMailAddress')
+			->willReturn('random@example.org');
 
 		$this->config->method('getUserValue')
 			->with('ValidTokenUser', 'core', 'lostpassword', null)


### PR DESCRIPTION
- also fixes the test which missed asserting the presence of it

was introduced with #28422 


### reproduction steps

use the password reset mechanism, or add a guest user and try to activate