### PR TITLE
Ignore errors when searching for bundled preview

### DIFF
--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -48,7 +48,7 @@ abstract class Bundled extends ProviderV2 {
 			$image->fixOrientation();
 
 			return $image;
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			return null;
 		}
 	}


### PR DESCRIPTION
When an odt file is xml and not zip, it would throw a ValueError.
It will now just ignore this file and return null for the preview.

Fix #25340 

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>