### PR TITLE
New Files internal link GET param to avoid opening the file

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -162,10 +162,10 @@ class ViewController extends Controller {
 	 * @return TemplateResponse|RedirectResponse
 	 * @throws NotFoundException
 	 */
-	public function showFile(string $fileid = null): Response {
+	public function showFile(string $fileid = null, int $openfile = 1): Response {
 		// This is the entry point from the `/f/{fileid}` URL which is hardcoded in the server.
 		try {
-			return $this->redirectToFile($fileid, true);
+			return $this->redirectToFile($fileid, $openfile !== 0);
 		} catch (NotFoundException $e) {
 			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index', ['fileNotFound' => true]));
 		}


### PR DESCRIPTION
This adds a `openfile` GET param to internal links (`/f/FILE_ID`) to avoid setting the `openfile` param in the redirect response.
This can be useful when the intention is to show the file's activity for example.
It is already possible to get there with links like `https://my.nc.org/index.php/apps/files/?dir=/&scrollto=name.txt` but it requires to know the file path.