### PR TITLE
Deprecate our old, internal background job base classes

### DIFF
--- a/lib/private/BackgroundJob/Job.php
+++ b/lib/private/BackgroundJob/Job.php
@@ -29,6 +29,9 @@ use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\ILogger;
 
+/**
+ * @deprecated internal class, use \OCP\BackgroundJob\Job
+ */
 abstract class Job implements IJob {
 	/** @var int */
 	protected $id;

--- a/lib/private/BackgroundJob/Legacy/QueuedJob.php
+++ b/lib/private/BackgroundJob/Legacy/QueuedJob.php
@@ -23,6 +23,9 @@
  */
 namespace OC\BackgroundJob\Legacy;
 
+/**
+ * @deprecated internal class, use \OCP\BackgroundJob\QueuedJob
+ */
 class QueuedJob extends \OC\BackgroundJob\QueuedJob {
 	public function run($argument) {
 		$class = $argument['klass'];

--- a/lib/private/BackgroundJob/Legacy/RegularJob.php
+++ b/lib/private/BackgroundJob/Legacy/RegularJob.php
@@ -24,6 +24,9 @@ namespace OC\BackgroundJob\Legacy;
 
 use OCP\AutoloadNotAllowedException;
 
+/**
+ * @deprecated internal class, use \OCP\BackgroundJob\QueuedJob
+ */
 class RegularJob extends \OC\BackgroundJob\Job {
 	public function run($argument) {
 		try {

--- a/lib/private/BackgroundJob/QueuedJob.php
+++ b/lib/private/BackgroundJob/QueuedJob.php
@@ -32,6 +32,8 @@ use OCP\ILogger;
  * create a background job that is to be executed once
  *
  * @package OC\BackgroundJob
+ *
+ * @deprecated internal class, use \OCP\BackgroundJob\QueuedJob
  */
 abstract class QueuedJob extends Job {
 	/**

--- a/lib/private/BackgroundJob/TimedJob.php
+++ b/lib/private/BackgroundJob/TimedJob.php
@@ -34,6 +34,8 @@ use OCP\ILogger;
  * create a background job that is to be executed at an interval
  *
  * @package OC\BackgroundJob
+ *
+ * @deprecated internal class, use \OCP\BackgroundJob\TimedJob
  */
 abstract class TimedJob extends Job {
 	protected $interval = 0;


### PR DESCRIPTION
The OCP ones should be used instead. This makes it more visible in our
IDEs that the base class of background job should be replaced.

Discovered while working on https://github.com/nextcloud/server/pull/31316.