### PR TITLE
Fix undefined values fallback in profileParameters

### DIFF
--- a/apps/settings/src/components/PersonalInfo/EmailSection/EmailSection.vue
+++ b/apps/settings/src/components/PersonalInfo/EmailSection/EmailSection.vue
@@ -81,7 +81,7 @@ import { validateEmail } from '../../../utils/validate'
 
 const { emailMap: { additionalEmails, primaryEmail, notificationEmail } } = loadState('settings', 'personalInfoParameters', {})
 const { displayNameChangeSupported } = loadState('settings', 'accountParameters', {})
-const { profileConfig: { email: { visibility } } } = loadState('settings', 'profileParameters', {})
+const { profileConfig } = loadState('settings', 'profileParameters', {})
 
 export default {
 	name: 'EmailSection',
@@ -101,7 +101,7 @@ export default {
 			primaryEmail,
 			savePrimaryEmailScope,
 			notificationEmail,
-			visibility,
+			visibility: profileConfig?.role?.visibility,
 		}
 	},
 

--- a/apps/settings/src/components/PersonalInfo/RoleSection/RoleSection.vue
+++ b/apps/settings/src/components/PersonalInfo/RoleSection/RoleSection.vue
@@ -47,8 +47,8 @@ import VisibilityDropdown from '../shared/VisibilityDropdown'
 
 import { ACCOUNT_PROPERTY_ENUM, ACCOUNT_PROPERTY_READABLE_ENUM } from '../../../constants/AccountPropertyConstants'
 
-const { roleMap: { primaryRole } } = loadState('settings', 'personalInfoParameters', {})
-const { profileConfig: { role: { visibility } } } = loadState('settings', 'profileParameters', {})
+const { roleMap } = loadState('settings', 'personalInfoParameters', {})
+const { profileConfig } = loadState('settings', 'profileParameters', {})
 
 export default {
 	name: 'RoleSection',
@@ -63,8 +63,8 @@ export default {
 		return {
 			accountProperty: ACCOUNT_PROPERTY_READABLE_ENUM.ROLE,
 			accountPropertyId: ACCOUNT_PROPERTY_ENUM.ROLE,
-			primaryRole,
-			visibility,
+			primaryRole: roleMap?.primaryRole,
+			visibility: profileConfig?.role?.visibility,
 		}
 	},
 }

--- a/apps/settings/src/components/PersonalInfo/shared/VisibilityDropdown.vue
+++ b/apps/settings/src/components/PersonalInfo/shared/VisibilityDropdown.vue
@@ -75,9 +75,9 @@ export default {
 
 	data() {
 		return {
-			initialVisibility: profileConfig[this.paramId].visibility,
+			initialVisibility: profileConfig[this.paramId]?.visibility,
 			profileEnabled,
-			visibility: profileConfig[this.paramId].visibility,
+			visibility: profileConfig[this.paramId]?.visibility,
 		}
 	},
 

--- a/apps/settings/src/main-personal-info.js
+++ b/apps/settings/src/main-personal-info.js
@@ -82,7 +82,8 @@ const visibilityDropdownParamIds = [
 ]
 
 for (const paramId of visibilityDropdownParamIds) {
-	const { displayId } = profileConfig[paramId]
+	const displayId = profileConfig[paramId]?.displayId
+
 	new VisibilityDropdownView({
 		propsData: {
 			paramId,


### PR DESCRIPTION
After #28751 

While the ES6 destructuring syntax is fancy, it doesn't offers proper undefined fallback.
Either we do it like I suggest or we use a proper full object fallback as the `loadState` fallback parameter 

It seems this still doesn't fixes everything as I'm personally still missing some values:
![image](https://user-images.githubusercontent.com/14975046/137913015-7d26504d-925f-4f3c-a66e-461618a9eebf.png)


I assume this is because I'm on a dev and wild instance, but I want to still make sure we catch that to ensure no one else also encounter that issue :smile: 