### PR TITLE
add a way to open the admin settings overview directly

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -134,7 +134,12 @@ trait CommonSettingsTrait {
 	}
 
 	private function getIndexResponse($type, $section) {
-		$this->navigationManager->setActiveEntry('settings');
+		if ($type === 'personal') {
+			$this->navigationManager->setActiveEntry('settings');
+		} elseif ($type === 'admin') {
+			$this->navigationManager->setActiveEntry('admin_settings');
+		}
+
 		$templateParams = [];
 		$templateParams = array_merge($templateParams, $this->getNavigationParameters($type, $section));
 		$templateParams = array_merge($templateParams, $this->getSettings($section));

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -211,17 +211,37 @@ class NavigationManager implements INavigationManager {
 					'icon' => $this->urlGenerator->imagePath('settings', 'apps.svg'),
 					'name' => $l->t('Apps'),
 				]);
-			}
 
-			// Personal and (if applicable) admin settings
-			$this->add([
-				'type' => 'settings',
-				'id' => 'settings',
-				'order' => 2,
-				'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
-				'name' => $l->t('Settings'),
-				'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
-			]);
+				// Personal settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'settings',
+					'order' => 2,
+					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
+					'name' => $l->t('Personal settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+
+				// Admin settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'admin_settings',
+					'order' => 3,
+					'href' => $this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'overview']),
+					'name' => $l->t('Admin settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+			} else {
+				// Personal settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'settings',
+					'order' => 2,
+					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
+					'name' => $l->t('Settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+			}
 
 			$logoutUrl = \OC_User::getLogoutUrl($this->urlGenerator);
 			if ($logoutUrl !== '') {


### PR DESCRIPTION
This is best reviewed like this: https://github.com/nextcloud/server/pull/31476/files?diff=unified&w=1

---

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/42591237/157017678-bb36e328-8a62-4965-b56d-455b196ce947.png)

</details>

---

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/admin-settings-directly \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>