### PR TITLE
Update images in scripts to run local tests in Docker

### DIFF
--- a/build/integration/run-docker.sh
+++ b/build/integration/run-docker.sh
@@ -213,8 +213,9 @@ trap cleanUp EXIT
 cd "$(dirname $0)"
 
 # "--image XXX" option can be provided to set the Docker image to use to run
-# the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" images).
-NEXTCLOUD_LOCAL_IMAGE="nextcloudci/php7.3:php7.3-5"
+# the integration tests (one of the "nextcloudci/phpX.Y:phpX.Y-Z" or
+# "ghcr.io/nextcloud/continuous-integration-integration-phpX.Y:latest" images).
+NEXTCLOUD_LOCAL_IMAGE="ghcr.io/nextcloud/continuous-integration-integration-php7.4:latest"
 if [ "$1" = "--image" ]; then
 	NEXTCLOUD_LOCAL_IMAGE=$2
 

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -144,7 +144,7 @@ function prepareDocker() {
 		--network=container:$SELENIUM_CONTAINER \
 		--volume composer_cache:/root/.composer \
 		--interactive \
-		--tty nextcloudci/acceptance-php7.3:acceptance-php7.3-2 bash
+		--tty ghcr.io/nextcloud/continuous-integration-acceptance-php7.4:latest bash
 
 	# Use the $TMPDIR or, if not set, fall back to /tmp.
 	NEXTCLOUD_LOCAL_TAR="$($MKTEMP --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-local-XXXXXXXXXX)"


### PR DESCRIPTION
PHP 7.3 support was dropped for Nextcloud 24. The Docker images are updated to the same images used for integration and acceptance tests in CI (personally I would prefer an explicit tag rather than `latest`, but as far as I know they are not available :shrug:).
