### PR TITLE
Always store and compare the email address as lower case

### DIFF
--- a/core/Migrations/Version24000Date20211210141942.php
+++ b/core/Migrations/Version24000Date20211210141942.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Email addresses are case insensitive
+ * But previously a user could enter any casing of the email address
+ * and we would in case of a login lower case the input and the database value.
+ *
+ */
+class Version24000Date20211210141942 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$update = $this->connection->getQueryBuilder();
+
+		$update->update('preferences')
+			->set('configvalue', $update->func()->lower('configvalue'))
+			->where($update->expr()->eq('appid', $update->createNamedParameter('core')))
+			->andWhere($update->expr()->eq('configkey', $update->createNamedParameter('email')));
+
+		$update->executeStatement();
+	}
+}

--- a/core/Migrations/Version24000Date20211210141942.php
+++ b/core/Migrations/Version24000Date20211210141942.php
@@ -55,7 +55,7 @@ class Version24000Date20211210141942 extends SimpleMigrationStep {
 
 		$update->update('preferences')
 			->set('configvalue', $update->func()->lower('configvalue'))
-			->where($update->expr()->eq('appid', $update->createNamedParameter('core')))
+			->where($update->expr()->eq('appid', $update->createNamedParameter('settings')))
 			->andWhere($update->expr()->eq('configkey', $update->createNamedParameter('email')));
 
 		$update->executeStatement();

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -988,6 +988,7 @@ return array(
     'OC\\Core\\Migrations\\Version23000Date20210906132259' => $baseDir . '/core/Migrations/Version23000Date20210906132259.php',
     'OC\\Core\\Migrations\\Version23000Date20210930122352' => $baseDir . '/core/Migrations/Version23000Date20210930122352.php',
     'OC\\Core\\Migrations\\Version23000Date20211203110726' => $baseDir . '/core/Migrations/Version23000Date20211203110726.php',
+    'OC\\Core\\Migrations\\Version24000Date20211210141942' => $baseDir . '/core/Migrations/Version24000Date20211210141942.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1017,6 +1017,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version23000Date20210906132259' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20210906132259.php',
         'OC\\Core\\Migrations\\Version23000Date20210930122352' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20210930122352.php',
         'OC\\Core\\Migrations\\Version23000Date20211203110726' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20211203110726.php',
+        'OC\\Core\\Migrations\\Version24000Date20211210141942' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211210141942.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -261,7 +261,7 @@ class AllConfig implements \OCP\IConfig {
 		$this->fixDIInit();
 
 		if ($appName === 'core' && $key === 'email') {
-			$value = strtolower($value);
+			$value = strtolower((string) $value);
 		}
 
 		$prevValue = $this->getUserValue($userId, $appName, $key, null);

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -260,7 +260,7 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
-		if ($appName === 'core' && $key === 'email') {
+		if ($appName === 'settings' && $key === 'email') {
 			$value = strtolower((string) $value);
 		}
 
@@ -518,7 +518,7 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
-		if ($appName === 'core' && $key === 'email') {
+		if ($appName === 'settings' && $key === 'email') {
 			// Email address is always stored lowercase in the database
 			return $this->getUsersForUserValue($appName, $key, strtolower($value));
 		}

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -260,6 +260,10 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
+		if ($appName === 'core' && $key === 'email') {
+			$value = strtolower($value);
+		}
+
 		$prevValue = $this->getUserValue($userId, $appName, $key, null);
 
 		if ($prevValue !== null) {
@@ -514,17 +518,22 @@ class AllConfig implements \OCP\IConfig {
 		// TODO - FIXME
 		$this->fixDIInit();
 
+		if ($appName === 'core' && $key === 'email') {
+			// Email address is always stored lowercase in the database
+			return $this->getUsersForUserValue($appName, $key, strtolower($value));
+		}
+
 		$sql = 'SELECT `userid` FROM `*PREFIX*preferences` ' .
 			'WHERE `appid` = ? AND `configkey` = ? ';
 
 		if ($this->getSystemValue('dbtype', 'sqlite') === 'oci') {
 			//oracle hack: need to explicitly cast CLOB to CHAR for comparison
-			$sql .= 'AND LOWER(to_char(`configvalue`)) = LOWER(?)';
+			$sql .= 'AND LOWER(to_char(`configvalue`)) = ?';
 		} else {
-			$sql .= 'AND LOWER(`configvalue`) = LOWER(?)';
+			$sql .= 'AND LOWER(`configvalue`) = ?';
 		}
 
-		$result = $this->connection->executeQuery($sql, [$appName, $key, $value]);
+		$result = $this->connection->executeQuery($sql, [$appName, $key, strtolower($value)]);
 
 		$userIDs = [];
 		while ($row = $result->fetch()) {

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [24, 0, 0, 1];
+$OC_Version = [24, 0, 0, 2];
 
 // The human readable string
 $OC_VersionString = '24.0.0 dev';


### PR DESCRIPTION
1. Needs a database query executed on updating:
    ```sql
    UPDATE `oc_preferences` SET `configvalue` = LOWER(`configvalue`) WHERE `appid` = 'settings' AND `configkey` = 'email';
    ```
2. Before merging into master, are the details stored somewhere else ❓ 
3. Add a partial index for the first ~80 characters ❓ 
4. Bump version number to trigger the migration
