### PR TITLE
Fix setting up 2FA when no providers are set up but backup codes

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -109,7 +109,7 @@ class TwoFactorMiddleware extends Middleware {
 			&& $this->twoFactorManager->needsSecondFactor($this->userSession->getUser())) {
 			$providers = $this->twoFactorManager->getProviderSet($this->userSession->getUser());
 
-			if ($providers->getProviders() === [] && !$providers->isProviderMissing()) {
+			if ($providers->getPrimaryProviders() === [] && !$providers->isProviderMissing()) {
 				return;
 			}
 		}


### PR DESCRIPTION
2FA set up is allowed when only backup codes are set up but no other
provider and no provider is failing.

This patch syncs up the login controller check with the challenge
controller check 10 lines above.

Fixes https://github.com/nextcloud/twofactor_totp/issues/1160

Side effect/regression of https://github.com/nextcloud/server/pull/28078