### PR TITLE
Add caching for local run of integration and acceptance tests

### DIFF
--- a/build/integration/run-docker.sh
+++ b/build/integration/run-docker.sh
@@ -140,7 +140,9 @@ function prepareDocker() {
 	echo "Starting the Nextcloud container"
 	# When using "nextcloudci/phpX.Y" images the container exits immediately if
 	# no command is given, so a Bash session is created to prevent that.
-	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER $NEXTCLOUD_LOCAL_CONTAINER_NETWORK_OPTIONS --interactive --tty $NEXTCLOUD_LOCAL_IMAGE bash
+	docker run \
+		--volume composer_cache:/root/.composer \
+		--detach --name=$NEXTCLOUD_LOCAL_CONTAINER $NEXTCLOUD_LOCAL_CONTAINER_NETWORK_OPTIONS --interactive --tty $NEXTCLOUD_LOCAL_IMAGE bash
 
 	# Use the $TMPDIR or, if not set, fall back to /tmp.
 	NEXTCLOUD_LOCAL_TAR="$($MKTEMP --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-local-XXXXXXXXXX)"

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -138,7 +138,13 @@ function prepareDocker() {
 	# Selenium server.
 	# The container exits immediately if no command is given, so a Bash session
 	# is created to prevent that.
-	docker run --detach --name=$NEXTCLOUD_LOCAL_CONTAINER --network=container:$SELENIUM_CONTAINER --interactive --tty nextcloudci/acceptance-php7.3:acceptance-php7.3-2 bash
+	docker run \
+		--detach \
+		--name=$NEXTCLOUD_LOCAL_CONTAINER \
+		--network=container:$SELENIUM_CONTAINER \
+		--volume composer_cache:/root/.composer \
+		--interactive \
+		--tty nextcloudci/acceptance-php7.3:acceptance-php7.3-2 bash
 
 	# Use the $TMPDIR or, if not set, fall back to /tmp.
 	NEXTCLOUD_LOCAL_TAR="$($MKTEMP --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-local-XXXXXXXXXX)"


### PR DESCRIPTION
Integration and acceptance tests can take some time to start on a local dev machine. Part of it comes from the installation of composer dependencies.

This PR improves the startup time by adding a volume binding to keep the composer cache between runs: `--volume composer_cache:/root/.composer`
