### PR TITLE
Fix core depending on theming app

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -406,7 +406,7 @@ class SCSSCacher {
 	}
 
 	/**
-	 * @return string SCSS code for variables from ThemingDefaults
+	 * @return string SCSS code for variables from OC_Defaults
 	 */
 	private function getInjectedVariables(string $cache = ''): string {
 		if ($this->injectedVariables !== null) {

--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -32,7 +32,6 @@ namespace OC\Template;
 use OC\AppConfig;
 use OC\Files\AppData\Factory;
 use OC\Memcache\NullCache;
-use OCA\Theming\ThemingDefaults;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
@@ -63,7 +62,7 @@ class SCSSCacher {
 	/** @var IConfig */
 	protected $config;
 
-	/** @var ThemingDefaults */
+	/** @var \OC_Defaults */
 	private $defaults;
 
 	/** @var string */
@@ -97,7 +96,7 @@ class SCSSCacher {
 	 * @param Factory $appDataFactory
 	 * @param IURLGenerator $urlGenerator
 	 * @param IConfig $config
-	 * @param ThemingDefaults $defaults
+	 * @param \OC_Defaults $defaults
 	 * @param string $serverRoot
 	 * @param ICacheFactory $cacheFactory
 	 * @param IconsCacher $iconsCacher
@@ -107,7 +106,7 @@ class SCSSCacher {
 								Factory $appDataFactory,
 								IURLGenerator $urlGenerator,
 								IConfig $config,
-								ThemingDefaults $defaults,
+								\OC_Defaults $defaults,
 								$serverRoot,
 								ICacheFactory $cacheFactory,
 								IconsCacher $iconsCacher,


### PR DESCRIPTION
This was introduced in https://github.com/nextcloud/server/commit/309354852f12ae88d5eef05d311d6ebcba8ee762
to fix a bug but I can't reproduce the bug after reverting this change.

Ideally, we would need to create an interface in OCP and cleanup OC_Defaults
instead of depending on OC_Defaults.

This needs testing of the new profile feature with this patch. 

Fix #29676

Signed-off-by: Carl Schwan <carl@carlschwan.eu>