### PR TITLE
Cast orphan subscription id to int

### DIFF
--- a/apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php
+++ b/apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php
@@ -41,7 +41,8 @@ class RemoveDeletedUsersCalendarSubscriptions implements IRepairStep {
 	/** @var int */
 	private $progress = 0;
 
-	private $orphanSubscriptions = [];
+	/** @var int[] */
+	private $orphanSubscriptionIds = [];
 
 	private const SUBSCRIPTIONS_CHUNK_SIZE = 1000;
 
@@ -74,7 +75,7 @@ class RemoveDeletedUsersCalendarSubscriptions implements IRepairStep {
 		$output->finishProgress();
 		$this->deleteOrphanSubscriptions();
 
-		$output->info(sprintf('%d calendar subscriptions without an user have been cleaned up', count($this->orphanSubscriptions)));
+		$output->info(sprintf('%d calendar subscriptions without an user have been cleaned up', count($this->orphanSubscriptionIds)));
 	}
 
 	/**
@@ -112,7 +113,7 @@ class RemoveDeletedUsersCalendarSubscriptions implements IRepairStep {
 		while ($row = $result->fetch()) {
 			$username = $this->getPrincipal($row['principaluri']);
 			if (!$this->userManager->userExists($username)) {
-				$this->orphanSubscriptions[] = $row['id'];
+				$this->orphanSubscriptionIds[] = (int) $row['id'];
 			}
 		}
 		$result->closeCursor();
@@ -122,7 +123,7 @@ class RemoveDeletedUsersCalendarSubscriptions implements IRepairStep {
 	 * @throws Exception
 	 */
 	private function deleteOrphanSubscriptions(): void {
-		foreach ($this->orphanSubscriptions as $orphanSubscriptionID) {
+		foreach ($this->orphanSubscriptionIds as $orphanSubscriptionID) {
 			$this->deleteOrphanSubscription($orphanSubscriptionID);
 		}
 	}


### PR DESCRIPTION
Fixes https://help.nextcloud.com/t/nextcloud-23-upgrade-problem-dav-app/128275/7

DB columns are of type int by default, so they need to be casted. Otherwise the invocation of `\OCA\DAV\Migration\RemoveDeletedUsersCalendarSubscriptions::deleteOrphanSubscription` causes a type error.

Ref https://github.com/nextcloud/server/pull/28716