### PR TITLE
Fix fail when keys/files folder already exists

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -768,7 +768,11 @@ class Encryption extends Wrapper {
 
 		if ($sourceStorage->is_dir($sourceInternalPath)) {
 			$dh = $sourceStorage->opendir($sourceInternalPath);
-			$result = $this->mkdir($targetInternalPath);
+			if (!$this->is_dir($targetInternalPath)) {
+				$result = $this->mkdir($targetInternalPath);
+			} else {
+				$result = true;
+			}
 			if (is_resource($dh)) {
 				while ($result and ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {


### PR DESCRIPTION
Fixes an issue with transfer ownership in move mode where the folder
"files_encryption/keys/files" already exists.

Instead of failing, its existence is checked before calling mkdir.

Fixes https://github.com/nextcloud/server/issues/30564

Note: normally the target folders don't exist yet when doing a copy over webdav because the webdav code (or higher layers) will first delete the target before starting the copy. With transfer ownership we operate on a different layer so this pre-deletion is not done but there's a check upfront that the target storage is empty.