### PR TITLE
Fix initialization of calendar search URIs

### DIFF
--- a/lib/private/Calendar/CalendarQuery.php
+++ b/lib/private/Calendar/CalendarQuery.php
@@ -47,8 +47,8 @@ class CalendarQuery implements ICalendarQuery {
 	/** @var int|null */
 	private $limit;
 
-	/** @var array */
-	private $calendarUris;
+	/** @var string[] */
+	private $calendarUris = [];
 
 	public function __construct(string $principalUri) {
 		$this->principalUri = $principalUri;
@@ -86,6 +86,9 @@ class CalendarQuery implements ICalendarQuery {
 		$this->calendarUris[] = $calendarUri;
 	}
 
+	/**
+	 * @return string[]
+	 */
 	public function getCalendarUris(): array {
 		return $this->calendarUris;
 	}


### PR DESCRIPTION
They are an empty array by default. If you don't initialize then
accessing them via the setter will throw a type error.

Follow-up of https://github.com/nextcloud/server/pull/28970