### PR TITLE
Default to language from request in L10N\Factory->getUserLanguage()

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -431,6 +431,15 @@ class Factory implements IFactory {
 			if ($language !== null) {
 				return $language;
 			}
+
+			// Use language from request
+			if ($this->userSession->getUser() instanceof IUser &&
+				$user->getUID() === $this->userSession->getUser()->getUID()) {
+				try {
+					return $this->getLanguageFromRequest();
+				} catch (LanguageNotFoundException $e) {
+				}
+			}
 		}
 
 		return $this->config->getSystemValue('default_language', 'en');


### PR DESCRIPTION
Try to get the language from request before falling back to the instance
default.

This fixes the detected user language during first login of a new user
and ensures that the returned language is consistent during the login.

Also partially fixes a bug with Collectives folder being initialized
in different languages at first login, see
https://gitlab.com/collectivecloud/collectives/-/issues/238

Signed-off-by: Jonas Meurer <jonas@freesources.org>