### PR TITLE
Add a few sensitive config keys

### DIFF
--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -83,6 +83,27 @@ class SystemConfig {
 				],
 			],
 		],
+		'objectstore_multibucket' => [
+			'arguments' => [
+				'options' => [
+					'credentials' => [
+						'key' => true,
+						'secret' => true,
+					]
+				],
+				// S3
+				'key' => true,
+				'secret' => true,
+				// Swift v2
+				'username' => true,
+				'password' => true,
+				// Swift v3
+				'user' => [
+					'name' => true,
+					'password' => true,
+				],
+			],
+		],
 	];
 
 	/** @var Config */


### PR DESCRIPTION
In config.php, if `objectstore` and `objectstore_multibucket` have the same content structure, then they can contain the same sensitive values.

This affects the system report content (generated by the support app).