### PR TITLE
Fall back to full file for video previews

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -50,17 +50,34 @@ class Movie extends ProviderV2 {
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
 		// TODO: use proc_open() and stream the source file ?
 
-		$absPath = $this->getLocalFile($file, 5242880); // only use the first 5MB
-
-		$result = $this->generateThumbNail($maxX, $maxY, $absPath, 5);
-		if ($result === null) {
-			$result = $this->generateThumbNail($maxX, $maxY, $absPath, 1);
-			if ($result === null) {
-				$result = $this->generateThumbNail($maxX, $maxY, $absPath, 0);
-			}
+		$result = null;
+		if ($this->useTempFile($file)) {
+			// try downloading 5 MB first as it's likely that the first frames are present there
+			// in some cases this doesn't work for example when the moov atom is at the
+			// end of the file, so if it fails we fall back to getting the full file
+			$sizeAttempts = [5242880, null];
+		} else {
+			// size is irrelevant, only attempt once
+			$sizeAttempts = [null];
 		}
 
-		$this->cleanTmpFiles();
+		foreach ($sizeAttempts as $size) {
+			$absPath = $this->getLocalFile($file, $size);
+
+			$result = $this->generateThumbNail($maxX, $maxY, $absPath, 5);
+			if ($result === null) {
+				$result = $this->generateThumbNail($maxX, $maxY, $absPath, 1);
+				if ($result === null) {
+					$result = $this->generateThumbNail($maxX, $maxY, $absPath, 0);
+				}
+			}
+
+			$this->cleanTmpFiles();
+
+			if ($result !== null) {
+				break;
+			}
+		}
 
 		return $result;
 	}

--- a/lib/private/Preview/ProviderV2.php
+++ b/lib/private/Preview/ProviderV2.php
@@ -70,6 +70,10 @@ abstract class ProviderV2 implements IProviderV2 {
 	 */
 	abstract public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage;
 
+	protected function useTempFile(File $file) {
+		return $file->isEncrypted() || !$file->getStorage()->isLocal();
+	}
+
 	/**
 	 * Get a path to either the local file or temporary file
 	 *
@@ -78,8 +82,7 @@ abstract class ProviderV2 implements IProviderV2 {
 	 * @return string
 	 */
 	protected function getLocalFile(File $file, int $maxSize = null): string {
-		$useTempFile = $file->isEncrypted() || !$file->getStorage()->isLocal();
-		if ($useTempFile) {
+		if ($this->useTempFile($file)) {
 			$absPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 			$content = $file->fopen('r');


### PR DESCRIPTION
If the first 5 MB are not enough to grab a useful frame for the
thumbnail preview, fall back to reading the full file.

Fixes https://github.com/nextcloud/server/issues/28694

To test you have to find a video file (mp4) that's big enough and for which thumbnail is not working.
I happened to have found one captured by my phone.

I've tested with master-key encryption as it will trigger the temporary file + use the first 5 MB logic.

Before the fix: some video files have no thumbnail.
After the fix: all video files have a thumbnail.
