### PR TITLE
Use proper translation source for direct editing

### DIFF
--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -82,7 +82,7 @@ class Manager implements IManager {
 		$this->connection = $connection;
 		$this->userId = $userSession->getUser() ? $userSession->getUser()->getUID() : null;
 		$this->rootFolder = $rootFolder;
-		$this->l10n = $l10nFactory->get('core');
+		$this->l10n = $l10nFactory->get('lib');
 		$this->encryptionManager = $encryptionManager;
 	}
 


### PR DESCRIPTION
Translations are in `lib` instead of `core`

Make sure that mobile apps show a translated version of "Empty file" instead of always using the English one.