### PR TITLE
21.0.8 RC3

### DIFF
--- a/version.php
+++ b/version.php
@@ -33,7 +33,7 @@
 $OC_Version = [21, 0, 8, 1];
 
 // The human readable string
-$OC_VersionString = '21.0.8 RC2';
+$OC_VersionString = '21.0.8 RC3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28199
* #28657
* #29325
* #29764
* #29803
* #29834
* #29851
* #29853
* #29883
* #29907
* #29963
* #29979
* #29997
* #30023
* #30039
* #30056
* #30061
* #30064
* #30082
* #30109
* #30117
* #30138
* #30153
* #30178
* #30182
* #30189
* #30192
* #30216
* #30248
* #30251
* #30261
* #30270
* #30287
* #30308
* #30314
* #30327
* #30341
* #30346
* #30348
* #30435
* #30442
* #30448
* #30454
* #30482
* #30488
* #30521
* #30524
* #30527
* #30559
* #30579
* #30583
* #30590
* #30596
* #30599
* #30601
* #30617
* #30629
* #30633
* #30638
* #30642
* #30665
* #30667
* #30669
* #30676
* #30677
* #30682
* #30686
* #30737
* #30749
* #30755
* [3rdparty#973](https://github.com/nextcloud/3rdparty/pull/973) Create block-merge-freeze.yml
* [files_pdfviewer#532](https://github.com/nextcloud/files_pdfviewer/pull/532) Bump actions
* [files_pdfviewer#546](https://github.com/nextcloud/files_pdfviewer/pull/546) Create block-merge-freeze.yml
* [files_pdfviewer#551](https://github.com/nextcloud/files_pdfviewer/pull/551) Updating lint-php.yml workflow from template
* [files_rightclick#133](https://github.com/nextcloud/files_rightclick/pull/133) Create block-merge-freeze.yml
* [files_videoplayer#258](https://github.com/nextcloud/files_videoplayer/pull/258) Create block-merge-freeze.yml
* [firstrunwizard#640](https://github.com/nextcloud/firstrunwizard/pull/640) Disable fade-out because of accessbility reasons
* [firstrunwizard#654](https://github.com/nextcloud/firstrunwizard/pull/654) Fix overlapping buttons
* [firstrunwizard#663](https://github.com/nextcloud/firstrunwizard/pull/663) Create block-merge-freeze.yml
* [logreader#638](https://github.com/nextcloud/logreader/pull/638) Create block-merge-freeze.yml
* [nextcloud_announcements#94](https://github.com/nextcloud/nextcloud_announcements/pull/94) Create block-merge-freeze.yml
* [notifications#1139](https://github.com/nextcloud/notifications/pull/1139) Create block-merge-freeze.yml
* [password_policy#317](https://github.com/nextcloud/password_policy/pull/317) Create block-merge-freeze.yml
* [photos#1000](https://github.com/nextcloud/photos/pull/1000) Create block-merge-freeze.yml
* [photos#959](https://github.com/nextcloud/photos/pull/959) Bump @nextcloud/vue from 3.3.1 to 3.3.2
* [photos#962](https://github.com/nextcloud/photos/pull/962) Fix Tags: Don't display tags without photos
* [photos#967](https://github.com/nextcloud/photos/pull/967) Bump vue-loader from 15.9.6 to 15.9.8
* [photos#969](https://github.com/nextcloud/photos/pull/969) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [photos#970](https://github.com/nextcloud/photos/pull/970) Bump autoprefixer from 9.8.6 to 9.8.8
* [photos#971](https://github.com/nextcloud/photos/pull/971) Bump regenerator-runtime from 0.13.7 to 0.13.9
* [photos#983](https://github.com/nextcloud/photos/pull/983) Update workflows
* [photos#990](https://github.com/nextcloud/photos/pull/990) Bump vue-virtual-grid from 2.3.0 to 2.3.2
* [photos#991](https://github.com/nextcloud/photos/pull/991) Bump vuex from 3.6.0 to 3.6.2
* [photos#992](https://github.com/nextcloud/photos/pull/992) Bump vue and vue-template-compiler
* [photos#993](https://github.com/nextcloud/photos/pull/993) Bump qs from 6.9.6 to 6.9.7
* [photos#994](https://github.com/nextcloud/photos/pull/994) Bump camelcase from 6.2.0 to 6.2.1
* [privacy#678](https://github.com/nextcloud/privacy/pull/678) Fix label of account name and hide parts with subscription
* [privacy#686](https://github.com/nextcloud/privacy/pull/686) Create block-merge-freeze.yml
* [serverinfo#354](https://github.com/nextcloud/serverinfo/pull/354) Create block-merge-freeze.yml
* [survey_client#125](https://github.com/nextcloud/survey_client/pull/125) Create block-merge-freeze.yml
* [text#1894](https://github.com/nextcloud/text/pull/1894) Bump @babel/preset-env from 7.15.6 to 7.15.8
* [text#1911](https://github.com/nextcloud/text/pull/1911) Bump babel-loader from 8.2.2 to 8.2.3
* [text#1937](https://github.com/nextcloud/text/pull/1937) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [text#1938](https://github.com/nextcloud/text/pull/1938) Bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2
* [text#1991](https://github.com/nextcloud/text/pull/1991) Make sure translations are parsed correctly
* [text#1994](https://github.com/nextcloud/text/pull/1994) Fix deprecated scss syntax
* [text#1998](https://github.com/nextcloud/text/pull/1998) Pin node/npm versions
* [text#2022](https://github.com/nextcloud/text/pull/2022) Fix: use stable21 branch for cypress tests
* [text#2043](https://github.com/nextcloud/text/pull/2043) Add stylelint to github actions
* [text#2110](https://github.com/nextcloud/text/pull/2110) Only show image author annotations if needed
* [viewer#1072](https://github.com/nextcloud/viewer/pull/1072) Fix github actions
* [viewer#1073](https://github.com/nextcloud/viewer/pull/1073) Add light ⬇️ download  icon
* [viewer#1078](https://github.com/nextcloud/viewer/pull/1078) Disable fade-out because of accessbility reasons
* [viewer#1091](https://github.com/nextcloud/viewer/pull/1091) Fix german (Sie) translations comming from nextcloud-vue
* [viewer#1095](https://github.com/nextcloud/viewer/pull/1095) Bump workflows
* [viewer#1101](https://github.com/nextcloud/viewer/pull/1101) Add engines support for cypress tests
* [viewer#1116](https://github.com/nextcloud/viewer/pull/1116) Disable swiping on viewer video controls
* [viewer#1124](https://github.com/nextcloud/viewer/pull/1124) Disable swiping on viewer audio controls
* [viewer#1135](https://github.com/nextcloud/viewer/pull/1135) Create block-merge-freeze.yml
* [viewer#1140](https://github.com/nextcloud/viewer/pull/1140) Update lint-php.yml


Pending PRs:

* [ ] #29380 
* [ ] #29552 
* [ ] #29564 
* [ ] #29924 @icewind1991
* [ ] #30006 
* [x] #30660 @skjnldsv
* [x] #30693 
* [ ] #30726 
* [ ] #30742 @acsfer
