### PR TITLE
Support LDAP dns longer than 255 characters

### DIFF
--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -62,6 +62,7 @@ return array(
     'OCA\\User_LDAP\\Migration\\UnsetDefaultProvider' => $baseDir . '/../lib/Migration/UnsetDefaultProvider.php',
     'OCA\\User_LDAP\\Migration\\Version1010Date20200630192842' => $baseDir . '/../lib/Migration/Version1010Date20200630192842.php',
     'OCA\\User_LDAP\\Migration\\Version1120Date20210917155206' => $baseDir . '/../lib/Migration/Version1120Date20210917155206.php',
+    'OCA\\User_LDAP\\Migration\\Version1130Date20211102154716' => $baseDir . '/../lib/Migration/Version1130Date20211102154716.php',
     'OCA\\User_LDAP\\Notification\\Notifier' => $baseDir . '/../lib/Notification/Notifier.php',
     'OCA\\User_LDAP\\PagedResults\\IAdapter' => $baseDir . '/../lib/PagedResults/IAdapter.php',
     'OCA\\User_LDAP\\PagedResults\\Php73' => $baseDir . '/../lib/PagedResults/Php73.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -77,6 +77,7 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\Migration\\UnsetDefaultProvider' => __DIR__ . '/..' . '/../lib/Migration/UnsetDefaultProvider.php',
         'OCA\\User_LDAP\\Migration\\Version1010Date20200630192842' => __DIR__ . '/..' . '/../lib/Migration/Version1010Date20200630192842.php',
         'OCA\\User_LDAP\\Migration\\Version1120Date20210917155206' => __DIR__ . '/..' . '/../lib/Migration/Version1120Date20210917155206.php',
+        'OCA\\User_LDAP\\Migration\\Version1130Date20211102154716' => __DIR__ . '/..' . '/../lib/Migration/Version1130Date20211102154716.php',
         'OCA\\User_LDAP\\Notification\\Notifier' => __DIR__ . '/..' . '/../lib/Notification/Notifier.php',
         'OCA\\User_LDAP\\PagedResults\\IAdapter' => __DIR__ . '/..' . '/../lib/PagedResults/IAdapter.php',
         'OCA\\User_LDAP\\PagedResults\\Php73' => __DIR__ . '/..' . '/../lib/PagedResults/Php73.php',

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -355,6 +355,17 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function map($fdn, $name, $uuid) {
+		if (mb_strlen($fdn) > 4096) {
+			\OC::$server->getLogger()->error(
+				'Cannot map, because the DN exceeds 4096 characters: {dn}',
+				[
+					'app' => 'user_ldap',
+					'dn' => $fdn,
+				]
+			);
+			return false;
+		}
+
 		$row = [
 			'ldap_dn_hash' => $this->getDNHash($fdn),
 			'ldap_dn' => $fdn,

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -191,7 +191,12 @@ abstract class AbstractMapping {
 	 * Get the hash to store in database column ldap_dn_hash for a given dn
 	 */
 	protected function getDNHash(string $fdn): string {
-		return (string)hash('sha256', $fdn, false);
+		$hash = hash('sha256', $fdn, false);
+		if (is_string($hash)) {
+			return $hash;
+		} else {
+			throw new \RuntimeException('hash function did not return a string');
+		}
 	}
 
 	/**

--- a/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
+++ b/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
@@ -47,12 +47,7 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			$table = $schema->createTable('ldap_user_mapping');
 			$table->addColumn('ldap_dn', Types::STRING, [
 				'notnull' => true,
-				'length' => 64,
-				'default' => '',
-			]);
-			$table->addColumn('ldap_full_dn', Types::STRING, [
-				'notnull' => true,
-				'length' => 4096,
+				'length' => 255,
 				'default' => '',
 			]);
 			$table->addColumn('owncloud_name', Types::STRING, [
@@ -73,12 +68,7 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			$table = $schema->createTable('ldap_group_mapping');
 			$table->addColumn('ldap_dn', Types::STRING, [
 				'notnull' => true,
-				'length' => 64,
-				'default' => '',
-			]);
-			$table->addColumn('ldap_full_dn', Types::STRING, [
-				'notnull' => true,
-				'length' => 4096,
+				'length' => 255,
 				'default' => '',
 			]);
 			$table->addColumn('owncloud_name', Types::STRING, [

--- a/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
+++ b/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
@@ -66,6 +66,7 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['owncloud_name']);
 			$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_user_dn_hashes');
+			$table->addUniqueIndex(['directory_uuid'], 'ldap_user_directory_uuid');
 		}
 
 		if (!$schema->hasTable('ldap_group_mapping')) {
@@ -91,6 +92,7 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['owncloud_name']);
 			$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_group_dn_hashes');
+			$table->addUniqueIndex(['directory_uuid'], 'ldap_group_directory_uuid');
 		}
 
 		if (!$schema->hasTable('ldap_group_members')) {

--- a/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
+++ b/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
@@ -60,8 +60,12 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 				'length' => 255,
 				'default' => '',
 			]);
+			$table->addColumn('ldap_dn_hash', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
 			$table->setPrimaryKey(['owncloud_name']);
-			$table->addUniqueIndex(['ldap_dn'], 'ldap_dn_users');
+			$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_user_dn_hashes');
 		}
 
 		if (!$schema->hasTable('ldap_group_mapping')) {
@@ -81,8 +85,12 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 				'length' => 255,
 				'default' => '',
 			]);
-			$table->setPrimaryKey(['ldap_dn']);
-			$table->addUniqueIndex(['owncloud_name'], 'owncloud_name_groups');
+			$table->addColumn('ldap_dn_hash', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$table->setPrimaryKey(['owncloud_name']);
+			$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_group_dn_hashes');
 		}
 
 		if (!$schema->hasTable('ldap_group_members')) {

--- a/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
+++ b/apps/user_ldap/lib/Migration/Version1010Date20200630192842.php
@@ -47,7 +47,12 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			$table = $schema->createTable('ldap_user_mapping');
 			$table->addColumn('ldap_dn', Types::STRING, [
 				'notnull' => true,
-				'length' => 255,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->addColumn('ldap_full_dn', Types::STRING, [
+				'notnull' => true,
+				'length' => 4096,
 				'default' => '',
 			]);
 			$table->addColumn('owncloud_name', Types::STRING, [
@@ -68,7 +73,12 @@ class Version1010Date20200630192842 extends SimpleMigrationStep {
 			$table = $schema->createTable('ldap_group_mapping');
 			$table->addColumn('ldap_dn', Types::STRING, [
 				'notnull' => true,
-				'length' => 255,
+				'length' => 64,
+				'default' => '',
+			]);
+			$table->addColumn('ldap_full_dn', Types::STRING, [
+				'notnull' => true,
+				'length' => 4096,
 				'default' => '',
 			]);
 			$table->addColumn('owncloud_name', Types::STRING, [

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -103,16 +103,16 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 	}
 
 	protected function handleDNHashes(string $table): void {
-		$q = $this->getSelectQuery($table);
-		$u = $this->getUpdateQuery($table);
+		$select = $this->getSelectQuery($table);
+		$update = $this->getUpdateQuery($table);
 
-		$r = $q->executeQuery();
-		while ($row = $r->fetch()) {
+		$result = $select->executeQuery();
+		while ($row = $result->fetch()) {
 			$dnHash = hash('sha256', $row['ldap_dn'], false);
-			$u->setParameter('name', $row['owncloud_name']);
-			$u->setParameter('dn_hash', $dnHash);
+			$update->setParameter('name', $row['owncloud_name']);
+			$update->setParameter('dn_hash', $dnHash);
 			try {
-				$u->executeStatement();
+				$update->executeStatement();
 			} catch (Exception $e) {
 				$this->logger->error('Failed to add hash "{dnHash}" ("{name}" of {table})',
 					[
@@ -125,22 +125,22 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 				);
 			}
 		}
-		$r->closeCursor();
+		$result->closeCursor();
 	}
 
 	protected function getSelectQuery(string $table): IQueryBuilder {
-		$q = $this->dbc->getQueryBuilder();
-		$q->select('owncloud_name', 'ldap_dn', 'ldap_dn_hash')
+		$qb = $this->dbc->getQueryBuilder();
+		$qb->select('owncloud_name', 'ldap_dn', 'ldap_dn_hash')
 			->from($table)
-			->where($q->expr()->isNull('ldap_dn_hash'));
-		return $q;
+			->where($qb->expr()->isNull('ldap_dn_hash'));
+		return $qb;
 	}
 
 	protected function getUpdateQuery(string $table): IQueryBuilder {
-		$q = $this->dbc->getQueryBuilder();
-		$q->update($table)
-			->set('ldap_dn_hash', $q->createParameter('dn_hash'))
-			->where($q->expr()->eq('owncloud_name', $q->createParameter('name')));
-		return $q;
+		$qb = $this->dbc->getQueryBuilder();
+		$qb->update($table)
+			->set('ldap_dn_hash', $qb->createParameter('dn_hash'))
+			->where($qb->expr()->eq('owncloud_name', $qb->createParameter('name')));
+		return $qb;
 	}
 }

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -45,9 +45,8 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 			$table = $schema->getTable($tableName);
 			if (!$table->hasColumn('ldap_dn_hash')) {
 				$table->addColumn('ldap_dn_hash', Types::STRING, [
-					'notnull' => true,
+					'notnull' => false,
 					'length' => 64,
-					'default' => '',
 				]);
 				$changeSchema = true;
 			}
@@ -74,7 +73,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 					$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_group_dn_hashes');
 					$changeSchema = true;
 				}
-				if ($table->getPrimaryKeyColumns() !== ['owncloud_name']) {
+				if (!$table->hasPrimaryKey() || ($table->getPrimaryKeyColumns() !== ['owncloud_name'])) {
 					$table->dropPrimaryKey();
 					$table->setPrimaryKey(['owncloud_name']);
 					$changeSchema = true;

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -57,7 +57,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 				$column->setLength(4096);
 				$changeSchema = true;
 			}
-			if ($table === 'ldap_user_mapping') {
+			if ($tableName === 'ldap_user_mapping') {
 				if ($table->hasIndex('ldap_dn_users')) {
 					$table->dropIndex('ldap_dn_users');
 					$changeSchema = true;
@@ -132,7 +132,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 	protected function getUpdateQuery(string $table): IQueryBuilder {
 		$q = $this->dbc->getQueryBuilder();
 		$q->update($table)
-			->set('ldap_dn_hash', $query->createParameter('dn_hash'))
+			->set('ldap_dn_hash', $q->createParameter('dn_hash'))
 			->where($q->expr()->eq('owncloud_name', $q->createParameter('name')));
 		return $q;
 	}

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -64,6 +64,10 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 					$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_user_dn_hashes');
 					$changeSchema = true;
 				}
+				if (!$table->hasIndex('ldap_user_directory_uuid')) {
+					$table->addUniqueIndex(['directory_uuid'], 'ldap_user_directory_uuid');
+					$changeSchema = true;
+				}
 			} else {
 				if ($table->hasIndex('owncloud_name_groups')) {
 					$table->dropIndex('owncloud_name_groups');
@@ -71,6 +75,10 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 				}
 				if (!$table->hasIndex('ldap_group_dn_hashes')) {
 					$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_group_dn_hashes');
+					$changeSchema = true;
+				}
+				if (!$table->hasIndex('ldap_group_directory_uuid')) {
+					$table->addUniqueIndex(['directory_uuid'], 'ldap_group_directory_uuid');
 					$changeSchema = true;
 				}
 				if (!$table->hasPrimaryKey() || ($table->getPrimaryKeyColumns() !== ['owncloud_name'])) {

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -43,8 +43,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 		$changeSchema = false;
 		foreach (['ldap_user_mapping', 'ldap_group_mapping'] as $tableName) {
 			$table = $schema->getTable($tableName);
-			$column = $table->getColumn('ldap_dn_hash');
-			if (!$column) {
+			if (!$table->hasColumn('ldap_dn_hash')) {
 				$table->addColumn('ldap_dn_hash', Types::STRING, [
 					'notnull' => true,
 					'length' => 64,
@@ -76,6 +75,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 					$changeSchema = true;
 				}
 				if ($table->getPrimaryKeyColumns() !== ['owncloud_name']) {
+					$table->dropPrimaryKey();
 					$table->setPrimaryKey(['owncloud_name']);
 					$changeSchema = true;
 				}

--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\User_LDAP\Migration;
+
+use Closure;
+use OCP\DB\Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+class Version1130Date20211102154716 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	private $dbc;
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(IDBConnection $dbc, LoggerInterface $logger) {
+		$this->dbc = $dbc;
+		$this->logger = $logger;
+	}
+
+	public function getName() {
+		return 'Adjust LDAP user and group ldap_dn column lengths and add ldap_dn_hash columns';
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$changeSchema = false;
+		foreach (['ldap_user_mapping', 'ldap_group_mapping'] as $tableName) {
+			$table = $schema->getTable($tableName);
+			$column = $table->getColumn('ldap_dn_hash');
+			if (!$column) {
+				$table->addColumn('ldap_dn_hash', Types::STRING, [
+					'notnull' => true,
+					'length' => 64,
+					'default' => '',
+				]);
+				$changeSchema = true;
+			}
+			$column = $table->getColumn('ldap_dn');
+			if ($column->getLength() < 4096) {
+				$column->setLength(4096);
+				$changeSchema = true;
+			}
+			if ($table === 'ldap_user_mapping') {
+				if ($table->hasIndex('ldap_dn_users')) {
+					$table->dropIndex('ldap_dn_users');
+					$changeSchema = true;
+				}
+				if (!$table->hasIndex('ldap_user_dn_hashes')) {
+					$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_user_dn_hashes');
+					$changeSchema = true;
+				}
+			} else {
+				if ($table->hasIndex('owncloud_name_groups')) {
+					$table->dropIndex('owncloud_name_groups');
+					$changeSchema = true;
+				}
+				if (!$table->hasIndex('ldap_group_dn_hashes')) {
+					$table->addUniqueIndex(['ldap_dn_hash'], 'ldap_group_dn_hashes');
+					$changeSchema = true;
+				}
+				if ($table->getPrimaryKeyColumns() !== ['owncloud_name']) {
+					$table->setPrimaryKey(['owncloud_name']);
+					$changeSchema = true;
+				}
+			}
+		}
+
+		return $changeSchema ? $schema : null;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$this->handleDNHashes('ldap_group_mapping');
+		$this->handleDNHashes('ldap_user_mapping');
+	}
+
+	protected function handleDNHashes(string $table): void {
+		$q = $this->getSelectQuery($table);
+		$u = $this->getUpdateQuery($table);
+
+		$r = $q->executeQuery();
+		while ($row = $r->fetch()) {
+			$dnHash = hash('sha256', $row['ldap_dn'], false);
+			$u->setParameter('name', $row['owncloud_name']);
+			$u->setParameter('dn_hash', $dnHash);
+			try {
+				$u->executeStatement();
+			} catch (Exception $e) {
+				$this->logger->error('Failed to add hash "{dnHash}" ("{name}" of {table})',
+					[
+						'app' => 'user_ldap',
+						'name' => $row['owncloud_name'],
+						'dnHash' => $dnHash,
+						'table' => $table,
+						'exception' => $e,
+					]
+				);
+			}
+		}
+		$r->closeCursor();
+	}
+
+	protected function getSelectQuery(string $table): IQueryBuilder {
+		$q = $this->dbc->getQueryBuilder();
+		$q->select('owncloud_name', 'ldap_dn', 'ldap_dn_hash')
+			->from($table)
+			->where($q->expr()->isNull('ldap_dn_hash'));
+		return $q;
+	}
+
+	protected function getUpdateQuery(string $table): IQueryBuilder {
+		$q = $this->dbc->getQueryBuilder();
+		$q->update($table)
+			->set('ldap_dn_hash', $query->createParameter('dn_hash'))
+			->where($q->expr()->eq('owncloud_name', $q->createParameter('name')));
+		return $q;
+	}
+}


### PR DESCRIPTION
Adds an `ldap_full_dn` column to store the dn, and only store a sha256 hash in the `ldap_dn` which is shorter and can be indexed without trouble.
Migration still needs to be implemented.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>