### PR TITLE
Add oauth2_clients migration for Owncloud

### DIFF
--- a/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
+++ b/apps/oauth2/lib/Migration/Version010402Date20190107124745.php
@@ -42,9 +42,12 @@ class Version010402Date20190107124745 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->getTable('oauth2_clients');
-		$table->dropIndex('oauth2_client_id_idx');
-		$table->addUniqueIndex(['client_identifier'], 'oauth2_client_id_idx');
-		return $schema;
+		// During an ownCloud migration, the client_identifier column identifier might not exist yet.
+		if ($schema->getTable('oauth2_clients')->hasColumn('client_identifier')) {
+			$table = $schema->getTable('oauth2_clients');
+			$table->dropIndex('oauth2_client_id_idx');
+			$table->addUniqueIndex(['client_identifier'], 'oauth2_client_id_idx');
+			return $schema;
+		}
 	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1381,6 +1381,7 @@ return array(
     'OC\\Repair\\Owncloud\\CleanPreviewsBackgroundJob' => $baseDir . '/lib/private/Repair/Owncloud/CleanPreviewsBackgroundJob.php',
     'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
     'OC\\Repair\\Owncloud\\InstallCoreBundle' => $baseDir . '/lib/private/Repair/Owncloud/InstallCoreBundle.php',
+    'OC\\Repair\\Owncloud\\MigrateOauthTables' => $baseDir . '/lib/private/Repair/Owncloud/MigrateOauthTables.php',
     'OC\\Repair\\Owncloud\\MoveAvatars' => $baseDir . '/lib/private/Repair/Owncloud/MoveAvatars.php',
     'OC\\Repair\\Owncloud\\MoveAvatarsBackgroundJob' => $baseDir . '/lib/private/Repair/Owncloud/MoveAvatarsBackgroundJob.php',
     'OC\\Repair\\Owncloud\\SaveAccountsTableData' => $baseDir . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -7,7 +7,7 @@ namespace Composer\Autoload;
 class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OC\\Core\\' => 8,
             'OC\\' => 3,
@@ -16,15 +16,15 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
     );
 
     public static $prefixDirsPsr4 = array (
-        'OC\\Core\\' => 
+        'OC\\Core\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/core',
         ),
-        'OC\\' => 
+        'OC\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/private',
         ),
-        'OCP\\' => 
+        'OCP\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/public',
         ),
@@ -1410,6 +1410,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Repair\\Owncloud\\CleanPreviewsBackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/CleanPreviewsBackgroundJob.php',
         'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
         'OC\\Repair\\Owncloud\\InstallCoreBundle' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/InstallCoreBundle.php',
+        'OC\\Repair\\Owncloud\\MigrateOauthTables' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MigrateOauthTables.php',
         'OC\\Repair\\Owncloud\\MoveAvatars' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MoveAvatars.php',
         'OC\\Repair\\Owncloud\\MoveAvatarsBackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MoveAvatarsBackgroundJob.php',
         'OC\\Repair\\Owncloud\\SaveAccountsTableData' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -47,6 +47,7 @@ use OC\Repair\Collation;
 use OC\Repair\MoveUpdaterStepFile;
 use OC\Repair\NC22\LookupServerSendCheck;
 use OC\Repair\Owncloud\CleanPreviews;
+use OC\Repair\Owncloud\MigrateOauthTables;
 use OC\Repair\NC11\FixMountStorages;
 use OC\Repair\Owncloud\MoveAvatars;
 use OC\Repair\Owncloud\InstallCoreBundle;
@@ -185,6 +186,7 @@ class Repair implements IOutput {
 				\OC::$server->getUserManager(),
 				\OC::$server->getConfig()
 			),
+			new MigrateOauthTables(\OC::$server->get(Connection::class)),
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
 			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new InstallCoreBundle(

--- a/lib/private/Repair/Owncloud/MigrateOauthTables.php
+++ b/lib/private/Repair/Owncloud/MigrateOauthTables.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright 2021 Louis Chemineau <louis@chmn.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Repair\Owncloud;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OC\DB\Connection;
+use OC\DB\SchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class MigrateOauthTables implements IRepairStep {
+
+	/** @var Connection */
+	protected $db;
+
+	/**
+	 * @param Connection $db
+	 */
+	public function __construct(Connection $db) {
+		$this->db = $db;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return 'Migrate oauth2_clients table to nextcloud schema';
+	}
+
+	public function run(IOutput $output) {
+		$schema = new SchemaWrapper($this->db);
+		if (!$schema->hasTable('oauth2_clients')) {
+			$output->info("oauth2_clients table does not exist.");
+			return;
+		}
+
+		$output->info("Update the oauth2_access_tokens table schema.");
+		$schema = new SchemaWrapper($this->db);
+		$table = $schema->getTable('oauth2_access_tokens');
+		$table->addColumn('hashed_code', 'string', [
+			'notnull' => true,
+			'length' => 128,
+		]);
+		$table->addColumn('encrypted_token', 'string', [
+			'notnull' => true,
+			'length' => 786,
+		]);
+		$table->addUniqueIndex(['hashed_code'], 'oauth2_access_hash_idx');
+		$table->addIndex(['client_id'], 'oauth2_access_client_id_idx');
+
+
+		$output->info("Update the oauth2_clients table schema.");
+		$schema = new SchemaWrapper($this->db);
+		$table = $schema->getTable('oauth2_clients');
+		$table->getColumn('name')->setLength(64);
+		$table->dropColumn('allow_subdomains');
+
+		if (!$schema->getTable('oauth2_clients')->hasColumn('client_identifier')) {
+			$table->addColumn('client_identifier', 'string', [
+				'notnull' => true,
+				'length' => 64,
+				'default' => ''
+			]);
+			$table->addIndex(['client_identifier'], 'oauth2_client_id_idx');
+		}
+
+		$this->db->migrateToSchema($schema->getWrappedSchema());
+
+
+		if ($schema->getTable('oauth2_clients')->hasColumn('identifier')) {
+			$output->info("Move identifier column's data to the new client_identifier column.");
+			// 1. Fetch all [id, identifier] couple.
+			$selectQuery = $this->db->getQueryBuilder();
+			$selectQuery->select('id', 'identifier')->from('oauth2_clients');
+			$result = $selectQuery->executeQuery();
+			$identifiers = $result->fetchAll();
+			$result->closeCursor();
+
+			// 2. Insert them into the client_identifier column.
+			foreach ($identifiers as ["id" => $id, "identifier" => $clientIdentifier]) {
+				$insertQuery = $this->db->getQueryBuilder();
+				$insertQuery->update('oauth2_clients')
+					->set('client_identifier', $insertQuery->createNamedParameter($clientIdentifier, IQueryBuilder::PARAM_STR))
+					->where($insertQuery->expr()->eq('id', $insertQuery->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
+					->executeStatement();
+			}
+
+			$output->info("Drop the identifier column.");
+			$schema = new SchemaWrapper($this->db);
+			$table = $schema->getTable('oauth2_clients');
+			$table->dropColumn('identifier');
+			$this->db->migrateToSchema($schema->getWrappedSchema());
+		}
+	}
+}


### PR DESCRIPTION
Handy script to test the migration. Use it from a nextcloud root directory containing the migration.

```shell
#!/bin/bash

set -eu

# Serving ownCloud then Nextcloud at localhost:8080
# Username: admin
# Password: admin

docker kill oc || true
docker rm oc || true

docker run \
	--rm \
	--name oc \
	--detach \
	--env OWNCLOUD_DOMAIN=localhost:8080 \
	--publish 8080:8080 \
	--volume /var/www/owncloud \
	--volume "$PWD":/mnt/local \
	owncloud/server:10.5

docker exec -it oc apt update
docker exec -it oc apt install -y nano rsync

docker exec -it oc sed -i '9,14d' /var/www/owncloud/config/config.php
docker exec -it oc occ app:enable oauth2
docker exec -it oc occ market:install calendar
docker exec -it oc occ app:enable configreport
docker exec -it oc cp /var/www/owncloud/config/config.php /var/www/config.php

instance=""
read -rp "> Double press enter to start the migration." instance

docker exec -it oc rsync --delete --recursive --human-readable --exclude .git --exclude node_modules /mnt/local/ /var/www/owncloud
docker exec -it oc cp /var/www/config.php /var/www/owncloud/config/config.php
docker exec -it oc chown -R www-data:www-data /var/www/owncloud

docker exec -it oc occ upgrade -vvv || true

occ db:convert-filecache-bigint
occ db:add-missing-columns
occ db:add-missing-indices
occ db:add-missing-primary-keys

# Use this command to copy your change in MigrateOauthTables.php to the docker container.
# docker exec -it oc cp /mnt/local/lib/private/Repair/Owncloud/MigrateOauthTables.php /var/www/owncloud/lib/private/Repair/Owncloud/MigrateOauthTables.php
```