### PR TITLE
Fix security issues when copying groupfolder with advanced ACL

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -525,7 +525,10 @@ class Local extends \OC\Files\Storage\Common {
 	 * @return bool
 	 */
 	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
-		if ($sourceStorage->instanceOfStorage(Local::class)) {
+		// Don't treat ACLStorageWrapper like local storage where copy can be done directly.
+		// Instead use the slower recursive copying in php from Common::copyFromStorage with
+		// more permissions checks.
+		if ($sourceStorage->instanceOfStorage(Local::class) && !$sourceStorage->instanceOfStorage('OCA\GroupFolders\ACL\ACLStorageWrapper')) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
 				 * @var \OC\Files\Storage\Wrapper\Jail $sourceStorage


### PR DESCRIPTION
Using advanced ACL, it is possible that an user has access to a
directory but not to a subdirectory, so the copying use
Common::copyFromStorage instead of Local::copyFromStorage.

We might want to create a new interface instead of using directly
OCA\GroupFolder\ACLStorageWrapper

Fix https://github.com/nextcloud/groupfolders/issues/1692

Signed-off-by: Carl Schwan <carl@carlschwan.eu>