### PR TITLE
Respect user enumeration settings on profile

### DIFF
--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -28,6 +28,7 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\KnownUser\KnownUserService;
 use OC\Share20\Manager;
 use OCA\Files_Sharing\Capabilities;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -94,7 +95,8 @@ class CapabilitiesTest extends \Test\TestCase {
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(\OC_Defaults::class),
 			$this->createMock(IEventDispatcher::class),
-			$this->createMock(IUserSession::class)
+			$this->createMock(IUserSession::class),
+			$this->createMock(KnownUserService::class)
 		);
 		$cap = new Capabilities($config, $shareManager);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1253,7 +1253,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IURLGenerator::class),
 				$c->get('ThemingDefaults'),
 				$c->get(IEventDispatcher::class),
-				$c->get(IUserSession::class)
+				$c->get(IUserSession::class),
+				$c->get(KnownUserService::class)
 			);
 
 			return $manager;

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -32,6 +32,7 @@ namespace OCP\Share;
 use OCP\Files\Folder;
 use OCP\Files\Node;
 
+use OCP\IUser;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 
@@ -446,6 +447,16 @@ interface IManager {
 	 * @since 21.0.1
 	 */
 	public function allowEnumerationFullMatch(): bool;
+
+	/**
+	 * Check if the current user can enumerate the target user
+	 *
+	 * @param IUser|null $currentUser
+	 * @param IUser $targetUser
+	 * @return bool
+	 * @since 23.0.0
+	 */
+	public function currentUserCanEnumerateTargetUser(?IUser $currentUser, IUser $targetUser): bool;
 
 	/**
 	 * Check if sharing is disabled for the given user

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -22,6 +22,7 @@
 namespace Test\Share20;
 
 use OC\Files\Mount\MoveableMount;
+use OC\KnownUser\KnownUserService;
 use OC\Share20\DefaultShareProvider;
 use OC\Share20\Exception;
 use OC\Share20\Manager;
@@ -105,7 +106,10 @@ class ManagerTest extends \Test\TestCase {
 	protected $urlGenerator;
 	/** @var  \OC_Defaults|MockObject */
 	protected $defaults;
+	/** @var IUserSession|MockObject  */
 	protected $userSession;
+	/** @var KnownUserService|MockObject  */
+	protected $knownUserService;
 
 	protected function setUp(): void {
 		$this->logger = $this->createMock(ILogger::class);
@@ -122,6 +126,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaults = $this->createMock(\OC_Defaults::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->knownUserService = $this->createMock(KnownUserService::class);
 
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l = $this->createMock(IL10N::class);
@@ -153,7 +158,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
@@ -183,7 +189,8 @@ class ManagerTest extends \Test\TestCase {
 				$this->urlGenerator,
 				$this->defaults,
 				$this->dispatcher,
-				$this->userSession
+				$this->userSession,
+				$this->knownUserService
 			]);
 	}
 
@@ -2696,7 +2703,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2741,7 +2749,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2793,7 +2802,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -4132,7 +4142,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 		$this->assertSame($expected,
 			$manager->shareProviderExists($shareType)
@@ -4166,7 +4177,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4231,7 +4243,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4348,7 +4361,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4474,7 +4488,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->urlGenerator,
 			$this->defaults,
 			$this->dispatcher,
-			$this->userSession
+			$this->userSession,
+			$this->knownUserService
 		);
 
 		$factory->setProvider($this->defaultProvider);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -54,6 +54,7 @@ use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Share\Exceptions\AlreadySharedException;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
@@ -171,7 +172,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @return MockBuilder
 	 */
 	private function createManagerMock() {
-		return 	$this->getMockBuilder('\OC\Share20\Manager')
+		return $this->getMockBuilder(Manager::class)
 			->setConstructorArgs([
 				$this->logger,
 				$this->config,
@@ -4520,6 +4521,83 @@ class ManagerTest extends \Test\TestCase {
 		$expects = [$share1, $share2, $share3, $share4];
 
 		$this->assertSame($expects, $result);
+	}
+
+	public function dataCurrentUserCanEnumerateTargetUser(): array {
+		return [
+			'Full match guest' => [true, true, false, false, false, false, false, true],
+			'Full match user' => [false, true, false, false, false, false, false, true],
+			'Enumeration off guest' => [true, false, false, false, false, false, false, false],
+			'Enumeration off user' => [false, false, false, false, false, false, false, false],
+			'Enumeration guest' => [true, false, true, false, false, false, false, true],
+			'Enumeration user' => [false, false, true, false, false, false, false, true],
+
+			// Restricted enumerations guests never works
+			'Guest phone' => [true, false, true, true, false, false, false, false],
+			'Guest group' => [true, false, true, false, true, false, false, false],
+			'Guest both' => [true, false, true, true, true, false, false, false],
+
+			// Restricted enumerations users
+			'User phone but not known' => [false, false, true, true, false, false, false, false],
+			'User phone known' => [false, false, true, true, false, true, false, true],
+			'User group but no match' => [false, false, true, false, true, false, false, false],
+			'User group with match' => [false, false, true, false, true, false, true, true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCurrentUserCanEnumerateTargetUser
+	 * @param bool $expected
+	 */
+	public function testCurrentUserCanEnumerateTargetUser(bool $currentUserIsGuest, bool $allowEnumerationFullMatch, bool $allowEnumeration, bool $limitEnumerationToPhone, bool $limitEnumerationToGroups, bool $isKnownToUser, bool $haveCommonGroup, bool $expected): void {
+		/** @var IManager|MockObject $manager */
+		$manager = $this->createManagerMock()
+			->setMethods([
+				'allowEnumerationFullMatch',
+				'allowEnumeration',
+				'limitEnumerationToPhone',
+				'limitEnumerationToGroups',
+			])
+		->getMock();
+
+		$manager->method('allowEnumerationFullMatch')
+			->willReturn($allowEnumerationFullMatch);
+		$manager->method('allowEnumeration')
+			->willReturn($allowEnumeration);
+		$manager->method('limitEnumerationToPhone')
+			->willReturn($limitEnumerationToPhone);
+		$manager->method('limitEnumerationToGroups')
+			->willReturn($limitEnumerationToGroups);
+
+		$this->knownUserService->method('isKnownToUser')
+			->with('current', 'target')
+			->willReturn($isKnownToUser);
+
+		$currentUser = null;
+		if (!$currentUserIsGuest) {
+			$currentUser = $this->createMock(IUser::class);
+			$currentUser->method('getUID')
+				->willReturn('current');
+		}
+		$targetUser = $this->createMock(IUser::class);
+		$targetUser->method('getUID')
+			->willReturn('target');
+
+		if ($haveCommonGroup) {
+			$this->groupManager->method('getUserGroupIds')
+				->willReturnMap([
+					[$targetUser, ['gid1', 'gid2']],
+					[$currentUser, ['gid2', 'gid3']],
+				]);
+		} else {
+			$this->groupManager->method('getUserGroupIds')
+				->willReturnMap([
+					[$targetUser, ['gid1', 'gid2']],
+					[$currentUser, ['gid3', 'gid4']],
+				]);
+		}
+
+		$this->assertSame($expected, $manager->currentUserCanEnumerateTargetUser($currentUser, $targetUser));
 	}
 }
 


### PR DESCRIPTION
The `shareapi_*` user enumeration settings are already respected and hide profile entrypoints (if needed) in the contacts menu, Avatar menu, and other areas which pass through `filterContacts` https://github.com/nextcloud/server/blob/e1c2c13585d5417db2ed490b2986c1ea04cd808d/lib/private/Contacts/ContactsMenu/ContactsStore.php#L150

This PR is for when users navigate to a user's profile page directly by the `/u/{userId}` URL and respects the user enumeration settings listed below.

- `shareapi_allow_share_dialog_user_enumeration`
- `shareapi_restrict_user_enumeration_full_match`
- `shareapi_restrict_user_enumeration_to_group`
- `shareapi_restrict_user_enumeration_to_phone`

The user's profile will not be displayed and instead show the "Profile not found" error page if restricted by any of these settings.

Contributes to https://github.com/nextcloud/server/issues/28139