### PR TITLE
Show the child folders in the breadcrumb menu when on a parent entry.

### DIFF
--- a/apps/files/tests/js/breadcrumbSpec.js
+++ b/apps/files/tests/js/breadcrumbSpec.js
@@ -56,13 +56,15 @@ describe('OCA.Files.BreadCrumb tests', function() {
 			expect($crumbs.eq(1).find('a').hasClass('icon-home')).toEqual(true);
 			expect($crumbs.eq(1).data('dir')).toEqual('/');
 		});
-		it('Renders root when switching to root', function() {
+		it('Renders complete directory when switching to root', function() {
 			var $crumbs;
 			bc.setDirectory('/somedir');
 			bc.setDirectory('/');
 			$crumbs = bc.$el.find('.crumb');
-			expect($crumbs.length).toEqual(2);
+			expect($crumbs.length).toEqual(3);
 			expect($crumbs.eq(1).data('dir')).toEqual('/');
+			expect($crumbs.eq(2).data('dir')).toEqual('/somedir');
+			expect($crumbs.eq(2).attr('class').includes("active")).toEqual(false);
 		});
 		it('Renders single path section', function() {
 			var $crumbs;

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -1202,6 +1202,13 @@ div.crumb {
 			order: 3;
 		}
 	}
+	&.active {
+		font-weight: bold;
+		// Allow multiple span next to the main 'a'
+		a ~ span {
+			padding-left: 0;
+		}
+	}
 	> a,
 	> span {
 		position: relative;
@@ -1225,14 +1232,6 @@ div.crumb {
 		width: 44px;
 	}
 	&:not(:first-child) a {
-	}
-	&:last-child {
-		font-weight: bold;
-		margin-right: 10px;
-		// Allow multiple span next to the main 'a'
-		a ~ span {
-			padding-left: 0;
-		}
 	}
 	&:hover, &:focus, a:focus, &:active {
 		opacity: 1;


### PR DESCRIPTION
Previously, clicking on an menu item in the breadcrumb menu removed the
child entries of the path, i.e.:
Clicking on the "to" entry in "/path/to/some/folder" changed the
breadcrumb menu to show only the "/path/to" entries.
With this change the breadcrumb menu changes this behaviour as the full
path is still visible (and usable) but with the "to" entry beeing
highlighted.

Closes #1079
cc @nextcloud/designers @nextcloud/javascript @jancborchardt @szaimen

Signed-off-by: Christian Paier <hallo+git@cpaier.com>