### PR TITLE
Fix listeners declaration in case of occ usage

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -730,6 +730,8 @@ class OC {
 		// Make sure that the application class is not loaded before the database is setup
 		if ($systemConfig->getValue("installed", false)) {
 			OC_App::loadApp('settings');
+			/* Build core application to make sure that listeners are registered */
+			self::$server->get(\OC\Core\Application::class);
 		}
 
 		//make sure temporary files are cleaned up


### PR DESCRIPTION
OC\Core\Application does not get constructed when an occ command is
 called so some listeners where not correctly plugged, and for instance
 calling occ user:delete would not clear user files.

So I moved these listener declarations to Server class instead where there were already some of them. It does fix occ user:delete but I am unsure about other effect.

I replace $container->query(Connection::class) in some listener to $this->get(Connection::class), not 100% sure about this either.
Moving the registerNotifierService calls would crash so I let them in OC\Core\Application instead. Maybe it’s fine that they are not called from occ?

An alternative would be to instantiate OC\Core\Application from occ command, but not sure if it makes sense.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>