### PR TITLE
Improve caching policy use immutable when loading versionned assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -47,6 +47,10 @@
     Header set Cache-Control "max-age=15778463"
   </FilesMatch>
 
+  <FilesMatch "\.(css|js|svg|gif|png|jpg|ico|wasm|tflite)(\?v=.*)?$">
+    Header set Cache-Control "max-age=15778463, immutable"
+  </FilesMatch>
+
   # Let browsers cache WOFF files for a week
   <FilesMatch "\.woff2?$">
     Header set Cache-Control "max-age=604800"

--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -96,7 +96,7 @@ class IconController extends Controller {
 			$iconFile = $this->imageManager->setCachedImage('icon-' . $app . '-' . str_replace('/', '_',$image), $icon);
 		}
 		$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/svg+xml']);
-		$response->cacheFor(86400);
+		$response->cacheFor(86400, false, true);
 		return $response;
 	}
 

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -104,7 +104,7 @@ class IconControllerTest extends TestCase {
 			->with('icon-core-filetypes_folder.svg')
 			->willReturn($file);
 		$expected = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/svg+xml']);
-		$expected->cacheFor(86400);
+		$expected->cacheFor(86400, false, true);
 		$this->assertEquals($expected, $this->iconController->getThemedIcon('core', 'filetypes/folder.svg'));
 	}
 

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -167,8 +167,10 @@ class PreviewController extends Controller {
 
 		try {
 			$f = $this->preview->getPreview($node, $x, $y, !$a, $mode);
-			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
-			$response->cacheFor(3600 * 24);
+			$response = new FileDisplayResponse($f, Http::STATUS_OK, [
+				'Content-Type' => $f->getMimeType(),
+			]);
+			$response->cacheFor(3600 * 24, false, true);
 			return $response;
 		} catch (NotFoundException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -110,10 +110,10 @@ class Response {
 	 * @return $this
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */
-	public function cacheFor(int $cacheSeconds, bool $public = false) {
+	public function cacheFor(int $cacheSeconds, bool $public = false, bool $immutable = false) {
 		if ($cacheSeconds > 0) {
 			$pragma = $public ? 'public' : 'private';
-			$this->addHeader('Cache-Control', $pragma . ', max-age=' . $cacheSeconds . ', must-revalidate');
+			$this->addHeader('Cache-Control', sprintf('%s, max-age=%s, %s', $pragma, $cacheSeconds, ($immutable ? 'immutable' : 'must-revalidate')));
 			$this->addHeader('Pragma', $pragma);
 
 			// Set expires header


### PR DESCRIPTION
* Cache the CSS with the version in the url. This makes most js and CSS requests to
  be cached by the browser

* Force caching previews, the ETag is in the URL so that if the propfind
  gives a new ETag, we will refresh it otherwise it's no use to try to
  fetch the new ETag and do tons of DB queries

Tested with firefox and 'debug' => false (important so that the js/css
urls are generated with ?v= parameter)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>