### PR TITLE
Set 'app_password' in session only when using a permanent token

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2381,7 +2381,7 @@
     </RedundantCondition>
   </file>
   <file src="lib/private/Authentication/Token/PublicKeyToken.php">
-    <UndefinedMethod occurrences="16">
+    <UndefinedMethod occurrences="17">
       <code>parent::getExpires()</code>
       <code>parent::getLastCheck()</code>
       <code>parent::getLoginName()</code>
@@ -2398,6 +2398,7 @@
       <code>parent::setScope(json_encode($scope))</code>
       <code>parent::setToken($token)</code>
       <code>parent::setType(IToken::WIPE_TOKEN)</code>
+      <code>parent::getType()</code>
     </UndefinedMethod>
   </file>
   <file src="lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php">

--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -115,6 +115,7 @@ interface IToken extends JsonSerializable {
 	 * Get the token type
 	 *
 	 * @return int
+	 * @psalm-return IToken::DO_NOT_REMEMBER|IToken::REMEMBER
 	 */
 	public function getType(): int;
 

--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -112,6 +112,13 @@ interface IToken extends JsonSerializable {
 	public function getRemember(): int;
 
 	/**
+	 * Get the token type
+	 *
+	 * @return int
+	 */
+	public function getType(): int;
+
+	/**
 	 * Set the token
 	 *
 	 * @param string $token

--- a/lib/private/Authentication/Token/PublicKeyToken.php
+++ b/lib/private/Authentication/Token/PublicKeyToken.php
@@ -35,7 +35,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setLoginName(string $loginname)
  * @method string getToken()
  * @method void setType(int $type)
- * @method int getType()
  * @method void setRemember(int $remember)
  * @method void setLastActivity(int $lastactivity)
  * @method int getLastActivity()
@@ -199,6 +198,10 @@ class PublicKeyToken extends Entity implements INamedToken, IWipeableToken {
 
 	public function setName(string $name): void {
 		parent::setName($name);
+	}
+
+	public function getType(): int {
+		return parent::getType();
 	}
 
 	public function getRemember(): int {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -835,8 +835,7 @@ class Session implements IUserSession, Emitter {
 			return true;
 		}
 
-		// Remember me tokens are not app_passwords
-		if ($dbToken->getRemember() === IToken::DO_NOT_REMEMBER) {
+		if ($dbToken->getType() === IToken::PERMANENT_TOKEN) {
 			// Set the session variable so we know this is an app password
 			$this->session->set('app_password', $token);
 		}


### PR DESCRIPTION
Like mentioned there https://github.com/nextcloud/globalsiteselector/pull/51#issuecomment-968890543
Maybe we should check the token type to decide if `app_password` should be set in the session.

`getType()` is now declared in `IToken` and implemented by `PublicKeyToken` and `DefaultToken`.