### PR TITLE
[stable20] Fix unable to login errors due to file system not being initialized

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -134,6 +134,7 @@ class ViewController extends Controller {
 	 * @throws \OCP\Files\NotFoundException
 	 */
 	protected function getStorageInfo() {
+		\OC_Util::setupFS();
 		$dirInfo = \OC\Files\Filesystem::getFileInfo('/', false);
 
 		return \OC_Helper::getStorageInfo('/', $dirInfo);


### PR DESCRIPTION
This unifies the getStorageInfo with the stable21 and later branches and
fix a login problems sometimes encountered.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>