### PR TITLE
Don't hide an overwritten class constant

### DIFF
--- a/apps/user_ldap/lib/Command/TestConfig.php
+++ b/apps/user_ldap/lib/Command/TestConfig.php
@@ -35,8 +35,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TestConfig extends Command {
-	protected const SUCCESS = 0;
-	protected const INVALID = 1;
+	public const SUCCESS = 0;
+	public const INVALID = 1;
 	protected const BINDFAILURE = 2;
 	protected const SEARCHFAILURE = 3;
 


### PR DESCRIPTION
This is not allowed with PHP8.1.

Ref https://github.com/nextcloud/server/issues/29287