### PR TITLE
Make calendar schedule options translatable

### DIFF
--- a/apps/dav/templates/schedule-response-options.php
+++ b/apps/dav/templates/schedule-response-options.php
@@ -24,8 +24,8 @@ style('dav', 'schedule-response');
 			</div>
 		</fieldset>
 		<fieldset id="more_options">
-			<input type="number" min="0" name="guests" placeholder="Guests" />
-			<input type="text" name="comment" placeholder="Comment" />
+			<input type="number" min="0" name="guests" placeholder="<?php p($l->t('Number of guests')); ?>" />
+			<input type="text" name="comment" placeholder="<?php p($l->t('Comment')); ?>" />
 		</fieldset>
 		<fieldset>
 			<input type="submit" value="<?php p($l->t('Save'));?>">


### PR DESCRIPTION
- Rename the guests input to "Number of guests" to be more descriptive
- Make placeholder of inputs translatable