### PR TITLE
Fix doc link in sharing settings

### DIFF
--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -32,10 +32,10 @@
 	<?php if ($_['sharingAppEnabled'] === false) { ?>
 		<p class="warning"><?php p($l->t('You need to enable the File sharing App.')); ?></p>
 	<?php } else { ?>
-	<div>
 		<a target="_blank" rel="noreferrer noopener" class="icon-info"
 		   title="<?php p($l->t('Open documentation'));?>"
 		   href="<?php p(link_to_docs('admin-sharing')); ?>"></a>
+	<div>
 			<p class="settings-hint"><?php p($l->t('As admin you can fine-tune the sharing behavior. Please see the documentation for more information.'));?></p>
 		<p id="enable">
 			<input type="checkbox" name="shareapi_enabled" id="shareAPIEnabled" class="checkbox"


### PR DESCRIPTION
The doc link "i" icon was on the wrong line.

Before:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/277525/142634623-247d85c6-5792-4caf-9ae9-fd9143f6c05f.png">

After:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/277525/142634584-bac688e5-cbd6-49b9-a728-6902e91592ec.png">

Regression from NC 22.2.2 happening on stable23 and master