### PR TITLE
explicitly close source stream on local / encryption storage

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -568,8 +568,11 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function writeStream(string $path, $stream, int $size = null): int {
 		$result = $this->file_put_contents($path, $stream);
+		if (is_resource($stream)) {
+			fclose($stream);
+		}
 		if ($result === false) {
-			throw new GenericFileException("Failed write steam to $path");
+			throw new GenericFileException("Failed write stream to $path");
 		} else {
 			return $result;
 		}

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -926,10 +926,10 @@ class Encryption extends Wrapper {
 		}
 
 		$result = [];
-		
+
 		// first check if it is an encrypted file at all
 		// We would do query to filecache only if we know that entry in filecache exists
-		
+
 		$info = $this->getCache()->get($path);
 		if (isset($info['encrypted']) && $info['encrypted'] === true) {
 			$firstBlock = $this->readFirstBlock($path);
@@ -1033,6 +1033,7 @@ class Encryption extends Wrapper {
 		// always fall back to fopen
 		$target = $this->fopen($path, 'w');
 		[$count, $result] = \OC_Helper::streamCopy($stream, $target);
+		fclose($stream);
 		fclose($target);
 		return $count;
 	}

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -658,6 +658,7 @@ abstract class Storage extends \Test\TestCase {
 
 		$storage->writeStream('test.txt', $source);
 		$this->assertTrue($storage->file_exists('test.txt'));
-		$this->assertEquals(file_get_contents($textFile), $storage->file_get_contents('test.txt'));
+		$this->assertStringEqualsFile($textFile, $storage->file_get_contents('test.txt'));
+		$this->assertEquals('resource (closed)', gettype($source));
 	}
 }


### PR DESCRIPTION
e60a829b42f0f4b74db835d8e10438a33e125051 local

```
Uncaught Error: Class 'OC\Log\ExceptionSerializer' not found in /var/www/html/lib/private/Log.php:316
Stack trace:
#0 /var/www/html/lib/private/Log/ErrorHandler.php(100): OC\Log->logException(Object(Error), Array)
#1 [internal function]: OC\Log\ErrorHandler::onAll(2, 'fwrite(): suppl...', '/var/www/html/a...', 62, Array)
#2 /var/www/html/apps-extra/files_antivirus/lib/Scanner/ExternalClam.php(62): fwrite(Resource id #1295, '\x00\x00\x00\x00')
#3 /var/www/html/apps-extra/files_antivirus/lib/Scanner/ScannerBase.php(143): OCA\Files_Antivirus\Scanner\ExternalClam->shutdownScanner()
#4 /var/www/html/apps-extra/files_antivirus/lib/AvirWrapper.php(118): OCA\Files_Antivirus\Scanner\ScannerBase->completeAsyncScan()
#5 [internal function]: OCA\Files_Antivirus\AvirWrapper->OCA\Files_Antivirus\{closure}()
#6 /var/www/html/apps/files_external/3rdparty/icewind/streams/src/CallbackWrapper.php(119): call_user_func(Object(Closure))
#7 [internal function]: Icewind\Streams\CallbackWrapper->stream_close()
#8 {main}
  thrown at /var/www/html/lib/private/Log.php#316
```

I run into the above error when scanning a chunked upload after assembly. files_antivirus is using a callback for [stream_close](https://github.com/nextcloud/files_antivirus/blob/f6c63f3a46550f040299c30bd7d7590741436c42/lib/AvirWrapper.php#L118) to fetch the status (infected yes/no) from clamav. When the stream is not closed explicitly it's happening so late that not even the autoloader is registered anymore. 

Fallback implementation for storage already closes the stream on close:
https://github.com/nextcloud/server/blob/dbf7905149222115a2cd0334efcf8c93afa8683e/lib/private/Files/Storage/Common.php#L873

ObjectStoreStorage is also closing the streams explicitly:
https://github.com/nextcloud/server/blob/dbf7905149222115a2cd0334efcf8c93afa8683e/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L491
https://github.com/nextcloud/server/blob/dbf7905149222115a2cd0334efcf8c93afa8683e/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L497



be3f4edf1f38b1ebfd91366334e5a3a91c63cffe encryption

1. The initial version https://github.com/nextcloud/server/commit/c6a48110bfbf5b3f100b0f2fc092e806e079e34e were closing the input stream. 
2. https://github.com/nextcloud/server/pull/13468 removed `fclose($stream)` to fix https://github.com/nextcloud/server/issues/13276. 
3. In the meantime https://github.com/nextcloud/server/pull/22739 update detection for failed writes to the storage. That's a better way to fix point 2. 

I'm able to upload empty files with and without encryption (via web and nautilus) to local storage and object store. 