### PR TITLE
Add index for direct editing cleanup job

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -206,6 +206,13 @@ class Application extends App {
 						$subject->addHintForMissingSubject($table->getName(), 'job_lastcheck_reserved');
 					}
 				}
+
+				if ($schema->hasTable('direct_edit')) {
+					$table = $schema->getTable('direct_edit');
+					if (!$table->hasIndex('direct_edit_timestamp')) {
+						$subject->addHintForMissingSubject($table->getName(), 'direct_edit_timestamp');
+					}
+				}
 			}
 		);
 

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -352,6 +352,19 @@ class AddMissingIndices extends Command {
 			}
 		}
 
+		$output->writeln('<info>Check indices of the oc_direct_edit table.</info>');
+		if ($schema->hasTable('direct_edit')) {
+			$table = $schema->getTable('direct_edit');
+			if (!$table->hasIndex('direct_edit_timestamp')) {
+				$output->writeln('<info>Adding direct_edit_timestamp index to the oc_direct_edit table, this can take some time...</info>');
+
+				$table->addIndex(['timestamp'], 'direct_edit_timestamp');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>oc_direct_edit table updated successfully.</info>');
+			}
+		}
+
 		if (!$updated) {
 			$output->writeln('<info>Done.</info>');
 		}

--- a/core/Migrations/Version18000Date20191014105105.php
+++ b/core/Migrations/Version18000Date20191014105105.php
@@ -89,6 +89,7 @@ class Version18000Date20191014105105 extends SimpleMigrationStep {
 
 		$table->setPrimaryKey(['id']);
 		$table->addIndex(['token']);
+		$table->addIndex(['timestamp'], 'direct_edit_timestamp');
 
 		return $schema;
 	}


### PR DESCRIPTION
Add a index in order to avoid slow queries on cleaning up direct editing tokens in the cleanup query in https://github.com/nextcloud/server/blob/8535dc4255704842b54fbe4c2eaf778248276a56/lib/private/DirectEditing/Manager.php#L216