### PR TITLE
Add IManager::getCalendarsForPrincipal API

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -167,15 +167,14 @@ class Manager implements IManager {
 		$this->calendarLoaders = [];
 	}
 
-	public function searchForPrincipal(ICalendarQuery $query): array {
+	public function getCalendarsForPrincipal(string $principalUri, array $calendarUris = []): array {
 		$context = $this->coordinator->getRegistrationContext();
 		if ($context === null) {
 			return [];
 		}
 
-		/** @var CalendarQuery $query */
-		$calendars = array_merge(
-			...array_map(function ($registration) use ($query) {
+		return array_merge(
+			...array_map(function ($registration) use ($principalUri, $calendarUris) {
 				try {
 					/** @var ICalendarProvider $provider */
 					$provider = $this->container->get($registration->getService());
@@ -186,8 +185,16 @@ class Manager implements IManager {
 					return [];
 				}
 
-				return $provider->getCalendars($query->getPrincipalUri(), $query->getCalendarUris());
+				return $provider->getCalendars($principalUri, $calendarUris);
 			}, $context->getCalendarProviders())
+		);
+	}
+
+	public function searchForPrincipal(ICalendarQuery $query): array {
+		/** @var CalendarQuery $query */
+		$calendars = $this->getCalendarsForPrincipal(
+			$query->getPrincipalUri(),
+			$query->getCalendarUris(),
 		);
 
 		$results = [];

--- a/lib/public/Calendar/ICalendarProvider.php
+++ b/lib/public/Calendar/ICalendarProvider.php
@@ -36,8 +36,8 @@ namespace OCP\Calendar;
 interface ICalendarProvider {
 
 	/**
-	 * @param string $principalUri
-	 * @param string[] $calendarUris
+	 * @param string $principalUri URI of the principal
+	 * @param string[] $calendarUris optionally specify which calendars to load, or all if this array is empty
 	 * @return ICalendar[]
 	 * @since 23.0.0
 	 */

--- a/lib/public/Calendar/IManager.php
+++ b/lib/public/Calendar/IManager.php
@@ -118,7 +118,7 @@ interface IManager {
 	/**
 	 * @return ICalendar[]
 	 * @since 13.0.0
-	 * @deprecated 23.0.0
+	 * @deprecated 23.0.0 use \OCP\Calendar\IManager::getCalendarsForPrincipal
 	 */
 	public function getCalendars();
 
@@ -130,6 +130,15 @@ interface IManager {
 	 * @deprecated 23.0.0
 	 */
 	public function clear();
+
+	/**
+	 * @param string $principalUri URI of the principal
+	 * @param string[] $calendarUris optionally specify which calendars to load, or all if this array is empty
+	 *
+	 * @return ICalendar[]
+	 * @since 23.0.0
+	 */
+	public function getCalendarsForPrincipal(string $principalUri, array $calendarUris = []): array;
 
 	/**
 	 * Query a principals calendar(s)


### PR DESCRIPTION
The Calendar app needs to access calendars of a given principal in the
back-end. The new calendar providers were not accessible for apps before
this patch. Now they can access the ICalendar objects on demand.

The logic for the new method was already in `searchForPrincipal`, so I only had to extract that into a new method and make it publicly accessible.
 
Required for https://github.com/nextcloud/calendar/issues/3478

@miaulalala please give this a test and see if it meets our requirements.