### PR TITLE
Remove iconv from dependencies and tests

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype,curl,dom,fileinfo,gd,iconv,imagick,intl,json,mbstring,oci8,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          extensions: ctype,curl,dom,fileinfo,gd,imagick,intl,json,mbstring,oci8,openssl,pdo_sqlite,posix,sqlite,xml,zip
           tools: phpunit:9
           coverage: none
 

--- a/.github/workflows/s3-external.yml
+++ b/.github/workflows/s3-external.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
+          extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
 
       - name: Set up Nextcloud
         run: |
@@ -94,7 +94,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
+          extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
 
       - name: Set up Nextcloud
         run: |

--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -18,7 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
-          extensions: ctype,curl,dom,fileinfo,gd,iconv,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
+          extensions: ctype,curl,dom,fileinfo,gd,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
 
       - name: Composer install

--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -65,10 +65,6 @@ class PlatformRepository {
 					$prettyVersion = $curlVersion['version'];
 					break;
 
-				case 'iconv':
-					$prettyVersion = ICONV_VERSION;
-					break;
-
 				case 'intl':
 					$name = 'ICU';
 					if (defined('INTL_ICU_VERSION')) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -837,7 +837,6 @@ class OC_Util {
 				'json_encode' => 'JSON',
 				'gd_info' => 'GD',
 				'gzencode' => 'zlib',
-				'iconv' => 'iconv',
 				'simplexml_load_string' => 'SimpleXML',
 				'hash' => 'HASH Message Digest Framework',
 				'curl_init' => 'cURL',


### PR DESCRIPTION
which is not used anymore since: #29470

When accepted, requires an update of the documentation which I'll then commit as well.