### PR TITLE
Fix passwordless app token generation

### DIFF
--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -190,7 +190,7 @@ class OC_User {
 					'post_login',
 					[
 						'uid' => $uid,
-						'password' => '',
+						'password' => null,
 						'isTokenLogin' => false,
 					]
 				);

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -199,7 +199,7 @@ class OC_User {
 				$dispatcher->dispatchTyped(new UserLoggedInEvent(
 						\OC::$server->get(IUserManager::class)->get($uid),
 						$uid,
-						'',
+						null,
 						false)
 				);
 

--- a/lib/public/User/Events/UserLoggedInEvent.php
+++ b/lib/public/User/Events/UserLoggedInEvent.php
@@ -37,7 +37,7 @@ class UserLoggedInEvent extends Event {
 	/** @var IUser */
 	private $user;
 
-	/** @var string */
+	/** @var string|null */
 	private $password;
 
 	/** @var bool */
@@ -49,7 +49,7 @@ class UserLoggedInEvent extends Event {
 	/**
 	 * @since 18.0.0
 	 */
-	public function __construct(IUser $user, string $loginName, string $password, bool $isTokenLogin) {
+	public function __construct(IUser $user, string $loginName, ?string $password, bool $isTokenLogin) {
 		parent::__construct();
 		$this->user = $user;
 		$this->password = $password;
@@ -74,7 +74,7 @@ class UserLoggedInEvent extends Event {
 	/**
 	 * @since 18.0.0
 	 */
-	public function getPassword(): string {
+	public function getPassword(): ?string {
 		return $this->password;
 	}
 


### PR DESCRIPTION
Even with #29122, we still face the app token invalidation issue after 5 minutes.

An app token generated in AppPasswordController with an empty string as the password parameter has a non empty password. It can be observed there
https://github.com/nextcloud/server/blob/da1b97decda88893cc26539439a15050953419ae/lib/private/Authentication/Token/PublicKeyTokenProvider.php#L239

when using the token like that for example:
`curl -H "Authorization: Bearer APP_TOKEN_GENERATED_USING_OIDC_TOKEN_TO_AUTHENTICATE" "https://what.e.ver/ocs/v1.php/cloud/users/number6" -H "OCS-APIRequest: true"`

I don't know if this is a proper way to fix this but setting a null password when generating an app token seems a safe way to make it passwordless and fixes the invalidation issue.