### PR TITLE
Revert "Improve layout for the public download page"

### DIFF
--- a/core/css/public.scss
+++ b/core/css/public.scss
@@ -1,25 +1,8 @@
+$footer-height: 65px;
+
 #body-public {
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
-
-	#content {
-		flex-grow: 2;
-		min-height: initial;
-
-		/** Center the shared content inside the page */
-		&.app-files_sharing {
-			justify-content: center;
-			align-items: center;
-			#app-content {
-				min-height: inherit;
-				padding-left: 1rem;
-				padding-right: 1rem;
-			}
-		}
-	}
-
 	.header-right {
+
 		#header-primary-action a {
 			color: var(--color-primary-text);
 		}
@@ -50,6 +33,12 @@
 				}
 			}
 		}
+	}
+
+	#content {
+		// 100% - footer
+		min-height: calc(100% - #{$footer-height});
+
 	}
 
 	/** don't apply content header padding on the base layout */
@@ -83,8 +72,8 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		height: $footer-height;
 		flex-direction: column;
-		padding: 0.5rem;
 		p {
 			text-align: center;
 			color: var(--color-text-lighter);


### PR DESCRIPTION
This reverts commit 30decc3ed1f6c15a799278274cf1a75776441b56.

There were still some issues with the layout in #30723. So revert the commit that broke text editing and probably also the grid layout.