### PR TITLE
Add Groupware back-end devs as CalDAV and CardDAV code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 */Activity/*                        @nickvergessen
 */Notifications/*                   @nickvergessen
+/apps/dav/lib/CalDAV                @ChristophWurst @miaulalala @tcitworld
+/apps/dav/lib/CardDAV               @ChristophWurst @miaulalala @tcitworld


### PR DESCRIPTION
> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

Ref https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners