### PR TITLE
handle notfound and notpermitted error in Smb::getDirectoryContent

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -620,9 +620,15 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	public function getDirectoryContent($directory): \Traversable {
-		$files = $this->getFolderContents($directory);
-		foreach ($files as $file) {
-			yield $this->getMetaDataFromFileInfo($file);
+		try {
+			$files = $this->getFolderContents($directory);
+			foreach ($files as $file) {
+				yield $this->getMetaDataFromFileInfo($file);
+			}
+		} catch (NotFoundException $e) {
+			return;
+		} catch (NotPermittedException $e) {
+			return;
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Robin Appelman <robin@icewind.nl>