### PR TITLE
Diagnostics event logging to log

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -35,6 +35,7 @@
 namespace OCA\DAV;
 
 use OCA\DAV\Connector\Sabre\RequestIdHeaderPlugin;
+use OCP\Diagnostics\IEventLogger;
 use Psr\Log\LoggerInterface;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\BirthdayService;
@@ -337,7 +338,11 @@ class Server {
 	}
 
 	public function exec() {
+		/** @var IEventLogger $eventLogger */
+		$eventLogger = \OC::$server->get(IEventLogger::class);
+		$eventLogger->start('dav_server_exec', '');
 		$this->server->exec();
+		$eventLogger->end('dav_server_exec');
 	}
 
 	private function requestIsForSubtree(array $subTrees): bool {

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2079,4 +2079,18 @@ $CONFIG = [
  * Also, it might log sensitive data into a plain text file.
  */
 'ldap_log_file' => '',
+
+/**
+ * Enable diagnostics event logging
+ *
+ * If enabled the timings of common execution steps will be logged to the
+ * Nextcloud log at debug level. log.condition is useful to enable this on
+ * production systems to only log under some conditions
+ */
+'diagnostics.logging' => true,
+
+/**
+ * Limit diagnostics event logging to events longer than the configured threshold in ms
+ */
+'diagnostics.logging.threshold' => 0,
 ];

--- a/lib/base.php
+++ b/lib/base.php
@@ -61,6 +61,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
@@ -595,8 +596,13 @@ class OC {
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();
+
 		$eventLogger = \OC::$server->getEventLogger();
 		$eventLogger->log('autoloader', 'Autoloader', $loaderStart, $loaderEnd);
+		$eventLogger->start('request', 'Full request after autoloading');
+		register_shutdown_function(function () use ($eventLogger) {
+			$eventLogger->end('request');
+		});
 		$eventLogger->start('boot', 'Initialize');
 
 		// Override php.ini and log everything if we're troubleshooting
@@ -792,6 +798,7 @@ class OC {
 			}
 		}
 		$eventLogger->end('boot');
+		$eventLogger->log('init', 'OC::init', $loaderStart, microtime(true));
 	}
 
 	/**

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -46,6 +46,7 @@ use OC\AppFramework\Middleware\SessionMiddleware;
 use OC\AppFramework\ScopedPsrLogger;
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\Core\Middleware\TwoFactorMiddleware;
+use OC\Diagnostics\EventLogger;
 use OC\Log\PsrLoggerAdapter;
 use OC\ServerContainer;
 use OC\Settings\AuthorizedGroupMapper;
@@ -184,7 +185,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c->get(IRequest::class),
 				$c->get(IConfig::class),
 				$c->get(IDBConnection::class),
-				$c->get(LoggerInterface::class)
+				$c->get(LoggerInterface::class),
+				$c->get(EventLogger::class)
 			);
 		});
 

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -81,7 +81,17 @@ class Connection extends \Doctrine\DBAL\Connection {
 	 */
 	public function connect() {
 		try {
-			return parent::connect();
+			if ($this->_conn) {
+				return parent::connect();
+			}
+
+			// Only trigger the event logger for the initial connect call
+			$eventLogger = \OC::$server->getEventLogger();
+			$eventLogger->start('connect:db', 'db connection opened');
+			$status = parent::connect();
+			$eventLogger->end('connect:db');
+
+			return $status;
 		} catch (Exception $e) {
 			// throw a new exception to prevent leaking info from the stacktrace
 			throw new Exception('Failed to connect to the database: ' . $e->getMessage(), $e->getCode());

--- a/lib/private/Diagnostics/Event.php
+++ b/lib/private/Diagnostics/Event.php
@@ -100,4 +100,8 @@ class Event implements IEvent {
 		}
 		return $this->end - $this->start;
 	}
+
+	public function __toString() {
+		return $this->getId() . ' ' . $this->getDescription() . ' ' . $this->getDuration();
+	}
 }

--- a/lib/private/Diagnostics/EventLogger.php
+++ b/lib/private/Diagnostics/EventLogger.php
@@ -24,18 +24,50 @@
  */
 namespace OC\Diagnostics;
 
+use OC\Log;
+use OC\SystemConfig;
+use OCP\Diagnostics\IEvent;
 use OCP\Diagnostics\IEventLogger;
+use Psr\Log\LoggerInterface;
 
 class EventLogger implements IEventLogger {
-	/**
-	 * @var \OC\Diagnostics\Event[]
-	 */
+
+	/** @var Event[] */
 	private $events = [];
-	
+
+	/** @var SystemConfig */
+	private $config;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var Log */
+	private $internalLogger;
+
 	/**
 	 * @var bool - Module needs to be activated by some app
 	 */
 	private $activated = false;
+
+	public function __construct(SystemConfig $config, LoggerInterface $logger, Log $internalLogger) {
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->internalLogger = $internalLogger;
+
+		if ($this->isLoggingActivated()) {
+			$this->activate();
+		}
+	}
+
+	public function isLoggingActivated(): bool {
+		if ($this->config->getValue('debug', false)) {
+			return true;
+		}
+
+		$isDebugLevel = $this->internalLogger->getLogLevel([]) === Log::DEBUG;
+		$systemValue = (bool)$this->config->getValue('diagnostics.logging', false);
+		return $systemValue && $isDebugLevel;
+	}
 
 	/**
 	 * @inheritdoc
@@ -43,6 +75,7 @@ class EventLogger implements IEventLogger {
 	public function start($id, $description) {
 		if ($this->activated) {
 			$this->events[$id] = new Event($id, $description, microtime(true));
+			$this->writeLog($this->events[$id]);
 		}
 	}
 
@@ -53,6 +86,7 @@ class EventLogger implements IEventLogger {
 		if ($this->activated && isset($this->events[$id])) {
 			$timing = $this->events[$id];
 			$timing->end(microtime(true));
+			$this->writeLog($timing);
 		}
 	}
 
@@ -63,6 +97,7 @@ class EventLogger implements IEventLogger {
 		if ($this->activated) {
 			$this->events[$id] = new Event($id, $description, $start);
 			$this->events[$id]->end($end);
+			$this->writeLog($this->events[$id]);
 		}
 	}
 
@@ -72,11 +107,29 @@ class EventLogger implements IEventLogger {
 	public function getEvents() {
 		return $this->events;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */
 	public function activate() {
 		$this->activated = true;
+	}
+
+	private function writeLog(IEvent $event) {
+		if ($this->activated) {
+			if ($event->getEnd() === null) {
+				return;
+			}
+			$duration = $event->getDuration();
+			$timeInMs = round($duration * 1000, 4);
+
+			$loggingMinimum = (int)$this->config->getValue('diagnostics.logging.threshold', 0);
+			if ($loggingMinimum > 0 && $timeInMs < $loggingMinimum) {
+				return;
+			}
+
+			$message = microtime() . ' - ' . $event->getId() . ': ' . $timeInMs . ' (' . $event->getDescription() . ')';
+			$this->logger->debug($message, ['app' => 'diagnostics']);
+		}
 	}
 }

--- a/lib/private/Diagnostics/EventLogger.php
+++ b/lib/private/Diagnostics/EventLogger.php
@@ -72,7 +72,7 @@ class EventLogger implements IEventLogger {
 	/**
 	 * @inheritdoc
 	 */
-	public function start($id, $description) {
+	public function start($id, $description = '') {
 		if ($this->activated) {
 			$this->events[$id] = new Event($id, $description, microtime(true));
 			$this->writeLog($this->events[$id]);

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -232,7 +232,7 @@ class Log implements ILogger, IDataLogger {
 		}
 	}
 
-	private function getLogLevel($context) {
+	public function getLogLevel($context) {
 		$logCondition = $this->config->getValue('log.condition', []);
 
 		/**

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -26,6 +26,8 @@
  */
 namespace OC;
 
+use OCP\Diagnostics\IEventLogger;
+
 class RedisFactory {
 	public const REDIS_MINIMAL_VERSION = '3.1.3';
 	public const REDIS_EXTRA_PARAMETERS_MINIMAL_VERSION = '5.3.0';
@@ -33,16 +35,18 @@ class RedisFactory {
 	/** @var  \Redis|\RedisCluster */
 	private $instance;
 
-	/** @var  SystemConfig */
-	private $config;
+	private SystemConfig $config;
+
+	private IEventLogger $eventLogger;
 
 	/**
 	 * RedisFactory constructor.
 	 *
 	 * @param SystemConfig $config
 	 */
-	public function __construct(SystemConfig $config) {
+	public function __construct(SystemConfig $config, IEventLogger $eventLogger) {
 		$this->config = $config;
+		$this->eventLogger = $eventLogger;
 	}
 
 	private function create() {
@@ -113,6 +117,7 @@ class RedisFactory {
 				$port = null;
 			}
 
+			$this->eventLogger->start('connect:redis', 'Connect to redis and send AUTH, SELECT');
 			// Support for older phpredis versions not supporting connectionParameters
 			if ($connectionParameters !== null) {
 				// Non-clustered redis requires connection parameters to be wrapped inside `stream`
@@ -141,6 +146,7 @@ class RedisFactory {
 			if (isset($config['dbindex'])) {
 				$this->instance->select($config['dbindex']);
 			}
+			$this->eventLogger->end('connect:redis');
 		}
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -718,7 +718,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService('RedisFactory', function (Server $c) {
 			$systemConfig = $c->get(SystemConfig::class);
-			return new RedisFactory($systemConfig);
+			return new RedisFactory($systemConfig, $c->getEventLogger());
 		});
 
 		$this->registerService(\OCP\Activity\IManager::class, function (Server $c) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -871,12 +871,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		$this->registerDeprecatedAlias('HttpClientService', IClientService::class);
 		$this->registerService(IEventLogger::class, function (ContainerInterface $c) {
-			$eventLogger = new EventLogger();
-			if ($c->get(SystemConfig::class)->getValue('debug', false)) {
-				// In debug mode, module is being activated by default
-				$eventLogger->activate();
-			}
-			return $eventLogger;
+			return new EventLogger($c->get(SystemConfig::class), $c->get(LoggerInterface::class), $c->get(Log::class));
 		});
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('EventLogger', IEventLogger::class);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -173,6 +173,7 @@ class OC_App {
 
 		$hasAppPhpFile = is_file($appPath . '/appinfo/app.php');
 
+		\OC::$server->getEventLogger()->start('bootstrap:load_app_' . $app, 'Load app: ' . $app);
 		if ($isBootable && $hasAppPhpFile) {
 			\OC::$server->getLogger()->error('/appinfo/app.php is not loaded when \OCP\AppFramework\Bootstrap\IBootstrap on the application class is used. Migrate everything from app.php to the Application class.', [
 				'app' => $app,
@@ -181,7 +182,6 @@ class OC_App {
 			\OC::$server->getLogger()->debug('/appinfo/app.php is deprecated, use \OCP\AppFramework\Bootstrap\IBootstrap on the application class instead.', [
 				'app' => $app,
 			]);
-			\OC::$server->getEventLogger()->start('load_app_' . $app, 'Load app: ' . $app);
 			try {
 				self::requireAppFile($app);
 			} catch (Throwable $ex) {
@@ -201,8 +201,9 @@ class OC_App {
 					]);
 				}
 			}
-			\OC::$server->getEventLogger()->end('load_app_' . $app);
 		}
+		\OC::$server->getEventLogger()->end('bootstrap:load_app_' . $app);
+
 		$coordinator->bootApp($app);
 
 		$info = self::getAppInfo($app);

--- a/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
+++ b/tests/lib/AppFramework/Bootstrap/CoordinatorTest.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\QueryException;
 use OCP\Dashboard\IManager;
+use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -57,6 +58,9 @@ class CoordinatorTest extends TestCase {
 	/** @var IEventDispatcher|MockObject */
 	private $eventDispatcher;
 
+	/** @var IEventLogger|MockObject */
+	private $eventLogger;
+
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 
@@ -71,6 +75,7 @@ class CoordinatorTest extends TestCase {
 		$this->crashReporterRegistry = $this->createMock(Registry::class);
 		$this->dashboardManager = $this->createMock(IManager::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->eventLogger = $this->createMock(IEventLogger::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->coordinator = new Coordinator(
@@ -78,6 +83,7 @@ class CoordinatorTest extends TestCase {
 			$this->crashReporterRegistry,
 			$this->dashboardManager,
 			$this->eventDispatcher,
+			$this->eventLogger,
 			$this->logger
 		);
 	}

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\Diagnostics\IEventLogger;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -99,6 +100,10 @@ class DispatcherTest extends \Test\TestCase {
 	private $config;
 	/** @var LoggerInterface|MockObject  */
 	private $logger;
+	/**
+	 * @var IEventLogger|MockObject
+	 */
+	private $eventLogger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -106,6 +111,7 @@ class DispatcherTest extends \Test\TestCase {
 
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->eventLogger = $this->createMock(IEventLogger::class);
 		$app = $this->getMockBuilder(
 			'OC\AppFramework\DependencyInjection\DIContainer')
 			->disableOriginalConstructor()
@@ -143,7 +149,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 
 		$this->response = $this->createMock(Response::class);
@@ -321,7 +328,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -355,7 +363,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -392,7 +401,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -428,7 +438,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -465,7 +476,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -504,7 +516,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->request,
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
-			$this->logger
+			$this->logger,
+			$this->eventLogger
 		);
 		$controller = new TestController('app', $this->request);
 

--- a/tests/lib/Diagnostics/EventLoggerTest.php
+++ b/tests/lib/Diagnostics/EventLoggerTest.php
@@ -21,18 +21,25 @@
 
 namespace Test\Diagnostics;
 
+use Psr\Log\LoggerInterface;
 use OC\Diagnostics\EventLogger;
+use OC\Log;
+use OC\SystemConfig;
 use Test\TestCase;
 
 class EventLoggerTest extends TestCase {
 
 	/** @var \OC\Diagnostics\EventLogger */
 	private $logger;
-	
+
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->logger = new EventLogger();
+		$this->logger = new EventLogger(
+			$this->createMock(SystemConfig::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(Log::class)
+		);
 	}
 
 	public function testQueryLogger() {


### PR DESCRIPTION
- Add diagnostics.logging to enable timing events being logged to the Nextcloud log at debug level
- log.condition can be used in order to limit the log generation to wished conditions
- diagnostics.logging.theshold allows to only log messages taking longer than the configured number of milliseconds
- Additional events added:
  - controller execution
  - app loading
  - Bootstrap register/boot
  - Time to connect to the database
  - Time to connect/auth/select the redis db

With this it is more easily possible to understand certain execution paths of slow requests on systems where a profiler cannot easily be attached.