### PR TITLE
Allow to serve static WebAssembly and TensorFlow Lite files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -43,7 +43,7 @@
   </IfModule>
 
   # Add cache control for static resources
-  <FilesMatch "\.(css|js|svg|gif|png|jpg|ico)$">
+  <FilesMatch "\.(css|js|svg|gif|png|jpg|ico|wasm|tflite)$">
     Header set Cache-Control "max-age=15778463"
   </FilesMatch>
 
@@ -75,6 +75,7 @@
 
 <IfModule mod_mime.c>
   AddType image/svg+xml svg svgz
+  AddType application/wasm wasm
   AddEncoding gzip svgz
 </IfModule>
 

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -530,7 +530,7 @@ class Setup {
 			$content .= "\n  Options -MultiViews";
 			$content .= "\n  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff2?|ico|jpg|jpeg|map|webm|mp4|mp3|ogg|wav)$";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff2?|ico|jpg|jpeg|map|webm|mp4|mp3|ogg|wav|wasm|tflite)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/ajax/update\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/img/(favicon\\.ico|manifest\\.json)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(cron|public|remote|status)\\.php";


### PR DESCRIPTION
[Since Talk 13](https://github.com/nextcloud/spreed/pull/6517) (and thus Nextcloud 23) WebAssembly (.wasm) and TensorFlow Lite (.tflite) files need to be loaded from the web server to provide certain features (like the background blur in the WebUI).

Those files can be treated in a similar way to other static resources, and there should not be any problem caching or compressing them. However, as compressed TensorFlow Lite files are only ~12% smaller, the compression directive depends on the MIME type and [there is no standard MIME type for TensorFlow Lite files](https://www.iana.org/assignments/media-types/media-types.xhtml) it is not worth to compress them.

Moreover, no directives to compress WebAssembly files were added either, as it seems that they would override any other compression directives set in the default server configuration (but it could just be that I do now know how to do it :-) ); for reference I tried with:
```
<IfModule mod_deflate.c>
  <IfModule mod_filter.c>
    AddOutputFilterByType DEFLATE application/wasm
  </IfModule>
</IfModule>
```

Depending on the setup _application/wasm_ may not be associated with _.wasm_ files, so the directive was added just in case, as otherwise browsers log a warning.

In any case my Apache knowledge is almost null, so please review carefully :-) (and if you know how to add compression for WebAssembly files while keeping the default compression directives that would be great!)