### PR TITLE
Fix the logger that is imported for critical actions

### DIFF
--- a/apps/admin_audit/composer/composer/autoload_classmap.php
+++ b/apps/admin_audit/composer/composer/autoload_classmap.php
@@ -19,6 +19,8 @@ return array(
     'OCA\\AdminAudit\\Actions\\UserManagement' => $baseDir . '/../lib/Actions/UserManagement.php',
     'OCA\\AdminAudit\\Actions\\Versions' => $baseDir . '/../lib/Actions/Versions.php',
     'OCA\\AdminAudit\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\AdminAudit\\AuditLogger' => $baseDir . '/../lib/AuditLogger.php',
     'OCA\\AdminAudit\\BackgroundJobs\\Rotate' => $baseDir . '/../lib/BackgroundJobs/Rotate.php',
+    'OCA\\AdminAudit\\IAuditLogger' => $baseDir . '/../lib/IAuditLogger.php',
     'OCA\\AdminAudit\\Listener\\CriticalActionPerformedEventListener' => $baseDir . '/../lib/Listener/CriticalActionPerformedEventListener.php',
 );

--- a/apps/admin_audit/composer/composer/autoload_static.php
+++ b/apps/admin_audit/composer/composer/autoload_static.php
@@ -34,7 +34,9 @@ class ComposerStaticInitAdminAudit
         'OCA\\AdminAudit\\Actions\\UserManagement' => __DIR__ . '/..' . '/../lib/Actions/UserManagement.php',
         'OCA\\AdminAudit\\Actions\\Versions' => __DIR__ . '/..' . '/../lib/Actions/Versions.php',
         'OCA\\AdminAudit\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\AdminAudit\\AuditLogger' => __DIR__ . '/..' . '/../lib/AuditLogger.php',
         'OCA\\AdminAudit\\BackgroundJobs\\Rotate' => __DIR__ . '/..' . '/../lib/BackgroundJobs/Rotate.php',
+        'OCA\\AdminAudit\\IAuditLogger' => __DIR__ . '/..' . '/../lib/IAuditLogger.php',
         'OCA\\AdminAudit\\Listener\\CriticalActionPerformedEventListener' => __DIR__ . '/..' . '/../lib/Listener/CriticalActionPerformedEventListener.php',
     );
 

--- a/apps/admin_audit/lib/Actions/Action.php
+++ b/apps/admin_audit/lib/Actions/Action.php
@@ -28,13 +28,13 @@ declare(strict_types=1);
  */
 namespace OCA\AdminAudit\Actions;
 
-use Psr\Log\LoggerInterface;
+use OCA\AdminAudit\IAuditLogger;
 
 class Action {
-	/** @var LoggerInterface */
+	/** @var IAuditLogger */
 	private $logger;
 
-	public function __construct(LoggerInterface $logger) {
+	public function __construct(IAuditLogger $logger) {
 		$this->logger = $logger;
 	}
 

--- a/apps/admin_audit/lib/AuditLogger.php
+++ b/apps/admin_audit/lib/AuditLogger.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @author Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AdminAudit;
+
+use OCP\IConfig;
+use OCP\Log\ILogFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logger that logs in the audit log file instead of the normal log file
+ */
+class AuditLogger implements IAuditLogger {
+
+	/** @var LoggerInterface */
+	private $parentLogger;
+
+	public function __construct(ILogFactory $logFactory, IConfig $config) {
+		$auditType = $config->getSystemValueString('log_type_audit', 'file');
+		$defaultTag = $config->getSystemValueString('syslog_tag', 'Nextcloud');
+		$auditTag = $config->getSystemValueString('syslog_tag_audit', $defaultTag);
+		$logFile = $config->getSystemValueString('logfile_audit', '');
+
+		if ($auditType === 'file' && !$logFile) {
+			$default = $config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/audit.log';
+			// Legacy way was appconfig, now it's paralleled with the normal log config
+			$logFile = $config->getAppValue('admin_audit', 'logfile', $default);
+		}
+
+		$this->parentLogger = $logFactory->getCustomPsrLogger($logFile, $auditType, $auditTag);
+	}
+
+	public function emergency($message, array $context = array()) {
+		$this->parentLogger->emergency($message, $context);
+	}
+
+	public function alert($message, array $context = array()) {
+		$this->parentLogger->alert($message, $context);
+	}
+
+	public function critical($message, array $context = array()) {
+		$this->parentLogger->critical($message, $context);
+	}
+
+	public function error($message, array $context = array()) {
+		$this->parentLogger->error($message, $context);
+	}
+
+	public function warning($message, array $context = array()) {
+		$this->parentLogger->warning($message, $context);
+	}
+
+	public function notice($message, array $context = array()) {
+		$this->parentLogger->notice($message, $context);
+	}
+
+	public function info($message, array $context = array()) {
+		$this->parentLogger->info($message, $context);
+	}
+
+	public function debug($message, array $context = array()) {
+		$this->parentLogger->debug($message, $context);
+	}
+
+	public function log($level, $message, array $context = array()) {
+		$this->parentLogger->log($level, $message, $context);
+	}
+}

--- a/apps/admin_audit/lib/IAuditLogger.php
+++ b/apps/admin_audit/lib/IAuditLogger.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @author Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AdminAudit;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Interface for a logger that logs in the audit log file instead of the normal log file
+ */
+interface IAuditLogger extends LoggerInterface {
+}

--- a/apps/admin_audit/tests/Actions/SecurityTest.php
+++ b/apps/admin_audit/tests/Actions/SecurityTest.php
@@ -44,7 +44,7 @@ class SecurityTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->logger = $this->createMock(AuditLogger::class);
 		$this->security = new Security($this->logger);
 
 		$this->user = $this->createMock(IUser::class);


### PR DESCRIPTION
Currently it's just using the normal psr logger

Needed for https://github.com/nextcloud/groupfolders/pull/1917