### PR TITLE
Remove inefficient fed share scanner

### DIFF
--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -50,18 +50,6 @@ class ScannerTest extends TestCase {
 		$this->scanner = new Scanner($this->storage);
 	}
 
-	public function testScanAll() {
-		$this->storage->expects($this->any())
-			->method('getShareInfo')
-			->willReturn(['status' => 'success', 'data' => []]);
-
-		// FIXME add real tests, we are currently only checking for
-		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
-		// compatible with OC\Files\Cache\Scanner::*()
-		$this->scanner->scanAll();
-		$this->addToAssertionCount(1);
-	}
-
 	public function testScan() {
 		$this->storage->expects($this->any())
 			->method('getShareInfo')


### PR DESCRIPTION
Remove scanAll which relies on the "shareinfo" endpoint that returns the
full cache tree.
The latter can become big for big shares and result in timeouts.
Furthermode, the full tree would be retrieved again for each and every
detected change which can become expensive quickly.

As discussed with @icewind1991

Draft for now, needs more extensive testing to confirm that the default scanner will work correctly for federated shares.

Fixes https://github.com/nextcloud/server/issues/29941