### PR TITLE
Add version of disabled apps when available

### DIFF
--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -87,12 +87,12 @@ class ListApps extends Base {
 
 		sort($enabledApps);
 		foreach ($enabledApps as $app) {
-			$apps['enabled'][$app] = isset($versions[$app]) ? $versions[$app] : true;
+			$apps['enabled'][$app] = $versions[$app] ?? true;
 		}
 
 		sort($disabledApps);
 		foreach ($disabledApps as $app) {
-			$apps['disabled'][$app] = null;
+			$apps['disabled'][$app] = $versions[$app] ?? null;
 		}
 
 		$this->writeAppList($input, $output, $apps);


### PR DESCRIPTION
### Before
Enabled:
…
  - workflowengine: 2.6.0
Disabled:
…
  - federation

### After
Enabled:
…
  - workflowengine: 2.6.0
Disabled:
…
  - federation: 1.14.0


Can help in some cases if you know which version of an app is laying there disabled