### PR TITLE
fix overlapping in the help settings section

### DIFF
--- a/apps/settings/css/help.css
+++ b/apps/settings/css/help.css
@@ -2,6 +2,10 @@
 	overflow: hidden !important;
 }
 
+.help-list__text {
+	margin-left: 24px;
+}
+
 .help-iframe {
 	width: 100%;
 	height: 100%;

--- a/apps/settings/templates/help.php
+++ b/apps/settings/templates/help.php
@@ -8,7 +8,9 @@
 	p('active');
 } ?>"
 				href="<?php print_unescaped($_['urlUserDocs']); ?>">
-				<?php p($l->t('User documentation')); ?>
+				<span class="help-list__text">
+					<?php p($l->t('User documentation')); ?>
+				</span>
 			</a>
 		</li>
 	<?php if ($_['admin']) { ?>
@@ -17,19 +19,25 @@
 	p('active');
 } ?>"
 				href="<?php print_unescaped($_['urlAdminDocs']); ?>">
-				<?php p($l->t('Administrator documentation')); ?>
+				<span class="help-list__text">
+					<?php p($l->t('Administrator documentation')); ?>
+				</span>
 			</a>
 		</li>
 	<?php } ?>
 
 		<li>
 			<a href="https://docs.nextcloud.com" class="icon-category-office" target="_blank" rel="noreferrer noopener">
-				<?php p($l->t('Documentation')); ?> ↗
+				<span class="help-list__text">
+					<?php p($l->t('Documentation')); ?> ↗
+				</span>
 			</a>
 		</li>
 		<li>
 			<a href="https://help.nextcloud.com" class="icon-comment" target="_blank" rel="noreferrer noopener">
-				<?php p($l->t('Forum')); ?> ↗
+				<span class="help-list__text">
+					<?php p($l->t('Forum')); ?> ↗
+				</span>
 			</a>
 		</li>
 </div>


### PR DESCRIPTION
This is best reviewed like this https://github.com/nextcloud/server/pull/30322/files?diff=unified&w=1

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/146605277-4f849935-6e3d-4ee7-834e-9d8ab2fc5862.png) |  ![image](https://user-images.githubusercontent.com/42591237/146605133-a066a498-f1b2-4f90-9b43-ccdab74e69d3.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/fix-help-settings-overlapping \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>