### PR TITLE
Reset job disabling timer on adding the job again

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -65,28 +65,34 @@ class JobList implements IJobList {
 	 * @param mixed $argument
 	 */
 	public function add($job, $argument = null) {
+		if ($job instanceof IJob) {
+			$class = get_class($job);
+		} else {
+			$class = $job;
+		}
+
+		$argumentJson = json_encode($argument);
+		if (strlen($argumentJson) > 4000) {
+			throw new \InvalidArgumentException('Background job arguments can\'t exceed 4000 characters (json encoded)');
+		}
+
+		$query = $this->connection->getQueryBuilder();
 		if (!$this->has($job, $argument)) {
-			if ($job instanceof IJob) {
-				$class = get_class($job);
-			} else {
-				$class = $job;
-			}
-
-			$argument = json_encode($argument);
-			if (strlen($argument) > 4000) {
-				throw new \InvalidArgumentException('Background job arguments can\'t exceed 4000 characters (json encoded)');
-			}
-
-			$query = $this->connection->getQueryBuilder();
 			$query->insert('jobs')
 				->values([
 					'class' => $query->createNamedParameter($class),
-					'argument' => $query->createNamedParameter($argument),
+					'argument' => $query->createNamedParameter($argumentJson),
 					'last_run' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 					'last_checked' => $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT),
 				]);
-			$query->execute();
+		} else {
+			$query->update('jobs')
+				->set('reserved_at', $query->expr()->literal(0, IQueryBuilder::PARAM_INT))
+				->set('last_checked', $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
+				->where($query->expr()->eq('class', $query->createNamedParameter($class)))
+				->andWhere($query->expr()->eq('argument', $query->createNamedParameter($argumentJson)));
 		}
+		$query->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
If a job run is triggered while having the app disabled the next execution will be delayed for 12 hours 

https://github.com/nextcloud/server/blob/60c3f15fa40840648d8fbb0192cfbd956ff1fe8a/lib/private/BackgroundJob/JobList.php#L235-L241

This PR ensures that the job is rescheduled immediately if an app gets enabled and the jobs from appinfo.xml get parsed again in https://github.com/nextcloud/server/blob/37f40cdd468a2826f6269bacc81ff74d8c606d23/lib/private/Installer.php#L160

Fixes https://github.com/nextcloud/server/issues/30285