### PR TITLE
Deprecate entity slugs

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -260,6 +260,7 @@ abstract class Entity {
 	 * @param string $attributeName the name of the attribute, which value should be slugified
 	 * @return string slugified value
 	 * @since 7.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function slugify($attributeName) {
 		// toSlug should only work for existing attributes


### PR DESCRIPTION
They are only used a single time in the whole Nextcloud Github
organization. We can inline the code there and slim down the public API.

https://github.com/nextcloud/bookmarks/blob/c98fe204b0e99e75285918eb996c99393118efce/lib/Service/CrawlService.php#L140 is the one and only usage. @marcelklehr you have three years until this will be removed :)