### PR TITLE
Reload page instead of file list when getting 401 authentification error

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2232,11 +2232,9 @@
 			this.hideMask();
 
 			if (status === 401) {
-				if (this.getCurrentDirectory() === '/') {
-					// Give up, if we are not authorized to access user root folder, we are logged out
-					location.reload(); // this will redirect the user to the login page while saving the current url
-				}
-				return false;
+				// We are not authentificated, so reload the page so that we get
+				// redirected to the login page while saving the current url.
+				location.reload(); 
 			}
 
 			// Firewall Blocked request?

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2232,6 +2232,10 @@
 			this.hideMask();
 
 			if (status === 401) {
+				if (this.getCurrentDirectory() === '/') {
+					// Give up, if we are not authorized to access user root folder, we are logged out
+					location.reload(); // this will redirect the user to the login page while saving the current url
+				}
 				return false;
 			}
 


### PR DESCRIPTION
When getting a 401 error, instead of reloading the file list and hopping we are now
authenticated, we reload the page completely. This triggers a redirection to the login
page automatically with the correct ?redirect_url= in the URL, so that once logged the
user goes back to the place they were previously.

## Test plan

1. Open file webui in two tabs
2. Logout in one of the two tabs
3. In the other tabs, try to open an folder

Signed-off-by: Carl Schwan <carl@carlschwan.eu>