### PR TITLE
Use strict comparison to detect usage of redis cluster

### DIFF
--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -46,7 +46,7 @@ class RedisFactory {
 	}
 
 	private function create() {
-		$isCluster = in_array('redis.cluster', $this->config->getKeys());
+		$isCluster = in_array('redis.cluster', $this->config->getKeys(), true);
 		$config = $isCluster
 			? $this->config->getValue('redis.cluster', [])
 			: $this->config->getValue('redis', []);


### PR DESCRIPTION
When checking the presence of the `redis.cluster` property in the config, the `in_array` function can return `true` when the config contains a `0` property as `(int)'redis.cluster' === 0`.

Puting aside the reason behind the presence of a `0` property, strict comparisons are always safer, and prevent weird bugs.

Fixes: https://github.com/nextcloud/server/issues/28609

Doc: https://www.php.net/manual/en/function.in-array.php