### PR TITLE
NMC-550- fixed guest view footer for pdf/text and added close option

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -68,12 +68,23 @@ $footer-height: 65px;
 
 	/* public footer */
 	footer {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: $footer-height;
-		flex-direction: column;
+		&.public-footer-content {
+			width: 100%;
+			box-sizing: border-box;
+			text-align: center;
+			background-color: #fff;
+			padding:24px;
+		}
+		.closeInfo{
+			position: absolute;
+			right: 18%;
+		}
+
+		&.fixed-dialog {
+			position: fixed;
+			bottom: 0;
+			z-index: 9999;
+		}
 		p {
 			text-align: center;
 			color: var(--color-text-lighter);

--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -44,3 +44,8 @@ $(document).mouseup(function(e) {
 		container.removeClass('open');
 	}
 });
+
+
+$('footer .closeInfo').click(function(e) {
+	$('footer.public-footer-content').hide();
+});

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -90,7 +90,15 @@
 		<?php print_unescaped($_['content']); ?>
 	</div>
 	<?php if (isset($template) && $template->getFooterVisible()) { ?>
-	<footer>
+		<footer class="public-footer-content <?php if ($_['previewEnabled'] && substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'application' || substr($_['mimetype'], 0, strpos($_['mimetype'], '/')) == 'text') {
+				echo "fixed-dialog";
+			} ?>">
+		<div class="closeInfo">
+          <a href="#" id="closeFooterInfo" class="button">
+            <span class="icon icon-close"></span>
+          </a>
+        </div>
+		<div class="content-section">
 		<p><?php print_unescaped($theme->getLongFooter()); ?></p>
 		<?php
 		if ($_['showSimpleSignUpLink']) {
@@ -103,6 +111,7 @@
 			<?php
 		}
 		?>
+		</div>
 	</footer>
 	<?php } ?>
 


### PR DESCRIPTION
**Positioning Guest View footer :**
1) PDF -
for PDF previews the footer info box as to be a closable overlay sticky to the view port bottom
2) Images & Videos
for guest views with an image or video the footer info box is outside of the view port at the bottom and will appear if the user scrolls down
3) Single file view without preview and File list (folders)
the footer info box inside the view port as long as it doesn't hit the file preview (at Smartphones) at the bottom of the page