### PR TITLE
Fix cliping issues in alternative logging buttons

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -151,6 +151,7 @@ form #datadirField legend {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 10px 5px;
 	position: relative; /* Make the wrapper the containing block of its
 						   absolutely positioned descendant icons */
 }
@@ -164,7 +165,7 @@ form #datadirField legend {
 }
 
 .alternative-logins a.button {
-	margin: 10px 5px;
+	margin: 0;
 	display: block;
 	font-size: 15px;
 	white-space: nowrap;


### PR DESCRIPTION
The issue was caused because the button with its margins was bigger
than the parent. Instead of setting the margin of the button, add
padding to the parent. This is more reliable.

Before:
![image](https://user-images.githubusercontent.com/23653902/137718878-45e4a279-884e-4ae5-bae4-dbaaa230bbf2.png)

After:
![image](https://user-images.githubusercontent.com/23653902/137718847-7bf5283b-4834-4708-8d80-f3050df8ffdd.png)
