### PR TITLE
Allow upgrade from 22.2.0.0 to 22.2.0.1

### DIFF
--- a/version.php
+++ b/version.php
@@ -40,6 +40,7 @@ $OC_VersionCanBeUpgradedFrom = [
 		'21.0' => true,
 		'22.0' => true,
 		'22.1' => true,
+		'22.2' => true,
 	],
 	'owncloud' => [
 		'10.5' => true,


### PR DESCRIPTION
If you keep your stable22 branch up to date and are on 22.2.0.0 when upgrading to 22.2.0.1, upgrade is blocked.