### PR TITLE
Move calendar resource/room backend registration to IBootstrap

### DIFF
--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -30,6 +30,8 @@ declare(strict_types=1);
 namespace OC\AppFramework\Bootstrap;
 
 use Closure;
+use OCP\Calendar\Resource\IBackend as IResourceBackend;
+use OCP\Calendar\Room\IBackend as IRoomBackend;
 use OCP\Talk\ITalkBackend;
 use RuntimeException;
 use function array_shift;
@@ -69,6 +71,12 @@ class RegistrationContext {
 
 	/** @var null|ServiceRegistration<ITalkBackend> */
 	private $talkBackendRegistration = null;
+
+	/** @var ServiceRegistration<IResourceBackend>[] */
+	private $calendarResourceBackendRegistrations = [];
+
+	/** @var ServiceRegistration<IRoomBackend>[] */
+	private $calendarRoomBackendRegistrations = [];
 
 	/** @var ServiceFactoryRegistration[] */
 	private $services = [];
@@ -271,6 +279,20 @@ class RegistrationContext {
 					$backend
 				);
 			}
+
+			public function registerCalendarResourceBackend(string $class): void {
+				$this->context->registerCalendarResourceBackend(
+					$this->appId,
+					$class
+				);
+			}
+
+			public function registerCalendarRoomBackend(string $class): void {
+				$this->context->registerCalendarRoomBackend(
+					$this->appId,
+					$class
+				);
+			}
 		};
 	}
 
@@ -374,6 +396,20 @@ class RegistrationContext {
 		}
 
 		$this->talkBackendRegistration = new ServiceRegistration($appId, $backend);
+	}
+
+	public function registerCalendarResourceBackend(string $appId, string $class) {
+		$this->calendarResourceBackendRegistrations[] = new ServiceRegistration(
+			$appId,
+			$class,
+		);
+	}
+
+	public function registerCalendarRoomBackend(string $appId, string $class) {
+		$this->calendarRoomBackendRegistrations[] = new ServiceRegistration(
+			$appId,
+			$class,
+		);
 	}
 
 	/**
@@ -634,5 +670,21 @@ class RegistrationContext {
 	 */
 	public function getTalkBackendRegistration(): ?ServiceRegistration {
 		return $this->talkBackendRegistration;
+	}
+
+	/**
+	 * @return ServiceRegistration[]
+	 * @psalm-return ServiceRegistration<IResourceBackend>[]
+	 */
+	public function getCalendarResourceBackendRegistrations(): array {
+		return $this->calendarResourceBackendRegistrations;
+	}
+
+	/**
+	 * @return ServiceRegistration[]
+	 * @psalm-return ServiceRegistration<IRoomBackend>[]
+	 */
+	public function getCalendarRoomBackendRegistrations(): array {
+		return $this->calendarRoomBackendRegistrations;
 	}
 }

--- a/lib/private/Calendar/Room/Manager.php
+++ b/lib/private/Calendar/Room/Manager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -24,26 +27,30 @@
  */
 namespace OC\Calendar\Room;
 
+use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\Calendar\Room\IBackend;
+use OCP\Calendar\Room\IManager;
 use OCP\IServerContainer;
 
-class Manager implements \OCP\Calendar\Room\IManager {
+class Manager implements IManager {
+	private Coordinator $bootstrapCoordinator;
 
-	/** @var IServerContainer */
-	private $server;
+	private IServerContainer $server;
 
-	/** @var string[] holds all registered resource backends */
-	private $backends = [];
-
-	/** @var IBackend[] holds all backends that have been initialized already */
-	private $initializedBackends = [];
+	private bool $bootstrapBackendsLoaded = false;
 
 	/**
-	 * Manager constructor.
-	 *
-	 * @param IServerContainer $server
+	 * @var string[] holds all registered resource backends
+	 * @psalm-var class-string<IBackend>[]
 	 */
-	public function __construct(IServerContainer $server) {
+	private array $backends = [];
+
+	/** @var IBackend[] holds all backends that have been initialized already */
+	private array $initializedBackends = [];
+
+	public function __construct(Coordinator $bootstrapCoordinator,
+								IServerContainer $server) {
+		$this->bootstrapCoordinator = $bootstrapCoordinator;
 		$this->server = $server;
 	}
 
@@ -69,17 +76,41 @@ class Manager implements \OCP\Calendar\Room\IManager {
 		unset($this->backends[$backendClass], $this->initializedBackends[$backendClass]);
 	}
 
+	private function fetchBootstrapBackends(): void {
+		if ($this->bootstrapBackendsLoaded) {
+			return;
+		}
+
+		$context = $this->bootstrapCoordinator->getRegistrationContext();
+		if ($context === null) {
+			// Too soon
+			return;
+		}
+
+		foreach ($context->getCalendarRoomBackendRegistrations() as $registration) {
+			$this->backends[] = $registration->getService();
+		}
+	}
+
 	/**
 	 * @return IBackend[]
 	 * @throws \OCP\AppFramework\QueryException
 	 * @since 14.0.0
 	 */
 	public function getBackends():array {
+		$this->fetchBootstrapBackends();
+
 		foreach ($this->backends as $backend) {
 			if (isset($this->initializedBackends[$backend])) {
 				continue;
 			}
 
+			/**
+			 * @todo fetch from the app container
+			 *
+			 * The backend might have services injected that can't be build from the
+			 * server container.
+			 */
 			$this->initializedBackends[$backend] = $this->server->query($backend);
 		}
 

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -275,4 +275,24 @@ interface IRegistrationContext {
 	 * @since 24.0.0
 	 */
 	public function registerTalkBackend(string $backend): void;
+
+	/**
+	 * Register a resource backend for the DAV server
+	 *
+	 * @param string $actionClass
+	 * @psalm-param class-string<\OCP\Calendar\Resource\IBackend> $actionClass
+	 * @return void
+	 * @since 24.0.0
+	 */
+	public function registerCalendarResourceBackend(string $class): void;
+
+	/**
+	 * Register a room backend for the DAV server
+	 *
+	 * @param string $actionClass
+	 * @psalm-param class-string<\OCP\Calendar\Room\IBackend> $actionClass
+	 * @return void
+	 * @since 24.0.0
+	 */
+	public function registerCalendarRoomBackend(string $class): void;
 }

--- a/lib/public/Calendar/Resource/IManager.php
+++ b/lib/public/Calendar/Resource/IManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -23,9 +26,8 @@
 namespace OCP\Calendar\Resource;
 
 /**
- * Interface IManager
- *
  * @since 14.0.0
+ * @deprecated 24.0.0
  */
 interface IManager {
 
@@ -35,6 +37,7 @@ interface IManager {
 	 * @param string $backendClass
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0 use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerCalendarResourceBackend
 	 */
 	public function registerBackend(string $backendClass);
 
@@ -44,12 +47,14 @@ interface IManager {
 	 * @param string $backendClass
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function unregisterBackend(string $backendClass);
 
 	/**
 	 * @return IBackend[]
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function getBackends():array;
 
@@ -57,6 +62,7 @@ interface IManager {
 	 * @param string $backendId
 	 * @return IBackend|null
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function getBackend($backendId);
 
@@ -64,6 +70,7 @@ interface IManager {
 	 * removes all registered backend instances
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function clear();
 }

--- a/lib/public/Calendar/Room/IManager.php
+++ b/lib/public/Calendar/Room/IManager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -23,9 +26,8 @@
 namespace OCP\Calendar\Room;
 
 /**
- * Interface IManager
- *
  * @since 14.0.0
+ * @deprecated 24.0.0
  */
 interface IManager {
 
@@ -35,6 +37,7 @@ interface IManager {
 	 * @param string $backendClass
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0 use \OC\AppFramework\Bootstrap\::registerCalendarRoomBackend
 	 */
 	public function registerBackend(string $backendClass);
 
@@ -44,12 +47,14 @@ interface IManager {
 	 * @param string $backendClass
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function unregisterBackend(string $backendClass);
 
 	/**
 	 * @return IBackend[]
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function getBackends():array;
 
@@ -57,6 +62,7 @@ interface IManager {
 	 * @param string $backendId
 	 * @return IBackend|null
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function getBackend($backendId);
 
@@ -64,6 +70,7 @@ interface IManager {
 	 * removes all registered backend instances
 	 * @return void
 	 * @since 14.0.0
+	 * @deprecated 24.0.0
 	 */
 	public function clear();
 }

--- a/tests/lib/Calendar/Room/ManagerTest.php
+++ b/tests/lib/Calendar/Room/ManagerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -23,101 +26,124 @@
 
 namespace Test\Calendar\Room;
 
+use OC\AppFramework\Bootstrap\Coordinator;
+use OC\AppFramework\Bootstrap\RegistrationContext;
+use OC\AppFramework\Bootstrap\ServiceRegistration;
 use OC\Calendar\Room\Manager;
 use OCP\Calendar\Room\IBackend;
 use OCP\IServerContainer;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
+	/** @var Coordinator|MockObject */
+	private $coordinator;
+
+	/** @var IServerContainer|MockObject */
+	private $server;
+
 	/** @var Manager */
 	private $manager;
-
-	/** @var IServerContainer */
-	private $server;
 
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->coordinator = $this->createMock(Coordinator::class);
 		$this->server = $this->createMock(IServerContainer::class);
-		$this->manager = new Manager($this->server);
+		$this->manager = new Manager(
+			$this->coordinator,
+			$this->server,
+		);
 	}
 
-	public function testRegisterUnregisterBackend() {
+	public function testRegisterUnregisterBackend(): void {
 		$backend1 = $this->createMock(IBackend::class);
 		$backend1->method('getBackendIdentifier')->willReturn('backend_1');
-		$this->server->expects($this->at(0))
-			->method('query')
-			->with('calendar_room_backend1')
-			->willReturn($backend1);
-
 		$backend2 = $this->createMock(IBackend::class);
 		$backend2->method('getBackendIdentifier')->willReturn('backend_2');
-		$this->server->expects($this->at(1))
+		$this->server->expects(self::exactly(2))
 			->method('query')
-			->with('calendar_room_backend2')
-			->willReturn($backend2);
+			->willReturnMap([
+				['calendar_room_backend1', true, $backend1,],
+				['calendar_room_backend2', true, $backend2,],
+			]);
 
 		$this->manager->registerBackend('calendar_room_backend1');
 		$this->manager->registerBackend('calendar_room_backend2');
 
-		$this->assertEquals([
+		self::assertEquals([
 			$backend1, $backend2
 		], $this->manager->getBackends());
 
 		$this->manager->unregisterBackend('calendar_room_backend1');
 
-		$this->assertEquals([
+		self::assertEquals([
 			$backend2
 		], $this->manager->getBackends());
 	}
 
-	public function testGetBackend() {
-		$backend1 = $this->createMock(IBackend::class);
-		$backend1->method('getBackendIdentifier')->willReturn('backend_1');
-		$this->server->expects($this->at(0))
+	public function testGetBackendFromBootstrapRegistration(): void {
+		$backendClass = '\\OCA\\CalendarRoomFoo\\Backend';
+		$backend = $this->createMock(IBackend::class);
+		$backend->method('getBackendIdentifier')->willReturn('from_bootstrap');
+		$context = $this->createMock(RegistrationContext::class);
+		$this->coordinator->expects(self::once())
+			->method('getRegistrationContext')
+			->willReturn($context);
+		$context->expects(self::once())
+			->method('getCalendarRoomBackendRegistrations')
+			->willReturn([
+				new ServiceRegistration('calendar_room_foo', $backendClass)
+			]);
+		$this->server->expects(self::once())
 			->method('query')
-			->with('calendar_room_backend1')
-			->willReturn($backend1);
+			->with($backendClass)
+			->willReturn($backend);
 
-		$backend2 = $this->createMock(IBackend::class);
-		$backend2->method('getBackendIdentifier')->willReturn('backend_2');
-		$this->server->expects($this->at(1))
-			->method('query')
-			->with('calendar_room_backend2')
-			->willReturn($backend2);
-
-		$this->manager->registerBackend('calendar_room_backend1');
-		$this->manager->registerBackend('calendar_room_backend2');
-
-		$this->assertEquals($backend1, $this->manager->getBackend('backend_1'));
-		$this->assertEquals($backend2, $this->manager->getBackend('backend_2'));
+		self::assertEquals($backend, $this->manager->getBackend('from_bootstrap'));
 	}
 
-	public function testClear() {
+	public function testGetBackend(): void {
 		$backend1 = $this->createMock(IBackend::class);
 		$backend1->method('getBackendIdentifier')->willReturn('backend_1');
-		$this->server->expects($this->at(0))
-			->method('query')
-			->with('calendar_room_backend1')
-			->willReturn($backend1);
-
 		$backend2 = $this->createMock(IBackend::class);
 		$backend2->method('getBackendIdentifier')->willReturn('backend_2');
-		$this->server->expects($this->at(1))
+		$this->server->expects(self::exactly(2))
 			->method('query')
-			->with('calendar_room_backend2')
-			->willReturn($backend2);
+			->willReturnMap([
+				['calendar_room_backend1', true, $backend1,],
+				['calendar_room_backend2', true, $backend2,],
+			]);
 
 		$this->manager->registerBackend('calendar_room_backend1');
 		$this->manager->registerBackend('calendar_room_backend2');
 
-		$this->assertEquals([
+		self::assertEquals($backend1, $this->manager->getBackend('backend_1'));
+		self::assertEquals($backend2, $this->manager->getBackend('backend_2'));
+	}
+
+	public function testClear(): void {
+		$backend1 = $this->createMock(IBackend::class);
+		$backend1->method('getBackendIdentifier')->willReturn('backend_1');
+		$backend2 = $this->createMock(IBackend::class);
+		$backend2->method('getBackendIdentifier')->willReturn('backend_2');
+		$this->server->expects(self::exactly(2))
+			->method('query')
+			->willReturnMap([
+				['calendar_room_backend1', true, $backend1,],
+				['calendar_room_backend2', true, $backend2,],
+			]);
+
+		$this->manager->registerBackend('calendar_room_backend1');
+		$this->manager->registerBackend('calendar_room_backend2');
+
+		self::assertEquals([
 			$backend1, $backend2
 		], $this->manager->getBackends());
 
 		$this->manager->clear();
 
-		$this->assertEquals([], $this->manager->getBackends());
+		self::assertEquals([], $this->manager->getBackends());
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/29563

## Old registration

```php
		$serverContainer = $context->getServerContainer();

		/** @var IResourceManager $resourceManager */
		/** @var IRoomManager $roomManager */
		$resourceManager = $serverContainer->get(IResourceManager::class);
		$roomManager = $serverContainer->get(IRoomManager::class);

		$resourceManager->registerBackend(Connector\Resource\Backend::class);
		$roomManager->registerBackend(Connector\Room\Backend::class);
```

^ only possible during `boot`, which imposes a potential loading order problem. Moreover both managers have to be instantiated and therefore cause a performance overhead for requests that don't need the backends.

## New registration

```php
		$context->registerCalendarResourceBackend(Connector\Resource\Backend::class);
		$context->registerCalendarRoomBackend(Connector\Room\Backend::class);
```

^ happens during `register`. No performance overhead, it's two string appended to arrays.

I've tested it with the modified `calendar_resource_management`. The backends are still loaded and processed during the background job.

Ref https://github.com/nextcloud/calendar_resource_management/pull/45