### PR TITLE
Add IConfig::getAllUserValues to get user settings for all applications

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -184,7 +184,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\AddAppPassword(\OC::$server->get(\OCP\IUserManager::class), \OC::$server->get(\OC\Authentication\Token\IProvider::class), \OC::$server->get(\OCP\Security\ISecureRandom::class), \OC::$server->get(\OCP\Security\ICrypto::class)));

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -312,7 +312,7 @@ class AllConfig implements \OCP\IConfig {
 	/**
 	 * Getting a user defined value
 	 *
-	 * @param string $userId the userId of the user that we want to store the value under
+	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param mixed $default the default value to be returned if the value isn't set
@@ -400,19 +400,19 @@ class AllConfig implements \OCP\IConfig {
 	/**
 	 * Returns all user configs sorted by app of one user
 	 *
-	 * @param string $userId the user ID to get the app configs from
+	 * @param ?string $userId the user ID to get the app configs from
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
 	 *         [ $key => $value ]
 	 *     ]
 	 */
-	public function getAllUserValues(string $userId): array {
+	public function getAllUserValues(?string $userId): array {
 		if (isset($this->userCache[$userId])) {
 			return $this->userCache[$userId];
 		}
 		if ($userId === null || $userId === '') {
-			$this->userCache[$userId] = [];
-			return $this->userCache[$userId];
+			$this->userCache[''] = [];
+			return $this->userCache[''];
 		}
 
 		// TODO - FIXME

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -401,6 +401,7 @@ class AllConfig implements \OCP\IConfig {
 	 * Returns all user configs sorted by app of one user
 	 *
 	 * @param ?string $userId the user ID to get the app configs from
+	 * @psalm-return array<string, array<string, string>>
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
 	 *         [ $key => $value ]

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -319,7 +319,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '') {
-		$data = $this->getUserValues($userId);
+		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName][$key])) {
 			return $data[$appName][$key];
 		} else {
@@ -335,7 +335,7 @@ class AllConfig implements \OCP\IConfig {
 	 * @return string[]
 	 */
 	public function getUserKeys($userId, $appName) {
-		$data = $this->getUserValues($userId);
+		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName])) {
 			return array_keys($data[$appName]);
 		} else {
@@ -406,7 +406,7 @@ class AllConfig implements \OCP\IConfig {
 	 *         [ $key => $value ]
 	 *     ]
 	 */
-	private function getUserValues($userId) {
+	public function getAllUserValues(string $userId): array {
 		if (isset($this->userCache[$userId])) {
 			return $this->userCache[$userId];
 		}

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -186,7 +186,7 @@ interface IConfig {
 	/**
 	 * Shortcut for getting a user defined value
 	 *
-	 * @param string $userId the userId of the user that we want to store the value under
+	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param mixed $default the default value to be returned if the value isn't set

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -220,6 +220,7 @@ interface IConfig {
 	 * Get all user configs sorted by app of one user
 	 *
 	 * @param string $userId the userId of the user that we want to get all values from
+	 * @psalm-return array<string, array<string, string>>
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
 	 *         [ $key => $value ]

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -217,6 +217,18 @@ interface IConfig {
 	public function getUserKeys($userId, $appName);
 
 	/**
+	 * Get all user configs sorted by app of one user
+	 *
+	 * @param string $userId the userId of the user that we want to get all values from
+	 * @return array[] - 2 dimensional array with the following structure:
+	 *     [ $appId =>
+	 *         [ $key => $value ]
+	 *     ]
+	 * @since 24.0.0
+	 */
+	public function getAllUserValues(string $userId): array;
+
+	/**
 	 * Delete a user value
 	 *
 	 * @param string $userId the userId of the user that we want to store the value under


### PR DESCRIPTION
The function is already there but private.
The command user:setting needs it but does direct database access instead.
The user_migration application will be able to use that to export settings.