### PR TITLE
Init user's file system if not existing on ownership transfer

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -144,13 +144,12 @@ class OwnershipTransferService {
 			throw new TransferOwnershipException("Unknown path provided: $path", 1);
 		}
 
-		if ($move && (
-				!$view->is_dir($finalTarget) || (
-					!$firstLogin &&
-					count($view->getDirectoryContent($finalTarget)) > 0
-				)
-			)
-		) {
+		if ($move && !$view->is_dir($finalTarget)) {
+			// Initialize storage
+			\OC_Util::setupFS($destinationUser->getUID());
+		}
+
+		if ($move && !$firstLogin && count($view->getDirectoryContent($finalTarget)) > 0) {
 			throw new TransferOwnershipException("Destination path does not exists or is not empty", 1);
 		}
 


### PR DESCRIPTION
This makes it a bit easier to transfer ownership when the new user
hasn't already logged in. This still doesn't support encrypted storage because the keys are not generated yet (this is already checked at the beginning of the method).