### PR TITLE
reduce 'Movie preview generation failed Output' log errors

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -159,8 +159,10 @@ class Movie extends ProviderV2 {
 			}
 		}
 
-		$logger = \OC::$server->get(LoggerInterface::class);
-		$logger->error('Movie preview generation failed Output: {output}', ['app' => 'core', 'output' => $output]);
+		if ($second === 0) {
+			$logger = \OC::$server->get(LoggerInterface::class);
+			$logger->error('Movie preview generation failed Output: {output}', ['app' => 'core', 'output' => $output]);
+		}
 
 		unlink($tmpPath);
 		return null;


### PR DESCRIPTION
for movies under 5 seconds

My log was getting spammed with "Movie preview generation failed Output" errors; I thought it was something wrong with my installation; So I went poking around finally at the PHP after searching endlessly for a solution.  Come to find out the code loops 3 times until it can generate a successful preview;  So I want to suppress these bogus logs until it gets to the last attempt to generate a preview.

```            
            $result = $this->generateThumbNail($maxX, $maxY, $absPath, 5); 
            if ($result === null) {
                $result = $this->generateThumbNail($maxX, $maxY, $absPath, 1); 
                if ($result === null) {
                    $result = $this->generateThumbNail($maxX, $maxY, $absPath, 0); 
                }   
            } 
```