### PR TITLE
Fix bugs with incorrect currentFileList in the favorite and share by you view

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2294,6 +2294,12 @@
 			this.setFiles(result);
 
 			if (this.dirInfo) {
+				// Make sure the currentFileList is the current one
+				// When navigating to the favorite or share with you virtual
+				// folder, this is not correctly set during the initialisation
+				// otherwise.
+				OCA.Files.App && OCA.Files.App.updateCurrentFileList(this);
+
 				var newFileId = this.dirInfo.id;
 				// update fileid in URL
 				var params = {


### PR DESCRIPTION
This was causing bugs when trying to create a new template in these views

## Steps to reproduce original bug

* Go to "shared with you" folder
* Enter one of the folder inside of it
* Try to create a template
* Get an error notification as the path the js frontend is sending is `null`