### PR TITLE
Backport #29260: Respect user enumeration settings in user status lists

### DIFF
--- a/build/integration/collaboration_features/user_status.feature
+++ b/build/integration/collaboration_features/user_status.feature
@@ -1,0 +1,20 @@
+Feature: user_status
+  Background:
+    Given using api version "2"
+    And user "user0" exists
+    And user "user0" has status "dnd"
+
+  Scenario: listing recent user statuses with default settings
+    Then user statuses for "admin" list "user0" with status "dnd"
+
+  Scenario: empty recent user statuses with disabled/limited user enumeration
+    When parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+    Then user statuses for "admin" are empty
+    When parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "yes"
+    When parameter "shareapi_restrict_user_enumeration_to_group" of app "core" is set to "yes"
+    Then user statuses for "admin" are empty
+    When parameter "shareapi_restrict_user_enumeration_to_group" of app "core" is set to "no"
+    When parameter "shareapi_restrict_user_enumeration_to_phone" of app "core" is set to "yes"
+    Then user statuses for "admin" are empty
+    When parameter "shareapi_restrict_user_enumeration_to_phone" of app "core" is set to "no"
+    Then user statuses for "admin" list "user0" with status "dnd"

--- a/build/integration/features/bootstrap/CollaborationContext.php
+++ b/build/integration/features/bootstrap/CollaborationContext.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
 use PHPUnit\Framework\Assert;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -68,5 +69,95 @@ class CollaborationContext implements Context {
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_to_phone');
 		$this->deleteServerConfig('core', 'shareapi_restrict_user_enumeration_full_match');
 		$this->deleteServerConfig('core', 'shareapi_only_share_with_group_members');
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has status "([^"]*)"$/
+	 * @param string $user
+	 * @param string $status
+	 */
+	public function assureUserHasStatus($user, $status) {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/user_status/api/v1/user_status/status";
+		$client = new Client();
+		$options = [
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+			],
+		];
+		if ($user === 'admin') {
+			$options['auth'] = $this->adminUser;
+		} else {
+			$options['auth'] = [$user, $this->regularUser];
+		}
+
+		$options['form_params'] = [
+			'statusType' => $status
+		];
+
+		$this->response = $client->put($fullUrl, $options);
+		$this->theHTTPStatusCodeShouldBe(200);
+
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/user_status/api/v1/user_status";
+		unset($options['form_params']);
+		$this->response = $client->get($fullUrl, $options);
+		$this->theHTTPStatusCodeShouldBe(200);
+
+		$returnedStatus = json_decode(json_encode(simplexml_load_string($this->response->getBody()->getContents())->data), true)['status'];
+		Assert::assertEquals($status, $returnedStatus);
+	}
+
+	/**
+	 * @param string $user
+	 * @return null|array
+	 */
+	public function getStatusList(string $user): ?array {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/user_status/api/v1/statuses";
+		$client = new Client();
+		$options = [
+			'headers' => [
+				'OCS-APIREQUEST' => 'true',
+			],
+		];
+		if ($user === 'admin') {
+			$options['auth'] = $this->adminUser;
+		} else {
+			$options['auth'] = [$user, $this->regularUser];
+		}
+
+		$this->response = $client->get($fullUrl, $options);
+		$this->theHTTPStatusCodeShouldBe(200);
+
+		$contents = $this->response->getBody()->getContents();
+		return json_decode(json_encode(simplexml_load_string($contents)->data), true);
+	}
+
+	/**
+	 * @Given /^user statuses for "([^"]*)" list "([^"]*)" with status "([^"]*)"$/
+	 * @param string $user
+	 * @param string $statusUser
+	 * @param string $status
+	 */
+	public function assertStatusesList(string $user, string $statusUser, string $status): void {
+		$statusList = $this->getStatusList($user);
+		Assert::assertArrayHasKey('element', $statusList, 'Returned status list empty or broken');
+		if (array_key_exists('userId', $statusList['element'])) {
+			// If only one user has a status set, the API returns their status directly
+			Assert::assertArrayHasKey('status', $statusList['element'], 'Returned status list empty or broken');
+			$filteredStatusList = [ $statusList['element']['userId'] => $statusList['element']['status'] ];
+		} else {
+			// If more than one user have their status set, the API returns an array of their statuses
+			$filteredStatusList = array_column($statusList['element'], 'status', 'userId');
+		}
+		Assert::assertArrayHasKey($statusUser, $filteredStatusList, 'User not listed in statuses: ' . $statusUser);
+		Assert::assertEquals($status, $filteredStatusList[$statusUser]);
+	}
+
+	/**
+	 * @Given /^user statuses for "([^"]*)" are empty$/
+	 * @param string $user
+	 */
+	public function assertStatusesEmpty(string $user): void {
+		$statusList = $this->getStatusList($user);
+		Assert::assertEmpty($statusList);
 	}
 }

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -13,6 +13,7 @@
  * @author Sergio Bertolín <sbertolin@solidgear.es>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Jonas Meurer <jonas@freesources.org>
  *
  * @license GNU AGPL version 3 or any later version
  *


### PR DESCRIPTION
Backport #29260: Respect user enumeration settings in user status lists

So far, the functions to find user statuses listed didn't respect user
enumeration settings (shareapi_allow_share_dialog_user_enumeration
and shareapi_restrict_user_enumeration_to_group core app settings).

Fix this privacy issue by returning an empty list in case
shareapi_allow_share_dialog_user_enumeration is unset or
shareapi_restrict_user_enumeration_to_group is set.

In the long run, we might want to return users from common groups if
shareapi_restrict_user_enumeration_to_group is set. It's complicated
to implement this in a way that scales, though. See the discussion at
#27879 (review)
for details.

Also, don't register the user_status dashboard widget at all if
shareapi_allow_share_dialog_user_enumeration is unset or
shareapi_restrict_user_enumeration_to_group is set.

Fixes: #27122

Signed-off-by: Jonas Meurer jonas@freesources.org