### PR TITLE
Fix missing calendar path for public write on Calendars

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -232,6 +232,11 @@
       <code>calendarSearch</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/CalDAV/CalendarImpl.php">
+    <UndefinedFunction occurrences="1">
+      <code>uriSplit($this-&gt;calendar-&gt;getPrincipalURI())</code>
+    </UndefinedFunction>
+  </file>
   <file src="apps/dav/lib/CalDAV/CalendarRoot.php">
     <ParamNameMismatch occurrences="1">
       <code>$principal</code>


### PR DESCRIPTION
When using the Public createFromString method, a public write isn't actually possible because the full calendar path is not available.

This PR fixes this issue by generating the full calendar path for a specific calendar instance.

Follow-up to https://github.com/nextcloud/server/pull/29188