### PR TITLE
23.0.1 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [23, 0, 1, 0];
+$OC_Version = [23, 0, 1, 1];
 
 // The human readable string
-$OC_VersionString = '23.0.1 RC1';
+$OC_VersionString = '23.0.1 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #30525
* #30528
* #30557
* #30576
* #30580
* #30592
* #30594
* #30602
* #30611
* #30619
* #30621
* #30623
* #30627
* #30636
* #30643
* #30659
* #30662
* #30663
* #30671
* #30672
* #30674
* #30684
* #30688
* #30689
* #30695
* #30698
* [circles#898](https://github.com/nextcloud/circles/pull/898) L10n: Improved grammar
* [photos#960](https://github.com/nextcloud/photos/pull/960) Fix Tags: Don't display tags without photos
* [photos#981](https://github.com/nextcloud/photos/pull/981) Update workflows
* [photos#985](https://github.com/nextcloud/photos/pull/985) Bump @nextcloud/webpack-vue-config from 4.1.0 to 4.1.4
* [photos#986](https://github.com/nextcloud/photos/pull/986) Bump url-parse from 1.5.3 to 1.5.4
* [photos#987](https://github.com/nextcloud/photos/pull/987) Bump vue-router from 3.5.2 to 3.5.3
* [photos#988](https://github.com/nextcloud/photos/pull/988) Bump qs from 6.10.1 to 6.10.3
* [photos#989](https://github.com/nextcloud/photos/pull/989) Bump camelcase from 6.2.0 to 6.2.1
* [privacy#676](https://github.com/nextcloud/privacy/pull/676) Fix label of account name and hide parts with subscription
* [text#2078](https://github.com/nextcloud/text/pull/2078) Bump @nextcloud/event-bus from 2.1.0 to 2.1.1
* [text#2081](https://github.com/nextcloud/text/pull/2081) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [text#2084](https://github.com/nextcloud/text/pull/2084) Bump @nextcloud/webpack-vue-config from 4.1.0 to 4.1.4
* [text#2085](https://github.com/nextcloud/text/pull/2085) Bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2
* [text#2086](https://github.com/nextcloud/text/pull/2086) Bump prosemirror-markdown from 1.6.0 to 1.6.2
* [text#2088](https://github.com/nextcloud/text/pull/2088) Bump @nextcloud/eslint-config from 6.1.0 to 6.1.2