### PR TITLE
Fix loading of the text app in public shared links

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -9,10 +9,19 @@
 
 		/** Center the shared content inside the page */
 		&.app-files_sharing {
-			justify-content: center;
-			align-items: center;
 			#app-content {
-				min-height: inherit;
+				min-height: 100%;
+				display: flex;
+			}
+
+			#files-public-content {
+				flex-grow: 2;
+				display: grid;
+			}
+
+			#preview {
+				justify-self: center;
+				align-self: center;
 				padding-left: 1rem;
 				padding-right: 1rem;
 			}


### PR DESCRIPTION
Instead of doing the centering for the entire public content, only do it
for the preview. This is more safe.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>