### PR TITLE
Allow to count comments with multiple verbs

### DIFF
--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -201,6 +201,17 @@ interface ICommentsManager {
 	 */
 	public function getNumberOfCommentsForObjectSinceComment(string $objectType, string $objectId, int $lastRead, string $verb = ''): int;
 
+
+	/**
+	 * @param string $objectType
+	 * @param string $objectId
+	 * @param int $lastRead
+	 * @param string[] $verbs
+	 * @return int
+	 * @since 24.0.0
+	 */
+	public function getNumberOfCommentsWithVerbsForObjectSinceComment(string $objectType, string $objectId, int $lastRead, array $verbs): int;
+
 	/**
 	 * @param string $objectType
 	 * @param string $objectId

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -101,6 +101,10 @@ class FakeManager implements ICommentsManager {
 		return 0;
 	}
 
+	public function getNumberOfCommentsWithVerbsForObjectSinceComment(string $objectType, string $objectId, int $lastRead, array $verbs): int {
+		return 0;
+	}
+
 	public function getLastCommentBeforeDate(string $objectType, string $objectId, \DateTime $beforeDate, string $verb = ''): int {
 		return 0;
 	}


### PR DESCRIPTION
A prerequirement to be able to count shared objects, files and voice messages as unread messages:
https://github.com/nextcloud/spreed/issues/6621