### PR TITLE
fix xml ocs response for serializable objects

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -159,6 +159,10 @@ abstract class BaseResponse extends Response {
 				$writer->startElement($k);
 				$this->toXML($v, $writer);
 				$writer->endElement();
+			} elseif ($v instanceof \JsonSerializable) {
+				$writer->startElement($k);
+				$this->toXML($v->jsonSerialize(), $writer);
+				$writer->endElement();
 			} else {
 				$writer->writeElement($k, $v);
 			}

--- a/tests/lib/AppFramework/OCS/BaseResponseTest.php
+++ b/tests/lib/AppFramework/OCS/BaseResponseTest.php
@@ -28,6 +28,17 @@ namespace Test\AppFramework\Middleware;
 
 use OC\AppFramework\OCS\BaseResponse;
 
+class ArrayValue implements \JsonSerializable {
+	private $array;
+	public function __construct(array $array) {
+		$this->array = $array;
+	}
+
+	public function jsonSerialize(): mixed {
+		return $this->array;
+	}
+}
+
 class BaseResponseTest extends \Test\TestCase {
 	public function testToXml(): void {
 		/** @var BaseResponse $response */
@@ -44,6 +55,34 @@ class BaseResponseTest extends \Test\TestCase {
 				'@test' => 'some data',
 				'someElement' => 'withAttribute',
 			],
+			'value without key',
+			'object' => new \stdClass(),
+		];
+
+		$this->invokePrivate($response, 'toXml', [$data, $writer]);
+		$writer->endDocument();
+
+		$this->assertEquals(
+			"<?xml version=\"1.0\"?>\n<hello>hello</hello><information test=\"some data\"><someElement>withAttribute</someElement></information><element>value without key</element><object/>\n",
+			$writer->outputMemory(true)
+		);
+	}
+	
+	public function testToXmlJsonSerializable(): void {
+		/** @var BaseResponse $response */
+		$response = $this->createMock(BaseResponse::class);
+
+		$writer = new \XMLWriter();
+		$writer->openMemory();
+		$writer->setIndent(false);
+		$writer->startDocument();
+
+		$data = [
+			'hello' => 'hello',
+			'information' => new ArrayValue([
+				'@test' => 'some data',
+				'someElement' => 'withAttribute',
+			]),
 			'value without key',
 			'object' => new \stdClass(),
 		];


### PR DESCRIPTION
If an OCS endpoint returns data which extends `JsonSerializable` the xml serialization should not fail.

Example in Nextcloud 23:

```php
public function index(): DataResponse {
  return new DataResponse(
			"recommendations" => [/* object implementing JsonSerializable */]
		);
}
```

Will result in:

```
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message>OK</message>
 </meta>
 <data>
  <recommendations/>
 </data>
</ocs>
```

The json response `?format=json` is showing the list of recommendations as expected.

With the following error message in the logs:

```
XMLWriter::writeElement() expects parameter 2 to be string, object given at \/opt\/nextcloud\/23\/lib\/private\/AppFramework\/OCS\/BaseResponse.php#148
```

Discovered in https://github.com/nextcloud/recommendations/pull/458

Edit: Of course this could also be done on the controller side, but I think it's so common and should be handled by the base response.