### PR TITLE
Add group_concat aggregator function

### DIFF
--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -49,6 +49,10 @@ class FunctionBuilder implements IFunctionBuilder {
 		return new QueryFunction('CONCAT(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . ')');
+	}
+
 	public function substring($input, $start, $length = null): IQueryFunction {
 		if ($length) {
 			return new QueryFunction('SUBSTR(' . $this->helper->quoteColumnName($input) . ', ' . $this->helper->quoteColumnName($start) . ', ' . $this->helper->quoteColumnName($length) . ')');

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -54,14 +54,9 @@ class FunctionBuilder implements IFunctionBuilder {
 		return new QueryFunction('CONCAT(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
-	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
-		if (is_null($orderBy)) {
-			$orderByClause = '';
-		} else {
-			$orderByClause = ' ORDER BY ' . $orderBy;
-		}
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
 		$separator = $this->connection->quote($separator);
-		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . $orderByClause . ' SEPARATOR ' . $separator . ')');
+		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . ' SEPARATOR ' . $separator . ')');
 	}
 
 	public function substring($input, $start, $length = null): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -26,23 +26,23 @@ namespace OC\DB\QueryBuilder\FunctionBuilder;
 use OC\DB\QueryBuilder\QueryFunction;
 use OC\DB\QueryBuilder\QuoteHelper;
 use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\IDBConnection;
 
 class FunctionBuilder implements IFunctionBuilder {
-	/** @var QuoteHelper */
-	protected $helper;
-
 	/** @var IDBConnection */
 	protected $connection;
 
-	/**
-	 * ExpressionBuilder constructor.
-	 *
-	 * @param QuoteHelper $helper
-	 */
-	public function __construct(IDBConnection $connection, QuoteHelper $helper) {
+	/** @var IQueryBuilder */
+	protected $queryBuilder;
+
+	/** @var QuoteHelper */
+	protected $helper;
+
+	public function __construct(IDBConnection $connection, IQueryBuilder $queryBuilder, QuoteHelper $helper) {
 		$this->connection = $connection;
+		$this->queryBuilder = $queryBuilder;
 		$this->helper = $helper;
 	}
 

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -72,4 +72,11 @@ class OCIFunctionBuilder extends FunctionBuilder {
 
 		return parent::least($x, $y);
 	}
+
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		if (is_null($separator)) {
+			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr));
+		}
+		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')");
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -73,11 +73,8 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		return parent::least($x, $y);
 	}
 
-	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
-		if (is_null($orderBy)) {
-			$orderBy = 'NULL';
-		}
-		$orderByClause = ' WITHIN GROUP(ORDER BY ' . $orderBy . ')';
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		$orderByClause = ' WITHIN GROUP(ORDER BY NULL)';
 		if (is_null($separator)) {
 			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . $orderByClause . ')');
 		}

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -81,7 +81,7 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		}
 
 		if ($separator === '\'') {
-			$separator = '\\\'';
+			$separator = '\'\'';
 		}
 
 		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')$orderByClause");

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -76,7 +76,7 @@ class OCIFunctionBuilder extends FunctionBuilder {
 	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
 		$orderByClause = ' WITHIN GROUP(ORDER BY NULL)';
 		if (is_null($separator)) {
-			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . $orderByClause . ')');
+			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ')' . $orderByClause);
 		}
 		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')$orderByClause");
 	}

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -26,6 +26,7 @@ namespace OC\DB\QueryBuilder\FunctionBuilder;
 use OC\DB\QueryBuilder\QueryFunction;
 use OCP\DB\QueryBuilder\ILiteral;
 use OCP\DB\QueryBuilder\IParameter;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 
 class OCIFunctionBuilder extends FunctionBuilder {
@@ -78,6 +79,11 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		if (is_null($separator)) {
 			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ')' . $orderByClause);
 		}
+
+		if ($separator === '\'') {
+			$separator = '\\\'';
+		}
+
 		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')$orderByClause");
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -73,10 +73,14 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		return parent::least($x, $y);
 	}
 
-	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
-		if (is_null($separator)) {
-			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr));
+	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
+		if (is_null($orderBy)) {
+			$orderBy = 'NULL';
 		}
-		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')");
+		$orderByClause = ' WITHIN GROUP(ORDER BY ' . $orderBy . ')';
+		if (is_null($separator)) {
+			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . $orderByClause . ')');
+		}
+		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')$orderByClause");
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -26,7 +26,6 @@ namespace OC\DB\QueryBuilder\FunctionBuilder;
 use OC\DB\QueryBuilder\QueryFunction;
 use OCP\DB\QueryBuilder\ILiteral;
 use OCP\DB\QueryBuilder\IParameter;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 
 class OCIFunctionBuilder extends FunctionBuilder {
@@ -80,10 +79,7 @@ class OCIFunctionBuilder extends FunctionBuilder {
 			return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ')' . $orderByClause);
 		}
 
-		if ($separator === '\'') {
-			$separator = '\'\'';
-		}
-
-		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ", '$separator')$orderByClause");
+		$separator = $this->connection->quote($separator);
+		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ', ' . $separator . ')' . $orderByClause);
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
@@ -30,4 +30,11 @@ class PgSqlFunctionBuilder extends FunctionBuilder {
 	public function concat($x, $y): IQueryFunction {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
+
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		if (is_null($separator)) {
+			return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr));
+		}
+		return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . ", '$separator')");
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
@@ -24,6 +24,7 @@
 namespace OC\DB\QueryBuilder\FunctionBuilder;
 
 use OC\DB\QueryBuilder\QueryFunction;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 
 class PgSqlFunctionBuilder extends FunctionBuilder {
@@ -32,10 +33,13 @@ class PgSqlFunctionBuilder extends FunctionBuilder {
 	}
 
 	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		$castedExpression = $this->queryBuilder->expr()->castColumn($expr, IQueryBuilder::PARAM_STR);
+
 		if (is_null($separator)) {
-			return new QueryFunction('string_agg(cast(' . $this->helper->quoteColumnName($expr) . ' AS varchar)');
+			return new QueryFunction('string_agg(' . $castedExpression . ')');
 		}
+
 		$separator = $this->connection->quote($separator);
-		return new QueryFunction('string_agg(cast(' . $this->helper->quoteColumnName($expr) . " AS varchar), $separator)");
+		return new QueryFunction('string_agg(' . $castedExpression . ', ' . $separator . ')');
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
@@ -31,10 +31,15 @@ class PgSqlFunctionBuilder extends FunctionBuilder {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
-	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
-		if (is_null($separator)) {
-			return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr));
+	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
+		if (is_null($orderBy)) {
+			$orderByClause = '';
+		} else {
+			$orderByClause = ' ORDER BY ' . $orderBy;
 		}
-		return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . ", '$separator')");
+		if (is_null($separator)) {
+			return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . $orderByClause . ')');
+		}
+		return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . ", '$separator'$orderByClause)");
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php
@@ -31,15 +31,11 @@ class PgSqlFunctionBuilder extends FunctionBuilder {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
-	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
-		if (is_null($orderBy)) {
-			$orderByClause = '';
-		} else {
-			$orderByClause = ' ORDER BY ' . $orderBy;
-		}
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
 		if (is_null($separator)) {
-			return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . $orderByClause . ')');
+			return new QueryFunction('string_agg(cast(' . $this->helper->quoteColumnName($expr) . ' AS varchar)');
 		}
-		return new QueryFunction('string_agg(' . $this->helper->quoteColumnName($expr) . ", '$separator'$orderByClause)");
+		$separator = $this->connection->quote($separator);
+		return new QueryFunction('string_agg(cast(' . $this->helper->quoteColumnName($expr) . " AS varchar), $separator)");
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -33,7 +33,7 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 
 	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
 		$separator = $this->connection->quote($separator);
-		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . ", $separator)");
+		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . ', ' . $separator . ')');
 	}
 
 	public function greatest($x, $y): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -31,9 +31,9 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
-	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
-		$separator = $this->helper->quoteColumnName($separator);
-		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . "$separator)");
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction {
+		$separator = $this->connection->quote($separator);
+		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . ", $separator)");
 	}
 
 	public function greatest($x, $y): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -31,6 +31,11 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 		return new QueryFunction('(' . $this->helper->quoteColumnName($x) . ' || ' . $this->helper->quoteColumnName($y) . ')');
 	}
 
+	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction {
+		$separator = $this->helper->quoteColumnName($separator);
+		return new QueryFunction('GROUP_CONCAT(' . $this->helper->quoteColumnName($expr) . "$separator)");
+	}
+
 	public function greatest($x, $y): IQueryFunction {
 		return new QueryFunction('MAX(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -155,16 +155,16 @@ class QueryBuilder implements IQueryBuilder {
 	 */
 	public function func() {
 		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
-			return new OCIFunctionBuilder($this->helper);
+			return new OCIFunctionBuilder($this->connection, $this->helper);
 		}
 		if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
-			return new SqliteFunctionBuilder($this->helper);
+			return new SqliteFunctionBuilder($this->connection, $this->helper);
 		}
 		if ($this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
-			return new PgSqlFunctionBuilder($this->helper);
+			return new PgSqlFunctionBuilder($this->connection, $this->helper);
 		}
 
-		return new FunctionBuilder($this->helper);
+		return new FunctionBuilder($this->connection, $this->helper);
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -155,16 +155,16 @@ class QueryBuilder implements IQueryBuilder {
 	 */
 	public function func() {
 		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
-			return new OCIFunctionBuilder($this->connection, $this->helper);
+			return new OCIFunctionBuilder($this->connection, $this, $this->helper);
 		}
 		if ($this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
-			return new SqliteFunctionBuilder($this->connection, $this->helper);
+			return new SqliteFunctionBuilder($this->connection, $this, $this->helper);
 		}
 		if ($this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
-			return new PgSqlFunctionBuilder($this->connection, $this->helper);
+			return new PgSqlFunctionBuilder($this->connection, $this, $this->helper);
 		}
 
-		return new FunctionBuilder($this->connection, $this->helper);
+		return new FunctionBuilder($this->connection, $this, $this->helper);
 	}
 
 	/**

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -62,10 +62,11 @@ interface IFunctionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $expr The expression to group
 	 * @param string|null $separator The separator
+	 * @param string|null $orderBy Optional SQL expression (and direction) to order the grouped rows by.
 	 * @return IQueryFunction
 	 * @since 24.0.0
 	 */
-	public function groupConcat($expr, ?string $separator = ','): IQueryFunction;
+	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction;
 
 	/**
 	 * Takes a substring from the input string

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -44,7 +44,7 @@ interface IFunctionBuilder {
 	 * Combines two input strings
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The first input string
-	 * @param string|ILiteral|IParameter|IQueryFunction $y The seccond input string
+	 * @param string|ILiteral|IParameter|IQueryFunction $y The second input string
 	 *
 	 * @return IQueryFunction
 	 * @since 12.0.0

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -52,6 +52,22 @@ interface IFunctionBuilder {
 	public function concat($x, $y): IQueryFunction;
 
 	/**
+	 * Returns a string which is the concatenation of all non-NULL values of X
+	 *
+	 * Usage examples:
+	 *
+	 * groupConcat('column') -- with comma as separator (default separator)
+	 *
+	 * groupConcat('column', ';') -- with different separator
+	 *
+	 * @param string|ILiteral|IParameter|IQueryFunction $expr The expression to group
+	 * @param string|null $separator The separator
+	 * @return IQueryFunction
+	 * @since 24.0.0
+	 */
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction;
+
+	/**
 	 * Takes a substring from the input string
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $input The input string

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -62,11 +62,10 @@ interface IFunctionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $expr The expression to group
 	 * @param string|null $separator The separator
-	 * @param string|null $orderBy Optional SQL expression (and direction) to order the grouped rows by.
 	 * @return IQueryFunction
 	 * @since 24.0.0
 	 */
-	public function groupConcat($expr, ?string $separator = ',', ?string $orderBy = null): IQueryFunction;
+	public function groupConcat($expr, ?string $separator = ','): IQueryFunction;
 
 	/**
 	 * Takes a substring from the input string

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -60,7 +60,7 @@ interface IFunctionBuilder {
 	 *
 	 * groupConcat('column', ';') -- with different separator
 	 *
-	 * @param string|ILiteral|IParameter|IQueryFunction $expr The expression to group
+	 * @param string|IQueryFunction $expr The expression to group
 	 * @param string|null $separator The separator
 	 * @return IQueryFunction
 	 * @since 24.0.0

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -54,6 +54,32 @@ class FunctionBuilderTest extends TestCase {
 		$this->assertEquals('foobar', $column);
 	}
 
+	public function testGroupConcatWithoutSeparatorAndOrder() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->groupConcat('appid'));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$result = $query->execute();
+		$column = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertGreaterThan(1, str_getcsv($column, ','));
+	}
+
+	public function testGroupConcatWithSeparatorAndOrder() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->groupConcat('appid', '#', 'appid'));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$result = $query->execute();
+		$column = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertGreaterThan(1, str_getcsv($column, '#', 'appid'));
+	}
+
 	public function testMd5() {
 		$query = $this->connection->getQueryBuilder();
 

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -58,7 +58,7 @@ class FunctionBuilderTest extends TestCase {
 		$delete = $this->connection->getQueryBuilder();
 
 		$delete->delete('appconfig')
-			->where($delete->expr()->eq('appid', $delete->createNamedParameter('group_concat', IQueryBuilder::PARAM_STR)));
+			->where($delete->expr()->eq('appid', $delete->createNamedParameter('group_concat')));
 		$delete->executeStatement();
 	}
 
@@ -67,9 +67,9 @@ class FunctionBuilderTest extends TestCase {
 		$insert = $this->connection->getQueryBuilder();
 
 		$insert->insert('appconfig')
-			->setValue('appid', $insert->createNamedParameter('group_concat', IQueryBuilder::PARAM_STR))
-			->setValue('configvalue', $insert->createNamedParameter('unittest', IQueryBuilder::PARAM_STR))
-			->setValue('configkey', $insert->createParameter('value', IQueryBuilder::PARAM_STR));
+			->setValue('appid', $insert->createNamedParameter('group_concat'))
+			->setValue('configvalue', $insert->createNamedParameter('unittest'))
+			->setValue('configkey', $insert->createParameter('value'));
 
 		$insert->setParameter('value', '1');
 		$insert->executeStatement();
@@ -90,10 +90,13 @@ class FunctionBuilderTest extends TestCase {
 		$result = $query->execute();
 		$column = $result->fetchOne();
 		$result->closeCursor();
-		$this->assertGreaterThan(1, str_getcsv($column, ','));
+		$this->assertStringContainsString(',', $column);
+		$actual = explode(',', $column);
+		$this->assertEqualsCanonicalizing([1,2,3], $actual);
 	}
 
-	public function testGroupConcatWithSeparatorAndOrder() {
+	public function testGroupConcatWithSeparator() {
+		$this->addDummyData();
 		$query = $this->connection->getQueryBuilder();
 
 		$query->select($query->func()->groupConcat('configkey', '#'))
@@ -103,7 +106,9 @@ class FunctionBuilderTest extends TestCase {
 		$result = $query->execute();
 		$column = $result->fetchOne();
 		$result->closeCursor();
-		$this->assertGreaterThan(1, str_getcsv($column, '#', 'appid'));
+		$this->assertStringContainsString('#', $column);
+		$actual = explode('#', $column);
+		$this->assertEqualsCanonicalizing([1,2,3], $actual);
 	}
 
 	public function testMd5() {


### PR DESCRIPTION
Returns a string which is the concatenation of all non-NULL values of _expression_

You can read more about different implementations on:
[MySQL](https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat), [SQLite](https://sqlite.org/lang_aggfunc.html#group_concat), [Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/LISTAGG.html), [PostgreSQL](https://www.postgresql.org/docs/current/functions-aggregate.html) and PostgreSQL [aggregate expression](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-AGGREGATES) usage.

Real example of usage on PR #30379:

https://github.com/nextcloud/server/blob/3c23050015ca7803778e2f49600e425edb41bd33/lib/private/Comments/Manager.php#L1024