### PR TITLE
22.2.4 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 2, 4, 0];
+$OC_Version = [22, 2, 4, 1];
 
 // The human readable string
-$OC_VersionString = '22.2.4 RC1';
+$OC_VersionString = '22.2.4 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #30526
* #30529
* #30558
* #30578
* #30581
* #30591
* #30598
* #30603
* #30610
* #30618
* #30622
* #30628
* #30637
* #30644
* #30658
* #30664
* #30666
* #30670
* #30673
* #30675
* #30683
* #30687
* #30690
* #30694
* #30697
* [circles#899](https://github.com/nextcloud/circles/pull/899) L10n: Improved grammar
* [photos#961](https://github.com/nextcloud/photos/pull/961) Fix Tags: Don't display tags without photos
* [photos#963](https://github.com/nextcloud/photos/pull/963) Bump qs from 6.10.1 to 6.10.3
* [photos#964](https://github.com/nextcloud/photos/pull/964) Bump url-parse from 1.5.3 to 1.5.4
* [photos#982](https://github.com/nextcloud/photos/pull/982) Update workflows
* [privacy#677](https://github.com/nextcloud/privacy/pull/677) Fix label of account name and hide parts with subscription
* [text#1912](https://github.com/nextcloud/text/pull/1912) Bump babel-loader from 8.2.2 to 8.2.3
* [text#1935](https://github.com/nextcloud/text/pull/1935) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [text#1936](https://github.com/nextcloud/text/pull/1936) Bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2
* [text#2057](https://github.com/nextcloud/text/pull/2057) Backport/1883/stable22
* [text#2074](https://github.com/nextcloud/text/pull/2074) Avoid creating invalid URIs from user input
* [text#2075](https://github.com/nextcloud/text/pull/2075) Allow to insert text after trailing codeblock
* [text#2076](https://github.com/nextcloud/text/pull/2076) Only register trailing node for rich text editing
* [text#2080](https://github.com/nextcloud/text/pull/2080) Bump cypress from 9.2.0 to 9.2.1
* [text#2094](https://github.com/nextcloud/text/pull/2094) Make collabora on top of text idle message