### PR TITLE
Allow writing audit log to syslog and systemdlog

### DIFF
--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -96,15 +96,19 @@ class Application extends App implements IBootstrap {
 	}
 
 	private function getLogger(IConfig $config,
-							   LoggerInterface $logger,
 							   ILogFactory $logFactory): LoggerInterface {
-		$default = $config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/audit.log';
-		$logFile = $config->getAppValue('admin_audit', 'logfile', $default);
+		$auditType = $config->getSystemValueString('log_type_audit', 'file');
+		$defaultTag = $config->getSystemValueString('syslog_tag', 'Nextcloud');
+		$auditTag = $config->getSystemValueString('syslog_tag_audit', $defaultTag);
+		$logFile = $config->getSystemValueString('logfile_audit', '');
 
-		if ($logFile === null) {
-			return $logger;
+		if ($auditType === 'file' && !$logFile) {
+			$default = $config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/audit.log';
+			// Legacy way was appconfig, now it's paralleled with the normal log config
+			$logFile = $config->getAppValue('admin_audit', 'logfile', $default);
 		}
-		return $logFactory->getCustomPsrLogger($logFile);
+
+		return $logFactory->getCustomPsrLogger($logFile, $auditType, $auditTag);
 	}
 
 	/**

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -840,6 +840,13 @@ $CONFIG = [
 'log_type' => 'file',
 
 /**
+ * This parameter determines where the audit logs are sent. See ``log_type`` for more information.
+ *
+ * Defaults to ``file``
+ */
+'log_type_audit' => 'file',
+
+/**
  * Name of the file to which the Nextcloud logs are written if parameter
  * ``log_type`` is set to ``file``.
  *
@@ -848,7 +855,15 @@ $CONFIG = [
 'logfile' => '/var/log/nextcloud.log',
 
 /**
- * Log file mode for the Nextcloud loggin type in octal notation.
+ * Name of the file to which the audit logs are written if parameter
+ * ``log_type`` is set to ``file``.
+ *
+ * Defaults to ``[datadirectory]/audit.log``
+ */
+'logfile_audit' => '/var/log/audit.log',
+
+/**
+ * Log file mode for the Nextcloud logging type in octal notation.
  *
  * Defaults to 0640 (writeable by user, readable by group).
  */
@@ -871,6 +886,16 @@ $CONFIG = [
  * The default value is ``Nextcloud``.
  */
 'syslog_tag' => 'Nextcloud',
+
+/**
+ * If you maintain different instances and aggregate the logs, you may want
+ * to distinguish between them. ``syslog_tag_audit`` can be set per instance
+ * with a unique id. Only available if ``log_type`` is set to ``syslog`` or
+ * ``systemd``.
+ *
+ * The default value is the value of ``syslog_tag``.
+ */
+'syslog_tag_audit' => 'Nextcloud',
 
 /**
  * Log condition for log level increase based on conditions. Once one of these

--- a/lib/private/Log/Errorlog.php
+++ b/lib/private/Log/Errorlog.php
@@ -29,6 +29,13 @@ use OCP\Log\IWriter;
 
 class Errorlog implements IWriter {
 
+	/** @var string */
+	protected $tag;
+
+	public function __construct(string $tag = 'owncloud') {
+		$this->tag = $tag;
+	}
+
 	/**
 	 * write a message in the log
 	 * @param string $app
@@ -36,6 +43,6 @@ class Errorlog implements IWriter {
 	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level) {
-		error_log('[owncloud]['.$app.']['.$level.'] '.$message);
+		error_log('[' . $this->tag . ']['.$app.']['.$level.'] '.$message);
 	}
 }

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -70,8 +70,24 @@ class LogFactory implements ILogFactory {
 		return new Log($log, $this->systemConfig);
 	}
 
-	public function getCustomPsrLogger(string $path): LoggerInterface {
-		$log = $this->buildLogFile($path);
+	protected function createNewLogger(string $type, string $tag, string $path): IWriter {
+		switch (strtolower($type)) {
+			case 'errorlog':
+				return new Errorlog($tag);
+			case 'syslog':
+				return new Syslog($this->systemConfig, $tag);
+			case 'systemd':
+				return new Systemdlog($this->systemConfig, $tag);
+			case 'file':
+			case 'owncloud':
+			case 'nextcloud':
+			default:
+				return $this->buildLogFile($path);
+		}
+	}
+
+	public function getCustomPsrLogger(string $path, string $type = 'file', string $tag = 'Nextcloud'): LoggerInterface {
+		$log = $this->createNewLogger($type, $tag, $path);
 		return new PsrLoggerAdapter(
 			new Log($log, $this->systemConfig)
 		);

--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -38,9 +38,12 @@ class Syslog extends LogDetails implements IWriter {
 		ILogger::FATAL => LOG_CRIT,
 	];
 
-	public function __construct(SystemConfig $config) {
+	public function __construct(SystemConfig $config, ?string $tag = null) {
 		parent::__construct($config);
-		openlog($config->getValue('syslog_tag', 'Nextcloud'), LOG_PID | LOG_CONS, LOG_USER);
+		if ($tag === null) {
+			$tag = $config->getValue('syslog_tag', 'Nextcloud');
+		}
+		openlog($tag, LOG_PID | LOG_CONS, LOG_USER);
 	}
 
 	public function __destruct() {

--- a/lib/private/Log/Systemdlog.php
+++ b/lib/private/Log/Systemdlog.php
@@ -56,14 +56,17 @@ class Systemdlog extends LogDetails implements IWriter {
 
 	protected $syslogId;
 
-	public function __construct(SystemConfig $config) {
+	public function __construct(SystemConfig $config, ?string $tag = null) {
 		parent::__construct($config);
 		if (!function_exists('sd_journal_send')) {
 			throw new HintException(
 				'PHP extension php-systemd is not available.',
 				'Please install and enable PHP extension systemd if you wish to log to the Systemd journal.');
 		}
-		$this->syslogId = $config->getValue('syslog_tag', 'Nextcloud');
+		if ($tag === null) {
+			$tag = $config->getValue('syslog_tag', 'Nextcloud');
+		}
+		$this->syslogId = $tag;
 	}
 
 	/**

--- a/lib/public/Log/ILogFactory.php
+++ b/lib/public/Log/ILogFactory.php
@@ -51,8 +51,10 @@ interface ILogFactory {
 
 	/**
 	 * @param string $path
+	 * @param string $type
+	 * @param string $tag
 	 * @return LoggerInterface
-	 * @since 22.0.0
+	 * @since 22.0.0 - Parameters $type and $tag were added in 24.0.0
 	 */
-	public function getCustomPsrLogger(string $path): LoggerInterface;
+	public function getCustomPsrLogger(string $path, string $type = 'file', string $tag = 'Nextcloud'): LoggerInterface;
 }


### PR DESCRIPTION
In case you think we should backport this, be aware that it might change the logging, as audit currently always logs to file and with this patch it starts falling back to the normal logging which could be syslog and others.
We could also change this, but I think it would make the most sense.

Also on merge and after discussion of above issue the documentation in https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/logging_configuration.html#admin-audit-log needs a treatment