### PR TITLE
fix potential unwarranted memberships in nested groups from LDAP

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -248,7 +248,12 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			// but not included in the results laters on
 			$excludeFromResult = $dnGroup;
 		}
+		// cache only base groups, otherwise groups get additional unwarranted members
+		$shouldCacheResult = count($seen) === 0;
+
+		static $rawMemberReads = []; // runtime cache for intermediate ldap read results
 		$allMembers = [];
+
 		if (array_key_exists($dnGroup, $seen)) {
 			return [];
 		}
@@ -290,7 +295,11 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		}
 
 		$seen[$dnGroup] = 1;
-		$members = $this->access->readAttribute($dnGroup, $this->access->connection->ldapGroupMemberAssocAttr);
+		$members = $rawMemberReads[$dnGroup] ?? null;
+		if ($members === null) {
+			$members = $this->access->readAttribute($dnGroup, $this->access->connection->ldapGroupMemberAssocAttr);
+			$rawMemberReads[$dnGroup] = $members;
+		}
 		if (is_array($members)) {
 			$fetcher = function ($memberDN) use (&$seen) {
 				return $this->_groupMembers($memberDN, $seen);
@@ -306,7 +315,10 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			}
 		}
 
-		$this->access->connection->writeToCache($cacheKey, $allMembers);
+		if ($shouldCacheResult) {
+			$this->access->connection->writeToCache($cacheKey, $allMembers);
+			unset($rawMemberReads[$dnGroup]);
+		}
 		if (isset($attemptedLdapMatchingRuleInChain)
 			&& $this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_UNKNOWN
 			&& !empty($allMembers)


### PR DESCRIPTION
# Fix

- the issue was present only when using PHP based resolving of nested  group members. Normally nested members are common in AD (and Samba4) and are resolved per LDAP_MATCHING_RULE_IN_CHAIN by default
- resolving nested members is recursive
- when the cache entry was created it happend for intermediate groups, too, containing members from the parent group
- the check was added to only cache the root group with its members
- a runtime cache stores intermediate ldap read results

# Background

I found it when running the `occ group:list` command over all groups and afterwards (with a hot cache) checking the results for a single group in a similar way.

```
# change config to clear the cache
php occ ldap:set-config ${CONFIGID} ldapCacheTTL  $(( $(php occ ldap:show-config ${CONFIGID} | grep ldapCacheTTL | tr -d ' ' | cut -d '|' -f3) + 1 ))
# fetch members of all (<=500) groups
php occ group:list --verbose -l500 | wc -l
# check number of members of a specific group
php occ group:list --verbose -l1 -o24 | grep '    - ' | wc -l
``` 

The result should match with following LDAP query (number of group members have to be subtracted)

```
ldapsearch -LLL -a find -H ${LDAP_HOST_URI} -D ${LDAP_BIND_DN} -w ${LDAP_BIND_PWD} -b "${LDAP_BASE}" "memberof:1.2.840.113556.1.4.1941:=${GROUPDN}" dn | egrep '^dn:'
```

(obviously only with AD or Samba4)

In my test setup I have about 200 LDAP groups with nested members (including groups). About 80 groups are enabled in Nextcloud, the remaining groups may be intermediaries.
