### PR TITLE
Fix missing setlocale with php 8

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1244,12 +1244,12 @@ class OC_Util {
 	 * @return bool
 	 */
 	private static function isNonUTF8Locale() {
-		if (function_exists("escapeshellcmd")) {
-			return ('' === escapeshellcmd('§'));
-		} else if (function_exists("escapeshellarg")) {
-			return ('\'\'' === escapeshellarg('§'));
+		if (function_exists('escapeshellcmd')) {
+			return '' === escapeshellcmd('§');
+		} elseif (function_exists('escapeshellarg')) {
+			return '\'\'' === escapeshellarg('§');
 		} else {
-			return (0 === preg_match('/utf-?8/i', setlocale(LC_CTYPE, 0)));
+			return 0 === preg_match('/utf-?8/i', setlocale(LC_CTYPE, 0));
 		}
 	}
 

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1254,7 +1254,7 @@ class OC_Util {
 	}
 
 	/**
-	 * Check if the setlocal call does not work. This can happen if the right
+	 * Check if the setlocale call does not work. This can happen if the right
 	 * local packages are not available on the server.
 	 *
 	 * @return bool

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1239,19 +1239,34 @@ class OC_Util {
 	}
 
 	/**
+	 * Check if current locale is non-UTF8
+	 *
+	 * @return bool
+	 */
+	private static function isNonUTF8Locale() {
+		if (function_exists("escapeshellcmd")) {
+			return ('' === escapeshellcmd('§'));
+		} else if (function_exists("escapeshellarg")) {
+			return ('\'\'' === escapeshellarg('§'));
+		} else {
+			return (0 === preg_match('/utf-?8/i', setlocale(LC_CTYPE, 0)));
+		}
+	}
+
+	/**
 	 * Check if the setlocal call does not work. This can happen if the right
 	 * local packages are not available on the server.
 	 *
 	 * @return bool
 	 */
 	public static function isSetLocaleWorking() {
-		if ('' === escapeshellcmd('§')) {
+		if (self::isNonUTF8Locale()) {
 			// Borrowed from \Patchwork\Utf8\Bootup::initLocale
 			setlocale(LC_ALL, 'C.UTF-8', 'C');
 			setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
 
 			// Check again
-			if ('' === escapeshellcmd('§')) {
+			if (self::isNonUTF8Locale()) {
 				return false;
 			}
 		}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1245,14 +1245,14 @@ class OC_Util {
 	 * @return bool
 	 */
 	public static function isSetLocaleWorking() {
-		if ('' === basename('§')) {
+		if ('' === escapeshellcmd('§')) {
 			// Borrowed from \Patchwork\Utf8\Bootup::initLocale
 			setlocale(LC_ALL, 'C.UTF-8', 'C');
 			setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
 		}
 
 		// Check again
-		if ('' === basename('§')) {
+		if ('' === escapeshellcmd('§')) {
 			return false;
 		}
 		return true;

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1249,12 +1249,13 @@ class OC_Util {
 			// Borrowed from \Patchwork\Utf8\Bootup::initLocale
 			setlocale(LC_ALL, 'C.UTF-8', 'C');
 			setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
+
+			// Check again
+			if ('' === escapeshellcmd('§')) {
+				return false;
+			}
 		}
 
-		// Check again
-		if ('' === escapeshellcmd('§')) {
-			return false;
-		}
 		return true;
 	}
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -79,6 +79,8 @@ class UtilTest extends \Test\TestCase {
 		$locale = setlocale(LC_CTYPE, 0);
 		setlocale(LC_CTYPE, 'C');
 		$this->assertEquals('', escapeshellcmd('§'));
+		setlocale(LC_CTYPE, 'C.UTF-8');
+		$this->assertEquals('§', escapeshellcmd('§'));
 		setlocale(LC_CTYPE, $locale);
 	}
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -74,13 +74,15 @@ class UtilTest extends \Test\TestCase {
 		$this->assertEquals("/%C2%A7%23%40test%25%26%5E%C3%A4/-child", $result);
 	}
 
-	public function testIsSetLocaleWorking() {
-		// OC_Util::isSetLocaleWorking() assumes escapeshellcmd('§') returns '' with non-UTF-8 locale.
+	public function testIsNonUTF8Locale() {
+		// OC_Util::isNonUTF8Locale() assumes escapeshellcmd('§') returns '' with non-UTF-8 locale.
 		$locale = setlocale(LC_CTYPE, 0);
 		setlocale(LC_CTYPE, 'C');
 		$this->assertEquals('', escapeshellcmd('§'));
+		$this->assertEquals('\'\'', escapeshellarg('§'));
 		setlocale(LC_CTYPE, 'C.UTF-8');
 		$this->assertEquals('§', escapeshellcmd('§'));
+		$this->assertEquals('\'§\'', escapeshellarg('§'));
 		setlocale(LC_CTYPE, $locale);
 	}
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -74,6 +74,14 @@ class UtilTest extends \Test\TestCase {
 		$this->assertEquals("/%C2%A7%23%40test%25%26%5E%C3%A4/-child", $result);
 	}
 
+	public function testIsSetLocaleWorking() {
+		// OC_Util::isSetLocaleWorking() assumes escapeshellcmd('§') returns '' with non-UTF-8 locale.
+		$locale = setlocale(LC_CTYPE, 0);
+		setlocale(LC_CTYPE, 'C');
+		$this->assertEquals('', escapeshellcmd('§'));
+		setlocale(LC_CTYPE, $locale);
+	}
+
 	public function testFileInfoLoaded() {
 		$expected = function_exists('finfo_open');
 		$this->assertEquals($expected, \OC_Util::fileInfoLoaded());


### PR DESCRIPTION
When php version = 8, basename('§') returns '§' even if LC_ALL is non-UTF-8 locale.
Since OC_Util::isSetLocaleWorking() assumes basename('§') returns empty string with non-UTF-8 locale,
the function  with php 8 incorrectly skips setlocale("C.UTF-8").

Fix it by using escapeshellcmd instead of basename.

This issue found in #29296 and The PR may be able to resolve it.

