### PR TITLE
Check if user's groups can see tag

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -363,6 +363,14 @@ class SystemTagManager implements ISystemTagManager {
 			return true;
 		}
 
+		$groupIds = $this->groupManager->getUserGroupIds($user);
+		if (!empty($groupIds)) {
+			$matchingGroups = array_intersect($groupIds, $this->getTagGroups($tag));
+			if (!empty($matchingGroups)) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Addresses at least one of the concerns in #4699, though not fully since there isn't a way to add a group to a tag from the frontend.