### PR TITLE
Add version handling to IMigrator

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -546,6 +546,7 @@ return array(
     'OCP\\UserMigration\\IExportDestination' => $baseDir . '/lib/public/UserMigration/IExportDestination.php',
     'OCP\\UserMigration\\IImportSource' => $baseDir . '/lib/public/UserMigration/IImportSource.php',
     'OCP\\UserMigration\\IMigrator' => $baseDir . '/lib/public/UserMigration/IMigrator.php',
+    'OCP\\UserMigration\\TMigratorBasicVersionHandling' => $baseDir . '/lib/public/UserMigration/TMigratorBasicVersionHandling.php',
     'OCP\\UserStatus\\IManager' => $baseDir . '/lib/public/UserStatus/IManager.php',
     'OCP\\UserStatus\\IProvider' => $baseDir . '/lib/public/UserStatus/IProvider.php',
     'OCP\\UserStatus\\IUserStatus' => $baseDir . '/lib/public/UserStatus/IUserStatus.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -575,6 +575,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\UserMigration\\IExportDestination' => __DIR__ . '/../../..' . '/lib/public/UserMigration/IExportDestination.php',
         'OCP\\UserMigration\\IImportSource' => __DIR__ . '/../../..' . '/lib/public/UserMigration/IImportSource.php',
         'OCP\\UserMigration\\IMigrator' => __DIR__ . '/../../..' . '/lib/public/UserMigration/IMigrator.php',
+        'OCP\\UserMigration\\TMigratorBasicVersionHandling' => __DIR__ . '/../../..' . '/lib/public/UserMigration/TMigratorBasicVersionHandling.php',
         'OCP\\UserStatus\\IManager' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IManager.php',
         'OCP\\UserStatus\\IProvider' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IProvider.php',
         'OCP\\UserStatus\\IUserStatus' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IUserStatus.php',

--- a/lib/public/UserMigration/IExportDestination.php
+++ b/lib/public/UserMigration/IExportDestination.php
@@ -67,6 +67,13 @@ interface IExportDestination {
 	public function copyFolder(Folder $folder, string $destinationPath): bool;
 
 	/**
+	 * @param array<string,int> $versions Migrators and their versions.
+	 *
+	 * @since 24.0.0
+	 */
+	public function setMigratorVersions(array $versions): bool;
+
+	/**
 	 * Called after export is complete
 	 *
 	 * @since 24.0.0

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -71,6 +71,15 @@ interface IImportSource {
 	public function getMigratorVersions(): array;
 
 	/**
+	 * @return ?int Version for this migrator from the export archive. Null means migrator missing.
+	 *
+	 * @param class-string<IMigrator> $migrator
+	 *
+	 * @since 24.0.0
+	 */
+	public function getMigratorVersion(string $migrator): ?int;
+
+	/**
 	 * Called after import is complete
 	 *
 	 * @since 24.0.0

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -64,6 +64,13 @@ interface IImportSource {
 	public function copyToFolder(Folder $destination, string $sourcePath): bool;
 
 	/**
+	 * @return array<string,int> Migrators and their versions from the export archive.
+	 *
+	 * @since 24.0.0
+	 */
+	public function getMigratorVersions(): array;
+
+	/**
 	 * Called after import is complete
 	 *
 	 * @since 24.0.0

--- a/lib/public/UserMigration/IMigrator.php
+++ b/lib/public/UserMigration/IMigrator.php
@@ -54,7 +54,8 @@ interface IMigrator {
 	public function import(
 		IUser $user,
 		IImportSource $importSource,
-		OutputInterface $output
+		OutputInterface $output,
+		?int $version
 	): void;
 
 	/**
@@ -67,7 +68,12 @@ interface IMigrator {
 	/**
 	 * Checks whether it is able to import a version of the export format for this migrator
 	 *
+	 * @param ?int $version Version stored in the import source for this migrator. Null means this migrator was not listed.
+	 *
 	 * @since 24.0.0
 	 */
-	public function canImport(int $version): bool;
+	public function canImport(
+		IImportSource $importSource,
+		?int $version
+	): bool;
 }

--- a/lib/public/UserMigration/IMigrator.php
+++ b/lib/public/UserMigration/IMigrator.php
@@ -54,8 +54,7 @@ interface IMigrator {
 	public function import(
 		IUser $user,
 		IImportSource $importSource,
-		OutputInterface $output,
-		?int $version
+		OutputInterface $output
 	): void;
 
 	/**
@@ -67,13 +66,11 @@ interface IMigrator {
 
 	/**
 	 * Checks whether it is able to import a version of the export format for this migrator
-	 *
-	 * @param ?int $version Version stored in the import source for this migrator. Null means this migrator was not listed.
+	 * Use $importSource->getMigratorVersion(static::class) to get the version from the archive
 	 *
 	 * @since 24.0.0
 	 */
 	public function canImport(
-		IImportSource $importSource,
-		?int $version
+		IImportSource $importSource
 	): bool;
 }

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -45,9 +45,9 @@ trait TMigratorBasicVersionHandling {
 	 * {@inheritDoc}
 	 */
 	public function canImport(
-		IImportSource $importSource,
-		?int $version
+		IImportSource $importSource
 	): bool {
+		$version = $importSource->getMigratorVersion(static::class);
 		if ($version === null) {
 			return !$this->mandatory;
 		}

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -36,6 +36,7 @@ trait TMigratorBasicVersionHandling {
 
 	/**
 	 * {@inheritDoc}
+	 * @since 24.0.0
 	 */
 	public function getVersion(): int {
 		return $this->version;
@@ -43,6 +44,7 @@ trait TMigratorBasicVersionHandling {
 
 	/**
 	 * {@inheritDoc}
+	 * @since 24.0.0
 	 */
 	public function canImport(
 		IImportSource $importSource

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright 2022 Christopher Ng <chrng8@gmail.com>
+ * @copyright Copyright (c) 2022 Côme Chilliet <come.chilliet@nextcloud.com>
  *
- * @author Christopher Ng <chrng8@gmail.com>
  * @author Côme Chilliet <come.chilliet@nextcloud.com>
  *
  * @license GNU AGPL version 3 or any later version
@@ -27,47 +26,23 @@ declare(strict_types=1);
 
 namespace OCP\UserMigration;
 
-use OCP\IUser;
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
- * @since 24.0.0
+ * Basic version handling: we can import older versions but not newer ones
  */
-interface IMigrator {
+trait TMigratorBasicVersionHandling {
+	protected int $version = 1;
 
 	/**
-	 * Export user data
-	 *
-	 * @since 24.0.0
+	 * {@inheritDoc}
 	 */
-	public function export(
-		IUser $user,
-		IExportDestination $exportDestination,
-		OutputInterface $output
-	): void;
+	public function getVersion(): int {
+		return $this->version;
+	}
 
 	/**
-	 * Import user data
-	 *
-	 * @since 24.0.0
+	 * {@inheritDoc}
 	 */
-	public function import(
-		IUser $user,
-		IImportSource $importSource,
-		OutputInterface $output
-	): void;
-
-	/**
-	 * Returns the version of the export format for this migrator
-	 *
-	 * @since 24.0.0
-	 */
-	public function getVersion(): int;
-
-	/**
-	 * Checks whether it is able to import a version of the export format for this migrator
-	 *
-	 * @since 24.0.0
-	 */
-	public function canImport(int $version): bool;
+	public function canImport(int $version): bool {
+		return ($this->version >= $version);
+	}
 }

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -32,6 +32,8 @@ namespace OCP\UserMigration;
 trait TMigratorBasicVersionHandling {
 	protected int $version = 1;
 
+	protected bool $mandatory = false;
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -42,7 +44,13 @@ trait TMigratorBasicVersionHandling {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function canImport(int $version): bool {
+	public function canImport(
+		IImportSource $importSource,
+		?int $version
+	): bool {
+		if ($version === null) {
+			return !$this->mandatory;
+		}
 		return ($this->version >= $version);
 	}
 }


### PR DESCRIPTION
Also adds a trait to implement basic version handling suited for most cases: forbids importing newer versions.

Question:
Maybe we should make the $version parameter of canImport nullable, with null meaning the migrator was not present in the export. In which case the function should return true to run anyway, and false to stop the import as not compatible.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>