### PR TITLE
Obtain the correct image type from buffered images

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -666,7 +666,7 @@ class OC_Image implements \OCP\IImage {
 	 * Get the correct file type from a buffered image
 	 *
 	 * @param string $buffer The image data to analyze
-	 * @return void
+	 * @return bool
 	 */
 	private function updateImageTypes($buffer) {
 		if ($this->valid()) {

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -721,6 +721,8 @@ class OC_Image implements \OCP\IImage {
 				return true;
 			}
 		}
+
+		return false;
 	}
 
 	/**

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -663,6 +663,42 @@ class OC_Image implements \OCP\IImage {
 	}
 
 	/**
+	 * Get the correct file type from a buffered image
+	 *
+	 * @param string $buffer The image data to analyze
+	 * @return void
+	 */
+	private function updateImageTypes($buffer) {
+		if ($this->valid()) {
+			$finfo = new finfo(FILEINFO_MIME_TYPE);
+			$this->mimeType = $finfo->buffer($buffer);
+			switch ($this->mimeType) {
+				case 'image/gif':
+					$this->imageType = IMAGETYPE_GIF;
+					break;
+				case 'image/jpeg':
+					$this->imageType = IMAGETYPE_JPEG;
+					break;
+				case 'image/png':
+					$this->imageType = IMAGETYPE_PNG;
+					break;
+				case 'image/xbm':
+					$this->imageType = IMAGETYPE_XBM;
+					break;
+				case 'image/vnd.wap.wbmp':
+					$this->imageType = IMAGETYPE_WBMP;
+					break;
+				case 'image/bmp':
+					$this->imageType = IMAGETYPE_BMP;
+					break;
+				case 'image/webp':
+					$this->imageType = IMAGETYPE_WEBP;
+					break;
+			}
+		}
+	}
+
+	/**
 	 * Loads an image from a string of data.
 	 *
 	 * @param string $str A string of image data as read from a file.
@@ -673,13 +709,11 @@ class OC_Image implements \OCP\IImage {
 			return false;
 		}
 		$this->resource = @imagecreatefromstring($str);
-		if ($this->fileInfo) {
-			$this->mimeType = $this->fileInfo->buffer($str);
-		}
 		if (is_resource($this->resource)) {
 			imagealphablending($this->resource, false);
 			imagesavealpha($this->resource, true);
 		}
+		$this->updateImageTypes($str);
 
 		if (!$this->resource) {
 			$this->logger->debug('OC_Image->loadFromFile, could not load', ['app' => 'core']);
@@ -701,9 +735,7 @@ class OC_Image implements \OCP\IImage {
 		$data = base64_decode($str);
 		if ($data) { // try to load from string data
 			$this->resource = @imagecreatefromstring($data);
-			if ($this->fileInfo) {
-				$this->mimeType = $this->fileInfo->buffer($data);
-			}
+			$this->updateImageTypes($data);
 			if (!$this->resource) {
 				$this->logger->debug('OC_Image->loadFromBase64, could not load', ['app' => 'core']);
 				return false;


### PR DESCRIPTION
Currently, there is the problem that for loading images from files (using `OC_Image->loadFromFile` [see here](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L555), there is a short check [at the end](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L657-L661) that updates the internal structures to represent the correct image type.

When loading an image from [string](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L671) or [base64-encoded string](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L697) these internal cached type information are not set correctly.

For example, when loading a JPEG from a string and [fixing the orientation](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L470), the `getOrientation` method fails with `-1`, as the image [is not considered a JPEG according to the internal cache](https://github.com/nextcloud/server/blob/9a809df960baad5db1840509f9f6acd19b5b66c7/lib/private/legacy/OC_Image.php#L417-L420).

I found this bug during debugging for https://github.com/nextcloud/cookbook/issues/803. I just hacked together a quick solution as I thought this might be faster than waiting for someone from the core team to tackle the problem. It can be considered open for discussion :smile: 