### PR TITLE
Scheduling plugin not updating responding attendee status

### DIFF
--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -121,4 +121,10 @@ class InvitationResponseServer {
 		$schedulingPlugin = $this->server->getPlugin('caldav-schedule');
 		$schedulingPlugin->scheduleLocalDelivery($iTipMessage);
 	}
+
+	public function isExternalAttendee(string $principalUri): bool {
+		/** @var \Sabre\DAVACL\Plugin $aclPlugin */
+		$aclPlugin = $this->server->getPlugin('acl');
+		return $aclPlugin->getPrincipalByUri($principalUri) === null;
+	}
 }

--- a/apps/dav/lib/Controller/InvitationResponseController.php
+++ b/apps/dav/lib/Controller/InvitationResponseController.php
@@ -198,7 +198,12 @@ class InvitationResponseController extends Controller {
 		$iTipMessage->method = 'REPLY';
 		$iTipMessage->sequence = $row['sequence'];
 		$iTipMessage->sender = $row['attendee'];
-		$iTipMessage->recipient = $row['attendee'];
+
+		if ($this->responseServer->isExternalAttendee($row['attendee'])) {
+			$iTipMessage->recipient = $row['organizer'];
+		} else {
+			$iTipMessage->recipient = $row['attendee'];
+		}
 
 		$message = <<<EOF
 BEGIN:VCALENDAR

--- a/apps/dav/lib/Controller/InvitationResponseController.php
+++ b/apps/dav/lib/Controller/InvitationResponseController.php
@@ -198,7 +198,7 @@ class InvitationResponseController extends Controller {
 		$iTipMessage->method = 'REPLY';
 		$iTipMessage->sequence = $row['sequence'];
 		$iTipMessage->sender = $row['attendee'];
-		$iTipMessage->recipient = $row['organizer'];
+		$iTipMessage->recipient = $row['attendee'];
 
 		$message = <<<EOF
 BEGIN:VCALENDAR


### PR DESCRIPTION
Take 2 on fixing the attendee's own status not updating.

Thanks to @kesselb we now know the correct way to create an iTip message.

From his comment on the other PR: https://github.com/nextcloud/server/pull/28094

The purpose of this pull request is to fix an issue with updating the attendance status for the attendee itself. To reproduce create a event and invite Alice and Bob. Wait for Bob's invitation email and accept the invite. The attendance status for the organizer and Alice is updated (Bob accepted the invite). In Bob's calendar event the attendance status is still pending. 

A possible explanation for this case is the way we handle event invitations. If a user accept or decline an invitation a iTip message is generated. 

https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/apps/dav/lib/Controller/InvitationResponseController.php#L200-L201

The recipient is used to select the right event from the calendar. When Alice accept the invite an iTip message is generated with sender = alice@example.org and recipient = organizer@example.org. The event for recipient organizer@example.org is selected and the attendance status for alice@example.org updated. Then for every other attendee another iTip message is generated to also update their event. 

https://github.com/nextcloud/3rdparty/blob/6876f1fce8d1c70790c165dd7ed0b4214364e397/sabre/dav/lib/CalDAV/Schedule/Plugin.php#L527-L538

![image](https://user-images.githubusercontent.com/3902676/134508461-e4ce4ea7-d4ee-48d1-b801-2996a32effaa.png)

Sabre assume that we already updated Alice event and there is no need to sent a iTip message to Alice. 

```
$iTipMessage->sender = $row['attendee']; 
$iTipMessage->recipient = $row['attendee']; 
```

When sender = recipient the calendar event for the attendee is updated and a iTip message for the organizer and other attendees generated and properly updated. 

Fixes https://github.com/nextcloud/calendar/issues/2861
