### PR TITLE
Don't redirect when loading files index page

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -184,7 +184,7 @@ class ViewController extends Controller {
 	 * @throws NotFoundException
 	 */
 	public function index($dir = '', $view = '', $fileid = null, $fileNotFound = false, $openfile = null) {
-		if ($fileid !== null) {
+		if ($fileid !== null && $dir === '') {
 			try {
 				return $this->redirectToFile($fileid);
 			} catch (NotFoundException $e) {


### PR DESCRIPTION
Currently we are redirecting from ?dir=/&fileid=2 to ?dir=/. This is an
issue because we then need to load two pages with full file system setup
and authentification instead of one and the assets won't start loading
until the second page is delivered to the user.

Additionally when loading ?dir=/, we then change the url back to
?dir=/&fileid=2 (without reload) so that the next time we load the page
again we do the same thing again.

Depending on the speed of the server and internet connection we can save
100ms to 400ms, improving the user experience.

Questions:
* Why was this introduced in the first place?
* Maybe we can instead fix the js to not rewrite the URL to ?dir=/&fileid=2 and
then were is no need to kill the redirection as this won't happen each time but
only when visiting an old URL with &fileid= in the url

Signed-off-by: Carl Schwan <carl@carlschwan.eu>