### PR TITLE
Fix background scan doc in config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1977,7 +1977,7 @@ $CONFIG = [
  *
  * By default, a background job runs every 10 minutes and execute a background
  * scan to sync filesystem and database. Only users with unscanned files
- * (size=0 in filecache) are included. Maximum 500 users per job.
+ * (size < 0 in filecache) are included. Maximum 500 users per job.
  *
  * Defaults to ``true``
  */


### PR DESCRIPTION
The background scanner only processes entries with size < 0

See https://github.com/nextcloud/server/blob/v21.0.5/apps/files/lib/BackgroundJob/ScanFiles.php#L107 and https://github.com/nextcloud/server/blob/v21.0.5/lib/private/Files/Cache/Cache.php#L922