### PR TITLE
22.2.1 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 2, 0, 2];
+$OC_Version = [22, 2, 1, 0];
 
 // The human readable string
-$OC_VersionString = '22.2.0';
+$OC_VersionString = '22.2.1 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28968
* #29016
* #29046
* #29062
* #29066
* #29073
* #29078
* #29086
* #29096
* #29113
* #29121
* #29124
* #29129
* #29133
* #29160
* #29162
* #29183
* #29196
* #29207
* #29217
* #29221
* #29225
* #29251
* #29262
* #29263
* #29283
* #29288
* #29301
* #29311
* #29316
* #29341
* #29359
* #29365
* #29381
* #29385
* #29389
* #29391
* #29393
* #29398
* #29409
* #29410
* #29415
* #29419
* #29427
* #29442
* #29459
* #29475
* #29494
* #29495
* #29519
* #29528
* [circles#816](https://github.com/nextcloud/circles/pull/816) Reduce the sleep time in test-dummy-token handler
* [circles#825](https://github.com/nextcloud/circles/pull/825) Dispatching event before the action
* [files_pdfviewer#513](https://github.com/nextcloud/files_pdfviewer/pull/513) Bump version
* [notifications#1078](https://github.com/nextcloud/notifications/pull/1078) Allow to open links in new tab
* [notifications#1088](https://github.com/nextcloud/notifications/pull/1088) Fix deleting notifications with numeric user ID
* [notifications#1095](https://github.com/nextcloud/notifications/pull/1095) Add integration tests for push registration
* [notifications#1103](https://github.com/nextcloud/notifications/pull/1103) Restore old device signature so the proxy works again
* [photos#902](https://github.com/nextcloud/photos/pull/902) Bump autoprefixer from 9.8.6 to 9.8.7
* [photos#907](https://github.com/nextcloud/photos/pull/907) Bump autoprefixer from 9.8.7 to 9.8.8
* [text#1871](https://github.com/nextcloud/text/pull/1871) Bump prosemirror-schema-list from 1.1.5 to 1.1.6
* [text#1881](https://github.com/nextcloud/text/pull/1881) Bump prosemirror-transform from 1.3.2 to 1.3.3
* [text#1885](https://github.com/nextcloud/text/pull/1885) Additional checks for workspace controller


Pending PRs:

* [ ] #28659 
* [ ] #29324 
* [x] #29383 
* [x] #29503 @blizzz
* [x] #29506 
* [ ] #29509 
* [x] #29534