### PR TITLE
Fix missing import of ILogger

### DIFF
--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -31,6 +31,7 @@ use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\ILoginSetupProvider;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\TwoFactorException;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;


### PR DESCRIPTION
```
There were 61 warnings:

1) Test\Core\Controller\TwoFactorChallengeControllerTest::testSelectChallenge
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

2) Test\Core\Controller\TwoFactorChallengeControllerTest::testShowChallenge
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

3) Test\Core\Controller\TwoFactorChallengeControllerTest::testShowInvalidChallenge
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

4) Test\Core\Controller\TwoFactorChallengeControllerTest::testSolveChallenge
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

5) Test\Core\Controller\TwoFactorChallengeControllerTest::testSolveValidChallengeAndRedirect
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

6) Test\Core\Controller\TwoFactorChallengeControllerTest::testSolveChallengeInvalidProvider
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

7) Test\Core\Controller\TwoFactorChallengeControllerTest::testSolveInvalidChallenge
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

8) Test\Core\Controller\TwoFactorChallengeControllerTest::testSolveChallengeTwoFactorException
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

9) Test\Core\Controller\TwoFactorChallengeControllerTest::testSetUpProviders
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

10) Test\Core\Controller\TwoFactorChallengeControllerTest::testSetUpInvalidProvider
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

11) Test\Core\Controller\TwoFactorChallengeControllerTest::testSetUpProvider
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist

12) Test\Core\Controller\TwoFactorChallengeControllerTest::testConfirmProviderSetup
Cannot stub or mock class or interface "Test\Core\Controller\ILogger" which does not exist
```