### PR TITLE
Downgrade CSP worker-src to child-src for Safari and iOS

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
@@ -74,6 +74,12 @@ class CSPMiddleware extends Middleware {
 		if ($this->cspNonceManager->browserSupportsCspV3()) {
 			$defaultPolicy->useJsNonce($this->csrfTokenManager->getToken()->getEncryptedValue());
 		}
+		
+		if (count($defaultPolicy->getAllowedWorkerSrcDomains()) > 0 && (preg_match("/Safari/S", $_SERVER['HTTP_USER_AGENT']) === 1 || preg_match("/iOS/S", $_SERVER['HTTP_USER_AGENT']) === 1)) {
+			$safariPolicy = $this->contentSecurityPolicyManager->getDefaultPolicy();
+			$safariPolicy->setAllowedChildSrcDomains($defaultPolicy->getAllowedWorkerSrcDomains());
+			$defaultPolicy = $this->contentSecurityPolicyManager->mergePolicies($defaultPolicy, $safariPolicy);
+		}
 
 		$response->setContentSecurityPolicy($defaultPolicy);
 


### PR DESCRIPTION
This modification will add to the CSP child-src chain the contents of the worker-src chain if the user-agent is Safari or iOS since both of them does not support worker-src. 
This should fix https://github.com/nextcloud/documentserver_community/issues/13 https://github.com/nextcloud/documentserver_community/issues/242 and probably others.

I'm not sure if this is the right spot to add this cod and this is probably not the most elegant solution since I'm not very fluent in PHP, but it does the job.