### PR TITLE
Fix undefined/unset scope in account properties

### DIFF
--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -152,6 +152,7 @@ class AccountProperty implements IAccountProperty {
 
 		switch ($scope) {
 			case IAccountManager::VISIBILITY_PRIVATE:
+			case '':
 				return IAccountManager::SCOPE_LOCAL;
 			case IAccountManager::VISIBILITY_CONTACTS_ONLY:
 				return IAccountManager::SCOPE_FEDERATED;

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -84,8 +84,8 @@ class AccountPropertyTest extends TestCase {
 			[IAccountManager::VISIBILITY_PRIVATE, IAccountManager::SCOPE_LOCAL],
 			[IAccountManager::VISIBILITY_CONTACTS_ONLY, IAccountManager::SCOPE_FEDERATED],
 			[IAccountManager::VISIBILITY_PUBLIC, IAccountManager::SCOPE_PUBLISHED],
+			['', IAccountManager::SCOPE_LOCAL],
 			// invalid values
-			['', null],
 			['unknown', null],
 			['v2-unknown', null],
 		];


### PR DESCRIPTION

### Log
<details>

```json
{
  "reqId": "6Y4E8WeiteeF6iMgH879",
  "level": 3,
  "time": "2022-01-03T17:47:34+00:00",
  "remoteAddr": "…",
  "user": "…",
  "app": "index",
  "method": "GET",
  "url": "/apps/files/",
  "message": "Invalid scope",
  "userAgent": "…",
  "version": "23.0.0.10",
  "exception": {
    "Exception": "InvalidArgumentException",
    "Message": "Invalid scope",
    "Code": 0,
    "Trace": [
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/Accounts/AccountProperty.php",
        "line": 52,
        "function": "setScope",
        "class": "OC\\Accounts\\AccountProperty",
        "type": "->",
        "args": [
          ""
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/Accounts/Account.php",
        "line": 55,
        "function": "__construct",
        "class": "OC\\Accounts\\AccountProperty",
        "type": "->",
        "args": [
          "displayname",
          "…",
          "",
          "0",
          ""
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/Accounts/AccountManager.php",
        "line": 749,
        "function": "setProperty",
        "class": "OC\\Accounts\\Account",
        "type": "->",
        "args": [
          "displayname",
          "…",
          "",
          "0"
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/Accounts/AccountManager.php",
        "line": 760,
        "function": "parseAccountData",
        "class": "OC\\Accounts\\AccountManager",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\User\\User"
          },
          [
            {
              "name": "displayname",
              "value": "…",
              "scope": "",
              "verified": "0"
            },
            {
              "name": "address",
              "value": "…",
              "scope": "private",
              "verified": "0"
            },
            {
              "name": "website",
              "value": "…",
              "scope": "private",
              "verified": "0"
            },
            {
              "name": "email",
              "value": "…",
              "scope": "",
              "verified": "0"
            },
            {
              "name": "avatar",
              "scope": ""
            },
            {
              "name": "phone",
              "value": "…",
              "scope": "private",
              "verified": "0"
            },
            {
              "name": "twitter",
              "value": "…",
              "scope": "private",
              "verified": "0"
            },
            {
              "name": "organisation",
              "value": "",
              "scope": "v2-local"
            },
            {
              "name": "role",
              "value": "",
              "scope": "v2-local"
            },
            {
              "name": "headline",
              "value": "",
              "scope": "v2-local"
            },
            {
              "name": "biography",
              "value": "",
              "scope": "v2-local"
            },
            {
              "name": "profile_enabled",
              "value": "1"
            }
          ]
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php",
        "line": 83,
        "function": "getAccount",
        "class": "OC\\Accounts\\AccountManager",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\User\\User"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 87,
        "function": "handle",
        "class": "OCA\\UserStatus\\Listener\\BeforeTemplateRenderedListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 251,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          },
          "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent",
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 88,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          },
          "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 100,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent",
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/AppFramework/Middleware/AdditionalScriptsMiddleware.php",
        "line": 73,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\AppFramework\\Http\\Events\\BeforeTemplateRenderedEvent"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/AppFramework/Middleware/MiddlewareDispatcher.php",
        "line": 143,
        "function": "afterController",
        "class": "OC\\AppFramework\\Middleware\\AdditionalScriptsMiddleware",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files\\Controller\\ViewController"
          },
          "index",
          {
            "__class__": "OCP\\AppFramework\\Http\\TemplateResponse"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 164,
        "function": "afterController",
        "class": "OC\\AppFramework\\Middleware\\MiddlewareDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files\\Controller\\ViewController"
          },
          "index",
          {
            "__class__": "OCP\\AppFramework\\Http\\TemplateResponse"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/AppFramework/App.php",
        "line": 157,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Files\\Controller\\ViewController"
          },
          "index"
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/private/Route/Router.php",
        "line": 302,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Files\\Controller\\ViewController",
          "index",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "_route": "files.view.index"
          }
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/lib/base.php",
        "line": 1006,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/files/"
        ]
      },
      {
        "file": "/srv/www/htdocs/nextcloud/index.php",
        "line": 36,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/srv/www/htdocs/nextcloud/lib/private/Accounts/AccountProperty.php",
    "Line": 96,
    "CustomMessage": "--"
  },
  "id": "61d336b80111d"
}
```
</details>

Somehow @camilasan  had an empty string as scope for some of her properties.
https://github.com/nextcloud/server/blob/19a3656fd95ea2a3ff5d00eb4332b0c8c6f71ea9/lib/private/Accounts/AccountManager.php#L752
But the code above is only fixing non-set scopes, not empty ones.
So it breaks further on as empty string is not a valid scope