### PR TITLE
Remove shortFooter/longFooter to avoid unnecessary navigation loading

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -301,8 +301,6 @@ class JSConfigHelper {
 				'docPlaceholderUrl' => $this->defaults->buildDocLinkToKey('PLACEHOLDER'),
 				'slogan' => $this->defaults->getSlogan(),
 				'logoClaim' => '',
-				'shortFooter' => $this->defaults->getShortFooter(),
-				'longFooter' => $this->defaults->getLongFooter(),
 				'folder' => \OC_Util::getTheme(),
 			]),
 		];


### PR DESCRIPTION
There doesn't seem to be any usages of those properties on the `_theme` global which I'd consider private API in the frontend code and fetching them can be quite expensive with loading all available entries in the navigation manager:

https://github.com/nextcloud/server/blob/da73990d1c407645bdbf0b52d30889c995b6c11b/apps/theming/lib/ThemingDefaults.php#L194
https://github.com/nextcloud/server/blob/a94236483e26785dcaf97fb10e863f82348eb068/lib/private/NavigationManager.php#L113