### PR TITLE
Collaboration, MailPlugin: Protect access to a potentially missing array component by ??.

### DIFF
--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -149,7 +149,7 @@ class MailPlugin implements ISearchPlugin {
 						}
 						if ($exactEmailMatch && $this->shareeEnumerationFullMatch) {
 							try {
-								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);
+								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
 							} catch (\InvalidArgumentException $e) {
 								continue;
 							}
@@ -174,7 +174,7 @@ class MailPlugin implements ISearchPlugin {
 
 						if ($this->shareeEnumeration) {
 							try {
-								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);
+								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
 							} catch (\InvalidArgumentException $e) {
 								continue;
 							}


### PR DESCRIPTION
Otherwise I get errors like
```
Error: Trying to access array offset on value of type null at /var/www/localhost/htdocs/nextcloud-git/lib/private/Collaboration/Collaborators/MailPlugin.php#178 /var/www/localhost/htdocs/nextcloud-git/lib/private/Log/ErrorHandler.php:95
```
and
```
Exception: OC\Federation\CloudIdManager::resolveCloudId(): Argument #1 ($cloudId) must be of type string, null given, called in /var/www/localhost/htdocs/nextcloud-git/lib/private/Collaboration/Collaborators/MailPlugin.php on line 178 in file '/var/www/localhost/htdocs/nextcloud-git/lib/private/Federation/CloudIdManager.php' line 58 /var/www/localhost/htdocs/nextcloud-git/lib/private/AppFramework/Http/Dispatcher.php:158
```