### PR TITLE
Return 404 when AJAX tries to list dir content but file given

### DIFF
--- a/apps/files/ajax/list.php
+++ b/apps/files/ajax/list.php
@@ -38,7 +38,7 @@ $dir = \OC\Files\Filesystem::normalizePath($dir);
 
 try {
 	$dirInfo = \OC\Files\Filesystem::getFileInfo($dir);
-	if (!$dirInfo || !$dirInfo->getType() === 'dir') {
+	if (!$dirInfo || $dirInfo->getType() !== 'dir') {
 		http_response_code(404);
 		exit();
 	}

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -835,7 +835,7 @@ class Filesystem {
 	 * @param string $path
 	 * @param boolean $includeMountPoints whether to add mountpoint sizes,
 	 * defaults to true
-	 * @return \OC\Files\FileInfo|bool False if file does not exist
+	 * @return \OC\Files\FileInfo|false False if file does not exist
 	 */
 	public static function getFileInfo($path, $includeMountPoints = true) {
 		return self::$defaultInstance->getFileInfo($path, $includeMountPoints);


### PR DESCRIPTION
Due to a code mistake, the expected 404 return when AJAX tries to list a directory content with a non-directory file path given, does not happen. It instead fails with another exception.

This commit restores the original intention to return 404 in the first place when passing a non-directory path with the "dir" parameter.

This solves related Psalm errors.

I'm not so good at writing tests, but probably it makes sense to add one for this case?