### PR TITLE
Add an OCP API to access the scheduling inbox(es)

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\CalDAV;
 
+use OCA\dav\lib\CalDAV\SchedulingInbox;
 use OCP\Calendar\ICalendarProvider;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -68,5 +69,11 @@ class CalendarProvider implements ICalendarProvider {
 			);
 		}
 		return $iCalendars;
+	}
+
+	public function getSchedulingInboxes(string $principalUri): array {
+		return [
+			new SchedulingInbox($principalUri)
+		];
 	}
 }

--- a/apps/dav/lib/CalDAV/SchedulingInbox.php
+++ b/apps/dav/lib/CalDAV/SchedulingInbox.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\dav\lib\CalDAV;
+
+use OCP\Calendar\ISchedulingInbox;
+
+class SchedulingInbox implements ISchedulingInbox {
+
+	/** @var string */
+	private $principalUri;
+
+	public function __construct(string $principalUri) {
+		$this->principalUri = $principalUri;
+	}
+
+	public function getAvailability(): ?string {
+		return null;
+	}
+}

--- a/lib/public/Calendar/ICalendarProvider.php
+++ b/lib/public/Calendar/ICalendarProvider.php
@@ -42,4 +42,15 @@ interface ICalendarProvider {
 	 * @since 23.0.0
 	 */
 	public function getCalendars(string $principalUri, array $calendarUris = []): array;
+
+	/**
+	 * Get the principal's scheduling inboxes
+	 *
+	 * @param string $principalUri
+	 *
+	 * @return ISchedulingInbox[]]
+	 *
+	 * @since 23.0.0
+	 */
+	public function getSchedulingInboxes(string $principalUri): array;
 }

--- a/lib/public/Calendar/IManager.php
+++ b/lib/public/Calendar/IManager.php
@@ -147,4 +147,15 @@ interface IManager {
 	 * @since 23.0.0
 	 */
 	public function newQuery(string $principalUri) : ICalendarQuery;
+
+	/**
+	 * Get the principal's scheduling inboxes
+	 *
+	 * @param string $principalUri
+	 *
+	 * @return ISchedulingInbox[]]
+	 *
+	 * @since 23.0.0
+	 */
+	public function getSchedulingInboxes(string $principalUri): array;
 }

--- a/lib/public/Calendar/ISchedulingInbox.php
+++ b/lib/public/Calendar/ISchedulingInbox.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\Calendar;
+
+/**
+ * @since 23.0.0
+ */
+interface ISchedulingInbox {
+
+	public function getAvailability(): ?string;
+
+}


### PR DESCRIPTION
We will need this for https://github.com/nextcloud/calendar/issues/1023

Putting as draft as I don't yet know if we need any other APIs as well and I want to avoid merging a soon to be broken API for this feature freeze.

Todo
- [x] Add new API
- [ ] Fetch availability within the dav app