### PR TITLE
Do not trigger events when setting active view in gotoplugin

### DIFF
--- a/apps/files/js/gotoplugin.js
+++ b/apps/files/js/gotoplugin.js
@@ -46,7 +46,7 @@
 				actionHandler: function (fileName, context) {
 					var fileModel = context.fileInfoModel;
 					OC.Apps.hideAppSidebar($('.detailsView'));
-					OCA.Files.App.setActiveView('files');
+					OCA.Files.App.setActiveView('files', { silent: true });
 					OCA.Files.App.fileList.changeDirectory(fileModel.get('path'), true, true).then(function() {
 						OCA.Files.App.fileList.scrollTo(fileModel.get('name'));
 					});


### PR DESCRIPTION
When using "View in folder" file action (in favorite view for example), the current view is set back to "All files" and the current directory is changed. This produces 2 simultaneous WebDav request to get the file list for (1) the root directory and (2) the actual target directory.

If (1) is the last WebDav request to finish, we end up displaying the root directory content instead of the target dir.

Thankfully there is a simple way to prevent event emission when setting the active view. This way we really make sure the target dir content will be displayed.