### PR TITLE
Fix ldap:check-user method for newly created LDAP users

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -488,7 +488,7 @@ class Access extends LDAPUtility {
 	/**
 	 * returns the internal Nextcloud name for the given LDAP DN of the user, false on DN outside of search DN or failure
 	 *
-	 * @param string $dn the dn of the user object
+	 * @param string $fdn the dn of the user object
 	 * @param string $ldapName optional, the display name of the object
 	 * @return string|false with with the name to use in Nextcloud
 	 * @throws \Exception
@@ -1770,7 +1770,7 @@ class Access extends LDAPUtility {
 	/**
 	 * @param string $dn
 	 * @param bool $isUser
-	 * @param null $ldapRecord
+	 * @param array|null $ldapRecord
 	 * @return false|string
 	 * @throws ServerNotAvailableException
 	 */

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -4,6 +4,7 @@
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
@@ -48,12 +49,6 @@ class CheckUser extends Command {
 	/** @var UserMapping */
 	protected $mapping;
 
-	/**
-	 * @param User_Proxy $uBackend
-	 * @param Helper $helper
-	 * @param DeletedUsersIndex $dui
-	 * @param UserMapping $mapping
-	 */
 	public function __construct(User_Proxy $uBackend, Helper $helper, DeletedUsersIndex $dui, UserMapping $mapping) {
 		$this->backend = $uBackend;
 		$this->helper = $helper;
@@ -62,7 +57,7 @@ class CheckUser extends Command {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('ldap:check-user')
 			->setDescription('checks whether a user exists on LDAP.')
@@ -89,7 +84,7 @@ class CheckUser extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$uid = $input->getArgument('ocName');
-			$this->isAllowed($input->getOption('force'));
+			$this->assertAllowed($input->getOption('force'));
 			$wasMapped = $this->userWasMapped($uid);
 			$exists = $this->backend->userExistsOnLDAP($uid, true);
 			if ($exists === true) {
@@ -125,9 +120,8 @@ class CheckUser extends Command {
 	/**
 	 * checks whether the setup allows reliable checking of LDAP user existence
 	 * @throws \Exception
-	 * @return true
 	 */
-	protected function isAllowed($force) {
+	protected function assertAllowed(bool $force): void {
 		if ($this->helper->haveDisabledConfigurations() && !$force) {
 			throw new \Exception('Cannot check user existence, because '
 				. 'disabled LDAP configurations are present.');
@@ -136,8 +130,6 @@ class CheckUser extends Command {
 		// we don't check ldapUserCleanupInterval from config.php because this
 		// action is triggered manually, while the setting only controls the
 		// background job.
-
-		return true;
 	}
 
 	private function updateUser(string $uid, OutputInterface $output): void {

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -64,7 +64,7 @@ class CheckUser extends Command {
 			->addArgument(
 					'ocName',
 					InputArgument::REQUIRED,
-					'the user name as used in Nextcloud'
+					'the user name as used in Nextcloud, or the LDAP DN'
 					 )
 			->addOption(
 					'force',
@@ -83,8 +83,14 @@ class CheckUser extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
-			$uid = $input->getArgument('ocName');
 			$this->assertAllowed($input->getOption('force'));
+			$uid = $input->getArgument('ocName');
+			if ($this->backend->getLDAPAccess($uid)->stringResemblesDN($uid)) {
+				$username = $this->backend->dn2UserName($uid);
+				if ($username !== false) {
+					$uid = $username;
+				}
+			}
 			$wasMapped = $this->userWasMapped($uid);
 			$exists = $this->backend->userExistsOnLDAP($uid, true);
 			if ($exists === true) {

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -119,7 +119,7 @@ class CheckUser extends Command {
 	 */
 	protected function userWasMapped(string $ocName): bool {
 		$dn = $this->mapping->getDNByName($ocName);
-		return ($dn !== false);
+		return $dn !== false;
 	}
 
 	/**

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -90,7 +90,7 @@ class CheckUser extends Command {
 		try {
 			$uid = $input->getArgument('ocName');
 			$this->isAllowed($input->getOption('force'));
-			$this->confirmUserIsMapped($uid);
+			$wasMapped = $this->userWasMapped($uid);
 			$exists = $this->backend->userExistsOnLDAP($uid, true);
 			if ($exists === true) {
 				$output->writeln('The user is still available on LDAP.');
@@ -98,13 +98,15 @@ class CheckUser extends Command {
 					$this->updateUser($uid, $output);
 				}
 				return 0;
+			} elseif ($wasMapped) {
+				$this->dui->markUser($uid);
+				$output->writeln('The user does not exists on LDAP anymore.');
+				$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
+					. $uid . '"');
+				return 0;
+			} else {
+				throw new \Exception('The given user is not a recognized LDAP user.');
 			}
-
-			$this->dui->markUser($uid);
-			$output->writeln('The user does not exists on LDAP anymore.');
-			$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
-				. $uid . '"');
-			return 0;
 		} catch (\Exception $e) {
 			$output->writeln('<error>' . $e->getMessage(). '</error>');
 			return 1;
@@ -114,16 +116,10 @@ class CheckUser extends Command {
 	/**
 	 * checks whether a user is actually mapped
 	 * @param string $ocName the username as used in Nextcloud
-	 * @throws \Exception
-	 * @return true
 	 */
-	protected function confirmUserIsMapped($ocName) {
+	protected function userWasMapped(string $ocName): bool {
 		$dn = $this->mapping->getDNByName($ocName);
-		if ($dn === false) {
-			throw new \Exception('The given user is not a recognized LDAP user.');
-		}
-
-		return true;
+		return ($dn !== false);
 	}
 
 	/**


### PR DESCRIPTION
This completes https://github.com/nextcloud/server/pull/29837 by also ignoring cache for newly created users instead of only newly deleted users.

This replaces https://github.com/nextcloud/server/pull/29837 (and https://github.com/nextcloud/server/pull/29326 and https://github.com/nextcloud/server/pull/29451) and should fix https://github.com/nextcloud/server/issues/27948

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>