### PR TITLE
Ignore cache in occ ldap:check-ldap command

### DIFF
--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -91,7 +91,7 @@ class CheckUser extends Command {
 			$uid = $input->getArgument('ocName');
 			$this->isAllowed($input->getOption('force'));
 			$this->confirmUserIsMapped($uid);
-			$exists = $this->backend->userExistsOnLDAP($uid);
+			$exists = $this->backend->userExistsOnLDAP($uid, true);
 			if ($exists === true) {
 				$output->writeln('The user is still available on LDAP.');
 				if ($input->getOption('update')) {

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -296,11 +296,10 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 *
 	 * @param string|\OCA\User_LDAP\User\User $user either the Nextcloud user
 	 * name or an instance of that user
-	 * @return bool
 	 * @throws \Exception
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function userExistsOnLDAP($user) {
+	public function userExistsOnLDAP($user, bool $ignoreCache = false): bool {
 		if (is_string($user)) {
 			$user = $this->access->userManager->get($user);
 		}
@@ -309,9 +308,11 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		}
 		$uid = $user instanceof User ? $user->getUsername() : $user->getOCName();
 		$cacheKey = 'userExistsOnLDAP' . $uid;
-		$userExists = $this->access->connection->getFromCache($cacheKey);
-		if (!is_null($userExists)) {
-			return (bool)$userExists;
+		if (!$ignoreCache) {
+			$userExists = $this->access->connection->getFromCache($cacheKey);
+			if (!is_null($userExists)) {
+				return (bool)$userExists;
+			}
 		}
 
 		$dn = $user->getDN();

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -204,11 +204,10 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	 *
 	 * @param string|\OCA\User_LDAP\User\User $user either the Nextcloud user
 	 * name or an instance of that user
-	 * @return boolean
 	 */
-	public function userExistsOnLDAP($user) {
+	public function userExistsOnLDAP($user, bool $ignoreCache = false): bool {
 		$id = ($user instanceof User) ? $user->getUsername() : $user;
-		return $this->handleRequest($id, 'userExistsOnLDAP', [$user]);
+		return $this->handleRequest($id, 'userExistsOnLDAP', [$user, $ignoreCache]);
 	}
 
 	/**


### PR DESCRIPTION
This avoids having to wait or reset the cache after deleting a user in the LDAP.
This also fixes a PHP error when running ldap:check-ldap --update on a deleted but cached user.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>