### PR TITLE
Add SCHEME_NULL to list of allowed auth mechanism

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -25,6 +25,7 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\Auth\AmazonS3\AccessKey;
+use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\DefinitionParameter;
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCP\IL10N;
@@ -54,6 +55,7 @@ class AmazonS3 extends Backend {
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
 			->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
+			->addAuthScheme(AuthMechanism::SCHEME_NULL)
 			->setLegacyAuthMechanism($legacyAuth)
 		;
 	}


### PR DESCRIPTION
Add AuthMechanism::SCHEME_NULL to list of allowed auth mechanism for AmazonS3 backend to allow attaching S3 storage to nextcloud instances running on already authorized instances (e.g. EC2 instances with IAM Instance roles)

USE CASE: When running nextcloud on AWS resources (eg. EC2 instances / EKS kubernetes pods), these instances can be associated with IAM roles that permit access to S3 buckets. In this case, no access-key is needed to access the bucket.

The files_external S3 configuration normally insists on the configuration of an Access-Key.

ADVANTAGES: By not using access keys to authorize access to the buckets the credentials do not need to be exposed and the management of IAM permissions is a little bit easier.