### PR TITLE
Reset composer for psalm baseline update

### DIFF
--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -22,9 +22,13 @@ jobs:
           extensions: ctype,curl,dom,fileinfo,gd,iconv,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
       - name: Composer install
-        run: composer i
+        run: composer install
       - name: Psalm
         run: composer run psalm -- --monochrome --no-progress --output-format=text --update-baseline
+      - name: Reset composer
+        run: |
+          git clean -f lib/composer
+          git checkout composer.json composer.lock lib/composer
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/29050

composer install will install also the dev dependencies include the vendor-bin plugin. We don't want the vendor-bin plugin in our production state.