### PR TITLE
Wrap S3 multipart upload exception

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -151,6 +151,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\Directory' => $baseDir . '/../lib/Connector/Sabre/Directory.php',
     'OCA\\DAV\\Connector\\Sabre\\DummyGetResponsePlugin' => $baseDir . '/../lib/Connector/Sabre/DummyGetResponsePlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\ExceptionLoggerPlugin' => $baseDir . '/../lib/Connector/Sabre/ExceptionLoggerPlugin.php',
+    'OCA\\DAV\\Connector\\Sabre\\Exception\\BadGateway' => $baseDir . '/../lib/Connector/Sabre/Exception/BadGateway.php',
     'OCA\\DAV\\Connector\\Sabre\\Exception\\EntityTooLarge' => $baseDir . '/../lib/Connector/Sabre/Exception/EntityTooLarge.php',
     'OCA\\DAV\\Connector\\Sabre\\Exception\\FileLocked' => $baseDir . '/../lib/Connector/Sabre/Exception/FileLocked.php',
     'OCA\\DAV\\Connector\\Sabre\\Exception\\Forbidden' => $baseDir . '/../lib/Connector/Sabre/Exception/Forbidden.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -166,6 +166,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\Directory' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Directory.php',
         'OCA\\DAV\\Connector\\Sabre\\DummyGetResponsePlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/DummyGetResponsePlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\ExceptionLoggerPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ExceptionLoggerPlugin.php',
+        'OCA\\DAV\\Connector\\Sabre\\Exception\\BadGateway' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Exception/BadGateway.php',
         'OCA\\DAV\\Connector\\Sabre\\Exception\\EntityTooLarge' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Exception/EntityTooLarge.php',
         'OCA\\DAV\\Connector\\Sabre\\Exception\\FileLocked' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Exception/FileLocked.php',
         'OCA\\DAV\\Connector\\Sabre\\Exception\\Forbidden' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Exception/Forbidden.php',

--- a/apps/dav/lib/Connector/Sabre/Exception/BadGateway.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/BadGateway.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021, Louis Chemineau <louis@chmn.me>
+ *
+ * @author Louis Chemineau <louis@chmn.me>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Connector\Sabre\Exception;
+
+/**
+ * Bad Gateway
+ *
+ * This exception is thrown whenever the server, while acting as a gateway or proxy, received an invalid response from the upstream server.
+ *
+ */
+class BadGateway extends \Sabre\DAV\Exception {
+
+	/**
+	 * Returns the HTTP status code for this exception
+	 *
+	 * @return int
+	 */
+	public function getHTTPCode() {
+		return 502;
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -47,6 +47,7 @@ use OCA\DAV\Connector\Sabre\Exception\EntityTooLarge;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
 use OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType;
+use OCA\DAV\Connector\Sabre\Exception\BadGateway;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\EntityTooLargeException;
 use OCP\Files\FileInfo;
@@ -206,6 +207,8 @@ class File extends Node implements IFile {
 					$count = $partStorage->writeStream($internalPartPath, $wrappedData);
 				} catch (GenericFileException $e) {
 					$result = false;
+				} catch (BadGateway $e) {
+					throw $e;
 				}
 
 

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -126,7 +126,7 @@ trait S3ObjectTrait {
 			if ($e->getState()->isInitiated() && (array_key_exists('UploadId', $uploadInfo))) {
 				$this->getConnection()->abortMultipartUpload($uploadInfo);
 			}
-			throw new \OCP\Files\StorageConnectionException("Error while upload to S3 bucket", $e);
+			throw new \OCA\DAV\Connector\Sabre\Exception\BadGateway("Error while uploading to S3 bucket", 0, $e);
 		}
 	}
 

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -126,7 +126,7 @@ trait S3ObjectTrait {
 			if ($e->getState()->isInitiated() && (array_key_exists('UploadId', $uploadInfo))) {
 				$this->getConnection()->abortMultipartUpload($uploadInfo);
 			}
-			throw $e;
+			throw new \OCP\Files\StorageConnectionException("Error while upload to S3 bucket", $e);
 		}
 	}
 


### PR DESCRIPTION
The returned HTTP code is now [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) instead of [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) in case of timeout during S3 bucket upload.

Hopefully, this would help unofficial clients to deal with this kind of error in a better way.