### PR TITLE
Fix accessing undefined offsets

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -108,14 +108,12 @@ class SMB extends Backend {
 							if (empty($realm)) {
 								$realm = 'WORKGROUP';
 							}
-							$userPart = $matches[1];
-							$domainPart = $matches[2];
 							if (count($matches) === 0) {
 								$username = $user;
 								$workgroup = $realm;
 							} else {
-								$username = $userPart;
-								$workgroup = $domainPart;
+								$username = $matches[1];;
+								$workgroup = $matches[2];
 							}
 							$smbAuth = new BasicAuth(
 								$username,


### PR DESCRIPTION
Move this to inside the else clause of the count($matches)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>