### PR TITLE
Fix files view change and undefined currentFileList

### DIFF
--- a/apps/files/js/gotoplugin.js
+++ b/apps/files/js/gotoplugin.js
@@ -46,7 +46,7 @@
 				actionHandler: function (fileName, context) {
 					var fileModel = context.fileInfoModel;
 					OC.Apps.hideAppSidebar($('.detailsView'));
-					OCA.Files.App.setActiveView('files', {silent: true});
+					OCA.Files.App.setActiveView('files');
 					OCA.Files.App.fileList.changeDirectory(fileModel.get('path'), true, true).then(function() {
 						OCA.Files.App.fileList.scrollTo(fileModel.get('name'));
 					});


### PR DESCRIPTION
Fix #26672

## Steps
1. Favourite a file
2. Go to favourites
3. Open file menu and click "View in folder"
4. Try to create a file

## Explanations
Because the change is set to `silent`, we don't emit the jQuery event to dispatch the view change.
So the app is not fully instantiated on the new view.
https://github.com/nextcloud/server/blob/f13b3ab4aee79eeb949f5a6641e772ca71d10fbf/apps/files/js/navigation.js#L153-L168