### PR TITLE
Make copy non-blocking for the encryption wrapper 

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -96,7 +96,12 @@ class TransferOwnership extends Command {
 				InputOption::VALUE_OPTIONAL,
 				'transfer incoming user file shares to destination user. Usage: --transfer-incoming-shares=1 (value required)',
 				'2'
-		);
+			)->addOption(
+				'ignore-encryption-error',
+				null,
+				InputOption::VALUE_NONE,
+				'ignore encryption error. Usage: --ignore-encryption-error',
+			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
@@ -145,6 +150,8 @@ class TransferOwnership extends Command {
 					return 1;
 					break;
 			}
+
+			$GLOBALS['ignore-encryption-error'] = $input->getOption('ignore-encryption-error');
 
 			$this->transferService->transfer(
 				$sourceUserObject,

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -759,7 +759,7 @@ class Encryption extends Wrapper {
 				fclose($source);
 				fclose($target);
 				$this->logger->logException(new \Exception("Fail to copy '$sourceInternalPath' to '$targetInternalPath'", 0, $e));
-				if (defined('STDERR')) {
+				if ($GLOBALS['ignore-encryption-error']) {
 					fwrite(STDERR, "	- Skipping '$sourceInternalPath'" . $e->getMessage() . PHP_EOL);
 					$result = true;
 				} else {
@@ -932,10 +932,10 @@ class Encryption extends Wrapper {
 		}
 
 		$result = [];
-		
+
 		// first check if it is an encrypted file at all
 		// We would do query to filecache only if we know that entry in filecache exists
-		
+
 		$info = $this->getCache()->get($path);
 		if (isset($info['encrypted']) && $info['encrypted'] === true) {
 			$firstBlock = $this->readFirstBlock($path);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -758,7 +758,13 @@ class Encryption extends Wrapper {
 			} catch (\Exception $e) {
 				fclose($source);
 				fclose($target);
-				throw $e;
+				$this->logger->logException(new \Exception("Fail to copy '$sourceInternalPath' to '$targetInternalPath'", 0, $e));
+				if (defined('STDERR')) {
+					fwrite(STDERR, "	- Skipping '$sourceInternalPath'" . $e->getMessage() . PHP_EOL);
+					$result = true;
+				} else {
+					throw $e;
+				}
 			}
 			if ($result) {
 				if ($preserveMtime) {


### PR DESCRIPTION
## Issue

During an ownership transfer, if a file fails to be moved, then the transfer stops. This PR partly changes this behaviour for encryption error.

## What this PR changes:

1. When called from the CLI, ignore the exceptions in `copyBetweenStorage` method of `Files/Storage/Wrapper/Encryption.php`
2. Log, in both the CLI and the log file to let the admin know which files are problematic.

## Testing steps from a fresh install with encryption enabled:

- add a new file `1.md` to Alice
- disable encryption `php occ encryption:disable`
- add a new file `2.md` to Alice
- enable encryption `php occ encryption:enable`
- set encryption=1 in `oc_filecache` for `2.md`
- add a new file `3.md` to Alice
- run `php occ files:transfer-ownership alice bob`
- run `file:scan bob`

### Without this PR:

- The transfer folder contains only `1.md`
- An error message is logged in the CLI but without any information about the failing files
- The files still exist in the original location
- The command return 1

### With this PR (depending on the chosen solution below):

- The transfer folder exists and contains all the files besides `2.md`
- All the files have been deleted from the original location
- An error message with the problematic file names is logged in the CLI
- A log with the problematic file names and the exception is added to the server logs
- The command return 1

## Problems

- If we ignore the encryption errors, the problematic files are not copied, but are still removed.
- If we do not ignore the encryption errors, the copy is stopped halfway through.

## Alternative solutions

- In the handling of the encryption error, we can copy the encrypted file "as is" without checking the encryption, and continue with the copy.

## Decision

We won't merge this as it is too hacky.