### PR TITLE
[stable22] Fix preview generation for office documents

### DIFF
--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -74,7 +74,7 @@ abstract class Office extends ProviderV2 {
 		}
 
 		$image = new \OC_Image();
-		$image->loadFromData($png);
+		$image->loadFromData((string) $png);
 
 		$this->cleanTmpFiles();
 		unlink($pngPreview);


### PR DESCRIPTION
`new \imagick()` returns an object, but we need the image blob (binary
string) from this object.

This is a partial backport of #26531, which brings a lot of refactoring
but also contains the fix.

Fixes: #29956

Signed-off-by: Jonas Meurer <jonas@freesources.org>