### PR TITLE
21.0.5

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 5, 0];
+$OC_Version = [21, 0, 5, 1];
 
 // The human readable string
-$OC_VersionString = '21.0.5 RC1';
+$OC_VersionString = '21.0.5';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Changes compare to RC1

* #27203 Fix Oracle query limit compliance in Comments
* #28905 Explicitly close source stream on object store upload even if count…
* #28950 Fix caching of objectsid searches
* #28963 Don't allow to change activity settings that don't work
* #28999 Fix redirect during initial setup
* [viewer#1023](https://github.com/nextcloud/viewer/pull/1023) Build(deps): bump @nextcloud/dialogs from 3.1.1 to 3.1.2
* [viewer#1039](https://github.com/nextcloud/viewer/pull/1039) Build(deps): bump regenerator-runtime from 0.13.7 to 0.13.9
* [viewer#1040](https://github.com/nextcloud/viewer/pull/1040) Build(deps-dev): bump eslint-webpack-plugin from 2.5.3 to 2.5.4

Pending PRs:

- none
