### PR TITLE
FullTextSearch: +IndexNotFoundException

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -333,6 +333,7 @@ return array(
     'OCP\\Files\\UnseekableException' => $baseDir . '/lib/public/Files/UnseekableException.php',
     'OCP\\Files_FullTextSearch\\Model\\AFilesDocument' => $baseDir . '/lib/public/Files_FullTextSearch/Model/AFilesDocument.php',
     'OCP\\FullTextSearch\\Exceptions\\FullTextSearchAppNotAvailableException' => $baseDir . '/lib/public/FullTextSearch/Exceptions/FullTextSearchAppNotAvailableException.php',
+    'OCP\\FullTextSearch\\Exceptions\\IndexNotFoundException' => $baseDir . '/lib/public/FullTextSearch/Exceptions/IndexNotFoundException.php',
     'OCP\\FullTextSearch\\IFullTextSearchManager' => $baseDir . '/lib/public/FullTextSearch/IFullTextSearchManager.php',
     'OCP\\FullTextSearch\\IFullTextSearchPlatform' => $baseDir . '/lib/public/FullTextSearch/IFullTextSearchPlatform.php',
     'OCP\\FullTextSearch\\IFullTextSearchProvider' => $baseDir . '/lib/public/FullTextSearch/IFullTextSearchProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -7,7 +7,7 @@ namespace Composer\Autoload;
 class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
 {
     public static $prefixLengthsPsr4 = array (
-        'O' => 
+        'O' =>
         array (
             'OC\\Core\\' => 8,
             'OC\\' => 3,
@@ -16,15 +16,15 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
     );
 
     public static $prefixDirsPsr4 = array (
-        'OC\\Core\\' => 
+        'OC\\Core\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/core',
         ),
-        'OC\\' => 
+        'OC\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/private',
         ),
-        'OCP\\' => 
+        'OCP\\' =>
         array (
             0 => __DIR__ . '/../../..' . '/lib/public',
         ),
@@ -362,6 +362,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Files\\UnseekableException' => __DIR__ . '/../../..' . '/lib/public/Files/UnseekableException.php',
         'OCP\\Files_FullTextSearch\\Model\\AFilesDocument' => __DIR__ . '/../../..' . '/lib/public/Files_FullTextSearch/Model/AFilesDocument.php',
         'OCP\\FullTextSearch\\Exceptions\\FullTextSearchAppNotAvailableException' => __DIR__ . '/../../..' . '/lib/public/FullTextSearch/Exceptions/FullTextSearchAppNotAvailableException.php',
+        'OCP\\FullTextSearch\\Exceptions\\IndexNotFoundException' => __DIR__ . '/../../..' . '/lib/public/FullTextSearch/Exceptions/IndexNotFoundException.php',
         'OCP\\FullTextSearch\\IFullTextSearchManager' => __DIR__ . '/../../..' . '/lib/public/FullTextSearch/IFullTextSearchManager.php',
         'OCP\\FullTextSearch\\IFullTextSearchPlatform' => __DIR__ . '/../../..' . '/lib/public/FullTextSearch/IFullTextSearchPlatform.php',
         'OCP\\FullTextSearch\\IFullTextSearchProvider' => __DIR__ . '/../../..' . '/lib/public/FullTextSearch/IFullTextSearchProvider.php',

--- a/lib/public/FullTextSearch/Exceptions/IndexNotFoundException.php
+++ b/lib/public/FullTextSearch/Exceptions/IndexNotFoundException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2022, Maxence Lange <maxence@artificial-owl.com>
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\FullTextSearch\Exceptions;
+
+/**
+ * @since 24.0.0
+ *
+ * Class IndexNotFoundException
+ *
+ */
+class IndexNotFoundException extends \Exception {
+}

--- a/lib/public/FullTextSearch/IFullTextSearchManager.php
+++ b/lib/public/FullTextSearch/IFullTextSearchManager.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 namespace OCP\FullTextSearch;
 
+use OCP\FullTextSearch\Exceptions\IndexNotFoundException;
 use OCP\FullTextSearch\Model\IIndex;
 use OCP\FullTextSearch\Model\ISearchResult;
 use OCP\FullTextSearch\Service\IIndexService;
@@ -143,6 +144,8 @@ interface IFullTextSearchManager {
 	 * @param string $documentId
 	 * @param int $status
 	 * @param bool $reset
+	 *
+	 * @throws IndexNotFoundException (since 24.0.0)
 	 */
 	public function updateIndexStatus(string $providerId, string $documentId, int $status, bool $reset = false);
 


### PR DESCRIPTION
adding an exception that can be thrown when updating an index from the fullTextSearchManager