### PR TITLE
Fix appstoreenabled check

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -131,7 +131,7 @@ class AppSettingsController extends Controller {
 	public function viewApps(): TemplateResponse {
 		\OC_Util::addScript('settings', 'apps');
 		$params = [];
-		$params['appstoreEnabled'] = $this->config->getSystemValue('appstoreenabled', true) === true;
+		$params['appstoreEnabled'] = $this->config->getSystemValueBool('appstoreenabled', true);
 		$params['updateCount'] = count($this->getAppsWithUpdates());
 		$params['developerDocumentation'] = $this->urlGenerator->linkToDocs('developer-manual');
 		$params['bundles'] = $this->getBundles();

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -190,7 +190,7 @@ class AppSettingsControllerTest extends TestCase {
 			->willReturn(false);
 		$this->config
 			->expects($this->once())
-			->method('getSystemValue')
+			->method('getSystemValueBool')
 			->with('appstoreenabled', true)
 			->willReturn(true);
 		$this->navigationManager
@@ -224,7 +224,7 @@ class AppSettingsControllerTest extends TestCase {
 		$this->bundleFetcher->expects($this->once())->method('getBundles')->willReturn([]);
 		$this->config
 			->expects($this->once())
-			->method('getSystemValue')
+			->method('getSystemValueBool')
 			->with('appstoreenabled', true)
 			->willReturn(false);
 		$this->navigationManager

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -90,7 +90,7 @@ abstract class Fetcher {
 	 * @return array
 	 */
 	protected function fetch($ETag, $content) {
-		$appstoreenabled = $this->config->getSystemValue('appstoreenabled', true);
+		$appstoreenabled = $this->config->getSystemValueBool('appstoreenabled', true);
 		if ((int)$this->config->getAppValue('settings', 'appstore-fetcher-lastFailure', '0') > time() - self::RETRY_AFTER_FAILURE_SECONDS) {
 			return [];
 		}
@@ -148,7 +148,7 @@ abstract class Fetcher {
 	 * @return array
 	 */
 	public function get($allowUnstable = false) {
-		$appstoreenabled = $this->config->getSystemValue('appstoreenabled', true);
+		$appstoreenabled = $this->config->getSystemValueBool('appstoreenabled', true);
 		$internetavailable = $this->config->getSystemValue('has_internet_connection', true);
 
 		if (!$appstoreenabled || !$internetavailable) {

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -1868,9 +1868,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 	public function testGetWithFilter() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.2';
 				} elseif ($key === 'appstoreurl' && $default === 'https://apps.nextcloud.com/api/v1') {
 					return 'https://custom.appsstore.endpoint/api/v1';
@@ -1878,6 +1876,10 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);
@@ -1951,13 +1953,15 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 		$this->config
 			->method('getSystemValue')
 			->willReturnCallback(function ($var, $default) {
-				if ($var === 'appstoreenabled') {
-					return false;
-				} elseif ($var === 'version') {
+				if ($var === 'version') {
 					return '11.0.0.2';
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(false);
 		$this->appData
 			->expects($this->never())
 			->method('getFolder');
@@ -1977,6 +1981,10 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 		$this->appData
 			->expects($this->never())
 			->method('getFolder');
@@ -1987,9 +1995,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 	public function testSetVersion() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '10.0.7.2';
 				} elseif ($key === 'appstoreurl' && $default === 'https://apps.nextcloud.com/api/v1') {
 					return 'https://custom.appsstore.endpoint/api/v1';
@@ -1997,6 +2003,10 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);
@@ -2070,9 +2080,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 	public function testGetAppsAllowlist() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.2';
 				} elseif ($key === 'appstoreurl' && $default === 'https://apps.nextcloud.com/api/v1') {
 					return 'https://custom.appsstore.endpoint/api/v1';
@@ -2082,7 +2090,11 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 					return $default;
 				}
 			});
-		
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
+
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$folder
@@ -2122,7 +2134,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->expects($this->once())
 			->method('getTime')
 			->willReturn(1234);
-			
+
 		$this->registry
 			->expects($this->exactly(2))
 			->method('delegateHasValidSubscription')

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -77,7 +77,7 @@ abstract class FetcherBase extends TestCase {
 	public function testGetWithAlreadyExistingFileAndUpToDateTimestampAndVersion() {
 		$this->config
 			->expects($this->at(0))
-			->method('getSystemValue')
+			->method('getSystemValueBool')
 			->with('appstoreenabled', true)
 			->willReturn(true);
 		$this->config
@@ -126,9 +126,7 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->method('getSystemValue')
 			->willReturnCallback(function ($var, $default) {
-				if ($var === 'appstoreenabled') {
-					return true;
-				} elseif ($var === 'has_internet_connection') {
+				if ($var === 'has_internet_connection') {
 					return true;
 				} elseif ($var === 'appstoreurl') {
 					return 'https://apps.nextcloud.com/api/v1';
@@ -137,6 +135,10 @@ abstract class FetcherBase extends TestCase {
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', $this->anything())
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -202,14 +204,16 @@ abstract class FetcherBase extends TestCase {
 	public function testGetWithAlreadyExistingFileAndOutdatedTimestamp() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.2';
 				} else {
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -279,9 +283,7 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->method('getSystemValue')
 			->willReturnCallback(function ($var, $default) {
-				if ($var === 'appstoreenabled') {
-					return true;
-				} elseif ($var === 'has_internet_connection') {
+				if ($var === 'has_internet_connection') {
 					return true;
 				} elseif ($var === 'appstoreurl') {
 					return 'https://apps.nextcloud.com/api/v1';
@@ -290,6 +292,10 @@ abstract class FetcherBase extends TestCase {
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -355,9 +361,7 @@ abstract class FetcherBase extends TestCase {
 		$this->config
 			->method('getSystemValue')
 			->willReturnCallback(function ($var, $default) {
-				if ($var === 'appstoreenabled') {
-					return true;
-				} elseif ($var === 'has_internet_connection') {
+				if ($var === 'has_internet_connection') {
 					return true;
 				} elseif ($var === 'appstoreurl') {
 					return 'https://apps.nextcloud.com/api/v1';
@@ -366,6 +370,10 @@ abstract class FetcherBase extends TestCase {
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -429,12 +437,12 @@ abstract class FetcherBase extends TestCase {
 	public function testGetWithExceptionInClient() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} else {
-					return $default;
-				}
+				return $default;
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -469,14 +477,16 @@ abstract class FetcherBase extends TestCase {
 	public function testGetMatchingETag() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.2';
 				} else {
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -550,14 +560,16 @@ abstract class FetcherBase extends TestCase {
 	public function testGetNoMatchingETag() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.2';
 				} else {
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
@@ -637,14 +649,16 @@ abstract class FetcherBase extends TestCase {
 	public function testFetchAfterUpgradeNoETag() {
 		$this->config->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) {
-				if ($key === 'appstoreenabled') {
-					return true;
-				} elseif ($key === 'version') {
+				if ($key === 'version') {
 					return '11.0.0.3';
 				} else {
 					return $default;
 				}
 			});
+		$this->config
+			->method('getSystemValueBool')
+			->with('appstoreenabled', true)
+			->willReturn(true);
 
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);


### PR DESCRIPTION
The `appstoreenabled` check is inconsistent between `lib/private/App/AppStore/Fetcher/Fetcher.php` and

https://github.com/nextcloud/server/blob/f7a4ff4d633ab9cd964e1f5f71158737e73ed1b7/apps/settings/lib/Controller/AppSettingsController.php#L134

So if `appstoreenabled` is a string, for example, the appstore is considered as enabled in `Fetcher.php` and the apps are fetched. The app settings page then receives a combined list of local apps and appstore ones.
But as the check is different in `AppSettingsController.php`, the appstore is considered as disabled there and the category list is not displayed in app settings.

Check is now the same in both places.

This can be backported to stable20, stable21 and stable22.