### PR TITLE
Fix wrong unified search link to folder

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -118,13 +118,12 @@ class FilesSearchProvider implements IProvider {
 				// Generate thumbnail url
 				$thumbnailUrl = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', ['x' => 32, 'y' => 32, 'fileId' => $result->getId()]);
 				$path = $userFolder->getRelativePath($result->getPath());
+
+				// Use shortened link to centralize the various
+				// files/folder url redirection in files.View.showFile
 				$link = $this->urlGenerator->linkToRoute(
-					'files.view.index',
-					[
-						'dir' => dirname($path),
-						'scrollto' => $result->getName(),
-						'openfile' => $result->getId(),
-					]
+					'files.View.showFile',
+					['fileid' => $result->getId()]
 				);
 
 				$searchResultEntry = new SearchResultEntry(


### PR DESCRIPTION
It now opens the folder directly
I think it's safer to use the shortened link as this is where we transform the final url. This is where we did all the changes in the past like
- Open the sidebar straight away or not
- Open the folder directly or not
- Open the file main action directly or not
- etc etc