### PR TITLE
Fix create share API permissions for links

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -460,6 +460,7 @@ class ShareAPIController extends OCSController {
 	): DataResponse {
 		$share = $this->shareManager->newShare();
 
+		$requestPermissions = $permissions;
 		if ($permissions === null) {
 			$permissions = $this->config->getAppValue('core', 'shareapi_default_permissions', Constants::PERMISSION_ALL);
 		}
@@ -558,7 +559,10 @@ class ShareAPIController extends OCSController {
 					Constants::PERMISSION_UPDATE |
 					Constants::PERMISSION_DELETE;
 			} else {
-				$permissions = Constants::PERMISSION_READ;
+				// do not ignore permissions request param if provided
+				if ($requestPermissions === null) {
+					$permissions = Constants::PERMISSION_READ;
+				}
 			}
 
 			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -2059,7 +2059,7 @@ class ShareAPIControllerTest extends TestCase {
 		)->willReturnArgument(0);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', 'password', null, '');
+		$result = $ocs->createShare('valid-path', null, IShare::TYPE_LINK, null, 'false', 'password', null, '');
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -2098,7 +2098,7 @@ class ShareAPIControllerTest extends TestCase {
 		)->willReturnArgument(0);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', 'password', 'true', '');
+		$result = $ocs->createShare('valid-path', null, IShare::TYPE_LINK, null, 'false', 'password', 'true', '');
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -2131,7 +2131,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->shareManager->expects($this->never())->method('createShare');
 
-		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', 'password', 'true', '');
+		$ocs->createShare('valid-path', null, IShare::TYPE_LINK, null, 'false', 'password', 'true', '');
 	}
 
 	public function testCreateShareValidExpireDate() {
@@ -2177,7 +2177,7 @@ class ShareAPIControllerTest extends TestCase {
 		)->willReturnArgument(0);
 
 		$expected = new DataResponse([]);
-		$result = $ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, '2000-01-01');
+		$result = $ocs->createShare('valid-path', null, IShare::TYPE_LINK, null, 'false', '', null, '2000-01-01');
 
 		$this->assertInstanceOf(get_class($expected), $result);
 		$this->assertEquals($expected->getData(), $result->getData());
@@ -2205,7 +2205,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
-		$ocs->createShare('valid-path', \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, 'a1b2d3');
+		$ocs->createShare('valid-path', null, IShare::TYPE_LINK, null, 'false', '', null, 'a1b2d3');
 	}
 
 	public function testCreateShareRemote() {


### PR DESCRIPTION
When `publicUpload` is false:
* default share link permissions (set in `settings/admin/sharing`)
* and the `permissions` request parameter

are ignored. `PERMISSION_READ` is always set.

The createShare api method still has some permission issues with `publicUpload` (#17504) and it's still impossible to create a share without expiration date if a default one is defined (#10178). But these issues are a bit trickier to fix.