### PR TITLE
Mark DAV background jobs as time sensitive/insensitive

### DIFF
--- a/apps/dav/lib/BackgroundJob/CalendarRetentionJob.php
+++ b/apps/dav/lib/BackgroundJob/CalendarRetentionJob.php
@@ -40,6 +40,7 @@ class CalendarRetentionJob extends TimedJob {
 
 		// Run four times a day
 		$this->setInterval(6 * 60 * 60);
+		$this->setTimeSensitivity(self::TIME_SENSITIVE);
 	}
 
 	protected function run($argument): void {

--- a/apps/dav/lib/BackgroundJob/CleanupDirectLinksJob.php
+++ b/apps/dav/lib/BackgroundJob/CleanupDirectLinksJob.php
@@ -26,26 +26,25 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
 use OCA\DAV\Db\DirectMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 
 class CleanupDirectLinksJob extends TimedJob {
-	/** @var ITimeFactory */
-	private $timeFactory;
-
 	/** @var DirectMapper */
 	private $mapper;
 
 	public function __construct(ITimeFactory $timeFactory, DirectMapper $mapper) {
-		$this->setInterval(60 * 60 * 24);
-
-		$this->timeFactory = $timeFactory;
+		parent::__construct($timeFactory);
 		$this->mapper = $mapper;
+
+		// Run once a day at off-peak time
+		$this->setInterval(24 * 60 * 60);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument) {
 		// Delete all shares expired 24 hours ago
-		$this->mapper->deleteExpired($this->timeFactory->getTime() - 60 * 60 * 24);
+		$this->mapper->deleteExpired($this->time->getTime() - 60 * 60 * 24);
 	}
 }

--- a/apps/dav/lib/BackgroundJob/EventReminderJob.php
+++ b/apps/dav/lib/BackgroundJob/EventReminderJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Thomas Citharel <nextcloud@tcit.fr>
  *
@@ -23,8 +26,9 @@
  */
 namespace OCA\DAV\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
 use OCA\DAV\CalDAV\Reminder\ReminderService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 
 class EventReminderJob extends TimedJob {
@@ -35,17 +39,16 @@ class EventReminderJob extends TimedJob {
 	/** @var IConfig */
 	private $config;
 
-	/**
-	 * EventReminderJob constructor.
-	 *
-	 * @param ReminderService $reminderService
-	 * @param IConfig $config
-	 */
-	public function __construct(ReminderService $reminderService, IConfig $config) {
+	public function __construct(ITimeFactory $time,
+								ReminderService $reminderService,
+								IConfig $config) {
+		parent::__construct($time);
 		$this->reminderService = $reminderService;
 		$this->config = $config;
-		/** Run every 5 minutes */
-		$this->setInterval(5);
+
+		// Run every 5 minutes
+		$this->setInterval(5 * 60);
+		$this->setTimeSensitivity(self::TIME_SENSITIVE);
 	}
 
 	/**

--- a/apps/dav/lib/BackgroundJob/GenerateBirthdayCalendarBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/GenerateBirthdayCalendarBackgroundJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2017 Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -22,8 +25,9 @@
  */
 namespace OCA\DAV\BackgroundJob;
 
-use OC\BackgroundJob\QueuedJob;
 use OCA\DAV\CalDAV\BirthdayService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
 use OCP\IConfig;
 
 class GenerateBirthdayCalendarBackgroundJob extends QueuedJob {
@@ -34,14 +38,11 @@ class GenerateBirthdayCalendarBackgroundJob extends QueuedJob {
 	/** @var IConfig */
 	private $config;
 
-	/**
-	 * GenerateAllBirthdayCalendarsBackgroundJob constructor.
-	 *
-	 * @param BirthdayService $birthdayService
-	 * @param IConfig $config
-	 */
-	public function __construct(BirthdayService $birthdayService,
+	public function __construct(ITimeFactory $time,
+								BirthdayService $birthdayService,
 								IConfig $config) {
+		parent::__construct($time);
+
 		$this->birthdayService = $birthdayService;
 		$this->config = $config;
 	}

--- a/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
+++ b/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
  *

--- a/apps/dav/lib/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJob.php
@@ -28,8 +28,9 @@ declare(strict_types=1);
 
 namespace OCA\DAV\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\Calendar\BackendTemporarilyUnavailableException;
 use OCP\Calendar\IMetadataProvider;
 use OCP\Calendar\Resource\IBackend as IResourceBackend;
@@ -53,17 +54,20 @@ class UpdateCalendarResourcesRoomsBackgroundJob extends TimedJob {
 	/** @var CalDavBackend */
 	private $calDavBackend;
 
-	public function __construct(IResourceManager $resourceManager,
+	public function __construct(ITimeFactory $time,
+								IResourceManager $resourceManager,
 								IRoomManager $roomManager,
 								IDBConnection $dbConnection,
 								CalDavBackend $calDavBackend) {
+		parent::__construct($time);
 		$this->resourceManager = $resourceManager;
 		$this->roomManager = $roomManager;
 		$this->dbConnection = $dbConnection;
 		$this->calDavBackend = $calDavBackend;
 
-		// run once an hour
+		// Run once an hour
 		$this->setInterval(60 * 60);
+		$this->setTimeSensitivity(self::TIME_SENSITIVE);
 	}
 
 	/**

--- a/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
@@ -30,27 +30,37 @@ namespace OCA\DAV\Tests\unit\BackgroundJob;
 
 use OCA\DAV\BackgroundJob\EventReminderJob;
 use OCA\DAV\CalDAV\Reminder\ReminderService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class EventReminderJobTest extends TestCase {
 
-	/** @var ReminderService|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITimeFactory|MockObject */
+	private $time;
+
+	/** @var ReminderService|MockObject */
 	private $reminderService;
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var EventReminderJob|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var EventReminderJob|MockObject */
 	private $backgroundJob;
 
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->time = $this->createMock(ITimeFactory::class);
 		$this->reminderService = $this->createMock(ReminderService::class);
 		$this->config = $this->createMock(IConfig::class);
 
-		$this->backgroundJob = new EventReminderJob($this->reminderService, $this->config);
+		$this->backgroundJob = new EventReminderJob(
+			$this->time,
+			$this->reminderService,
+			$this->config,
+		);
 	}
 
 	public function data(): array {

--- a/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017, Georg Ehrke
  *
@@ -27,15 +30,20 @@ namespace OCA\DAV\Tests\unit\BackgroundJob;
 
 use OCA\DAV\BackgroundJob\GenerateBirthdayCalendarBackgroundJob;
 use OCA\DAV\CalDAV\BirthdayService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 
-	/** @var BirthdayService | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITimeFactory|MockObject */
+	private $time;
+
+	/** @var BirthdayService | MockObject */
 	private $birthdayService;
 
-	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig | MockObject */
 	private $config;
 
 	/** @var \OCA\DAV\BackgroundJob\GenerateBirthdayCalendarBackgroundJob */
@@ -44,11 +52,15 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->time = $this->createMock(ITimeFactory::class);
 		$this->birthdayService = $this->createMock(BirthdayService::class);
 		$this->config = $this->createMock(IConfig::class);
 
 		$this->backgroundJob = new GenerateBirthdayCalendarBackgroundJob(
-			$this->birthdayService, $this->config);
+			$this->time,
+			$this->birthdayService,
+			$this->config,
+		);
 	}
 
 	public function testRun() {

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018, Georg Ehrke
  *

--- a/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -45,9 +48,6 @@ class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
 	/** @var IJobList | \PHPUnit\Framework\MockObject\MockObject */
 	private $jobList;
 
-	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-
 	/** @var RegisterRegenerateBirthdayCalendars */
 	private $backgroundJob;
 
@@ -57,10 +57,12 @@ class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->jobList = $this->createMock(IJobList::class);
-		$this->config = $this->createMock(IConfig::class);
 
-		$this->backgroundJob = new RegisterRegenerateBirthdayCalendars($this->time,
-			$this->userManager, $this->jobList);
+		$this->backgroundJob = new RegisterRegenerateBirthdayCalendars(
+			$this->time,
+			$this->userManager,
+			$this->jobList
+		);
 	}
 
 	public function testRun() {

--- a/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2018, Georg Ehrke
  *
@@ -29,12 +32,14 @@ namespace OCA\DAV\Tests\unit\BackgroundJob;
 use OCA\DAV\BackgroundJob\UpdateCalendarResourcesRoomsBackgroundJob;
 
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Calendar\BackendTemporarilyUnavailableException;
 use OCP\Calendar\IMetadataProvider;
 use OCP\Calendar\Resource\IBackend;
 use OCP\Calendar\Resource\IManager as IResourceManager;
 use OCP\Calendar\Resource\IResource;
 use OCP\Calendar\Room\IManager as IRoomManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 interface tmpI extends IResource, IMetadataProvider {
@@ -42,28 +47,36 @@ interface tmpI extends IResource, IMetadataProvider {
 
 class UpdateCalendarResourcesRoomsBackgroundJobTest extends TestCase {
 
-	/** @var UpdateCalendarResourcesRoomsBackgroundJob */
-	private $backgroundJob;
+	/** @var ITimeFactory|MockObject */
+	private $time;
 
-	/** @var IResourceManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IResourceManager|MockObject */
 	private $resourceManager;
 
-	/** @var IRoomManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IRoomManager|MockObject */
 	private $roomManager;
 
-	/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var CalDavBackend|MockObject */
 	private $calDavBackend;
+
+	/** @var UpdateCalendarResourcesRoomsBackgroundJob */
+	private $backgroundJob;
 
 	protected function setUp(): void {
 		parent::setUp();
 
+		$this->time = $this->createMock(ITimeFactory::class);
 		$this->resourceManager = $this->createMock(IResourceManager::class);
 		$this->roomManager = $this->createMock(IRoomManager::class);
 		$this->calDavBackend = $this->createMock(CalDavBackend::class);
 
 		$this->backgroundJob = new UpdateCalendarResourcesRoomsBackgroundJob(
-			$this->resourceManager, $this->roomManager, self::$realDatabase,
-			$this->calDavBackend);
+			$this->time,
+			$this->resourceManager,
+			$this->roomManager,
+			self::$realDatabase,
+			$this->calDavBackend
+		);
 	}
 
 	protected function tearDown(): void {

--- a/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
+++ b/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
@@ -56,8 +56,8 @@ class RetryJob extends Job {
 
 
 	public function __construct(Notifications $notifications,
-								ITimeFactory $timeFactory) {
-		parent::__construct($timeFactory);
+								ITimeFactory $time) {
+		parent::__construct($time);
 		$this->notifications = $notifications;
 	}
 


### PR DESCRIPTION
* As a bonus they are now all using OCP base classes
* Strict typing is now enforced

Fixes https://github.com/nextcloud/groupware/issues/28