### PR TITLE
Use the unjailed-path in OC_Helper::getStorageInfo() for files located in SharedStorage.

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -506,6 +506,9 @@ class OC_Helper {
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			$includeExtStorage = false;
 			$sourceStorage = $storage->getSourceStorage();
+			$internalPath = $storage->getUnjailedPath($rootInfo->getInternalPath());
+		} else {
+			$internalPath = $rootInfo->getInternalPath();
 		}
 		if ($includeExtStorage) {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home')
@@ -528,7 +531,7 @@ class OC_Helper {
 			/** @var \OC\Files\Storage\Wrapper\Quota $storage */
 			$quota = $sourceStorage->getQuota();
 		}
-		$free = $sourceStorage->free_space($rootInfo->getInternalPath());
+		$free = $sourceStorage->free_space($internalPath);
 		if ($free >= 0) {
 			$total = $free + $used;
 		} else {


### PR DESCRIPTION
The current implementation already switches the storage-backend to `$storage->getSourceStorage()`. However, it then calls
`$rootInfo->getInternalPath()` which returns the internal path relative to the storage where the share is mounted. This is wrong, we need also to unjail the path. Compare, e.g., with `OCA\Files_Sharing\SharedStorage::file_get/put_contents()` for the
"logic".

Fix #30992

Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>