### PR TITLE
Fixed 'overwritewebroot' not work with 'overwritecondaddr'.

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -161,6 +161,9 @@ class OC {
 				'SCRIPT_FILENAME' => $_SERVER['SCRIPT_FILENAME'] ?? null,
 			],
 		];
+		if (isset($_SERVER['REMOTE_ADDR'])) {
+			$params['server']['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'];
+		}
 		$fakeRequest = new \OC\AppFramework\Http\Request(
 			$params,
 			new \OC\AppFramework\Http\RequestId($_SERVER['UNIQUE_ID'] ?? '', new \OC\Security\SecureRandom()),


### PR DESCRIPTION
Client ip address must be passed to fakeRequest (OC\AppFramework\Http\Request).
Since this is not case, 'overwritewebroot' under 'overwritecondaddr' does not work through OC\AppFramework\HTTP\Request#getScriptName and its isOverwriteCondition.

In order for 'overwritecondaddr' to work properly, PR #30654 must be also merged.