### PR TITLE
FullTextSearch/IIndex: +getCollection(): string;

### DIFF
--- a/lib/public/FullTextSearch/Model/IIndex.php
+++ b/lib/public/FullTextSearch/Model/IIndex.php
@@ -85,6 +85,17 @@ interface IIndex {
 
 
 	/**
+	 * Get the collection of the index.
+	 * If empty (''), means collection is the default one used by the internal framework
+	 *
+	 * @since 24.0.0
+	 *
+	 * @return string
+	 */
+	public function getCollection(): string;
+
+
+	/**
 	 * Set the source of the original document.
 	 *
 	 * @since 15.0.0


### PR DESCRIPTION
With nc24, FullTextSearch can act as a collection of indexes and queue unindexed document for a 3rd party tool.

`getCollection()` returns the string that identify the collection the index belongs to.