### PR TITLE
Draft: Don't reset password if it is against policy

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -130,7 +130,7 @@
 			menu-align="right"
 			:open.sync="open"
 			@close="onMenuClose">
-			<template v-if="share">
+			<template v-if="share && share.id">
 				<template v-if="share.canEdit && canReshare">
 					<!-- Custom Label -->
 					<ActionInput
@@ -685,8 +685,8 @@ export default {
 				if (this.share && !this.share.id) {
 					// if the share is valid, create it on the server
 					if (this.checkShare(this.share)) {
-						await this.pushNewLinkShare(this.share, true)
-						return true
+						 await this.pushNewLinkShare(this.share, true)
+						 return true
 					} else {
 						this.open = true
 						OC.Notification.showTemporary(t('files_sharing', 'Error, please enter proper password and/or expiration date'))
@@ -779,14 +779,19 @@ export default {
 				}
 
 			} catch ({ response }) {
-				const message = response.data.ocs.meta.message
-				if (message.match(/password/i)) {
-					this.onSyncError('password', message)
-				} else if (message.match(/date/i)) {
-					this.onSyncError('expireDate', message)
-				} else {
-					this.onSyncError('pending', message)
+				const message = response?.data?.ocs?.meta?.message
+				if (message) {
+					if (message.match(/password/i)) { // TODO that doesn't work with other locales!!!
+						this.onSyncError('password', message)
+					} else if (message.match(/date/i)) {
+						this.onSyncError('expireDate', message)
+					} else {
+						this.onSyncError('pending', message)
+					}
 				}
+
+				this.pending = false
+				this.open = true
 			} finally {
 				this.loading = false
 			}

--- a/apps/files_sharing/src/mixins/ShareRequests.js
+++ b/apps/files_sharing/src/mixins/ShareRequests.js
@@ -62,11 +62,6 @@ export default {
 				return new Share(request.data.ocs.data)
 			} catch (error) {
 				console.error('Error while creating share', error)
-				const errorMessage = error?.response?.data?.ocs?.meta?.message
-				OC.Notification.showTemporary(
-					errorMessage ? t('files_sharing', 'Error creating the share: {errorMessage}', { errorMessage }) : t('files_sharing', 'Error creating the share'),
-					{ type: 'error' }
-				)
 				throw error
 			}
 		},


### PR DESCRIPTION
Instead, show error message and let the user modify their password.

This code doesn't work perfectly yet and it seems like the tooltip with the error message is often not located in the right position. I'm not sure why and could need help figuring the issue.

Fix https://github.com/nextcloud/server/issues/30318

Signed-off-by: Carl Schwan <carl@carlschwan.eu>