### PR TITLE
Explicitly name node build workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -3,7 +3,7 @@
 # https://github.com/nextcloud/.github
 # https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
 
-name: Node
+name: Node Build
 
 on:
   pull_request:
@@ -16,7 +16,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: node
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
As addition to: #30077

This way it can be better identified on GitHub's checks list among the Node test workflows.

Also the jobs dedicated name "node" has been remove, so that it will fallback to the jobs key "build", which fits better here.