### PR TITLE
fix translation source in directEditing templates

### DIFF
--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -82,7 +82,7 @@ class Manager implements IManager {
 		$this->connection = $connection;
 		$this->userId = $userSession->getUser() ? $userSession->getUser()->getUID() : null;
 		$this->rootFolder = $rootFolder;
-		$this->l10n = $l10nFactory->get('core');
+		$this->l10n = $l10nFactory->get('lib');
 		$this->encryptionManager = $encryptionManager;
 	}
 


### PR DESCRIPTION
The 'Empty file' string is translated in `lib` - not in `core`.

Signed-off-by: Azul <azul@riseup.net>