### PR TITLE
Limit parameter count per query in Cache.removeChildren

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -587,10 +587,13 @@ class Cache implements ICache {
 				return $cacheEntry->getId();
 			}, $children);
 
-			$query = $this->getQueryBuilder();
-			$query->delete('filecache_extended')
-				->where($query->expr()->in('fileid', $query->createNamedParameter($childIds, IQueryBuilder::PARAM_INT_ARRAY)));
-			$query->execute();
+			$childIdChunks = array_chunk($childIds, 2048);
+			foreach ($childIdChunks as $childIdChunk) {
+				$query = $this->getQueryBuilder();
+				$query->delete('filecache_extended')
+					->where($query->expr()->in('fileid', $query->createNamedParameter($childIdChunk, IQueryBuilder::PARAM_INT_ARRAY)));
+				$query->execute();
+			}
 
 			/** @var ICacheEntry[] $childFolders */
 			$childFolders = array_filter($children, function ($child) {
@@ -602,10 +605,13 @@ class Cache implements ICache {
 			}
 		}
 
-		$query = $this->getQueryBuilder();
-		$query->delete('filecache')
-			->whereParentIn($parentIds);
-		$query->execute();
+		$parentIdChunks = array_chunk($parentIds, 2048);
+		foreach ($parentIdChunks as $parentIdChunk) {
+			$query = $this->getQueryBuilder();
+			$query->delete('filecache')
+				->whereParentIn($parentIdChunk);
+			$query->execute();
+		}
 	}
 
 	/**

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -587,11 +587,12 @@ class Cache implements ICache {
 				return $cacheEntry->getId();
 			}, $children);
 
-			$childIdChunks = array_chunk($childIds, 2048);
-			foreach ($childIdChunks as $childIdChunk) {
-				$query = $this->getQueryBuilder();
-				$query->delete('filecache_extended')
-					->where($query->expr()->in('fileid', $query->createNamedParameter($childIdChunk, IQueryBuilder::PARAM_INT_ARRAY)));
+			$query = $this->getQueryBuilder();
+			$query->delete('filecache_extended')
+				->where($query->expr()->in('fileid', $query->createParameter('childIds')));
+			
+			foreach (array_chunk($childIds, 1000) as $childIdChunk) {
+				$query->setParameter('childIds', $childIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
 				$query->execute();
 			}
 
@@ -605,11 +606,12 @@ class Cache implements ICache {
 			}
 		}
 
-		$parentIdChunks = array_chunk($parentIds, 2048);
-		foreach ($parentIdChunks as $parentIdChunk) {
-			$query = $this->getQueryBuilder();
-			$query->delete('filecache')
-				->whereParentIn($parentIdChunk);
+		$query = $this->getQueryBuilder();
+		$query->delete('filecache')
+			->whereParentInParameter('parentIds');
+
+		foreach (array_chunk($parentIds, 1000) as $parentIdChunk) {
+			$query->setParameter('parentIds', $parentIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$query->execute();
 		}
 	}

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -91,7 +91,7 @@ class CacheQueryBuilder extends QueryBuilder {
 		return $this;
 	}
 
-	public function whereParentIn(array $parents) {
+	public function whereParentInParameter(string $parameter) {
 		$alias = $this->alias;
 		if ($alias) {
 			$alias .= '.';
@@ -99,7 +99,7 @@ class CacheQueryBuilder extends QueryBuilder {
 			$alias = '';
 		}
 
-		$this->andWhere($this->expr()->in("{$alias}parent", $this->createNamedParameter($parents, IQueryBuilder::PARAM_INT_ARRAY)));
+		$this->andWhere($this->expr()->in("{$alias}parent", $this->createParameter($parameter)));
 
 		return $this;
 	}


### PR DESCRIPTION
Fixes #25732 by limiting the amount of IDs in `Cache.removeChildren`'s `IN` clauses to ~2048~ 1000. 

~This number was determined by the reported (but untested by me) parameter limit of mssql being 2100 (which way under the parameter limits of the other database engines), rounding it down to the next power of 2 to provide a nice safety margin.~ 1000 was used [elsewhere](https://github.com/nextcloud/server/pull/27187) in the code, so that was used instead

In limited performance testing, this did not seem to have any negative impact on performance, with PostgreSQL benchmarks (on my laptop on battery power) even reporting a significant positive impact.

### Testing
To test this, I've first created a bunch of folders, each with a bunch of subfolders, with a single file in each of those by running the following bash command in the `data/admin/files/` directory:

```bash
for i in {0..100}; do
    mkdir -p test/spam$i/{0..1000}
    touch test/spam$i/{0..1000}/file
done
```

Now scan the directory (`php occ files:scan --all`) - this is gonna take a while, I recommend making a back-up of the database at this point to return to this state later). When this is done remove the `test` directory, then scan again.

This results in a `$parentIds` element count of over 100,000, which consistently reproduces the issue.