### PR TITLE
Trigger "changeDirectory" event on URL change

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -316,7 +316,7 @@
 		 * Event handler for when an app notified that its directory changed
 		 */
 		_onDirectoryChanged: function(e) {
-			if (e.dir) {
+			if (e.dir && !e.changedThroughUrl) {
 				this._changeUrl(this.navigation.getActiveItem(), e.dir, e.fileId);
 			}
 		},
@@ -386,9 +386,11 @@
 				params.fileid = fileId;
 			}
 			var currentParams = OC.Util.History.parseUrlQuery();
-			if (currentParams.dir === params.dir && currentParams.view === params.view && currentParams.fileid !== params.fileid) {
-				// if only fileid changed or was added, replace instead of push
-				OC.Util.History.replaceState(this._makeUrlParams(params));
+			if (currentParams.dir === params.dir && currentParams.view === params.view) {
+				if (currentParams.fileid !== params.fileid) {
+					// if only fileid changed or was added, replace instead of push
+					OC.Util.History.replaceState(this._makeUrlParams(params));
+				}
 			} else {
 				OC.Util.History.pushState(this._makeUrlParams(params));
 			}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -794,7 +794,7 @@
 				if( (this._currentDirectory || this.$el.find('#dir').val()) && currentDir === e.dir) {
 					return;
 				}
-				this.changeDirectory(e.dir, false, true);
+				this.changeDirectory(e.dir, true, true, undefined, true);
 			}
 		},
 
@@ -2057,15 +2057,16 @@
 		 * @param {boolean} [changeUrl=true] if the URL must not be changed (defaults to true)
 		 * @param {boolean} [force=false] set to true to force changing directory
 		 * @param {string} [fileId] optional file id, if known, to be appended in the URL
+		 * @param {bool} [changedThroughUrl=false] true if the dir was set through a URL change
 		 */
-		changeDirectory: function(targetDir, changeUrl, force, fileId) {
+		changeDirectory: function(targetDir, changeUrl, force, fileId, changedThroughUrl) {
 			var self = this;
 			var currentDir = this.getCurrentDirectory();
 			targetDir = targetDir || '/';
 			if (!force && currentDir === targetDir) {
 				return;
 			}
-			this._setCurrentDir(targetDir, changeUrl, fileId);
+			this._setCurrentDir(targetDir, changeUrl, fileId, changedThroughUrl);
 
 			// discard finished uploads list, we'll get it through a regular reload
 			this._uploads = {};
@@ -2100,8 +2101,9 @@
 		 * @param targetDir directory to display
 		 * @param changeUrl true to also update the URL, false otherwise (default)
 		 * @param {string} [fileId] file id
+		 * @param {bool} changedThroughUrl true if the dir was set through a URL change
 		 */
-		_setCurrentDir: function(targetDir, changeUrl, fileId) {
+		_setCurrentDir: function(targetDir, changeUrl, fileId, changedThroughUrl) {
 			targetDir = targetDir.replace(/\\/g, '/');
 			if (!this._isValidPath(targetDir)) {
 				targetDir = '/';
@@ -2133,6 +2135,7 @@
 				if (fileId) {
 					params.fileId = fileId;
 				}
+				params.changedThroughUrl = changedThroughUrl
 				this.$el.trigger(jQuery.Event('changeDirectory', params));
 			}
 			this.breadcrumb.setDirectory(this.getCurrentDirectory());
@@ -2234,7 +2237,7 @@
 			if (status === 401) {
 				// We are not authentificated, so reload the page so that we get
 				// redirected to the login page while saving the current url.
-				location.reload(); 
+				location.reload();
 			}
 
 			// Firewall Blocked request?


### PR DESCRIPTION
When using the browser back button or clicking on sections on the left
sidebar (like favorites), the "changeDirectory" jQuery event did not get
called, so apps like recommendations would not notice the directory
change.

This fixes the issue by also setting changeUrl to true when the file
list's directory got changed as a result from a URL change.

Note that in the past this argument was there to prevent repushing the
same URL to the history stack but is obsolete already as there's a check
in place to not push again whatever is already there.

Fixes https://github.com/nextcloud/server/issues/19048
I've tested this PR with both scenarios from the ticket.
