### PR TITLE
Unpin webpack version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "vue-jest": "^4.0.1",
         "vue-loader": "^15.9.8",
         "vue-template-compiler": "^2.6.14",
-        "webpack": "~5.66.0",
+        "webpack": "^5.66.0",
         "webpack-cli": "^4.9.1",
         "webpack-merge": "^5.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "vue-jest": "^4.0.1",
     "vue-loader": "^15.9.8",
     "vue-template-compiler": "^2.6.14",
-    "webpack": "~5.66.0",
+    "webpack": "^5.66.0",
     "webpack-cli": "^4.9.1",
     "webpack-merge": "^5.8.0"
   },


### PR DESCRIPTION
https://github.com/webpack/webpack/pull/14628 is now merged, it should be safe to unpin the webpack version.