### PR TITLE
Expose additional emails in {DAV:}alternate-URI-set

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -34,6 +34,7 @@ use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccountManager;
 use Psr\Log\LoggerInterface;
 
 $authBackend = new Auth(
@@ -47,6 +48,7 @@ $authBackend = new Auth(
 $principalBackend = new Principal(
 	\OC::$server->getUserManager(),
 	\OC::$server->getGroupManager(),
+	\OC::$server->get(IAccountManager::class),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getAppManager(),

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -35,6 +35,7 @@ use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Plugin;
@@ -50,6 +51,7 @@ $authBackend = new Auth(
 $principalBackend = new Principal(
 	\OC::$server->getUserManager(),
 	\OC::$server->getGroupManager(),
+	\OC::$server->get(IAccountManager::class),
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getAppManager(),

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -29,6 +29,7 @@ use OC\KnownUser\KnownUserService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccountManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -83,6 +84,7 @@ class CreateCalendar extends Command {
 		$principalBackend = new Principal(
 			$this->userManager,
 			$this->groupManager,
+			\OC::$server->get(IAccountManager::class),
 			\OC::$server->getShareManager(),
 			\OC::$server->getUserSession(),
 			\OC::$server->getAppManager(),

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -41,6 +41,9 @@ use OC\KnownUser\KnownUserService;
 use OCA\Circles\Exceptions\CircleNotFoundException;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Traits\PrincipalProxyTrait;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\QueryException;
 use OCP\Constants;
@@ -63,6 +66,9 @@ class Principal implements BackendInterface {
 
 	/** @var IGroupManager */
 	private $groupManager;
+
+	/** @var IAccountManager */
+	private $accountManager;
 
 	/** @var IShareManager */
 	private $shareManager;
@@ -95,6 +101,7 @@ class Principal implements BackendInterface {
 
 	public function __construct(IUserManager $userManager,
 								IGroupManager $groupManager,
+								IAccountManager $accountManager,
 								IShareManager $shareManager,
 								IUserSession $userSession,
 								IAppManager $appManager,
@@ -105,6 +112,7 @@ class Principal implements BackendInterface {
 								string $principalPrefix = 'principals/users/') {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
+		$this->accountManager = $accountManager;
 		$this->shareManager = $shareManager;
 		$this->userSession = $userSession;
 		$this->appManager = $appManager;
@@ -506,6 +514,7 @@ class Principal implements BackendInterface {
 	/**
 	 * @param IUser $user
 	 * @return array
+	 * @throws PropertyDoesNotExistException
 	 */
 	protected function userToPrincipal($user) {
 		$userId = $user->getUID();
@@ -517,9 +526,16 @@ class Principal implements BackendInterface {
 			'{http://nextcloud.com/ns}language' => $this->languageFactory->getUserLanguage($user),
 		];
 
+		$account = $this->accountManager->getAccount($user);
+		$alternativeEmails = array_map(fn (IAccountProperty $property) => 'mailto:' . $property->getValue(), $account->getPropertyCollection(IAccountManager::COLLECTION_EMAIL)->getProperties());
+
 		$email = $user->getSystemEMailAddress();
 		if (!empty($email)) {
 			$principal['{http://sabredav.org/ns}email-address'] = $email;
+		}
+
+		if (!empty($alternativeEmails)) {
+			$principal['{DAV:}alternate-URI-set'] = $alternativeEmails;
 		}
 
 		return $principal;

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -43,6 +43,7 @@ use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCA\DAV\DAV\SystemPrincipalBackend;
 use OCA\DAV\Provisioning\Apple\AppleProvisioningNode;
 use OCA\DAV\Upload\CleanupService;
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -68,6 +69,7 @@ class RootCollection extends SimpleCollection {
 		$userPrincipalBackend = new Principal(
 			$userManager,
 			$groupManager,
+			\OC::$server->get(IAccountManager::class),
 			$shareManager,
 			\OC::$server->getUserSession(),
 			\OC::$server->getAppManager(),

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -30,6 +30,7 @@ use OC\KnownUser\KnownUserService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -89,6 +90,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 			->setConstructorArgs([
 				$this->userManager,
 				$this->groupManager,
+				$this->createMock(IAccountManager::class),
 				$this->createMock(ShareManager::class),
 				$this->createMock(IUserSession::class),
 				$this->createMock(IAppManager::class),

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -37,6 +37,7 @@ use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -136,6 +137,7 @@ class CardDavBackendTest extends TestCase {
 			->setConstructorArgs([
 				$this->userManager,
 				$this->groupManager,
+				$this->createMock(IAccountManager::class),
 				$this->createMock(ShareManager::class),
 				$this->createMock(IUserSession::class),
 				$this->createMock(IAppManager::class),

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -34,6 +34,10 @@ use OC\User\User;
 use OCA\DAV\CalDAV\Proxy\Proxy;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\IAccountPropertyCollection;
 use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -59,6 +63,9 @@ class PrincipalTest extends TestCase {
 	/** @var IGroupManager | MockObject */
 	private $groupManager;
 
+	/** @var IAccountManager|MockObject */
+	private $accountManager;
+
 	/** @var IManager | MockObject */
 	private $shareManager;
 
@@ -81,6 +88,7 @@ class PrincipalTest extends TestCase {
 	protected function setUp(): void {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->accountManager = $this->createMock(IAccountManager::class);
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->appManager = $this->createMock(IAppManager::class);
@@ -92,6 +100,7 @@ class PrincipalTest extends TestCase {
 		$this->connector = new Principal(
 			$this->userManager,
 			$this->groupManager,
+			$this->accountManager,
 			$this->shareManager,
 			$this->userSession,
 			$this->appManager,
@@ -143,6 +152,45 @@ class PrincipalTest extends TestCase {
 			->withConsecutive([$fooUser], [$barUser])
 			->willReturnOnConsecutiveCalls('de', 'en');
 
+		$fooAccountPropertyCollection = $this->createMock(IAccountPropertyCollection::class);
+		$fooAccountPropertyCollection->expects($this->once())
+			->method('getProperties')
+			->with()
+			->willReturn([]);
+		$fooAccount = $this->createMock(IAccount::class);
+		$fooAccount->expects($this->once())
+			->method('getPropertyCollection')
+			->with(IAccountManager::COLLECTION_EMAIL)
+			->willReturn($fooAccountPropertyCollection);
+
+		$emailPropertyOne = $this->createMock(IAccountProperty::class);
+		$emailPropertyOne->expects($this->once())
+			->method('getValue')
+			->with()
+			->willReturn('alias@nextcloud.com');
+		$emailPropertyTwo = $this->createMock(IAccountProperty::class);
+		$emailPropertyTwo->expects($this->once())
+			->method('getValue')
+			->with()
+			->willReturn('alias2@nextcloud.com');
+
+		$barAccountPropertyCollection = $this->createMock(IAccountPropertyCollection::class);
+		$barAccountPropertyCollection->expects($this->once())
+			->method('getProperties')
+			->with()
+			->willReturn([$emailPropertyOne, $emailPropertyTwo]);
+		$barAccount = $this->createMock(IAccount::class);
+		$barAccount->expects($this->once())
+			->method('getPropertyCollection')
+			->with(IAccountManager::COLLECTION_EMAIL)
+			->willReturn($barAccountPropertyCollection);
+
+		$this->accountManager
+			->expects($this->exactly(2))
+			->method('getAccount')
+			->withConsecutive([$fooUser], [$barUser])
+			->willReturnOnConsecutiveCalls($fooAccount, $barAccount);
+
 		$expectedResponse = [
 			0 => [
 				'uri' => 'principals/users/foo',
@@ -156,6 +204,7 @@ class PrincipalTest extends TestCase {
 				'{urn:ietf:params:xml:ns:caldav}calendar-user-type' => 'INDIVIDUAL',
 				'{http://nextcloud.com/ns}language' => 'en',
 				'{http://sabredav.org/ns}email-address' => 'bar@nextcloud.com',
+				'{DAV:}alternate-URI-set' => ['mailto:alias@nextcloud.com', 'mailto:alias2@nextcloud.com']
 			]
 		];
 		$response = $this->connector->getPrincipalsByPrefix('principals/users');

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -38,6 +38,7 @@ use OCA\Files_Versions\Listener\LoadAdditionalListener;
 use OCA\Files_Versions\Listener\LoadSidebarListener;
 use OCA\Files_Versions\Versions\IVersionManager;
 use OCA\Files_Versions\Versions\VersionManager;
+use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -75,6 +76,7 @@ class Application extends App implements IBootstrap {
 			return new Principal(
 				$server->get(IUserManager::class),
 				$server->get(IGroupManager::class),
+				\OC::$server->get(IAccountManager::class),
 				$server->get(IShareManager::class),
 				$server->get(IUserSession::class),
 				$server->get(IAppManager::class),


### PR DESCRIPTION
This allows iMip invitations to be send with an alternative email as "Reply-To" field.

The emails are provided in the `alternate-URI-set` prop, and through `calendar-user-address-set` and `email-address-set` on a CalDAV principal.

https://github.com/nextcloud/3rdparty/blob/41d5f9752c7e0f2b690480a38ef5b9dddc357166/sabre/dav/lib/CalDAV/Plugin.php#L347-L367

However, it's not possible to find users principals from their alternative emails by filtering through `{http://sabredav.org/ns}email-address` or `calendar-user-address-set` (which only use the system email address).

https://github.com/nextcloud/server/blob/9c2db7f4e40d690890024636856ec51fbcb00005/apps/dav/lib/Connector/Sabre/Principal.php#L299-L311

Closes #27201
