### PR TITLE
Force Calendar Object Change Path to support public write

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarImpl.php
+++ b/apps/dav/lib/CalDAV/CalendarImpl.php
@@ -154,6 +154,11 @@ class CalendarImpl implements ICreateFromString {
 		[, $user] = uriSplit($this->calendar->getPrincipalURI());
 		$fullCalendarFilename = sprintf('calendars/%s/%s/%s', $user, $this->calendarInfo['uri'], $name);
 
+		// Force calendar change URI
+		/** @var Schedule\Plugin $schedulingPlugin */
+		$schedulingPlugin = $server->server->getPlugin('caldav-schedule');
+		$schedulingPlugin->setPathOfCalendarObjectChange($fullCalendarFilename);
+
 		$stream = fopen('php://memory', 'rb+');
 		fwrite($stream, $calendarData);
 		rewind($stream);

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -89,6 +89,16 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 	}
 
 	/**
+	 * Allow manual setting of the object change URL
+	 * to support public write
+	 *
+	 * @param string $path
+	 */
+	public function setPathOfCalendarObjectChange(string $path): void {
+		$this->pathOfCalendarObjectChange = $path;
+	}
+
+	/**
 	 * This method handler is invoked during fetching of properties.
 	 *
 	 * We use this event to add calendar-auto-schedule-specific properties.


### PR DESCRIPTION
This PR forces the path of the object calendar change to a value set by the public write api.

Forcing the change URI is neccessary because we're stepping into the logic a layer below a HTTP Request that would typically send this parameter and provide it to the scheduling plugin.

Without this change, a scheduling message will not be generated for the attendee(s).