### PR TITLE
23.0.0 beta 2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [23, 0, 0, 4];
+$OC_Version = [23, 0, 0, 5];
 
 // The human readable string
-$OC_VersionString = '23.0.0 beta 1';
+$OC_VersionString = '23.0.0 beta 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #23171
* #25392
* #26347
* #26531
* #26725
* #26841
* #26989
* #27196
* #27440
* #27731
* #27876
* #27949
* #28138
* #28314
* #28389
* #28541
* #28997
* #29021
* #29220
* #29255
* #29256
* #29260
* #29269
* #29304
* #29313
* #29318
* #29320
* #29330
* #29331
* #29332
* #29334
* #29342
* #29343
* #29344
* #29345
* #29346
* #29351
* #29355
* #29357
* #29362
* #29363
* #29373
* #29375
* #29378
* #29382
* #29397
* #29400
* #29401
* #29402
* #29408
* #29412
* #29413
* #29425
* #29435
* [3rdparty#837](https://github.com/nextcloud/3rdparty/pull/837) Bump doctrine/dbal from 3.0.0 to 3.1.3
* [3rdparty#857](https://github.com/nextcloud/3rdparty/pull/857) Bump Symfony family and friends to v4.4.30
* [3rdparty#863](https://github.com/nextcloud/3rdparty/pull/863) Ignore Symfony 5 bumps for now
* [files_pdfviewer#509](https://github.com/nextcloud/files_pdfviewer/pull/509) Bump pdfjs-dist from 2.9.359 to 2.10.377
* [firstrunwizard#623](https://github.com/nextcloud/firstrunwizard/pull/623) Bump eslint-plugin-promise from 5.1.0 to 5.1.1
* [firstrunwizard#625](https://github.com/nextcloud/firstrunwizard/pull/625) Bump eslint-plugin-vue from 7.19.1 to 7.20.0
* [notifications#1080](https://github.com/nextcloud/notifications/pull/1080) Describe how to activate the app
* [notifications#1093](https://github.com/nextcloud/notifications/pull/1093) Fix id selection
* [notifications#1094](https://github.com/nextcloud/notifications/pull/1094) Add integration tests for push registration
* [notifications#1098](https://github.com/nextcloud/notifications/pull/1098) Fair use of push notifications
* [photos#915](https://github.com/nextcloud/photos/pull/915) Bump postcss from 8.3.9 to 8.3.11
* [text#1860](https://github.com/nextcloud/text/pull/1860) Make collabora on top of text idle message
* [text#1888](https://github.com/nextcloud/text/pull/1888) Only show image author annotations if needed
* [text#1899](https://github.com/nextcloud/text/pull/1899) Bump prosemirror-view from 1.20.2 to 1.20.3
* [text#1902](https://github.com/nextcloud/text/pull/1902) Remove superfluous scrollbar caused by menububble
* [text#1904](https://github.com/nextcloud/text/pull/1904) Fix wrong generation of ocs url for rich workspaces
* [text#1907](https://github.com/nextcloud/text/pull/1907) Use viewer theme
* [text#1908](https://github.com/nextcloud/text/pull/1908) Cypress: Avoid failing tests due to page reload conditions causing exceptions
* [text#1909](https://github.com/nextcloud/text/pull/1909) Bump jest from 27.2.5 to 27.3.1
* [viewer#1051](https://github.com/nextcloud/viewer/pull/1051) Implement dark/light/default theme for viewer handlers
* [viewer#1053](https://github.com/nextcloud/viewer/pull/1053) Fix header button selector after rebase
* [viewer#1054](https://github.com/nextcloud/viewer/pull/1054) Build(deps-dev): bump jest from 27.2.5 to 27.3.1


Pending PRs:

* [ ] #22943 @icewind1991
* [ ] #25332 @danxuliu
* [ ] #25418 @kaktuspalme
* [ ] #27034 @juliushaertl
* [ ] #27378 @icewind1991
* [ ] #27493 @cuppett
* [ ] #27538 @icewind1991
* [ ] #27562 @j-be
* [ ] #27961 @CarlSchwan
* [ ] #28385 @icewind1991
* [ ] #28438 @csware
* [ ] #28772 @icewind1991
* [ ] #28911 @danxuliu
* [ ] #29029 @Pytal
* [ ] #29300 @icewind1991
* [ ] #29329 @blizzz
* [ ] #29349 @blizzz
* [ ] #29360 @artonge
* [ ] #29405 
* [x] #29436 @Pytal
* [ ] [3rdparty#710](https://github.com/nextcloud/3rdparty/pull/710) Bump php-opencloud/openstack from 3.1.0 to 3.2.1 
* [ ] [activity#589](https://github.com/nextcloud/activity/pull/589) Rewrite the settings in vue @artonge
* [ ] [logreader#476](https://github.com/nextcloud/logreader/pull/476) Add feature to view admin_audit log files @Abijeet
* [x] [text#1883](https://github.com/nextcloud/text/pull/1883) Add automatic line break on txt files @luka-nextcloud
* [ ] [text#1900](https://github.com/nextcloud/text/pull/1900) [WIP] Insert images from local device (or link) @eneiluj
