### PR TITLE
fix: only use jquery once it is available

### DIFF
--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -31,16 +31,17 @@ window.addEventListener('DOMContentLoaded', function () {
 		$('#remote_address').focus();
 	});
 
-});
 
-$(document).mouseup(function(e) {
-	var toggle = $('#body-public').find('.header-right .menutoggle');
-	var container = toggle.next('.popovermenu');
+	$(document).mouseup(function(e) {
+		var toggle = $('#body-public').find('.header-right .menutoggle');
+		var container = toggle.next('.popovermenu');
 
-	// if the target of the click isn't the menu toggle, nor a descendant of the
-	// menu toggle, nor the container nor a descendant of the container
-	if (!toggle.is(e.target) && toggle.has(e.target).length === 0 &&
-		!container.is(e.target) && container.has(e.target).length === 0) {
-		container.removeClass('open');
-	}
+		// if the target of the click isn't the menu toggle, nor a descendant of the
+		// menu toggle, nor the container nor a descendant of the container
+		if (!toggle.is(e.target) && toggle.has(e.target).length === 0 &&
+			!container.is(e.target) && container.has(e.target).length === 0) {
+			container.removeClass('open');
+		}
+	});
+
 });


### PR DESCRIPTION
publicpage.js is loaded very early and cannot rely on jquery being loaded already.

Move the use of `$` into the `DomContentLoaded` handler.