### PR TITLE
Fix public shared folder page when quota includes external storages

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -403,6 +403,13 @@ class ShareController extends AuthPublicShareController {
 
 			$shareTmpl['dir'] = $shareNode->getRelativePath($folderNode->getPath());
 
+			// In some cases (for example, when quota includes the external
+			// storages) the filesystem needs to be mounted to be able to check
+			// the free space.
+			/* FIXME: We should do this all nicely in OCP */
+			OC_Util::tearDownFS();
+			OC_Util::setupFS($share->getShareOwner());
+
 			/*
 			 * The OC_Util methods require a view. This just uses the node API
 			 */

--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -151,6 +151,23 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then /^public page of last share can be shown$/
+	 */
+	public function publicPageOfLastShareCanBeShown() {
+		if (count($this->lastShareData->data->element) > 0) {
+			$token = $this->lastShareData->data[0]->token;
+		} else {
+			$token = $this->lastShareData->data->token;
+		}
+
+		$fullUrl = substr($this->baseUrl, 0, -4) . "index.php/s/" . $token;
+
+		$client = new Client();
+		$this->response = $client->get($fullUrl);
+		Assert::assertEquals(200, $this->response->getStatusCode());
+	}
+
+	/**
 	 * @Then /^last link share can be downloaded$/
 	 */
 	public function lastLinkShareCanBeDownloaded() {

--- a/build/integration/features/bootstrap/SharingContext.php
+++ b/build/integration/features/bootstrap/SharingContext.php
@@ -47,4 +47,11 @@ class SharingContext implements Context, SnippetAcceptingContext {
 		$this->deleteServerConfig('core', 'shareapi_expire_after_n_days');
 		$this->deleteServerConfig('core', 'link_defaultExpDays');
 	}
+
+	/**
+	 * @AfterScenario
+	 */
+	public function resetSystemConfigs() {
+		$this->invokingTheCommand('config:system:delete quota_include_external_storage');
+	}
 }

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -357,6 +357,17 @@ Feature: sharing
       | url | AN_URL |
       | mimetype | httpd/unix-directory |
 
+  Scenario: Creating a new public shared folder by user with quota but without external storages and show the share
+    Given user "user0" exists
+    And As an "admin"
+    And user "user0" has a quota of "10 MB"
+    And invoking occ with "config:system:set quota_include_external_storage --value=true --type boolean"
+    And As an "user0"
+    When creating a share with
+      | path | FOLDER |
+      | shareType | 3 |
+    Then public page of last share can be shown
+
   Scenario: Creating a new share of a file with default permissions
     Given user "user0" exists
     And user "user1" exists


### PR DESCRIPTION
Fixes #27322

When the quota storage wrapper is used (that is, when the share owner has a quota set) and `quota_include_external_storage` is enabled [when checking the free space `Filesystem::getFileInfo('', 'ext')` is called](https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Files/Storage/Wrapper/Quota.php#L75), which [requires the file system to have been initialized](https://github.com/nextcloud/server/blob/a70fd1bad1626e67982ac59d8b3da486ffad70c5/lib/private/Files/Filesystem.php#L736). This is explicitly done now in `showShare` similar to what is done in [`downloadShare`](https://github.com/nextcloud/server/blob/c56c317d82e6015739549a606578e963578f4de6/apps/files_sharing/lib/Controller/ShareController.php#L651-L653).

Pending:
- [X] Fix the issue :-) ~~For now this just includes an integration test that shows it.~~
- [ ] Verify that the fix is the proper one and not just a dirty hack. Maybe something should be fixed instead in the Quota wrapper or the Filesystem itself?

## How to reproduce
- Log in to Nextcloud as an admin
- Create a user
- Set a quota for that user (for example, 1 GB)
- Enable `quota_include_external_storage`, for example, with `occ config:system:set quota_include_external_storage --value=true --type boolean`
  - Note that you do not need to setup an external storage, only to enable the setting
- Log in as the user
- Create a new folder
- Create a public share for that folder
- Open the link to the public share

### Result with this pull request
The public shared folder page is opened

### Result without this pull request
The server returns an internal error