### PR TITLE
Make duplicate HTTP headers pass the checking.

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -639,7 +639,7 @@
 				};
 				for (var header in securityHeaders) {
 					var option = securityHeaders[header][0];
-					if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== option.toLowerCase()) {
+					if (!xhr.getResponseHeader(header) || !xhr.getResponseHeader(header).toLowerCase().split(', ').includes(option.toLowerCase())) {
 						var msg = t('core', 'The "{header}" HTTP header is not set to "{expected}". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.', {header: header, expected: option});
 						if(xhr.getResponseHeader(header) && securityHeaders[header].length > 1 && xhr.getResponseHeader(header).toLowerCase() === securityHeaders[header][1].toLowerCase()) {
 							msg = t('core', 'The "{header}" HTTP header is not set to "{expected}". Some features might not work correctly, as it is recommended to adjust this setting accordingly.', {header: header, expected: option});


### PR DESCRIPTION
If both HTTP server and Nextcloud app set the same header, its values get concatenated.
<https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9>
<https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2>
~~~ js
$.ajax({type: 'GET', url: OC.generateUrl('heartbeat'), allowAuthErrors: true})
  .then(function(data, statusText, xhr) { console.log(xhr.getAllResponseHeaders()) });
...
x-content-type-options: nosniff, nosniff
x-download-options: noopen
x-frame-options: SAMEORIGIN, SAMEORIGIN
~~~
In order to pass the check, the field should be split and each part checked individually.
I believe it fixes #24129.