### PR TITLE
Ignore partial data when removing files

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -537,7 +537,7 @@ class Cache implements ICache {
 	public function remove($file) {
 		$entry = $this->get($file);
 
-		if ($entry) {
+		if ($entry && !is_array($entry)) {
 			$query = $this->getQueryBuilder();
 			$query->delete('filecache')
 				->whereFileId($entry->getId());


### PR DESCRIPTION
On external storages, removing files sometimes tries to remove partial
data, represented in an array.

`lib/private/Files/Cache/Cache.php:remove()` doesn't support to process
arrays.

According to @icewind1991, we can ignore this partial data in
`remove()`.

Fixes: #26544