### PR TITLE
fix caching of objectsid searches

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -409,6 +409,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	private function getNameOfGroup(string $filter, string $cacheKey) {
 		$result = $this->access->searchGroups($filter, ['dn'], 1);
 		if (empty($result)) {
+			$this->access->connection->writeToCache($cacheKey, false);
 			return null;
 		}
 		$dn = $result[0]['dn'][0];
@@ -533,10 +534,10 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	 * @throws ServerNotAvailableException
 	 */
 	public function primaryGroupID2Name(string $gid, string $dn) {
-		$cacheKey = 'primaryGroupIDtoName';
-		$groupNames = $this->access->connection->getFromCache($cacheKey);
-		if (!is_null($groupNames) && isset($groupNames[$gid])) {
-			return $groupNames[$gid];
+		$cacheKey = 'primaryGroupIDtoName_' . $gid;
+		$groupName = $this->access->connection->getFromCache($cacheKey);
+		if (!is_null($groupName)) {
+			return $groupName;
 		}
 
 		$domainObjectSid = $this->access->getSID($dn);

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -320,6 +320,38 @@ class Group_LDAPTest extends TestCase {
 		$this->assertSame(false, $gid);
 	}
 
+	public function testPrimaryGroupID2NameSuccessCache() {
+		$access = $this->getAccessMock();
+		$pluginManager = $this->getPluginManagerMock();
+
+		$this->enableGroups($access);
+
+		$userDN = 'cn=alice,cn=foo,dc=barfoo,dc=bar';
+		$gid = '3117';
+		$groupDN = 'cn=foo,dc=barfoo,dc=bar';
+
+		/** @var MockObject $connection */
+		$connection = $access->connection;
+		$connection->expects($this->once())
+			->method('getFromCache')
+			->with('primaryGroupIDtoName_' . $gid)
+			->willReturn('MyGroup');
+
+		$access->expects($this->never())
+			->method('getSID');
+
+		$access->expects($this->never())
+			->method('searchGroups');
+
+		$access->expects($this->never())
+			->method('dn2groupname');
+
+		$groupBackend = new GroupLDAP($access, $pluginManager);
+		$group = $groupBackend->primaryGroupID2Name($gid, $userDN);
+
+		$this->assertSame('MyGroup', $group);
+	}
+
 	public function testPrimaryGroupID2NameSuccess() {
 		$access = $this->getAccessMock();
 		$pluginManager = $this->getPluginManagerMock();


### PR DESCRIPTION
- store result when no name could be retrieved, too
- cached value is not an array, was treated wrongly

