### PR TITLE
Add missing index for propertypath only queries of DAV properties

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -195,6 +195,9 @@ class Application extends App {
 					if (!$table->hasIndex('properties_path_index')) {
 						$subject->addHintForMissingSubject($table->getName(), 'properties_path_index');
 					}
+					if (!$table->hasIndex('properties_pathonly_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'properties_pathonly_index');
+					}
 				}
 
 				if ($schema->hasTable('jobs')) {

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -316,11 +316,24 @@ class AddMissingIndices extends Command {
 		$output->writeln('<info>Check indices of the oc_properties table.</info>');
 		if ($schema->hasTable('properties')) {
 			$table = $schema->getTable('properties');
+			$propertiesUpdated = false;
+
 			if (!$table->hasIndex('properties_path_index')) {
 				$output->writeln('<info>Adding properties_path_index index to the oc_properties table, this can take some time...</info>');
 
 				$table->addIndex(['userid', 'propertypath'], 'properties_path_index');
 				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$propertiesUpdated = true;
+			}
+			if (!$table->hasIndex('properties_pathonly_index')) {
+				$output->writeln('<info>Adding properties_pathonly_index index to the oc_properties table, this can take some time...</info>');
+
+				$table->addIndex(['propertypath'], 'properties_pathonly_index');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$propertiesUpdated = true;
+			}
+
+			if ($propertiesUpdated) {
 				$updated = true;
 				$output->writeln('<info>oc_properties table updated successfully.</info>');
 			}

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -363,6 +363,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['userid'], 'property_index');
 			$table->addIndex(['userid', 'propertypath'], 'properties_path_index');
+			$table->addIndex(['propertypath'], 'properties_pathonly_index');
 		} else {
 			$table = $schema->getTable('properties');
 			if ($table->hasColumn('propertytype')) {


### PR DESCRIPTION
This is a performance regression of https://github.com/nextcloud/server/pull/27426.

All other queries of this class select rows by their `propertypath` *and* `userid`, so the index from https://github.com/nextcloud/server/pull/20716 is used. The new query only selects by `propertypath`, therefore the old index did not apply.

Todo
* [x] Apply the index during the initial migration that creates the table

### How to test

Run ```EXPLAIN SELECT * FROM `oc_properties` WHERE `propertypath` = 'calendars/admin/inbox';``` on mariadb/mysql or the equivalent for any other DB before/after applying the optional index. Before no index used. Afterwards it uses an index.