### PR TITLE
Allow scripts prioritization based on other apps

### DIFF
--- a/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
@@ -37,8 +37,10 @@ class LoadAdditionalListener implements IEventListener {
 			return;
 		}
 
-		Util::addScript(Application::APP_ID, 'dist/files_sharing');
-		Util::addScript(Application::APP_ID, 'dist/additionalScripts');
+		// After files for the files list shared content
+		Util::addScript(Application::APP_ID, 'dist/files_sharing', 'files');
+		// After files for the breadcrumb share indicator
+		Util::addScript(Application::APP_ID, 'dist/additionalScripts', 'files');
 		Util::addStyle(Application::APP_ID, 'icons');
 	}
 }

--- a/apps/files_sharing/lib/Listener/LoadSidebarListener.php
+++ b/apps/files_sharing/lib/Listener/LoadSidebarListener.php
@@ -37,6 +37,6 @@ class LoadSidebarListener implements IEventListener {
 			return;
 		}
 
-		Util::addScript(Application::APP_ID, 'dist/files_sharing_tab');
+		Util::addScript(Application::APP_ID, 'dist/files_sharing_tab', 'files');
 	}
 }

--- a/apps/systemtags/lib/AppInfo/Application.php
+++ b/apps/systemtags/lib/AppInfo/Application.php
@@ -52,8 +52,7 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(
 				'OCA\Files::loadAdditionalScripts',
 				function () {
-					// FIXME: no public API for these ?
-					\OCP\Util::addScript('dist/systemtags');
+					\OCP\Util::addScript('core', 'dist/systemtags');
 					\OCP\Util::addScript(self::APP_ID, 'systemtags');
 				}
 			);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -96,7 +96,7 @@ class TemplateLayout extends \OC_Template {
 
 			$this->initialState->provideInitialState('core', 'active-app', $this->navigationManager->getActiveEntry());
 			$this->initialState->provideInitialState('unified-search', 'limit-default', SearchQuery::LIMIT_DEFAULT);
-			Util::addScript('dist/unified-search', null, true);
+			Util::addScript('core', 'dist/unified-search', 'core');
 
 			// Add navigation entry
 			$this->assign('application', '');
@@ -209,7 +209,7 @@ class TemplateLayout extends \OC_Template {
 		}
 
 		// Add the js files
-		$jsFiles = self::findJavascriptFiles(\OC_Util::$scripts);
+		$jsFiles = self::findJavascriptFiles(array_merge(\OC_Util::$scripts, Util::getScripts()));
 		$this->assign('jsfiles', []);
 		if ($this->config->getSystemValue('installed', false) && $renderAs != TemplateResponse::RENDER_AS_ERROR) {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -580,6 +580,8 @@ class OC_Util {
 	/**
 	 * add a javascript file
 	 *
+	 * @deprecated 24.0.0
+	 *
 	 * @param string $application application id
 	 * @param string|null $file filename
 	 * @param bool $prepend prepend the Script to the beginning of the list
@@ -610,6 +612,8 @@ class OC_Util {
 
 	/**
 	 * add a translation JS file
+	 *
+	 * @deprecated 24.0.0
 	 *
 	 * @param string $application application id
 	 * @param string|null $languageCode language code, defaults to the current language

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -232,6 +232,8 @@ class Util {
 
 	/**
 	 * Return the list of scripts injected to the page
+	 * @return array
+	 * @since 24.0.0
 	 */
 	public static function getScripts(): array {
 		// merging first and last data set

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -72,8 +72,11 @@ class Util {
 	 */
 	public const FATAL = 4;
 
-	/** \OCP\Share\IManager */
+	/** @var \OCP\Share\IManager */
 	private static $shareManager;
+
+	/** @var array */
+	private static $scripts = [];
 
 	/**
 	 * get the current installed version of Nextcloud
@@ -173,10 +176,73 @@ class Util {
 	 * add a javascript file
 	 * @param string $application
 	 * @param string $file
+	 * @param string $afterAppId
 	 * @since 4.0.0
 	 */
-	public static function addScript($application, $file = null) {
-		\OC_Util::addScript($application, $file);
+	public static function addScript($application, $file = null, $afterAppId = null) {
+		if (!empty($application)) {
+			$path = "$application/js/$file";
+		} else {
+			$path = "js/$file";
+		}
+
+		// Inject js translations if we load a script for
+		// a specific app that is not core, as those js files
+		// need separate handling
+		if ($application !== 'core'
+			&& $file !== null
+			&& strpos($file, 'l10n') === false) {
+			self::addTranslations($application);
+		}
+
+		// manage priorities if defined
+		// we store the data like this, then flatten everything
+		// [
+		// 	'core' => [
+		// 		'first' => [
+		// 			'/core/js/main.js',
+		// 		],
+		// 		'last' => [
+		// 			'/apps/viewer/js/viewer-main.js',
+		// 		]
+		// 	],
+		// 	'viewer' => [
+		// 		'first' => [
+		// 			'/apps/viewer/js/viewer-public.js',
+		// 		],
+		// 		'last' => [
+		// 			'/apps/files_pdfviewer/js/files_pdfviewer-main.js',
+		// 		]
+		// 	]
+		// ]
+		if (!empty($afterAppId)) {
+			// init afterAppId app array if it doesn't exists
+			if (!array_key_exists($afterAppId, self::$scripts)) {
+				self::$scripts[$afterAppId] = ['first' => [], 'last' => []];
+			}
+			self::$scripts[$afterAppId]['last'][] = $path;
+		} else {
+			// init app array if it doesn't exists
+			if (!array_key_exists($application, self::$scripts)) {
+				self::$scripts[$application] = ['first' => [], 'last' => []];
+			}
+			self::$scripts[$application]['first'][] = $path;
+		}
+	}
+
+	/**
+	 * Return the list of scripts injected to the page
+	 */
+	public static function getScripts(): array {
+		// merging first and last data set
+		$mapFunc = function (array $scriptsArray): array {
+			return array_merge(...array_values($scriptsArray));
+		};
+		$appScripts = array_map($mapFunc, self::$scripts);
+		// sort core first
+		$scripts = array_merge(isset($appScripts['core']) ? $appScripts['core'] : [], ...array_values($appScripts));
+		// remove duplicates
+		return array_unique($scripts);
 	}
 
 	/**
@@ -186,7 +252,15 @@ class Util {
 	 * @since 8.0.0
 	 */
 	public static function addTranslations($application, $languageCode = null) {
-		\OC_Util::addTranslations($application, $languageCode);
+		if (is_null($languageCode)) {
+			$languageCode = \OC::$server->getL10NFactory()->findLanguage($application);
+		}
+		if (!empty($application)) {
+			$path = "$application/l10n/$languageCode";
+		} else {
+			$path = "l10n/$languageCode";
+		}
+		self::$scripts[$application]['first'][] = $path;
 	}
 
 	/**

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -225,30 +225,35 @@ class UtilTest extends \Test\TestCase {
 
 		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
+		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
 	}
 	protected function tearDown(): void {
 		parent::tearDown();
 
 		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
+		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
 	}
 
 	public function testAddScript() {
-		\OC_Util::addScript('core', 'myFancyJSFile1');
-		\OC_Util::addScript('myApp', 'myFancyJSFile2');
-		\OC_Util::addScript('core', 'myFancyJSFile0', true);
-		\OC_Util::addScript('core', 'myFancyJSFile10', true);
+		\OCP\Util::addScript('core', 'myFancyJSFile1');
+		\OCP\Util::addScript('files', 'myFancyJSFile2', 'core');
+		\OCP\Util::addScript('myApp', 'myFancyJSFile3');
+		\OCP\Util::addScript('core', 'myFancyJSFile4');
+		// after itself
+		\OCP\Util::addScript('core', 'myFancyJSFile5', 'core');
 		// add duplicate
-		\OC_Util::addScript('core', 'myFancyJSFile1');
+		\OCP\Util::addScript('core', 'myFancyJSFile1');
 
 		$this->assertEquals([
-			'core/js/myFancyJSFile10',
-			'core/js/myFancyJSFile0',
 			'core/js/myFancyJSFile1',
+			'core/js/myFancyJSFile4',
+			'files/js/myFancyJSFile2',
+			'core/js/myFancyJSFile5',
+			'files/l10n/en',
 			'myApp/l10n/en',
-			'myApp/js/myFancyJSFile2',
-		], \OC_Util::$scripts);
-		$this->assertEquals([], \OC_Util::$styles);
+			'myApp/js/myFancyJSFile3',
+		], array_values(\OCP\Util::getScripts()));
 	}
 
 	public function testAddVendorScript() {


### PR DESCRIPTION
1. This allow to set after which app some scripts should be loaded.
2. This creates a bit more flexibility and control over script dependencies.
3. This deprecates the current old addScript legacy behaviour

Example given:
- `files_pdfviewer` depends on `viewer` (https://github.com/nextcloud/files_pdfviewer/pull/522)
- `viewer` depends on `files` (https://github.com/nextcloud/viewer/pull/1081)
- `files` depends on `core`

Before we had to rely on luck, then use a watcher to catch any initialization that came after Viewer got updated.
Now, I can only check on viewer initialization and that's it.

## Rules:
1. Core always gets prioritized
2. You can specify only **_ONE_** dependency
3. If the dependency does **_NOT_** exists, it will fallback to the php process order (default current)