### PR TITLE
hide download button for images

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -77,10 +77,12 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 								<div>
 									<?php p($_['filename'])?> (<?php p($_['fileSize']) ?>)
 								</div>
-								<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
-									<span class="icon icon-download"></span>
-									<?php p($l->t('Download'))?>
-								</a>
+								<?php if (!$_['hideDownload']) { ?>
+									<a href="<?php p($_['downloadURL']); ?>" id="downloadFile" class="button">
+										<span class="icon icon-download"></span>
+										<?php p($l->t('Download'))?>
+									</a>
+								<?php } ?>
 							</div>							
 						<?php } ?>									
 				<?php endif; ?>


### PR DESCRIPTION
### Steps to reproduce the bug:

1. Share an image via link and select the option to hide the download button
2. visit the link

### Before this change: 

3. The download button ist shown

### After this change: 

3. The download button is hidden

---

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/hide-download-button-for-images \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>