### PR TITLE
Avoid loading anything else than core scripts/styles on empty/base renderAs tempalte

### DIFF
--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -113,9 +113,11 @@ class OC_Template extends \OC\Template\Base {
 			Util::addTranslations('core');
 
 			if (\OC::$server->getSystemConfig()->getValue('installed', false) && !\OCP\Util::needUpgrade()) {
-				Util::addScript('core', 'files_fileinfo');
-				Util::addScript('core', 'files_client');
-				Util::addScript('core', 'merged-template-prepend');
+				if ($renderAs !== TemplateResponse::RENDER_AS_BLANK && $renderAs !== TemplateResponse::RENDER_AS_BASE) {
+					Util::addScript('core', 'files_fileinfo');
+					Util::addScript('core', 'files_client');
+					Util::addScript('core', 'merged-template-prepend');
+				}
 			}
 
 			// If installed and background job is set to ajax, add dedicated script


### PR DESCRIPTION
This PR will remove anything but the core js bundle from the base or empty template rendering. This is basically what is described in https://github.com/nextcloud/server/issues/10142

The existing RENDER_AS_BASE should be sufficient for this already and seems to be only used in Collabora/ONLYOFFICE these days anyways (as far as my git checkouts showed). We could even discuss if dropping the server.scss might be a good idea and instead just load the css variables.

Things kept:
- Core js bundle
- Server styles
- CSS variables
- Translations

Since this may be a breaking change, this should be added to the developer docs after merge.