### PR TITLE
[stable22] Revert split capability "AccountPropertyScopesFederationEnabled"

### DIFF
--- a/apps/provisioning_api/lib/Capabilities.php
+++ b/apps/provisioning_api/lib/Capabilities.php
@@ -41,23 +41,20 @@ class Capabilities implements ICapability {
 	 * @return array Array containing the apps capabilities
 	 */
 	public function getCapabilities() {
-		$federatedScopeEnabled = $this->appManager->isEnabledForUser('federation');
-
-		$publishedScopeEnabled = false;
+		$federationScopesEnabled = false;
 
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
 			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
-			$publishedScopeEnabled = $shareProvider->isLookupServerUploadEnabled();
+			$federationScopesEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 
 		return [
 			'provisioning_api' => [
 				'version' => $this->appManager->getAppVersion('provisioning_api'),
 				'AccountPropertyScopesVersion' => 2,
-				'AccountPropertyScopesFederatedEnabled' => $federatedScopeEnabled,
-				'AccountPropertyScopesPublishedEnabled' => $publishedScopeEnabled,
+				'AccountPropertyScopesFederationEnabled' => $federationScopesEnabled,
 			]
 		];
 	}

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -57,25 +57,20 @@ class CapabilitiesTest extends TestCase {
 
 	public function getCapabilitiesProvider() {
 		return [
-			[true, false, false, true, false],
-			[true, true, false, true, false],
-			[true, true, true, true, true],
-			[false, false, false, false, false],
-			[false, true, false, false, false],
-			[false, true, true, false, true],
+			[false, false, false],
+			[true, false, false],
+			[true, true, true],
 		];
 	}
 
 	/**
 	 * @dataProvider getCapabilitiesProvider
 	 */
-	public function testGetCapabilities($federationAppEnabled, $federatedFileSharingAppEnabled, $lookupServerEnabled, $expectedFederatedScopeEnabled, $expectedPublishedScopeEnabled) {
-		$this->appManager->expects($this->any())
-			->method('isEnabledForUser')
-			->will($this->returnValueMap([
-				['federation', null, $federationAppEnabled],
-				['federatedfilesharing', null, $federatedFileSharingAppEnabled],
-			]));
+	public function testGetCapabilities($federationAppEnabled, $lookupServerEnabled, $expectedFederationScopesEnabled) {
+		$this->appManager->expects($this->once())
+		   ->method('isEnabledForUser')
+		   ->with('federatedfilesharing')
+		   ->willReturn($federationAppEnabled);
 
 		$federatedShareProvider = $this->createMock(FederatedShareProvider::class);
 		$this->overwriteService(FederatedShareProvider::class, $federatedShareProvider);
@@ -88,8 +83,7 @@ class CapabilitiesTest extends TestCase {
 			'provisioning_api' => [
 				'version' => '1.12',
 				'AccountPropertyScopesVersion' => 2,
-				'AccountPropertyScopesFederatedEnabled' => $expectedFederatedScopeEnabled,
-				'AccountPropertyScopesPublishedEnabled' => $expectedPublishedScopeEnabled,
+				'AccountPropertyScopesFederationEnabled' => $expectedFederationScopesEnabled,
 			],
 		];
 		$this->assertSame($expected, $this->capabilities->getCapabilities());


### PR DESCRIPTION
Follow up to #29393

The backport was merged [before the commit was dropped](https://github.com/nextcloud/server/pull/29393#pullrequestreview-787176452), but the commit was meant only for Nextcloud 23, as it may require changes in the clients.