### PR TITLE
Increase timeout when looking for user in list

### DIFF
--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -272,7 +272,7 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 		if (!WaitFor::elementToBeEventuallyShown(
 				$this->actor,
 				self::rowForUser($user),
-				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+				$timeout = 15 * $this->actor->getFindTimeoutMultiplier())) {
 			Assert::fail("The user $user in the list of users is not shown yet after $timeout seconds");
 		}
 	}


### PR DESCRIPTION
My empirical findings show that https://github.com/nextcloud/server/blob/master/tests/acceptance/features/users.feature#L48 is causing half of the failures of acceptances tests in CI.

My assumption is that the server is not powerful enough and that a 100 seconds timeout is too short. But without more context like screenshots on failures, it is difficult to know for sure. Also, it is hard to reproduce locally as this does not fail all the time.

This PR simply increase the timeout to 150 seconds, hoping that this will fix the regular CI failures and help us having more trust in our CI tests.