### PR TITLE
Add additional logging on SMB failure to read folder content

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -239,6 +239,7 @@ class SMB extends Common implements INotifyStorage {
 			try {
 				$files = $this->share->dir($path);
 			} catch (ForbiddenException $e) {
+				$this->logger->critical($e->getMessage(), ['exception' => $e]);
 				throw new NotPermittedException();
 			}
 			foreach ($files as $file) {


### PR DESCRIPTION
Currently we discard the error comming from the SMB library and create a
new exception for nextcloud. This patch makes sure that the
access/permission exception from the SMB library are logged correctly.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>