### PR TITLE
Don't provide favorite activity settings

### DIFF
--- a/apps/files/lib/Activity/Settings/FavoriteAction.php
+++ b/apps/files/lib/Activity/Settings/FavoriteAction.php
@@ -55,7 +55,7 @@ class FavoriteAction extends FileActivitySettings {
 	 * @since 11.0.0
 	 */
 	public function canChangeStream() {
-		return true;
+		return false;
 	}
 
 	/**
@@ -71,7 +71,7 @@ class FavoriteAction extends FileActivitySettings {
 	 * @since 11.0.0
 	 */
 	public function canChangeMail() {
-		return true;
+		return false;
 	}
 
 	/**
@@ -79,6 +79,14 @@ class FavoriteAction extends FileActivitySettings {
 	 * @since 11.0.0
 	 */
 	public function isDefaultEnabledMail() {
+		return false;
+	}
+
+	/**
+	 * @return bool True when the option can be changed for the notification
+	 * @since 20.0.0
+	 */
+	public function canChangeNotification() {
 		return false;
 	}
 }


### PR DESCRIPTION
Since mails and notifications are only available for actions of other users
it does not make sense to allow changing this.
It also prevents the common misunderstanding with
"file was changed inside a favorited folder"
