### PR TITLE
Additional index on oc_preferences to make queries without a user filter faster

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -213,6 +213,13 @@ class Application extends App {
 						$subject->addHintForMissingSubject($table->getName(), 'direct_edit_timestamp');
 					}
 				}
+
+				if ($schema->hasTable('preferences')) {
+					$table = $schema->getTable('preferences');
+					if (!$table->hasIndex('preferences_app_key')) {
+						$subject->addHintForMissingSubject($table->getName(), 'preferences_app_key');
+					}
+				}
 			}
 		);
 

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -435,6 +435,19 @@ class AddMissingIndices extends Command {
 			}
 		}
 
+		$output->writeln('<info>Check indices of the oc_preferences table.</info>');
+		if ($schema->hasTable('preferences')) {
+			$table = $schema->getTable('preferences');
+			if (!$table->hasIndex('preferences_app_key')) {
+				$output->writeln('<info>Adding preferences_app_key index to the oc_preferences table, this can take some time...</info>');
+
+				$table->addIndex(['appid', 'configkey'], 'preferences_app_key');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>oc_properties table updated successfully.</info>');
+			}
+		}
+
 		if (!$updated) {
 			$output->writeln('<info>Done.</info>');
 		}

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -333,6 +333,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'notnull' => false,
 			]);
 			$table->setPrimaryKey(['userid', 'appid', 'configkey']);
+			$table->addIndex(['appid', 'configkey'], 'preferences_app_key');
 		}
 
 		if (!$schema->hasTable('properties')) {

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -497,6 +497,8 @@ class AllConfig implements \OCP\IConfig {
 			$sql .= 'AND `configvalue` = ?';
 		}
 
+		$sql .= ' ORDER BY `userid`';
+
 		$result = $this->connection->executeQuery($sql, [$appName, $key, $value]);
 
 		$userIDs = [];
@@ -533,6 +535,8 @@ class AllConfig implements \OCP\IConfig {
 		} else {
 			$sql .= 'AND LOWER(`configvalue`) = ?';
 		}
+
+		$sql .= ' ORDER BY `userid`';
 
 		$result = $this->connection->executeQuery($sql, [$appName, $key, strtolower($value)]);
 


### PR DESCRIPTION
Fixes #30421

IConfig methods may issue queries which are causing a full table scan on oc_preferences with using the existing primary key as an index as it is only partially filtered for in the where clause, as the order seems to be relevant `(userid,appid,configkey)`

https://github.com/nextcloud/server/blob/c92ac3471166f2697db1d9a696e31d0c06ac2e64/lib/private/AllConfig.php#L485-L490

https://github.com/nextcloud/server/blob/c92ac3471166f2697db1d9a696e31d0c06ac2e64/lib/private/AllConfig.php#L387-L392