### PR TITLE
Fix OC\Files\Storage\DAV::hasUpdated when cache is not set

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -792,10 +792,7 @@ class DAV extends Common {
 			}
 			if (isset($response['{DAV:}getetag'])) {
 				$cachedData = $this->getCache()->get($path);
-				$etag = null;
-				if (isset($response['{DAV:}getetag'])) {
-					$etag = trim($response['{DAV:}getetag'], '"');
-				}
+				$etag = trim($response['{DAV:}getetag'], '"');
 				if (($cachedData === false) || (!empty($etag) && ($cachedData['etag'] !== $etag))) {
 					return true;
 				} elseif (isset($response['{http://open-collaboration-services.org/ns}share-permissions'])) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -796,7 +796,7 @@ class DAV extends Common {
 				if (isset($response['{DAV:}getetag'])) {
 					$etag = trim($response['{DAV:}getetag'], '"');
 				}
-				if (!empty($etag) && $cachedData['etag'] !== $etag) {
+				if (($cachedData === false) || (!empty($etag) && ($cachedData['etag'] !== $etag))) {
 					return true;
 				} elseif (isset($response['{http://open-collaboration-services.org/ns}share-permissions'])) {
 					$sharePermissions = (int)$response['{http://open-collaboration-services.org/ns}share-permissions'];


### PR DESCRIPTION
Fixes the test OCA\Files_External\Tests\Storage\WebdavTest::testStat on PHP>=7.4

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>