### PR TITLE
Tokens without password should not trigger changed password invalidation

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -224,7 +224,7 @@ class DefaultTokenProvider implements IProvider {
 	 */
 	public function getPassword(IToken $savedToken, string $tokenId): string {
 		$password = $savedToken->getPassword();
-		if (is_null($password)) {
+		if ($password === null || $password === '') {
 			throw new PasswordlessTokenException();
 		}
 		return $this->decryptPassword($password, $tokenId);


### PR DESCRIPTION
Before this app passwords that were generated through a login method that doesn't provide a password (e.g. when using an oidc id token as bearer auth header) did invalidate themselves on the first use ([after the 5 minute offset for token checking](https://github.com/nextcloud/server/blob/7dff30efd3597ddcfce227c3496ec66daf1c4489/lib/private/User/Session.php#L734)).

Steps to reproduce:
- Setup user_oidc and enable bearer token validation for oidc tokens
- Request an app password through `curl -X GET "https://nextcloud.local/ocs/v1.php/core/getapppassword" -H "OCS-APIRequest: true" -H "Accept: application/json" -H "Authorization: Bearer OIDC_ID_TOKEN"`
- Wait for 5 minutes
- Request any endpoint with the app password
- Any follow up request would fail before as markPasswordInvalid gets called for the app password

This is similar to https://github.com/nextcloud/server/pull/27886 but gets only triggered when using an IApacheBackend where an empty string is set in https://github.com/nextcloud/server/blob/57a816a1a6a895515b5d0a23db86861df3c2e333/lib/private/legacy/OC_User.php#L193. This will then lead to a token being generated with an empty string as password instead of a password which should not trigger a comparison with the real password when either SAML with LDAP as a user backend or a passwordless user backend like oidc is used.