### PR TITLE
[stable22] Keep pw based auth tokens valid when pw-less login happens

### DIFF
--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -48,6 +48,11 @@ class UserLoggedInListener implements IEventListener {
 			return;
 		}
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($event->getPassword()==='') {
+			return;
+		}
+
 		// If this is already a token login there is nothing to do
 		if ($event->isTokenLogin()) {
 			return;

--- a/lib/private/Authentication/Listeners/UserLoggedInListener.php
+++ b/lib/private/Authentication/Listeners/UserLoggedInListener.php
@@ -49,7 +49,7 @@ class UserLoggedInListener implements IEventListener {
 		}
 
 		// prevent setting an empty pw as result of pw-less-login
-		if ($event->getPassword()==='') {
+		if ($event->getPassword() === '') {
 			return;
 		}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -413,6 +413,11 @@ class PublicKeyTokenProvider implements IProvider {
 	public function updatePasswords(string $uid, string $password) {
 		$this->cache->clear();
 
+		// prevent setting an empty pw as result of pw-less-login
+		if ($password==='') {
+			return;
+		}
+
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
 		foreach ($tokens as $t) {

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -414,7 +414,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		// prevent setting an empty pw as result of pw-less-login
-		if ($password==='') {
+		if ($password === '') {
 			return;
 		}
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/27886