### PR TITLE
Fix acceptance test 'app-files'

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppContext.php
@@ -116,7 +116,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function notFavoritedStateIconInFileDetailsInDetailsView() {
-		return Locator::forThe()->css(".icon-star")->
+		return Locator::forThe()->css(".star--star")->
 				descendantOf(self::favoriteActionInFileDetailsInDetailsView())->
 				describedAs("Not favorited state icon in file details in details view in Files app");
 	}
@@ -125,7 +125,7 @@ class FilesAppContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function favoritedStateIconInFileDetailsInDetailsView() {
-		return Locator::forThe()->css(".icon-starred")->
+		return Locator::forThe()->css(".star--starred")->
 				descendantOf(self::favoriteActionInFileDetailsInDetailsView())->
 				describedAs("Favorited state icon in file details in details view in Files app");
 	}


### PR DESCRIPTION
Some tests were failing due to a [class name change](https://github.com/nextcloud/nextcloud-vue/pull/2265/files#diff-43c55b9d7246a23e8b456853911f8e659a2b7d69925d876e4471e96a179c677eR192) in `nextcloud-vue`