### PR TITLE
Discard duplicate collection name from account serialization

### DIFF
--- a/lib/private/Accounts/Account.php
+++ b/lib/private/Accounts/Account.php
@@ -104,9 +104,16 @@ class Account implements IAccount {
 		return $result;
 	}
 
-	/** @return IAccountPropertyCollection[]|IAccountProperty[] */
+	/** @return array<string, IAccountProperty|array<int, IAccountProperty>> */
 	public function jsonSerialize(): array {
-		return $this->properties;
+		$properties = $this->properties;
+		foreach ($properties as $propertyName => $propertyObject) {
+			if ($propertyObject instanceof IAccountPropertyCollection) {
+				// Override collection serialization to discard duplicate name
+				$properties[$propertyName] = $propertyObject->jsonSerialize()[$propertyName];
+			}
+		}
+		return $properties;
 	}
 
 	public function getUser(): IUser {

--- a/tests/lib/Accounts/AccountTest.php
+++ b/tests/lib/Accounts/AccountTest.php
@@ -120,11 +120,25 @@ class AccountTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$properties = [
 			IAccountManager::PROPERTY_WEBSITE => new AccountProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::NOT_VERIFIED, ''),
-			IAccountManager::PROPERTY_EMAIL => new AccountProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::SCOPE_LOCAL, IAccountManager::VERIFIED, '')
+			IAccountManager::PROPERTY_EMAIL => new AccountProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::SCOPE_LOCAL, IAccountManager::VERIFIED, ''),
+			IAccountManager::COLLECTION_EMAIL => [
+				new AccountProperty(IAccountManager::COLLECTION_EMAIL, 'apple@orange.com', IAccountManager::SCOPE_LOCAL, IAccountManager::NOT_VERIFIED, ''),
+				new AccountProperty(IAccountManager::COLLECTION_EMAIL, 'banana@orange.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::VERIFICATION_IN_PROGRESS, ''),
+				new AccountProperty(IAccountManager::COLLECTION_EMAIL, 'kiwi@watermelon.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::VERIFIED, ''),
+			],
 		];
+
 		$account = new Account($user);
 		$account->setProperty(IAccountManager::PROPERTY_WEBSITE, 'https://example.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::NOT_VERIFIED);
 		$account->setProperty(IAccountManager::PROPERTY_EMAIL, 'user@example.com', IAccountManager::SCOPE_LOCAL, IAccountManager::VERIFIED);
+
+		$col = new AccountPropertyCollection(IAccountManager::COLLECTION_EMAIL);
+		$col->setProperties([
+			new AccountProperty($col->getName(), 'apple@orange.com', IAccountManager::SCOPE_LOCAL, IAccountManager::NOT_VERIFIED, ''),
+			new AccountProperty($col->getName(), 'banana@orange.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::VERIFICATION_IN_PROGRESS, ''),
+			new AccountProperty($col->getName(), 'kiwi@watermelon.com', IAccountManager::SCOPE_PUBLISHED, IAccountManager::VERIFIED, ''),
+		]);
+		$account->setPropertyCollection($col);
 
 		$this->assertEquals($properties, $account->jsonSerialize());
 	}


### PR DESCRIPTION
Required for https://github.com/nextcloud/server/pull/31382

### To Do
- [x] Update test

#### Before
```json
{
  "displayname": {
    "name": "displayname",
    "value": "admin",
    "scope": "v2-federated",
    "verified": "0",
    "verificationData": ""
  },
  ...
  "additional_mail": {
    "additional_mail": [
      {
        "name": "additional_mail",
        "value": "a@b.com",
        "scope": "v2-local",
        "verified": "0",
        "verificationData": ""
      },
      {
        "name": "additional_mail",
        "value": "a@b.org",
        "scope": "v2-local",
        "verified": "0",
        "verificationData": ""
      }
    ]
  }
}
```

#### After
```json
{
  "displayname": {
    "name": "displayname",
    "value": "admin",
    "scope": "v2-federated",
    "verified": "0",
    "verificationData": ""
  },
  ...
  "additional_mail": [
    {
      "name": "additional_mail",
      "value": "a@b.com",
      "scope": "v2-local",
      "verified": "0",
      "verificationData": ""
    },
    {
      "name": "additional_mail",
      "value": "a@b.org",
      "scope": "v2-local",
      "verified": "0",
      "verificationData": ""
    }
  ]
}
```