### PR TITLE
Avoid file system access on checking if an image exists

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -78,10 +78,8 @@ class ImageManager {
 
 	public function getImageUrl(string $key, bool $useSvg = true): string {
 		$cacheBusterCounter = $this->config->getAppValue('theming', 'cachebuster', '0');
-		try {
-			$image = $this->getImage($key, $useSvg);
+		if ($this->hasImage($key)) {
 			return $this->urlGenerator->linkToRoute('theming.Theming.getImage', [ 'key' => $key ]) . '?v=' . $cacheBusterCounter;
-		} catch (NotFoundException $e) {
 		}
 
 		switch ($key) {
@@ -130,6 +128,11 @@ class ImageManager {
 			}
 		}
 		return $folder->getFile($key);
+	}
+
+	public function hasImage(string $key): bool {
+		$mimeSetting = $this->config->getAppValue('theming', $key . 'Mime', '');
+		return $mimeSetting !== '';
 	}
 
 	/**

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -136,7 +136,6 @@ class ImageManagerTest extends TestCase {
 				['theming', 'logoMime', '']
 				)
 			->willReturn(0);
-		$this->mockGetImage('logo', $file);
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->willReturn('url-to-image');
@@ -148,9 +147,9 @@ class ImageManagerTest extends TestCase {
 			->method('getAppValue')
 			->withConsecutive(
 				['theming', 'cachebuster', '0'],
-				['theming', 'logoMime', false]
+				['theming', 'logoMime', '']
 			)
-			->willReturnOnConsecutiveCalls(0, false);
+			->willReturnOnConsecutiveCalls(0, '');
 		$this->urlGenerator->expects($this->once())
 			->method('imagePath')
 			->with('core', 'logo/logo.png')
@@ -167,15 +166,8 @@ class ImageManagerTest extends TestCase {
 				['theming', 'cachebuster', '0'],
 				['theming', 'logoMime', '']
 			)
-			->willReturn(0);
-		$this->mockGetImage('logo', $file);
-		$this->urlGenerator->expects($this->at(0))
-			->method('getBaseUrl')
-			->willReturn('baseurl');
-		$this->urlGenerator->expects($this->at(1))
-			->method('getAbsoluteUrl')
-			->willReturn('url-to-image-absolute?v=0');
-		$this->urlGenerator->expects($this->at(2))
+			->willReturnOnConsecutiveCalls(0, 0);
+		$this->urlGenerator->expects($this->any())
 			->method('getAbsoluteUrl')
 			->willReturn('url-to-image-absolute?v=0');
 		$this->assertEquals('url-to-image-absolute?v=0', $this->imageManager->getImageUrlAbsolute('logo', false));
@@ -207,7 +199,7 @@ class ImageManagerTest extends TestCase {
 			->method('getAppValue')
 			->with('theming', 'cachebuster', '0')
 			->willReturn('0');
-		$this->appData->expects($this->at(0))
+		$this->appData->expects($this->once())
 			->method('getFolder')
 			->with('0')
 			->willReturn($folder);


### PR DESCRIPTION
Save some time and potential file system setup when obtaining capabilities (which is done on every template response) for gathering theming capabilities by not getting the background image file but just checking if one is configured.