### PR TITLE
find users for background scan one by one

### DIFF
--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -116,11 +116,17 @@ class ScanFiles extends \OC\BackgroundJob\TimedJob {
 		}
 
 		$usersScanned = 0;
+		$lastUser = '';
 		$user = $this->getUserToScan();
-		while ($user && $usersScanned < self::USERS_PER_SESSION) {
+		while ($user && $usersScanned < self::USERS_PER_SESSION && $lastUser !== $user) {
 			$this->runScanner($user);
+			$lastUser = $user;
 			$user = $this->getUserToScan();
 			$usersScanned += 1;
+		}
+
+		if ($lastUser === $user) {
+			$this->logger->warning("User $user still has unscanned files after running background scan, background scan might be stopped prematurely");
 		}
 	}
 }

--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -30,7 +30,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\ILogger;
-use OCP\IUserManager;
 
 /**
  * Class ScanFiles is a background job used to run the file scanner over the user
@@ -57,10 +56,10 @@ class ScanFiles extends \OC\BackgroundJob\TimedJob {
 	 * @param IDBConnection $connection
 	 */
 	public function __construct(
-		IConfig          $config,
+		IConfig $config,
 		IEventDispatcher $dispatcher,
-		ILogger          $logger,
-		IDBConnection    $connection
+		ILogger $logger,
+		IDBConnection $connection
 	) {
 		// Run once per 10 minutes
 		$this->setInterval(60 * 10);

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -30,7 +30,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
-use OCP\IUserManager;
 use Test\TestCase;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
@@ -54,7 +53,6 @@ class ScanFilesTest extends TestCase {
 		parent::setUp();
 
 		$config = $this->createMock(IConfig::class);
-		$userManager = $this->createMock(IUserManager::class);
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 		$logger = $this->createMock(ILogger::class);
 		$connection = \OC::$server->getDatabaseConnection();
@@ -63,7 +61,6 @@ class ScanFilesTest extends TestCase {
 		$this->scanFiles = $this->getMockBuilder('\OCA\Files\BackgroundJob\ScanFiles')
 			->setConstructorArgs([
 				$config,
-				$userManager,
 				$dispatcher,
 				$logger,
 				$connection,

--- a/apps/files_sharing/lib/ISharedStorage.php
+++ b/apps/files_sharing/lib/ISharedStorage.php
@@ -22,5 +22,7 @@
  */
 namespace OCA\Files_Sharing;
 
-interface ISharedStorage {
+use OCP\Files\Storage\IStorage;
+
+interface ISharedStorage extends IStorage {
 }

--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -22,6 +22,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\Files_Sharing;
 
 use OC\Files\ObjectStore\NoopScanner;

--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -135,8 +135,8 @@ class FileSystemTags implements ICheck, IFileCheck {
 		// TODO: Fix caching inside group folders
 		// Do not cache file ids inside group folders because multiple file ids might be mapped to
 		// the same combination of cache id + path.
-		$shouldCacheFileIds = !$this->storage
-			->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
+		/** @psalm-suppress InvalidArgument */
+		$shouldCacheFileIds = !$this->storage->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
 		$cacheId = $cache->getNumericStorageId();
 		if ($shouldCacheFileIds && isset($this->fileIds[$cacheId][$path])) {
 			return $this->fileIds[$cacheId][$path];

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -166,10 +166,6 @@ class Scanner extends PublicEmitter {
 				continue;
 			}
 
-			// don't scan received local shares, these can be scanned when scanning the owner's storage
-			if ($storage->instanceOfStorage(SharedStorage::class)) {
-				continue;
-			}
 			$scanner = $storage->getScanner();
 			$this->attachListener($mount);
 

--- a/lib/public/Files/IHomeStorage.php
+++ b/lib/public/Files/IHomeStorage.php
@@ -26,10 +26,12 @@
 
 namespace OCP\Files;
 
+use OCP\Files\Storage\IStorage;
+
 /**
  * Interface IHomeStorage
  *
  * @since 7.0.0
  */
-interface IHomeStorage {
+interface IHomeStorage extends IStorage {
 }

--- a/lib/public/Files/Storage.php
+++ b/lib/public/Files/Storage.php
@@ -368,9 +368,12 @@ interface Storage extends IStorage {
 	/**
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
 	 *
+	 * @template T of IStorage
 	 * @param string $class
+	 * @psalm-param class-string<T> $class
 	 * @return bool
 	 * @since 7.0.0
+	 * @psalm-assert-if-true T $this
 	 */
 	public function instanceOfStorage($class);
 

--- a/lib/public/Files/Storage/IDisableEncryptionStorage.php
+++ b/lib/public/Files/Storage/IDisableEncryptionStorage.php
@@ -28,5 +28,5 @@ namespace OCP\Files\Storage;
  *
  * @since 16.0.0
  */
-interface IDisableEncryptionStorage {
+interface IDisableEncryptionStorage extends IStorage {
 }

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -356,9 +356,12 @@ interface IStorage {
 	/**
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
 	 *
+	 * @template T of IStorage
 	 * @param string $class
+	 * @psalm-param class-string<T> $class
 	 * @return bool
 	 * @since 9.0.0
+	 * @psalm-assert-if-true T $this
 	 */
 	public function instanceOfStorage($class);
 

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -11,7 +11,6 @@ namespace Test\Files\Utils;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
-use OCA\Files_Sharing\SharedStorage;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
@@ -190,25 +189,6 @@ class ScannerTest extends \Test\TestCase {
 		$newRoot = $cache->get('');
 
 		$this->assertNotEquals($oldRoot->getEtag(), $newRoot->getEtag());
-	}
-
-	public function testSkipLocalShares() {
-		$sharedStorage = $this->createMock(SharedStorage::class);
-		$sharedMount = new MountPoint($sharedStorage, '/share');
-		Filesystem::getMountManager()->addMount($sharedMount);
-
-		$sharedStorage->method('instanceOfStorage')
-			->willReturnCallback(function (string $c) {
-				return $c === SharedStorage::class;
-			});
-		$sharedStorage->expects($this->never())
-			->method('getScanner');
-
-		$scanner = new TestScanner('', \OC::$server->getDatabaseConnection(), $this->createMock(IEventDispatcher::class), \OC::$server->getLogger());
-		$scanner->addMount($sharedMount);
-		$scanner->scan('');
-
-		$scanner->backgroundScan('');
 	}
 
 	public function testShallow() {


### PR DESCRIPTION
The current query for finding a list of users to trigger the background scan for has performance issue on large instances due to the grouping/deduplicating in the query.

This changes the logic to find a single user to scan, run the scan, and find a new user to scan.

Some additional work in how background scanning was handled for shared storages and other jails was needed to ensure this doesn't get stuck on a single user.

As an additional bonus, this improves the situation where a storage with unscanned files is accessible for multiple users. Currently the background scan would be triggered for all users with access, even if there is no longer anything to scan after the first user.
With these changes it will only trigger the scan for one user.