### PR TITLE
22.2.4 Final

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 2, 4, 2];
+$OC_Version = [22, 2, 4, 3];
 
 // The human readable string
-$OC_VersionString = '22.2.4 RC3';
+$OC_VersionString = '22.2.4';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #28659
* #29324
* #29799
* #29962
* #30010
* #30057
* #30116
* #30137
* #30145
* #30152
* #30171
* #30177
* #30181
* #30185
* #30188
* #30191
* #30209
* #30237
* #30247
* #30250
* #30260
* #30288
* #30300
* #30307
* #30316
* #30323
* #30340
* #30345
* #30347
* #30357
* #30391
* #30432
* #30434
* #30444
* #30450
* #30453
* #30481
* #30487
* #30515
* #30523
* #30526
* #30529
* #30558
* #30578
* #30581
* #30591
* #30598
* #30603
* #30610
* #30618
* #30622
* #30628
* #30637
* #30644
* #30658
* #30664
* #30666
* #30670
* #30673
* #30675
* #30683
* #30687
* #30690
* #30692
* #30694
* #30697
* #30727
* #30736
* #30748
* #30752
* #30754
* #30760
* #30774
* #30780
* #30786
* #30807
* #30812
* [3rdparty#972](https://github.com/nextcloud/3rdparty/pull/972) Create block-merge-freeze.yml
* [activity#667](https://github.com/nextcloud/activity/pull/667) Pass activity link to notification
* [circles#827](https://github.com/nextcloud/circles/pull/827) Backport of #797
* [circles#864](https://github.com/nextcloud/circles/pull/864) Filter allowed type of member
* [circles#868](https://github.com/nextcloud/circles/pull/868) Lighten select for single circle
* [circles#874](https://github.com/nextcloud/circles/pull/874) Bypass moderator check on CFG_FRIEND
* [circles#877](https://github.com/nextcloud/circles/pull/877) Better display of federated user
* [circles#883](https://github.com/nextcloud/circles/pull/883) Strtolower on mail address
* [circles#886](https://github.com/nextcloud/circles/pull/886) Only returns population on direct request from the front-end or occ command
* [circles#888](https://github.com/nextcloud/circles/pull/888) Enforce password on new share
* [circles#893](https://github.com/nextcloud/circles/pull/893) Exception on null token
* [circles#895](https://github.com/nextcloud/circles/pull/895) Ignore exception to group sync
* [circles#899](https://github.com/nextcloud/circles/pull/899) L10n: Improved grammar
* [circles#908](https://github.com/nextcloud/circles/pull/908) Create block-merge-freeze.yml
* [files_pdfviewer#531](https://github.com/nextcloud/files_pdfviewer/pull/531) Bump actions
* [files_pdfviewer#545](https://github.com/nextcloud/files_pdfviewer/pull/545) Create block-merge-freeze.yml
* [files_pdfviewer#550](https://github.com/nextcloud/files_pdfviewer/pull/550) Updating lint-php.yml workflow from template
* [files_rightclick#132](https://github.com/nextcloud/files_rightclick/pull/132) Create block-merge-freeze.yml
* [files_videoplayer#257](https://github.com/nextcloud/files_videoplayer/pull/257) Create block-merge-freeze.yml
* [firstrunwizard#639](https://github.com/nextcloud/firstrunwizard/pull/639) Disable fade-out because of accessbility reasons
* [firstrunwizard#653](https://github.com/nextcloud/firstrunwizard/pull/653) Fix overlapping buttons
* [firstrunwizard#662](https://github.com/nextcloud/firstrunwizard/pull/662) Create block-merge-freeze.yml
* [logreader#637](https://github.com/nextcloud/logreader/pull/637) Create block-merge-freeze.yml
* [nextcloud_announcements#93](https://github.com/nextcloud/nextcloud_announcements/pull/93) Create block-merge-freeze.yml
* [notifications#1138](https://github.com/nextcloud/notifications/pull/1138) Create block-merge-freeze.yml
* [password_policy#316](https://github.com/nextcloud/password_policy/pull/316) Create block-merge-freeze.yml
* [photos#924](https://github.com/nextcloud/photos/pull/924) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [photos#952](https://github.com/nextcloud/photos/pull/952) Fix default previews
* [photos#961](https://github.com/nextcloud/photos/pull/961) Fix Tags: Don't display tags without photos
* [photos#963](https://github.com/nextcloud/photos/pull/963) Bump qs from 6.10.1 to 6.10.3
* [photos#964](https://github.com/nextcloud/photos/pull/964) Bump url-parse from 1.5.3 to 1.5.4
* [photos#982](https://github.com/nextcloud/photos/pull/982) Update workflows
* [photos#999](https://github.com/nextcloud/photos/pull/999) Create block-merge-freeze.yml
* [privacy#677](https://github.com/nextcloud/privacy/pull/677) Fix label of account name and hide parts with subscription
* [privacy#685](https://github.com/nextcloud/privacy/pull/685) Create block-merge-freeze.yml
* [recommendations#471](https://github.com/nextcloud/recommendations/pull/471) Create block-merge-freeze.yml
* [recommendations#474](https://github.com/nextcloud/recommendations/pull/474) Update test.yml
* [serverinfo#353](https://github.com/nextcloud/serverinfo/pull/353) Create block-merge-freeze.yml
* [survey_client#124](https://github.com/nextcloud/survey_client/pull/124) Create block-merge-freeze.yml
* [text#1912](https://github.com/nextcloud/text/pull/1912) Bump babel-loader from 8.2.2 to 8.2.3
* [text#1935](https://github.com/nextcloud/text/pull/1935) Bump @nextcloud/initial-state from 1.2.0 to 1.2.1
* [text#1936](https://github.com/nextcloud/text/pull/1936) Bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2
* [text#1967](https://github.com/nextcloud/text/pull/1967) Hide menu and keep focus when using menubar popover items
* [text#1977](https://github.com/nextcloud/text/pull/1977) Update mark input/paste rules to tiptap v2 regular expressions
* [text#1980](https://github.com/nextcloud/text/pull/1980) Don't show "Link file" button when using direct edition
* [text#1989](https://github.com/nextcloud/text/pull/1989) Make sure translations are parsed correctly
* [text#1993](https://github.com/nextcloud/text/pull/1993) Fix scss deprecated syntax
* [text#1997](https://github.com/nextcloud/text/pull/1997) Pin node/npm versions
* [text#2003](https://github.com/nextcloud/text/pull/2003) Fix header popover in richworkspace
* [text#2010](https://github.com/nextcloud/text/pull/2010) Fix only the first item gets tasklist-ified issue
* [text#2019](https://github.com/nextcloud/text/pull/2019) Azul/rebase stable22 fix 1677 menububble position
* [text#2021](https://github.com/nextcloud/text/pull/2021) Fix: use stable22 branch for cypress tests
* [text#2036](https://github.com/nextcloud/text/pull/2036) Fix autofocus on empty documents without a node (Fixes: #1974)
* [text#2042](https://github.com/nextcloud/text/pull/2042) Add stylelint to github actions
* [text#2054](https://github.com/nextcloud/text/pull/2054) Stable22 update cypress
* [text#2055](https://github.com/nextcloud/text/pull/2055) Fix: cypress login with new session feature
* [text#2057](https://github.com/nextcloud/text/pull/2057) Backport/1883/stable22
* [text#2074](https://github.com/nextcloud/text/pull/2074) Avoid creating invalid URIs from user input
* [text#2075](https://github.com/nextcloud/text/pull/2075) Allow to insert text after trailing codeblock
* [text#2076](https://github.com/nextcloud/text/pull/2076) Only register trailing node for rich text editing
* [text#2080](https://github.com/nextcloud/text/pull/2080) Bump cypress from 9.2.0 to 9.2.1
* [text#2094](https://github.com/nextcloud/text/pull/2094) Make collabora on top of text idle message
* [text#2095](https://github.com/nextcloud/text/pull/2095) Only show image author annotations if needed
* [text#2113](https://github.com/nextcloud/text/pull/2113) Backport/stable22/2020
* [text#2116](https://github.com/nextcloud/text/pull/2116) Create block-merge-freeze.yml
* [viewer#1067](https://github.com/nextcloud/viewer/pull/1067) Disable fade-out because of accessbility reasons
* [viewer#1070](https://github.com/nextcloud/viewer/pull/1070) Add light ⬇️ dowload icon
* [viewer#1071](https://github.com/nextcloud/viewer/pull/1071) Fix github actions
* [viewer#1074](https://github.com/nextcloud/viewer/pull/1074) Add light ⬇️ dowload icon (fixed)
* [viewer#1076](https://github.com/nextcloud/viewer/pull/1076) Build(deps): bump camelcase from 6.2.0 to 6.2.1
* [viewer#1090](https://github.com/nextcloud/viewer/pull/1090) Fix german (Sie) translations comming from nextcloud-vue
* [viewer#1093](https://github.com/nextcloud/viewer/pull/1093) Add cypress summary for easier branch protection mgmt
* [viewer#1100](https://github.com/nextcloud/viewer/pull/1100) Add engines support for cypress tests
* [viewer#1109](https://github.com/nextcloud/viewer/pull/1109) Always check for `OCA.Files` before using it (Fixes: #1106)
* [viewer#1115](https://github.com/nextcloud/viewer/pull/1115) Disable swiping on viewer video controls
* [viewer#1123](https://github.com/nextcloud/viewer/pull/1123) Disable swiping on viewer audio controls
* [viewer#1134](https://github.com/nextcloud/viewer/pull/1134) Create block-merge-freeze.yml
* [viewer#1139](https://github.com/nextcloud/viewer/pull/1139) Update lint-php.yml


Pending PRs:

* [ ] #29565 
* [ ] #29607 @CarlSchwan
* [x] #30741 @acsfer
* [x] #30826 @CarlSchwan
* [ ] [circles#915](https://github.com/nextcloud/circles/pull/915) Fix loosing memberships in low depth 
