### PR TITLE
Fix loading all principal calendars in the dav app calendar provider

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -49,7 +49,7 @@ class CalendarProvider implements ICalendarProvider {
 	public function getCalendars(string $principalUri, array $calendarUris = []): array {
 		$calendarInfos = [];
 		if (empty($calendarUris)) {
-			$calendarInfos[] = $this->calDavBackend->getCalendarsForUser($principalUri);
+			$calendarInfos = $this->calDavBackend->getCalendarsForUser($principalUri);
 		} else {
 			foreach ($calendarUris as $calendarUri) {
 				$calendarInfos[] = $this->calDavBackend->getCalendarByUri($principalUri, $calendarUri);


### PR DESCRIPTION
If we load all calendar infos of a principal then we get back an array
and not a single calendar info. This was handled incorrectly and an
array of calendar infos were passed to the calendar implementation,
resulting in interesting bugs.
