### PR TITLE
Fix users can't login external mount user entered credentials not set

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -76,6 +76,10 @@ class SMB extends Backend {
 	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
 		$auth = $storage->getAuthMechanism();
 		if ($auth->getScheme() === AuthMechanism::SCHEME_PASSWORD) {
+			if (!is_string($storage->getBackendOption('user')) || !is_string($storage->getBackendOption('password'))) {
+				throw new \InvalidArgumentException('user or password is not set');
+			}
+
 			$smbAuth = new BasicAuth(
 				$storage->getBackendOption('user'),
 				$storage->getBackendOption('domain'),


### PR DESCRIPTION
When using external mount with "Global credentials, user entered", users without it set won't be able to login.
This happens because BasicAuth requires username and password as string, but will be null when user didn't set it yet.

It happens because since the commit: 66781e74ada3fd22bb5b246a59897ac146cda4dd update icewind/smb to 3.4.0
the file `apps/files_external/3rdparty/icewind/smb/src/BasicAuth.php` was changed to use php 7.4 typed properties.
```
-	public function __construct($username, $workgroup, $password) {
+	public function __construct(string $username, ?string $workgroup, string $password) {
```

BasicAuth with username as null throws TypeError:
```
Argument 1 passed to Icewind\\SMB\\BasicAuth::__construct() must be of the type string, null given, called in apps/files_external/lib/Lib/Backend/SMB.php on line 82
```

`apps/files_external/lib/Lib/Backend/SMB.php`
```
public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
[...]
$smbAuth = new BasicAuth(
	$storage->getBackendOption('user'),
	$storage->getBackendOption('domain'),
	$storage->getBackendOption('password')
);
```

TypeError is a subclass of Error, not a subclass of Exception, it won't catch it at FailedStorage:

`apps/files_external/lib/Config/ConfigAdapter.php`
```
public function getMountsForUser(IUser $user, IStorageFactory $loader) {
	[...]
	$storages = array_map(function (StorageConfig $storageConfig) use ($user) {
		try {
			$this->prepareStorageConfig($storageConfig, $user);
			return $this->constructStorage($storageConfig);
		} catch (\Exception $e) {
			// propagate exception into filesystem
			return new FailedStorage(['exception' => $e]);
		}
	}, $storageConfigs);
```



The proposed fix is to check if user and password is string instead of null, and throw InvalidArgumentException if it's not.

`apps/files_external/lib/Lib/Backend/SMB.php`
```
public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
	[...]
	if(!is_string($storage->getBackendOption('user')) || !is_string($storage->getBackendOption('password')))
		throw new \InvalidArgumentException('user or password is not set');
```

This commit can be cherry-picked to master, stable22, stable21.

Fix #28229 .
Fix #26697 .
Stable22 PR #29638 .
