### PR TITLE
Avoid use of iconv to get rid of unicode

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1433,12 +1433,15 @@ class Access extends LDAPUtility {
 			return $name;
 		}
 
-		// Transliteration to ASCII
-		$transliterated = @iconv('UTF-8', 'ASCII//TRANSLIT', $name);
-		if ($transliterated !== false) {
-			// depending on system config iconv can work or not
-			$name = $transliterated;
-		}
+		// Use htmlentities to get rid of accents
+		$name = htmlentities($name, ENT_NOQUOTES, 'UTF-8');
+
+		// Remove accents
+		$name = preg_replace('#&([A-za-z])(?:acute|cedil|caron|circ|grave|orn|ring|slash|th|tilde|uml);#', '\1', $name);
+		// Remove ligatures
+		$name = preg_replace('#&([A-za-z]{2})(?:lig);#', '\1', $name);
+		// Remove unknown leftover entities
+		$name = preg_replace('#&[^;]+;#', '', $name);
 
 		// Replacements
 		$name = str_replace(' ', '_', $name);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1437,9 +1437,9 @@ class Access extends LDAPUtility {
 		$name = htmlentities($name, ENT_NOQUOTES, 'UTF-8');
 
 		// Remove accents
-		$name = preg_replace('#&([A-za-z])(?:acute|cedil|caron|circ|grave|orn|ring|slash|th|tilde|uml);#', '\1', $name);
+		$name = preg_replace('#&([A-Za-z])(?:acute|cedil|caron|circ|grave|orn|ring|slash|th|tilde|uml);#', '\1', $name);
 		// Remove ligatures
-		$name = preg_replace('#&([A-za-z]{2})(?:lig);#', '\1', $name);
+		$name = preg_replace('#&([A-Za-z]{2})(?:lig);#', '\1', $name);
 		// Remove unknown leftover entities
 		$name = preg_replace('#&[^;]+;#', '', $name);
 

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -689,16 +689,13 @@ class AccessTest extends TestCase {
 	}
 
 	public function intUsernameProvider() {
-		// system dependent :-/
-		$translitExpected = @iconv('UTF-8', 'ASCII//TRANSLIT', 'fränk') ? 'frank' : 'frnk';
-
 		return [
 			['alice', 'alice'],
 			['b/ob', 'bob'],
 			['charly🐬', 'charly'],
 			['debo rah', 'debo_rah'],
 			['epost@poste.test', 'epost@poste.test'],
-			['fränk', $translitExpected],
+			['fränk', 'frank'],
 			[' gerda ', 'gerda'],
 			['🕱🐵🐘🐑', null],
 			[
@@ -732,9 +729,6 @@ class AccessTest extends TestCase {
 	 * @param $expected
 	 */
 	public function testSanitizeUsername($name, $expected) {
-		if ($name === 'fränk' && PHP_MAJOR_VERSION > 7) {
-			$this->markTestSkipped('Special chars do boom still on CI in php8');
-		}
 		if ($expected === null) {
 			$this->expectException(\InvalidArgumentException::class);
 		}

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -696,6 +696,7 @@ class AccessTest extends TestCase {
 			['debo rah', 'debo_rah'],
 			['epost@poste.test', 'epost@poste.test'],
 			['fränk', 'frank'],
+			[' UPPÉR Case/[\]^`', 'UPPER_Case'],
 			[' gerda ', 'gerda'],
 			['🕱🐵🐘🐑', null],
 			[


### PR DESCRIPTION
Using iconv for translit depends upon server configuration, locale, and PHP version. 
Using htmlentities instead to have a consistent behavior independent of configuration.

In theory using iconv for translit is better because it can do smart things like turing ä to ae or ß to ss, but in practice that only works if you know which locale to set before calling iconv, which we cannot know for usernames.

I did not remove the iconv dependency check as I am not sure if this is our only use of iconv?

Also, I found this in Symfony, which could be used instead of having our own code for this: https://symfony.com/doc/current/components/string.html#slugger