### PR TITLE
Normalize file name before existence check in scanner

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -105,15 +105,6 @@ class Scan extends Base {
 			);
 	}
 
-	public function checkScanWarning($fullPath, OutputInterface $output) {
-		$normalizedPath = basename(\OC\Files\Filesystem::normalizePath($fullPath));
-		$path = basename($fullPath);
-
-		if ($normalizedPath !== $path) {
-			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
-		}
-	}
-
 	protected function scanFiles($user, $path, OutputInterface $output, $backgroundScan = false, $recursive = true, $homeOnly = false) {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner(
@@ -141,12 +132,8 @@ class Scan extends Base {
 			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
-			$this->checkScanWarning($path, $output);
-		});
-
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
-			$this->checkScanWarning($path, $output);
+		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
+			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
 		});
 
 		try {

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -73,15 +73,6 @@ class ScanAppData extends Base {
 		$this->addArgument('folder', InputArgument::OPTIONAL, 'The appdata subfolder to scan', '');
 	}
 
-	public function checkScanWarning($fullPath, OutputInterface $output) {
-		$normalizedPath = basename(\OC\Files\Filesystem::normalizePath($fullPath));
-		$path = basename($fullPath);
-
-		if ($normalizedPath !== $path) {
-			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
-		}
-	}
-
 	protected function scanFiles(OutputInterface $output, string $folder): int {
 		try {
 			$appData = $this->getAppDataFolder();
@@ -124,12 +115,8 @@ class ScanAppData extends Base {
 			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
-			$this->checkScanWarning($path, $output);
-		});
-
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
-			$this->checkScanWarning($path, $output);
+		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
+			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
 		});
 
 		try {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1161,6 +1161,7 @@ return array(
     'OC\\Files\\Storage\\Temporary' => $baseDir . '/lib/private/Files/Storage/Temporary.php',
     'OC\\Files\\Storage\\Wrapper\\Availability' => $baseDir . '/lib/private/Files/Storage/Wrapper/Availability.php',
     'OC\\Files\\Storage\\Wrapper\\Encoding' => $baseDir . '/lib/private/Files/Storage/Wrapper/Encoding.php',
+    'OC\\Files\\Storage\\Wrapper\\EncodingDirectoryWrapper' => $baseDir . '/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php',
     'OC\\Files\\Storage\\Wrapper\\Encryption' => $baseDir . '/lib/private/Files/Storage/Wrapper/Encryption.php',
     'OC\\Files\\Storage\\Wrapper\\Jail' => $baseDir . '/lib/private/Files/Storage/Wrapper/Jail.php',
     'OC\\Files\\Storage\\Wrapper\\PermissionsMask' => $baseDir . '/lib/private/Files/Storage/Wrapper/PermissionsMask.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1190,6 +1190,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Files\\Storage\\Temporary' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Temporary.php',
         'OC\\Files\\Storage\\Wrapper\\Availability' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/Availability.php',
         'OC\\Files\\Storage\\Wrapper\\Encoding' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/Encoding.php',
+        'OC\\Files\\Storage\\Wrapper\\EncodingDirectoryWrapper' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php',
         'OC\\Files\\Storage\\Wrapper\\Encryption' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/Encryption.php',
         'OC\\Files\\Storage\\Wrapper\\Jail' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/Jail.php',
         'OC\\Files\\Storage\\Wrapper\\PermissionsMask' => __DIR__ . '/../../..' . '/lib/private/Files/Storage/Wrapper/PermissionsMask.php',

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -37,6 +37,7 @@ namespace OC\Files\Cache;
 
 use Doctrine\DBAL\Exception;
 use OC\Files\Filesystem;
+use OC\Files\Storage\Wrapper\Encoding;
 use OC\Hooks\BasicEmitter;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
@@ -419,8 +420,13 @@ class Scanner extends BasicEmitter implements IScanner {
 			if ($permissions === 0) {
 				continue;
 			}
-			$file = $fileMeta['name'];
-			$file = trim(\OC\Files\Filesystem::normalizePath($file), '/');
+			$originalFile = $fileMeta['name'];
+			$file = trim(\OC\Files\Filesystem::normalizePath($originalFile), '/');
+			if (trim($originalFile, '/') !== $file && !$this->storage->instanceOfStorage(Encoding::class)) {
+				// encoding mismatch, might require compatibility wrapper
+				$this->emit('\OC\Files\Cache\Scanner', 'normalizedNameMismatch', [$path ? $path . '/' . $originalFile : $originalFile]);
+			}
+
 			$newChildNames[] = $file;
 			$child = $path ? $path . '/' . $file : $file;
 			try {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -420,6 +420,7 @@ class Scanner extends BasicEmitter implements IScanner {
 				continue;
 			}
 			$file = $fileMeta['name'];
+			$file = trim(\OC\Files\Filesystem::normalizePath($file), '/');
 			$newChildNames[] = $file;
 			$child = $path ? $path . '/' . $file : $file;
 			try {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -422,9 +422,12 @@ class Scanner extends BasicEmitter implements IScanner {
 			}
 			$originalFile = $fileMeta['name'];
 			$file = trim(\OC\Files\Filesystem::normalizePath($originalFile), '/');
-			if (trim($originalFile, '/') !== $file && !$this->storage->instanceOfStorage(Encoding::class)) {
+			if (trim($originalFile, '/') !== $file) {
 				// encoding mismatch, might require compatibility wrapper
+				\OC::$server->getLogger()->debug('Scanner: Skipping non-normalized file name "'. $originalFile . '" in path "' . $path . '".', ['app' => 'core']);
 				$this->emit('\OC\Files\Cache\Scanner', 'normalizedNameMismatch', [$path ? $path . '/' . $originalFile : $originalFile]);
+				// skip this entry
+				continue;
 			}
 
 			$newChildNames[] = $file;

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -29,6 +29,7 @@
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Cache\CappedMemoryCache;
+use OC\Files\Filesystem;
 use OCP\Files\Storage\IStorage;
 use OCP\ICache;
 
@@ -162,7 +163,8 @@ class Encoding extends Wrapper {
 	 * @return resource|bool
 	 */
 	public function opendir($path) {
-		return $this->storage->opendir($this->findPathToUse($path));
+		$handle = $this->storage->opendir($this->findPathToUse($path));
+		return EncodingDirectoryWrapper::wrap($handle);
 	}
 
 	/**
@@ -532,10 +534,16 @@ class Encoding extends Wrapper {
 	}
 
 	public function getMetaData($path) {
-		return $this->storage->getMetaData($this->findPathToUse($path));
+		$entry = $this->storage->getMetaData($this->findPathToUse($path));
+		$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+		return $entry;
 	}
 
 	public function getDirectoryContent($directory): \Traversable {
-		return $this->storage->getDirectoryContent($this->findPathToUse($directory));
+		$entries = $this->storage->getDirectoryContent($this->findPathToUse($directory));
+		foreach ($entries as $entry) {
+			$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+			yield $entry;
+		}
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php
+++ b/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021, Nextcloud GmbH.
+ *
+ * @author Robin Appelman <robin@icewind.nl>
+ * @author Vincent Petry <vincent@nextcloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage\Wrapper;
+
+use Icewind\Streams\DirectoryWrapper;
+use OC\Files\Filesystem;
+
+/**
+ * Normalize file names while reading directory entries
+ */
+class EncodingDirectoryWrapper extends DirectoryWrapper {
+	/**
+	 * @return string
+	 */
+	public function dir_readdir() {
+		$file = readdir($this->source);
+		if ($file !== false && $file !== '.' && $file !== '..') {
+			$file = trim(Filesystem::normalizePath($file), '/');
+		}
+
+		return $file;
+	}
+
+	/**
+	 * @param resource $source
+	 * @param callable $filter
+	 * @return resource|bool
+	 */
+	public static function wrap($source) {
+		return self::wrapSource($source, [
+			'source' => $source,
+		]);
+	}
+}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -145,6 +145,9 @@ class Scanner extends PublicEmitter {
 			$this->emit('\OC\Files\Utils\Scanner', 'postScanFolder', [$mount->getMountPoint() . $path]);
 			$this->dispatcher->dispatchTyped(new FolderScannedEvent($mount->getMountPoint() . $path));
 		});
+		$scanner->listen('\OC\Files\Cache\Scanner', 'normalizedNameMismatch', function ($path) use ($mount) {
+			$this->emit('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', [$path]);
+		});
 	}
 
 	/**

--- a/tests/lib/Files/Storage/Wrapper/EncodingTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncodingTest.php
@@ -32,7 +32,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 
 	public function directoryProvider() {
 		$a = parent::directoryProvider();
-		$a[] = [self::NFD_NAME];
+		$a[] = [self::NFC_NAME];
 		return $a;
 	}
 
@@ -198,5 +198,47 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($this->instance->file_exists(self::NFC_NAME . '2/test2.txt'));
 
 		$this->assertEquals('bar', $this->instance->file_get_contents(self::NFC_NAME . '2/test2.txt'));
+	}
+
+	public function testNormalizedDirectoryEntriesOpenDir() {
+		$this->sourceStorage->mkdir('/test');
+		$this->sourceStorage->mkdir('/test/' . self::NFD_NAME);
+
+		$this->assertTrue($this->instance->file_exists('/test/' . self::NFC_NAME));
+		$this->assertTrue($this->instance->file_exists('/test/' . self::NFD_NAME));
+
+		$dh = $this->instance->opendir('/test');
+		$content = [];
+		while ($file = readdir($dh)) {
+			if ($file != '.' and $file != '..') {
+				$content[] = $file;
+			}
+		}
+
+		$this->assertCount(1, $content);
+		$this->assertEquals(self::NFC_NAME, $content[0]);
+	}
+
+	public function testNormalizedDirectoryEntriesGetDirectoryContent() {
+		$this->sourceStorage->mkdir('/test');
+		$this->sourceStorage->mkdir('/test/' . self::NFD_NAME);
+
+		$this->assertTrue($this->instance->file_exists('/test/' . self::NFC_NAME));
+		$this->assertTrue($this->instance->file_exists('/test/' . self::NFD_NAME));
+
+		$content = iterator_to_array($this->instance->getDirectoryContent('/test'));
+		$this->assertCount(1, $content);
+		$this->assertEquals(self::NFC_NAME, $content[0]['name']);
+	}
+
+	public function testNormalizedGetMetaData() {
+		$this->sourceStorage->mkdir('/test');
+		$this->sourceStorage->mkdir('/test/' . self::NFD_NAME);
+
+		$entry = $this->instance->getMetaData('/test/' . self::NFC_NAME);
+		$this->assertEquals(self::NFC_NAME, $entry['name']);
+
+		$entry = $this->instance->getMetaData('/test/' . self::NFD_NAME);
+		$this->assertEquals(self::NFC_NAME, $entry['name']);
 	}
 }


### PR DESCRIPTION
The scanner would not find a NFD-encoded file name in an
existing file list that is normalized.

This normalizes the file name before scanning.

Fixes issues where scanning repeatedly would make NFD files flicker in
and out of existence in the file cache both with compatibility mode on and off.

Fixes https://github.com/nextcloud/server/issues/29603

- [x] BUG: breaks the [compatibility warning](https://github.com/nextcloud/server/blob/bugfix/29603/fix-scanner-nfd-existenz/apps/files/lib/Command/Scan.php#L113) because the file is already pre-normalized before scanning.

TETS: For a quick test with "Local" storage, you need to remove the "isLocal" check on this line: https://github.com/nextcloud/server/blob/master/lib/private/legacy/OC_Util.php#L244