### PR TITLE
Allow to set a strict-dynamic CSP through the API

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -244,4 +244,11 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	public function setReportTo(array $reportTo) {
 		$this->reportTo = $reportTo;
 	}
+
+	/**
+	 * @param boolean $strictDynamicAllowed
+	 */
+	public function setStrictDynamicAllowed(bool $strictDynamicAllowed) {
+		$this->strictDynamicAllowed = $strictDynamicAllowed;
+	}
 }

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -44,6 +44,8 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	protected $inlineScriptAllowed = false;
 	/** @var bool Whether eval in JS scripts is allowed */
 	protected $evalScriptAllowed = false;
+	/** @var bool Whether strict-dynamic should be set */
+	protected $strictDynamicAllowed = null;
 	/** @var array Domains from which scripts can get loaded */
 	protected $allowedScriptDomains = [
 		'\'self\'',

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -41,6 +41,8 @@ class EmptyContentSecurityPolicy {
 	protected $inlineScriptAllowed = null;
 	/** @var string Whether JS nonces should be used */
 	protected $useJsNonce = null;
+	/** @var bool Whether strict-dynamic should be used */
+	protected $strictDynamicAllowed = null;
 	/**
 	 * @var bool Whether eval in JS scripts is allowed
 	 * TODO: Disallow per default
@@ -90,6 +92,16 @@ class EmptyContentSecurityPolicy {
 	 */
 	public function allowInlineScript($state = false) {
 		$this->inlineScriptAllowed = $state;
+		return $this;
+	}
+
+	/**
+	 * @param bool $state
+	 * @return EmptyContentSecurityPolicy
+	 * @since 24.0.0
+	 */
+	public function useStrictDynamic(bool $state = false): self {
+		$this->strictDynamicAllowed = $state;
 		return $this;
 	}
 
@@ -438,6 +450,9 @@ class EmptyContentSecurityPolicy {
 		if (!empty($this->allowedScriptDomains) || $this->inlineScriptAllowed || $this->evalScriptAllowed) {
 			$policy .= 'script-src ';
 			if (is_string($this->useJsNonce)) {
+				if ($this->strictDynamicAllowed) {
+					$policy .= '\'strict-dynamic\' ';
+				}
 				$policy .= '\'nonce-'.base64_encode($this->useJsNonce).'\'';
 				$allowedScriptDomains = array_flip($this->allowedScriptDomains);
 				unset($allowedScriptDomains['\'self\'']);

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -472,4 +472,21 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 		$this->contentSecurityPolicy->allowEvalScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
+
+	public function testGetPolicyNonce() {
+		$nonce = 'my-nonce';
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+
+		$this->contentSecurityPolicy->useJsNonce($nonce);
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
+	public function testGetPolicyNonceStrictDynamic() {
+		$nonce = 'my-nonce';
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+
+		$this->contentSecurityPolicy->useJsNonce($nonce);
+		$this->contentSecurityPolicy->useStrictDynamic(true);
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -86,6 +86,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 			$policy = new \OCP\AppFramework\Http\ContentSecurityPolicy();
 			$policy->addAllowedFontDomain('mydomain.com');
 			$policy->addAllowedImageDomain('anotherdomain.de');
+			$policy->useStrictDynamic(true);
 
 			$e->addPolicy($policy);
 		});
@@ -117,6 +118,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$expected->addAllowedImageDomain('example.org');
 		$expected->addAllowedChildSrcDomain('childdomain');
 		$expected->addAllowedFormActionDomain('thirdDomain');
+		$expected->useStrictDynamic(true);
 		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self';form-action 'self' thirdDomain";
 
 		$this->assertEquals($expected, $this->contentSecurityPolicyManager->getDefaultPolicy());


### PR DESCRIPTION
This can be used for apps like [jsloader](https://github.com/nextcloud/jsloader/) in order to allow dynamic loading of additional scripts within the initially loaded one by widening the content security policy with `strict-dynamic` through the API.

By default the nonce is used for any loaded script but if 3rdparty integrations do loading as described in https://content-security-policy.com/strict-dynamic/ this will not have an effect.

Patch to enable it in jsloader:
```diff
diff --git a/appinfo/app.php b/appinfo/app.php
index 347daa9..edbb7be 100644
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -47,6 +47,7 @@ if ($snippet !== '') {
        if ($url !== '') {
                $CSPManager = \OC::$server->getContentSecurityPolicyManager();
                $policy = new ContentSecurityPolicy();
+               $policy->useStrictDynamic(true);
                $policy->addAllowedScriptDomain($url);
                $policy->addAllowedImageDomain($url);
                $policy->addAllowedConnectDomain($url);
```