### PR TITLE
Avoid always setting up the user file system when only querying appdata

### DIFF
--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -466,9 +466,8 @@ class CacheTest extends TestCase {
 		$share = $this->shareManager->createShare($share);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
-		\OC_Util::tearDownFS();
-
 		[$sourceStorage] = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
+		\OC_Util::tearDownFS();
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue(\OC\Files\Filesystem::file_exists('/foo'));

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -346,9 +346,7 @@ class Filesystem {
 		self::getLoader();
 		self::$defaultInstance = new View($root);
 
-		if (!self::$mounts) {
-			self::$mounts = \OC::$server->getMountManager();
-		}
+		self::initMountManager();
 
 		//load custom mount config
 		self::initMountPoints($user);
@@ -505,6 +503,7 @@ class Filesystem {
 			self::$usersSetup = [];
 			self::$mounts->clear();
 			self::$mounts = null;
+			self::initMountManager();
 		}
 	}
 

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -504,6 +504,7 @@ class Filesystem {
 		if (self::$mounts) {
 			self::$usersSetup = [];
 			self::$mounts->clear();
+			self::$mounts = null;
 		}
 	}
 

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -88,7 +88,7 @@ class Manager implements IMountManager {
 	 * @return MountPoint|null
 	 */
 	public function find(string $path) {
-		\OC_Util::setupFS();
+		\OC_Util::setupFS(null);
 		$path = Filesystem::normalizePath($path);
 
 		if (isset($this->pathCache[$path])) {
@@ -121,7 +121,7 @@ class Manager implements IMountManager {
 	 * @return MountPoint[]
 	 */
 	public function findIn(string $path): array {
-		\OC_Util::setupFS();
+		\OC_Util::setupFS(null);
 		$path = $this->formatPath($path);
 
 		if (isset($this->inPathCache[$path])) {


### PR DESCRIPTION
This should contribute to unnecessary user mountpoint setup when fetching css or avatars from appdata for example. I couldn't see any side-effect so far, but I'm curious about the test results.

Using null instead of the empty string default will make sure that the filesystem is not setup for the current user.