### PR TITLE
Specify code owners for 2FA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,9 @@
 */Notifications/*                   @nickvergessen
 /apps/dav/lib/CalDAV                @ChristophWurst @miaulalala @tcitworld
 /apps/dav/lib/CardDAV               @ChristophWurst @miaulalala @tcitworld
+
+# Two-Factor Authentication
+# https://github.com/nextcloud/wg-two-factor-authentication#members
+/apps/twofactor_backupcodes        @ChristophWurst @miaulalala @nickvergessen
+*/TwoFactorAuth/*                  @ChristophWurst @miaulalala @nickvergessen
+/core/templates/twofactor*         @ChristophWurst @miaulalala @nickvergessen


### PR DESCRIPTION
This will ping us for review automagically.

Ref https://github.com/nextcloud/wg-two-factor-authentication#members
Ref https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners