### PR TITLE
Expose DAV:creationdate for propfind/proppatch

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -65,6 +65,7 @@ class FilesPlugin extends ServerPlugin {
 	public const SIZE_PROPERTYNAME = '{http://owncloud.org/ns}size';
 	public const GETETAG_PROPERTYNAME = '{DAV:}getetag';
 	public const LASTMODIFIED_PROPERTYNAME = '{DAV:}lastmodified';
+	public const CREATIONDATE_PROPERTYNAME = '{DAV:}creationdate';
 	public const OWNER_ID_PROPERTYNAME = '{http://owncloud.org/ns}owner-id';
 	public const OWNER_DISPLAY_NAME_PROPERTYNAME = '{http://owncloud.org/ns}owner-display-name';
 	public const CHECKSUMS_PROPERTYNAME = '{http://owncloud.org/ns}checksums';
@@ -395,6 +396,11 @@ class FilesPlugin extends ServerPlugin {
 			$propFind->handle(self::DATA_FINGERPRINT_PROPERTYNAME, function () use ($node) {
 				return $this->config->getSystemValue('data-fingerprint', '');
 			});
+			$propFind->handle(self::CREATIONDATE_PROPERTYNAME, function () use ($node) {
+				return (new \DateTimeImmutable())
+					->setTimestamp($node->getFileInfo()->getCreationTime())
+					->format(\DateTimeInterface::ATOM);
+			});
 			$propFind->handle(self::CREATION_TIME_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getCreationTime();
 			});
@@ -494,6 +500,14 @@ class FilesPlugin extends ServerPlugin {
 				return true;
 			}
 			return false;
+		});
+		$propPatch->handle(self::CREATIONDATE_PROPERTYNAME, function ($time) use ($node) {
+			if (empty($time)) {
+				return false;
+			}
+			$dateTime = new \DateTimeImmutable($time);
+			$node->setCreationTime($dateTime->getTimestamp());
+			return true;
 		});
 		$propPatch->handle(self::CREATION_TIME_PROPERTYNAME, function ($time) use ($node) {
 			if (empty($time)) {

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -65,6 +65,7 @@ class FilesPluginTest extends TestCase {
 	public const SIZE_PROPERTYNAME = FilesPlugin::SIZE_PROPERTYNAME;
 	public const PERMISSIONS_PROPERTYNAME = FilesPlugin::PERMISSIONS_PROPERTYNAME;
 	public const LASTMODIFIED_PROPERTYNAME = FilesPlugin::LASTMODIFIED_PROPERTYNAME;
+	public const CREATIONDATE_PROPERTYNAME = FilesPlugin::CREATIONDATE_PROPERTYNAME;
 	public const DOWNLOADURL_PROPERTYNAME = FilesPlugin::DOWNLOADURL_PROPERTYNAME;
 	public const OWNER_ID_PROPERTYNAME = FilesPlugin::OWNER_ID_PROPERTYNAME;
 	public const OWNER_DISPLAY_NAME_PROPERTYNAME = FilesPlugin::OWNER_DISPLAY_NAME_PROPERTYNAME;
@@ -168,6 +169,9 @@ class FilesPluginTest extends TestCase {
 		$fileInfo->expects($this->any())
 			->method('isReadable')
 			->willReturn(true);
+		$fileInfo->expects($this->any())
+			->method('getCreationTime')
+			->willReturn(123456789);
 
 		$node->expects($this->any())
 			->method('getFileInfo')
@@ -192,6 +196,7 @@ class FilesPluginTest extends TestCase {
 				self::OWNER_ID_PROPERTYNAME,
 				self::OWNER_DISPLAY_NAME_PROPERTYNAME,
 				self::DATA_FINGERPRINT_PROPERTYNAME,
+				self::CREATIONDATE_PROPERTYNAME,
 			],
 			0
 		);
@@ -222,6 +227,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('"abc"', $propFind->get(self::GETETAG_PROPERTYNAME));
 		$this->assertEquals('00000123instanceid', $propFind->get(self::FILEID_PROPERTYNAME));
 		$this->assertEquals('123', $propFind->get(self::INTERNAL_FILEID_PROPERTYNAME));
+		$this->assertEquals('1973-11-29T21:33:09+00:00', $propFind->get(self::CREATIONDATE_PROPERTYNAME));
 		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
 		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals('http://example.com/', $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
@@ -396,6 +402,7 @@ class FilesPluginTest extends TestCase {
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
 		$testDate = 'Fri, 13 Feb 2015 00:01:02 GMT';
+		$testCreationDate = '2007-08-31T16:47+00:00';
 
 		$node->expects($this->once())
 			->method('touch')
@@ -406,10 +413,15 @@ class FilesPluginTest extends TestCase {
 			->with('newetag')
 			->willReturn(true);
 
+		$node->expects($this->once())
+			->method('setCreationTime')
+			->with('1188578820');
+
 		// properties to set
 		$propPatch = new PropPatch([
 			self::GETETAG_PROPERTYNAME => 'newetag',
-			self::LASTMODIFIED_PROPERTYNAME => $testDate
+			self::LASTMODIFIED_PROPERTYNAME => $testDate,
+			self::CREATIONDATE_PROPERTYNAME => $testCreationDate,
 		]);
 
 		$this->plugin->handleUpdateProperties(
@@ -424,6 +436,7 @@ class FilesPluginTest extends TestCase {
 		$result = $propPatch->getResult();
 		$this->assertEquals(200, $result[self::LASTMODIFIED_PROPERTYNAME]);
 		$this->assertEquals(200, $result[self::GETETAG_PROPERTYNAME]);
+		$this->assertEquals(200, $result[self::CREATIONDATE_PROPERTYNAME]);
 	}
 
 	public function testUpdatePropsForbidden() {


### PR DESCRIPTION
Make sure we follow [RFC4918 Section 15.1](https://datatracker.ietf.org/doc/html/rfc4918#section-15.1) for supporting the creationdate DAV property on files/folders in PROPFIND/PROPPATCH requests.