### PR TITLE
Explicitly allow access on some (public) routes also without 2FA

### DIFF
--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -98,6 +98,7 @@ class OCJSController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
+	 * @NoTwoFactorRequired
 	 * @PublicPage
 	 *
 	 * @return DataDisplayResponse

--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -83,6 +83,12 @@ class TwoFactorMiddleware extends Middleware {
 	 * @param string $methodName
 	 */
 	public function beforeController($controller, $methodName) {
+		if ($this->reflector->hasAnnotation('NoTwoFactorRequired')) {
+			// Route handler explicitly marked to work without finished 2FA are
+			// not blocked
+			return;
+		}
+
 		if ($controller instanceof APIController && $methodName === 'poll') {
 			// Allow polling the twofactor nextcloud notifications state
 			return;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_totp/issues/1147 and many similar bugs in 2FA apps.

This is kind of a revert of https://github.com/nextcloud/server/pull/28725, or another revision. The problem is that we have *some* public routes (`@PublicPage`) that should be accessible during the 2FA setup. That is after the login (user context exists) but before completing any 2FA challenge or setting up a 2FA provider (other routes have to remain blocked).

This new annotation will allow us to mark (public) routes to be accessible again.

This follows @nickvergessen's suggestion from https://github.com/nextcloud/server/pull/29056#discussion_r726001703

We will have to add this annotation to the 2FA provider routes.