### PR TITLE
Set package-lock.json as binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /dist/* binary
-/package-lock.json
+/package-lock.json binary
+/build/package-lock.json binary

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,6 @@ nbproject
 /build/jsdocs/
 /npm-debug.log
 /PhantomJS_*
-/build/package-lock.json
 
 # puphpet
 puphpet


### PR DESCRIPTION
Set `package-lock.json` as binaries and remove `build/package-lock.json` from `.gitignore` even though it was already tracked by git.