### PR TITLE
Specify string as nullable for credentials password

### DIFF
--- a/lib/public/Authentication/LoginCredentials/ICredentials.php
+++ b/lib/public/Authentication/LoginCredentials/ICredentials.php
@@ -53,7 +53,7 @@ interface ICredentials {
 	 *
 	 * @since 12
 	 *
-	 * @return string
+	 * @return string|null
 	 * @throws PasswordUnavailableException
 	 */
 	public function getPassword();


### PR DESCRIPTION
ICredentials::getPassword is null in some cases (passwordless signin)

Context:

https://github.com/nextcloud/mail/pull/5944#pullrequestreview-894860148