### PR TITLE
Adjust footer height

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -1,4 +1,4 @@
-$footer-height: 100px;
+$footer-height: 80px;
 
 #body-public {
 	.header-right {

--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -1,4 +1,4 @@
-$footer-height: 65px;
+$footer-height: 100px;
 
 #body-public {
 	.header-right {


### PR DESCRIPTION
65px is not enough when you have 3 lines (Cloud name, Legal notice and Signup link)

![image](https://user-images.githubusercontent.com/12234510/148902879-2658e6aa-0492-4fa6-ad71-7d93ec754d99.png)
