### PR TITLE
Detect mimetype by content only with content

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -127,7 +127,7 @@ class FileMimeType extends AbstractStringCheck implements IFileCheck {
 			return $this->cacheAndReturnMimeType($this->storage->getId(), $this->path, 'httpd/unix-directory');
 		}
 
-		if ($this->storage->file_exists($this->path)) {
+		if ($this->storage->file_exists($this->path) && $this->storage->filesize($this->path)) {
 			$path = $this->storage->getLocalFile($this->path);
 			$mimeType = $this->mimeTypeDetector->detectContent($path);
 			return $this->cacheAndReturnMimeType($this->storage->getId(), $this->path, $mimeType);


### PR DESCRIPTION
### Steps

1. Add an access rule which only allows folders and documents by mimetype
2. Upload a 0 byte file with `test.docx` as name
3. Afterwards refresh the folder
4. File is blocked, debugger says mimetype is `application/octet-stream`