### PR TITLE
fix populating account array with missing default values

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -473,15 +473,16 @@ class AccountManager implements IAccountManager {
 	 * Make sure that all expected data are set
 	 */
 	protected function addMissingDefaultValues(array $userData, array $defaultUserData): array {
-		foreach ($defaultUserData as $i => $value) {
-			// If property doesn't exists, initialize it
-			if (!array_key_exists($i, $userData)) {
-				$userData[$i] = [];
+		foreach ($defaultUserData as $defaultDataItem) {
+			// If property does not exist, initialize it
+			$userDataIndex = array_search($defaultDataItem['name'], array_column($userData, 'name'));
+			if ($userDataIndex === false) {
+				$userData[] = $defaultDataItem;
+				continue;
 			}
 
 			// Merge and extend default missing values
-			$defaultValueIndex = array_search($value['name'], array_column($defaultUserData, 'name'));
-			$userData[$i] = array_merge($defaultUserData[$defaultValueIndex], $userData[$i]);
+			$userData[$userDataIndex] = array_merge($defaultDataItem, $userData[$userDataIndex]);
 		}
 
 		return $userData;

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -516,8 +516,6 @@ class AccountManagerTest extends TestCase {
 				'value' => 'bob',
 				'verified' => IAccountManager::NOT_VERIFIED,
 			],
-			[],
-			[],
 			[
 				'name' => IAccountManager::PROPERTY_EMAIL,
 				'value' => 'bob@bob.bob',
@@ -533,6 +531,13 @@ class AccountManagerTest extends TestCase {
 			],
 
 			[
+				'name' => IAccountManager::PROPERTY_EMAIL,
+				'value' => 'bob@bob.bob',
+				'scope' => IAccountManager::SCOPE_FEDERATED,
+				'verified' => IAccountManager::NOT_VERIFIED,
+			],
+
+			[
 				'name' => IAccountManager::PROPERTY_ADDRESS,
 				'value' => '',
 				'scope' => IAccountManager::SCOPE_LOCAL,
@@ -543,13 +548,6 @@ class AccountManagerTest extends TestCase {
 				'name' => IAccountManager::PROPERTY_WEBSITE,
 				'value' => '',
 				'scope' => IAccountManager::SCOPE_LOCAL,
-				'verified' => IAccountManager::NOT_VERIFIED,
-			],
-
-			[
-				'name' => IAccountManager::PROPERTY_EMAIL,
-				'value' => 'bob@bob.bob',
-				'scope' => IAccountManager::SCOPE_FEDERATED,
 				'verified' => IAccountManager::NOT_VERIFIED,
 			],
 


### PR DESCRIPTION
Today I was greeted with the blue page of death and "OCP\Accounts\PropertyDoesNotExistException Property organisation does not exist.". Turns out the population of missing default values was having a glitch.

- both $userData and $defaultUserData have numeric indices
- each element contains at least the name and other fields
- appending the missing data array is sufficient

