### PR TITLE
Optimize FileSystemTags workflow for groupfolder

### DIFF
--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -140,22 +140,18 @@ class FileSystemTags implements ICheck, IFileCheck {
 	protected function getFileIds(ICache $cache, $path, $isExternalStorage) {
 		/** @psalm-suppress InvalidArgument */
 		if ($this->storage->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class)) {
-			static $groupFolderStorage = null;
-			if ($groupFolderStorage === null) {
-				// Special implementation for groupfolder since all groupfolder chare the same storage
-				// so add the group folder id in the cache key too.
-				$groupFolderStorage = $this->storage;
-				$groupFolderStoragClass = \OCA\GroupFolders\Mount\GroupFolderStorage::class;
-				while ($groupFolderStorage->instanceOfStorage(Wrapper::class)) {
-					if ($groupFolderStorage instanceof $groupFolderStoragClass) {
-						break;
-					}
-					/**
-					 * @var Wrapper $sourceStorage
-					 */
-					$groupFolderStorage = $groupFolderStorage->getWrapperStorage();
+			// Special implementation for groupfolder since all groupfolders share the same storage
+			// id so add the group folder id in the cache key too.
+			$groupFolderStorage = $this->storage;
+			$groupFolderStorageClass = \OCA\GroupFolders\Mount\GroupFolderStorage::class;
+			while ($groupFolderStorage->instanceOfStorage(Wrapper::class)) {
+				if ($groupFolderStorage instanceof $groupFolderStorageClass) {
+					break;
 				}
+				/** @var Wrapper $groupFolderStorage */
+				$groupFolderStorage = $groupFolderStorage->getWrapperStorage();
 			}
+			/** @psalm-suppress UndefinedMethod */
 			$cacheId = $cache->getNumericStorageId() . '/' . $groupFolderStorage->getFolderId();
 		} else {
 			$cacheId = $cache->getNumericStorageId();
@@ -173,7 +169,7 @@ class FileSystemTags implements ICheck, IFileCheck {
 
 		$fileId = $cache->getId($path);
 		if ($fileId !== -1) {
-			$parentIds[] = $cache->getId($path);
+			$parentIds[] = $fileId;
 		}
 
 		$this->fileIds[$cacheId][$path] = $parentIds;

--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -144,7 +144,10 @@ class FileSystemTags implements ICheck, IFileCheck {
 			if ($groupFolderStorage === null) {
 				throw new \LogicException('Should not happen: Storage is instance of GroupFolderStorage but no group folder storage found while unwrapping.');
 			}
-			/** @psalm-suppress UndefinedMethod */
+			/**
+			 * @psalm-suppress UndefinedDocblockClass
+			 * @psalm-suppress UndefinedInterfaceMethod
+			 */
 			$cacheId = $cache->getNumericStorageId() . '/' . $groupFolderStorage->getFolderId();
 		} else {
 			$cacheId = $cache->getNumericStorageId();

--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -36,6 +36,7 @@ use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\SystemTag\TagNotFoundException;
 use OCP\WorkflowEngine\ICheck;
 use OCP\WorkflowEngine\IFileCheck;
+use OC\Files\Storage\Wrapper\Wrapper;
 
 class FileSystemTags implements ICheck, IFileCheck {
 	use TFileCheck;
@@ -72,6 +73,11 @@ class FileSystemTags implements ICheck, IFileCheck {
 	 * @return bool
 	 */
 	public function executeCheck($operator, $value) {
+		if (str_starts_with($this->path,  '__groupfolders')) {
+			// System tags are always empty in this case and executeCheck is called
+			// a second time with the jailedPath
+			return false;
+		}
 		$systemTags = $this->getSystemTags();
 		return ($operator === 'is') === in_array($value, $systemTags);
 	}
@@ -132,13 +138,29 @@ class FileSystemTags implements ICheck, IFileCheck {
 	 * @return int[]
 	 */
 	protected function getFileIds(ICache $cache, $path, $isExternalStorage) {
-		// TODO: Fix caching inside group folders
-		// Do not cache file ids inside group folders because multiple file ids might be mapped to
-		// the same combination of cache id + path.
 		/** @psalm-suppress InvalidArgument */
-		$shouldCacheFileIds = !$this->storage->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
-		$cacheId = $cache->getNumericStorageId();
-		if ($shouldCacheFileIds && isset($this->fileIds[$cacheId][$path])) {
+		if ($this->storage->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class)) {
+			static $groupFolderStorage = null;
+			if ($groupFolderStorage === null) {
+				// Special implementation for groupfolder since all groupfolder chare the same storage
+				// so add the group folder id in the cache key too.
+				$groupFolderStorage = $this->storage;
+				$groupFolderStoragClass = \OCA\GroupFolders\Mount\GroupFolderStorage::class;
+				while ($groupFolderStorage->instanceOfStorage(Wrapper::class)) {
+					if ($groupFolderStorage instanceof $groupFolderStoragClass) {
+						break;
+					}
+					/**
+					 * @var Wrapper $sourceStorage
+					 */
+					$groupFolderStorage = $groupFolderStorage->getWrapperStorage();
+				}
+			}
+			$cacheId = $cache->getNumericStorageId() . '/' . $groupFolderStorage->getFolderId();
+		} else {
+			$cacheId = $cache->getNumericStorageId();
+		}
+		if (isset($this->fileIds[$cacheId][$path])) {
 			return $this->fileIds[$cacheId][$path];
 		}
 
@@ -154,9 +176,7 @@ class FileSystemTags implements ICheck, IFileCheck {
 			$parentIds[] = $cache->getId($path);
 		}
 
-		if ($shouldCacheFileIds) {
-			$this->fileIds[$cacheId][$path] = $parentIds;
-		}
+		$this->fileIds[$cacheId][$path] = $parentIds;
 
 		return $parentIds;
 	}

--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -73,11 +73,6 @@ class FileSystemTags implements ICheck, IFileCheck {
 	 * @return bool
 	 */
 	public function executeCheck($operator, $value) {
-		if (str_starts_with($this->path,  '__groupfolders')) {
-			// System tags are always empty in this case and executeCheck is called
-			// a second time with the jailedPath
-			return false;
-		}
 		$systemTags = $this->getSystemTags();
 		return ($operator === 'is') === in_array($value, $systemTags);
 	}
@@ -143,13 +138,11 @@ class FileSystemTags implements ICheck, IFileCheck {
 			// Special implementation for groupfolder since all groupfolders share the same storage
 			// id so add the group folder id in the cache key too.
 			$groupFolderStorage = $this->storage;
-			$groupFolderStorageClass = \OCA\GroupFolders\Mount\GroupFolderStorage::class;
-			while ($groupFolderStorage->instanceOfStorage(Wrapper::class)) {
-				if ($groupFolderStorage instanceof $groupFolderStorageClass) {
-					break;
-				}
-				/** @var Wrapper $groupFolderStorage */
-				$groupFolderStorage = $groupFolderStorage->getWrapperStorage();
+			if ($this->storage instanceof Wrapper) {
+				$groupFolderStorage = $this->storage->getInstanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
+			}
+			if ($groupFolderStorage === null) {
+				throw new \LogicException('Should not happen: Storage is instance of GroupFolderStorage but no group folder storage found while unwrapping.');
 			}
 			/** @psalm-suppress UndefinedMethod */
 			$cacheId = $cache->getNumericStorageId() . '/' . $groupFolderStorage->getFolderId();

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -498,19 +498,19 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	}
 
 	/**
-	 * @template T of IStorage
-	 * @param class-string<T> $class
-	 * @return ?T
+	 * @psalm-template T of IStorage
+	 * @psalm-param class-string<T> $class
+	 * @psalm-return T|null
 	 */
-	public function getInstanceOfStorage(string $class): ?IStorage {
+	public function getInstanceOfStorage(string $class) {
 		$storage = $this;
-		while ($storage->instanceOfStorage(Wrapper::class)) {
+		while ($storage instanceof Wrapper) {
 			if ($storage instanceof $class) {
 				break;
 			}
 			$storage = $storage->getWrapperStorage();
 		}
-		if (!is_a($storage, $class)) {
+		if (!($storage instanceof $class)) {
 			return null;
 		}
 		return $storage;

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -486,7 +486,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	/**
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
 	 *
-	 * @param string $class
+	 * @param class-string<IStorage> $class
 	 * @return bool
 	 */
 	public function instanceOfStorage($class) {
@@ -495,6 +495,25 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 			$class = '\OCA\Files_Sharing\SharedStorage';
 		}
 		return is_a($this, $class) or $this->getWrapperStorage()->instanceOfStorage($class);
+	}
+
+	/**
+	 * @template T of IStorage
+	 * @param class-string<T> $class
+	 * @return ?T
+	 */
+	public function getInstanceOfStorage(string $class): ?IStorage {
+		$storage = $this;
+		while ($storage->instanceOfStorage(Wrapper::class)) {
+			if ($storage instanceof $class) {
+				break;
+			}
+			$storage = $storage->getWrapperStorage();
+		}
+		if (!is_a($storage, $class)) {
+			return null;
+		}
+		return $storage;
 	}
 
 	/**


### PR DESCRIPTION
In https://github.com/nextcloud/server/pull/28774 we disabled the
caching for the groupfolder application since it worked due to the fact
that in groupfolders, getFileIds could be called with the same $cacheId
and path for actually different groupfolders.

This revert this change and instead add the folderId from the
groupFolder to the cacheId. This solve the issue of the uniqueness of
the cacheId inside GroupFolder. Downside is that we introduce
groupfolder specific implementation inside the server repo.

<details>
  <summary>Query log before</summary>
<pre>
     61 SELECT `fileid` FROM `oc_filecache` WHERE (`storage` = :dcValue1) AND (`path_hash` = :dcValue2)
     47 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE (`storage` = :dcValue1) AND (`path_hash` = :dcValue2)
     14 SELECT `id`, `numeric_id`, `available`, `last_checked` FROM `oc_storages` WHERE `id` = :dcValue1
     11 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED
     11 SET SESSION AUTOCOMMIT=1
     11 SELECT `uid`, `displayname` FROM `oc_users` WHERE `uid_lower` = :dcValue1
     11 SELECT `id`, `configuration` FROM `oc_user_saml_configurations` WHERE `id` = :dcValue1
     11 SELECT `id`, `configuration` FROM `oc_user_saml_configurations` ORDER BY `id` ASC
     11 SELECT `gu`.`gid`, `g`.`displayname` FROM `oc_group_user` `gu` LEFT JOIN `oc_groups` `g` ON `gu`.`gid` = `g`.`gid` WHERE `uid` = :dcValue1
     11 SELECT `class`, `entity`, `events` AS `events` FROM `oc_flow_operations` WHERE `events` <> :dcValue1 GROUP BY `class`, `entity`, `events`
     11 SELECT `appid`, `configkey`, `configvalue` FROM `oc_preferences` WHERE `userid` = ?
     11 SELECT * FROM `oc_authtoken` WHERE (`token` = :dcValue1) AND (`version` = :dcValue2)
     11 SELECT * FROM `oc_appconfig`
     10 SELECT `provider_id`, `enabled` FROM `oc_twofactor_providers` WHERE `uid` = :dcValue1
      7 SELECT `systemtagid`, `objectid` FROM `oc_systemtag_object_mapping` WHERE (`objectid` IN (:objectids)) AND (`objecttype` = :objecttype) ORDER BY `objectid` ASC, `systemtagid` ASC
      7 SELECT `storage_id`, `root_id`, `user_id`, `mount_point`, `mount_id`, `f`.`path` FROM `oc_mounts` `m` INNER JOIN `oc_filecache` `f` ON `m`.`root_id` = `f`.`fileid` WHERE `user_id` = ?
      7 SELECT `s`.*, `f`.`fileid`, `f`.`path`, `f`.`permissions` as `f_permissions`, `f`.`storage`, `f`.`path_hash`, `f`.`parent` as `f_parent`, `f`.`name`, `f`.`mimetype`, `f`.`mimepart`, `f`.`size`, `f`.`mtime`, `f`.`storage_mtime`, `f`.`encrypted`, `f`.`unencrypted_size`, `f`.`etag`, `f`.`checksum`, `st`.`id` AS `storage_string_id` FROM `oc_share` `s` LEFT JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` LEFT JOIN `oc_storages` `st` ON `f`.`storage` = `st`.`numeric_id` WHERE (`share_type` = :dcValue1) AND (`share_with` IN (:dcValue2)) AND ((`item_type` = :dcValue3) OR (`item_type` = :dcValue4)) ORDER BY `s`.`id` ASC
      7 SELECT `s`.*, `f`.`fileid`, `f`.`path`, `f`.`permissions` as `f_permissions`, `f`.`storage`, `f`.`path_hash`, `f`.`parent` as `f_parent`, `f`.`name`, `f`.`mimetype`, `f`.`mimepart`, `f`.`size`, `f`.`mtime`, `f`.`storage_mtime`, `f`.`encrypted`, `f`.`unencrypted_size`, `f`.`etag`, `f`.`checksum`, `st`.`id` AS `storage_string_id` FROM `oc_share` `s` LEFT JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` LEFT JOIN `oc_storages` `st` ON `f`.`storage` = `st`.`numeric_id` WHERE (`share_type` = :dcValue1) AND (`share_with` = :dcValue2) AND ((`item_type` = :dcValue3) OR (`item_type` = :dcValue4)) ORDER BY `s`.`id` ASC
      7 SELECT `path` FROM `oc_filecache` WHERE (`storage` = :dcValue1) AND (`path_hash` IN (:dcValue2))
      7 SELECT `id`, `mimetype` FROM `oc_mimetypes`
      7 SELECT `f`.`folder_id`, `mount_point`, `quota`, `acl`, `fileid`, `storage`, `path`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `etag`, `encrypted`, `parent`, `a`.`permissions` AS `group_permissions`, `c`.`permissions` AS `permissions` FROM `oc_group_folders` `f` INNER JOIN `oc_group_folders_groups` `a` ON `f`.`folder_id` = `a`.`folder_id` LEFT JOIN `oc_filecache` `c` ON (`name` = CONCAT(`f`.`folder_id`, '')) AND (`parent` = :dcValue1) WHERE `a`.`group_id` IN (:groupIds)
      3 SELECT `o`.*, `s`.`type` AS `scope_type`, `s`.`value` AS `scope_actor_id` FROM `oc_flow_operations` `o` LEFT JOIN `oc_flow_operations_scope` `s` ON `o`.`id` = `s`.`operation_id` WHERE `s`.`type` = :scope
      3 SELECT `o`.*, `s`.`type` AS `scope_type`, `s`.`value` AS `scope_actor_id` FROM `oc_flow_operations` `o` LEFT JOIN `oc_flow_operations_scope` `s` ON `o`.`id` = `s`.`operation_id` WHERE (`s`.`type` = :scope) AND (`s`.`value` = :scopeId)
      3 SELECT * FROM `oc_user_status` WHERE (`user_id` = :dcValue1) AND (`is_backup` = :dcValue2)
      3 SELECT * FROM `oc_share` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND (`share_type` = :dcValue3) AND (`uid_initiator` = :dcValue4) AND (`file_source` = :dcValue5) ORDER BY `id` ASC
      3 SELECT * FROM `oc_flow_checks` WHERE `id` IN (:dcValue1)
      2 SELECT `data` FROM `oc_accounts` WHERE `uid` = :uid
      2 SELECT * FROM `oc_user_status` WHERE `user_id` IN (:dcValue1)
      2 SELECT * FROM `oc_share` `s` INNER JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND (`share_type` = :dcValue3) AND ((`uid_owner` = :dcValue4) OR (`uid_initiator` = :dcValue5)) AND (`f`.`parent` = :dcValue6) ORDER BY `id` ASC
      2 SELECT * FROM `oc_share` WHERE (`share_type` = :dcValue1) AND ((`uid_initiator` = :dcValue3) OR ((`uid_owner` = :dcValue2) AND (`uid_initiator` IS NULL))) AND (`file_source` = :dcValue4) ORDER BY `id` ASC
      1 SELECT `storage`, `path`, `mimetype` FROM `oc_filecache` WHERE `fileid` = :dcValue1
      1 SELECT `storage_id`, `root_id`, `user_id`, `mount_point`, `mount_id`, `f`.`path` FROM `oc_mounts` `m` INNER JOIN `oc_filecache` `f` ON `m`.`root_id` = `f`.`fileid` WHERE (`storage_id` = ?) AND (`user_id` = ?)
      1 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE `filecache`.`parent` = :dcValue1 ORDER BY `name` ASC
      1 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE `filecache`.`fileid` = :dcValue1
      1 SELECT `category`, `categoryid`, `objid` FROM `oc_vcategory_to_object` r, `oc_vcategory` WHERE `categoryid` = `id` AND `uid` = ? AND r.`type` = ? AND `objid` IN (?)
      1 SELECT `c`.`object_id`, COUNT(`c`.`id`) AS `num_comments` FROM `oc_comments` `c` LEFT JOIN `oc_comments_read_markers` `m` ON (`m`.`user_id` = :dcValue1) AND (`c`.`object_type` = `m`.`object_type`) AND (`c`.`object_id` = `m`.`object_id`) WHERE (`c`.`object_type` = :dcValue2) AND (`c`.`object_id` IN (:ids)) AND ((`c`.`creation_timestamp` > `m`.`marker_datetime`) OR (`m`.`marker_datetime` IS NULL)) GROUP BY `c`.`object_id`
      1 SELECT COUNT(*) AS `attempts` FROM `oc_bruteforce_attempts` WHERE (`occurred` > :dcValue1) AND (`subnet` = :dcValue2)
      1 SELECT * FROM `oc_share` `s` INNER JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND ((`share_type` = :dcValue3) OR (`share_type` = :dcValue4) OR (`share_type` = :dcValue5)) AND ((`uid_owner` = :dcValue6) OR (`uid_initiator` = :dcValue7)) AND (`f`.`parent` = :dcValue8) ORDER BY `id` ASC
      1 SELECT * FROM `oc_notifications` WHERE `user` = :dcValue1 ORDER BY `notification_id` DESC LIMIT 25
</pre>
</details>

<details>
  <summary>Query log after</summary>
<pre>
     47 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE (`storage` = :dcValue1) AND (`path_hash` = :dcValue2)
     20 SELECT `fileid` FROM `oc_filecache` WHERE (`storage` = :dcValue1) AND (`path_hash` = :dcValue2)
     14 SELECT `id`, `numeric_id`, `available`, `last_checked` FROM `oc_storages` WHERE `id` = :dcValue1
     11 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED
     11 SET SESSION AUTOCOMMIT=1
     11 SELECT `uid`, `displayname` FROM `oc_users` WHERE `uid_lower` = :dcValue1
     11 SELECT `id`, `configuration` FROM `oc_user_saml_configurations` WHERE `id` = :dcValue1
     11 SELECT `id`, `configuration` FROM `oc_user_saml_configurations` ORDER BY `id` ASC
     11 SELECT `gu`.`gid`, `g`.`displayname` FROM `oc_group_user` `gu` LEFT JOIN `oc_groups` `g` ON `gu`.`gid` = `g`.`gid` WHERE `uid` = :dcValue1
     11 SELECT `class`, `entity`, `events` AS `events` FROM `oc_flow_operations` WHERE `events` <> :dcValue1 GROUP BY `class`, `entity`, `events`
     11 SELECT `appid`, `configkey`, `configvalue` FROM `oc_preferences` WHERE `userid` = ?
     11 SELECT * FROM `oc_authtoken` WHERE (`token` = :dcValue1) AND (`version` = :dcValue2)
     11 SELECT * FROM `oc_appconfig`
     10 SELECT `provider_id`, `enabled` FROM `oc_twofactor_providers` WHERE `uid` = :dcValue1
      7 SELECT `storage_id`, `root_id`, `user_id`, `mount_point`, `mount_id`, `f`.`path` FROM `oc_mounts` `m` INNER JOIN `oc_filecache` `f` ON `m`.`root_id` = `f`.`fileid` WHERE `user_id` = ?
      7 SELECT `s`.*, `f`.`fileid`, `f`.`path`, `f`.`permissions` as `f_permissions`, `f`.`storage`, `f`.`path_hash`, `f`.`parent` as `f_parent`, `f`.`name`, `f`.`mimetype`, `f`.`mimepart`, `f`.`size`, `f`.`mtime`, `f`.`storage_mtime`, `f`.`encrypted`, `f`.`unencrypted_size`, `f`.`etag`, `f`.`checksum`, `st`.`id` AS `storage_string_id` FROM `oc_share` `s` LEFT JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` LEFT JOIN `oc_storages` `st` ON `f`.`storage` = `st`.`numeric_id` WHERE (`share_type` = :dcValue1) AND (`share_with` IN (:dcValue2)) AND ((`item_type` = :dcValue3) OR (`item_type` = :dcValue4)) ORDER BY `s`.`id` ASC
      7 SELECT `s`.*, `f`.`fileid`, `f`.`path`, `f`.`permissions` as `f_permissions`, `f`.`storage`, `f`.`path_hash`, `f`.`parent` as `f_parent`, `f`.`name`, `f`.`mimetype`, `f`.`mimepart`, `f`.`size`, `f`.`mtime`, `f`.`storage_mtime`, `f`.`encrypted`, `f`.`unencrypted_size`, `f`.`etag`, `f`.`checksum`, `st`.`id` AS `storage_string_id` FROM `oc_share` `s` LEFT JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` LEFT JOIN `oc_storages` `st` ON `f`.`storage` = `st`.`numeric_id` WHERE (`share_type` = :dcValue1) AND (`share_with` = :dcValue2) AND ((`item_type` = :dcValue3) OR (`item_type` = :dcValue4)) ORDER BY `s`.`id` ASC
      7 SELECT `path` FROM `oc_filecache` WHERE (`storage` = :dcValue1) AND (`path_hash` IN (:dcValue2))
      7 SELECT `id`, `mimetype` FROM `oc_mimetypes`
      7 SELECT `f`.`folder_id`, `mount_point`, `quota`, `acl`, `fileid`, `storage`, `path`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `etag`, `encrypted`, `parent`, `a`.`permissions` AS `group_permissions`, `c`.`permissions` AS `permissions` FROM `oc_group_folders` `f` INNER JOIN `oc_group_folders_groups` `a` ON `f`.`folder_id` = `a`.`folder_id` LEFT JOIN `oc_filecache` `c` ON (`name` = CONCAT(`f`.`folder_id`, '')) AND (`parent` = :dcValue1) WHERE `a`.`group_id` IN (:groupIds)
      5 SELECT `systemtagid`, `objectid` FROM `oc_systemtag_object_mapping` WHERE (`objectid` IN (:objectids)) AND (`objecttype` = :objecttype) ORDER BY `objectid` ASC, `systemtagid` ASC
      3 SELECT `o`.*, `s`.`type` AS `scope_type`, `s`.`value` AS `scope_actor_id` FROM `oc_flow_operations` `o` LEFT JOIN `oc_flow_operations_scope` `s` ON `o`.`id` = `s`.`operation_id` WHERE `s`.`type` = :scope
      3 SELECT `o`.*, `s`.`type` AS `scope_type`, `s`.`value` AS `scope_actor_id` FROM `oc_flow_operations` `o` LEFT JOIN `oc_flow_operations_scope` `s` ON `o`.`id` = `s`.`operation_id` WHERE (`s`.`type` = :scope) AND (`s`.`value` = :scopeId)
      3 SELECT * FROM `oc_user_status` WHERE (`user_id` = :dcValue1) AND (`is_backup` = :dcValue2)
      3 SELECT * FROM `oc_share` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND (`share_type` = :dcValue3) AND (`uid_initiator` = :dcValue4) AND (`file_source` = :dcValue5) ORDER BY `id` ASC
      3 SELECT * FROM `oc_flow_checks` WHERE `id` IN (:dcValue1)
      2 SELECT `data` FROM `oc_accounts` WHERE `uid` = :uid
      2 SELECT * FROM `oc_user_status` WHERE `user_id` IN (:dcValue1)
      2 SELECT * FROM `oc_share` `s` INNER JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND (`share_type` = :dcValue3) AND ((`uid_owner` = :dcValue4) OR (`uid_initiator` = :dcValue5)) AND (`f`.`parent` = :dcValue6) ORDER BY `id` ASC
      2 SELECT * FROM `oc_share` WHERE (`share_type` = :dcValue1) AND ((`uid_initiator` = :dcValue3) OR ((`uid_owner` = :dcValue2) AND (`uid_initiator` IS NULL))) AND (`file_source` = :dcValue4) ORDER BY `id` ASC
      1 UPDATE `oc_authtoken` SET `last_activity` = :dcValue1 WHERE (`id` = :dcValue2) AND (`last_activity` < :dcValue3)
      1 SELECT `storage`, `path`, `mimetype` FROM `oc_filecache` WHERE `fileid` = :dcValue1
      1 SELECT `storage_id`, `root_id`, `user_id`, `mount_point`, `mount_id`, `f`.`path` FROM `oc_mounts` `m` INNER JOIN `oc_filecache` `f` ON `m`.`root_id` = `f`.`fileid` WHERE (`storage_id` = ?) AND (`user_id` = ?)
      1 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE `filecache`.`parent` = :dcValue1 ORDER BY `name` ASC
      1 SELECT `filecache`.`fileid`, `storage`, `path`, `path_hash`, `filecache`.`parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum`, `metadata_etag`, `creation_time`, `upload_time` FROM `oc_filecache` `filecache` LEFT JOIN `oc_filecache_extended` `fe` ON `filecache`.`fileid` = `fe`.`fileid` WHERE `filecache`.`fileid` = :dcValue1
      1 SELECT `category`, `categoryid`, `objid` FROM `oc_vcategory_to_object` r, `oc_vcategory` WHERE `categoryid` = `id` AND `uid` = ? AND r.`type` = ? AND `objid` IN (?)
      1 SELECT `c`.`object_id`, COUNT(`c`.`id`) AS `num_comments` FROM `oc_comments` `c` LEFT JOIN `oc_comments_read_markers` `m` ON (`m`.`user_id` = :dcValue1) AND (`c`.`object_type` = `m`.`object_type`) AND (`c`.`object_id` = `m`.`object_id`) WHERE (`c`.`object_type` = :dcValue2) AND (`c`.`object_id` IN (:ids)) AND ((`c`.`creation_timestamp` > `m`.`marker_datetime`) OR (`m`.`marker_datetime` IS NULL)) GROUP BY `c`.`object_id`
      1 SELECT COUNT(*) AS `attempts` FROM `oc_bruteforce_attempts` WHERE (`occurred` > :dcValue1) AND (`subnet` = :dcValue2)
      1 SELECT * FROM `oc_share` `s` INNER JOIN `oc_filecache` `f` ON `s`.`file_source` = `f`.`fileid` WHERE ((`item_type` = :dcValue1) OR (`item_type` = :dcValue2)) AND ((`share_type` = :dcValue3) OR (`share_type` = :dcValue4) OR (`share_type` = :dcValue5)) AND ((`uid_owner` = :dcValue6) OR (`uid_initiator` = :dcValue7)) AND (`f`.`parent` = :dcValue8) ORDER BY `id` ASC
      1 SELECT * FROM `oc_notifications` WHERE `user` = :dcValue1 ORDER BY `notification_id` DESC LIMIT 25
</pre>
</details>

Signed-off-by: Carl Schwan <carl@carlschwan.eu>