### PR TITLE
Fix collaborative tags styles

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -485,6 +485,10 @@ div.select2-drop {
 			text-overflow: ellipsis;
 			span {
 				cursor: pointer;
+				em {
+					cursor: inherit;
+					background: unset;
+				}
 			}
 		}
 		.select2-result,


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/30017

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/24800714/144290863-e674db55-76f7-42ff-8bfa-996e689ca1d2.png" /> | <img src="https://user-images.githubusercontent.com/24800714/144290881-93baef14-de26-4eec-a1eb-10121d62eda5.png" /> |

The background colour was added by https://github.com/select2/select2/blob/3.5.1/select2.css#L412