### PR TITLE
Type the autentication provider passwords as nullable strings

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -71,21 +71,12 @@ class DefaultTokenProvider implements IProvider {
 	}
 
 	/**
-	 * Create and persist a new token
-	 *
-	 * @param string $token
-	 * @param string $uid
-	 * @param string $loginName
-	 * @param string|null $password
-	 * @param string $name
-	 * @param int $type token type
-	 * @param int $remember whether the session token should be used for remember-me
-	 * @return IToken
+	 * {@inheritDoc}
 	 */
 	public function generateToken(string $token,
 								  string $uid,
 								  string $loginName,
-								  $password,
+								  ?string $password,
 								  string $name,
 								  int $type = IToken::TEMPORARY_TOKEN,
 								  int $remember = IToken::DO_NOT_REMEMBER): IToken {

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -53,7 +53,7 @@ interface IProvider {
 	public function generateToken(string $token,
 								  string $uid,
 								  string $loginName,
-								  $password,
+								  ?string $password,
 								  string $name,
 								  int $type = IToken::TEMPORARY_TOKEN,
 								  int $remember = IToken::DO_NOT_REMEMBER): IToken;

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -80,7 +80,7 @@ class PublicKeyTokenProvider implements IProvider {
 	public function generateToken(string $token,
 								  string $uid,
 								  string $loginName,
-								  $password,
+								  ?string $password,
 								  string $name,
 								  int $type = IToken::TEMPORARY_TOKEN,
 								  int $remember = IToken::DO_NOT_REMEMBER): IToken {


### PR DESCRIPTION
For historic reasons we couldn't add a nullable type hint before
nullable type hints were supported by our target php versions. This is
now possible.

This change does not break our API, this type was already documented with phpdoc.

Discovered while studying code for https://github.com/nextcloud/server/pull/29187