### PR TITLE
prevent default right-click options when hideDownload is enabled

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -50,6 +50,14 @@ OCA.Sharing.PublicApp = {
 		var token = $('#sharingToken').val();
 		var hideDownload = $('#hideDownload').val();
 
+		// Prevent all right-click options if hideDownload is enabled
+		if (hideDownload === 'true') {
+			window.oncontextmenu = function(event) {
+				event.preventDefault();
+				event.stopPropagation();
+				return false;
+		   };
+		}
 
 		// file list mode ?
 		if ($el.find('#filestable').length) {


### PR DESCRIPTION
### For testing:
1. share a single picture or audio file and select hideDownload
2. open the link
3. right-click (or long press on Android) on the image or audio controls

### Before this change:
4. See the default Browser options of which one is to download the file

### After this change:
4. The default Browser options are gone

### I Verified that it works on:
- [x] Chromium based Browser on Desktop
- [x] Chromium based Browser on Android 

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/prevent-right-click-for-hide-download \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>