### PR TITLE
Do not clear all results when searching from users address books

### DIFF
--- a/build/integration/collaboration_features/autocomplete.feature
+++ b/build/integration/collaboration_features/autocomplete.feature
@@ -38,6 +38,47 @@ Feature: autocomplete
     Then get autocomplete for "autocomplete"
       | id | source |
 
+  Scenario: getting autocomplete emails from address book with enumeration
+    Given As an "admin"
+    And sending "PUT" to "/cloud/users/autocomplete" with
+      | key | email |
+      | value | autocomplete@example.com |
+    And there is a contact in an addressbook
+    Then get email autocomplete for "example"
+      | id | source |
+      | autocomplete | users |
+      | user@example.com | emails |
+    Then get email autocomplete for "auto"
+      | id | source |
+      | autocomplete | users |
+    Then get email autocomplete for "example"
+      | id | source |
+      | autocomplete | users |
+      | user@example.com | emails |
+    Then get email autocomplete for "autocomplete@example.com"
+      | id | source |
+      | autocomplete | users |
+
+  Scenario: getting autocomplete emails from address book without enumeration
+    Given As an "admin"
+    And sending "PUT" to "/cloud/users/autocomplete" with
+      | key | email |
+      | value | autocomplete@example.com |
+    And there is a contact in an addressbook
+    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+    When parameter "shareapi_restrict_user_enumeration_full_match" of app "core" is set to "no"
+    Then get email autocomplete for "example"
+      | id | source |
+      | user@example.com | emails |
+    When parameter "shareapi_restrict_user_enumeration_full_match" of app "core" is set to "yes"
+    Then get email autocomplete for "auto"
+      | id | source |
+    Then get email autocomplete for "example"
+      | id | source |
+      | user@example.com | emails |
+    Then get email autocomplete for "autocomplete@example.com"
+      | id | source |
+      | autocomplete | users |
 
   Scenario: getting autocomplete with limited enumeration by group
     Given As an "admin"

--- a/build/integration/features/bootstrap/CollaborationContext.php
+++ b/build/integration/features/bootstrap/CollaborationContext.php
@@ -33,15 +33,28 @@ require __DIR__ . '/../../vendor/autoload.php';
 class CollaborationContext implements Context {
 	use Provisioning;
 	use AppConfiguration;
+	use WebDav;
 
 	/**
 	 * @Then /^get autocomplete for "([^"]*)"$/
 	 * @param TableNode|null $formData
 	 */
-	public function getAutocomplete(string $search, TableNode $formData): void {
+	public function getAutocompleteForUser(string $search, TableNode $formData): void {
+		$this->getAutocompleteWithType(0, $search, $formData);
+	}
+
+	/**
+	 * @Then /^get email autocomplete for "([^"]*)"$/
+	 * @param TableNode|null $formData
+	 */
+	public function getAutocompleteForEmail(string $search, TableNode $formData): void {
+		$this->getAutocompleteWithType(4, $search, $formData);
+	}
+
+	private function getAutocompleteWithType(int $type, string $search, TableNode $formData): void {
 		$query = $search === 'null' ? null : $search;
 
-		$this->sendRequestForJSON('GET', '/core/autocomplete/get?itemType=files&itemId=123&search=' . $query, [
+		$this->sendRequestForJSON('GET', '/core/autocomplete/get?itemType=files&itemId=123&shareTypes[]=' . $type . '&search=' . $query, [
 			'itemType' => 'files',
 			'itemId' => '123',
 			'search' => $query,
@@ -62,6 +75,46 @@ class CollaborationContext implements Context {
 			}
 			return $data;
 		}, $suggestions, $formData->getHash()));
+	}
+
+	/**
+	 * @Given /^there is a contact in an addressbook$/
+	 */
+	public function thereIsAContactInAnAddressbook() {
+		$this->usingNewDavPath();
+		try {
+			$destination = '/users/admin/myaddressbook';
+			$data = '<x0:mkcol xmlns:x0="DAV:"><x0:set><x0:prop><x0:resourcetype><x0:collection/><x4:addressbook xmlns:x4="urn:ietf:params:xml:ns:carddav"/></x0:resourcetype><x0:displayname>myaddressbook</x0:displayname></x0:prop></x0:set></x0:mkcol>';
+			$this->response = $this->makeDavRequest($this->currentUser, "MKCOL", $destination, ['Content-Type' => 'application/xml'], $data, "addressbooks");
+		} catch (\GuzzleHttp\Exception\ServerException $e) {
+			// 5xx responses cause a server exception
+			$this->response = $e->getResponse();
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			// 4xx responses cause a client exception
+			$this->response = $e->getResponse();
+		}
+
+		try {
+			$destination = '/users/admin/myaddressbook/contact1.vcf';
+			$data = <<<EOF
+BEGIN:VCARD
+VERSION:4.0
+PRODID:-//Nextcloud Contacts v4.0.2
+UID:a0f4088a-4dca-4308-9b63-09a1ebcf78f3
+FN:A person
+ADR;TYPE=HOME:;;;;;;
+EMAIL;TYPE=HOME:user@example.com
+REV;VALUE=DATE-AND-OR-TIME:20211130T140111Z
+END:VCARD
+EOF;
+			$this->response = $this->makeDavRequest($this->currentUser, "PUT", $destination, [], $data, "addressbooks");
+		} catch (\GuzzleHttp\Exception\ServerException $e) {
+			// 5xx responses cause a server exception
+			$this->response = $e->getResponse();
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			// 4xx responses cause a client exception
+			$this->response = $e->getResponse();
+		}
 	}
 
 	protected function resetAppConfigs(): void {

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -90,6 +90,8 @@ trait WebDav {
 			$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . "$path";
 		} elseif ($type === "uploads") {
 			$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . "$path";
+		} else {
+			$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . '/' . $type .  "$path";
 		}
 		$client = new GClient();
 		$options = [

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -235,10 +235,7 @@ class MailPlugin implements ISearchPlugin {
 		}
 
 		$reachedEnd = true;
-		if (!$this->shareeEnumeration) {
-			$result['wide'] = [];
-			$userResults['wide'] = [];
-		} else {
+		if ($this->shareeEnumeration) {
 			$reachedEnd = (count($result['wide']) < $offset + $limit) &&
 				(count($userResults['wide']) < $offset + $limit);
 

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -209,6 +209,7 @@ class MailPluginTest extends TestCase {
 						],
 					],
 					[
+						'isLocalSystemBook' => true,
 						'UID' => 'uid1',
 						'FN' => 'User @ Localhost',
 						'EMAIL' => [
@@ -263,6 +264,7 @@ class MailPluginTest extends TestCase {
 						],
 					],
 					[
+						'isLocalSystemBook' => true,
 						'UID' => 'uid1',
 						'FN' => 'User @ Localhost',
 						'EMAIL' => [
@@ -373,6 +375,7 @@ class MailPluginTest extends TestCase {
 						],
 					],
 					[
+						'isLocalSystemBook' => true,
 						'UID' => 'uid1',
 						'FN' => 'User @ Localhost',
 						'EMAIL' => [


### PR DESCRIPTION
Steps to reproduce:
- Have any additional addressbook enabled (e.g. contacts app with a contact "A contact user" that has the email "contact@example.com")
- Restrict autocompletion in sharing
- Search for "A contact" in the sharing dialog

Before:
- The users own contact does not show up

After:
- The users own contact shows up while results from the system address book are still bocked

Problem: The wide matches in
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Collaboration/Collaborators/MailPlugin.php#L239-L240 are always cleared even though this should only happen for the system address book (actual users of the instance)