### PR TITLE
Move calendar objects between calendars

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -34,6 +34,7 @@ use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
+use Psr\Log\LoggerInterface;
 
 $authBackend = new Auth(
 	\OC::$server->getSession(),
@@ -83,7 +84,7 @@ $sendInvitations = \OC::$server->getConfig()->getAppValue('dav', 'sendInvitation
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
 $principalCollection->disableListing = !$debugging; // Disable listing
 
-$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend);
+$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend, 'principals', \OC::$server->get(LoggerInterface::class));
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
 $nodes = [

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -63,6 +63,7 @@ use OCA\DAV\Events\CalendarUpdatedEvent;
 use OCA\DAV\Events\SubscriptionCreatedEvent;
 use OCA\DAV\Events\SubscriptionDeletedEvent;
 use OCA\DAV\Events\SubscriptionUpdatedEvent;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -1122,7 +1123,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 *
 	 * @param string $principalUri
 	 * @return array
-	 * @throws \OCP\DB\Exception
+	 * @throws Exception
 	 */
 	public function getDeletedCalendarObjectsByPrincipal(string $principalUri): array {
 		$query = $this->db->getQueryBuilder();
@@ -1414,6 +1415,56 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 		return '"' . $extraData['etag'] . '"';
 	}
+
+	/**
+	 * Moves a calendar object from calendar to calendar.
+	 *
+	 * @param int $sourceCalendarId
+	 * @param int $targetCalendarId
+	 * @param int $objectId
+	 * @param string $principalUri
+	 * @param int $calendarType
+	 * @return bool
+	 * @throws Exception
+	 */
+	public function moveCalendarObject(int $sourceCalendarId, int $targetCalendarId, int $objectId, string $principalUri, int $calendarType = self::CALENDAR_TYPE_CALENDAR): bool {
+		$object = $this->getCalendarObjectById($principalUri, $objectId);
+		if (empty($object)) {
+			return false;
+		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->update('calendarobjects')
+			->set('calendarid', $query->createNamedParameter($targetCalendarId, IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('id', $query->createNamedParameter($objectId, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
+			->andWhere($query->expr()->eq('calendartype', $query->createNamedParameter($calendarType, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
+			->executeStatement();
+
+		$this->purgeProperties($sourceCalendarId, $objectId);
+		$this->updateProperties($targetCalendarId, $object['uri'], $object['calendardata'], $calendarType);
+
+		$this->addChange($sourceCalendarId, $object['uri'], 1, $calendarType);
+		$this->addChange($targetCalendarId, $object['uri'], 3, $calendarType);
+
+		$object = $this->getCalendarObjectById($principalUri, $objectId);
+		// Calendar Object wasn't found - possibly because it was deleted in the meantime by a different client
+		if (empty($object)) {
+			return false;
+		}
+
+		$calendarRow = $this->getCalendarById($targetCalendarId);
+		// the calendar this event is being moved to does not exist any longer
+		if (empty($calendarRow)) {
+			return false;
+		}
+
+		if ($calendarType === self::CALENDAR_TYPE_CALENDAR) {
+			$shares = $this->getShares($targetCalendarId);
+			$this->dispatcher->dispatchTyped(new CalendarObjectUpdatedEvent($targetCalendarId, $calendarRow, $shares, $object));
+		}
+		return true;
+	}
+
 
 	/**
 	 * @param int $calendarObjectId

--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -33,11 +33,15 @@ use DateTimeInterface;
 use OCA\DAV\CalDAV\Trashbin\Plugin as TrashbinPlugin;
 use OCA\DAV\DAV\Sharing\IShareable;
 use OCA\DAV\Exception\UnsupportedLimitOnInitialSyncException;
+use OCP\DB\Exception;
 use OCP\IConfig;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend\BackendInterface;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\IMoveTarget;
+use Sabre\DAV\INode;
 use Sabre\DAV\PropPatch;
 
 /**
@@ -46,7 +50,7 @@ use Sabre\DAV\PropPatch;
  * @package OCA\DAV\CalDAV
  * @property CalDavBackend $caldavBackend
  */
-class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable {
+class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable, IMoveTarget {
 
 	/** @var IConfig */
 	private $config;
@@ -57,6 +61,9 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 	/** @var bool */
 	private $useTrashbin = true;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	/**
 	 * Calendar constructor.
 	 *
@@ -65,7 +72,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 	 * @param IL10N $l10n
 	 * @param IConfig $config
 	 */
-	public function __construct(BackendInterface $caldavBackend, $calendarInfo, IL10N $l10n, IConfig $config) {
+	public function __construct(BackendInterface $caldavBackend, $calendarInfo, IL10N $l10n, IConfig $config, LoggerInterface $logger) {
 		// Convert deletion date to ISO8601 string
 		if (isset($calendarInfo[TrashbinPlugin::PROPERTY_DELETED_AT])) {
 			$calendarInfo[TrashbinPlugin::PROPERTY_DELETED_AT] = (new DateTimeImmutable())
@@ -85,6 +92,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 
 		$this->config = $config;
 		$this->l10n = $l10n;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -415,11 +423,30 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 		return parent::getChanges($syncToken, $syncLevel, $limit);
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function restore(): void {
 		$this->caldavBackend->restoreCalendar((int) $this->calendarInfo['id']);
 	}
 
 	public function disableTrashbin(): void {
 		$this->useTrashbin = false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function moveInto($targetName, $sourcePath, INode $sourceNode) {
+		if (!($sourceNode instanceof CalendarObject)) {
+			return false;
+		}
+
+		try {
+			return $this->caldavBackend->moveCalendarObject($sourceNode->getCalendarId(), (int)$this->calendarInfo['id'], $sourceNode->getId(), $sourceNode->getPrincipalUri());
+		} catch (Exception $e) {
+			$this->logger->error('Could not move calendar object: ' . $e->getMessage(), ['exception' => $e]);
+			return false;
+		}
 	}
 }

--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -30,6 +30,7 @@ use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
+use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend\BackendInterface;
 use Sabre\CalDAV\Backend\NotificationSupport;
 use Sabre\CalDAV\Backend\SchedulingSupport;
@@ -55,7 +56,10 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 	/** @var bool */
 	private $returnCachedSubscriptions = false;
 
-	public function __construct(BackendInterface $caldavBackend, $principalInfo) {
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(BackendInterface $caldavBackend, $principalInfo, LoggerInterface $logger) {
 		parent::__construct($caldavBackend, $principalInfo);
 		$this->l10n = \OC::$server->getL10N('dav');
 		$this->config = \OC::$server->getConfig();
@@ -63,6 +67,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 			\OC::$server,
 			\OC::$server->getAppManager()
 		);
+		$this->logger = $logger;
 	}
 
 	/**
@@ -95,7 +100,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		$calendars = $this->caldavBackend->getCalendarsForUser($this->principalInfo['uri']);
 		$objects = [];
 		foreach ($calendars as $calendar) {
-			$objects[] = new Calendar($this->caldavBackend, $calendar, $this->l10n, $this->config);
+			$objects[] = new Calendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
 		}
 
 		if ($this->caldavBackend instanceof SchedulingSupport) {
@@ -157,7 +162,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		// Calendars
 		foreach ($this->caldavBackend->getCalendarsForUser($this->principalInfo['uri']) as $calendar) {
 			if ($calendar['uri'] === $name) {
-				return new Calendar($this->caldavBackend, $calendar, $this->l10n, $this->config);
+				return new Calendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
 			}
 		}
 

--- a/apps/dav/lib/CalDAV/CalendarManager.php
+++ b/apps/dav/lib/CalDAV/CalendarManager.php
@@ -27,6 +27,7 @@ namespace OCA\DAV\CalDAV;
 use OCP\Calendar\IManager;
 use OCP\IConfig;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 
 class CalendarManager {
 
@@ -39,6 +40,9 @@ class CalendarManager {
 	/** @var IConfig */
 	private $config;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	/**
 	 * CalendarManager constructor.
 	 *
@@ -46,10 +50,11 @@ class CalendarManager {
 	 * @param IL10N $l10n
 	 * @param IConfig $config
 	 */
-	public function __construct(CalDavBackend $backend, IL10N $l10n, IConfig $config) {
+	public function __construct(CalDavBackend $backend, IL10N $l10n, IConfig $config, LoggerInterface $logger) {
 		$this->backend = $backend;
 		$this->l10n = $l10n;
 		$this->config = $config;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -67,7 +72,7 @@ class CalendarManager {
 	 */
 	private function register(IManager $cm, array $calendars) {
 		foreach ($calendars as $calendarInfo) {
-			$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n, $this->config);
+			$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 			$cm->registerCalendar(new CalendarImpl(
 				$calendar,
 				$calendarInfo,

--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -154,4 +154,12 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 		}
 		return true;
 	}
+
+	public function getCalendarId(): int {
+		return (int)$this->objectData['calendarId'];
+	}
+
+	public function getPrincipalUri(): string {
+		return $this->objectData['principaluri'];
+	}
 }

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -28,6 +28,7 @@ namespace OCA\DAV\CalDAV;
 use OCP\Calendar\ICalendarProvider;
 use OCP\IConfig;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 
 class CalendarProvider implements ICalendarProvider {
 
@@ -40,10 +41,14 @@ class CalendarProvider implements ICalendarProvider {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(CalDavBackend $calDavBackend, IL10N $l10n, IConfig $config) {
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(CalDavBackend $calDavBackend, IL10N $l10n, IConfig $config, LoggerInterface $logger) {
 		$this->calDavBackend = $calDavBackend;
 		$this->l10n = $l10n;
 		$this->config = $config;
+		$this->logger = $logger;
 	}
 
 	public function getCalendars(string $principalUri, array $calendarUris = []): array {
@@ -60,7 +65,7 @@ class CalendarProvider implements ICalendarProvider {
 
 		$iCalendars = [];
 		foreach ($calendarInfos as $calendarInfo) {
-			$calendar = new Calendar($this->calDavBackend, $calendarInfo, $this->l10n, $this->config);
+			$calendar = new Calendar($this->calDavBackend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 			$iCalendars[] = new CalendarImpl(
 				$calendar,
 				$calendarInfo,

--- a/apps/dav/lib/CalDAV/CalendarRoot.php
+++ b/apps/dav/lib/CalDAV/CalendarRoot.php
@@ -25,9 +25,22 @@
  */
 namespace OCA\DAV\CalDAV;
 
+use Psr\Log\LoggerInterface;
+use Sabre\CalDAV\Backend;
+use Sabre\DAVACL\PrincipalBackend;
+
 class CalendarRoot extends \Sabre\CalDAV\CalendarRoot {
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $caldavBackend, $principalPrefix = 'principals', LoggerInterface $logger) {
+		parent::__construct($principalBackend, $caldavBackend, $principalPrefix);
+		$this->logger = $logger;
+	}
+
 	public function getChildForPrincipal(array $principal) {
-		return new CalendarHome($this->caldavBackend, $principal);
+		return new CalendarHome($this->caldavBackend, $principal, $this->logger);
 	}
 
 	public function getName() {

--- a/apps/dav/lib/CalDAV/PublicCalendarRoot.php
+++ b/apps/dav/lib/CalDAV/PublicCalendarRoot.php
@@ -27,6 +27,7 @@ namespace OCA\DAV\CalDAV;
 
 use OCP\IConfig;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 use Sabre\DAV\Collection;
 
 class PublicCalendarRoot extends Collection {
@@ -40,6 +41,9 @@ class PublicCalendarRoot extends Collection {
 	/** @var \OCP\IConfig */
 	protected $config;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	/**
 	 * PublicCalendarRoot constructor.
 	 *
@@ -48,10 +52,11 @@ class PublicCalendarRoot extends Collection {
 	 * @param IConfig $config
 	 */
 	public function __construct(CalDavBackend $caldavBackend, IL10N $l10n,
-						 IConfig $config) {
+						 IConfig $config, LoggerInterface $logger) {
 		$this->caldavBackend = $caldavBackend;
 		$this->l10n = $l10n;
 		$this->config = $config;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -66,7 +71,7 @@ class PublicCalendarRoot extends Collection {
 	 */
 	public function getChild($name) {
 		$calendar = $this->caldavBackend->getPublicCalendar($name);
-		return new PublicCalendar($this->caldavBackend, $calendar, $this->l10n, $this->config);
+		return new PublicCalendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
 	}
 
 	/**

--- a/apps/dav/lib/Command/DeleteCalendar.php
+++ b/apps/dav/lib/Command/DeleteCalendar.php
@@ -30,6 +30,7 @@ use OCA\DAV\CalDAV\Calendar;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -49,6 +50,9 @@ class DeleteCalendar extends Command {
 	/** @var IUserManager */
 	private $userManager;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	/**
 	 * @param CalDavBackend $calDav
 	 * @param IConfig $config
@@ -59,13 +63,15 @@ class DeleteCalendar extends Command {
 		CalDavBackend $calDav,
 		IConfig $config,
 		IL10N $l10n,
-		IUserManager $userManager
+		IUserManager $userManager,
+		LoggerInterface $logger
 	) {
 		parent::__construct();
 		$this->calDav = $calDav;
 		$this->config = $config;
 		$this->l10n = $l10n;
 		$this->userManager = $userManager;
+		$this->logger = $logger;
 	}
 
 	protected function configure(): void {
@@ -123,7 +129,9 @@ class DeleteCalendar extends Command {
 			$this->calDav,
 			$calendarInfo,
 			$this->l10n,
-			$this->config);
+			$this->config,
+			$this->logger
+		);
 
 		$force = $input->getOption('force');
 		if ($force) {

--- a/apps/dav/lib/Command/MoveCalendar.php
+++ b/apps/dav/lib/Command/MoveCalendar.php
@@ -33,6 +33,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Share\IManager as IShareManager;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -63,6 +64,9 @@ class MoveCalendar extends Command {
 	/** @var CalDavBackend */
 	private $calDav;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	public const URI_USERS = 'principals/users/';
 
 	/**
@@ -79,7 +83,8 @@ class MoveCalendar extends Command {
 		IShareManager $shareManager,
 		IConfig $config,
 		IL10N $l10n,
-		CalDavBackend $calDav
+		CalDavBackend $calDav,
+		LoggerInterface $logger
 	) {
 		parent::__construct();
 		$this->userManager = $userManager;
@@ -88,6 +93,7 @@ class MoveCalendar extends Command {
 		$this->config = $config;
 		$this->l10n = $l10n;
 		$this->calDav = $calDav;
+		$this->logger = $logger;
 	}
 
 	protected function configure() {
@@ -218,7 +224,7 @@ class MoveCalendar extends Command {
 			 */
 			if ($this->shareManager->shareWithGroupMembersOnly() === true && 'groups' === $prefix && !$this->groupManager->isInGroup($userDestination, $userOrGroup)) {
 				if ($force) {
-					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config), [], ['href' => 'principal:principals/groups/' . $userOrGroup]);
+					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config, $this->logger), [], ['href' => 'principal:principals/groups/' . $userOrGroup]);
 				} else {
 					throw new \InvalidArgumentException("User <$userDestination> is not part of the group <$userOrGroup> with whom the calendar <" . $calendar['uri'] . "> was shared. You may use -f to move the calendar while deleting this share.");
 				}
@@ -229,7 +235,7 @@ class MoveCalendar extends Command {
 			 */
 			if ($userOrGroup === $userDestination) {
 				if ($force) {
-					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config), [], ['href' => 'principal:principals/users/' . $userOrGroup]);
+					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config, $this->logger), [], ['href' => 'principal:principals/users/' . $userOrGroup]);
 				} else {
 					throw new \InvalidArgumentException("The calendar <" . $calendar['uri'] . "> is already shared to user <$userDestination>.You may use -f to move the calendar while deleting this share.");
 				}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -47,6 +47,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 use Sabre\DAV\SimpleCollection;
 
 class RootCollection extends SimpleCollection {
@@ -54,6 +55,7 @@ class RootCollection extends SimpleCollection {
 		$l10n = \OC::$server->getL10N('dav');
 		$random = \OC::$server->getSecureRandom();
 		$logger = \OC::$server->getLogger();
+		$psrLogger = \OC::$server->get(LoggerInterface::class);
 		$userManager = \OC::$server->getUserManager();
 		$userSession = \OC::$server->getUserSession();
 		$groupManager = \OC::$server->getGroupManager();
@@ -107,15 +109,15 @@ class RootCollection extends SimpleCollection {
 			$legacyDispatcher,
 			$config
 		);
-		$userCalendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
+		$userCalendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users', $psrLogger);
 		$userCalendarRoot->disableListing = $disableListing;
 
-		$resourceCalendarRoot = new CalendarRoot($calendarResourcePrincipalBackend, $caldavBackend, 'principals/calendar-resources');
+		$resourceCalendarRoot = new CalendarRoot($calendarResourcePrincipalBackend, $caldavBackend, 'principals/calendar-resources', $psrLogger);
 		$resourceCalendarRoot->disableListing = $disableListing;
-		$roomCalendarRoot = new CalendarRoot($calendarRoomPrincipalBackend, $caldavBackend, 'principals/calendar-rooms');
+		$roomCalendarRoot = new CalendarRoot($calendarRoomPrincipalBackend, $caldavBackend, 'principals/calendar-rooms', $psrLogger);
 		$roomCalendarRoot->disableListing = $disableListing;
 
-		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config);
+		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config, $psrLogger);
 		$publicCalendarRoot->disableListing = $disableListing;
 
 		$systemTagCollection = new SystemTag\SystemTagsByIdCollection(

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -134,6 +134,8 @@ class CalDavBackendTest extends AbstractCalDavBackend {
 				return vsprintf($text, $parameters);
 			});
 
+		$logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+
 		$config = $this->createMock(IConfig::class);
 
 		$this->userManager->expects($this->any())
@@ -147,14 +149,14 @@ class CalDavBackendTest extends AbstractCalDavBackend {
 		$calendarId = $this->createTestCalendar();
 		$calendars = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER);
 		$this->assertCount(1, $calendars);
-		$calendar = new Calendar($this->backend, $calendars[0], $l10n, $config);
+		$calendar = new Calendar($this->backend, $calendars[0], $l10n, $config, $logger);
 		$this->legacyDispatcher->expects($this->at(0))
 			->method('dispatch')
 			->with('\OCA\DAV\CalDAV\CalDavBackend::updateShares');
 		$this->backend->updateShares($calendar, $add, []);
 		$calendars = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER1);
 		$this->assertCount(1, $calendars);
-		$calendar = new Calendar($this->backend, $calendars[0], $l10n, $config);
+		$calendar = new Calendar($this->backend, $calendars[0], $l10n, $config, $logger);
 		$acl = $calendar->getACL();
 		$this->assertAcl(self::UNIT_TEST_USER, '{DAV:}read', $acl);
 		$this->assertAcl(self::UNIT_TEST_USER, '{DAV:}write', $acl);
@@ -500,8 +502,8 @@ EOD;
 		/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
 		$config = $this->createMock(IConfig::class);
-
-		$calendar = new Calendar($this->backend, $calendarInfo, $l10n, $config);
+		$logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+		$calendar = new Calendar($this->backend, $calendarInfo, $l10n, $config, $logger);
 		$calendar->setPublishStatus(true);
 		$this->assertNotEquals(false, $calendar->getPublishStatus());
 
@@ -1237,7 +1239,9 @@ EOD;
 
 		$sharerCalendars = $this->backend->getCalendarsForUser($sharer);
 		$this->assertCount(1, $sharerCalendars);
-		$sharerCalendar = new Calendar($this->backend, $sharerCalendars[0], $l10n, $config);
+
+		$logger = $this->createMock(\Psr\Log\LoggerInterface::class);
+		$sharerCalendar = new Calendar($this->backend, $sharerCalendars[0], $l10n, $config, $logger);
 		$this->backend->updateShares($sharerCalendar, [
 			[
 				'href' => 'principal:' . $me,

--- a/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
@@ -32,13 +32,15 @@ use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\DAV\CalDAV\Outbox;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Schedule\Inbox;
 use Sabre\DAV\MkCol;
 use Test\TestCase;
 
 class CalendarHomeTest extends TestCase {
 
-	/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var CalDavBackend | MockObject */
 	private $backend;
 
 	/** @var array */
@@ -50,6 +52,9 @@ class CalendarHomeTest extends TestCase {
 	/** @var CalendarHome */
 	private $calendarHome;
 
+	/** @var MockObject|LoggerInterface */
+	private $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -58,9 +63,13 @@ class CalendarHomeTest extends TestCase {
 			'uri' => 'user-principal-123',
 		];
 		$this->pluginManager = $this->createMock(PluginManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
-		$this->calendarHome = new CalendarHome($this->backend,
-			$this->principalInfo);
+		$this->calendarHome = new CalendarHome(
+			$this->backend,
+			$this->principalInfo,
+			$this->logger
+		);
 
 		// Replace PluginManager with our mock
 		$reflection = new \ReflectionClass($this->calendarHome);
@@ -70,7 +79,7 @@ class CalendarHomeTest extends TestCase {
 	}
 
 	public function testCreateCalendarValidName() {
-		/** @var MkCol | \PHPUnit\Framework\MockObject\MockObject $mkCol */
+		/** @var MkCol | MockObject $mkCol */
 		$mkCol = $this->createMock(MkCol::class);
 
 		$mkCol->method('getResourceType')
@@ -90,7 +99,7 @@ class CalendarHomeTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('The resource you tried to create has a reserved name');
 
-		/** @var MkCol | \PHPUnit\Framework\MockObject\MockObject $mkCol */
+		/** @var MkCol | MockObject $mkCol */
 		$mkCol = $this->createMock(MkCol::class);
 
 		$this->calendarHome->createExtendedCollection('contact_birthdays', $mkCol);
@@ -100,7 +109,7 @@ class CalendarHomeTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('The resource you tried to create has a reserved name');
 
-		/** @var MkCol | \PHPUnit\Framework\MockObject\MockObject $mkCol */
+		/** @var MkCol | MockObject $mkCol */
 		$mkCol = $this->createMock(MkCol::class);
 
 		$this->calendarHome->createExtendedCollection('app-generated--example--foo-1', $mkCol);

--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -32,28 +32,38 @@ use OCA\DAV\CalDAV\CalendarManager;
 use OCP\Calendar\IManager;
 use OCP\IConfig;
 use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class CalendarManagerTest extends \Test\TestCase {
 
-	/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var CalDavBackend | MockObject */
 	private $backend;
 
-	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IL10N | MockObject */
 	private $l10n;
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
 	/** @var CalendarManager */
 	private $manager;
+
+	/** @var MockObject|LoggerInterface */
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->backend = $this->createMock(CalDavBackend::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->manager = new CalendarManager($this->backend,
-			$this->l10n, $this->config);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->manager = new CalendarManager(
+			$this->backend,
+			$this->l10n,
+			$this->config,
+			$this->logger
+		);
 	}
 
 	public function testSetupCalendarProvider() {
@@ -65,7 +75,7 @@ class CalendarManagerTest extends \Test\TestCase {
 				['id' => 456, 'uri' => 'blablub2'],
 			]);
 
-		/** @var IManager | \PHPUnit\Framework\MockObject\MockObject $calendarManager */
+		/** @var IManager | MockObject $calendarManager */
 		$calendarManager = $this->createMock(Manager::class);
 		$calendarManager->expects($this->at(0))
 			->method('registerCalendar')

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -33,6 +33,8 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
 use OCP\IConfig;
 use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Sabre\DAV\PropPatch;
 use Sabre\VObject\Reader;
 use Test\TestCase;
@@ -45,11 +47,15 @@ class CalendarTest extends TestCase {
 	/** @var IConfig */
 	protected $config;
 
+	/** @var MockObject|LoggerInterface  */
+	protected $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->l10n
 			->expects($this->any())
 			->method('t')
@@ -59,7 +65,7 @@ class CalendarTest extends TestCase {
 	}
 
 	public function testDelete() {
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -71,7 +77,7 @@ class CalendarTest extends TestCase {
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$c->delete();
 	}
 
@@ -79,7 +85,7 @@ class CalendarTest extends TestCase {
 	public function testDeleteFromGroup() {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->never())->method('updateShares');
 		$backend->expects($this->any())->method('getShares')->willReturn([
@@ -91,12 +97,12 @@ class CalendarTest extends TestCase {
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$c->delete();
 	}
 
 	public function testDeleteOwn() {
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->createMock(CalDavBackend::class);
 		$backend->expects($this->never())->method('updateShares');
 		$backend->expects($this->never())->method('getShares');
@@ -112,12 +118,12 @@ class CalendarTest extends TestCase {
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$c->delete();
 	}
 
 	public function testDeleteBirthdayCalendar() {
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->createMock(CalDavBackend::class);
 		$backend->expects($this->once())->method('deleteCalendar')
 			->with(666);
@@ -133,7 +139,7 @@ class CalendarTest extends TestCase {
 			'uri' => 'contact_birthdays',
 		];
 
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$c->delete();
 	}
 
@@ -168,7 +174,7 @@ class CalendarTest extends TestCase {
 	 * @dataProvider dataPropPatch
 	 */
 	public function testPropPatch($ownerPrincipal, $principalUri, $mutations, $shared) {
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => $ownerPrincipal,
@@ -176,7 +182,7 @@ class CalendarTest extends TestCase {
 			'id' => 666,
 			'uri' => 'default'
 		];
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$propPatch = new PropPatch($mutations);
 
 		if (!$shared) {
@@ -192,7 +198,7 @@ class CalendarTest extends TestCase {
 	 * @dataProvider providesReadOnlyInfo
 	 */
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default') {
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
 		$calendarInfo = [
@@ -206,7 +212,7 @@ class CalendarTest extends TestCase {
 		if ($hasOwnerSet) {
 			$calendarInfo['{http://owncloud.org/ns}owner-principal'] = 'user1';
 		}
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$acl = $c->getACL();
 		$childAcl = $c->getChildACL();
 
@@ -299,7 +305,7 @@ class CalendarTest extends TestCase {
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2
@@ -322,7 +328,7 @@ class CalendarTest extends TestCase {
 		if ($isShared) {
 			$calendarInfo['{http://owncloud.org/ns}owner-principal'] = 'user1';
 		}
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 		$children = $c->getChildren();
 		$this->assertEquals($expectedChildren, count($children));
 		$children = $c->getMultipleChildren(['event-0', 'event-1', 'event-2']);
@@ -386,7 +392,7 @@ EOD;
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL, 'calendardata' => $calData];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2
@@ -406,7 +412,7 @@ EOD;
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
 
 		$this->assertEquals(count($c->getChildren()), $expectedChildren);
 
@@ -439,7 +445,7 @@ EOD;
 			$l10n->expects($this->never())
 				->method('t');
 		}
-		$c = new Calendar($backend, $calendarInfo, $l10n, $this->config);
+		$c = new Calendar($backend, $calendarInfo, $l10n, $this->config, $this->logger);
 
 		$calData = $c->getChild('event-1')->get();
 		$event = Reader::read($calData);
@@ -554,7 +560,7 @@ EOD;
 			'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL,
 			'calendardata' => $confidentialObjectData];
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->createMock(CalDavBackend::class);
 		$backend->expects($this->any())
 			->method('getCalendarObjects')
@@ -604,13 +610,13 @@ EOD;
 			'uri' => 'cal',
 		];
 
-		$ownerCalendar = new Calendar($backend, $calendarInfoOwner, $this->l10n, $this->config);
-		$rwCalendar = new Calendar($backend, $calendarInfoSharedRW, $this->l10n, $this->config);
-		$roCalendar = new Calendar($backend, $calendarInfoSharedRO, $this->l10n, $this->config);
+		$ownerCalendar = new Calendar($backend, $calendarInfoOwner, $this->l10n, $this->config, $this->logger);
+		$rwCalendar = new Calendar($backend, $calendarInfoSharedRW, $this->l10n, $this->config, $this->logger);
+		$roCalendar = new Calendar($backend, $calendarInfoSharedRO, $this->l10n, $this->config, $this->logger);
 
-		$this->assertEquals(count($ownerCalendar->getChildren()), 2);
-		$this->assertEquals(count($rwCalendar->getChildren()), 2);
-		$this->assertEquals(count($roCalendar->getChildren()), 2);
+		$this->assertCount(2, $ownerCalendar->getChildren());
+		$this->assertCount(2, $rwCalendar->getChildren());
+		$this->assertCount(2, $roCalendar->getChildren());
 
 		// calendar data shall not be altered for the owner
 		$this->assertEquals($ownerCalendar->getChild('event-0')->get(), $publicObjectData);

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -42,6 +42,7 @@ use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
@@ -83,6 +84,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->random = \OC::$server->getSecureRandom();
 		$this->logger = $this->createMock(ILogger::class);
+		$this->psrLogger = $this->createMock(LoggerInterface::class);
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 		$legacyDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$config = $this->createMock(IConfig::class);
@@ -111,7 +113,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 
 		$this->publicCalendarRoot = new PublicCalendarRoot($this->backend,
-			$this->l10n, $this->config);
+			$this->l10n, $this->config, $this->psrLogger);
 	}
 
 	protected function tearDown(): void {
@@ -165,11 +167,11 @@ class PublicCalendarRootTest extends TestCase {
 		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
 
 		$calendarInfo = $this->backend->getCalendarsForUser(self::UNIT_TEST_USER)[0];
-		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config);
+		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->psrLogger);
 		$publicUri = $calendar->setPublishStatus(true);
 
 		$calendarInfo = $this->backend->getPublicCalendar($publicUri);
-		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config);
+		$calendar = new PublicCalendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->psrLogger);
 
 		return $calendar;
 	}

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -28,6 +28,8 @@ namespace OCA\DAV\Tests\unit\CalDAV;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\PublicCalendar;
 use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Sabre\VObject\Reader;
 
 class PublicCalendarTest extends CalendarTest {
@@ -42,7 +44,7 @@ class PublicCalendarTest extends CalendarTest {
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2
@@ -62,10 +64,11 @@ class PublicCalendarTest extends CalendarTest {
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		/** @var \PHPUnit\Framework\MockObject\MockObject | IConfig $config */
+		/** @var MockObject | IConfig $config */
 		$config = $this->createMock(IConfig::class);
-
-		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n, $config);
+		/** @var  MockObject | LoggerInterface $logger */
+		$logger = $this->createMock(LoggerInterface::class);
+		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n, $config,$logger);
 		$children = $c->getChildren();
 		$this->assertEquals(2, count($children));
 		$children = $c->getMultipleChildren(['event-0', 'event-1', 'event-2']);
@@ -129,7 +132,7 @@ EOD;
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL, 'calendardata' => $calData];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject | CalDavBackend $backend */
+		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('getCalendarObjects')->willReturn([
 			$calObject0, $calObject1, $calObject2
@@ -149,9 +152,11 @@ EOD;
 			'id' => 666,
 			'uri' => 'cal',
 		];
-		/** @var \PHPUnit\Framework\MockObject\MockObject | IConfig $config */
+		/** @var MockObject | IConfig $config */
 		$config = $this->createMock(IConfig::class);
-		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n, $config);
+		/** @var  MockObject | LoggerInterface $logger */
+		$logger = $this->createMock(LoggerInterface::class);
+		$c = new PublicCalendar($backend, $calendarInfo, $this->l10n, $config,$logger);
 
 		$this->assertEquals(count($c->getChildren()), 2);
 

--- a/apps/dav/tests/unit/Command/DeleteCalendarTest.php
+++ b/apps/dav/tests/unit/Command/DeleteCalendarTest.php
@@ -31,6 +31,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -57,6 +58,9 @@ class DeleteCalendarTest extends TestCase {
 
 	/** @var DeleteCalendar */
 	private $command;
+	
+	/** @var MockObject|LoggerInterface */
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -65,12 +69,14 @@ class DeleteCalendarTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->command = new DeleteCalendar(
 			$this->calDav,
 			$this->config,
 			$this->l10n,
 			$this->userManager,
+			$this->logger
 		);
 	}
 

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -34,6 +34,8 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -44,26 +46,29 @@ use Test\TestCase;
  */
 class MoveCalendarTest extends TestCase {
 
-	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject $userManager */
+	/** @var \OCP\IUserManager|MockObject $userManager */
 	private $userManager;
 
-	/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject $groupManager */
+	/** @var \OCP\IGroupManager|MockObject $groupManager */
 	private $groupManager;
 
-	/** @var \OCP\Share\IManager|\PHPUnit\Framework\MockObject\MockObject $shareManager */
+	/** @var \OCP\Share\IManager|MockObject $shareManager */
 	private $shareManager;
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject $l10n */
+	/** @var IConfig|MockObject $l10n */
 	private $config;
 
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject $l10n */
+	/** @var IL10N|MockObject $l10n */
 	private $l10n;
 
-	/** @var CalDavBackend|\PHPUnit\Framework\MockObject\MockObject $l10n */
+	/** @var CalDavBackend|MockObject $l10n */
 	private $calDav;
 
 	/** @var MoveCalendar */
 	private $command;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -74,6 +79,7 @@ class MoveCalendarTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->calDav = $this->createMock(CalDavBackend::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->command = new MoveCalendar(
 			$this->userManager,
@@ -81,7 +87,8 @@ class MoveCalendarTest extends TestCase {
 			$this->shareManager,
 			$this->config,
 			$this->l10n,
-			$this->calDav
+			$this->calDav,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
When moving a calendar object from calendar A to calendar B, move the object instead of copying it to the new calendar and deleting the old object.

Fixes nextcloud/calendar#3325