### PR TITLE
Build instances of the calendar providers before using them

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -31,6 +31,11 @@ use OCP\Calendar\ICalendar;
 use OCP\Calendar\ICalendarProvider;
 use OCP\Calendar\ICalendarQuery;
 use OCP\Calendar\IManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use function array_map;
+use function array_merge;
 
 class Manager implements IManager {
 
@@ -47,8 +52,18 @@ class Manager implements IManager {
 	/** @var Coordinator */
 	private $coordinator;
 
-	public function __construct(Coordinator $coordinator) {
+	/** @var ContainerInterface */
+	private $container;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(Coordinator $coordinator,
+								ContainerInterface $container,
+								LoggerInterface $logger) {
 		$this->coordinator = $coordinator;
+		$this->container = $container;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -159,9 +174,21 @@ class Manager implements IManager {
 		}
 
 		/** @var CalendarQuery $query */
-		$calendars = array_merge(...array_map(static function (ICalendarProvider $p) use ($query) {
-			return $p->getCalendars($query->getPrincipalUri(), $query->getCalendarUris());
-		}, $context->getCalendarProviders()));
+		$calendars = array_merge(
+			...array_map(function ($registration) use ($query) {
+				try {
+					/** @var ICalendarProvider $provider */
+					$provider = $this->container->get($registration->getService());
+				} catch (Throwable $e) {
+					$this->logger->error('Could not load calendar provider ' . $registration->getService() . ': ' . $e->getMessage(), [
+						'exception' => $e,
+					]);
+					return [];
+				}
+
+				return $provider->getCalendars($query->getPrincipalUri(), $query->getCalendarUris());
+			}, $context->getCalendarProviders())
+		);
 
 		$results = [];
 		/** @var ICalendar $calendar */

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -27,12 +27,20 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Calendar\Manager;
 use OCP\Calendar\ICalendar;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
 	/** @var Coordinator|MockObject */
 	private $coordinator;
+
+	/** @var MockObject|ContainerInterface */
+	private $container;
+
+	/** @var MockObject|LoggerInterface */
+	private $logger;
 
 	/** @var Manager */
 	private $manager;
@@ -41,9 +49,13 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->coordinator = $this->createMock(Coordinator::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->manager = new Manager(
-			$this->coordinator
+			$this->coordinator,
+			$this->container,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
What we get from the registration context are only the class names. We
still have to load the classes before we can use them.

Follow-up to https://github.com/nextcloud/server/pull/28970