### PR TITLE
Don't call session_start() when PHP session is still or already open.

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -107,6 +107,7 @@ class Internal extends Session {
 		$this->reopen();
 		$this->invoke('session_unset');
 		$this->regenerateId();
+		$this->invoke('session_write_close');
 		$this->startSession(true);
 		$_SESSION = [];
 	}


### PR DESCRIPTION
Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>

See #31248