### PR TITLE
Fixes occ user:info when the user never logged in

### DIFF
--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -97,7 +97,11 @@ class Info extends Base {
 	protected function getStorageInfo(IUser $user): array {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($user->getUID());
-		$storage = \OC_Helper::getStorageInfo('/');
+		try {
+			$storage = \OC_Helper::getStorageInfo('/');
+		} catch (\OCP\Files\NotFoundException $e) {
+			return [];
+		}
 		return [
 			'free' => $storage['free'],
 			'used' => $storage['used'],


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/30715

When running occ user:info on a non-existing user you get:
```
user not found
```
which is expected, but when running occ user:info on a user which exists but never logged id, you get:
```

In OC_Helper.php line 496:
                                 
  [OCP\Files\NotFoundException]  
                                 

user:info [--output [OUTPUT]] [--] <user>
```
with this PR you will get:
```
  - user_id: user2
  - display_name: user2
  - email: 
  - cloud_id: user2@nextcloud.local
  - enabled: true
  - groups:
  - quota: none
  - storage:
  - last_seen: 1970-01-01T00:00:00+00:00
  - user_directory: /var/www/html/data/user2
  - backend: Database
```
Here is what it looks like for a user who did log in:
```
  - user_id: user4
  - display_name: user4
  - email: 
  - cloud_id: user4@nextcloud.local
  - enabled: true
  - groups:
  - quota: none
  - storage:
    - free: 275530956800
    - used: 20575003
    - total: 275551531803
    - relative: 0.01
    - quota: -3
  - last_seen: 1970-01-01T00:00:00+00:00
  - user_directory: /var/www/html/data/user4
  - backend: Database
```


Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>