### PR TITLE
Enforce existance of /files/ inside object store home folder

### DIFF
--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -39,6 +39,9 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 		}
 		$this->user = $params['user'];
 		parent::__construct($params);
+		// Enforce existence of files directory inside home folder. Required for
+		// login.
+		$this->mkdir('/files/');
 	}
 
 	public function getId() {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -76,9 +76,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			$this->objectPrefix = $params['objectPrefix'];
 		}
 		//initialize cache with root directory in cache
-		if (!$this->is_dir('/')) {
-			$this->mkdir('/');
-		}
+		$this->mkdir('/');
 
 		$this->logger = \OC::$server->getLogger();
 	}


### PR DESCRIPTION
**Steps to reproduce:**

1. Use ObjectStore as primary storage
2. delete from oc_filecache where storage = 1; // 1 == admin home
   storage
3. Try to login or go to the files app => breaks
4. This doesn't happens on a local storage

Also add a minor optimization in ObjectStoreStorage since mkdir already
checks if file exists before creating a folder.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>