### PR TITLE
Fix "Nextcloud is not allowed to use the OPcache API" warning

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -477,7 +477,7 @@ Raw output
 		// Check whether Nextcloud is allowed to use the OPcache API
 		$isPermitted = true;
 		$permittedPath = $this->iniGetWrapper->getString('opcache.restrict_api');
-		if (isset($permittedPath) && $permittedPath !== '' && !str_starts_with(\OC::$SERVERROOT, $permittedPath)) {
+		if (isset($permittedPath) && $permittedPath !== '' && !str_starts_with(\OC::$SERVERROOT, rtrim($permittedPath, '/'))) {
 			$isPermitted = false;
 		}
 


### PR DESCRIPTION
This aims to fix "Nextcloud is not allowed to use the OPcache API" warning being displayed even though OPcache is configured and running fine.

With the latest update to 23 the above warning appeared but there were no warnings or any issues before the update.

So i dug into this and found the string comparison to be causing the warning: in my setup `opcache.restrict_api` has a trailing slash whereas `OC::$SERVEROOT` has not. 🙈 

To be honest i wasn't sure wether to add a slash to the server root for comparison or to remove the trailing slash and in the end i decided for the latter. Also please note that i'm not an every day PHP developer at all so don't mind if this attempt of solving the issue is not the right way to fix it at all. I'm just trying to follow the idea of submitting patches instead of just filing bugs and it was quite interesting to read through all of this. 😉 

Why is there a trailing slash in my `opcache.restrict_api` and why dont i just remove it? I'm running a self-hosted Nextcloud instance on a server that is otherwise managed using [Froxlor Server Management Panel](https://froxlor.org/). With this management panel the `opcache.restrict_api` gets somewhat dynamically configured per virtual host using a placeholder `{DOCUMENT_ROOT}` wich in turn has this trailing slash.