### PR TITLE
feat(updater): hide overwrites from disabled apps list on upgrade

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -88,6 +88,7 @@ class Upgrade extends Command {
 
 			$self = $this;
 			$updater = \OCP\Server::get(Updater::class);
+			$incompatibleOverwrites = $this->config->getSystemValue('app_install_overwrite', []);
 
 			/** @var IEventDispatcher $dispatcher */
 			$dispatcher = \OC::$server->get(IEventDispatcher::class);
@@ -179,8 +180,10 @@ class Upgrade extends Command {
 			$updater->listen('\OC\Updater', 'dbUpgrade', function () use ($output) {
 				$output->writeln('<info>Updated database</info>');
 			});
-			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output) {
-				$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
+			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use ($output, &$incompatibleOverwrites) {
+				if (!in_array($app, $incompatibleOverwrites)) {
+					$output->writeln('<comment>Disabled incompatible app: ' . $app . '</comment>');
+				}
 			});
 			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use ($output) {
 				$output->writeln('<info>Update app ' . $app . ' from App Store</info>');

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -120,6 +120,7 @@ if (\OCP\Util::needUpgrade()) {
 		\OC::$server->query(\OC\Installer::class)
 	);
 	$incompatibleApps = [];
+	$incompatibleOverwrites = $config->getSystemValue('app_install_overwrite', []);
 
 	/** @var IEventDispatcher $dispatcher */
 	$dispatcher = \OC::$server->get(IEventDispatcher::class);
@@ -162,8 +163,10 @@ if (\OCP\Util::needUpgrade()) {
 	$updater->listen('\OC\Updater', 'appUpgrade', function ($app, $version) use ($eventSource, $l) {
 		$eventSource->send('success', $l->t('Updated "%1$s" to %2$s', [$app, $version]));
 	});
-	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps) {
-		$incompatibleApps[] = $app;
+	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps, &$incompatibleOverwrites) {
+		if (!in_array($app, $incompatibleOverwrites)) {
+			$incompatibleApps[] = $app;
+		}
 	});
 	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource, $config) {
 		$eventSource->send('failure', $message);

--- a/lib/base.php
+++ b/lib/base.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author MartB <mart.b@outlook.de>
  * @author Michael Gapczynski <GapczynskiM@gmail.com>
+ * @author MichaIng <micha@dietpi.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Owen Winkler <a_github@midnightcircus.com>
  * @author Phil Davis <phil.davis@inf.org>
@@ -388,10 +389,15 @@ class OC {
 		$ocVersion = \OCP\Util::getVersion();
 		$ocVersion = implode('.', $ocVersion);
 		$incompatibleApps = $appManager->getIncompatibleApps($ocVersion);
+		$incompatibleOverwrites = $systemConfig->getValue('app_install_overwrite', []);
 		$incompatibleShippedApps = [];
+		$incompatibleDisabledApps = [];
 		foreach ($incompatibleApps as $appInfo) {
 			if ($appManager->isShipped($appInfo['id'])) {
 				$incompatibleShippedApps[] = $appInfo['name'] . ' (' . $appInfo['id'] . ')';
+			}
+			if (!in_array($appInfo['id'], $incompatibleOverwrites)) {
+				$incompatibleDisabledApps[] = $appInfo;
 			}
 		}
 
@@ -402,7 +408,7 @@ class OC {
 		}
 
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
-		$tmpl->assign('incompatibleAppsList', $incompatibleApps);
+		$tmpl->assign('incompatibleAppsList', $incompatibleDisabledApps);
 		try {
 			$defaults = new \OC_Defaults();
 			$tmpl->assign('productName', $defaults->getName());


### PR DESCRIPTION
If an incompatible app is enabled manually, it is added to the `app_install_overwrite` array in `config.php`. Nextcloud upgrades won't disable any app in this array, but they were still shown on the upgrade page as being disabled.

This commit assures that only apps are shown as "These incompatible apps will be disabled:" which are really disabled, i.e. which are not in the `app_install_overwrite` array.