### PR TITLE
Issue 16719: CheckSetupController.php now checks configured temporary directory for existence and if it's writable

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -75,6 +75,7 @@ use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\Lock\ILockingProvider;
 use OCP\Security\ISecureRandom;
@@ -111,6 +112,8 @@ class CheckSetupController extends Controller {
 	private $iniGetWrapper;
 	/** @var IDBConnection */
 	private $connection;
+	/** @var ITempManager */
+	private $tempManager;
 
 	public function __construct($AppName,
 								IRequest $request,
@@ -127,7 +130,8 @@ class CheckSetupController extends Controller {
 								MemoryInfo $memoryInfo,
 								ISecureRandom $secureRandom,
 								IniGetWrapper $iniGetWrapper,
-								IDBConnection $connection) {
+								IDBConnection $connection,
+								ITempManager $tempManager) {
 		parent::__construct($AppName, $request);
 		$this->config = $config;
 		$this->clientService = $clientService;
@@ -143,6 +147,7 @@ class CheckSetupController extends Controller {
 		$this->secureRandom = $secureRandom;
 		$this->iniGetWrapper = $iniGetWrapper;
 		$this->connection = $connection;
+		$this->tempManager = $tempManager;
 	}
 
 	/**
@@ -556,7 +561,7 @@ Raw output
 
 	private function isTemporaryDirectoryWritable(): bool {
 		try {
-			if (!empty(OC::$server->getTempManager()->getTempBaseDir())) {
+			if (!empty($this->tempManager->getTempBaseDir())) {
 				return true;
 			}
 		} catch (\Exception $e) {

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -554,6 +554,16 @@ Raw output
 		return extension_loaded('Zend OPcache');
 	}
 
+	private function isTemporaryDirectoryWritable(): bool {
+		try {
+			if (!empty(OC::$server->getTempManager()->getTempBaseDir())) {
+				return true;
+			}
+		} catch (\Exception $e) {
+		}
+		return false;
+	}
+
 	/**
 	 * Iterates through the configured app roots and
 	 * tests if the subdirectories are owned by the same user than the current user.
@@ -779,6 +789,7 @@ Raw output
 				CheckUserCertificates::class => ['pass' => $checkUserCertificates->run(), 'description' => $checkUserCertificates->description(), 'severity' => $checkUserCertificates->severity(), 'elements' => $checkUserCertificates->elements()],
 				'isDefaultPhoneRegionSet' => $this->config->getSystemValueString('default_phone_region', '') !== '',
 				SupportedDatabase::class => ['pass' => $supportedDatabases->run(), 'description' => $supportedDatabases->description(), 'severity' => $supportedDatabases->severity()],
+				'temporaryDirectoryWritable' => $this->isTemporaryDirectoryWritable(),
 			]
 		);
 	}

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -52,6 +52,7 @@ use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\Lock\ILockingProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -99,6 +100,8 @@ class CheckSetupControllerTest extends TestCase {
 	private $iniGetWrapper;
 	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
 	private $connection;
+	/** @var ITempManager|\PHPUnit\Framework\MockObject\MockObject */
+	private $tempManager;
 
 	/**
 	 * Holds a list of directories created during tests.
@@ -141,6 +144,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->iniGetWrapper = $this->getMockBuilder(IniGetWrapper::class)->getMock();
 		$this->connection = $this->getMockBuilder(IDBConnection::class)
 			->disableOriginalConstructor()->getMock();
+		$this->tempManager = $this->getMockBuilder(ITempManager::class)->getMock();
 		$this->checkSetupController = $this->getMockBuilder(CheckSetupController::class)
 			->setConstructorArgs([
 				'settings',
@@ -159,6 +163,7 @@ class CheckSetupControllerTest extends TestCase {
 				$this->secureRandom,
 				$this->iniGetWrapper,
 				$this->connection,
+				$this->tempManager,
 			])
 			->setMethods([
 				'isReadOnlyConfig',
@@ -180,6 +185,7 @@ class CheckSetupControllerTest extends TestCase {
 				'hasRecommendedPHPModules',
 				'hasBigIntConversionPendingColumns',
 				'isMysqlUsedWithoutUTF8MB4',
+				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed',
 				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed',
 			])->getMock();
 	}

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -487,6 +487,15 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						})
 					}
+					if (!data.temporaryDirectoryWritable) {
+						messages.push({
+							msg: t(
+								'core',
+								'The temporary directory of this instance points to an either non-existing or non-writable directory.'
+							),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						})
+					}
 					if (window.location.protocol === 'https:' && data.reverseProxyGeneratedURL.split('/')[0] !== 'https:') {
 						messages.push({
 							msg: t('core', 'You are accessing your instance over a secure connection, however your instance is generating insecure URLs. This most likely means that you are behind a reverse proxy and the overwrite config variables are not set correctly. Please read {linkstart}the documentation page about this ↗{linkend}.')

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -1261,7 +1261,7 @@ describe('OC.SetupChecks tests', function() {
 					recommendedPHPModules: [],
 					pendingBigIntConversionColumns: [],
 					isMysqlUsedWithoutUTF8MB4: false,
-					isDefaultPhoneRegionSet: false,
+					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: false,

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -254,6 +254,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -310,6 +311,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -367,6 +369,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -422,6 +425,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -475,6 +479,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -530,6 +535,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -583,6 +589,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -636,6 +643,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -689,6 +697,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -763,6 +772,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -817,6 +827,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -871,6 +882,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -925,6 +937,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -978,6 +991,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -1036,6 +1050,7 @@ describe('OC.SetupChecks tests', function() {
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -1090,6 +1105,7 @@ describe('OC.SetupChecks tests', function() {
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -1140,6 +1156,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: true,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: false,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -1193,6 +1210,7 @@ describe('OC.SetupChecks tests', function() {
 					isDefaultPhoneRegionSet: false,
 					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: true,
 				})
 			);
 
@@ -1200,6 +1218,60 @@ describe('OC.SetupChecks tests', function() {
 				expect(data).toEqual([{
 					msg: 'Your installation has no default phone region set. This is required to validate phone numbers in the profile settings without a country code. To allow numbers without a country code, please add "default_phone_region" with the respective <a target="_blank" rel="noreferrer noopener" class="external" href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements">ISO 3166-1 code ↗</a> of the region to your config file.',
 					type: OC.SetupChecks.MESSAGE_TYPE_INFO
+				}]);
+				done();
+			});
+		});
+
+		it('should return an info if the temporary directory is either non-existent or non-writable', function(done) {
+			var async = OC.SetupChecks.checkSetup();
+
+			suite.server.requests[0].respond(
+				200,
+				{
+					'Content-Type': 'application/json',
+				},
+				JSON.stringify({
+					hasFileinfoInstalled: true,
+					isGetenvServerWorking: true,
+					isReadOnlyConfig: false,
+					hasWorkingFileLocking: true,
+					hasValidTransactionIsolationLevel: true,
+					suggestedOverwriteCliURL: '',
+					isRandomnessSecure: true,
+					securityDocs: 'https://docs.nextcloud.com/myDocs.html',
+					serverHasInternetConnectionProblems: false,
+					isMemcacheConfigured: true,
+					forwardedForHeadersWorking: true,
+					isCorrectMemcachedPHPModuleInstalled: true,
+					hasPassedCodeIntegrityCheck: true,
+					isOpcacheProperlySetup: true,
+					hasOpcacheLoaded: true,
+					isSettimelimitAvailable: true,
+					hasFreeTypeSupport: true,
+					missingIndexes: [],
+					missingPrimaryKeys: [],
+					missingColumns: [],
+					cronErrors: [],
+					cronInfo: {
+						diffInSeconds: 0
+					},
+					isMemoryLimitSufficient: true,
+					appDirsWithDifferentOwner: [],
+					recommendedPHPModules: [],
+					pendingBigIntConversionColumns: [],
+					isMysqlUsedWithoutUTF8MB4: false,
+					isDefaultPhoneRegionSet: false,
+					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
+					reverseProxyGeneratedURL: 'https://server',
+					temporaryDirectoryWritable: false,
+				})
+			);
+
+			async.done(function( data, s, x ){
+				expect(data).toEqual([{
+					msg: 'The temporary directory of this instance points to an either non-existing or non-writable directory.',
+					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}]);
 				done();
 			});


### PR DESCRIPTION
[Issue 16719](https://github.com/nextcloud/server/issues/16719) discusses missing CheckSetupController.php feature to notify the user about misconfigured temporary directory settings.
This PR adds such a capability.

**Note:** Tests for CheckSetupController.php:792 / isTemporaryDirectoryWritable() are missing

Fix https://github.com/nextcloud/server/issues/16719