### PR TITLE
Add already used optional sizeDifference parameter to IPropagator

### DIFF
--- a/lib/public/Files/Cache/IPropagator.php
+++ b/lib/public/Files/Cache/IPropagator.php
@@ -49,7 +49,8 @@ interface IPropagator {
 	/**
 	 * @param string $internalPath
 	 * @param int $time
+	 * @param int $sizeDifference
 	 * @since 9.0.0
 	 */
-	public function propagateChange($internalPath, $time);
+	public function propagateChange($internalPath, $time, $sizeDifference = 0);
 }


### PR DESCRIPTION
Adapt the public interface to the optional sizeDifference parameter which seems to be there in all implementing cases anyways.