### PR TITLE
Fix position sticky declaration

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1556,7 +1556,7 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 
 			/* various */
 			&#grid-header {
-				@include position('sticky');
+				position: sticky;
 				align-self: normal;
 				background-color: var(--color-main-background);
 				z-index: 100; /* above multiselect */


### PR DESCRIPTION
Before the generated css was: "position: 'sticky'", now it is
position: sticky. Firefox considered the old value has invalid.