### PR TITLE
Prevent the OpenDocument preview generator from trying to open empty files.

### DIFF
--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -32,6 +32,11 @@ use OCP\IImage;
  */
 abstract class Bundled extends ProviderV2 {
 	protected function extractThumbnail(File $file, $path): ?IImage {
+
+		if ($file->getSize() == 0) {
+			return null;
+		}
+
 		$sourceTmp = \OC::$server->getTempManager()->getTemporaryFile();
 		$targetTmp = \OC::$server->getTempManager()->getTemporaryFile();
 

--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -33,7 +33,7 @@ use OCP\IImage;
 abstract class Bundled extends ProviderV2 {
 	protected function extractThumbnail(File $file, $path): ?IImage {
 
-		if ($file->getSize() == 0) {
+		if ($file->getSize() === 0) {
 			return null;
 		}
 

--- a/lib/private/Preview/OpenDocument.php
+++ b/lib/private/Preview/OpenDocument.php
@@ -43,7 +43,7 @@ class OpenDocument extends Bundled {
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
 		$image = $this->extractThumbnail($file, 'Thumbnails/thumbnail.png');
-		if ($image->valid()) {
+		if (!empty($image) && $image->valid()) {
 			return $image;
 		}
 		return null;


### PR DESCRIPTION
Rationale: does not make sense, and triggers a deprecation error in
\ZipArchive.

Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>