### PR TITLE
Improve syntax error reporting

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -155,7 +155,7 @@ class Dispatcher {
 			$response = $this->middlewareDispatcher->afterException(
 				$controller, $methodName, $exception);
 		} catch (\Throwable $throwable) {
-			$exception = new \Exception($throwable->getMessage(), $throwable->getCode(), $throwable);
+			$exception = new \Exception($throwable->getMessage() . ' in file \'' . $throwable->getFile() . '\' line ' . $throwable->getLine(), $throwable->getCode(), $throwable);
 			$response = $this->middlewareDispatcher->afterException(
 			$controller, $methodName, $exception);
 		}


### PR DESCRIPTION
In some cases the error information is not enough to debug it.

Before:

```
syntax error, unexpected '<<' (T_SL)
/var/www/html/lib/private/AppFramework/Http/Dispatcher.php
158
```

After:

```
syntax error, unexpected '<<' (T_SL) in file '/var/www/html/apps/groupfolders/lib/Mount/GroupFolderStorage.php' line 88
/var/www/html/lib/private/AppFramework/Http/Dispatcher.php
158
```

Signed-off-by: Carl Schwan <carl@carlschwan.eu>