### PR TITLE
Removed fixed Rowtype for mariadb 10.6

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -228,7 +228,6 @@ class ConnectionFactory {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',
-				'row_format' => 'compressed',
 				'tablePrefix' => $connectionParams['tablePrefix']
 			];
 		}


### PR DESCRIPTION
While MariaDB is dropping support for ROW_TYPE "Compressed", that line causes errors while updating as described in #25436 when hard-coding that rowtype.