### PR TITLE
Remove setting defaultUsernamePath dynamically

### DIFF
--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -84,7 +84,6 @@ class InvitationResponseServer {
 		$acl->principalCollectionSet = [
 			'principals/users', 'principals/groups'
 		];
-		$acl->defaultUsernamePath = 'principals/users';
 		$this->server->addPlugin($acl);
 
 		// calendar plugins

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -155,7 +155,6 @@ class Server {
 			'principals/calendar-resources',
 			'principals/calendar-rooms',
 		];
-		$acl->defaultUsernamePath = 'principals/users';
 		$this->server->addPlugin($acl);
 
 		// calendar plugins

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -243,11 +243,6 @@
       <code>$principal</code>
     </ParamNameMismatch>
   </file>
-  <file src="apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php">
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$acl-&gt;defaultUsernamePath</code>
-    </UndefinedPropertyAssignment>
-  </file>
   <file src="apps/dav/lib/CalDAV/Plugin.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>string|null</code>
@@ -939,9 +934,6 @@
       <code>dispatch</code>
       <code>dispatch</code>
     </TooManyArguments>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$acl-&gt;defaultUsernamePath</code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsByIdCollection.php">
     <InvalidNullableReturnType occurrences="1">


### PR DESCRIPTION
Since Sabre 3.0.6 this is no longer possible.

See https://github.com/sabre-io/dav/pull/582 and specifically https://github.com/sabre-io/dav/commit/09169c5880d44e8e40df2bbb31b94b5f25d2ad29

Extracting the smaller bits of #30335 :boom: 