### PR TITLE
Connectivity check: test https OR ELSE http

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -198,19 +198,24 @@ class CheckSetupController extends Controller {
 	}
 
 	/**
-	 * Checks if the Nextcloud server can connect to a specific URL using both HTTPS and HTTP
+	 * Checks if the Nextcloud server can connect to a specific URL
+	 * @param string $site site domain or full URL with http/https protocol
 	 * @return bool
 	 */
-	private function isSiteReachable($sitename) {
-		$httpSiteName = 'http://' . $sitename . '/';
-		$httpsSiteName = 'https://' . $sitename . '/';
-
+	private function isSiteReachable(string $site): bool {
 		try {
 			$client = $this->clientService->newClient();
-			$client->get($httpSiteName);
-			$client->get($httpsSiteName);
+			// if there is no protocol, test http:// AND https://
+			if (preg_match('/^https?:\/\//', $site) !== 1) {
+				$httpSite = 'http://' . $site . '/';
+				$client->get($httpSite);
+				$httpsSite = 'https://' . $site . '/';
+				$client->get($httpsSite);
+			} else {
+				$client->get($site);
+			}
 		} catch (\Exception $e) {
-			$this->logger->error('Cannot connect to: ' . $sitename, [
+			$this->logger->error('Cannot connect to: ' . $site, [
 				'app' => 'internet_connection_check',
 				'exception' => $e,
 			]);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -767,6 +767,10 @@ $CONFIG = [
  * connection. If none of these hosts are reachable, the administration panel
  * will show a warning. Set to an empty list to not do any such checks (warning
  * will still be shown).
+ * If no protocol is provided, both http and https will be tested.
+ * For example, 'http://www.nextcloud.com' and 'https://www.nextcloud.com'
+ * will be tested for 'www.nextcloud.com'
+ * If a protocol is provided, only this one will be tested.
  *
  * Defaults to the following domains:
  *


### PR DESCRIPTION
Instead of https AND http.

As tested domains can be set by admins with `connectivity_check_domains` config value, we can't know for sure those domains are reachable with both http and https.

This avoids the connectivity warning in admin setting's overview section when a domain is only accessible via either http or https.