### PR TITLE
Fix alternative login buttons

### DIFF
--- a/apps/theming/css/theming.scss
+++ b/apps/theming/css/theming.scss
@@ -167,8 +167,7 @@ $invert: luma($color-primary) > 0.6;
 	}
 }
 
-input.primary,
-.alternative-logins a, {
+input.primary {
 	background-color: $color-primary-element;
 	border: 1px solid $color-primary-text;
 	color: $color-primary-text;
@@ -202,17 +201,15 @@ input.primary,
 			}
 		}
 
-		input,
-		.alternative-logins a {
+		input {
 			border: 1px solid nc-lighten($color-primary-text, 50%);
 		}
 		input.primary,
-		button.primary,
-		.alternative-logins a {
+		button.primary {
 			background-color: $color-primary;
 			color: $color-primary-text;
 		}
-		a,
+		:not(div.alternative-logins) > a,
 		label,
 		footer p,
 		.alternative-logins legend,
@@ -257,7 +254,7 @@ input.primary,
 	}
 	#body-login {
 
-		a, label, p {
+		:not(.alternative-logins) a, label, p {
 			color: $color-primary-text;
 		}
 

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -587,9 +587,17 @@ form .warning input[type='checkbox']+label {
 	display: inline-block;
 	text-align: center;
 	box-sizing: border-box;
+	border: 2px solid #ffffff;
 	background-color: #0082c9;
-	color: white;
+	color: #ffffff;
 	border-radius: 100px; /* --border-radius-pill */
+}
+
+.alternative-logins a.button:focus,
+.alternative-logins li a:focus {
+	border: 2px solid #000000;
+	background-image: linear-gradient(40deg, #0082c9 0%, #30b6ff 100%);
+	background-position: initial;
 }
 
 /* fixes for update page TODO should be fixed some time in a proper way */

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -381,26 +381,7 @@ body {
 }
 
 /* fixes for update page TODO should be fixed some time in a proper way */
-/* this is just for an error while updating the ownCloud instance */
-
-/* Alternative Logins */
-
-#alternative-logins {
-	legend {
-		margin-bottom: 10px;
-	}
-	li {
-		height: 40px;
-		display: inline-block;
-		white-space: nowrap;
-	}
-}
-
-/* Log in and install button */
-
-#remember_login {
-	margin: 18px 5px 0 16px !important;
-}
+/* this is just for an error while updating the Nextcloud instance */
 
 /* Sticky footer */
 


### PR DESCRIPTION
I tabbed to the google button in all cases, so the missing focus in Before it is fixed by this PR. Also notice how for bright colors the theming color was used and for dark theming colors it switched to nextcloud blue. This also caused long standing troubles in the registration app: https://github.com/nextcloud/registration/issues/347

Theming color | Before | After
---|---|---
`#0082C9` | ![Bildschirmfoto von 2022-03-09 11-46-14](https://user-images.githubusercontent.com/213943/157427286-e865530d-b196-45ea-9aef-3fb48ba8f097.png) | ![Bildschirmfoto von 2022-03-09 11-46-23](https://user-images.githubusercontent.com/213943/157427310-877f9c30-e5fb-44e1-b3b9-4b43ded91c83.png)
`#B1BDC9`| ![Bildschirmfoto von 2022-03-09 11-46-53](https://user-images.githubusercontent.com/213943/157427328-ab60644a-e9b5-487b-89c2-dd8dfb6daaee.png) | ![Bildschirmfoto von 2022-03-09 11-47-03](https://user-images.githubusercontent.com/213943/157427348-8b59acd9-265b-4b21-a238-f19db18a1949.png)
`#1B1D1F` | ![Bildschirmfoto von 2022-03-09 11-47-40](https://user-images.githubusercontent.com/213943/157427371-0051a6c7-bb0c-46c4-8425-5df4136e872e.png) | ![Bildschirmfoto von 2022-03-09 11-47-52](https://user-images.githubusercontent.com/213943/157427382-70760268-531b-4e9c-a132-a0b7605df211.png)
 