### PR TITLE
Fix path handling when transferring incoming shares

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -444,13 +444,17 @@ class OwnershipTransferService {
 		$output->writeln("Restoring incoming shares ...");
 		$progress = new ProgressBar($output, count($sourceShares));
 		$prefix = "$destinationUid/files";
+		$finalShareTarget = '';
 		if (substr($finalTarget, 0, strlen($prefix)) === $prefix) {
 			$finalShareTarget = substr($finalTarget, strlen($prefix));
 		}
 		foreach ($sourceShares as $share) {
 			try {
 				// Only restore if share is in given path.
-				$pathToCheck = '/' . trim($path) . '/';
+				$pathToCheck = '/';
+				if (trim($path, '/') !== '') {
+					$pathToCheck = '/' . trim($path) . '/';
+				}
 				if (substr($share->getTarget(), 0, strlen($pathToCheck)) !== $pathToCheck) {
 					continue;
 				}


### PR DESCRIPTION
When transferring incoming shares from a guest user without specifying a
path, the $path is empty.
The fix properly handles that situation to avoid looking for shares in a
path with doubled slashes which failed to find shares to transfer.

Fixes https://github.com/nextcloud/server/issues/31096