### PR TITLE
Check resource before closing in encryption wrapper

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -784,8 +784,12 @@ class Encryption extends Wrapper {
 				fclose($source);
 				fclose($target);
 			} catch (\Exception $e) {
-				fclose($source);
-				fclose($target);
+				if (is_resource($source)) {
+					fclose($source);
+				}
+				if (is_resource($target)) {
+					fclose($target);
+				}
 				throw $e;
 			}
 			if ($result) {


### PR DESCRIPTION
In case of error there is no guarantee that $source or $target is set or
is a resource when handling an error.

Without this fix, there's a risk that fclose will fail and the actual
exception will not be thrown, making it impossible to find out about the
root cause.
