### PR TITLE
Fix non-ascii characters present in the header

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -681,7 +681,7 @@ class Session implements IUserSession, Emitter {
 			// User does not exist
 			return false;
 		}
-		$name = isset($request->server['HTTP_USER_AGENT']) ? $request->server['HTTP_USER_AGENT'] : 'unknown browser';
+		$name = isset($request->server['HTTP_USER_AGENT']) ? utf8_encode($request->server['HTTP_USER_AGENT']) : 'unknown browser';
 		try {
 			$sessionId = $this->session->getId();
 			$pwd = $this->getPassword($password);


### PR DESCRIPTION
The http headers according to rfc 2616 is iso-8859-1. This patch fixes the behavior when non-ascii characters are present in the header.