### PR TITLE
Reintroduce `libxml_disable_entity_loader()` calls

### DIFF
--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -61,13 +61,9 @@ class InfoParser {
 		}
 
 		libxml_use_internal_errors(true);
-		if ((PHP_VERSION_ID < 80000)) {
-			$loadEntities = libxml_disable_entity_loader(false);
-			$xml = simplexml_load_file($file);
-			libxml_disable_entity_loader($loadEntities);
-		} else {
-			$xml = simplexml_load_file($file);
-		}
+		$loadEntities = @libxml_disable_entity_loader(false);
+		$xml = simplexml_load_file($file);
+		@libxml_disable_entity_loader($loadEntities);
 
 		if ($xml === false) {
 			libxml_clear_errors();

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -335,13 +335,9 @@ class Installer {
 						}
 
 						// Check if appinfo/info.xml has the same app ID as well
-						if ((PHP_VERSION_ID < 80000)) {
-							$loadEntities = libxml_disable_entity_loader(false);
-							$xml = simplexml_load_file($extractDir . '/' . $folders[0] . '/appinfo/info.xml');
-							libxml_disable_entity_loader($loadEntities);
-						} else {
-							$xml = simplexml_load_file($extractDir . '/' . $folders[0] . '/appinfo/info.xml');
-						}
+						$loadEntities = @libxml_disable_entity_loader(false);
+						$xml = simplexml_load_file($extractDir . '/' . $folders[0] . '/appinfo/info.xml');
+						@libxml_disable_entity_loader($loadEntities);
 						if ((string)$xml->id !== $appId) {
 							throw new \Exception(
 								sprintf(


### PR DESCRIPTION
Long answer/description https://blog.sonarsource.com/wordpress-xxe-security-vulnerability

