### PR TITLE
Avoid double-loading dist/core-main.js when apps have scripts named main

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -74,7 +74,7 @@ class JSResourceLocator extends ResourceLocator {
 			|| $this->cacheAndAppendCombineJsonIfExist($this->serverroot, $script.'.json')
 			|| $this->appendIfExist($this->serverroot, $theme_dir.'core/'.$script.'.js')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$script.'.js')
-			|| $this->appendIfExist($this->serverroot, "dist/core-$scriptName.js")
+			|| (strpos($scriptName, '/') === -1 && $this->appendIfExist($this->serverroot, "dist/core-$scriptName.js"))
 			|| $this->cacheAndAppendCombineJsonIfExist($this->serverroot, 'core/'.$script.'.json')
 		) {
 			return;


### PR DESCRIPTION
There may be apps (recommendations, onlyoffice for example) which use main.js as the filename for their scripts which currently causes basically to get dist/core-main.js being loaded multiple times. This ensures that we only trigger the core loading if no directory separator is present in the script name, which is the case for all scripts from apps.

Small edge case bug that was introduced with https://github.com/nextcloud/server/pull/30020