### PR TITLE
allow using of disabled password reset mechanism for special cases

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -134,22 +134,24 @@ class LostController extends Controller {
 	 * @return TemplateResponse
 	 */
 	public function resetform($token, $userId) {
-		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
-			return new TemplateResponse('core', 'error', [
-				'errors' => [['error' => $this->l10n->t('Password reset is disabled')]]
-			],
-				'guest'
-			);
-		}
-
 		try {
 			$this->checkPasswordResetToken($token, $userId);
 		} catch (\Exception $e) {
-			return new TemplateResponse(
-				'core', 'error', [
-					"errors" => [["error" => $e->getMessage()]]
-				],
-				'guest'
+			if ($this->config->getSystemValue('lost_password_link', '') !== 'disabled'
+				|| ($e instanceof InvalidTokenException
+					&& !in_array($e->getCode(), [InvalidTokenException::TOKEN_NOT_FOUND, InvalidTokenException::USER_UNKNOWN]))
+			) {
+				return new TemplateResponse(
+					'core', 'error', [
+						"errors" => [["error" => $e->getMessage()]]
+					],
+					TemplateResponse::RENDER_AS_GUEST
+				);
+			}
+			return new TemplateResponse('core', 'error', [
+				'errors' => [['error' => $this->l10n->t('Password reset is disabled')]]
+			],
+				TemplateResponse::RENDER_AS_GUEST
 			);
 		}
 		$this->initialStateService->provideInitialState('core', 'resetPasswordUser', $userId);
@@ -241,10 +243,6 @@ class LostController extends Controller {
 	 * @return array
 	 */
 	public function setPassword($token, $userId, $password, $proceed) {
-		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
-			return $this->error($this->l10n->t('Password reset is disabled'));
-		}
-
 		if ($this->encryptionManager->isEnabled() && !$proceed) {
 			$encryptionModules = $this->encryptionManager->getEncryptionModules();
 			foreach ($encryptionModules as $module) {


### PR DESCRIPTION
- LostController has three endpoints
- door opener email() still rejects
- resetform(), reachable from mail, checks the token first and may report
  that password reset is disabled
- setPassword() got its check removed as it is behind CSFR anyway and still
  requires a valid token
- this allows special cases like activating a freshly created guest account


fixes https://github.com/nextcloud/guests/issues/85

* [x] https://github.com/nextcloud/server/pull/28792 required by master and stable22 

### How to reproduce

1. add to config.php: `'lost_password_link' => 'disabled',`
2. enable guest app
3. invite guest user
4. on the received invitation email, click "activate"