### PR TITLE
Avoid PHP errors in the checkers drone step

### DIFF
--- a/build/triple-dot-checker.php
+++ b/build/triple-dot-checker.php
@@ -32,7 +32,7 @@ foreach ($directories as $dir) {
 	$it = new \RecursiveDirectoryIterator($dir);
 
 	foreach (new RecursiveIteratorIterator($it) as $file) {
-		if ($file->getExtension() === 'map') {
+		if (($file->getExtension() === 'map') || $file->isDir()) {
 			continue;
 		}
 		$content = file_get_contents($file->getPathname());


### PR DESCRIPTION
Fixes the all the `PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory in /drone/src/build/triple-dot-checker.php on line 38` errors

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>