### PR TITLE
Return false if LDAP server is not available

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -354,8 +354,6 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 			if ($backendUsers !== false) {
 				$users += $backendUsers;
 				}
-			}
-		} 
 		return $users;
 	}
 

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -31,6 +31,7 @@
  */
 namespace OCA\User_LDAP;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
 use OCP\IUserSession;
@@ -344,11 +345,15 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	 */
 	public function countUsers() {
 		$users = false;
-		foreach ($this->backends as $backend) {
-			$backendUsers = $backend->countUsers();
-			if ($backendUsers !== false) {
-				$users += $backendUsers;
+		try {
+			foreach ($this->backends as $backend) {
+				$backendUsers = $backend->countUsers();
+				if ($backendUsers !== false) {
+					$users += $backendUsers;
+				}
 			}
+			}catch(ServerNotAvailableException $e){
+			return false;
 		}
 		return $users;
 	}

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -31,7 +31,6 @@
  */
 namespace OCA\User_LDAP;
 
-use OC\ServerNotAvailableException;
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
 use OCP\IUserSession;
@@ -348,12 +347,12 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 		foreach ($this->backends as $backend) {
 			try{
 				$backendUsers = $backend->countUsers();
-			} catch (ServerNotAvailableException $e) {
-					return false;
-					}
+			} catch (\Exception $e) {
+					// ignore
+			}
 			if ($backendUsers !== false) {
 				$users += $backendUsers;
-				}
+			}
 		}
 		return $users;
 	}

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -345,16 +345,17 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 	 */
 	public function countUsers() {
 		$users = false;
-		try {
-			foreach ($this->backends as $backend) {
+		foreach ($this->backends as $backend) {
+			try{
 				$backendUsers = $backend->countUsers();
-				if ($backendUsers !== false) {
-					$users += $backendUsers;
+			} catch (ServerNotAvailableException $e) {
+					return false;
+					}
+			if ($backendUsers !== false) {
+				$users += $backendUsers;
 				}
 			}
-		} catch (ServerNotAvailableException $e) {
-			return false;
-		}
+		} 
 		return $users;
 	}
 

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -354,6 +354,7 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 			if ($backendUsers !== false) {
 				$users += $backendUsers;
 				}
+		}
 		return $users;
 	}
 

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -352,8 +352,8 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 					$users += $backendUsers;
 				}
 			}
-			}catch(ServerNotAvailableException $e){
-			return false;
+		} catch (ServerNotAvailableException $e) {
+				return false;
 		}
 		return $users;
 	}

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -353,7 +353,7 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface,
 				}
 			}
 		} catch (ServerNotAvailableException $e) {
-				return false;
+			return false;
 		}
 		return $users;
 	}


### PR DESCRIPTION
Hi
There were two things i could have done.
-  change **Access.php** to not throw exception 
- change the first function above **Access.php** to catch the exception and return `false`

I though it might be cleaner and more consistent to catch the exception in the above function.


This code is submitted for the  following [issue](https://github.com/nextcloud/server/issues/30422).
