### PR TITLE
Ignore non-existing groups when notifying group shares

### DIFF
--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -192,7 +192,7 @@ class Notifier implements INotifier {
 				}
 
 				$group = $this->groupManager->get($share->getSharedWith());
-				if (!$group->inGroup($user)) {
+				if ($group === null || !$group->inGroup($user)) {
 					throw new AlreadyProcessedException();
 				}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/30280

Group shares might exist even after a group got deleted.
To prevent log pollution when fetching notifications, this fix catches
the non-existing group situation and throws a different exception that
gets ignored. Without this, the log will contain an error about calling
inGroup on null.

The solution uses the same approach (InvalidArgumentException) that exists already in the code for the case where the user is null.

But this doesn't solve the mystery why deleting a group doesn't delete the share... there might be a cron job that does so at some point but I'm not sure