### PR TITLE
Load core before the update script

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -365,7 +365,10 @@ class OC {
 
 		$oldTheme = $systemConfig->getValue('theme');
 		$systemConfig->setValue('theme', '');
-		OC_Util::addScript('update');
+		OC_Util::addScript('core', 'common');
+		OC_Util::addScript('core', 'main');
+		OC_Util::addTranslations('core');
+		OC_Util::addScript('update', null, 'core');
 
 		/** @var \OC\App\AppManager $appManager */
 		$appManager = \OC::$server->getAppManager();


### PR DESCRIPTION
Updating in the web interface is currently not possible:
```
 Uncaught ReferenceError: OC is not defined
    <anonymous> https://nextcloud24.local/core/js/update.js:12
    <anonymous> https://nextcloud24.local/core/js/update.js:147
```