### PR TITLE
[stable22] Revert "Explicitly allow some routes without 2FA"

### DIFF
--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -98,7 +98,6 @@ class OCJSController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
-	 * @NoTwoFactorRequired
 	 * @PublicPage
 	 *
 	 * @return DataDisplayResponse

--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -83,12 +83,6 @@ class TwoFactorMiddleware extends Middleware {
 	 * @param string $methodName
 	 */
 	public function beforeController($controller, $methodName) {
-		if ($this->reflector->hasAnnotation('NoTwoFactorRequired')) {
-			// Route handler explicitly marked to work without finished 2FA are
-			// not blocked
-			return;
-		}
-
 		if ($controller instanceof APIController && $methodName === 'poll') {
 			// Allow polling the twofactor nextcloud notifications state
 			return;


### PR DESCRIPTION
Accidentally pushed against stable22 instead of a backport branch.