### PR TITLE
Add an OCS endpoint for the hovercard contact actions

### DIFF
--- a/core/Controller/HoverCardController.php
+++ b/core/Controller/HoverCardController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Core\Controller;
+
+use OC\Contacts\ContactsMenu\Manager;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Contacts\ContactsMenu\IEntry;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Share\IShare;
+
+class HoverCardController extends \OCP\AppFramework\OCSController {
+
+	/** @var Manager */
+	private $manager;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/**
+	 * @param IRequest $request
+	 * @param IUserSession $userSession
+	 * @param Manager $manager
+	 */
+	public function __construct(IRequest $request, IUserSession $userSession, Manager $manager) {
+		parent::__construct('core', $request);
+		$this->userSession = $userSession;
+		$this->manager = $manager;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $userId
+	 * @return DataResponse
+	 */
+	public function getUser(string $userId): DataResponse {
+		$contact = $this->manager->findOne($this->userSession->getUser(), IShare::TYPE_USER, $userId);
+
+		if (!$contact) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$data = $this->entryToArray($contact);
+
+		$actions = $data['actions'];
+		if ($data['topAction']) {
+			array_unshift($actions, $data['topAction']);
+		}
+
+		return new DataResponse([
+			'userId' => $userId,
+			'displayName' => $contact->getFullName(),
+			'actions' => $actions,
+		]);
+	}
+
+	protected function entryToArray(IEntry $entry): array {
+		return json_decode(json_encode($entry), true);
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -110,6 +110,8 @@ $application->registerRoutes($this, [
 		['root' => '/core', 'name' => 'AppPassword#rotateAppPassword', 'url' => '/apppassword/rotate', 'verb' => 'POST'],
 		['root' => '/core', 'name' => 'AppPassword#deleteAppPassword', 'url' => '/apppassword', 'verb' => 'DELETE'],
 
+		['root' => '/hovercard', 'name' => 'HoverCard#getUser', 'url' => '/v1/{userId}', 'verb' => 'GET'],
+
 		['root' => '/collaboration', 'name' => 'CollaborationResources#searchCollections', 'url' => '/resources/collections/search/{filter}', 'verb' => 'GET'],
 		['root' => '/collaboration', 'name' => 'CollaborationResources#listCollection', 'url' => '/resources/collections/{collectionId}', 'verb' => 'GET'],
 		['root' => '/collaboration', 'name' => 'CollaborationResources#renameCollection', 'url' => '/resources/collections/{collectionId}', 'verb' => 'PUT'],

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -920,6 +920,7 @@ return array(
     'OC\\Core\\Controller\\ContactsMenuController' => $baseDir . '/core/Controller/ContactsMenuController.php',
     'OC\\Core\\Controller\\CssController' => $baseDir . '/core/Controller/CssController.php',
     'OC\\Core\\Controller\\GuestAvatarController' => $baseDir . '/core/Controller/GuestAvatarController.php',
+    'OC\\Core\\Controller\\HoverCardController' => $baseDir . '/core/Controller/HoverCardController.php',
     'OC\\Core\\Controller\\JsController' => $baseDir . '/core/Controller/JsController.php',
     'OC\\Core\\Controller\\LoginController' => $baseDir . '/core/Controller/LoginController.php',
     'OC\\Core\\Controller\\LostController' => $baseDir . '/core/Controller/LostController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -949,6 +949,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Controller\\ContactsMenuController' => __DIR__ . '/../../..' . '/core/Controller/ContactsMenuController.php',
         'OC\\Core\\Controller\\CssController' => __DIR__ . '/../../..' . '/core/Controller/CssController.php',
         'OC\\Core\\Controller\\GuestAvatarController' => __DIR__ . '/../../..' . '/core/Controller/GuestAvatarController.php',
+        'OC\\Core\\Controller\\HoverCardController' => __DIR__ . '/../../..' . '/core/Controller/HoverCardController.php',
         'OC\\Core\\Controller\\JsController' => __DIR__ . '/../../..' . '/core/Controller/JsController.php',
         'OC\\Core\\Controller\\LoginController' => __DIR__ . '/../../..' . '/core/Controller/LoginController.php',
         'OC\\Core\\Controller\\LostController' => __DIR__ . '/../../..' . '/core/Controller/LostController.php',

--- a/lib/private/Contacts/ContactsMenu/ActionFactory.php
+++ b/lib/private/Contacts/ContactsMenu/ActionFactory.php
@@ -32,13 +32,15 @@ class ActionFactory implements IActionFactory {
 	 * @param string $icon
 	 * @param string $name
 	 * @param string $href
+	 * @param string $appName
 	 * @return ILinkAction
 	 */
-	public function newLinkAction($icon, $name, $href) {
+	public function newLinkAction(string $icon, string $name, string $href, string $appName = ''): ILinkAction {
 		$action = new LinkAction();
 		$action->setName($name);
 		$action->setIcon($icon);
 		$action->setHref($href);
+		$action->setAppName($appName);
 		return $action;
 	}
 
@@ -46,9 +48,10 @@ class ActionFactory implements IActionFactory {
 	 * @param string $icon
 	 * @param string $name
 	 * @param string $email
+	 * @param string $appName
 	 * @return ILinkAction
 	 */
-	public function newEMailAction($icon, $name, $email) {
-		return $this->newLinkAction($icon, $name, 'mailto:' . $email);
+	public function newEMailAction(string $icon, string $name, string $email, string $appName = ''): ILinkAction {
+		return $this->newLinkAction($icon, $name, 'mailto:' . $email, $appName);
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/ActionFactory.php
+++ b/lib/private/Contacts/ContactsMenu/ActionFactory.php
@@ -29,29 +29,21 @@ use OCP\Contacts\ContactsMenu\ILinkAction;
 class ActionFactory implements IActionFactory {
 
 	/**
-	 * @param string $icon
-	 * @param string $name
-	 * @param string $href
-	 * @param string $appName
-	 * @return ILinkAction
+	 * {@inheritDoc}
 	 */
-	public function newLinkAction(string $icon, string $name, string $href, string $appName = ''): ILinkAction {
+	public function newLinkAction(string $icon, string $name, string $href, string $appId = ''): ILinkAction {
 		$action = new LinkAction();
 		$action->setName($name);
 		$action->setIcon($icon);
 		$action->setHref($href);
-		$action->setAppName($appName);
+		$action->setAppId($appId);
 		return $action;
 	}
 
 	/**
-	 * @param string $icon
-	 * @param string $name
-	 * @param string $email
-	 * @param string $appName
-	 * @return ILinkAction
+	 * {@inheritDoc}
 	 */
-	public function newEMailAction(string $icon, string $name, string $email, string $appName = ''): ILinkAction {
-		return $this->newLinkAction($icon, $name, 'mailto:' . $email, $appName);
+	public function newEMailAction(string $icon, string $name, string $email, string $appId = ''): ILinkAction {
+		return $this->newLinkAction($icon, $name, 'mailto:' . $email, $appId);
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
+++ b/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
@@ -38,6 +38,9 @@ class LinkAction implements ILinkAction {
 	/** @var int */
 	private $priority = 10;
 
+	/** @var string */
+	private $appName;
+
 	/**
 	 * @param string $icon absolute URI to an icon
 	 */
@@ -88,6 +91,22 @@ class LinkAction implements ILinkAction {
 	}
 
 	/**
+	 * @param string $appName
+	 * @since 23.0.0
+	 */
+	public function setAppName(string $appName) {
+		$this->appName = $appName;
+	}
+
+	/**
+	 * @return string
+	 * @since 23.0.0
+	 */
+	public function getAppName(): string {
+		return $this->appName;
+	}
+
+	/**
 	 * @return array
 	 */
 	public function jsonSerialize() {
@@ -95,6 +114,7 @@ class LinkAction implements ILinkAction {
 			'title' => $this->name,
 			'icon' => $this->icon,
 			'hyperlink' => $this->href,
+			'appName' => $this->appName,
 		];
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
+++ b/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
@@ -39,7 +39,7 @@ class LinkAction implements ILinkAction {
 	private $priority = 10;
 
 	/** @var string */
-	private $appName;
+	private $appId;
 
 	/**
 	 * @param string $icon absolute URI to an icon
@@ -91,19 +91,19 @@ class LinkAction implements ILinkAction {
 	}
 
 	/**
-	 * @param string $appName
+	 * @param string $appId
 	 * @since 23.0.0
 	 */
-	public function setAppName(string $appName) {
-		$this->appName = $appName;
+	public function setAppId(string $appId) {
+		$this->appId = $appId;
 	}
 
 	/**
 	 * @return string
 	 * @since 23.0.0
 	 */
-	public function getAppName(): string {
-		return $this->appName;
+	public function getAppId(): string {
+		return $this->appId;
 	}
 
 	/**
@@ -114,7 +114,7 @@ class LinkAction implements ILinkAction {
 			'title' => $this->name,
 			'icon' => $this->icon,
 			'hyperlink' => $this->href,
-			'appName' => $this->appName,
+			'appId' => $this->appId,
 		];
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
@@ -54,7 +54,7 @@ class EMailProvider implements IProvider {
 				// Skip
 				continue;
 			}
-			$action = $this->actionFactory->newEMailAction($iconUrl, $address, $address);
+			$action = $this->actionFactory->newEMailAction($iconUrl, $address, $address, 'email');
 			$entry->addAction($action);
 		}
 	}

--- a/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
@@ -83,7 +83,7 @@ class ProfileProvider implements IProvider {
 				$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/profile.svg'));
 				$profileActionText = $this->l10nFactory->get('core')->t('View profile');
 				$profileUrl = $this->urlGenerator->linkToRouteAbsolute('core.ProfilePage.index', ['targetUserId' => $targetUserId]);
-				$action = $this->actionFactory->newLinkAction($iconUrl, $profileActionText, $profileUrl);
+				$action = $this->actionFactory->newLinkAction($iconUrl, $profileActionText, $profileUrl, 'profile');
 				// Set highest priority (by descending order), other actions have the default priority 10 as defined in lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
 				$action->setPriority(20);
 				$entry->addAction($action);

--- a/lib/public/Contacts/ContactsMenu/IAction.php
+++ b/lib/public/Contacts/ContactsMenu/IAction.php
@@ -60,4 +60,16 @@ interface IAction extends JsonSerializable {
 	 * @since 12.0
 	 */
 	public function getPriority();
+
+	/**
+	 * @param string $appName
+	 * @since 23.0.0
+	 */
+	public function setAppName(string $appName);
+
+	/**
+	 * @return string
+	 * @since 23.0.0
+	 */
+	public function getAppName(): string;
 }

--- a/lib/public/Contacts/ContactsMenu/IAction.php
+++ b/lib/public/Contacts/ContactsMenu/IAction.php
@@ -62,14 +62,14 @@ interface IAction extends JsonSerializable {
 	public function getPriority();
 
 	/**
-	 * @param string $appName
+	 * @param string $appId
 	 * @since 23.0.0
 	 */
-	public function setAppName(string $appName);
+	public function setAppId(string $appId);
 
 	/**
 	 * @return string
 	 * @since 23.0.0
 	 */
-	public function getAppName(): string;
+	public function getAppId(): string;
 }

--- a/lib/public/Contacts/ContactsMenu/IActionFactory.php
+++ b/lib/public/Contacts/ContactsMenu/IActionFactory.php
@@ -35,9 +35,10 @@ interface IActionFactory {
 	 * @param string $icon full path to the action's icon
 	 * @param string $name localized name of the action
 	 * @param string $href target URL
+	 * @param string $appName the appName registering the action
 	 * @return ILinkAction
 	 */
-	public function newLinkAction($icon, $name, $href);
+	public function newLinkAction(string $icon, string $name, string $href, string $appName = ''): ILinkAction;
 
 	/**
 	 * Construct and return a new email action for the contacts menu
@@ -47,7 +48,8 @@ interface IActionFactory {
 	 * @param string $icon full path to the action's icon
 	 * @param string $name localized name of the action
 	 * @param string $email target e-mail address
+	 * @param string $appName the appName registering the action
 	 * @return ILinkAction
 	 */
-	public function newEMailAction($icon, $name, $email);
+	public function newEMailAction(string $icon, string $name, string $email, string $appName = ''): ILinkAction;
 }

--- a/lib/public/Contacts/ContactsMenu/IActionFactory.php
+++ b/lib/public/Contacts/ContactsMenu/IActionFactory.php
@@ -35,10 +35,10 @@ interface IActionFactory {
 	 * @param string $icon full path to the action's icon
 	 * @param string $name localized name of the action
 	 * @param string $href target URL
-	 * @param string $appName the appName registering the action
+	 * @param string $appId the app ID registering the action
 	 * @return ILinkAction
 	 */
-	public function newLinkAction(string $icon, string $name, string $href, string $appName = ''): ILinkAction;
+	public function newLinkAction(string $icon, string $name, string $href, string $appId = ''): ILinkAction;
 
 	/**
 	 * Construct and return a new email action for the contacts menu
@@ -48,8 +48,8 @@ interface IActionFactory {
 	 * @param string $icon full path to the action's icon
 	 * @param string $name localized name of the action
 	 * @param string $email target e-mail address
-	 * @param string $appName the appName registering the action
+	 * @param string $appId the appName registering the action
 	 * @return ILinkAction
 	 */
-	public function newEMailAction(string $icon, string $name, string $email, string $appName = ''): ILinkAction;
+	public function newEMailAction(string $icon, string $name, string $email, string $appId = ''): ILinkAction;
 }

--- a/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
@@ -75,12 +75,12 @@ class LinkActionTest extends TestCase {
 		$this->action->setName('Nickie Works');
 		$this->action->setPriority(33);
 		$this->action->setHref('example.com');
-		$this->action->setAppName('contacts');
+		$this->action->setAppId('contacts');
 		$expected = [
 			'title' => 'Nickie Works',
 			'icon' => 'icon-contacts',
 			'hyperlink' => 'example.com',
-			'appName' => 'contacts',
+			'appId' => 'contacts',
 		];
 
 		$json = $this->action->jsonSerialize();
@@ -97,7 +97,7 @@ class LinkActionTest extends TestCase {
 			'title' => 'Nickie Works',
 			'icon' => 'icon-contacts',
 			'hyperlink' => 'example.com',
-			'appName' => '',
+			'appId' => '',
 		];
 
 		$json = $this->action->jsonSerialize();

--- a/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
@@ -75,10 +75,29 @@ class LinkActionTest extends TestCase {
 		$this->action->setName('Nickie Works');
 		$this->action->setPriority(33);
 		$this->action->setHref('example.com');
+		$this->action->setAppName('contacts');
 		$expected = [
 			'title' => 'Nickie Works',
 			'icon' => 'icon-contacts',
 			'hyperlink' => 'example.com',
+			'appName' => 'contacts',
+		];
+
+		$json = $this->action->jsonSerialize();
+
+		$this->assertEquals($expected, $json);
+	}
+
+	public function testJsonSerializeNoAppName() {
+		$this->action->setIcon('icon-contacts');
+		$this->action->setName('Nickie Works');
+		$this->action->setPriority(33);
+		$this->action->setHref('example.com');
+		$expected = [
+			'title' => 'Nickie Works',
+			'icon' => 'icon-contacts',
+			'hyperlink' => 'example.com',
+			'appName' => '',
 		];
 
 		$json = $this->action->jsonSerialize();

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -99,7 +99,7 @@ class ContactsStoreTest extends TestCase {
 					],
 				],
 			]);
-		$user->expects($this->once())
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user123');
 
@@ -129,7 +129,7 @@ class ContactsStoreTest extends TestCase {
 					],
 				],
 			]);
-		$user->expects($this->once())
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user123');
 
@@ -157,7 +157,7 @@ class ContactsStoreTest extends TestCase {
 					'PHOTO' => base64_encode('photophotophoto'),
 				],
 			]);
-		$user->expects($this->once())
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user123');
 
@@ -186,7 +186,7 @@ class ContactsStoreTest extends TestCase {
 					'PHOTO' => 'VALUE=uri:https://photo',
 				],
 			]);
-		$user->expects($this->once())
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user123');
 
@@ -210,7 +210,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -253,7 +253,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -332,7 +332,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -411,7 +411,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -469,7 +469,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -555,7 +555,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -624,7 +624,7 @@ class ContactsStoreTest extends TestCase {
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
-		$currentUser->expects($this->once())
+		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
@@ -963,9 +963,8 @@ class ContactsStoreTest extends TestCase {
 					'isLocalSystemBook' => false
 				],
 			]);
-		$user->expects($this->once())
-			->method('getUID')
-			->willReturn('user123');
+		$user->expects($this->never())
+			->method('getUID');
 
 		$entry = $this->contactsStore->findOne($user, 0, 'a567');
 


### PR DESCRIPTION
Ref #28751
Ref nextcloud/files-clients#1

Alternate attempt to https://github.com/nextcloud/server/pull/29249

* Less intrusive
* Only populating data that is needed now (since OCS has to stay compatible 3 years)
* Instead of shareTypes and POST, the userId is a url parameter and therefor much more straight forward
* In case hovercards get extended in the future, we can add more details to it and just bump the version parameter in the URL