### PR TITLE
[stable22] Explicitly allow some routes without 2FA

### DIFF
--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -98,6 +98,7 @@ class OCJSController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
+	 * @NoTwoFactorRequired
 	 * @PublicPage
 	 *
 	 * @return DataDisplayResponse

--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -83,6 +83,12 @@ class TwoFactorMiddleware extends Middleware {
 	 * @param string $methodName
 	 */
 	public function beforeController($controller, $methodName) {
+		if ($this->reflector->hasAnnotation('NoTwoFactorRequired')) {
+			// Route handler explicitly marked to work without finished 2FA are
+			// not blocked
+			return;
+		}
+
 		if ($controller instanceof APIController && $methodName === 'poll') {
 			// Allow polling the twofactor nextcloud notifications state
 			return;


### PR DESCRIPTION
Backport of #29752

Previously i pushed accidentally to stable22, the revert  should be in first. Apologies!
- [x] https://github.com/nextcloud/server/pull/29762