### PR TITLE
Don't use LIKE query when we have the full uid

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -90,7 +90,7 @@ class CloudIdManager implements ICloudIdManager {
 	}
 
 	protected function getDisplayNameFromContact(string $cloudId): ?string {
-		$addressBookEntries = $this->contactsManager->search($cloudId, ['CLOUD']);
+		$addressBookEntries = $this->contactsManager->search($cloudId, ['CLOUD'], ["strict_search" => true]);
 		foreach ($addressBookEntries as $entry) {
 			if (isset($entry['CLOUD'])) {
 				foreach ($entry['CLOUD'] as $cloudID) {


### PR DESCRIPTION
## Rational

[`CloudIdManager::getDisplayNameFromContact`](https://github.com/nextcloud/server/blob/7179002600ccde6d6757c068c9388430ed71a2f1/lib/private/Federation/CloudIdManager.php#L92) specifically [checks for a strictly matching `cloudId`](https://github.com/nextcloud/server/blob/7179002600ccde6d6757c068c9388430ed71a2f1/lib/private/Federation/CloudIdManager.php#L97) in the results, so a LIKE query is superfluous.

This PR adds an option to use an equivalence query `=` in [`CardDavBackend::searchByAddressBookIds`](https://github.com/nextcloud/server/blob/7179002600ccde6d6757c068c9388430ed71a2f1/apps/dav/lib/CardDAV/CardDavBackend.php#L1060) to improve matching speed. `CloudIdManager::getDisplayNameFromContact` now uses this option.

Follow up of https://github.com/nextcloud/server/pull/27884