### PR TITLE
Deprecate PHP7.3 for Nextcloud 23

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -299,7 +299,7 @@ class CheckSetupController extends Controller {
 	 * @return bool
 	 */
 	protected function isPhpOutdated(): bool {
-		return PHP_VERSION_ID < 70300;
+		return PHP_VERSION_ID < 70400;
 	}
 
 	/**

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -290,9 +290,9 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}
-					if (data.phpSupported && data.phpSupported.version.substr(0, 3) === '7.2') {
+					if (data.phpSupported && data.phpSupported.version.substr(0, 3) === '7.3') {
 						messages.push({
-							msg: t('core', 'Nextcloud 20 is the last release supporting PHP 7.2. Nextcloud 21 requires at least PHP 7.3.'),
+							msg: t('core', 'Nextcloud 23 is the last release supporting PHP 7.3. Nextcloud 24 requires at least PHP 7.4.'),
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}


### PR DESCRIPTION
* 7.3 reaches EOL shortly after the release of 23.0.0
* Nextcloud 24 will require PHP7.4

Ref https://github.com/nextcloud/server/issues/29258