### PR TITLE
Revert "Explicitly name node tests workflow"

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,4 +1,4 @@
-name: Node Tests
+name: Node
 
 on:
   pull_request:
@@ -28,7 +28,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: versions
-
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
   handlebars:
     runs-on: ubuntu-latest
     needs: versions
-
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Reverts https://github.com/nextcloud/server/pull/30077

See https://github.com/nextcloud/.github/blob/master/workflow-templates/node.yml

If the change have to be done, please do it for the entire Nextcloud after a discussion.
Not just locally.