### PR TITLE
Also cache non-existing to reuse it

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -97,12 +97,17 @@ class PublicKeyTokenProvider implements IProvider {
 		$tokenHash = $this->hashToken($tokenId);
 
 		if (isset($this->cache[$tokenHash])) {
+			if ($this->cache[$tokenHash] instanceof DoesNotExistException) {
+				$ex = $this->cache[$tokenHash];
+				throw new InvalidTokenException("Token does not exist: " . $ex->getMessage(), 0, $ex);
+			}
 			$token = $this->cache[$tokenHash];
 		} else {
 			try {
 				$token = $this->mapper->getToken($this->hashToken($tokenId));
 				$this->cache[$token->getToken()] = $token;
 			} catch (DoesNotExistException $ex) {
+				$this->cache[$tokenHash] = $ex;
 				throw new InvalidTokenException("Token does not exist: " . $ex->getMessage(), 0, $ex);
 			}
 		}


### PR DESCRIPTION
Strips of a query per OCS request in my integration test runs.

Screenshot of the query log. The yellow one is the entry where we now cache the exception additionally
![Bildschirmfoto von 2022-02-16 16-56-24](https://user-images.githubusercontent.com/213943/154305270-5e5cdf33-6a9d-4880-b224-c0106787acab.png)

