### PR TITLE
Require the secret config to be configured

### DIFF
--- a/.github/workflows/s3-external.yml
+++ b/.github/workflows/s3-external.yml
@@ -55,7 +55,7 @@ jobs:
           php -S localhost:8080 &
       - name: PHPUnit
         run: |
-          echo "<?php return ['run' => true,'hostname' => 'localhost','key' => 'minio','secret' => 'minio123', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/${{ env.APP_NAME }}/tests/config.amazons3.php
+          echo "<?php return ['run' => true, 'secret' => 'actually-not-secret', 'hostname' => 'localhost','key' => 'minio','secret' => 'minio123', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/${{ env.APP_NAME }}/tests/config.amazons3.php
           phpunit --configuration tests/phpunit-autotest-external.xml apps/files_external/tests/Storage/Amazons3Test.php
           phpunit --configuration tests/phpunit-autotest-external.xml apps/files_external/tests/Storage/VersionedAmazonS3Test.php
       - name: S3 logs

--- a/.github/workflows/s3-external.yml
+++ b/.github/workflows/s3-external.yml
@@ -55,7 +55,7 @@ jobs:
           php -S localhost:8080 &
       - name: PHPUnit
         run: |
-          echo "<?php return ['run' => true, 'secret' => 'actually-not-secret', 'hostname' => 'localhost','key' => 'minio','secret' => 'minio123', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/${{ env.APP_NAME }}/tests/config.amazons3.php
+          echo "<?php return ['run' => true, 'secret' => 'actually-not-secret', 'passwordsalt' => 'actually-not-secret', 'hostname' => 'localhost','key' => 'minio','secret' => 'minio123', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/${{ env.APP_NAME }}/tests/config.amazons3.php
           phpunit --configuration tests/phpunit-autotest-external.xml apps/files_external/tests/Storage/Amazons3Test.php
           phpunit --configuration tests/phpunit-autotest-external.xml apps/files_external/tests/Storage/VersionedAmazonS3Test.php
       - name: S3 logs

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -970,7 +970,7 @@ class OC_Util {
 		}
 
 		foreach (['secret', 'instanceid', 'passwordsalt'] as $requiredConfig) {
-			if ($config->getValue($requiredConfig, '') === '' && !\OC::$CLI) {
+			if ($config->getValue($requiredConfig, '') === '' && !\OC::$CLI && $config->getValue('installed', false)) {
 				$errors[] = [
 					'error' => $l->t('The required \'' . $requiredConfig . '\' config variable is not configued in the config.php file.'),
 					'hint' => $l->t('Please ask your server administrator to check the Nextcloud configuration.')

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -969,6 +969,13 @@ class OC_Util {
 			];
 		}
 
+		if ($config->getValue('secret', '') === '' && !\OC::$CLI) {
+			$errors[] = [
+				'error' => $l->t('The required \'secret\' config variable is not configued in the config.php file.'),
+				'hint' => $l->t('Please ask your server administrator to check the Nextcloud configuration.')
+			];
+		}
+
 		$errors = array_merge($errors, self::checkDatabaseVersion());
 
 		// Cache the result of this function

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -969,11 +969,13 @@ class OC_Util {
 			];
 		}
 
-		if ($config->getValue('secret', '') === '' && !\OC::$CLI) {
-			$errors[] = [
-				'error' => $l->t('The required \'secret\' config variable is not configued in the config.php file.'),
-				'hint' => $l->t('Please ask your server administrator to check the Nextcloud configuration.')
-			];
+		foreach (['secret', 'instanceid', 'passwordsalt'] as $requiredConfig) {
+			if ($config->getValue($requiredConfig, '') === '' && !\OC::$CLI) {
+				$errors[] = [
+					'error' => $l->t('The required \'' . $requiredConfig . '\' config variable is not configued in the config.php file.'),
+					'hint' => $l->t('Please ask your server administrator to check the Nextcloud configuration.')
+				];
+			}
 		}
 
 		$errors = array_merge($errors, self::checkDatabaseVersion());

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -44,6 +44,7 @@ echo "Using database $DATABASENAME"
 cat > ./tests/autoconfig-sqlite.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
+  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'sqlite',
   'dbtableprefix' => 'oc_',
@@ -56,6 +57,7 @@ DELIM
 cat > ./tests/autoconfig-mysql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
+  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'mysql',
   'dbtableprefix' => 'oc_',
@@ -72,6 +74,7 @@ DELIM
 cat > ./tests/autoconfig-pgsql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
+  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'pgsql',
   'dbtableprefix' => 'oc_',
@@ -88,6 +91,7 @@ DELIM
 cat > ./tests/autoconfig-oracle.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
+  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'oci',
   'dbtableprefix' => 'oc_',

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -44,7 +44,6 @@ echo "Using database $DATABASENAME"
 cat > ./tests/autoconfig-sqlite.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
-  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'sqlite',
   'dbtableprefix' => 'oc_',
@@ -57,7 +56,6 @@ DELIM
 cat > ./tests/autoconfig-mysql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
-  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'mysql',
   'dbtableprefix' => 'oc_',
@@ -74,7 +72,6 @@ DELIM
 cat > ./tests/autoconfig-pgsql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
-  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'pgsql',
   'dbtableprefix' => 'oc_',
@@ -91,7 +88,6 @@ DELIM
 cat > ./tests/autoconfig-oracle.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
-  'secret' => 'actually-not-secret',
   'installed' => false,
   'dbtype' => 'oci',
   'dbtableprefix' => 'oc_',


### PR DESCRIPTION
If it's not configured the instance will look like it is working but
various features will silently break (end to end encryption, setting
alternate email and probably more).

One issue is that changing the secret from empty to something will
break various other stuff (app token). I don't think there is a good way
to solve this issue other than breaking early instead of having to
handle a painful migration later on.

![image](https://user-images.githubusercontent.com/23653902/157246762-4cde9bf5-8568-4665-860b-b2c7c9154cb5.png)