### PR TITLE
Don't create cards_abiduri it if already exists

### DIFF
--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -258,11 +258,15 @@ class AddMissingIndices extends Command {
 			$table = $schema->getTable('cards');
 
 			if ($table->hasIndex('addressbookid_uri_index')) {
-				$output->writeln('<info>Renaming addressbookid_uri_index index to  to the cards table, this can take some time...</info>');
+				if ($table->hasIndex('cards_abiduri')) {
+					$table->dropIndex('addressbookid_uri_index');
+				} else {
+					$output->writeln('<info>Renaming addressbookid_uri_index index to cards_abiduri in the cards table, this can take some time...</info>');
 
-				foreach ($table->getIndexes() as $index) {
-					if ($index->getColumns() === ['addressbookid', 'uri']) {
-						$table->renameIndex('addressbookid_uri_index', 'cards_abiduri');
+					foreach ($table->getIndexes() as $index) {
+						if ($index->getColumns() === ['addressbookid', 'uri']) {
+							$table->renameIndex('addressbookid_uri_index', 'cards_abiduri');
+						}
 					}
 				}
 


### PR DESCRIPTION
During migration from ownCloud, the `cards_abiduri` index is created but the `addressbookid_uri_index` index is not deleted. This leads to an error in this code path.

This PR make sure that we do not try to create the `cards_abiduri` index if it already exists and that the `addressbookid_uri_index` index is properly deleted.

Handy script to test the migration. Use it from a nextcloud root directory containing the migration.

```shell
#!/bin/bash

set -eu

# Serving ownCloud then Nextcloud at localhost:8080
# Username: admin
# Password: admin

docker kill oc || true
docker rm oc || true

docker run \
	--rm \
	--name oc \
	--detach \
	--env OWNCLOUD_DOMAIN=localhost:8080 \
	--publish 8080:8080 \
	--volume /var/www/owncloud \
	--volume "$PWD":/mnt/local \
	owncloud/server:10.5

docker exec -it oc apt update
docker exec -it oc apt install -y nano rsync

docker exec -it oc sed -i '9,14d' /var/www/owncloud/config/config.php
docker exec -it oc occ app:enable oauth2
docker exec -it oc occ market:install calendar
docker exec -it oc occ app:enable configreport
docker exec -it oc cp /var/www/owncloud/config/config.php /var/www/config.php

instance=""
read -rp "> Double press enter to start the migration." instance

docker exec -it oc rsync --delete --recursive --human-readable --exclude .git --exclude node_modules /mnt/local/ /var/www/owncloud
docker exec -it oc cp /var/www/config.php /var/www/owncloud/config/config.php
docker exec -it oc chown -R www-data:www-data /var/www/owncloud

docker exec -it oc occ upgrade -vvv || true

occ db:convert-filecache-bigint
occ db:add-missing-columns
occ db:add-missing-indices
occ db:add-missing-primary-keys

# Use this command to copy your change in MigrateOauthTables.php to the docker container.
# docker exec -it oc cp /mnt/local/lib/private/Repair/Owncloud/MigrateOauthTables.php /var/www/owncloud/lib/private/Repair/Owncloud/MigrateOauthTables.php
```