### PR TITLE
Fix basic auth for OAuth token endpoint

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -987,7 +987,13 @@ class OC {
 			} else {
 				// For guests: Load only filesystem and logging
 				OC_App::loadApps(['filesystem', 'logging']);
-				self::handleLogin($request);
+
+				// Don't try to login when a client is trying to get a OAuth token.
+				// OAuth needs to support basic auth too, so the login is not valid
+				// inside Nextcloud and the Login exception would ruin it.
+				if ($request->getRawPathInfo() !== '/apps/oauth2/api/v1/token') {
+					self::handleLogin($request);
+				}
 			}
 		}
 


### PR DESCRIPTION
Don't try to login when a client is trying to get a OAuth token.
OAuth needs to support basic auth too, so the login is not valid
inside Nextcloud and the Login exception would ruin it.

Fix #28261 