### PR TITLE
Do not print verbose info about app updates if there are none

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -204,14 +204,8 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output) {
 				$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
 			});
-			$updater->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use ($output) {
-				$output->writeln('<info>Checking for update of app ' . $app . ' in appstore</info>');
-			});
 			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($output) {
 				$output->writeln('<info>Update app ' . $app . ' from App Store</info>');
-			});
-			$updater->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use ($output) {
-				$output->writeln('<info>Checked for update of app "' . $app . '" in App Store </info>');
 			});
 			$updater->listen('\OC\Updater', 'appSimulateUpdate', function ($app) use ($output) {
 				$output->writeln("<info>Checking whether the database schema for <$app> can be updated (this can take a long time depending on the database size)</info>");

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -160,14 +160,8 @@ if (\OCP\Util::needUpgrade()) {
 	$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($eventSource, $l) {
 		$eventSource->send('success', $l->t('Updated database'));
 	});
-	$updater->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use ($eventSource, $l) {
-		$eventSource->send('success', $l->t('Checking for update of app "%s" in App Store', [$app]));
-	});
 	$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($eventSource, $l) {
 		$eventSource->send('success', $l->t('Update app "%s" from App Store', [$app]));
-	});
-	$updater->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use ($eventSource, $l) {
-		$eventSource->send('success', $l->t('Checked for update of app "%s" in App Store', [$app]));
 	});
 	$updater->listen('\OC\Updater', 'appSimulateUpdate', function ($app) use ($eventSource, $l) {
 		$eventSource->send('success', $l->t('Checking whether the database schema for %s can be updated (this can take a long time depending on the database size)', [$app]));

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -545,13 +545,13 @@ class Updater extends BasicEmitter {
 			$log->info('\OC\Updater::incompatibleAppDisabled: Disabled incompatible app: ' . $app, ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'checkAppStoreAppBefore', function ($app) use ($log) {
-			$log->info('\OC\Updater::checkAppStoreAppBefore: Checking for update of app "' . $app . '" in appstore', ['app' => 'updater']);
+			$log->debug('\OC\Updater::checkAppStoreAppBefore: Checking for update of app "' . $app . '" in appstore', ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($log) {
 			$log->info('\OC\Updater::upgradeAppStoreApp: Update app "' . $app . '" from appstore', ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'checkAppStoreApp', function ($app) use ($log) {
-			$log->info('\OC\Updater::checkAppStoreApp: Checked for update of app "' . $app . '" in appstore', ['app' => 'updater']);
+			$log->debug('\OC\Updater::checkAppStoreApp: Checked for update of app "' . $app . '" in appstore', ['app' => 'updater']);
 		});
 		$this->listen('\OC\Updater', 'appSimulateUpdate', function ($app) use ($log) {
 			$log->info('\OC\Updater::appSimulateUpdate: Checking whether the database schema for <' . $app . '> can be updated (this can take a long time depending on the database size)', ['app' => 'updater']);


### PR DESCRIPTION
This is cosmetic but if you have a large number of apps installed then
you'll see a wall of text during the server and app upgrade when it
tries to update each app via the app store. In may cases nothing will be
updated. For those boring cases we can hide the verbose info, but show
when occ is run with -v. Any actual update will still print a few lines.
Those are the important ones for the admin.

## Before

```
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Setting log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Disabled incompatible app: mail
Updating <calendar> ...
Updated <calendar> to 2.4.0-RC.2
Checking for update of app accessibility in appstore
Checked for update of app "accessibility" in App Store 
Checking for update of app admin_audit in appstore
Checked for update of app "admin_audit" in App Store 
Checking for update of app calendar in appstore
Checked for update of app "calendar" in App Store 
Checking for update of app cloud_federation_api in appstore
Checked for update of app "cloud_federation_api" in App Store 
Checking for update of app comments in appstore
Checked for update of app "comments" in App Store 
Checking for update of app contactsinteraction in appstore
Checked for update of app "contactsinteraction" in App Store 
Checking for update of app dashboard in appstore
Checked for update of app "dashboard" in App Store 
Checking for update of app dav in appstore
Checked for update of app "dav" in App Store 
Checking for update of app federatedfilesharing in appstore
Checked for update of app "federatedfilesharing" in App Store 
Checking for update of app federation in appstore
Checked for update of app "federation" in App Store 
Checking for update of app files in appstore
Checked for update of app "files" in App Store 
Checking for update of app files_external in appstore
Checked for update of app "files_external" in App Store 
Checking for update of app files_sharing in appstore
Checked for update of app "files_sharing" in App Store 
Checking for update of app files_trashbin in appstore
Checked for update of app "files_trashbin" in App Store 
Checking for update of app files_versions in appstore
Checked for update of app "files_versions" in App Store 
Checking for update of app lookup_server_connector in appstore
Checked for update of app "lookup_server_connector" in App Store 
Checking for update of app oauth2 in appstore
Checked for update of app "oauth2" in App Store 
Checking for update of app provisioning_api in appstore
Checked for update of app "provisioning_api" in App Store 
Checking for update of app settings in appstore
Checked for update of app "settings" in App Store 
Checking for update of app sharebymail in appstore
Checked for update of app "sharebymail" in App Store 
Checking for update of app systemtags in appstore
Checked for update of app "systemtags" in App Store 
Checking for update of app theming in appstore
Checked for update of app "theming" in App Store 
Checking for update of app twofactor_backupcodes in appstore
Checked for update of app "twofactor_backupcodes" in App Store 
Checking for update of app updatenotification in appstore
Checked for update of app "updatenotification" in App Store 
Checking for update of app user_ldap in appstore
Checked for update of app "user_ldap" in App Store 
Checking for update of app user_status in appstore
Checked for update of app "user_status" in App Store 
Checking for update of app viewer in appstore
Checked for update of app "viewer" in App Store 
Checking for update of app weather_status in appstore
Checked for update of app "weather_status" in App Store 
Checking for update of app workflowengine in appstore
Checked for update of app "workflowengine" in App Store 
Checking for update of app mail in appstore
Checked for update of app "mail" in App Store 
Update successful
Turned off maintenance mode
Resetting log level
```

## After

```
Nextcloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Setting log level to debug
Turned on maintenance mode
Updating database schema
Updated database
Updating <calendar> ...
Updated <calendar> to 2.4.0-RC.3
Update successful
Turned off maintenance mode
Resetting log level
```