### PR TITLE
Use correct icon for dir-external-root

### DIFF
--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -50,7 +50,7 @@ OC.MimeType = {
 			return 'folder-shared';
 		} else if (mimeType === 'dir-public' && $.inArray('folder-public', files) !== -1) {
 			return 'folder-public';
-		} else if (mimeType === 'dir-external' && $.inArray('folder-external', files) !== -1) {
+		} else if ((mimeType === 'dir-external' || mimeType === 'dir-external-root') && $.inArray('folder-external', files) !== -1) {
 			return 'folder-external';
 		} else if ($.inArray(icon, files) !== -1) {
 			return icon;


### PR DESCRIPTION
When an external storage mount is shared with circles, it triggers the
share icon state to be rerendered. The picking of the mime type icon
would use the regular file icon because there is no actual icon for
"dir-external-root" that is shared.

This fixes the logic to use the "folder-external" icon in such
scenarios.

Note: the actual bug only seems to appear on stable21 because of another bug that prevents the share status to be displayed on the row (to be raised separately)