### PR TITLE
Removes misleading error message in occ files:scan for new users.

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -216,7 +216,7 @@ class Scanner extends PublicEmitter {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
-				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
+				if ($storage->is_dir('files')) {
 					throw new ForbiddenException();
 				} else {// if the root exists in neither the cache nor the storage the user isn't setup yet
 					break;


### PR DESCRIPTION
Previously the occ files:scan command printed an error message for any
new users without any files/folders in the data directory.
With this change only users with any file/folder is scanned.

This fixes #25433.

Signed-off-by: Christian Paier <hallo+git@cpaier.com>