### PR TITLE
Explicitly cast char in the query builder

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -427,6 +427,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *
 	 * @param string|IQueryFunction $column
 	 * @param mixed $type One of IQueryBuilder::PARAM_*
+	 * @psalm-param IQueryBuilder::PARAM_* $type
 	 * @return IQueryFunction
 	 */
 	public function castColumn($column, $type): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -26,7 +26,9 @@
 namespace OC\DB\QueryBuilder\ExpressionBuilder;
 
 use OC\DB\ConnectionAdapter;
+use OC\DB\QueryBuilder\QueryFunction;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
 
 class MySqlExpressionBuilder extends ExpressionBuilder {
 
@@ -51,5 +53,22 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
 		return $this->expressionBuilder->comparison($x, ' COLLATE ' . $this->collation . ' LIKE', $y);
+	}
+
+	/**
+	 * Returns a IQueryFunction that casts the column to the given type
+	 *
+	 * @param string|IQueryFunction $column
+	 * @param mixed $type One of IQueryBuilder::PARAM_*
+	 * @psalm-param IQueryBuilder::PARAM_* $type
+	 * @return IQueryFunction
+	 */
+	public function castColumn($column, $type): IQueryFunction {
+		switch ($type) {
+			case IQueryBuilder::PARAM_STR:
+				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS CHAR)');
+			default:
+				return parent::castColumn($column, $type);
+		}
 	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -163,6 +163,7 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	 *
 	 * @param string|IQueryFunction $column
 	 * @param mixed $type One of IQueryBuilder::PARAM_*
+	 * @psalm-param IQueryBuilder::PARAM_* $type
 	 * @return IQueryFunction
 	 */
 	public function castColumn($column, $type): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
@@ -35,6 +35,7 @@ class PgSqlExpressionBuilder extends ExpressionBuilder {
 	 *
 	 * @param string|IQueryFunction $column
 	 * @param mixed $type One of IQueryBuilder::PARAM_*
+	 * @psalm-param IQueryBuilder::PARAM_* $type
 	 * @return IQueryFunction
 	 */
 	public function castColumn($column, $type): IQueryFunction {

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -433,6 +433,7 @@ interface IExpressionBuilder {
 	 *
 	 * @param string|IQueryFunction $column
 	 * @param mixed $type One of IQueryBuilder::PARAM_*
+	 * @psalm-param IQueryBuilder::PARAM_* $type
 	 * @return IQueryFunction
 	 * @since 9.0.0
 	 *


### PR DESCRIPTION
If a query with a cast method is built, it should also result in an actual CAST function call in the sql query, as that may allow the query to make proper use of indexes as found in https://github.com/nextcloud/deck/pull/3497

Now ideally we should allow casting other types as well, however automatically mapping from the parameter type does not work globally for PARAM_INT as for the CAST there would be two separate types (UNSIGNED/SIGNED)

- https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast
- https://mariadb.com/kb/en/cast/