### PR TITLE
add better index for finding unindexed paths

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -114,6 +114,10 @@ class Application extends App {
 					if (!$table->hasIndex('fs_size')) {
 						$subject->addHintForMissingSubject($table->getName(), 'fs_size');
 					}
+
+					if (!$table->hasIndex('fs_id_storage_size')) {
+						$subject->addHintForMissingSubject($table->getName(), 'fs_id_storage_size');
+					}
 				}
 
 				if ($schema->hasTable('twofactor_providers')) {

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -144,6 +144,13 @@ class AddMissingIndices extends Command {
 				$updated = true;
 				$output->writeln('<info>Filecache table updated successfully.</info>');
 			}
+			if (!$table->hasIndex('fs_id_storage_size')) {
+				$output->writeln('<info>Adding additional size index to the filecache table, this can take some time...</info>');
+				$table->addIndex(['fileid', 'storage', 'size'], 'fs_id_storage_size');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>Filecache table updated successfully.</info>');
+			}
 		}
 
 		$output->writeln('<info>Check indices of the twofactor_providers table.</info>');

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -261,6 +261,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage', 'mimetype'], 'fs_storage_mimetype');
 			$table->addIndex(['storage', 'mimepart'], 'fs_storage_mimepart');
 			$table->addIndex(['storage', 'size', 'fileid'], 'fs_storage_size');
+			$table->addIndex(['fileid', 'storage', 'size'], 'fs_id_storage_size');
 			$table->addIndex(['mtime'], 'fs_mtime');
 			$table->addIndex(['size'], 'fs_size');
 		}


### PR DESCRIPTION
for the following query `SELECT "path" FROM "oc_filecache" WHERE ("storage" = $storage) AND ("size" < 0) ORDER BY "fileid" DESC LIMIT 1;` which is used by the background scanner.

currently the database will in some cases decide to prioritize the sort by fileid over the filter when picking what index to use, resulting in a much slower query.

by creating an index that allows first sorting by fileid and also filter by storage and size this case will be greatly sped up

Signed-off-by: Robin Appelman <robin@icewind.nl>