### PR TITLE
Add Nextcloud docs link to OPcache recommends

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -469,7 +469,7 @@ Raw output
 	protected function getOpcacheSetupRecommendations(): array {
 		// If the module is not loaded, return directly to skip inapplicable checks
 		if (!extension_loaded('Zend OPcache')) {
-			return ['The PHP OPcache module is not loaded. <a target="_blank" rel="noreferrer noopener" class="external" href="' . $this->urlGenerator->linkToDocs('admin-php-opcache') . '">For better performance it is recommended</a> to load it into your PHP installation.'];
+			return ['The PHP OPcache module is not loaded. For better performance it is recommended to load it into your PHP installation.'];
 		}
 
 		$recommendations = [];

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -582,9 +582,6 @@ class CheckSetupControllerTest extends TestCase {
 				if ($key === 'admin-code-integrity') {
 					return 'http://docs.example.org/server/go.php?to=admin-code-integrity';
 				}
-				if ($key === 'admin-php-opcache') {
-					return 'http://docs.example.org/server/go.php?to=admin-php-opcache';
-				}
 				if ($key === 'admin-db-conversion') {
 					return 'http://docs.example.org/server/go.php?to=admin-db-conversion';
 				}

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -342,10 +342,9 @@
 							listOfOPcacheRecommendations += "<li>" + element + "</li>";
 						});
 						messages.push({
-							msg: t(
-								'core',
-								'The PHP OPcache module is not properly configured:'
-							) + "<ul>" + listOfOPcacheRecommendations + "</ul>",
+							msg: t('core', 'The PHP OPcache module is not properly configured. See the {linkstart}documentation ↗{linkend} for more information.')
+								.replace('{linkstart}', '<a target="_blank" rel="noreferrer noopener" class="external" href="' + OC.theme.docPlaceholderUrl.replace('PLACEHOLDER', 'admin-php-opcache') + '">')
+								.replace('{linkend}', '</a>') + '<ul>' + listOfOPcacheRecommendations + '</ul>',
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						});
 					}

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -522,7 +522,6 @@ describe('OC.SetupChecks tests', function() {
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
-					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
@@ -876,7 +875,6 @@ describe('OC.SetupChecks tests', function() {
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: ['recommendation1', 'recommendation2'],
-					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: true,
 					missingIndexes: [],
@@ -900,7 +898,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-						msg: 'The PHP OPcache module is not properly configured:<ul><li>recommendation1</li><li>recommendation2</li></ul>',
+						msg: 'The PHP OPcache module is not properly configured. See the <a target="_blank" rel="noreferrer noopener" class="external" href="https://docs.example.org/admin-php-opcache">documentation ↗</a> for more information.<ul><li>recommendation1</li><li>recommendation2</li></ul>',
 						type: OC.SetupChecks.MESSAGE_TYPE_INFO
 					}]);
 				done();
@@ -932,7 +930,6 @@ describe('OC.SetupChecks tests', function() {
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
-					phpOpcacheDocumentation: 'https://example.org/link/to/doc',
 					isSettimelimitAvailable: true,
 					hasFreeTypeSupport: false,
 					missingIndexes: [],


### PR DESCRIPTION
A link to the Nextcloud documentation is currently only shown when the OPcache module is not loaded at all. This commit moves the link to the generic text above the individual recommendations list.

There have been a number of reports from users where the default 8 MiB interned strings buffer was full, in rare cases even 16 MiB were not sufficient (ignoring the cases where Nextcloud is not the only website on the same OPcache instance). The recommendation is accurate since a full interned strings buffer means that the full potential performance benefit of OPcache is not reached. I will extend the documentation to cover the interned strings buffer and add a small section about best practice to apply PHP settings. However, if we get more negative feedback about interned strings buffer in particular, we may need to reconsider whether measuring/showing it or not show it when 16 MiB or more are applied already.