### PR TITLE
Fix cleaning reminders after subscription purge

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -305,11 +305,11 @@ class Application extends App implements IBootstrap {
 				]);
 
 				/** @var CalDavBackend $calDavBackend */
-				$calDavBackend = $container->query(CalDavBackend::class);
+				$calDavBackend = $container->get(CalDavBackend::class);
 				$calDavBackend->purgeAllCachedEventsForSubscription($subscriptionData['id']);
 				/** @var ReminderBackend $calDavBackend */
-				$reminderBackend = $container->query(ReminderBackend::class);
-				$reminderBackend->cleanRemindersForCalendar($subscriptionData['id']);
+				$reminderBackend = $container->get(ReminderBackend::class);
+				$reminderBackend->cleanRemindersForCalendar((int) $subscriptionData['id']);
 			}
 		);
 


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/20766, `$subscriptionData['id']` may be a string and `cleanRemindersForCalendar` only accepts ints.

Also `container->query` :arrow_right: `container->get`.