### PR TITLE
Fix missing focus highlight for guest buttons

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -270,6 +270,10 @@ select {
 	border-radius: 100px; /* --border-radius-pill */
 	cursor: pointer;
 }
+input[type='submit']:focus {
+	border: 2px solid black !important;
+	padding: 8px;
+}
 input[type='text'],
 input[type='tel'],
 input[type='password'],


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2022-02-25 11-43-55](https://user-images.githubusercontent.com/213943/155701982-1debe29b-457f-4433-9fb8-2f313de9d93a.png) | ![Bildschirmfoto von 2022-02-25 11-45-15](https://user-images.githubusercontent.com/213943/155701991-0e660f34-55d9-45d5-8805-6b76b347b0f5.png)

Can be most easily tested with the registration app:
https://github.com/nextcloud/registration
