### PR TITLE
tell mysql to ignore the sort index for search queries

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1353,4 +1353,21 @@ class QueryBuilder implements IQueryBuilder {
 
 		return $this->helper->quoteColumnName($alias);
 	}
+
+	/**
+	 * Either appends to or replaces a single, generic query part.
+	 *
+	 * The available parts are: 'select', 'from', 'set', 'where',
+	 * 'groupBy', 'having' and 'orderBy'.
+	 *
+	 * @param string $sqlPartName
+	 * @param mixed  $sqlPart
+	 * @param bool   $append
+	 *
+	 * @return $this This QueryBuilder instance.
+	 */
+	public function add(string $sqlPartName, $sqlPart, bool $append = false) {
+		$this->queryBuilder->add($sqlPartName, $sqlPart, $append);
+		return $this;
+	}
 }

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 namespace OC\Files\Cache;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -41,12 +42,24 @@ class CacheQueryBuilder extends QueryBuilder {
 		parent::__construct($connection, $systemConfig, $logger);
 	}
 
-	public function selectFileCache(string $alias = null) {
+	public function selectFileCache(string $alias = null, string $mysqlIndexHint = '') {
 		$name = $alias ? $alias : 'filecache';
 		$this->select("$name.fileid", 'storage', 'path', 'path_hash', "$name.parent", 'name', 'mimetype', 'mimepart', 'size', 'mtime',
 			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'metadata_etag', 'creation_time', 'upload_time')
-			->from('filecache', $name)
-			->leftJoin($name, 'filecache_extended', 'fe', $this->expr()->eq("$name.fileid", 'fe.fileid'));
+			->from('filecache', $name);
+		if ($mysqlIndexHint !== '' && $this->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+			$this->add('join', [
+				$this->quoteAlias($name) => [
+					// horrible query builder crimes to sneak in raw sql after the "FROM oc_filecache $name"
+					'joinType' => $mysqlIndexHint . ' left',
+					'joinTable' => $this->getTableName('filecache_extended'),
+					'joinAlias' => $this->quoteAlias('fe'),
+					'joinCondition' => $this->expr()->eq("$name.fileid", 'fe.fileid'),
+				],
+			], true);
+		} else {
+			$this->leftJoin($name, 'filecache_extended', 'fe', $this->expr()->eq("$name.fileid", 'fe.fileid'));
+		}
 
 		$this->alias = $name;
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -103,7 +103,13 @@ class QuerySearchHelper {
 
 		$builder = $this->getQueryBuilder();
 
-		$query = $builder->selectFileCache('file');
+		// mysql really likes to pick an index for sorting if it can't fully satisfy the where
+		// filter with an index, since search queries pretty much never are fully filtered by index
+		// mysql often picks an index for sorting instead of the *much* more useful index for filtering.
+		//
+		// To bypass this, we tell mysql explicitly not to use the mtime (the default order field) index,
+		// so it will instead pick an index that is actually useful.
+		$query = $builder->selectFileCache('file', 'ignore index for order by (fs_mtime)');
 
 		if ($this->searchBuilder->shouldJoinTags($searchQuery->getSearchOperation())) {
 			$user = $searchQuery->getUser();


### PR DESCRIPTION
Involves some *creative* query builder usage to sneak the index hint into the query

mysql really likes to pick an index for sorting if it can't fully satisfy the where
filter with an index, since search queries pretty much never are fully filtered by index
mysql often picks an index for sorting instead of the *much* more useful index for filtering.

To bypass this, we tell mysql explicitly not to use the mtime (the default order field) index,
so it will instead pick an index that is actually useful.