### PR TITLE
Don't further setup disabled users when logging in with apache

### DIFF
--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -35,6 +35,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IUserManager;
@@ -170,6 +172,10 @@ class OC_User {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
 				$userSession = \OC::$server->getUserSession();
+				if ($userSession->getUser() && !$userSession->getUser()->isEnabled()) {
+					$message = \OC::$server->getL10N('lib')->t('User disabled');
+					throw new LoginException($message);
+				}
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();
 				$userSession->createSessionToken($request, $uid, $uid);


### PR DESCRIPTION
### Steps
1. Set up SAML
2. Create a saml user
3. Disable the saml user
4. Try to login as the saml user

### Before
1. Infinite redirect: https://github.com/nextcloud/user_saml/issues/549
2. Admin audit logs a successful login:
```json
{"reqId":"YUxAmk6ad8CsAHoiDyFoMAAAAAM","level":1,"time":"2021-09-23T10:53:46+02:00","remoteAddr":"127.0.0.1","user":"admin","app":"admin_audit","method":"PUT","url":"/ocs/v2.php/cloud/users/saml1/disable","message":"User disabled: \"saml1\"","userAgent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0","version":"23.0.0.1"}
{"reqId":"YUxA7k6ad8CsAHoiDyFoNAAAAAM","level":1,"time":"2021-09-23T10:55:10+02:00","remoteAddr":"127.0.0.1","user":"--","app":"admin_audit","method":"GET","url":"/","message":"Login attempt: \"saml1\"","userAgent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0","version":"23.0.0.1"}
{"reqId":"YUxA7k6ad8CsAHoiDyFoNAAAAAM","level":1,"time":"2021-09-23T10:55:10+02:00","remoteAddr":"127.0.0.1","user":"saml1","app":"admin_audit","method":"GET","url":"/","message":"Login successful: \"saml1\"","userAgent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0","version":"23.0.0.1"}
```

### After
1. User sees default screen:
> ### Error
> User disabled


2. Admin audit logs only the login attempt, no successful login:
```json
{"reqId":"YUxGTMunf0qR2-3A3U3I2wAAAAU","level":1,"time":"2021-09-23T11:18:04+02:00","remoteAddr":"127.0.0.1","user":"--","app":"admin_audit","method":"GET","url":"/","message":"Login attempt: \"saml1\"","userAgent":"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0","version":"23.0.0.1"}
```