### PR TITLE
Add a top margin for application list

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1021,6 +1021,7 @@ span.version {
 }
 
 .apps-list {
+	margin-top: 30px;
 	.section {
 		cursor: pointer;
 	}


### PR DESCRIPTION
Solution for issue: #31069.

A top margin for the application list has been added.

**_Before change:_**
![obraz](https://user-images.githubusercontent.com/47037905/153164921-bfcd1e50-66dc-407e-86ec-ef0d72f3efee.png)
![obraz](https://user-images.githubusercontent.com/47037905/153165076-7052d10b-f5db-4aca-8729-27e33c381b18.png)
![obraz](https://user-images.githubusercontent.com/47037905/153165259-0bf8b8d4-bf41-4ded-a292-db776127662c.png)

**_After change:_**
![obraz](https://user-images.githubusercontent.com/47037905/153164080-e5b31384-93a8-45db-8569-b5ae27a70617.png)
![obraz](https://user-images.githubusercontent.com/47037905/153164326-b6802434-a7dd-4bef-93ba-a6e306a3e05a.png)
![obraz](https://user-images.githubusercontent.com/47037905/153164461-19cd76f0-11d0-4421-ba31-9b89a486d9de.png)

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>