### PR TITLE
Fix return type of avatar file

### DIFF
--- a/lib/public/IAvatar.php
+++ b/lib/public/IAvatar.php
@@ -26,8 +26,8 @@
  */
 namespace OCP;
 
-use OCP\Files\File;
 use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
 
 /**
  * This class provides avatar functionality
@@ -80,7 +80,7 @@ interface IAvatar {
 	/**
 	 * Get the file of the avatar
 	 * @param int $size -1 can be used to not scale the image
-	 * @return File
+	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @since 9.0.0
 	 */


### PR DESCRIPTION
The implementations return either `ISimpleFile` or `InMemoryFile`
- https://github.com/nextcloud/server/blob/213e75b78a76e55254ba59e15c3e2697cc632dad/lib/private/Avatar/UserAvatar.php#L235-L246
- https://github.com/nextcloud/server/blob/213e75b78a76e55254ba59e15c3e2697cc632dad/lib/private/Avatar/PlaceholderAvatar.php#L105-L116
- https://github.com/nextcloud/server/blob/213e75b78a76e55254ba59e15c3e2697cc632dad/lib/private/Avatar/GuestAvatar.php#L89-L94