### PR TITLE
Fix inactive profile parameters being displayed in the Profile visibility section

### DIFF
--- a/lib/private/Profile/ProfileManager.php
+++ b/lib/private/Profile/ProfileManager.php
@@ -425,6 +425,7 @@ class ProfileManager {
 		];
 
 		$paramMetadata = array_merge($actionsMetadata, $propertiesMetadata);
+		$configArray = array_intersect_key($configArray, $paramMetadata);
 
 		foreach ($configArray as $paramId => $paramConfig) {
 			if (isset($paramMetadata[$paramId])) {


### PR DESCRIPTION
Before this fix `$configArray` may contain an inactive parameter i.e. if Talk is disabled then it's visibility dropdown would still show up