### PR TITLE
21.0.5 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 4, 2];
+$OC_Version = [21, 0, 5, 0];
 
 // The human readable string
-$OC_VersionString = '21.0.4';
+$OC_VersionString = '21.0.5 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #27234 Bump @babel/core from 7.12.10 to 7.12.17
* #27406 Avoid fread on directories and unencrypted files
* #27640 Bump clipboard from 2.0.6 to 2.0.8
* #27681 Harden bootstrap context registrations when apps are missing
* #27917 Bump css-loader from 5.0.1 to 5.0.2
* #27983 Bump vue and vue-template-compiler
* #28203 Bump url-search-params-polyfill from 8.1.0 to 8.1.1
* #28253 Add h2 to personal info page, fixing accessibility issue
* #28275 Fix CI failures when building settings app
* #28287 Check that php was compiled with argon2 support or that the php-sodium extensions is installed
* #28354 Change the concurrent upload limit to less than 10
* #28358 Bump debounce from 1.2.0 to 1.2.1
* #28361 Fix Folder->getById() when a single storage is mounted multiple times
* #28383 Make "name" column nullable for workflows
* #28386 Dont show trusted proxy warning when the proxy and remote are both localhost
* #28400 Better cleanup of user files on user deletion
* #28415 Gracefully handle smb acls for users without a domain
* #28440 Bump vue-loader from 15.9.7 to 15.9.8
* #28442 Add missing files for Composer v2
* #28447 Improve auto expiration hint for trashbin and file versions
* #28455 UnifiedSearchController: strip webroot from URL before finding a route
* #28469 Only trap E_ERROR in session handling
* #28490 Emit an error log when the app token login name does not match
* #28495 Hash cache key
* #28498 Fix #20913: Check image resource before attempting to preserve alpha
* #28517 Output exception in cron
* #28523 Properly log errors in Movie previews generation
* #28535 Fix folder size contained in S3 buckets
* #28537 Set alias for result of cast column function
* #28546 Do not load versions tab view if the files app is not available
* #28577 Log exception message during failed ownership transfer share restore
* #28597 Fix setting up 2FA providers when 2FA is enforced and bc are generated
* #28604 Fix encrypted version to 0 when finding unencrypted file
* #28623 Bump css-vars-ponyfill from 2.4.5 to 2.4.6
* #28656 Only recommand for php-sodium on >= PHP 7.4
* #28673 Fix position of search bar
* #28702 Fix user list infinite loading state in user settings
* #28706 Pin Psalm version for security analysis
* #28709 Bump css-vars-ponyfill from 2.4.6 to 2.4.7
* #28735 Check if SVG path is valid
* #28741 Remove 2FA exemption from PublicPage annotation
* #28749 Send attendence links to required and optinal attendees of an event without an RSVP
* #28753 Bump 3rdparty ref
* #28770 Fix trashbin files view sticky action bar
* #28782 Dashboard - fix touch layout
* #28786 Scan the shared external storage source on access
* #28800 Bump vue-clipboard2 from 0.3.1 to 0.3.2
* #28811 Bump 3rdparty reference
* #28815 Add database ratelimiting backend
* #28829 Update .htaccess (php8+ and mod_lsapi)
* #28831 Do not cache file ids in FileSystemTags inside group folders
* #28849 L10n: ignore packed js files from TX sync
* #28859 Add email addresses to contacts menu
* #28879 Fix files view change and undefined currentFileList
* #28882 Fix file creation from template without ext
* #28887 Bump vue-clipboard2 from 0.3.2 to 0.3.3
* #28896 Fall back to full file for video previews
* #28901 Update CRL due to revoked twofactor_email.crt
* #28909 Support seeking also from the end of file on S3 storage
* #28920 Use IRoomMetadata as source of truth for supported room types
* [3rdparty#782](https://github.com/nextcloud/3rdparty/pull/782) Bump Archive_Tar to latest release
* [3rdparty#784](https://github.com/nextcloud/3rdparty/pull/784) Bump Webauthn Lib to 3.3.9
* [3rdparty#811](https://github.com/nextcloud/3rdparty/pull/811) Composer install
* [activity#634](https://github.com/nextcloud/activity/pull/634) Fix activity design
* [activity#642](https://github.com/nextcloud/activity/pull/642) Increase activity email speed in instances with more than 500 users
* [files_pdfviewer#462](https://github.com/nextcloud/files_pdfviewer/pull/462) Fix hide download and printing
* [files_pdfviewer#464](https://github.com/nextcloud/files_pdfviewer/pull/464) Fix body footer hiding
* [files_pdfviewer#470](https://github.com/nextcloud/files_pdfviewer/pull/470) Disable download for pdf files
* [files_pdfviewer#474](https://github.com/nextcloud/files_pdfviewer/pull/474) Fix download & print view
* [files_pdfviewer#481](https://github.com/nextcloud/files_pdfviewer/pull/481) Bump @babel/preset-env from 7.12.11 to 7.12.17
* [files_pdfviewer#482](https://github.com/nextcloud/files_pdfviewer/pull/482) Bump @babel/core from 7.12.10 to 7.12.17
* [files_pdfviewer#484](https://github.com/nextcloud/files_pdfviewer/pull/484) Bump eslint-import-resolver-webpack from 0.13.0 to 0.13.1
* [files_pdfviewer#486](https://github.com/nextcloud/files_pdfviewer/pull/486) Bump vue-loader from 15.9.6 to 15.9.8
* [files_pdfviewer#488](https://github.com/nextcloud/files_pdfviewer/pull/488) Bump vue-template-compiler from 2.6.12 to 2.6.14
* [files_pdfviewer#496](https://github.com/nextcloud/files_pdfviewer/pull/496) Use setup-php v2
* [files_pdfviewer#497](https://github.com/nextcloud/files_pdfviewer/pull/497) Update workflows
* [files_rightclick#120](https://github.com/nextcloud/files_rightclick/pull/120) Fix share option being displayed erroneously
* [notifications#1063](https://github.com/nextcloud/notifications/pull/1063) Give twofactor nextcloud notifications a high priority
* [notifications#1066](https://github.com/nextcloud/notifications/pull/1066) Always show the dismiss all button
* [notifications#1071](https://github.com/nextcloud/notifications/pull/1071) High priority for the PhoneTrack app
* [photos#874](https://github.com/nextcloud/photos/pull/874) Update dependabot
* [text#1752](https://github.com/nextcloud/text/pull/1752) Bump vue from 2.6.12 to 2.6.14
* [text#1816](https://github.com/nextcloud/text/pull/1816) Bump vue-loader from 15.9.7 to 15.9.8
* [text#1840](https://github.com/nextcloud/text/pull/1840) Bump core-js from 3.16.2 to 3.16.3
* [text#1846](https://github.com/nextcloud/text/pull/1846) Bump core-js from 3.16.3 to 3.16.4
* [text#1850](https://github.com/nextcloud/text/pull/1850) Bump prosemirror-markdown from 1.5.1 to 1.5.2
* [text#1858](https://github.com/nextcloud/text/pull/1858) Bump @babel/preset-env from 7.15.0 to 7.15.6
* [text#1859](https://github.com/nextcloud/text/pull/1859) Bump @babel/core from 7.15.0 to 7.15.5
* [viewer#1009](https://github.com/nextcloud/viewer/pull/1009) Build(deps-dev): bump @babel/core from 7.13.14 to 7.13.16
* [viewer#1011](https://github.com/nextcloud/viewer/pull/1011) Build(deps-dev): bump vue-loader from 15.9.6 to 15.9.8
* [viewer#1012](https://github.com/nextcloud/viewer/pull/1012) Build(deps-dev): bump @babel/preset-env from 7.13.12 to 7.13.15
* [viewer#1014](https://github.com/nextcloud/viewer/pull/1014) Build(deps-dev): bump eslint-import-resolver-webpack from 0.13.0 to 0.13.1
* [viewer#1021](https://github.com/nextcloud/viewer/pull/1021) Build(deps-dev): bump eslint-config-standard from 16.0.2 to 16.0.3


Pending PRs:

* [ ] #27203 Fix Oracle query limit compliance in Comments 
* [ ] #28199 Better cleanup of filecache when deleting an external storage 
* [ ] #28657 Delete calendar subscriptions as well when deleting user 
* [ ] #28730 Handle case where storage can't be created in getStorageRootId 
* [x] #28790 Fix null displayname crash as described in #21885 
* [ ] #28905 Explicitly close source stream on object store upload even if count… @kesselb
* [x] #28929 Bump 3rdparty ref @LukasReschke
* [ ] [text#1770](https://github.com/nextcloud/text/pull/1770) Fix: rich workspaces overlap with new file dropdown @szaimen