### PR TITLE
Allow using an app token to login with v2 flow auth

### DIFF
--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -186,6 +186,23 @@ class LoginFlowV2Service {
 		return true;
 	}
 
+	public function flowDoneWithAppPassword(string $loginToken, string $server, string $loginName, string $appPassword): bool {
+		try {
+			$data = $this->mapper->getByLoginToken($loginToken);
+		} catch (DoesNotExistException $e) {
+			return false;
+		}
+
+		$data->setLoginName($loginName);
+		$data->setServer($server);
+
+		// Properly encrypt
+		$data->setAppPassword($this->encryptPassword($appPassword, $data->getPublicKey()));
+
+		$this->mapper->update($data);
+		return true;
+	}
+
 	public function createTokens(string $userAgent): LoginFlowV2Tokens {
 		$flow = new LoginFlowV2();
 		$pollToken = $this->random->generate(128, ISecureRandom::CHAR_DIGITS.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_UPPER);

--- a/core/css/login/authpicker.css
+++ b/core/css/login/authpicker.css
@@ -7,3 +7,8 @@
 	border-radius: 3px;
 	cursor: default;
 }
+
+.apptoken-link {
+	margin: 20px;
+	display: block;
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -68,6 +68,7 @@ $application->registerRoutes($this, [
 		['name' => 'ClientFlowLoginV2#grantPage', 'url' => '/login/v2/grant', 'verb' => 'GET'],
 		['name' => 'ClientFlowLoginV2#generateAppPassword', 'url' => '/login/v2/grant', 'verb' => 'POST'],
 		['name' => 'ClientFlowLoginV2#init', 'url' => '/login/v2', 'verb' => 'POST'],
+		['name' => 'ClientFlowLoginV2#apptokenRedirect', 'url' => '/login/v2/apptoken', 'verb' => 'POST'],
 		['name' => 'TwoFactorChallenge#selectChallenge', 'url' => '/login/selectchallenge', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#showChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'GET'],
 		['name' => 'TwoFactorChallenge#solveChallenge', 'url' => '/login/challenge/{challengeProviderId}', 'verb' => 'POST'],

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -64,8 +64,8 @@ $urlGenerator = $_['urlGenerator'];
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
 		<input id="submit-app-token-login" type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Grant access')) ?>">
 	</form>
-</div>
 
-<?php if (empty($_['oauthState'])): ?>
-<a id="app-token-login" class="warning" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
-<?php endif; ?>
+	<?php if (empty($_['oauthState'])): ?>
+		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
+	<?php endif; ?>
+</div>

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -20,6 +20,7 @@
  */
 
 style('core', 'login/authpicker');
+script('core', 'login/authpicker');
 
 /** @var array $_ */
 /** @var \OCP\IURLGenerator $urlGenerator */
@@ -50,4 +51,21 @@ $urlGenerator = $_['urlGenerator'];
 		</a>
 	</p>
 
+	<form action="<?php p($urlGenerator->linkToRouteAbsolute('core.ClientFlowLoginV2.apptokenRedirect')); ?>" method="post" id="app-token-login-field" class="hidden">
+		<p class="grouptop">
+			<input type="text" name="user" id="user" placeholder="<?php p($l->t('Username')) ?>">
+			<label for="user" class="infield"><?php p($l->t('Username')) ?></label>
+		</p>
+		<p class="groupbottom">
+			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App token')) ?>">
+			<label for="password" class="infield"><?php p($l->t('Password')) ?></label>
+		</p>
+		<input type="hidden" name="stateToken" value="<?php p($_['stateToken']) ?>" />
+		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
+		<input id="submit-app-token-login" type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Grant access')) ?>">
+	</form>
+
 </div>
+<?php if (empty($_['oauthState'])): ?>
+	<a id="app-token-login" class="warning" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
+<?php endif; ?>

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -65,7 +65,7 @@ $urlGenerator = $_['urlGenerator'];
 		<input id="submit-app-token-login" type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Grant access')) ?>">
 	</form>
 
+	<?php if (empty($_['oauthState'])): ?>
+		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
+	<?php endif; ?>
 </div>
-<?php if (empty($_['oauthState'])): ?>
-	<a id="app-token-login" class="warning" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
-<?php endif; ?>


### PR DESCRIPTION
The possibility to authenticate using an existing app token was only present in v1 flow auth, however there are use cases for it with v2 as well, e.g. when SAML is setup as primary login method but there are some local users that might need to login with the desktop client.

This is the button that this is adding for v2:

![image](https://user-images.githubusercontent.com/3404133/140044602-8a1d9bd1-0b43-4f29-bd08-18d6e23f4de3.png)
