### PR TITLE
Add support for `?view=grid` query param to allow shared links to default to grid view

### DIFF
--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -31,6 +31,10 @@ window.addEventListener('DOMContentLoaded', function () {
 		$('#remote_address').focus();
 	});
 
+	if (new URLSearchParams(window.location.search).get('view') == 'grid') {
+		$('#view-toggle').removeClass('icon-toggle-pictures').addClass('icon-toggle-filelist');
+		$('#filestable').addClass('view-grid');
+	}
 
 	$(document).mouseup(function(e) {
 		var toggle = $('#body-public').find('.header-right .menutoggle');


### PR DESCRIPTION
inspired by https://help.nextcloud.com/t/question-display-grid-view-when-sharing-a-folder-of-photos-via-url/56812/8 

fixes #17762

- I'm open to using a hash instead of a query param as the help forum post suggests. Query param just felt like it made more sense to me.
- Does not implement any UI for setting this query param
- Does not add any documentation that this query param exists
- Subject to the same bug as the forum post: the user must double click the list view button to switch from grid to list view

I'm open to attempting to improve on any of the bullet points above if requested

