### PR TITLE
Nmc 434-changed the process of sharing

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -430,6 +430,7 @@ class ShareAPIController extends OCSController {
 	 * @param string $sendPasswordByTalk
 	 * @param string $expireDate
 	 * @param string $label
+	 * @param string $hideDownload
 	 *
 	 * @return DataResponse
 	 * @throws NotFoundException
@@ -449,7 +450,8 @@ class ShareAPIController extends OCSController {
 		string $password = '',
 		string $sendPasswordByTalk = null,
 		string $expireDate = '',
-		string $label = ''
+		string $label = '',
+		string $hideDownload = null
 	): DataResponse {
 		$share = $this->shareManager->newShare();
 
@@ -506,6 +508,15 @@ class ShareAPIController extends OCSController {
 			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
+
+			if ($expireDate !== '') {
+				try {
+					$expireDate = $this->parseDate($expireDate);
+					$share->setExpirationDate($expireDate);
+				} catch (\Exception $e) {
+					throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
+				}
+			}
 		} elseif ($shareType === IShare::TYPE_GROUP) {
 			if (!$this->shareManager->allowGroupSharing()) {
 				throw new OCSNotFoundException($this->l->t('Group sharing is disabled by the administrator'));
@@ -517,6 +528,15 @@ class ShareAPIController extends OCSController {
 			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
+
+			if ($expireDate !== '') {
+				try {
+					$expireDate = $this->parseDate($expireDate);
+					$share->setExpirationDate($expireDate);
+				} catch (\Exception $e) {
+					throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
+				}
+			}
 		} elseif ($shareType === IShare::TYPE_LINK
 			|| $shareType === IShare::TYPE_EMAIL) {
 
@@ -542,6 +562,13 @@ class ShareAPIController extends OCSController {
 					Constants::PERMISSION_DELETE;
 			} else {
 				$permissions = Constants::PERMISSION_READ;
+			}
+
+			// Update hide download state
+			if ($hideDownload === 'true') {
+				$share->setHideDownload(true);
+			} elseif ($hideDownload === 'false') {
+				$share->setHideDownload(false);
 			}
 
 			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -43,100 +43,6 @@
 			menu-align="right"
 			class="sharing-entry__actions"
 			@close="onMenuClose">
-<<<<<<< HEAD
-			<template v-if="share.canEdit">
-				<!-- edit permission -->
-				<ActionCheckbox
-					ref="canEdit"
-					:checked.sync="canEdit"
-					:value="permissionsEdit"
-					:disabled="saving || !canSetEdit">
-					{{ t('files_sharing', 'Allow editing') }}
-				</ActionCheckbox>
-
-				<!-- create permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canCreate"
-					:checked.sync="canCreate"
-					:value="permissionsCreate"
-					:disabled="saving || !canSetCreate">
-					{{ t('files_sharing', 'Allow creating') }}
-				</ActionCheckbox>
-
-				<!-- delete permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canDelete"
-					:checked.sync="canDelete"
-					:value="permissionsDelete"
-					:disabled="saving || !canSetDelete">
-					{{ t('files_sharing', 'Allow deleting') }}
-				</ActionCheckbox>
-
-				<!-- reshare permission -->
-				<ActionCheckbox
-					v-if="config.isResharingAllowed"
-					ref="canReshare"
-					:checked.sync="canReshare"
-					:value="permissionsShare"
-					:disabled="saving || !canSetReshare">
-					{{ t('files_sharing', 'Allow resharing') }}
-				</ActionCheckbox>
-
-				<!-- expiration date -->
-				<ActionCheckbox :checked.sync="hasExpirationDate"
-					:disabled="config.isDefaultInternalExpireDateEnforced || saving"
-					@uncheck="onExpirationDisable">
-					{{ config.isDefaultInternalExpireDateEnforced
-						? t('files_sharing', 'Expiration date enforced')
-						: t('files_sharing', 'Set expiration date') }}
-				</ActionCheckbox>
-				<ActionInput v-if="hasExpirationDate"
-					ref="expireDate"
-					v-tooltip.auto="{
-						content: errors.expireDate,
-						show: errors.expireDate,
-						trigger: 'manual'
-					}"
-					:class="{ error: errors.expireDate}"
-					:disabled="saving"
-					:first-day-of-week="firstDay"
-					:lang="lang"
-					:value="share.expireDate"
-					value-type="format"
-					icon="icon-calendar-dark"
-					type="date"
-					:disabled-date="disabledDate"
-					@update:value="onExpirationChange">
-					{{ t('files_sharing', 'Enter a date') }}
-				</ActionInput>
-
-				<!-- note -->
-				<template v-if="canHaveNote">
-					<ActionCheckbox
-						:checked.sync="hasNote"
-						:disabled="saving"
-						@uncheck="queueUpdate('note')">
-						{{ t('files_sharing', 'Note to recipient') }}
-					</ActionCheckbox>
-					<ActionTextEditable v-if="hasNote"
-						ref="note"
-						v-tooltip.auto="{
-							content: errors.note,
-							show: errors.note,
-							trigger: 'manual'
-						}"
-						:class="{ error: errors.note}"
-						:disabled="saving"
-						:value="share.newNote || share.note"
-						icon="icon-edit"
-						@update:value="onNoteChange"
-						@submit="onNoteSubmit" />
-				</template>
-			</template>
-
-=======
 			<ActionButton v-if="share.canEdit"
 				icon="icon-settings"
 				:disabled="saving"
@@ -151,7 +57,6 @@
 				@click.prevent="editNotes">
 				{{ t('files_sharing', 'Send new mail') }}
 			</ActionButton>
->>>>>>> e994a1f60d... NMC-434 - changed the process of file sharing for internal and external sharee
 			<ActionButton v-if="share.canDelete"
 				icon="icon-close"
 				:disabled="saving"

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -166,61 +166,9 @@ export default {
 			return null
 		},
 
-		canHaveNote() {
-			return !this.isRemote
-		},
-
 		isRemote() {
 			return this.share.type === this.SHARE_TYPES.SHARE_TYPE_REMOTE
 				|| this.share.type === this.SHARE_TYPES.SHARE_TYPE_REMOTE_GROUP
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can edit the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetEdit() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_UPDATE) || this.canEdit
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can create the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetCreate() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_CREATE) || this.canCreate
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can delete the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetDelete() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_DELETE) || this.canDelete
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can reshare the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetReshare() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_SHARE) || this.canReshare
 		},
 
 		/**
@@ -288,33 +236,6 @@ export default {
 		isFolder() {
 			return this.fileInfo.type === 'dir'
 		},
-
-		/**
-		 * Does the current share have an expiration date
-		 * @returns {boolean}
-		 */
-		// hasExpirationDate: {
-		// 	get() {
-		// 		return this.config.isDefaultInternalExpireDateEnforced || !!this.share.expireDate
-		// 	},
-		// 	set(enabled) {
-		// 		this.share.expireDate = enabled
-		// 			? this.config.defaultInternalExpirationDateString !== ''
-		// 				? this.config.defaultInternalExpirationDateString
-		// 				: moment().format('YYYY-MM-DD')
-		// 			: ''
-		// 	},
-		// },
-
-		// dateMaxEnforced() {
-		// 	if (!this.isRemote) {
-		// 		return this.config.isDefaultInternalExpireDateEnforced
-		// 			&& moment().add(1 + this.config.defaultInternalExpireDate, 'days')
-		// 	} else {
-		// 		return this.config.isDefaultRemoteExpireDateEnforced
-		// 			&& moment().add(1 + this.config.defaultRemoteExpireDate, 'days')
-		// 	}
-		// },
 
 		/**
 		 * @returns {bool}

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -39,10 +39,11 @@
 				<span>{{ share.status.message || '' }}</span>
 			</p>
 		</component>
-		<Actions
+		<Actions v-if="open === false"
 			menu-align="right"
 			class="sharing-entry__actions"
 			@close="onMenuClose">
+<<<<<<< HEAD
 			<template v-if="share.canEdit">
 				<!-- edit permission -->
 				<ActionCheckbox
@@ -135,6 +136,22 @@
 				</template>
 			</template>
 
+=======
+			<ActionButton v-if="share.canEdit"
+				icon="icon-settings"
+				:disabled="saving"
+				:share="share"
+				@click.prevent="editPermissions">
+				{{ t('files_sharing', 'Advanced permission') }}
+			</ActionButton>
+			<ActionButton v-if="share.canEdit"
+				icon="icon-mail"
+				:disabled="saving"
+				:share="share"
+				@click.prevent="editNotes">
+				{{ t('files_sharing', 'Send new mail') }}
+			</ActionButton>
+>>>>>>> e994a1f60d... NMC-434 - changed the process of file sharing for internal and external sharee
 			<ActionButton v-if="share.canDelete"
 				icon="icon-close"
 				:disabled="saving"
@@ -181,10 +198,33 @@ export default {
 			permissionsDelete: OC.PERMISSION_DELETE,
 			permissionsRead: OC.PERMISSION_READ,
 			permissionsShare: OC.PERMISSION_SHARE,
+
+			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
+			publicUploadRValue: OC.PERMISSION_READ,
+			publicUploadWValue: OC.PERMISSION_CREATE,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 		}
 	},
 
 	computed: {
+		/**
+		 * Return the current share permissions
+		 * We always ignore the SHARE permission as this is used for the
+		 * federated sharing.
+		 * @returns {number}
+		 */
+		sharePermissions() {
+			return this.share.permissions & ~OC.PERMISSION_SHARE
+		},
+
+		/**
+		 * Generate a unique random id for this SharingEntry only
+		 * @returns {string}
+		 */
+		randomId() {
+			return Math.random().toString(27).substr(2)
+		},
+
 		title() {
 			let title = this.share.shareWithDisplayName
 			if (this.share.type === this.SHARE_TYPES.SHARE_TYPE_GROUP) {
@@ -348,28 +388,28 @@ export default {
 		 * Does the current share have an expiration date
 		 * @returns {boolean}
 		 */
-		hasExpirationDate: {
-			get() {
-				return this.config.isDefaultInternalExpireDateEnforced || !!this.share.expireDate
-			},
-			set(enabled) {
-				this.share.expireDate = enabled
-					? this.config.defaultInternalExpirationDateString !== ''
-						? this.config.defaultInternalExpirationDateString
-						: moment().format('YYYY-MM-DD')
-					: ''
-			},
-		},
+		// hasExpirationDate: {
+		// 	get() {
+		// 		return this.config.isDefaultInternalExpireDateEnforced || !!this.share.expireDate
+		// 	},
+		// 	set(enabled) {
+		// 		this.share.expireDate = enabled
+		// 			? this.config.defaultInternalExpirationDateString !== ''
+		// 				? this.config.defaultInternalExpirationDateString
+		// 				: moment().format('YYYY-MM-DD')
+		// 			: ''
+		// 	},
+		// },
 
-		dateMaxEnforced() {
-			if (!this.isRemote) {
-				return this.config.isDefaultInternalExpireDateEnforced
-					&& moment().add(1 + this.config.defaultInternalExpireDate, 'days')
-			} else {
-				return this.config.isDefaultRemoteExpireDateEnforced
-					&& moment().add(1 + this.config.defaultRemoteExpireDate, 'days')
-			}
-		},
+		// dateMaxEnforced() {
+		// 	if (!this.isRemote) {
+		// 		return this.config.isDefaultInternalExpireDateEnforced
+		// 			&& moment().add(1 + this.config.defaultInternalExpireDate, 'days')
+		// 	} else {
+		// 		return this.config.isDefaultRemoteExpireDateEnforced
+		// 			&& moment().add(1 + this.config.defaultRemoteExpireDate, 'days')
+		// 	}
+		// },
 
 		/**
 		 * @returns {bool}
@@ -404,6 +444,18 @@ export default {
 		onMenuClose() {
 			this.onNoteSubmit()
 		},
+
+		editPermissions() {
+			this.$store.commit('addFromInput', false)
+			this.$store.commit('addShare', this.share)
+			this.$store.commit('addCurrentTab', 'permissions')
+		},
+
+		editNotes() {
+			this.$store.commit('addFromInput', false)
+			this.$store.commit('addShare', this.share)
+			this.$store.commit('addCurrentTab', 'notes')
+		},
 	},
 }
 </script>
@@ -412,7 +464,7 @@ export default {
 .sharing-entry {
 	display: flex;
 	align-items: center;
-	height: 44px;
+	min-height: 44px;
 	&__desc {
 		display: flex;
 		flex-direction: column;

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -131,176 +131,26 @@
 			:open.sync="open"
 			@close="onMenuClose">
 			<template v-if="share">
-				<template v-if="share.canEdit && canReshare">
-					<!-- Custom Label -->
-					<ActionInput
-						ref="label"
-						v-tooltip.auto="{
-							content: errors.label,
-							show: errors.label,
-							trigger: 'manual',
-							defaultContainer: '.app-sidebar'
-						}"
-						:class="{ error: errors.label }"
-						:disabled="saving"
-						:aria-label="t('files_sharing', 'Share label')"
-						:value="share.newLabel !== undefined ? share.newLabel : share.label"
-						icon="icon-edit"
-						maxlength="255"
-						@update:value="onLabelChange"
-						@submit="onLabelSubmit">
-						{{ t('files_sharing', 'Share label') }}
-					</ActionInput>
-					<!-- folder -->
-					<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
-						<ActionRadio :checked="sharePermissions === publicUploadRValue"
-							:value="publicUploadRValue"
-							:name="randomId"
-							:disabled="saving"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Read only') }}
-						</ActionRadio>
-						<ActionRadio :checked="sharePermissions === publicUploadRWValue"
-							:value="publicUploadRWValue"
-							:disabled="saving"
-							:name="randomId"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Allow upload and editing') }}
-						</ActionRadio>
-						<ActionRadio :checked="sharePermissions === publicUploadWValue"
-							:value="publicUploadWValue"
-							:disabled="saving"
-							:name="randomId"
-							class="sharing-entry__action--public-upload"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'File drop (upload only)') }}
-						</ActionRadio>
-					</template>
-
-					<!-- file -->
-					<ActionCheckbox v-else
-						:checked.sync="canUpdate"
-						:disabled="saving"
-						@change="queueUpdate('permissions')">
-						{{ t('files_sharing', 'Allow editing') }}
-					</ActionCheckbox>
-
-					<ActionCheckbox
-						:checked.sync="share.hideDownload"
-						:disabled="saving"
-						@change="queueUpdate('hideDownload')">
-						{{ t('files_sharing', 'Hide download') }}
-					</ActionCheckbox>
-
-					<!-- password -->
-					<ActionCheckbox :checked.sync="isPasswordProtected"
-						:disabled="config.enforcePasswordForPublicLink || saving"
-						class="share-link-password-checkbox"
-						@uncheck="onPasswordDisable">
-						{{ config.enforcePasswordForPublicLink
-							? t('files_sharing', 'Password protection (enforced)')
-							: t('files_sharing', 'Password protect') }}
-					</ActionCheckbox>
-					<ActionInput v-if="isPasswordProtected"
-						ref="password"
-						v-tooltip.auto="{
-							content: errors.password,
-							show: errors.password,
-							trigger: 'manual',
-							defaultContainer: '#app-sidebar'
-						}"
-						class="share-link-password"
-						:class="{ error: errors.password}"
-						:disabled="saving"
-						:required="config.enforcePasswordForPublicLink"
-						:value="hasUnsavedPassword ? share.newPassword : '***************'"
-						icon="icon-password"
-						autocomplete="new-password"
-						:type="hasUnsavedPassword ? 'text': 'password'"
-						@update:value="onPasswordChange"
-						@submit="onPasswordSubmit">
-						{{ t('files_sharing', 'Enter a password') }}
-					</ActionInput>
-
-					<!-- password protected by Talk -->
-					<ActionCheckbox v-if="isPasswordProtectedByTalkAvailable"
-						:checked.sync="isPasswordProtectedByTalk"
-						:disabled="!canTogglePasswordProtectedByTalkAvailable || saving"
-						class="share-link-password-talk-checkbox"
-						@change="onPasswordProtectedByTalkChange">
-						{{ t('files_sharing', 'Video verification') }}
-					</ActionCheckbox>
-
-					<!-- expiration date -->
-					<ActionCheckbox :checked.sync="hasExpirationDate"
-						:disabled="config.isDefaultExpireDateEnforced || saving"
-						class="share-link-expire-date-checkbox"
-						@uncheck="onExpirationDisable">
-						{{ config.isDefaultExpireDateEnforced
-							? t('files_sharing', 'Expiration date (enforced)')
-							: t('files_sharing', 'Set expiration date') }}
-					</ActionCheckbox>
-					<ActionInput v-if="hasExpirationDate"
-						ref="expireDate"
-						v-tooltip.auto="{
-							content: errors.expireDate,
-							show: errors.expireDate,
-							trigger: 'manual',
-							defaultContainer: '#app-sidebar'
-						}"
-						class="share-link-expire-date"
-						:class="{ error: errors.expireDate}"
-						:disabled="saving"
-						:first-day-of-week="firstDay"
-						:lang="lang"
-						:value="share.expireDate"
-						value-type="format"
-						icon="icon-calendar-dark"
-						type="date"
-						:disabled-date="disabledDate"
-						@update:value="onExpirationChange">
-						{{ t('files_sharing', 'Enter a date') }}
-					</ActionInput>
-
-					<!-- note -->
-					<ActionCheckbox :checked.sync="hasNote"
-						:disabled="saving"
-						@uncheck="queueUpdate('note')">
-						{{ t('files_sharing', 'Note to recipient') }}
-					</ActionCheckbox>
-					<ActionTextEditable v-if="hasNote"
-						ref="note"
-						v-tooltip.auto="{
-							content: errors.note,
-							show: errors.note,
-							trigger: 'manual',
-							defaultContainer: '#app-sidebar'
-						}"
-						:class="{ error: errors.note}"
-						:disabled="saving"
-						:placeholder="t('files_sharing', 'Enter a note for the share recipient')"
-						:value="share.newNote || share.note"
-						icon="icon-edit"
-						@update:value="onNoteChange"
-						@submit="onNoteSubmit" />
-				</template>
-
-				<!-- external actions -->
-				<ExternalShareAction v-for="action in externalLinkActions"
-					:id="action.id"
-					:key="action.id"
-					:action="action"
-					:file-info="fileInfo"
-					:share="share" />
-
-				<!-- external legacy sharing via url (social...) -->
-				<ActionLink v-for="({icon, url, name}, index) in externalLegacyLinkActions"
+				<!-- external sharing via url (social...) -->
+				<ActionLink v-for="({icon, url, name}, index) in externalActions"
 					:key="index"
 					:href="url(shareLink)"
 					:icon="icon"
 					target="_blank">
 					{{ name }}
 				</ActionLink>
+				<ActionButton v-if="share.canEdit"
+					icon="icon-settings"
+					:disabled="saving"
+					@click.prevent="editPermissions">
+					{{ t('files_sharing', 'Advanced permission') }}
+				</ActionButton>
+				<ActionButton v-if="share.canEdit"
+					icon="icon-mail"
+					:disabled="saving"
+					@click.prevent="editNotes">
+					{{ t('files_sharing', 'Send new mail') }}
+				</ActionButton>
 
 				<ActionButton v-if="share.canDelete"
 					icon="icon-close"
@@ -340,7 +190,7 @@ import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import ActionRadio from '@nextcloud/vue/dist/Components/ActionRadio'
 import ActionText from '@nextcloud/vue/dist/Components/ActionText'
-import ActionTextEditable from '@nextcloud/vue/dist/Components/ActionTextEditable'
+import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
@@ -357,11 +207,9 @@ export default {
 		Actions,
 		ActionButton,
 		ActionCheckbox,
-		ActionRadio,
 		ActionInput,
 		ActionLink,
 		ActionText,
-		ActionTextEditable,
 		Avatar,
 		ExternalShareAction,
 	},
@@ -408,8 +256,6 @@ export default {
 		},
 		/**
 		 * Generate a unique random id for this SharingEntryLink only
-		 * This allows ActionRadios to have the same name prop
-		 * but not to impact others SharingEntryLink
 		 * @returns {string}
 		 */
 		randomId() {
@@ -921,8 +767,19 @@ export default {
 			// YET. We can safely delete the share :)
 			this.$emit('remove:share', this.share)
 		},
-	},
 
+		editPermissions() {
+			this.$store.commit('addFromInput', false)
+			this.$store.commit('addShare', this.share)
+			this.$store.commit('addCurrentTab', 'permissions')
+		},
+
+		editNotes() {
+			this.$store.commit('addFromInput', false)
+			this.$store.commit('addShare', this.share)
+			this.$store.commit('addCurrentTab', 'notes')
+		},
+	},
 }
 </script>
 

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -310,32 +310,6 @@ export default {
 		},
 
 		/**
-		 * Does the current share have an expiration date
-		 * @returns {boolean}
-		 */
-		hasExpirationDate: {
-			get() {
-				return this.config.isDefaultExpireDateEnforced
-					|| !!this.share.expireDate
-			},
-			set(enabled) {
-				let dateString = moment(this.config.defaultExpirationDateString)
-				if (!dateString.isValid()) {
-					dateString = moment()
-				}
-				this.share.state.expiration = enabled
-					? dateString.format('YYYY-MM-DD')
-					: ''
-				console.debug('Expiration date status', enabled, this.share.expireDate)
-			},
-		},
-
-		dateMaxEnforced() {
-			return this.config.isDefaultExpireDateEnforced
-				&& moment().add(1 + this.config.defaultExpireDate, 'days')
-		},
-
-		/**
 		 * Is the current share password protected ?
 		 * @returns {boolean}
 		 */
@@ -352,35 +326,6 @@ export default {
 		},
 
 		/**
-		 * Is Talk enabled?
-		 * @returns {boolean}
-		 */
-		isTalkEnabled() {
-			return OC.appswebroots.spreed !== undefined
-		},
-
-		/**
-		 * Is it possible to protect the password by Talk?
-		 * @returns {boolean}
-		 */
-		isPasswordProtectedByTalkAvailable() {
-			return this.isPasswordProtected && this.isTalkEnabled
-		},
-
-		/**
-		 * Is the current share password protected by Talk?
-		 * @returns {boolean}
-		 */
-		isPasswordProtectedByTalk: {
-			get() {
-				return this.share.sendPasswordByTalk
-			},
-			async set(enabled) {
-				this.share.sendPasswordByTalk = enabled
-			},
-		},
-
-		/**
 		 * Is the current share an email share ?
 		 * @returns {boolean}
 		 */
@@ -388,20 +333,6 @@ export default {
 			return this.share
 				? this.share.type === this.SHARE_TYPES.SHARE_TYPE_EMAIL
 				: false
-		},
-
-		canTogglePasswordProtectedByTalkAvailable() {
-			if (!this.isPasswordProtected) {
-				// Makes no sense
-				return false
-			} else if (this.isEmailShareType && !this.hasUnsavedPassword) {
-				// For email shares we need a new password in order to enable or
-				// disable
-				return false
-			}
-
-			// Anything else should be fine
-			return true
 		},
 
 		/**
@@ -415,21 +346,6 @@ export default {
 		},
 		pendingExpirationDate() {
 			return this.config.isDefaultExpireDateEnforced && this.share && !this.share.id
-		},
-
-		/**
-		 * Can the recipient edit the file ?
-		 * @returns {boolean}
-		 */
-		canUpdate: {
-			get() {
-				return this.share.hasUpdatePermission
-			},
-			set(enabled) {
-				this.share.permissions = enabled
-					? OC.PERMISSION_READ | OC.PERMISSION_UPDATE
-					: OC.PERMISSION_READ
-			},
 		},
 
 		// if newPassword exists, but is empty, it means
@@ -649,24 +565,6 @@ export default {
 			this.queueUpdate('permissions')
 		},
 
-		/**
-		 * Label changed, let's save it to a different key
-		 * @param {String} label the share label
-		 */
-		onLabelChange(label) {
-			this.$set(this.share, 'newLabel', label.trim())
-		},
-
-		/**
-		 * When the note change, we trim, save and dispatch
-		 */
-		onLabelSubmit() {
-			if (typeof this.share.newLabel === 'string') {
-				this.share.label = this.share.newLabel
-				this.$delete(this.share, 'newLabel')
-				this.queueUpdate('label')
-			}
-		},
 		async copyLink() {
 			try {
 				await this.$copyText(this.shareLink)
@@ -684,19 +582,6 @@ export default {
 					this.copied = false
 				}, 4000)
 			}
-		},
-
-		/**
-		 * Update newPassword values
-		 * of share. If password is set but not newPassword
-		 * then the user did not changed the password
-		 * If both co-exists, the password have changed and
-		 * we show it in plain text.
-		 * Then on submit (or menu close), we sync it.
-		 * @param {string} password the changed password
-		 */
-		onPasswordChange(password) {
-			this.$set(this.share, 'newPassword', password)
 		},
 
 		/**
@@ -734,22 +619,6 @@ export default {
 		},
 
 		/**
-		 * Update the password along with "sendPasswordByTalk".
-		 *
-		 * If the password was modified the new password is sent; otherwise
-		 * updating a mail share would fail, as in that case it is required that
-		 * a new password is set when enabling or disabling
-		 * "sendPasswordByTalk".
-		 */
-		onPasswordProtectedByTalkChange() {
-			if (this.hasUnsavedPassword) {
-				this.share.password = this.share.newPassword.trim()
-			}
-
-			this.queueUpdate('sendPasswordByTalk', 'password')
-		},
-
-		/**
 		 * Save potential changed data on menu close
 		 */
 		onMenuClose() {
@@ -762,9 +631,6 @@ export default {
 		 * Used in the pending popover
 		 */
 		onCancel() {
-			// this.share already exists at this point,
-			// but is incomplete as not pushed to server
-			// YET. We can safely delete the share :)
 			this.$emit('remove:share', this.share)
 		},
 

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -32,6 +32,31 @@
 			<p v-if="subtitle">
 				{{ subtitle }}
 			</p>
+
+			<template v-if="share">
+				<template v-if="share.canEdit">
+					<!-- folder -->
+					<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+						<select
+							:name="randomId"
+							@change="togglePermissions">
+							<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+							<option :value="publicUploadRWValue" :selected="sharePermissions === publicUploadRWValue">{{ t('files_sharing', 'Read, write and upload') }}</option>
+							<option :value="publicUploadWValue" :selected="sharePermissions === publicUploadWValue">{{ t('files_sharing', 'File drop (upload only)') }}</option>
+						</select>
+					</template>
+
+					<!-- file -->
+					<template v-else>
+						<select
+							:name="randomId"
+							@change="togglePermissions">
+							<option :value="publicUploadRValue" :selected="sharePermissions === publicUploadRValue">{{ t('files_sharing', 'Read only') }}</option>
+							<option :value="publicUploadEValue" :selected="sharePermissions === publicUploadEValue">{{ t('files_sharing', 'Read and write') }}</option>
+						</select>
+					</template>
+				</template>
+			</template>
 		</div>
 
 		<!-- clipboard -->

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -588,6 +588,11 @@ export default {
 			const permissions = parseInt(event.target.value, 10)
 			this.share.permissions = permissions
 			this.queueUpdate('permissions')
+
+			if (permissions === OC.PERMISSION_CREATE) {
+				this.share.hideDownload = false
+				this.queueUpdate('hideDownload')
+			}
 		},
 
 		async copyLink() {

--- a/apps/files_sharing/src/components/SharingInput.vue
+++ b/apps/files_sharing/src/components/SharingInput.vue
@@ -443,6 +443,8 @@ export default {
 			this.$store.commit('addFromInput', true)
 			const newShare = new Share({})
 			newShare.permissions = OC.PERMISSION_READ
+			newShare.expireDate = ''
+			newShare.password = ''
 			this.$store.commit('addShare', newShare)
 			this.$store.commit('addCurrentTab', 'permissions')
 		},

--- a/apps/files_sharing/src/components/SharingNotes.vue
+++ b/apps/files_sharing/src/components/SharingNotes.vue
@@ -30,8 +30,8 @@
 				</label>
 				<div>
 					<textarea
-						v-model="shareNote"
 						ref="note"
+						v-model="shareNote"
 						class="sharing-note"
 						:disabled="saving" />
 				</div>
@@ -91,7 +91,7 @@ export default {
 			recommendations: [],
 			ShareSearch: OCA.Sharing.ShareSearch.state,
 			suggestions: [],
-			shareNote: this.share.newNote || this.share.note,
+			shareNote: this.share.newNote || this.share.note || '',
 			sendPasswordByTalk: null,
 			hideDownload: null,
 		}
@@ -153,8 +153,6 @@ export default {
 					this.hideDownload = this.share.hideDownload.toString()
 				}
 
-				console.info('note ', this.shareNote)
-
 				const share = await this.createShare({
 					path,
 					shareType: this.optionValues.shareType,
@@ -168,7 +166,7 @@ export default {
 
 				// add notes to share if any
 				this.share = share
-				share.note = this.shareNote
+				this.share.note = this.shareNote
 				this.queueUpdate('note')
 
 				// reset the search string when done

--- a/apps/files_sharing/src/components/SharingNotes.vue
+++ b/apps/files_sharing/src/components/SharingNotes.vue
@@ -1,0 +1,192 @@
+<!--
+  - @copyright Copyright (c) 2021 Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+  -
+  - @author Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div :class="{ 'icon-loading': loading }">
+		<div class="sharing-notes">
+			<!-- note -->
+			<template>
+				<label>
+					{{ t('files_sharing', 'Note to recipient') }}
+				</label>
+				<div>
+					<textarea
+						v-model="shareNote"
+						ref="note"
+						class="sharing-note"
+						:disabled="saving" />
+				</div>
+				<div>
+					<button class="status-buttons__select"
+						:name="randomId"
+						:disabled="saving"
+						@click="cancelSharing">
+						{{ t('files_sharing', 'Cancel') }}
+					</button>
+					<template v-if="share.id > 0">
+						<button class="status-buttons__primary primary"
+							:name="randomId"
+							:disabled="saving"
+							@click="sendEmail">
+							{{ t('files_sharing', 'Send email') }}
+						</button>
+					</template>
+					<template v-else>
+						<button class="status-buttons__primary primary"
+							:name="randomId"
+							:disabled="saving"
+							@click="addShare">
+							{{ t('files_sharing', 'Send share') }}
+						</button>
+					</template>
+				</div>
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import Config from '../services/ConfigService'
+import SharesMixin from '../mixins/SharesMixin'
+import Share from '../models/Share'
+import ShareRequests from '../mixins/ShareRequests'
+import ShareTypes from '../mixins/ShareTypes'
+import { mapGetters } from 'vuex'
+
+export default {
+	name: 'SharingNotes',
+
+	components: {
+	},
+
+	mounted() {
+		// this.$root.$on('optionValues', data => {
+		// 	optionValues = data
+		// })
+	},
+
+	directives: {
+	},
+
+	mixins: [SharesMixin, ShareRequests, ShareTypes],
+
+	data() {
+		return {
+			config: new Config(),
+			loading: false,
+			query: '',
+			recommendations: [],
+			ShareSearch: OCA.Sharing.ShareSearch.state,
+			suggestions: [],
+			shareNote: this.share.newNote || this.share.note,
+		}
+	},
+
+	computed: {
+		...mapGetters({
+			optionValues: 'getOption',
+			// share: 'getShare',
+		}),
+
+		/**
+		 * Generate a unique random id for this SharingPermissions only
+		 * This allows ActionRadios to have the same name prop
+		 * but not to impact others SharingPermissions
+		 * @returns {string}
+		 */
+		randomId() {
+			return Math.random().toString(27).substr(2)
+		},
+	},
+
+	methods: {
+		cancelSharing() {
+			this.$store.commit('addCurrentTab', 'default')
+		},
+
+		sendEmail() {
+			this.loading = true
+			this.share.newNote = this.shareNote
+			this.onNoteSubmit()
+			this.loading = false
+			this.$store.commit('addCurrentTab', 'default')
+			// console.info('this is send email')
+		},
+
+		/**
+		 * Process the new share request
+		 * @param {Object} optionValues the multiselect option
+		 */
+		async addShare() {
+			// handle externalResults from OCA.Sharing.ShareSearch
+			if (this.share.handler) {
+				console.debug('addShare this.share handler ', this.share)
+				const share = await this.share.handler(this)
+				this.$emit('add:share', new Share(share))
+				return true
+			}
+
+			this.loading = true
+			console.debug('Adding a new share from the input for', this.share)
+			try {
+				const path = (this.fileInfo.path + '/' + this.fileInfo.name).replace('//', '/')
+				const share = await this.createShare({
+					path,
+					shareType: this.optionValues.shareType,
+					shareWith: this.optionValues.shareWith,
+					password: this.share.password,
+					password_by_talk: this.share.sendPasswordByTalk,
+					expiration: this.share.expireDate,
+					permissions: this.fileInfo.sharePermissions & OC.getCapabilities().files_sharing.default_permissions & this.share.permissions,
+				})
+
+				// add notes to share if any
+				this.share = share
+				this.share.note = this.shareNote
+				this.queueUpdate('note')
+
+				// reset the search string when done
+				// FIXME: https://github.com/shentao/vue-multiselect/issues/633
+				if (this.$refs.multiselect?.$refs?.VueMultiselect?.search) {
+					this.$refs.multiselect.$refs.VueMultiselect.search = ''
+				}
+
+				this.$root.$emit('update', this.fileInfo)
+				await this.$root.$emit('getRecommendations')
+				this.cancelSharing()
+			} catch (error) {
+				this.query = this.share.shareWith
+				console.error('Error while adding new share', error)
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.sharing-note {
+	width: 100%;
+	height: 200px;
+}
+</style>

--- a/apps/files_sharing/src/components/SharingNotes.vue
+++ b/apps/files_sharing/src/components/SharingNotes.vue
@@ -78,12 +78,6 @@ export default {
 	components: {
 	},
 
-	mounted() {
-		// this.$root.$on('optionValues', data => {
-		// 	optionValues = data
-		// })
-	},
-
 	directives: {
 	},
 
@@ -98,6 +92,8 @@ export default {
 			ShareSearch: OCA.Sharing.ShareSearch.state,
 			suggestions: [],
 			shareNote: this.share.newNote || this.share.note,
+			sendPasswordByTalk: null,
+			hideDownload: null,
 		}
 	},
 
@@ -129,7 +125,6 @@ export default {
 			this.onNoteSubmit()
 			this.loading = false
 			this.$store.commit('addCurrentTab', 'default')
-			// console.info('this is send email')
 		},
 
 		/**
@@ -149,19 +144,31 @@ export default {
 			console.debug('Adding a new share from the input for', this.share)
 			try {
 				const path = (this.fileInfo.path + '/' + this.fileInfo.name).replace('//', '/')
+
+				if (this.share.sendPasswordByTalk) {
+					this.sendPasswordByTalk = this.share.sendPasswordByTalk.toString()
+				}
+
+				if (this.share.hideDownload) {
+					this.hideDownload = this.share.hideDownload.toString()
+				}
+
+				console.info('note ', this.shareNote)
+
 				const share = await this.createShare({
 					path,
 					shareType: this.optionValues.shareType,
 					shareWith: this.optionValues.shareWith,
 					password: this.share.password,
-					password_by_talk: this.share.sendPasswordByTalk,
-					expiration: this.share.expireDate,
+					sendPasswordByTalk: this.sendPasswordByTalk,
+					expireDate: this.share.expireDate,
+					hideDownload: this.hideDownload,
 					permissions: this.fileInfo.sharePermissions & OC.getCapabilities().files_sharing.default_permissions & this.share.permissions,
 				})
 
 				// add notes to share if any
 				this.share = share
-				this.share.note = this.shareNote
+				share.note = this.shareNote
 				this.queueUpdate('note')
 
 				// reset the search string when done

--- a/apps/files_sharing/src/components/SharingPermissions.vue
+++ b/apps/files_sharing/src/components/SharingPermissions.vue
@@ -73,7 +73,7 @@
 				{{ t('files_sharing', 'Advanced settings') }}
 			</label>
 			<ActionCheckbox :checked.sync="share.hideDownload"
-				:disabled="saving"
+				:disabled="saving || sharePermissions === publicUploadWValue"
 				@change="addHideDownload">
 				{{ t('files_sharing', 'Hide download') }}
 			</ActionCheckbox>
@@ -422,6 +422,9 @@ export default {
 			let permissions = 0
 			if (this.isExteranlShare) {
 				permissions = parseInt(event.target.value, 10)
+				if (permissions === OC.PERMISSION_CREATE) {
+					this.share.hideDownload = false
+				}
 				this.share.permissions = permissions
 			} else {
 				permissions = parseInt(event.target.value, 10)

--- a/apps/files_sharing/src/components/SharingPermissions.vue
+++ b/apps/files_sharing/src/components/SharingPermissions.vue
@@ -1,0 +1,556 @@
+<!--
+  - @copyright Copyright (c) 2021 Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+  -
+  - @author Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<ul class="sharing-permissions">
+		<!-- for email and link share -->
+		<template v-if="isExteranlShare">
+			<!-- folder -->
+			<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+				<ActionRadio :checked="sharePermissions === publicUploadRValue"
+					:value="publicUploadRValue"
+					:name="randomId"
+					:disabled="saving"
+					@change="addPermissions">
+					{{ t('files_sharing', 'Read only') }}
+				</ActionRadio>
+				<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+					:value="publicUploadRWValue"
+					:disabled="saving"
+					:name="randomId"
+					@change="addPermissions">
+					{{ t('files_sharing', 'Allow upload and editing') }}
+				</ActionRadio>
+				<ActionRadio :checked="sharePermissions === publicUploadWValue"
+					:value="publicUploadWValue"
+					:disabled="saving"
+					:name="randomId"
+					class="sharing-entry__action--public-upload"
+					@change="addPermissions">
+					{{ t('files_sharing', 'File drop (upload only)') }}
+				</ActionRadio>
+			</template>
+
+			<!-- file -->
+			<template v-else>
+				<ActionRadio :checked="sharePermissions === publicUploadRValue"
+					:value="publicUploadRValue"
+					:name="randomId"
+					:disabled="saving"
+					@change="addPermissions">
+					{{ t('files_sharing', 'Read only') }}
+				</ActionRadio>
+
+				<ActionRadio :checked="sharePermissions === publicUploadEValue"
+					:value="publicUploadEValue"
+					:disabled="saving"
+					:name="randomId"
+					@change="addPermissions">
+					{{ t('files_sharing', 'Editing') }}
+				</ActionRadio>
+			</template>
+
+			<label>
+				{{ t('files_sharing', 'Advanced settings') }}
+			</label>
+			<ActionCheckbox :checked.sync="share.hideDownload"
+				:disabled="saving"
+				@change="addHideDownload">
+				{{ t('files_sharing', 'Hide download') }}
+			</ActionCheckbox>
+
+			<!-- password -->
+			<ActionCheckbox :checked.sync="isPasswordProtected"
+				:disabled="config.enforcePasswordForPublicLink || saving"
+				class="share-link-password-checkbox">
+				{{ config.enforcePasswordForPublicLink
+					? t('files_sharing', 'Password protection (enforced)')
+					: t('files_sharing', 'Password protect') }}
+			</ActionCheckbox>
+			<ActionInput v-if="isPasswordProtected"
+				ref="password"
+				v-tooltip.auto="{
+					content: errors.password,
+					show: errors.password,
+					trigger: 'manual',
+					defaultContainer: '#app-sidebar'
+				}"
+				class="share-link-password"
+				:class="{ error: errors.password}"
+				:disabled="saving"
+				:required="config.enforcePasswordForPublicLink"
+				:value="hasUnsavedPassword ? share.newPassword : '***************'"
+				autocomplete="new-password"
+				:type="hasUnsavedPassword ? 'text': 'password'">
+				{{ t('files_sharing', 'Enter a password') }}
+			</ActionInput>
+
+			<!-- password protected by Talk -->
+			<ActionCheckbox :checked.sync="share.sendPasswordByTalk"
+				:disabled="!canTogglePasswordProtectedByTalkAvailable || saving"
+				class="share-link-password-talk-checkbox"
+				@change="addPasswordProtectedByTalkChange">
+				{{ t('files_sharing', 'Video verification') }}
+			</ActionCheckbox>
+
+			<!-- expiration date -->
+			<ActionCheckbox
+				v-if="canHaveExpirationDate"
+				:checked.sync="hasExpirationDate"
+				:disabled="config.isDefaultInternalExpireDateEnforced || saving"
+				@uncheck="onExpirationDisable">
+				{{ config.isDefaultInternalExpireDateEnforced
+					? t('files_sharing', 'Expiration date enforced')
+					: t('files_sharing', 'Set expiration date') }}
+			</ActionCheckbox>
+			<ActionInput v-if="canHaveExpirationDate && hasExpirationDate"
+				ref="expireDate"
+				v-tooltip.auto="{
+					content: errors.expireDate,
+					show: errors.expireDate,
+					trigger: 'manual'
+				}"
+				:class="{ error: errors.expireDate}"
+				:disabled="saving"
+				:first-day-of-week="firstDay"
+				:lang="lang"
+				:value="share.expireDate"
+				value-type="format"
+				icon="icon-calendar-dark"
+				type="date"
+				@change:value="addExpirationDate">
+				{{ t('files_sharing', 'Enter a date') }}
+			</ActionInput>
+		</template>
+		<template v-else>
+			<!-- folder -->
+			<template v-if="isFolder && config.isPublicUploadEnabled">
+				<ActionRadio :checked="sharePermissions === publicUploadRValue"
+					:value="publicUploadRValue"
+					:name="randomId"
+					@change="addPermissions"
+					:disabled="saving">
+					{{ t('files_sharing', 'Read only') }}
+				</ActionRadio>
+
+				<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+					:value="publicUploadRWValue"
+					:disabled="saving"
+					@change="addPermissions"
+					:name="randomId">
+					{{ t('files_sharing', 'Allow upload and editing') }}
+				</ActionRadio>
+			</template>
+			<!-- file -->
+			<template v-else>
+				<ActionRadio :checked="sharePermissions === publicUploadRValue"
+					:value="publicUploadRValue"
+					:name="randomId"
+					@change="addPermissions"
+					:disabled="saving">
+					{{ t('files_sharing', 'Read only') }}
+				</ActionRadio>
+
+				<ActionRadio :checked="sharePermissions === publicUploadEValue"
+					:value="publicUploadEValue"
+					:disabled="saving"
+					@change="addPermissions"
+					:name="randomId">
+					{{ t('files_sharing', 'Editing') }}
+				</ActionRadio>
+			</template>
+
+			<label>
+				{{ t('files_sharing', 'Advanced settings') }}
+			</label>
+			<!-- reshare permission -->
+			<ActionCheckbox
+				v-if="config.isResharingAllowed"
+				ref="canReshare"
+				:checked.sync="canReshare"
+				@change="updatePermissions"
+				:disabled="saving || !canSetReshare">
+				{{ t('files_sharing', 'Allow resharing') }}
+			</ActionCheckbox>
+			<!-- expiration date -->
+			<ActionCheckbox
+				v-if="canHaveExpirationDate"
+				:checked.sync="hasExpirationDate"
+				:disabled="config.isDefaultInternalExpireDateEnforced || saving"
+				@uncheck="onExpirationDisable">
+				{{ config.isDefaultInternalExpireDateEnforced
+					? t('files_sharing', 'Expiration date enforced')
+					: t('files_sharing', 'Set expiration date') }}
+			</ActionCheckbox>
+			<ActionInput v-if="canHaveExpirationDate && hasExpirationDate"
+				ref="expireDate"
+				v-tooltip.auto="{
+					content: errors.expireDate,
+					show: errors.expireDate,
+					trigger: 'manual'
+				}"
+				:class="{ error: errors.expireDate}"
+				:disabled="saving"
+				:first-day-of-week="firstDay"
+				:lang="lang"
+				:value="share.expireDate"
+				value-type="format"
+				icon="icon-calendar-dark"
+				type="date"
+				@change:value="addExpirationDate">
+				{{ t('files_sharing', 'Enter a date') }}
+			</ActionInput>
+		</template>
+
+		<button class="status-buttons__select"
+			:name="randomId"
+			:disabled="saving"
+			@click="cancelSharing">
+			{{ t('files_sharing', 'Cancel') }}
+		</button>
+		<template v-if="share.id > 0">
+			<button class="status-buttons__primary primary"
+				:name="randomId"
+				:disabled="saving"
+				@click="confirmSharing">
+				{{ t('files_sharing', 'Confirm') }}
+			</button>
+		</template>
+		<template v-else>
+			<button class="status-buttons__primary primary"
+				:name="randomId"
+				:disabled="saving"
+				@click="nextSharing">
+				{{ t('files_sharing', 'Next') }}
+			</button>
+		</template>
+	</ul>
+</template>
+
+<script>
+import ActionRadio from '@nextcloud/vue/dist/Components/ActionRadio'
+import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
+import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
+import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+
+import SharesMixin from '../mixins/SharesMixin'
+import ShareTypes from '../mixins/ShareTypes'
+import GeneratePassword from '../utils/GeneratePassword'
+import Vue from 'vue'
+import { mapGetters } from 'vuex'
+import ShareRequests from '../mixins/ShareRequests'
+
+export default {
+	name: 'SharingPermissions',
+
+	components: {
+		ActionRadio,
+		ActionCheckbox,
+		ActionInput,
+	},
+
+	mounted() {
+		// this.$root.$on('optionValues', data => {
+		// 	this.optionValues = data
+		// })
+	},
+
+	directives: {
+		Tooltip,
+	},
+
+	mixins: [SharesMixin, ShareTypes, ShareRequests],
+
+	data() {
+		return {
+			permissionsEdit: OC.PERMISSION_UPDATE,
+			permissionsCreate: OC.PERMISSION_CREATE,
+			permissionsDelete: OC.PERMISSION_DELETE,
+			permissionsRead: OC.PERMISSION_READ,
+			permissionsShare: OC.PERMISSION_SHARE,
+
+			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
+			publicUploadRValue: OC.PERMISSION_READ,
+			publicUploadWValue: OC.PERMISSION_CREATE,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
+		}
+	},
+
+	computed: {
+		...mapGetters({
+			fromInput: 'getFromInput',
+			optionValues: 'getOption'
+		}),
+		/**
+		 * Return the current share permissions
+		 * We always ignore the SHARE permission as this is used for the
+		 * federated sharing.
+		 * @returns {number}
+		 */
+		sharePermissions() {
+			if (this.isExteranlShare) {
+				return this.share.permissions
+			} else {
+				return ~OC.PERMISSION_SHARE & this.share.permissions
+			}
+		},
+		/**
+		 * Generate a unique random id for this SharingPermissions only
+		 * This allows ActionRadios to have the same name prop
+		 * but not to impact others SharingPermissions
+		 * @returns {string}
+		 */
+		randomId() {
+			return Math.random().toString(27).substr(2)
+		},
+
+		canHaveNote() {
+			return !this.isRemote
+		},
+
+		canHaveExpirationDate() {
+			return !this.isRemoteShare
+		},
+
+		/**
+		 * Can the sharer set whether the sharee can edit the file ?
+		 *
+		 * @returns {boolean}
+		 */
+		canSetEdit() {
+			// If the owner revoked the permission after the resharer granted it
+			// the share still has the permission, and the resharer is still
+			// allowed to revoke it too (but not to grant it again).
+			return (this.fileInfo.sharePermissions & OC.PERMISSION_UPDATE) || this.canEdit
+		},
+
+		/**
+		 * Can the sharer set whether the sharee can create the file ?
+		 *
+		 * @returns {boolean}
+		 */
+		canSetCreate() {
+			// If the owner revoked the permission after the resharer granted it
+			// the share still has the permission, and the resharer is still
+			// allowed to revoke it too (but not to grant it again).
+			return (this.fileInfo.sharePermissions & OC.PERMISSION_CREATE) || this.canCreate
+		},
+
+		/**
+		 * Can the sharer set whether the sharee can delete the file ?
+		 *
+		 * @returns {boolean}
+		 */
+		canSetDelete() {
+			// If the owner revoked the permission after the resharer granted it
+			// the share still has the permission, and the resharer is still
+			// allowed to revoke it too (but not to grant it again).
+			return (this.fileInfo.sharePermissions & OC.PERMISSION_DELETE) || this.canDelete
+		},
+
+		/**
+		 * Can the sharer set whether the sharee can reshare the file ?
+		 *
+		 * @returns {boolean}
+		 */
+		canSetReshare() {
+			// If the owner revoked the permission after the resharer granted it
+			// the share still has the permission, and the resharer is still
+			// allowed to revoke it too (but not to grant it again).
+			return (this.fileInfo.sharePermissions & OC.PERMISSION_SHARE) || this.canReshare
+		},
+
+		/**
+		 * Can the sharee reshare the file ?
+		 */
+		canReshare: {
+			get() {
+				return this.share.hasSharePermission
+			},
+			set(checked) {
+				this.updatePermissions({ isReshareChecked: checked })
+			},
+		},
+
+		// if newPassword exists, but is empty, it means
+		// the user deleted the original password
+		hasUnsavedPassword() {
+			return this.share.newPassword !== undefined
+		},
+
+		/**
+		 * Is the current share a folder ?
+		 * @returns {boolean}
+		 */
+		isFolder() {
+			return this.fileInfo.type === 'dir'
+		},
+
+		/**
+		 * Does the current share have an expiration date
+		 * @returns {boolean}
+		 */
+		hasExpirationDate: {
+			get() {
+				return this.config.isDefaultInternalExpireDateEnforced || !!this.share.expireDate
+			},
+			set(enabled) {
+				this.share.expireDate = enabled
+					? this.config.defaultInternalExpirationDateString !== ''
+						? this.config.defaultInternalExpirationDateString
+						: moment().format('YYYY-MM-DD')
+					: ''
+			},
+		},
+
+		/**
+		 * Is the current share password protected ?
+		 * @returns {boolean}
+		 */
+		isPasswordProtected: {
+			get() {
+				return this.config.enforcePasswordForPublicLink || !!this.share.password
+			},
+			async set(enabled) {
+				// TODO: directly save after generation to make sure the share is always protected
+				Vue.set(this.share, 'password', enabled ? await GeneratePassword() : '')
+				Vue.set(this.share, 'newPassword', this.share.password)
+			},
+		},
+
+		/**
+		 * Does the current file/folder have create permissions
+		 * TODO: move to a proper FileInfo model?
+		 * @returns {boolean}
+		 */
+		fileHasCreatePermission() {
+			return !!(this.fileInfo.permissions & OC.PERMISSION_CREATE)
+		},
+
+		dateMaxEnforced() {
+			if (!this.isRemote) {
+				return this.config.isDefaultInternalExpireDateEnforced
+					&& moment().add(1 + this.config.defaultInternalExpireDate, 'days')
+			} else {
+				return this.config.isDefaultRemoteExpireDateEnforced
+					&& moment().add(1 + this.config.defaultRemoteExpireDate, 'days')
+			}
+		},
+
+		isExteranlShare() {
+			if (this.fromInput) {
+				return Boolean(this.SHARE_TYPES.SHARE_TYPE_EMAIL === this.optionValues.shareType
+				|| this.SHARE_TYPES.SHARE_TYPE_LINK === this.optionValues.shareType)
+			} else {
+				return Boolean(this.SHARE_TYPES.SHARE_TYPE_EMAIL === this.share.type
+				|| this.SHARE_TYPES.SHARE_TYPE_LINK === this.share.type)
+			}
+		},
+
+	},
+
+	methods: {
+		addPasswordProtectedByTalkChange(event) {
+			this.share.sendPasswordByTalk = event.target.checked
+		},
+
+		addHideDownload(event) {
+			this.share.hideDownload = event.target.checked
+		},
+
+		addExpirationDate(date) {
+			// format to YYYY-MM-DD
+			const value = moment(date).format('YYYY-MM-DD')
+			this.share.expireDate = value
+			// this.queueUpdate('expireDate')
+		},
+
+		/**
+		 * On permissions change
+		 * @param {Event} event js event
+		 */
+		updatePermissions() {
+			console.debug('can reshare ', this.canReshare)
+			console.debug('share permissions ', this.permissionsShare)
+			const permissions = this.share.permissions
+			| (this.canReshare ? this.permissionsShare : 0)
+			this.share.permissions = permissions
+			console.debug('update permissions ', this.share.permissions)
+		},
+
+		addPermissions(event) {
+			if (this.isExteranlShare) {
+				const permissions = parseInt(event.target.value, 10)
+				this.share.permissions = permissions
+			} else {
+				const permissions = parseInt(event.target.value, 10)
+				| (this.canReshare ? this.permissionsShare : 0)
+				this.share.permissions = permissions
+			}
+		},
+
+		cancelSharing() {
+			this.$store.commit('addCurrentTab', 'default')
+		},
+
+		nextSharing() {
+			this.$store.commit('addShare', this.share)
+			this.$store.commit('addCurrentTab', 'notes')
+		},
+
+		confirmSharing() {
+			this.loading = true
+			this.updateShare(this.share.id, {
+				permissions: this.share.permissions,
+				hide_download: this.share.hideDownload,
+				password: this.share.password,
+				expiration: this.share.expireDate,
+				password_by_talk: this.share.sendPasswordByTalk,
+			})
+			this.loading = true
+			this.$store.commit('addCurrentTab', 'default')
+		},
+
+		/**
+		 * Is it possible to protect the password by Talk?
+		 * @returns {boolean}
+		 */
+		isPasswordProtectedByTalkAvailable() {
+			return this.isPasswordProtected && this.isTalkEnabled
+		},
+
+		canTogglePasswordProtectedByTalkAvailable() {
+			if (!this.isPasswordProtected) {
+				// Makes no sense
+				return false
+			} else if (this.isEmailShareType && !this.hasUnsavedPassword) {
+				// For email shares we need a new password in order to enable or
+				// disable
+				return false
+			}
+
+			// Anything else should be fine
+			return true
+		},
+	},
+}
+</script>

--- a/apps/files_sharing/src/components/SharingPermissions.vue
+++ b/apps/files_sharing/src/components/SharingPermissions.vue
@@ -38,7 +38,7 @@
 					:disabled="saving"
 					:name="randomId"
 					@change="addPermissions">
-					{{ t('files_sharing', 'Allow upload and editing') }}
+					{{ t('files_sharing', 'Read, write and upload') }}
 				</ActionRadio>
 				<ActionRadio :checked="sharePermissions === publicUploadWValue"
 					:value="publicUploadWValue"
@@ -65,7 +65,7 @@
 					:disabled="saving"
 					:name="randomId"
 					@change="addPermissions">
-					{{ t('files_sharing', 'Editing') }}
+					{{ t('files_sharing', 'Read and write') }}
 				</ActionRadio>
 			</template>
 
@@ -143,7 +143,7 @@
 					:disabled="saving"
 					@change="addPermissions"
 					:name="randomId">
-					{{ t('files_sharing', 'Allow upload and editing') }}
+					{{ t('files_sharing', 'Read, write and upload') }}
 				</ActionRadio>
 			</template>
 			<!-- file -->
@@ -161,7 +161,7 @@
 					:disabled="saving"
 					@change="addPermissions"
 					:name="randomId">
-					{{ t('files_sharing', 'Editing') }}
+					{{ t('files_sharing', 'Read and write') }}
 				</ActionRadio>
 			</template>
 

--- a/apps/files_sharing/src/components/SharingPermissions.vue
+++ b/apps/files_sharing/src/components/SharingPermissions.vue
@@ -88,14 +88,7 @@
 			</ActionCheckbox>
 			<ActionInput v-if="isPasswordProtected"
 				ref="password"
-				v-tooltip.auto="{
-					content: errors.password,
-					show: errors.password,
-					trigger: 'manual',
-					defaultContainer: '#app-sidebar'
-				}"
-				class="share-link-password"
-				:class="{ error: errors.password}"
+				icon=""
 				:disabled="saving"
 				:required="config.enforcePasswordForPublicLink"
 				:value="hasUnsavedPassword ? share.newPassword : '***************'"
@@ -105,7 +98,8 @@
 			</ActionInput>
 
 			<!-- password protected by Talk -->
-			<ActionCheckbox :checked.sync="share.sendPasswordByTalk"
+			<ActionCheckbox v-if="isPasswordProtectedByTalkAvailable"
+				:checked.sync="share.sendPasswordByTalk"
 				:disabled="!canTogglePasswordProtectedByTalkAvailable || saving"
 				class="share-link-password-talk-checkbox"
 				@change="addPasswordProtectedByTalkChange">
@@ -115,21 +109,13 @@
 			<!-- expiration date -->
 			<ActionCheckbox
 				v-if="canHaveExpirationDate"
-				:checked.sync="hasExpirationDate"
-				:disabled="config.isDefaultInternalExpireDateEnforced || saving"
-				@uncheck="onExpirationDisable">
+				:checked.sync="hasExpirationDate">
 				{{ config.isDefaultInternalExpireDateEnforced
 					? t('files_sharing', 'Expiration date enforced')
 					: t('files_sharing', 'Set expiration date') }}
 			</ActionCheckbox>
-			<ActionInput v-if="canHaveExpirationDate && hasExpirationDate"
+			<ActionInput v-if="hasExpirationDate"
 				ref="expireDate"
-				v-tooltip.auto="{
-					content: errors.expireDate,
-					show: errors.expireDate,
-					trigger: 'manual'
-				}"
-				:class="{ error: errors.expireDate}"
 				:disabled="saving"
 				:first-day-of-week="firstDay"
 				:lang="lang"
@@ -137,7 +123,7 @@
 				value-type="format"
 				icon="icon-calendar-dark"
 				type="date"
-				@change:value="addExpirationDate">
+				@update:value="addExpirationDate">
 				{{ t('files_sharing', 'Enter a date') }}
 			</ActionInput>
 		</template>
@@ -187,28 +173,21 @@
 				v-if="config.isResharingAllowed"
 				ref="canReshare"
 				:checked.sync="canReshare"
-				@change="updatePermissions"
+				:value="permissionsShare"
 				:disabled="saving || !canSetReshare">
 				{{ t('files_sharing', 'Allow resharing') }}
 			</ActionCheckbox>
+
 			<!-- expiration date -->
 			<ActionCheckbox
 				v-if="canHaveExpirationDate"
-				:checked.sync="hasExpirationDate"
-				:disabled="config.isDefaultInternalExpireDateEnforced || saving"
-				@uncheck="onExpirationDisable">
+				:checked.sync="hasExpirationDate">
 				{{ config.isDefaultInternalExpireDateEnforced
 					? t('files_sharing', 'Expiration date enforced')
 					: t('files_sharing', 'Set expiration date') }}
 			</ActionCheckbox>
-			<ActionInput v-if="canHaveExpirationDate && hasExpirationDate"
+			<ActionInput v-if="hasExpirationDate"
 				ref="expireDate"
-				v-tooltip.auto="{
-					content: errors.expireDate,
-					show: errors.expireDate,
-					trigger: 'manual'
-				}"
-				:class="{ error: errors.expireDate}"
 				:disabled="saving"
 				:first-day-of-week="firstDay"
 				:lang="lang"
@@ -216,7 +195,7 @@
 				value-type="format"
 				icon="icon-calendar-dark"
 				type="date"
-				@change:value="addExpirationDate">
+				@update:value="addExpirationDate">
 				{{ t('files_sharing', 'Enter a date') }}
 			</ActionInput>
 		</template>
@@ -268,12 +247,6 @@ export default {
 		ActionInput,
 	},
 
-	mounted() {
-		// this.$root.$on('optionValues', data => {
-		// 	this.optionValues = data
-		// })
-	},
-
 	directives: {
 		Tooltip,
 	},
@@ -307,11 +280,7 @@ export default {
 		 * @returns {number}
 		 */
 		sharePermissions() {
-			if (this.isExteranlShare) {
-				return this.share.permissions
-			} else {
-				return ~OC.PERMISSION_SHARE & this.share.permissions
-			}
+			return this.share.permissions & ~OC.PERMISSION_SHARE
 		},
 		/**
 		 * Generate a unique random id for this SharingPermissions only
@@ -323,48 +292,8 @@ export default {
 			return Math.random().toString(27).substr(2)
 		},
 
-		canHaveNote() {
-			return !this.isRemote
-		},
-
 		canHaveExpirationDate() {
 			return !this.isRemoteShare
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can edit the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetEdit() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_UPDATE) || this.canEdit
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can create the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetCreate() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_CREATE) || this.canCreate
-		},
-
-		/**
-		 * Can the sharer set whether the sharee can delete the file ?
-		 *
-		 * @returns {boolean}
-		 */
-		canSetDelete() {
-			// If the owner revoked the permission after the resharer granted it
-			// the share still has the permission, and the resharer is still
-			// allowed to revoke it too (but not to grant it again).
-			return (this.fileInfo.sharePermissions & OC.PERMISSION_DELETE) || this.canDelete
 		},
 
 		/**
@@ -387,7 +316,7 @@ export default {
 				return this.share.hasSharePermission
 			},
 			set(checked) {
-				this.updatePermissions({ isReshareChecked: checked })
+				this.updatePermissions({ isReshareChecked: checked, otherPermissions: this.sharePermissions })
 			},
 		},
 
@@ -415,9 +344,9 @@ export default {
 			},
 			set(enabled) {
 				this.share.expireDate = enabled
-					? this.config.defaultInternalExpirationDateString !== ''
+					? (this.config.defaultInternalExpirationDateString !== ''
 						? this.config.defaultInternalExpirationDateString
-						: moment().format('YYYY-MM-DD')
+						: ' ')
 					: ''
 			},
 		},
@@ -446,16 +375,6 @@ export default {
 			return !!(this.fileInfo.permissions & OC.PERMISSION_CREATE)
 		},
 
-		dateMaxEnforced() {
-			if (!this.isRemote) {
-				return this.config.isDefaultInternalExpireDateEnforced
-					&& moment().add(1 + this.config.defaultInternalExpireDate, 'days')
-			} else {
-				return this.config.isDefaultRemoteExpireDateEnforced
-					&& moment().add(1 + this.config.defaultRemoteExpireDate, 'days')
-			}
-		},
-
 		isExteranlShare() {
 			if (this.fromInput) {
 				return Boolean(this.SHARE_TYPES.SHARE_TYPE_EMAIL === this.optionValues.shareType
@@ -481,28 +400,31 @@ export default {
 			// format to YYYY-MM-DD
 			const value = moment(date).format('YYYY-MM-DD')
 			this.share.expireDate = value
-			// this.queueUpdate('expireDate')
 		},
 
 		/**
 		 * On permissions change
 		 * @param {Event} event js event
 		 */
-		updatePermissions() {
-			console.debug('can reshare ', this.canReshare)
-			console.debug('share permissions ', this.permissionsShare)
-			const permissions = this.share.permissions
-			| (this.canReshare ? this.permissionsShare : 0)
+		updatePermissions({ isReshareChecked = this.canReshare, otherPermissions = 0 } = {}) {
+			// calc permissions if checked
+			const permissions = 0
+				| otherPermissions
+				// | (isWrite ? isWrite : 0)
+				// | (isReadOnly ? isReadOnly : 0)
+				// | (isUpdateOnly ? isUpdateOnly : 0)
+				| (isReshareChecked ? this.permissionsShare : 0)
+
 			this.share.permissions = permissions
-			console.debug('update permissions ', this.share.permissions)
 		},
 
 		addPermissions(event) {
+			let permissions = 0
 			if (this.isExteranlShare) {
-				const permissions = parseInt(event.target.value, 10)
+				permissions = parseInt(event.target.value, 10)
 				this.share.permissions = permissions
 			} else {
-				const permissions = parseInt(event.target.value, 10)
+				permissions = parseInt(event.target.value, 10)
 				| (this.canReshare ? this.permissionsShare : 0)
 				this.share.permissions = permissions
 			}
@@ -519,13 +441,15 @@ export default {
 
 		confirmSharing() {
 			this.loading = true
-			this.updateShare(this.share.id, {
+			const result = this.updateShare(this.share.id, {
 				permissions: this.share.permissions,
-				hide_download: this.share.hideDownload,
+				hideDownload: this.share.hideDownload.toString(),
 				password: this.share.password,
-				expiration: this.share.expireDate,
-				password_by_talk: this.share.sendPasswordByTalk,
+				expireDate: this.share.expireDate,
+				sendPasswordByTalk: this.share.sendPasswordByTalk.toString(),
 			})
+			// this.$emit('add:share', this.share)
+			console.debug('updated share', result)
 			this.loading = true
 			this.$store.commit('addCurrentTab', 'default')
 		},
@@ -554,3 +478,8 @@ export default {
 	},
 }
 </script>
+<style lang="scss">
+.action-input__label {
+	display: none !important;
+}
+</style>

--- a/apps/files_sharing/src/files_sharing_tab.js
+++ b/apps/files_sharing/src/files_sharing_tab.js
@@ -30,6 +30,7 @@ import ShareSearch from './services/ShareSearch'
 import ExternalLinkActions from './services/ExternalLinkActions'
 import ExternalShareActions from './services/ExternalShareActions'
 import TabSections from './services/TabSections'
+import store from './store'
 
 // Init Sharing Tab Service
 if (!window.OCA.Sharing) {
@@ -62,6 +63,7 @@ window.addEventListener('DOMContentLoaded', function() {
 				TabInstance = new View({
 					// Better integration with vue parent component
 					parent: context,
+					store,
 				})
 				// Only mount after we have all the info we need
 				await TabInstance.update(fileInfo)
@@ -69,6 +71,7 @@ window.addEventListener('DOMContentLoaded', function() {
 			},
 			update(fileInfo) {
 				TabInstance.update(fileInfo)
+				store.commit('addCurrentTab', 'default')
 			},
 			destroy() {
 				TabInstance.$destroy()

--- a/apps/files_sharing/src/mixins/ShareRequests.js
+++ b/apps/files_sharing/src/mixins/ShareRequests.js
@@ -50,12 +50,13 @@ export default {
 		 * @param {boolean} [data.sendPasswordByTalk=false] send the password via a talk conversation
 		 * @param {string} [data.expireDate=''] expire the shareautomatically after
 		 * @param {string} [data.label=''] custom label
+		 * @param {string} [data.hideDownload=''] custom hideDownload
 		 * @returns {Share} the new share
 		 * @throws {Error}
 		 */
-		async createShare({ path, permissions, shareType, shareWith, publicUpload, password, sendPasswordByTalk, expireDate, label }) {
+		async createShare({ path, permissions, shareType, shareWith, publicUpload, password, sendPasswordByTalk, expireDate, label, hideDownload }) {
 			try {
-				const request = await axios.post(shareUrl, { path, permissions, shareType, shareWith, publicUpload, password, sendPasswordByTalk, expireDate, label })
+				const request = await axios.post(shareUrl, { path, permissions, shareType, shareWith, publicUpload, password, sendPasswordByTalk, expireDate, label, hideDownload })
 				if (!request?.data?.ocs) {
 					throw request
 				}

--- a/apps/files_sharing/src/mixins/SharesMixin.js
+++ b/apps/files_sharing/src/mixins/SharesMixin.js
@@ -25,7 +25,7 @@
  *
  */
 
-import PQueue from 'p-queue/dist/index'
+import PQueue from 'p-queue'
 import debounce from 'debounce'
 
 import Share from '../models/Share'
@@ -188,7 +188,7 @@ export default {
 		 */
 		onExpirationDisable() {
 			this.share.expireDate = ''
-			// this.queueUpdate('expireDate')
+			this.queueUpdate('expireDate')
 		},
 
 		/**

--- a/apps/files_sharing/src/mixins/SharesMixin.js
+++ b/apps/files_sharing/src/mixins/SharesMixin.js
@@ -188,7 +188,7 @@ export default {
 		 */
 		onExpirationDisable() {
 			this.share.expireDate = ''
-			this.queueUpdate('expireDate')
+			// this.queueUpdate('expireDate')
 		},
 
 		/**

--- a/apps/files_sharing/src/store.js
+++ b/apps/files_sharing/src/store.js
@@ -1,0 +1,78 @@
+/**
+ * @copyright Copyright (c) 2021 Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Vue from 'vue'
+import Vuex from 'vuex'
+import Share from './models/Share'
+
+Vue.use(Vuex)
+
+const store = new Vuex.Store({
+	state: {
+		share: {
+			type: Share,
+			default: null,
+		},
+		option: {},
+		fromInput: Boolean,
+		currentTab: 'default',
+	},
+	mutations: {
+		addShare(state, share) {
+			state.share = share
+			console.debug('this is addShare mutation', share)
+		},
+		addOption(state, option) {
+			state.option = option
+			console.debug('this is addOptions mutation', option)
+		},
+		addFromInput(state, fromInput) {
+			state.fromInput = fromInput
+			console.debug('this is addFromInput mutation', fromInput)
+		},
+		addCurrentTab(state, currentTab) {
+			state.currentTab = currentTab
+			console.debug('this is addCurrentTab mutation', currentTab)
+		},
+	},
+	actions: {
+
+	},
+	getters: {
+		getShare(state) {
+			console.debug('this is getter getShare', state.share)
+			return state.share
+		},
+		getOption(state) {
+			console.debug('this is getter getOption', state.option)
+			return state.option
+		},
+		getFromInput(state) {
+			console.debug('this is getter getFromInput', state.fromInput)
+			return state.fromInput
+		},
+		getCurrentTab(state) {
+			console.debug('this is getter getCurrentTab', state.currentTab)
+			return state.currentTab
+		},
+	},
+})
+
+export default store

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -505,7 +505,7 @@ class ShareAPIControllerTest extends TestCase {
 
 	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $path, $permissions,
 								$shareTime, $expiration, $parent, $target, $mail_send, $note = '', $token = null,
-								$password = null, $label = '', $hideDownload = null) {
+								$password = null, $label = '', $hideDownload = false) {
 		$share = $this->getMockBuilder(IShare::class)->getMock();
 		$share->method('getId')->willReturn($id);
 		$share->method('getShareType')->willReturn($shareType);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -505,7 +505,7 @@ class ShareAPIControllerTest extends TestCase {
 
 	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $path, $permissions,
 								$shareTime, $expiration, $parent, $target, $mail_send, $note = '', $token = null,
-								$password = null, $label = '') {
+								$password = null, $label = '', $hideDownload = null) {
 		$share = $this->getMockBuilder(IShare::class)->getMock();
 		$share->method('getId')->willReturn($id);
 		$share->method('getShareType')->willReturn($shareType);
@@ -524,6 +524,7 @@ class ShareAPIControllerTest extends TestCase {
 		$share->method('getMailSend')->willReturn($mail_send);
 		$share->method('getToken')->willReturn($token);
 		$share->method('getPassword')->willReturn($password);
+		$share->method('getHideDownload')->willReturn($hideDownload);
 
 		if ($shareType === IShare::TYPE_USER ||
 			$shareType === IShare::TYPE_GROUP ||


### PR DESCRIPTION
Step 1:
Folders
Internal Share:
we removed the checkboxes "Allow editing", "Allow creating" and "Allow deleting"
we added a radio button group containing the options: "Read only" (Nur Lesen), "Allow upload and editing" (Hochladen & Bearbeiten)
External Share: no changes
Link Share: no changes

Files
Internal Share:
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)
External Share:
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)
Link Share:
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)

Step 2:
We added a new dropdown button under the display of the email-address or account name of the recipient

For folders
Internal user - Ready only and Allow upload and editing
External user - Read only, allow upload and editing, file drop
Share link - Read only, allow upload and editing, file drop
For files
Internal user - Read only, editing
External user - Read only ,editing
Share link - Read only ,editing
Ignored hasStatus which is having message and icon below user name or email address. We are removing this functionality in sharing 4. Also Nextcloud will change something with that function after we added this new button as discussed with Jens.
Also keeping the existing options in hamburger menu, as we will remove those in sharing 3.

In Step 3:
we want to change the conplete process of sharing. Let's explain it also in small steps:
-> We don't want to send directly an Email for internal and external shares to the recipient after we entered the Email address
->instead of sending directly the Email, the user will now get lead to a full right menu view with the sharing and premission options first
-> after the first page of sharing and permission options, there will be a second full right menu view for entering a message to the Email (note to recipient option of Nextcloud)

Please ignore as well the shown permission options in the full right menu views. Please concentrate to extract existing sharing options of the different sharing systems (internal, external & link shares). So we are extracting all existing options (except "note to recipeient") to build the first full right menu view and we use the existing "note to recipient" function to create a second full right menu view. We combine them to the flow, which is drafted within the attached screens.

Acceptance Criteria:
if the user enters an Email-address and confirms it by pressing 'enter', the autofill function of Nextcloud will provide suggestions (it is already like this in Nextcloud and we keep that)
when the user now tabs on a provided Email-Address, we are not anymore sending directly an Email to the repient
we are instead leading the user to a first full right menu view with the permission and sharing options containing:
Radio button group with permission options (Read only, Upload and editing, Filedrop if it is a folder)
we group up under a small headline called "Advanced settings" (ger: "Erweiterte Einstellungen") all the rest of the sharing options e.g. password, expiration date, hide download, and so on) but not the "note to recipient" option!
on this full right menu view ** the user can "Cancel" or "Next" by having two buttons
if the user continues by clicking on "Next" he will get lead to another full right menu view ** with the last sharing option of "note to recipient" of Nextloud. Here the user can enter text.
on this view the user can "Cancel" or "Send share" by having two buttons
we removing all options from the exisitng "..."-menu except "unshare"
hide download should disable on file drop permission
 
After the process
clicking on the "..."-menu will slide in a button menu (like on the big "add" button n Nextcloud) with the following options:**
"Open in..." (ger: "Öffnen mit...") -> will open the Android share screen for sharing with other applications
we added"Advanced permissions" (ger: "Erweiterte Berechtigungen")
"Advanced permissions" will lead to the first new full right menu view ** with all the permission option (except note to recipient) with 2 Button: "Cancel" (ger: "Abbrechen") and "Confirm" (ger: "Übernehmen")
we added to the existing "..."-menu "Send new email" (ger: "Neue Email versenden")
"Send new email" will lead to the second new full right menu view ** with the text field to enter a message; we added two buttons: "Cancel" (ger: "Abbrechen") and "Send email" (ger: "Email senden")
"Unshare" (ger: "Freigabe beenden") will remove the share
we removed all the other remaining options by hiding them
clicking on the new permission button ot of Sharing #2 will lead to standard Nextccloud dialog box with the radio button options (read only, can edit, file drop if it is a folder)


![Screenshot from 2021-09-16 11-28-52](https://user-images.githubusercontent.com/88780169/133558023-c70a8e1e-bd26-4270-8601-868b5f8cfc97.png)
![Screenshot from 2021-09-16 11-28-16](https://user-images.githubusercontent.com/88780169/133558029-28b3201c-3068-44a3-8d3a-f9d0775ab2df.png)
![Screenshot from 2021-09-16 11-27-58](https://user-images.githubusercontent.com/88780169/133558031-2b4edb70-22f1-45cc-8216-0a04e6d890a5.png)
![Screenshot from 2021-09-16 11-27-42](https://user-images.githubusercontent.com/88780169/133558034-baff40c5-452e-4fe7-aa1a-4ccdfbf549c3.png)
![Screenshot from 2021-09-16 11-27-26](https://user-images.githubusercontent.com/88780169/133558038-77ec8e4e-b90e-4817-b096-e7bca9d3fdc2.png)
![Screenshot from 2021-09-16 11-27-14](https://user-images.githubusercontent.com/88780169/133558043-f944a4ff-4426-4355-9cee-4f67cfcdc311.png)
