### PR TITLE
Always call flush() as getAllKeys() is broken

### DIFF
--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -134,27 +134,8 @@ class Memcached extends Cache implements IMemcache {
 	}
 
 	public function clear($prefix = '') {
-		$prefix = $this->getNameSpace() . $prefix;
-		$allKeys = self::$cache->getAllKeys();
-		if ($allKeys === false) {
-			// newer Memcached doesn't like getAllKeys(), flush everything
-			self::$cache->flush();
-			return true;
-		}
-		$keys = [];
-		$prefixLength = strlen($prefix);
-		foreach ($allKeys as $key) {
-			if (substr($key, 0, $prefixLength) === $prefix) {
-				$keys[] = $key;
-			}
-		}
-		if (method_exists(self::$cache, 'deleteMulti')) {
-			self::$cache->deleteMulti($keys);
-		} else {
-			foreach ($keys as $key) {
-				self::$cache->delete($key);
-			}
-		}
+		// Newer Memcached doesn't like getAllKeys(), flush everything
+		self::$cache->flush();
 		return true;
 	}
 


### PR DESCRIPTION
This should fix memcached test on PHP 7.4 which is failing in CI of https://github.com/nextcloud/server/pull/29286

Context:
PHP documentation for Memcached::getAllKeys states:
Memcached::getAllKeys() queries each memcache server and retrieves an array of all keys stored on them at that point in time. This is not an atomic operation, so it isn't a truly consistent snapshot of the keys at point in time. **As memcache doesn't guarantee to return all keys you also cannot assume that all keys have been returned.**
https://www.php.net/manual/en/memcached.getallkeys.php

In the 7.4 CI getAllKeys is always returning an empty array. As the documentation suggets that even if not empty the method may return incomplete result, I just always do a complete flush.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>