### PR TITLE
Always load scripts from files app second (Fixes: #30278)

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -222,6 +222,14 @@ class Util {
 				return 1;
 			}
 
+			// Always sort files second
+			if ($app1 === 'files') {
+				return -1;
+			}
+			if ($app2 === 'files') {
+				return 1;
+			}
+
 			// If app1 has a dependency
 			if (array_key_exists($app1, self::$scriptDeps)) {
 				$apps = array_keys(self::$scripts);


### PR DESCRIPTION
Apparently the scripts of many apps depend on the files scripts being
initialized first. So let's keep this for now and always load the files
scripts second (after core).