### PR TITLE
Avoid calling image* methods on boolean

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -124,7 +124,11 @@ class OC_Image implements \OCP\IImage {
 	 * @return int
 	 */
 	public function width() {
-		return $this->valid() ? imagesx($this->resource) : -1;
+		if ($this->valid() && (($width = imagesx($this->resource)) !== false)) {
+			return $width;
+		} else {
+			return -1;
+		}
 	}
 
 	/**
@@ -133,7 +137,11 @@ class OC_Image implements \OCP\IImage {
 	 * @return int
 	 */
 	public function height() {
-		return $this->valid() ? imagesy($this->resource) : -1;
+		if ($this->valid() && (($height = imagesy($this->resource)) !== false)) {
+			return $height;
+		} else {
+			return -1;
+		}
 	}
 
 	/**

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -124,11 +124,13 @@ class OC_Image implements \OCP\IImage {
 	 * @return int
 	 */
 	public function width() {
-		if ($this->valid() && (($width = imagesx($this->resource)) !== false)) {
-			return $width;
-		} else {
-			return -1;
+		if ($this->valid()) {
+			$width = imagesx($this->resource);
+			if ($width !== false) {
+				return $width;
+			}
 		}
+		return -1;
 	}
 
 	/**
@@ -137,11 +139,13 @@ class OC_Image implements \OCP\IImage {
 	 * @return int
 	 */
 	public function height() {
-		if ($this->valid() && (($height = imagesy($this->resource)) !== false)) {
-			return $height;
-		} else {
-			return -1;
+		if ($this->valid()) {
+			$height = imagesy($this->resource);
+			if ($height !== false) {
+				return $height;
+			}
 		}
+		return -1;
 	}
 
 	/**

--- a/lib/public/IImage.php
+++ b/lib/public/IImage.php
@@ -98,7 +98,7 @@ interface IImage {
 	public function save($filePath = null, $mimeType = null);
 
 	/**
-	 * @return resource|\GdImage Returns the image resource in any.
+	 * @return false|resource|\GdImage Returns the image resource if any
 	 * @since 8.1.0
 	 */
 	public function resource();


### PR DESCRIPTION
This avoids fatal errors on PHP>=8, and warnings on older versions.
Log should also be clearer.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

Fixes https://github.com/nextcloud/server/issues/29990