### PR TITLE
Make sure mapping cache is cleared when deleting a user

### DIFF
--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -379,6 +379,11 @@ abstract class AbstractMapping {
 			DELETE FROM `' . $this->getTableName() . '`
 			WHERE `owncloud_name` = ?');
 
+		$dn = array_search($name, $this->cache);
+		if ($dn !== false) {
+			unset($this->cache[$dn]);
+		}
+
 		return $this->modify($statement, [$name]);
 	}
 

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -127,8 +127,12 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 		[$mapper, $data] = $this->initTest();
 
 		foreach ($data as $entry) {
+			$fdnBefore = $mapper->getDNByName($entry['name']);
 			$result = $mapper->unmap($entry['name']);
+			$fdnAfter = $mapper->getDNByName($entry['name']);
 			$this->assertTrue($result);
+			$this->assertSame($fdnBefore, $entry['dn']);
+			$this->assertFalse($fdnAfter);
 		}
 
 		$result = $mapper->unmap('notAnEntry');


### PR DESCRIPTION
This avoids phantom remnants staying after user deletion

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>