### PR TITLE
Hash job argument

### DIFF
--- a/core/Migrations/Version24000Date20211230140012.php
+++ b/core/Migrations/Version24000Date20211230140012.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version24000Date20211230140012 extends SimpleMigrationStep {
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('jobs');
+		if (!$table->hasColumn('argument_hash')) {
+			$table->addColumn('argument_hash', Types::STRING, [
+				'notnull' => false,
+				'length' => 32,
+			]);
+			$table->addIndex(['class', 'argument_hash'], 'job_argument_hash');
+			return $schema;
+		}
+		return null;
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$update = $this->connection->getQueryBuilder();
+
+		$update->update('jobs')
+			->set('argument_hash', $update->func()->md5('argument'));
+
+		$update->executeStatement();
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -992,6 +992,7 @@ return array(
     'OC\\Core\\Migrations\\Version23000Date20211203110726' => $baseDir . '/core/Migrations/Version23000Date20211203110726.php',
     'OC\\Core\\Migrations\\Version23000Date20211213203940' => $baseDir . '/core/Migrations/Version23000Date20211213203940.php',
     'OC\\Core\\Migrations\\Version24000Date20211210141942' => $baseDir . '/core/Migrations/Version24000Date20211210141942.php',
+    'OC\\Core\\Migrations\\Version24000Date20211230140012' => $baseDir . '/core/Migrations/Version24000Date20211230140012.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1021,6 +1021,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version23000Date20211203110726' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20211203110726.php',
         'OC\\Core\\Migrations\\Version23000Date20211213203940' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20211213203940.php',
         'OC\\Core\\Migrations\\Version24000Date20211210141942' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211210141942.php',
+        'OC\\Core\\Migrations\\Version24000Date20211230140012' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211230140012.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -82,6 +82,7 @@ class JobList implements IJobList {
 				->values([
 					'class' => $query->createNamedParameter($class),
 					'argument' => $query->createNamedParameter($argumentJson),
+					'argument_hash' => $query->createNamedParameter(md5($argumentJson)),
 					'last_run' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 					'last_checked' => $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT),
 				]);
@@ -90,7 +91,7 @@ class JobList implements IJobList {
 				->set('reserved_at', $query->expr()->literal(0, IQueryBuilder::PARAM_INT))
 				->set('last_checked', $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
 				->where($query->expr()->eq('class', $query->createNamedParameter($class)))
-				->andWhere($query->expr()->eq('argument', $query->createNamedParameter($argumentJson)));
+				->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argumentJson))));
 		}
 		$query->executeStatement();
 	}
@@ -145,7 +146,7 @@ class JobList implements IJobList {
 		$query->select('id')
 			->from('jobs')
 			->where($query->expr()->eq('class', $query->createNamedParameter($class)))
-			->andWhere($query->expr()->eq('argument', $query->createNamedParameter($argument)))
+			->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argument))))
 			->setMaxResults(1);
 
 		$result = $query->execute();

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [24, 0, 0, 3];
+$OC_Version = [24, 0, 0, 4];
 
 // The human readable string
 $OC_VersionString = '24.0.0 dev';


### PR DESCRIPTION
Based on #30358 

Fixes https://github.com/nextcloud/server/issues/28467

Adding a hashed argument column in order to allow to check if a job already exists with an indexed SQL query instead of filtering by the content of the `varchar(4000)` argument column.

@nickvergessen @skjnldsv The update time seems pretty reasonable to me when doing some tests with fake data, but if there are any concerns on having that done in the migration itself, we could have a separate occ command and allow admins to do this separate from the upgrade. Any objections on that? 

```
# 56.560 rows, short argument text with random data
MariaDB [nextcloud]> update oc_jobs set argument_hash = md5(argument);
Query OK, 56560 rows affected (1.584 sec)
Rows matched: 102490  Changed: 56560  Warnings: 0

# 1.566.125 rows, 3000 character argument with random data
MariaDB [nextcloud]> update oc_jobs set argument_hash = md5(argument);
Query OK, 1566125 rows affected (8 min 53.272 sec)
Rows matched: 1668594  Changed: 1566125  Warnings: 0
```

