### PR TITLE
delete files before cleaning cache when cleaning user files

### DIFF
--- a/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
@@ -72,12 +72,12 @@ class UserDeletedFilesCleanupListener implements IEventListener {
 			}
 			$storage = $this->homeStorageCache[$event->getUser()->getUID()];
 			$cache = $storage->getCache();
+			$storage->rmdir('');
 			if ($cache instanceof Cache) {
 				$cache->clear();
 			} else {
 				throw new \Exception("Home storage has invalid cache");
 			}
-			$storage->rmdir('');
 		}
 	}
 }


### PR DESCRIPTION
otherwise, when using object store, we loose track of which files the user owns before we can delete them

Signed-off-by: Robin Appelman <robin@icewind.nl>