### PR TITLE
fixes an undefined index when getAccessList returns an empty array

### DIFF
--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -141,7 +141,7 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 				return true;
 			}
 			$acl = $this->shareManager->getAccessList($node, true, true);
-			return array_key_exists($uid, $acl['users']);
+			return isset($acl['users']) && array_key_exists($uid, $acl['users']);
 		} catch (NotFoundException $e) {
 			return false;
 		}


### PR DESCRIPTION
`[]` is a valid return value that should be honored as having no access

fixes https://github.com/nextcloud/flow_notifications/issues/37