### PR TITLE
[stable23] Document allowed property names for calendar property searches

### DIFF
--- a/lib/public/Calendar/ICalendarQuery.php
+++ b/lib/public/Calendar/ICalendarQuery.php
@@ -51,6 +51,11 @@ interface ICalendarQuery {
 	/**
 	 * Define the property name(s) to search for
 	 *
+	 * Note: Nextcloud only indexes *some* properties. You can not search for
+	 *       arbitrary properties.
+	 *
+	 * @param string $value one of CATEGORIES, COMMENT, DESCRIPTION, LOCATION, RESOURCES, STATUS, SUMMARY, ATTENDEE, CONTACT or ORGANIZER
+	 *
 	 * @since 23.0.0
 	 */
 	public function addSearchProperty(string $value): void;


### PR DESCRIPTION
Soft backport of https://github.com/nextcloud/server/pull/29661 without any breaking changes.

For API users it looked like any properties could be searched. But it
turned out to be a hand picked list of properties that we index and then
use for the search. To prevent application errors where special props
are not found, I suggest we document the allowed values.

