### PR TITLE
Allow changing the top-left logo link target in config.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -354,6 +354,13 @@ $CONFIG = [
 'lost_password_link' => 'https://example.org/link/to/password/reset',
 
 /**
+ * URL to use as target for the logo link in the header (top-left logo)
+ *
+ * Defaults to the base URL of your Nextcloud instance
+ */
+'logo_url' => 'https://example.org',
+
+/**
  * Mail Parameters
  *
  * These configure the email settings for Nextcloud notifications and password

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -56,7 +56,7 @@ $getUserAvatar = static function (int $size) use ($_): string {
 		</div>
 		<header role="banner" id="header">
 			<div class="header-left">
-				<a href="<?php print_unescaped(link_to('', 'index.php')); ?>"
+				<a href="<?php print_unescaped($_['logoUrl'] ?: link_to('', 'index.php')); ?>"
 					id="nextcloud">
 					<div class="logo logo-icon">
 						<h1 class="hidden-visually">

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -98,6 +98,10 @@ class TemplateLayout extends \OC_Template {
 			$this->initialState->provideInitialState('unified-search', 'limit-default', SearchQuery::LIMIT_DEFAULT);
 			Util::addScript('core', 'unified-search', 'core');
 
+			// set logo link target
+			$logoUrl = $this->config->getSystemValueString('logo_url', '');
+			$this->assign('logoUrl', $logoUrl);
+
 			// Add navigation entry
 			$this->assign('application', '');
 			$this->assign('appid', $appId);


### PR DESCRIPTION
This can be useful if the instance is part of a tool set and we want the top left logo to point on a portal for example.

The use case is not very common and definitely is not worth adding stuff in the theming admin settings.

This could also be done with an app value.