### PR TITLE
Changed wording to align with calendar

### DIFF
--- a/apps/dav/src/views/Availability.vue
+++ b/apps/dav/src/views/Availability.vue
@@ -43,7 +43,7 @@
 					</div>
 					<span v-if="day.slots.length === 0"
 						class="empty-content">
-						{{ $t('dav', 'No working hours set') }}
+						{{ $t('dav', 'Non-working hours set') }}
 					</span>
 				</div>
 				<button :key="`add-slot-${day.id}`"


### PR DESCRIPTION
Same string exists on calendar and meaning sounds better.

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>