### PR TITLE
Do not make action icons too transparent

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -215,7 +215,7 @@ input[type='reset'] {
 		color: #fff !important;
 	}
 }
-button:not(.button-vue), .button:not(.button-vue) {
+button:not(.button-vue):not(.action-button), .button:not(.button-vue) {
 	> span {
 		/* icon position inside buttons */
 		&[class^='icon-'],


### PR DESCRIPTION
Fix regression introduced in https://github.com/nextcloud/server/pull/25774

| Before | After |
|---|---|
| <img width="204" alt="Screenshot 2021-10-19 at 18 15 37" src="https://user-images.githubusercontent.com/26852655/137950975-11bc3c53-3b43-4957-8df9-429e7e1378da.png"> | <img width="207" alt="Screenshot 2021-10-19 at 18 14 47" src="https://user-images.githubusercontent.com/26852655/137950995-4601090d-74a5-4cb5-aff7-ece27ebcce0d.png"> | 

Signed-off-by: marco <marcoambrosini@pm.me>