### PR TITLE
Only pass previousEnabledState if group restriction is actually in place

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -418,7 +418,7 @@ class Updater extends BasicEmitter {
 
 				if (!empty($previousEnableStates)) {
 					$ocApp = new \OC_App();
-					if (!empty($previousEnableStates[$app])) {
+					if (!empty($previousEnableStates[$app]) && is_array($previousEnableStates[$app])) {
 						$ocApp->enable($app, $previousEnableStates[$app]);
 					} else {
 						$ocApp->enable($app);


### PR DESCRIPTION
Found when upgrading my personal instance to 23.0.0 beta 3:

When reenabling an app the second parameter should only be passed when the previous enabled state actually contains a list of groups to enable the app for (otherwise it is "yes" or "no" as a string).

Thrown error:

```
An unhandled exception has been thrown:
TypeError: Argument 2 passed to OC_App::enable() must be of the type array, string given, called in /var/www/nextcloud/lib/private/Updater.php on line 422 and defined in /var/www/nextcloud/lib/private/legacy/OC_App.php:428
Stack trace:
#0 /var/www/nextcloud/lib/private/Updater.php(422): OC_App->enable()
#1 /var/www/nextcloud/lib/private/Updater.php(277): OC\Updater->upgradeAppStoreApps()
#2 /var/www/nextcloud/lib/private/Updater.php(133): OC\Updater->doUpgrade()
#3 /var/www/nextcloud/core/Command/Upgrade.php(241): OC\Updater->upgrade()
#4 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(255): OC\Core\Command\Upgrade->execute()
#5 /var/www/nextcloud/3rdparty/symfony/console/Application.php(1009): Symfony\Component\Console\Command\Command->run()
#6 /var/www/nextcloud/3rdparty/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#7 /var/www/nextcloud/3rdparty/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun()
#8 /var/www/nextcloud/lib/private/Console/Application.php(211): Symfony\Component\Console\Application->run()
#9 /var/www/nextcloud/console.php(99): OC\Console\Application->run()
#10 /var/www/nextcloud/occ(11): require_once('/var/www/nextcl...')
```