### PR TITLE
Add source mount provider to the oc_mounts table

### DIFF
--- a/apps/files_external/lib/Config/ExternalMountPoint.php
+++ b/apps/files_external/lib/Config/ExternalMountPoint.php
@@ -34,7 +34,7 @@ class ExternalMountPoint extends MountPoint {
 
 	public function __construct(StorageConfig $storageConfig, $storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
 		$this->storageConfig = $storageConfig;
-		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId);
+		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId, ConfigAdapter::class);
 	}
 
 	public function getMountType() {

--- a/apps/files_sharing/lib/External/Mount.php
+++ b/apps/files_sharing/lib/External/Mount.php
@@ -42,7 +42,7 @@ class Mount extends MountPoint implements MoveableMount {
 	 * @param \OC\Files\Storage\StorageFactory $loader
 	 */
 	public function __construct($storage, $mountpoint, $options, $manager, $loader = null) {
-		parent::__construct($storage, $mountpoint, $options, $loader);
+		parent::__construct($storage, $mountpoint, $options, $loader, null, null, MountProvider::class);
 		$this->manager = $manager;
 	}
 

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -78,7 +78,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 
 		$newMountPoint = $this->verifyMountPoint($this->superShare, $mountpoints, $folderExistCache);
 		$absMountPoint = '/' . $this->user . '/files' . $newMountPoint;
-		parent::__construct($storage, $absMountPoint, $arguments, $loader);
+		parent::__construct($storage, $absMountPoint, $arguments, $loader, null, null, MountProvider::class);
 	}
 
 	/**

--- a/core/Migrations/Version240000Date20220202150027.php
+++ b/core/Migrations/Version240000Date20220202150027.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version240000Date20220202150027 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('mounts');
+		if (!$table->hasColumn('mount_provider_class')) {
+			$table->addColumn('mount_provider_class', Types::STRING, [
+				'notnull' => false,
+				'length' => 128,
+			]);
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1001,6 +1001,7 @@ return array(
     'OC\\Core\\Migrations\\Version23000Date20210930122352' => $baseDir . '/core/Migrations/Version23000Date20210930122352.php',
     'OC\\Core\\Migrations\\Version23000Date20211203110726' => $baseDir . '/core/Migrations/Version23000Date20211203110726.php',
     'OC\\Core\\Migrations\\Version23000Date20211213203940' => $baseDir . '/core/Migrations/Version23000Date20211213203940.php',
+    'OC\\Core\\Migrations\\Version240000Date20220202150027' => $baseDir . '/core/Migrations/Version240000Date20220202150027.php',
     'OC\\Core\\Migrations\\Version24000Date20211210141942' => $baseDir . '/core/Migrations/Version24000Date20211210141942.php',
     'OC\\Core\\Migrations\\Version24000Date20211213081506' => $baseDir . '/core/Migrations/Version24000Date20211213081506.php',
     'OC\\Core\\Migrations\\Version24000Date20211213081604' => $baseDir . '/core/Migrations/Version24000Date20211213081604.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1030,6 +1030,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\Core\\Migrations\\Version23000Date20210930122352' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20210930122352.php',
         'OC\\Core\\Migrations\\Version23000Date20211203110726' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20211203110726.php',
         'OC\\Core\\Migrations\\Version23000Date20211213203940' => __DIR__ . '/../../..' . '/core/Migrations/Version23000Date20211213203940.php',
+        'OC\\Core\\Migrations\\Version240000Date20220202150027' => __DIR__ . '/../../..' . '/core/Migrations/Version240000Date20220202150027.php',
         'OC\\Core\\Migrations\\Version24000Date20211210141942' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211210141942.php',
         'OC\\Core\\Migrations\\Version24000Date20211213081506' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211213081506.php',
         'OC\\Core\\Migrations\\Version24000Date20211213081604' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20211213081604.php',

--- a/lib/private/Files/Config/CachedMountFileInfo.php
+++ b/lib/private/Files/Config/CachedMountFileInfo.php
@@ -30,12 +30,21 @@ class CachedMountFileInfo extends CachedMountInfo implements ICachedMountFileInf
 	/** @var string */
 	private $internalPath;
 
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId, $rootInternalPath, $internalPath) {
-		parent::__construct($user, $storageId, $rootId, $mountPoint, $mountId, $rootInternalPath);
+	public function __construct(
+		IUser $user,
+		int $storageId,
+		int $rootId,
+		string $mountPoint,
+		?int $mountId,
+		string $mountProvider,
+		string $rootInternalPath,
+		string $internalPath
+	) {
+		parent::__construct($user, $storageId, $rootId, $mountPoint, $mountProvider, $mountId, $rootInternalPath);
 		$this->internalPath = $internalPath;
 	}
 
-	public function getInternalPath() {
+	public function getInternalPath(): string {
 		if ($this->getRootInternalPath()) {
 			return substr($this->internalPath, strlen($this->getRootInternalPath()) + 1);
 		} else {
@@ -43,7 +52,7 @@ class CachedMountFileInfo extends CachedMountInfo implements ICachedMountFileInf
 		}
 	}
 
-	public function getPath() {
+	public function getPath(): string {
 		return $this->getMountPoint() . $this->getInternalPath();
 	}
 }

--- a/lib/private/Files/Config/CachedMountInfo.php
+++ b/lib/private/Files/Config/CachedMountInfo.php
@@ -58,6 +58,9 @@ class CachedMountInfo implements ICachedMountInfo {
 	 */
 	protected $rootInternalPath;
 
+	/** @var string */
+	protected $mountProvider;
+
 	/**
 	 * CachedMountInfo constructor.
 	 *
@@ -68,13 +71,25 @@ class CachedMountInfo implements ICachedMountInfo {
 	 * @param int|null $mountId
 	 * @param string $rootInternalPath
 	 */
-	public function __construct(IUser $user, $storageId, $rootId, $mountPoint, $mountId = null, $rootInternalPath = '') {
+	public function __construct(
+		IUser $user,
+		int $storageId,
+		int $rootId,
+		string $mountPoint,
+		string $mountProvider,
+		int $mountId = null,
+		string $rootInternalPath = ''
+	) {
 		$this->user = $user;
 		$this->storageId = $storageId;
 		$this->rootId = $rootId;
 		$this->mountPoint = $mountPoint;
 		$this->mountId = $mountId;
 		$this->rootInternalPath = $rootInternalPath;
+		if (strlen($mountProvider) > 128) {
+			throw new \Exception("Mount provider $mountProvider name exceeds the limit of 128 characters");
+		}
+		$this->mountProvider = $mountProvider;
 	}
 
 	/**
@@ -137,5 +152,9 @@ class CachedMountInfo implements ICachedMountInfo {
 	 */
 	public function getRootInternalPath() {
 		return $this->rootInternalPath;
+	}
+
+	public function getMountProvider(): string {
+		return $this->mountProvider;
 	}
 }

--- a/lib/private/Files/Config/LazyStorageMountInfo.php
+++ b/lib/private/Files/Config/LazyStorageMountInfo.php
@@ -81,4 +81,8 @@ class LazyStorageMountInfo extends CachedMountInfo {
 	public function getRootInternalPath() {
 		return $this->mount->getInternalPath($this->mount->getMountPoint());
 	}
+
+	public function getMountProvider(): string {
+		return $this->mount->getMountProvider();
+	}
 }

--- a/lib/private/Files/Mount/CacheMountProvider.php
+++ b/lib/private/Files/Mount/CacheMountProvider.php
@@ -61,8 +61,8 @@ class CacheMountProvider implements IMountProvider {
 			}
 
 			return [
-				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir, $loader]),
-				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads', $loader])
+				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir], $loader, null, null, self::class),
+				new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'], $loader, null, null, self::class)
 			];
 		} else {
 			return [];

--- a/lib/private/Files/Mount/LocalHomeMountProvider.php
+++ b/lib/private/Files/Mount/LocalHomeMountProvider.php
@@ -38,6 +38,6 @@ class LocalHomeMountProvider implements IHomeMountProvider {
 	 */
 	public function getHomeMountForUser(IUser $user, IStorageFactory $loader) {
 		$arguments = ['user' => $user];
-		return new MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), $arguments, $loader);
+		return new MountPoint('\OC\Files\Storage\Home', '/' . $user->getUID(), $arguments, $loader, null, null, self::class);
 	}
 }

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -34,6 +34,7 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\StorageFactory;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorageFactory;
 use OCP\ILogger;
 
 class MountPoint implements IMountPoint {
@@ -76,6 +77,9 @@ class MountPoint implements IMountPoint {
 	/** @var int|null */
 	protected $mountId;
 
+	/** @var string */
+	protected $mountProvider;
+
 	/**
 	 * @param string|\OC\Files\Storage\Storage $storage
 	 * @param string $mountpoint
@@ -83,9 +87,18 @@ class MountPoint implements IMountPoint {
 	 * @param \OCP\Files\Storage\IStorageFactory $loader
 	 * @param array $mountOptions mount specific options
 	 * @param int|null $mountId
+	 * @param string|null $mountProvider
 	 * @throws \Exception
 	 */
-	public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
+	public function __construct(
+		$storage,
+		string $mountpoint,
+		array $arguments = null,
+		IStorageFactory $loader = null,
+		array $mountOptions = null,
+		int $mountId = null,
+		string $mountProvider = null
+	) {
 		if (is_null($arguments)) {
 			$arguments = [];
 		}
@@ -113,6 +126,12 @@ class MountPoint implements IMountPoint {
 			$this->class = $storage;
 			$this->arguments = $arguments;
 		}
+		if ($mountProvider) {
+			if (strlen($mountProvider) > 128) {
+				throw new \Exception("Mount provider $mountProvider name exceeds the limit of 128 characters");
+			}
+		}
+		$this->mountProvider = $mountProvider ?? '';
 	}
 
 	/**
@@ -285,5 +304,9 @@ class MountPoint implements IMountPoint {
 
 	public function getMountType() {
 		return '';
+	}
+
+	public function getMountProvider(): string {
+		return $this->mountProvider;
 	}
 }

--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -65,7 +65,7 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 			return null;
 		}
 
-		return new MountPoint('\OC\Files\ObjectStore\HomeObjectStoreStorage', '/' . $user->getUID(), $config['arguments'], $loader);
+		return new MountPoint('\OC\Files\ObjectStore\HomeObjectStoreStorage', '/' . $user->getUID(), $config['arguments'], $loader, null, null, self::class);
 	}
 
 	/**

--- a/lib/private/Files/Mount/ObjectStorePreviewCacheMountProvider.php
+++ b/lib/private/Files/Mount/ObjectStorePreviewCacheMountProvider.php
@@ -69,7 +69,10 @@ class ObjectStorePreviewCacheMountProvider implements IRootMountProvider {
 					AppdataPreviewObjectStoreStorage::class,
 					'/appdata_' . $instanceId . '/preview/' . $parent . '/' . $child,
 					$this->getMultiBucketObjectStore($i),
-					$loader
+					$loader,
+					null,
+					null,
+					self::class
 				);
 				$i++;
 			}
@@ -87,7 +90,10 @@ class ObjectStorePreviewCacheMountProvider implements IRootMountProvider {
 			$fakeRootStorageJail,
 			'/appdata_' . $instanceId . '/preview/old-multibucket',
 			null,
-			$loader
+			$loader,
+			null,
+			null,
+			self::class
 		);
 
 		return $mountPoints;

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -38,7 +38,7 @@ class LazyFolder implements \OCP\Files\Folder {
 	private $folderClosure;
 
 	/** @var LazyFolder | null */
-	private $folder = null;
+	protected $folder = null;
 
 	/**
 	 * LazyFolder constructor.

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -29,6 +29,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OC\Files\Node;
 
 use OC\Cache\CappedMemoryCache;
@@ -87,8 +88,8 @@ class Root extends Folder implements IRootFolder {
 	 * @param IUserManager $userManager
 	 */
 	public function __construct($manager,
-								$view,
-								$user,
+		$view,
+		$user,
 								IUserMountCache $userMountCache,
 								ILogger $logger,
 								IUserManager $userManager) {
@@ -189,9 +190,9 @@ class Root extends Folder implements IRootFolder {
 
 	/**
 	 * @param string $path
-	 * @throws \OCP\Files\NotFoundException
-	 * @throws \OCP\Files\NotPermittedException
 	 * @return Node
+	 * @throws \OCP\Files\NotPermittedException
+	 * @throws \OCP\Files\NotFoundException
 	 */
 	public function get($path) {
 		$path = $this->normalizePath($path);
@@ -212,8 +213,8 @@ class Root extends Folder implements IRootFolder {
 
 	/**
 	 * @param string $targetPath
-	 * @throws \OCP\Files\NotPermittedException
 	 * @return \OC\Files\Node\Node
+	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function rename($targetPath) {
 		throw new NotPermittedException();
@@ -225,8 +226,8 @@ class Root extends Folder implements IRootFolder {
 
 	/**
 	 * @param string $targetPath
-	 * @throws \OCP\Files\NotPermittedException
 	 * @return \OC\Files\Node\Node
+	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function copy($targetPath) {
 		throw new NotPermittedException();

--- a/lib/public/Files/Config/ICachedMountInfo.php
+++ b/lib/public/Files/Config/ICachedMountInfo.php
@@ -76,4 +76,12 @@ interface ICachedMountInfo {
 	 * @since 11.0.0
 	 */
 	public function getRootInternalPath();
+
+	/**
+	 * Get the class of the mount provider that this mount originates from
+	 *
+	 * @return string
+	 * @since 24.0.0
+	 */
+	public function getMountProvider(): string;
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -128,4 +128,12 @@ interface IMountPoint {
 	 * @since 12.0.0
 	 */
 	public function getMountType();
+
+	/**
+	 * Get the class of the mount provider that this mount originates from
+	 *
+	 * @return string
+	 * @since 24.0.0
+	 */
+	public function getMountProvider(): string;
 }

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -499,6 +499,7 @@ class FolderTest extends NodeTest {
 				1,
 				0,
 				'/bar/',
+				'test',
 				1,
 				''
 			)]);
@@ -549,6 +550,7 @@ class FolderTest extends NodeTest {
 				1,
 				0,
 				'/bar/',
+				'test',
 				1,
 				''
 			)]);
@@ -595,6 +597,7 @@ class FolderTest extends NodeTest {
 				1,
 				0,
 				'/bar/',
+				'test',
 				1,
 				''
 			)]);
@@ -645,6 +648,7 @@ class FolderTest extends NodeTest {
 					1,
 					0,
 					'/bar/',
+					'test',
 					1,
 					''
 				),

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [24, 0, 0, 4];
+$OC_Version = [24, 0, 0, 5];
 
 // The human readable string
 $OC_VersionString = '24.0.0 dev';


### PR DESCRIPTION
Doesn't do anything useful on it's own for now.

But allows being more efficient when setting up the filesystem in the future by only setting up the mounts from a specific provider.