### PR TITLE
Fix redirect during initial setup

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -271,7 +271,8 @@ class URLGenerator implements IURLGenerator {
 	 * @return string base url of the current request
 	 */
 	public function getBaseUrl(): string {
-		if ($this->baseUrl === null) {
+		// BaseUrl can be equal to 'http(s)://' during the first steps of the intial setup.
+		if ($this->baseUrl === null || $this->baseUrl === "http://" || $this->baseUrl === "https://") {
 			$this->baseUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost() . \OC::$WEBROOT;
 		}
 		return $this->baseUrl;


### PR DESCRIPTION
`$this->request->getServerHost()` return an empty string during the initial setup [as it validate the request's domain against the trusted domains list](https://github.com/nextcloud/server/blob/master/lib/private/AppFramework/Http/Request.php#L902).

Combined with the [recently added cache of `URLGenerator->baseUrl`](https://github.com/nextcloud/server/blob/master/lib/private/URLGenerator.php#L274), this leads to a wrong redirect during the initial setup process.

This PR adds a check to ensure that the cached `baseUrl` is not used if it only contains the protocol.

Fix: https://github.com/nextcloud/server/issues/27575