### PR TITLE
Revert "Fix "never catch" catches in OC_App"

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -63,7 +63,6 @@ use OCP\Authentication\IAlternativeLogin;
 use OCP\ILogger;
 use OCP\Settings\IManager as ISettingsManager;
 use Psr\Log\LoggerInterface;
-use Throwable;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the


### PR DESCRIPTION
Reverts nextcloud/server#28138 to get rid of the warning spam:

> The use statement with non-compound name 'Throwable' has no effect

OC_App file has no namespace so importing a non-namespaced thing yields the warning.