### PR TITLE
Fix caching of the user avatar

### DIFF
--- a/apps/settings/templates/settings/personal/personal.info.php
+++ b/apps/settings/templates/settings/personal/personal.info.php
@@ -73,6 +73,7 @@ script('settings', [
 
 				<div id="cropper" class="hidden">
 					<div class="inner-container">
+						<p style="width: 300px; margin-top: 0.5rem"><?php p($l->t('Please note that it can take up to 24 hours for the avatar to get updated everywhere.')); ?></p>
 						<div class="inlineblock button" id="abortcropperbutton"><?php p($l->t('Cancel')); ?></div>
 						<div class="inlineblock button primary" id="sendcropperbutton"><?php p($l->t('Choose as profile picture')); ?></div>
 					</div>

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -139,7 +139,7 @@ class AvatarController extends Controller {
 		}
 
 		// Cache for 1 day
-		$response->cacheFor(60 * 60 * 24);
+		$response->cacheFor(60 * 60 * 24, false, true);
 		return $response;
 	}
 


### PR DESCRIPTION
Now on firefox/safari it is only fetched once a day. On Chrom{e,ium}
we keep the previous behavior of maybe fetching it more often (random
probability).

This also notifies the user about this behavior when they upload an avatar
picture.

![image](https://user-images.githubusercontent.com/23653902/155722843-33ad9edc-8b13-4477-ae5b-5286b39002ee.png)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>