### PR TITLE
Makes untrusted domain error a warning.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -775,7 +775,7 @@ class OC {
 			if (!$isScssRequest) {
 				http_response_code(400);
 
-				\OC::$server->getLogger()->info(
+				\OC::$server->getLogger()->warning(
 					'Trusted domain error. "{remoteAddress}" tried to access using "{host}" as host.',
 					[
 						'app' => 'core',


### PR DESCRIPTION
It sends a 400 to the client, so I could even argue that it should be an error.

But currently as an admin, I'm quiet surprised that I get a 400 in the UI, and nothing in the log with the default level.

I saw [this commit](https://github.com/nextcloud/server/commit/0d5142be7080fba001d74609676e7e1ddd5b547f) that explains the reason why info. But I disagree.

Feel free to close the PR if you don't agree with it.

(sorry, I wanted to create the branch on my own repo :/)