### PR TITLE
Allow "TwoFactor Nextcloud Notifications" to pull the state of the 2FA again

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -31,6 +31,7 @@ use OC\Authentication\TwoFactorAuth\Manager;
 use OC\Core\Controller\LoginController;
 use OC\Core\Controller\TwoFactorChallengeController;
 use OC\User\Session;
+use OCA\TwoFactorNextcloudNotification\Controller\APIController;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Middleware;
@@ -82,6 +83,11 @@ class TwoFactorMiddleware extends Middleware {
 	 * @param string $methodName
 	 */
 	public function beforeController($controller, $methodName) {
+		if ($controller instanceof APIController && $methodName === 'poll') {
+			// Allow polling the twofactor nextcloud notifications state
+			return;
+		}
+
 		if ($controller instanceof TwoFactorChallengeController
 			&& $this->userSession->getUser() !== null
 			&& !$this->reflector->hasAnnotation('TwoFactorSetUpDoneRequired')) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -80,6 +80,7 @@
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="OCA\GroupFolders\Mount\GroupFolderStorage"/>
+				<referencedClass name="OCA\TwoFactorNextcloudNotification\Controller\APIController"/>
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedFunction>


### PR DESCRIPTION
…A again

* Regression from #28725  which broken the https://github.com/nickv-nextcloud/twofactor_nextcloud_notification app
* Fixes https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/issues/555
* Fixes https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/issues/556
* Fixes https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/issues/551