### PR TITLE
Add fallback routines for empty secret cases

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -107,8 +107,14 @@ class PublicKeyTokenProvider implements IProvider {
 				$token = $this->mapper->getToken($this->hashToken($tokenId));
 				$this->cache[$token->getToken()] = $token;
 			} catch (DoesNotExistException $ex) {
-				$this->cache[$tokenHash] = $ex;
-				throw new InvalidTokenException("Token does not exist: " . $ex->getMessage(), 0, $ex);
+				try {
+					$token = $this->mapper->getToken($this->hashTokenWithEmptySecret($tokenId));
+					$this->cache[$token->getToken()] = $token;
+					$this->rotate($token, $tokenId, $tokenId);
+				} catch (DoesNotExistException $ex2) {
+					$this->cache[$tokenHash] = $ex2;
+					throw new InvalidTokenException("Token does not exist: " . $ex->getMessage(), 0, $ex);
+				}
 			}
 		}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -339,7 +339,7 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	/**
-	 * @depreacted Fallback for instances where the secret might not have been set by accident
+	 * @deprecated Fallback for instances where the secret might not have been set by accident
 	 */
 	private function hashTokenWithEmptySecret(string $token): string {
 		return hash('sha512', $token);

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -125,6 +125,15 @@ class Crypto implements ICrypto {
 		if ($password === '') {
 			$password = $this->config->getSystemValue('secret');
 		}
+		try {
+			return $this->decryptWithoutSecret($authenticatedCiphertext, $password);
+		} catch (Exception $e) {
+			// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
+			return $this->decryptWithoutSecret($authenticatedCiphertext, '');
+		}
+	}
+
+	private function decryptWithoutSecret(string $authenticatedCiphertext, string $password = ''): string {
 		$hmacKey = $encryptionKey = $password;
 
 		$parts = explode('|', $authenticatedCiphertext);

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -122,14 +122,19 @@ class Crypto implements ICrypto {
 	 * @throws Exception If the decryption failed
 	 */
 	public function decrypt(string $authenticatedCiphertext, string $password = ''): string {
-		if ($password === '') {
-			$password = $this->config->getSystemValue('secret');
-		}
+		$secret = $this->config->getSystemValue('secret');
 		try {
+			if ($password === '') {
+				return $this->decryptWithoutSecret($authenticatedCiphertext, $secret);
+			}
 			return $this->decryptWithoutSecret($authenticatedCiphertext, $password);
 		} catch (Exception $e) {
-			// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
-			return $this->decryptWithoutSecret($authenticatedCiphertext, '');
+			if ($password === '') {
+				// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
+				return $this->decryptWithoutSecret($authenticatedCiphertext, '');
+			}
+
+			throw $e;
 		}
 	}
 

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -133,7 +133,6 @@ class Crypto implements ICrypto {
 				// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
 				return $this->decryptWithoutSecret($authenticatedCiphertext, '');
 			}
-
 			throw $e;
 		}
 	}

--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -137,6 +137,15 @@ class Hasher implements IHasher {
 			return true;
 		}
 
+		// Verify whether it matches a legacy PHPass or SHA1 string
+		// Retry with empty passwordsalt for cases where it was not set
+		$hashLength = \strlen($hash);
+		if (($hashLength === 60 && password_verify($message, $hash)) ||
+			($hashLength === 40 && hash_equals($hash, sha1($message)))) {
+			$newHash = $this->hash($message);
+			return true;
+		}
+
 		return false;
 	}
 

--- a/lib/private/Security/VerificationToken/VerificationToken.php
+++ b/lib/private/Security/VerificationToken/VerificationToken.php
@@ -84,10 +84,15 @@ class VerificationToken implements IVerificationToken {
 		try {
 			$decryptedToken = $this->crypto->decrypt($encryptedToken, $passwordPrefix.$this->config->getSystemValue('secret'));
 		} catch (\Exception $e) {
-			$this->throwInvalidTokenException(InvalidTokenException::TOKEN_DECRYPTION_ERROR);
+			// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
+			try {
+				$decryptedToken = $this->crypto->decrypt($encryptedToken, $passwordPrefix);
+			} catch (\Exception $e2) {
+				$this->throwInvalidTokenException(InvalidTokenException::TOKEN_DECRYPTION_ERROR);
+			}
 		}
 
-		$splitToken = explode(':', $decryptedToken ?? '');
+		$splitToken = explode(':', $decryptedToken);
 		if (count($splitToken) !== 2) {
 			$this->throwInvalidTokenException(InvalidTokenException::TOKEN_INVALID_FORMAT);
 		}

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -220,9 +220,12 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testInvalidateToken() {
-		$this->mapper->expects($this->once())
+		$this->mapper->expects($this->at(0))
 			->method('invalidate')
 			->with(hash('sha512', 'token7'.'1f4h9s'));
+		$this->mapper->expects($this->at(1))
+			->method('invalidate')
+			->with(hash('sha512', 'token7'));
 
 		$this->tokenProvider->invalidateToken('token7');
 	}
@@ -355,10 +358,19 @@ class PublicKeyTokenProviderTest extends TestCase {
 	public function testGetInvalidToken() {
 		$this->expectException(InvalidTokenException::class);
 
-		$this->mapper->method('getToken')
+		$this->mapper->expects($this->at(0))
+			->method('getToken')
 			->with(
-				$this->callback(function (string $token) {
+				$this->callback(function (string $token): bool {
 					return hash('sha512', 'unhashedToken'.'1f4h9s') === $token;
+				})
+			)->willThrowException(new DoesNotExistException('nope'));
+
+		$this->mapper->expects($this->at(1))
+			->method('getToken')
+			->with(
+				$this->callback(function (string $token): bool {
+					return hash('sha512', 'unhashedToken') === $token;
 				})
 			)->willThrowException(new DoesNotExistException('nope'));
 


### PR DESCRIPTION
Make sure to keep authentication working when an instance has been setup without a secret after adding the secret manually afterwards.

- Password auth to webdav still works
- App password auth to webdav still works
- Browser session keeps being active
- PublicKeyTokens get rotated if the fallback is hit so their private key is reencrypted with the secret now

Provides a possible migration path for https://github.com/nextcloud/server/pull/31492

## ToDo
- [ ] Add migration step to update the config if possible and set a secret before the upgrade
  - [ ] secret
  - [ ] paswordsalt