### PR TITLE
Update ICommentsManager with reaction methods

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -969,7 +969,7 @@ class Manager implements ICommentsManager {
 	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
 	 * use reactions
 	 *
-	 * @param integer $parentId
+	 * @param int $parentId
 	 * @param string $actorType
 	 * @param string $actorId
 	 * @param string $reaction
@@ -997,14 +997,46 @@ class Manager implements ICommentsManager {
 	}
 
 	/**
-	 * Retrieve all reactions with specific reaction of a message
+	 * Retrieve all reactions of a message
 	 *
-	 * @param integer $parentId
-	 * @param string $reaction
+	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
+	 * use reactions
+	 *
+	 * @param int $parentId
 	 * @return IComment[]
+	 * @throws PreConditionNotMetException
 	 * @since 24.0.0
 	 */
-	public function retrieveAllReactionsWithSpecificReaction(int $parentId, string $reaction): ?array {
+	public function retrieveAllReactions(int $parentId): array {
+		$this->throwIfNotSupportReactions();
+		$qb = $this->dbConn->getQueryBuilder();
+		$result = $qb
+			->select('message_id')
+			->from('reactions')
+			->where($qb->expr()->eq('parent_id', $qb->createNamedParameter($parentId)))
+			->executeQuery();
+
+		$commentIds = [];
+		while ($data = $result->fetch()) {
+			$commentIds[] = $data['message_id'];
+		}
+
+		return $this->getCommentsById($commentIds);
+	}
+
+	/**
+	 * Retrieve all reactions with specific reaction of a message
+	 *
+	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
+	 * use reactions
+	 *
+	 * @param int $parentId
+	 * @param string $reaction
+	 * @return IComment[]
+	 * @throws PreConditionNotMetException
+	 * @since 24.0.0
+	 */
+	public function retrieveAllReactionsWithSpecificReaction(int $parentId, string $reaction): array {
 		$this->throwIfNotSupportReactions();
 		$qb = $this->dbConn->getQueryBuilder();
 		$result = $qb
@@ -1029,7 +1061,7 @@ class Manager implements ICommentsManager {
 	/**
 	 * Support reactions
 	 *
-	 * @return boolean
+	 * @return bool
 	 * @since 24.0.0
 	 */
 	public function supportReactions(): bool {
@@ -1047,38 +1079,9 @@ class Manager implements ICommentsManager {
 	}
 
 	/**
-	 * Retrieve all reactions of a message
-	 *
-	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
-	 * use reactions
-	 *
-	 * @param integer $parentId
-	 * @param string $reaction
-	 * @throws PreConditionNotMetException
-	 * @return IComment[]
-	 * @since 24.0.0
-	 */
-	public function retrieveAllReactions(int $parentId): array {
-		$this->throwIfNotSupportReactions();
-		$qb = $this->dbConn->getQueryBuilder();
-		$result = $qb
-			->select('message_id')
-			->from('reactions')
-			->where($qb->expr()->eq('parent_id', $qb->createNamedParameter($parentId)))
-			->executeQuery();
-
-		$commentIds = [];
-		while ($data = $result->fetch()) {
-			$commentIds[] = $data['message_id'];
-		}
-
-		return $this->getCommentsById($commentIds);
-	}
-
-	/**
 	 * Get all comments on list
 	 *
-	 * @param integer[] $commentIds
+	 * @param int[] $commentIds
 	 * @return IComment[]
 	 * @since 24.0.0
 	 */

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -29,6 +29,7 @@
 namespace OCP\Comments;
 
 use OCP\IUser;
+use OCP\PreConditionNotMetException;
 
 /**
  * Interface ICommentsManager
@@ -299,6 +300,58 @@ interface ICommentsManager {
 	 * @since 9.0.0
 	 */
 	public function delete($id);
+
+	/**
+	 * Get comment related with user reaction
+	 *
+	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
+	 * use reactions
+	 *
+	 * @param int $parentId
+	 * @param string $actorType
+	 * @param string $actorId
+	 * @param string $reaction
+	 * @return IComment
+	 * @throws NotFoundException
+	 * @throws PreConditionNotMetException
+	 * @since 24.0.0
+	 */
+	public function getReactionComment(int $parentId, string $actorType, string $actorId, string $reaction): IComment;
+
+	/**
+	 * Retrieve all reactions of a message
+	 *
+	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
+	 * use reactions
+	 *
+	 * @param int $parentId
+	 * @return IComment[]
+	 * @throws PreConditionNotMetException
+	 * @since 24.0.0
+	 */
+	public function retrieveAllReactions(int $parentId): array;
+
+	/**
+	 * Retrieve all reactions with specific reaction of a message
+	 *
+	 * Throws PreConditionNotMetException when the system haven't the minimum requirements to
+	 * use reactions
+	 *
+	 * @param int $parentId
+	 * @param string $reaction
+	 * @return IComment[]
+	 * @throws PreConditionNotMetException
+	 * @since 24.0.0
+	 */
+	public function retrieveAllReactionsWithSpecificReaction(int $parentId, string $reaction): array;
+
+	/**
+	 * Support reactions
+	 *
+	 * @return bool
+	 * @since 24.0.0
+	 */
+	public function supportReactions(): bool;
 
 	/**
 	 * saves the comment permanently

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -2,6 +2,7 @@
 
 namespace Test\Comments;
 
+use OC\Comments\Comment;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\IUser;
@@ -59,6 +60,22 @@ class FakeManager implements ICommentsManager {
 	}
 
 	public function delete($id) {
+	}
+
+	public function getReactionComment(int $parentId, string $actorType, string $actorId, string $reaction): IComment {
+		return new Comment();
+	}
+
+	public function retrieveAllReactions(int $parentId): array {
+		return [];
+	}
+
+	public function retrieveAllReactionsWithSpecificReaction(int $parentId, string $reaction): array {
+		return [];
+	}
+
+	public function supportReactions(): bool {
+		return false;
 	}
 
 	public function save(IComment $comment) {


### PR DESCRIPTION
Objective: update https://github.com/ChristophWurst/nextcloud_composer/ with reaction methods.

The script [build.sh](https://github.com/ChristophWurst/nextcloud_composer/blob/master/build.sh) only get `lib/public classes`.
The reaction methods was implemented on `lib/private/Comments/Manager.php`
