### PR TITLE
23.0.0 Beta3

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [23, 0, 0, 5];
+$OC_Version = [23, 0, 0, 6];
 
 // The human readable string
-$OC_VersionString = '23.0.0 beta 2';
+$OC_VersionString = '23.0.0 beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #27378
* #28385
* #29281
* #29465
* #29479
* #29480
* #29481
* #29487
* #29489
* #29490
* #29497
* #29502
* #29524
* #29525
* [notifications#1083](https://github.com/nextcloud/notifications/pull/1083) Bump @nextcloud/event-bus from 2.0.0 to 2.1.0
* [notifications#1084](https://github.com/nextcloud/notifications/pull/1084) Bump @nextcloud/axios from 1.6.0 to 1.7.0
* [notifications#1085](https://github.com/nextcloud/notifications/pull/1085) Bump @nextcloud/vue from 4.1.0 to 4.2.0
* [notifications#1101](https://github.com/nextcloud/notifications/pull/1101) Improve feedback in test-push when device is too old
* [photos#895](https://github.com/nextcloud/photos/pull/895) Bump @nextcloud/axios from 1.6.0 to 1.7.0
* [photos#919](https://github.com/nextcloud/photos/pull/919) Bump psalm/phar from 4.10.0 to 4.11.2
* [text#1916](https://github.com/nextcloud/text/pull/1916) Only register trailing node for rich text editing
* [text#1920](https://github.com/nextcloud/text/pull/1920) Bump psalm/phar from 4.10.0 to 4.11.2
* [viewer#1057](https://github.com/nextcloud/viewer/pull/1057) Build(deps-dev): bump @babel/plugin-proposal-class-properties from 7.14.5 to 7.16.0
* [viewer#1058](https://github.com/nextcloud/viewer/pull/1058) Build(deps-dev): bump cypress from 8.6.0 to 8.7.0


Pending PRs:

* [ ] #25332 @danxuliu
* [ ] #27034 @juliushaertl
* [ ] #27538 @icewind1991
* [ ] #27562 @j-be
* [ ] #27961 @CarlSchwan
* [ ] #28438 @csware
* [ ] #28911 @danxuliu
* [ ] #29029 @Pytal
* [ ] #29300 @icewind1991
* [ ] #29329 @blizzz
* [ ] #29349 @blizzz
* [ ] #29360 @artonge
* [x] #29477 @ChristophWurst
* [ ] #29482 @Pytal
* [ ] #29522 @nickvergessen
* [ ] #29531 @juliushaertl
* [ ] [3rdparty#710](https://github.com/nextcloud/3rdparty/pull/710) Bump php-opencloud/openstack from 3.1.0 to 3.2.1 
* [ ] [text#1900](https://github.com/nextcloud/text/pull/1900) [WIP] Insert images from local device (or link) @eneiluj