### PR TITLE
[stable21] Fix jsunit CI job

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -52,6 +52,9 @@ jobs:
 
   jsunit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use node ${{ matrix.node-version }}


### PR DESCRIPTION
Add the missing node version matrix for the jsunit CI job