### PR TITLE
add 'supported'-label to all supported apps

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -204,12 +204,17 @@ class AppSettingsController extends Controller {
 		}
 
 		$apps = $this->getAppsForCategory('');
+		$supportedApps = $appClass->getSupportedApps();
 		foreach ($apps as $app) {
 			$app['appstore'] = true;
 			if (!array_key_exists($app['id'], $this->allApps)) {
 				$this->allApps[$app['id']] = $app;
 			} else {
 				$this->allApps[$app['id']] = array_merge($app, $this->allApps[$app['id']]);
+			}
+
+			if (in_array($app['id'], $supportedApps)) {
+				$this->allApps[$app['id']]['level'] = \OC_App::supportedApp;
 			}
 		}
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -774,6 +774,18 @@ class OC_App {
 	}
 
 	/**
+	 * List all supported apps
+	 *
+	 * @return array
+	 */
+	public function getSupportedApps(): array {
+		/** @var \OCP\Support\Subscription\IRegistry $subscriptionRegistry */
+		$subscriptionRegistry = \OC::$server->query(\OCP\Support\Subscription\IRegistry::class);
+		$supportedApps = $subscriptionRegistry->delegateGetSupportedApps();
+		return $supportedApps;
+	}
+
+	/**
 	 * List all apps, this is used in apps.php
 	 *
 	 * @return array
@@ -787,9 +799,7 @@ class OC_App {
 		$appList = [];
 		$langCode = \OC::$server->getL10N('core')->getLanguageCode();
 		$urlGenerator = \OC::$server->getURLGenerator();
-		/** @var \OCP\Support\Subscription\IRegistry $subscriptionRegistry */
-		$subscriptionRegistry = \OC::$server->query(\OCP\Support\Subscription\IRegistry::class);
-		$supportedApps = $subscriptionRegistry->delegateGetSupportedApps();
+		$supportedApps = $this->getSupportedApps();
 
 		foreach ($installedApps as $app) {
 			if (array_search($app, $blacklist) === false) {


### PR DESCRIPTION
At the moment we add the "supported"-label only to apps which are already downloaded to the apps folder.

As a user with a valid Nextcloud subscription I would like to see directly which app is supported by my subscription, also if it is not yet downloaded from app.nextcloud.com.

This PR also check apps from apps.nextcloud.com against the list of supported apps and add the "supported" label if the app is covered by the users subscription.