### PR TITLE
Handle external share with invalid host

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -44,6 +44,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Http\Client\LocalServerException;
 
 class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage {
 	/** @var ICloudId */
@@ -314,9 +315,16 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage {
 		$token = $this->getToken();
 		$password = $this->getPassword();
 
-		// If remote is not an ownCloud do not try to get any share info
-		if (!$this->remoteIsOwnCloud()) {
-			return ['status' => 'unsupported'];
+		try {
+			// If remote is not an ownCloud do not try to get any share info
+			if (!$this->remoteIsOwnCloud()) {
+				return ['status' => 'unsupported'];
+			}
+		} catch (LocalServerException $e) {
+			// throw this to be on the safe side: the share will still be visible
+			// in the UI in case the failure is intermittent, and the user will
+			// be able to decide whether to remove it if it's really gone
+			throw new StorageNotAvailableException();
 		}
 
 		$url = rtrim($remote, '/') . '/index.php/apps/files_sharing/shareinfo?t=' . $token;


### PR DESCRIPTION
remoteIsOwnCloud might throw an exception when the host is localhost.
Handle this case instead of aborting completely. The behavior is the
same as that is done 10 lines under it

Signed-off-by: Carl Schwan <carl@carlschwan.eu>