### PR TITLE
updateEncryptedVersion: cleanup on target if cache already got renamed

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -694,7 +694,16 @@ class Encryption extends Wrapper {
 			'encrypted' => $isEncrypted,
 		];
 		if ($isEncrypted) {
-			$encryptedVersion = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
+			$sourceCacheEntry = $sourceStorage->getCache()->get($sourceInternalPath);
+			$targetCacheEntry = $this->getCache()->get($targetInternalPath);
+
+			// Rename of the cache already happened, so we do the cleanup on the target
+			if ($sourceCacheEntry === false && $targetCacheEntry !== false) {
+				$encryptedVersion = $targetCacheEntry['encryptedVersion'];
+				$isRename = false;
+			} else {
+				$encryptedVersion = $sourceCacheEntry['encryptedVersion'];
+			}
 
 			// In case of a move operation from an unencrypted to an encrypted
 			// storage the old encrypted version would stay with "0" while the


### PR DESCRIPTION
When moving a file to trash with encryption enabled, the cache gets
moved before the actual file. According to @icewind1991 this is in order
to not break object storage.

When moving a file from an unencrypted storage (e.g. a collectives
storage) to the encrypted trashbin storage, this causes errors, see

This commit fixes it by doing `updateEncryptedVersion()` on the target
cache entry *if* the source cache entry doesn't exist anymore, but the
corresponding target cache entry does exist already.

Fixes: #26544

Signed-off-by: Jonas Meurer <jonas@freesources.org>