### PR TITLE
obey  accounts_data column length when inserting and searching

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -343,6 +343,10 @@ class AccountManager implements IAccountManager {
 	}
 
 	public function searchUsers(string $property, array $values): array {
+		// the value col is limited to 255 bytes. It is used for searches only.
+		$values = array_map(function (string $value) {
+			return Util::shortenMultibyteString($value, 255);
+		}, $values);
 		$chunks = array_chunk($values, 500);
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
@@ -625,8 +629,11 @@ class AccountManager implements IAccountManager {
 				continue;
 			}
 
+			// the value col is limited to 255 bytes. It is used for searches only.
+			$value = $property['value'] ? Util::shortenMultibyteString($property['value'],  255) : '';
+
 			$query->setParameter('name', $property['name'])
-				->setParameter('value', $property['value'] ?? '');
+				->setParameter('value', $value);
 			$query->executeStatement();
 		}
 	}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -513,4 +513,28 @@ class Util {
 		}
 		return self::$needUpgradeCache;
 	}
+
+	/**
+	 * Sometimes a string has to be shortened to fit within a certain maximum
+	 * data length in bytes. substr() you may break multibyte characters,
+	 * because it operates on single byte level. mb_substr() operates on
+	 * characters, so does not ensure that the shortend string satisfies the
+	 * max length in bytes.
+	 *
+	 * For example, json_encode is messing with multibyte characters a lot,
+	 * replacing them with something along "\u1234".
+	 *
+	 * This function shortens the string with by $accurancy (-5) from
+	 * $dataLength characters, until it fits within $dataLength bytes.
+	 *
+	 * @since 23.0.0
+	 */
+	public static function shortenMultibyteString(string $subject, int $dataLength, int $accuracy = 5): string {
+		$temp = mb_substr($subject, 0, $dataLength);
+		// json encodes encapsulates the string in double quotes, they need to be substracted
+		while ((strlen(json_encode($temp)) - 2) > $dataLength) {
+			$temp = mb_substr($temp, 0, -$accuracy);
+		}
+		return $temp;
+	}
 }

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -310,4 +310,11 @@ class UtilTest extends \Test\TestCase {
 			'myApp/vendor/myFancyCSSFile2',
 		], \OC_Util::$styles);
 	}
+
+	public function testShortenMultibyteString() {
+		$this->assertEquals('Short nuff', \OCP\Util::shortenMultibyteString('Short nuff', 255));
+		$this->assertEquals('ABC', \OCP\Util::shortenMultibyteString('ABCDEF', 3));
+		// each of the characters is 12 bytes
+		$this->assertEquals('🙈', \OCP\Util::shortenMultibyteString('🙈🙊🙉', 16, 2));
+	}
 }


### PR DESCRIPTION
This was caught with  the following scenario:

1. In personal account settings write a biography with more than 255 characters
1. Observe an error message about failed saving
  1. it is saved in oc_accounts
  1. but writing to  oc_accounts_data caused a DB exception: `"An exception occurred while executing a query: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column value at row 1"'
1.  This is logged regularly with VerifyUserData background job and spams the log

Solution: since this table is only used for searching phone numbers and additional email currently, it is save to cut off the value that is being written there. To ensure searches work, we prepare the  values accordingly. The shortener is taken and adjusted from https://github.com/nextcloud/notifications/blob/67aae02222755d0c7672c634bdfce3859be117b1/lib/Push.php#L485-L491.