### PR TITLE
Don't set up full filesystem to check for certificates

### DIFF
--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -85,6 +85,9 @@ class Manager implements IMountManager {
 		if (strpos($path, '/appdata_' . \OC_Util::getInstanceId()) === 0) {
 			// for appdata, we only setup the root bits, not the user bits
 			\OC_Util::setupRootFS();
+		} elseif (strpos($path, '/files_external/uploads/') === 0) {
+			// for OC\Security\CertificateManager, we only setup the root bits, not the user bits
+			\OC_Util::setupRootFS();
 		} else {
 			\OC_Util::setupFS();
 		}


### PR DESCRIPTION
Ref:
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Security/CertificateManager.php#L90-L93

### Case
* Set up Talk with HPB
* Join a call => sends HPB message to inform all users => sets up your FS