### PR TITLE
Fix unsynced account email from LDAP

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -440,10 +440,7 @@ class User {
 		if ($email !== '') {
 			$user = $this->userManager->get($this->uid);
 			if (!is_null($user)) {
-				$currentEmail = (string)$user->getSystemEMailAddress();
-				if ($currentEmail !== $email) {
-					$user->setEMailAddress($email);
-				}
+				$user->setEMailAddress($email);
 			}
 		}
 	}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -196,6 +196,11 @@ class User implements IUser {
 		if ($oldMailAddress !== $mailAddress) {
 			$this->triggerChange('eMailAddress', $mailAddress, $oldMailAddress);
 		}
+
+		$accountMailAddress = $this->accountManager->getAccount($this)->getProperty(IAccountManager::PROPERTY_EMAIL)->getValue();
+		if ($accountMailAddress !== $mailAddress) {
+			$this->triggerChange('eMailAddress', $mailAddress, $accountMailAddress);
+		}
 	}
 
 	/**


### PR DESCRIPTION
When setting an LDAP synced email the `oc_preferences` table would be updated while `oc_accounts`, if it differed from `oc_preferences`, would not

This fixes that with a new check in the email setter and delegates the check in `user_ldap` to the email setter to ensure that emails are synced

Any suggestions from LDAP connoisseurs welcome :)