### PR TITLE
20.0.14 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -29,10 +29,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [20, 0, 13, 1];
+$OC_Version = [20, 0, 14, 0];
 
 // The human readable string
-$OC_VersionString = '20.0.13';
+$OC_VersionString = '20.0.14 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #26630
* #28971
* #29048
* #29069
* #29085
* #29098
* #29131
* #29158
* #29166
* #29167
* #29181
* #29192
* #29198
* #29205
* #29219
* #29223
* #29253
* #29291
* #29297
* #29298
* #29303
* #29366
* #29387
* #29388
* #29396
* #29421
* #29426
* #29429
* #29441
* #29457
* [3rdparty#855](https://github.com/nextcloud/3rdparty/pull/855) Bump icewind/streams from 0.7.1 to 0.7.5
* [files_pdfviewer#512](https://github.com/nextcloud/files_pdfviewer/pull/512) Bump version
* [notifications#1090](https://github.com/nextcloud/notifications/pull/1090) Fix deleting notifications with numeric user ID
* [notifications#1097](https://github.com/nextcloud/notifications/pull/1097) Add integration tests for push registration
* [notifications#1105](https://github.com/nextcloud/notifications/pull/1105) Restore old device signature so the proxy works again
* [photos#864](https://github.com/nextcloud/photos/pull/864) Bump vue and vue-template-compiler
* [text#1868](https://github.com/nextcloud/text/pull/1868) Bump prosemirror-schema-list from 1.1.5 to 1.1.6
* [text#1887](https://github.com/nextcloud/text/pull/1887) Additional checks for workspace controller


Pending PRs:

* [ ] #26409 
* [ ] #27207 
* [ ] #27989 @skjnldsv
* [ ] #28654 
* [x] #29072 @nickvergessen
* [x] #29095 
* [x] #29290 
* [ ] #29299 @PVince81
* [x] #29314 
* [ ] #29407 
* [x] #29417 
* [ ] #29491 
* [x] #29505 @blizzz
* [ ] #29508 
* [ ] [3rdparty#847](https://github.com/nextcloud/3rdparty/pull/847) Bump icewind/streams to 0.7.5 @icewind1991
