### PR TITLE
[stable23] Disable bulk upload by not advertising it

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -29,8 +29,8 @@ class Capabilities implements ICapability {
 		return [
 			'dav' => [
 				'chunking' => '1.0',
-// disabled because of https://github.com/nextcloud/desktop/issues/4243
-//				'bulkupload' => '1.0',
+				// disabled because of https://github.com/nextcloud/desktop/issues/4243
+				// 'bulkupload' => '1.0',
 			]
 		];
 	}

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -29,7 +29,8 @@ class Capabilities implements ICapability {
 		return [
 			'dav' => [
 				'chunking' => '1.0',
-				'bulkupload' => '1.0',
+// disabled because of https://github.com/nextcloud/desktop/issues/4243
+//				'bulkupload' => '1.0',
 			]
 		];
 	}

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -35,7 +35,8 @@ class CapabilitiesTest extends TestCase {
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
-				'bulkupload' => '1.0',
+				// disabled because of https://github.com/nextcloud/desktop/issues/4243
+				// 'bulkupload' => '1.0',
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());


### PR DESCRIPTION
It has been reported broken on many instances.
Disable it for now until it can be fixed.

@matthieugallien FYI

to be put into the 23.0.3 hotfix release, to avoid more surprises for now