### PR TITLE
Fix more than 1000 entries in queries exception in CardDavBackend

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1130,15 +1130,18 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			return (int)$match['cardid'];
 		}, $matches);
 
-		$query = $this->db->getQueryBuilder();
-		$query->select('c.addressbookid', 'c.carddata', 'c.uri')
-			->from($this->dbCardsTable, 'c')
-			->where($query->expr()->in('c.id', $query->createNamedParameter($matches, IQueryBuilder::PARAM_INT_ARRAY)));
+		$cards = [];
+		foreach (array_chunk($matches, 1000) as $matche) {
+			$query = $this->db->getQueryBuilder();
+			$query->select('c.addressbookid', 'c.carddata', 'c.uri')
+				->from($this->dbCardsTable, 'c')
+				->where($query->expr()->in('c.id', $query->createNamedParameter($matche, IQueryBuilder::PARAM_INT_ARRAY)));
 
-		$result = $query->execute();
-		$cards = $result->fetchAll();
+			$result = $query->execute();
+			$cards = array_merge($cards, $result->fetchAll());
+			$result->closeCursor();
+		}
 
-		$result->closeCursor();
 
 		return array_map(function ($array) {
 			$array['addressbookid'] = (int) $array['addressbookid'];


### PR DESCRIPTION
Fix the following backtrace:

```
{"reqId":"------------------","level":0,"time":"-------------------","remoteAddr":"--------------","user":"-----------------------","app":"user_ldap","method":"GET","ur
l":"/apps/circles/v1/globalsearch?search=m&order=4","message":"Ready for a paged search","userAgent":"Mozilla/5.0 ---------------- ","version":"20.0.14.4"}
{"reqId":"------------------","level":3,"time":"-------------------","remoteAddr":"--------------3","user":"---------------","app":"core","method":"GET","url":"/
apps/circles/v1/globalsearch?search=m&order=4","message":{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"More than 1000 expressions in a list are not allowed on Oracle.","Cod
e":0,"Trace":[{"file":"/var/www/nextcloud/apps/dav/lib/CardDAV/CardDavBackend.php","line":1111,"function":"execute","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->","args":[]},{"file
":"/var/www/nextcloud/apps/dav/lib/CardDAV/CardDavBackend.php","line":1009,"function":"searchByAddressBookIds","class":"OCA\\DAV\\CardDAV\\CardDavBackend","type":"->","args":[["2"],"m",["FN"
,"ORG","EMAIL"],[]]},{"file":"/var/www/nextcloud/apps/dav/lib/CardDAV/AddressBookImpl.php","line":118,"function":"search","class":"OCA\\DAV\\CardDAV\\CardDavBackend","type":"->","args":["2",
"m",["FN","ORG","EMAIL"],[]]},{"file":"/var/www/nextcloud/lib/private/ContactsManager.php","line":52,"function":"search","class":"OCA\\DAV\\CardDAV\\AddressBookImpl","type":"->","args":["m",
["FN","ORG","EMAIL"],[]]},{"file":"/var/www/nextcloud/apps/circles/lib/Search/Contacts.php","line":45,"function":"search","class":"OC\\ContactsManager","type":"->","args":["m",["FN","ORG","E
MAIL"]]},{"file":"/var/www/nextcloud/apps/circles/lib/Service/SearchService.php","line":95,"function":"search","class":"OCA\\Circles\\Search\\Contacts","type":"->","args":["m"]},{"file":"/va
r/www/nextcloud/apps/circles/lib/Controller/MembersController.php","line":246,"function":"searchGlobal","class":"OCA\\Circles\\Service\\SearchService","type":"->","args":["m"]},{"file":"/var
/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php","line":169,"function":"searchGlobal","class":"OCA\\Circles\\Controller\\MembersController","type":"->","args":["m",4]},{"file":"/
var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php","line":100,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\
Circles\\Controller\\MembersController"},"searchGlobal"]},{"file":"/var/www/nextcloud/lib/private/AppFramework/App.php","line":152,"function":"dispatch","class":"OC\\AppFramework\\Http\\Disp
atcher","type":"->","args":[{"__class__":"OCA\\Circles\\Controller\\MembersController"},"searchGlobal"]},{"file":"/var/www/nextcloud/lib/private/Route/Router.php","line":309,"function":"main
","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Circles\\Controller\\MembersController","searchGlobal",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},{"_route
":"circles.Members.searchGlobal"}]},{"file":"/var/www/nextcloud/lib/base.php","line":1008,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/apps/circles/v1/globalsearch"]}
,{"file":"/var/www/nextcloud/index.php","line":37,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php","Li
ne":229,"CustomMessage":"More than 1000 expressions in a list are not allowed on Oracle."},"userAgent":"Mozilla/5.0 -------------------------","version":"20.0.14.4"}
```

Signed-off-by: Carl Schwan <carl@carlschwan.eu>