### PR TITLE
Delete S3 versions in rmdir

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -311,10 +311,32 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 					$connection->deleteObjects([
 						'Bucket' => $this->bucket,
 						'Delete' => [
-							'Objects' => $objects['Contents']
+							'Objects' => $objects['Contents'],
 						]
 					]);
 					$this->testTimeout();
+				}
+				// we reached the end when the list is no longer truncated
+			} while ($objects['IsTruncated']);
+
+			do {
+				// delete all contained versions and deletion markers
+				$objects = $connection->listObjectVersions($params);
+				if (isset($objects['Versions'])) {
+					$connection->deleteObjects([
+						'Bucket' => $this->bucket,
+						'Delete' => [
+							'Objects' => $objects['Versions'],
+						]
+					]);
+				}
+				if (isset($objects['DeleteMarkers'])) {
+					$connection->deleteObjects([
+						'Bucket' => $this->bucket,
+						'Delete' => [
+							'Objects' => $objects['DeleteMarkers'],
+						]
+					]);
 				}
 				// we reached the end when the list is no longer truncated
 			} while ($objects['IsTruncated']);


### PR DESCRIPTION
When deleting a complete folder in a bucket that has versioning enabled,
also make sure to delete all associated versions and delete markers

Fixes https://github.com/nextcloud/files_versions_s3/issues/11

### Tests

- [x] TEST: with Minio versioned bucket
    - [x] rename folder with 2 levels
    - [x] rename empty folder
    - [x] delete folder with 2 levels
    - [x] delete empty folder
- [x] TEST: with Minio non-versioned bucket
    - [x] rename folder with 2 levels
    - [x] rename empty folder
    - [x] delete folder with 2 levels
    - [x] delete empty folder

### Todos

- [ ] check what's up with deleteObject and https://github.com/nextcloud/server/pull/24185 and whether it needs version purging as well
- [ ] backports