### PR TITLE
Add optional WebDav propfind properties to count sub elements

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -77,6 +77,8 @@ class FilesPlugin extends ServerPlugin {
 	public const UPLOAD_TIME_PROPERTYNAME = '{http://nextcloud.org/ns}upload_time';
 	public const CREATION_TIME_PROPERTYNAME = '{http://nextcloud.org/ns}creation_time';
 	public const SHARE_NOTE = '{http://nextcloud.org/ns}note';
+	public const SUBFOLDER_COUNT_PROPERTYNAME = '{http://nextcloud.org/ns}contained-folder-count';
+	public const SUBFILE_COUNT_PROPERTYNAME = '{http://nextcloud.org/ns}contained-file-count';
 
 	/**
 	 * Reference to main server object
@@ -435,7 +437,7 @@ class FilesPlugin extends ServerPlugin {
 			});
 		}
 
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Directory) {
+		if ($node instanceof Directory) {
 			$propFind->handle(self::SIZE_PROPERTYNAME, function () use ($node) {
 				return $node->getSize();
 			});
@@ -443,6 +445,23 @@ class FilesPlugin extends ServerPlugin {
 			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->isEncrypted() ? '1' : '0';
 			});
+
+			$requestProperties = $propFind->getRequestedProperties();
+			if (in_array(self::SUBFILE_COUNT_PROPERTYNAME, $requestProperties, true)
+				|| in_array(self::SUBFOLDER_COUNT_PROPERTYNAME, $requestProperties, true)) {
+				$nbFiles = 0;
+				$nbFolders = 0;
+				foreach ($node->getChildren() as $child) {
+					if ($child instanceof File) {
+						$nbFiles++;
+					} elseif ($child instanceof Directory) {
+						$nbFolders++;
+					}
+				}
+
+				$propFind->handle(self::SUBFILE_COUNT_PROPERTYNAME, $nbFiles);
+				$propFind->handle(self::SUBFOLDER_COUNT_PROPERTYNAME, $nbFolders);
+			}
 		}
 	}
 


### PR DESCRIPTION
This allows requesting `{http://owncloud.org/ns}contained-folder-count` and `{http://owncloud.org/ns}contained-files-count` PROPFIND properties which results in getting the number of files and directories contained by the element:
``` xml
<nc:contained-folder-count>10</nc:contained-folder-count>
<nc:contained-file-count>58</nc:contained-file-count>
```
This can be useful in a folder tree view of a WebDav client to know in advance if a directory can be expanded without having to use depth=2 and make the Dav response potentially a lot bigger.