### PR TITLE
Let repair step query exceptions bubble up

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -80,6 +80,7 @@ use OCP\Migration\IRepairStep;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Throwable;
 
 class Repair implements IOutput {
 
@@ -140,7 +141,13 @@ class Repair implements IOutput {
 				$s = \OC::$server->query($repairStep);
 			} catch (QueryException $e) {
 				if (class_exists($repairStep)) {
-					$s = new $repairStep();
+					try {
+						// Last resort: hope there are no constructor arguments
+						$s = new $repairStep();
+					} catch (Throwable $inner) {
+						// Well, it was worth a try
+						throw new \Exception("Repair step '$repairStep' can't be instantiated: " . $e->getMessage(), 0, $e);
+					}
 				} else {
 					throw new \Exception("Repair step '$repairStep' is unknown");
 				}

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -149,7 +149,7 @@ class Repair implements IOutput {
 						throw new \Exception("Repair step '$repairStep' can't be instantiated: " . $e->getMessage(), 0, $e);
 					}
 				} else {
-					throw new \Exception("Repair step '$repairStep' is unknown");
+					throw new \Exception("Repair step '$repairStep' is unknown", 0, $e);
 				}
 			}
 


### PR DESCRIPTION
And hide the type error caused by a constructor call with missing
arguments.

`new $repairStep();` only works for the rare case that no arguments are
required. Anything else will throw. Then we previously hid the trace of
the more important query exception.

This will help debug bugs like https://github.com/nextcloud/mail/issues/5755.