### PR TITLE
Handle empty directory drag-and-drop in Files UI

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -215,6 +215,12 @@ OC.FileUpload.prototype = {
 		var data = this.data;
 		var file = this.getFile();
 
+		// if file is a directory, just create it
+		// files are handled separately
+		if (file.isDirectory) {
+			return this.uploader.ensureFolderExists(OC.joinPaths(this._targetFolder, file.fullPath));
+		}
+
 		if (self.aborted === true) {
 			return $.Deferred().resolve().promise();
 		}

--- a/apps/files/js/jquery.fileupload.js
+++ b/apps/files/js/jquery.fileupload.js
@@ -1029,7 +1029,12 @@
             } else {
                 paramNameSet = paramName;
             }
-            data.originalFiles = files;
+            data.originalFiles = [];
+            $.each(files, function (file) {
+                if (!file.isDirectory) {
+                    data.originalFiles.push(file);
+                }
+            });
             $.each(fileSet || files, function (index, element) {
                 var newData = $.extend({}, data);
                 newData.files = fileSet ? element : [element];
@@ -1098,7 +1103,12 @@
                         entries,
                         path + entry.name + '/'
                     ).done(function (files) {
-                        dfd.resolve(files);
+                        // empty folder
+                        if (!files.length && entry.isDirectory) {
+                            dfd.resolve(entry);
+                        } else {
+                            dfd.resolve(files);
+                        }
                     }).fail(errorHandler);
                 },
                 readEntries = function () {


### PR DESCRIPTION
refs #11864

This is highly inspired by https://github.com/owncloud/core/pull/39285 :grin:.

This fixes 2 use cases:
* dropping an empty directory in Files
* dropping a directory which contains directories (any depth) but no files