### PR TITLE
Stop adding passwords to passwordless authtokens during `updatePasswords()`

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -396,6 +396,10 @@ class PublicKeyTokenProvider implements IProvider {
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
 		foreach ($tokens as $t) {
+			// But, do not add a password to passwordless tokens.
+			if (is_null($t->getPassword())) {
+				continue;
+			}
 			$publicKey = $t->getPublicKey();
 			$t->setPassword($this->encryptPassword($password, $publicKey));
 			$t->setPasswordInvalid(false);


### PR DESCRIPTION
Fixes #30894 (at least, it is supposed to).

Signed-off-by: Matt Marjanovic <maddog@mir.com>