### PR TITLE
Fix bad request when creating users without a password

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -398,7 +398,7 @@ class UsersController extends AUserData {
 			$this->eventDispatcher->dispatchTyped($passwordEvent);
 
 			$password = $passwordEvent->getPassword();
-			if ($password === null) {
+			if ($password === null || $password === '') {
 				// Fallback: ensure to pass password_policy in any case
 				$password = $this->secureRandom->generate(10)
 					. $this->secureRandom->generate(1, ISecureRandom::CHAR_UPPER)


### PR DESCRIPTION
As requested in #30241, here is a pull-request containing the suggested
changes.

---

Commit summary:

When the minimal password length is set to 0, the generated password by
`GenerateSecurePasswordEvent` is '', which would bypass the fallback
password generation. `UserManager` would then throw an error since the
password is an empty string.