### PR TITLE
Convert properties value to string before passing them to database

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -303,6 +303,11 @@ class CustomPropertiesBackend implements BackendInterface {
 					);
 				}
 			} else {
+				if ($propertyValue instanceOf \Sabre\DAV\Xml\Property\Complex) {
+					$propertyValue = $propertyValue->getXml();
+				} elseif (!is_string($propertyValue)) {
+					$propertyValue = (string)$propertyValue;
+				}
 				if (!array_key_exists($propertyName, $existing)) {
 					$this->connection->executeUpdate($insertStatement,
 						[


### PR DESCRIPTION
This avoids an error when passing a complex property to PROPPATCH under PHP >= 7.4.

See litmus failures in https://github.com/nextcloud/server/pull/29286

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>