### PR TITLE
Don't query the bruteforce attempts when we just deleted them

### DIFF
--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -66,6 +66,8 @@ class Throttler {
 	private $logger;
 	/** @var IConfig */
 	private $config;
+	/** @var bool */
+	private $hasAttemptsDeleted = false;
 
 	/**
 	 * @param IDBConnection $db
@@ -230,7 +232,7 @@ class Throttler {
 			$maxAgeHours = 48;
 		}
 
-		if ($ip === '') {
+		if ($ip === '' || $this->hasAttemptsDeleted) {
 			return 0;
 		}
 
@@ -306,7 +308,9 @@ class Throttler {
 			->andWhere($qb->expr()->eq('action', $qb->createNamedParameter($action)))
 			->andWhere($qb->expr()->eq('metadata', $qb->createNamedParameter(json_encode($metadata))));
 
-		$qb->execute();
+		$qb->executeStatement();
+
+		$this->hasAttemptsDeleted = true;
 	}
 
 	/**


### PR DESCRIPTION
E.g. this happens after you log in (e.g. each curl request)