### PR TITLE
fix a broken tooltip

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1770,7 +1770,6 @@
 					fileData.extraData = fileData.extraData.substr(1);
 				}
 				nameSpan.addClass('extra-data').attr('title', fileData.extraData);
-				nameSpan.tooltip({placement: 'top'});
 			}
 			// dirs can show the number of uploaded files
 			if (mime === 'httpd/unix-directory') {


### PR DESCRIPTION
### Steps to reproduce the bug:

1. create a folder and a subfolder in that folder
2. share the subfolder via link
3. click on Shares (in the left sidebar)
4. See the subfolder that should get listed there
5. click on this subfolder and get redirected to the subfolder

### Before this change: 

6. The tooltip stays and doesn't get removed

### After this change: 

6. The tooltip is removed

---

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/fix-broken-tooltip \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>