### PR TITLE
21.0.8 RC2

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [21, 0, 8, 0];
+$OC_Version = [21, 0, 8, 1];
 
 // The human readable string
-$OC_VersionString = '21.0.8 RC1';
+$OC_VersionString = '21.0.8 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #30454
* #30527
* #30559
* #30579
* #30583
* #30590
* #30596
* #30599
* #30601
* #30617
* #30629
* #30633
* #30638
* #30642
* #30665
* #30667
* #30669
* #30676
* #30677
* #30682
* #30686
* [photos#959](https://github.com/nextcloud/photos/pull/959) Bump @nextcloud/vue from 3.3.1 to 3.3.2
* [photos#962](https://github.com/nextcloud/photos/pull/962) Fix Tags: Don't display tags without photos
* [photos#967](https://github.com/nextcloud/photos/pull/967) Bump vue-loader from 15.9.6 to 15.9.8
* [photos#969](https://github.com/nextcloud/photos/pull/969) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [photos#970](https://github.com/nextcloud/photos/pull/970) Bump autoprefixer from 9.8.6 to 9.8.8
* [photos#971](https://github.com/nextcloud/photos/pull/971) Bump regenerator-runtime from 0.13.7 to 0.13.9
* [photos#983](https://github.com/nextcloud/photos/pull/983) Update workflows
* [photos#990](https://github.com/nextcloud/photos/pull/990) Bump vue-virtual-grid from 2.3.0 to 2.3.2
* [photos#991](https://github.com/nextcloud/photos/pull/991) Bump vuex from 3.6.0 to 3.6.2
* [photos#992](https://github.com/nextcloud/photos/pull/992) Bump vue and vue-template-compiler
* [photos#993](https://github.com/nextcloud/photos/pull/993) Bump qs from 6.9.6 to 6.9.7
* [photos#994](https://github.com/nextcloud/photos/pull/994) Bump camelcase from 6.2.0 to 6.2.1
* [privacy#678](https://github.com/nextcloud/privacy/pull/678) Fix label of account name and hide parts with subscription
* [text#1894](https://github.com/nextcloud/text/pull/1894) Bump @babel/preset-env from 7.15.6 to 7.15.8
* [text#1911](https://github.com/nextcloud/text/pull/1911) Bump babel-loader from 8.2.2 to 8.2.3
* [text#1937](https://github.com/nextcloud/text/pull/1937) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [text#1938](https://github.com/nextcloud/text/pull/1938) Bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2