### PR TITLE
Fix permissions when copying from ObjectStorage

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -1009,7 +1009,7 @@ class Cache implements ICache {
 	 * @param ICache $sourceCache
 	 * @param ICacheEntry $sourceEntry
 	 * @param string $targetPath
-	 * @return int fileid of copied entry
+	 * @return int fileId of copied entry
 	 */
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
 		if ($sourceEntry->getId() < 0) {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -539,7 +539,15 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class)) {
 			/** @var ObjectStoreStorage $sourceStorage */
 			if ($sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
+				/** @var CacheEntry $sourceEntry */
 				$sourceEntry = $sourceStorage->getCache()->get($sourceInternalPath);
+				$sourceEntryData = $sourceEntry->getData();
+				// $sourceEntry['permissions'] here is the permissions from the jailed storage for the current
+				// user. Instead we use $sourceEntryData['scan_permissions'] that are the permissions from the
+				// unjailed storage.
+				if (is_array($sourceEntryData) && array_key_exists('scan_permissions', $sourceEntryData)) {
+					$sourceEntry['permissions'] = $sourceEntryData['scan_permissions'];
+				}
 				$this->copyInner($sourceEntry, $targetInternalPath);
 				return true;
 			}


### PR DESCRIPTION
Make sure that when a user copy a file from a directory they don't have
all permissions to a directory where they have more permissions, the
permissions are correctly set to the one from the parent taget folder.

This was caused by the ObjectStoreStorage::copyFromStorage using
the jailed storage and cache entry instead of the unjailed one like other
storages (the local one).

## Steps to reproduce

1. Use object storage
2. Create a groupfolder with one group having full permission and another one
who can just read files.
3. With an user who is in the second group, copy a file from the groupfolder to
    the home folder of this user.
4. The file in the home folder of the user will be read only and can't be deleted
    even though it is in their home folder and they are the owner.
    In oc_filecache, the permissions stored for this file are 1 (READ)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>