### PR TITLE
Implement multibucket shift for ObjectStore

### DIFF
--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -121,7 +121,7 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 			if (!isset($config['arguments']['bucket'])) {
 				$config['arguments']['bucket'] = '';
 			}
-			$mapper = new \OC\Files\ObjectStore\Mapper($user);
+			$mapper = new \OC\Files\ObjectStore\Mapper($user, $this->config);
 			$numBuckets = isset($config['arguments']['num_buckets']) ? $config['arguments']['num_buckets'] : 64;
 			$config['arguments']['bucket'] .= $mapper->getBucket($numBuckets);
 

--- a/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
+++ b/tests/lib/Files/Mount/ObjectHomeMountProviderTest.php
@@ -54,7 +54,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	}
 
 	public function testMultiBucket() {
-		$this->config->expects($this->once())
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValue')
 			->with($this->equalTo('objectstore_multibucket'), '')
 			->willReturn([
@@ -98,9 +98,9 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	}
 
 	public function testMultiBucketWithPrefix() {
-		$this->config->expects($this->once())
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with($this->equalTo('objectstore_multibucket'), '')
+			->with('objectstore_multibucket')
 			->willReturn([
 				'class' => 'Test\Files\Mount\FakeObjectStore',
 				'arguments' => [
@@ -147,7 +147,7 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	public function testMultiBucketBucketAlreadySet() {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
-			->with($this->equalTo('objectstore_multibucket'), '')
+			->with('objectstore_multibucket')
 			->willReturn([
 				'class' => 'Test\Files\Mount\FakeObjectStore',
 				'arguments' => [
@@ -185,9 +185,9 @@ class ObjectHomeMountProviderTest extends \Test\TestCase {
 	}
 
 	public function testMultiBucketConfigFirst() {
-		$this->config->expects($this->once())
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with($this->equalTo('objectstore_multibucket'))
+			->with('objectstore_multibucket')
 			->willReturn([
 				'class' => 'Test\Files\Mount\FakeObjectStore',
 			]);


### PR DESCRIPTION
On a multibucket setup:
- As we don't evenly distribute the data but we randomly spread accross all buckets,
- And when the first buckets are filled
 
It might be interesting to add new ones without filling the old ones.
The number of buckets stay the same, but we shift the number.

Example given:

```php
'objectstore_multibucket' => array(
        'class' => 'Object\\Storage\\Backend\\Class',
        'arguments' => array(
                // optional, defaults to 64
                'num_buckets' => 128,
                // int, shift the bucket number (default 0)
                'min_bucket' => 64,
                // n integer in the range from 0 to (num_buckets-1) will be appended
                'bucket' => 'nextcloud_',
                ...
        ),
),
```

This will write to buckets from 64 to 127. Still using 64 buckets
