### PR TITLE
Fix hiding default share permissions header

### DIFF
--- a/apps/settings/js/admin.js
+++ b/apps/settings/js/admin.js
@@ -32,7 +32,7 @@ window.addEventListener('DOMContentLoaded', function(){
 	});
 
 	$('#shareAPIEnabled').change(function() {
-		$('#shareAPI p:not(#enable)').toggleClass('hidden', !this.checked);
+		$('#shareAPI p:not(#enable), #shareAPI h3').toggleClass('hidden', !this.checked);
 	});
 
 	$('#enableEncryption').change(function() {

--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -151,6 +151,9 @@
 } ?>">
 			<input name="shareapi_allow_links_exclude_groups" type="hidden" id="linksExcludedGroups" value="<?php p($_['allowLinksExcludeGroups']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
 		</p>
+		<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
+	p('hidden');
+}?>">
 			<input type="checkbox" name="shareapi_allow_resharing" id="allowResharing" class="checkbox"
 				   value="1" <?php if ($_['allowResharing'] === 'yes') {
 	print_unescaped('checked="checked"');


### PR DESCRIPTION
This PR fixes #17371 by hiding `h3` tags in addition to `p` tags when the share API is disabled.
It also adds a missing `p` tag for the allowResharing checkbox, which also didn't get hidden. (The corresponding end tag already exists)
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/2340865/150376353-42fcf671-1f12-4a3f-9450-0ab24094c602.png)|![image](https://user-images.githubusercontent.com/2340865/150378591-a08dcedc-2def-48b7-a183-f24d0095ea2a.png)
