### PR TITLE
23.0.3 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [23, 0, 2, 2];
+$OC_Version = [23, 0, 3, 0];
 
 // The human readable string
-$OC_VersionString = '23.0.2';
+$OC_VersionString = '23.0.3 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #30852
* #30949
* #30965
* #30967
* #30969
* #30998
* #30999
* #31000
* #31023
* #31050
* #31059
* #31084
* #31098
* #31102
* #31120
* #31179
* #31183
* #31184
* #31192
* #31204
* #31226
* #31244
* #31253
* #31255
* #31262
* #31297
* #31299
* #31302
* #31306
* #31313
* #31318
* #31331
* #31350
* #31369
* #31392
* #31399
* #31401
* #31402
* #31410
* #31412
* #31423
* #31424
* #31427
* #31432
* #31437
* #31438
* #31442
* #31445
* #31450
* #31457
* #31479
* #31481
* #31485
* #31490
* [activity#731](https://github.com/nextcloud/activity/pull/731) Try to reduce the load from writing
* [activity#735](https://github.com/nextcloud/activity/pull/735) Allow specify a config prefix for another database connection
* [activity#739](https://github.com/nextcloud/activity/pull/739) Adjust nextcloud lib version
* [activity#741](https://github.com/nextcloud/activity/pull/741) Make background job time insensitive
* [circles#932](https://github.com/nextcloud/circles/pull/932) Fix cached circle returning bool before being parsed as JSON
* [circles#934](https://github.com/nextcloud/circles/pull/934) MembershipsService -> membershipService
* [circles#938](https://github.com/nextcloud/circles/pull/938) Block/force circle types
* [circles#940](https://github.com/nextcloud/circles/pull/940) Set member as INVITED only if not external
* [circles#944](https://github.com/nextcloud/circles/pull/944) Allow configuration of one single password per circle
* [circles#949](https://github.com/nextcloud/circles/pull/949) Display spent time on request
* [notifications#1155](https://github.com/nextcloud/notifications/pull/1155) Only refresh notifications once with notify push
* [notifications#1156](https://github.com/nextcloud/notifications/pull/1156) Improve mass notification processing
* [photos#1043](https://github.com/nextcloud/photos/pull/1043) Bump url-parse from 1.5.4 to 1.5.10
* [privacy#707](https://github.com/nextcloud/privacy/pull/707) Fix privacy UI with subscription
* [privacy#712](https://github.com/nextcloud/privacy/pull/712) Bump vue-loader from 15.9.6 to 15.9.8
* [privacy#715](https://github.com/nextcloud/privacy/pull/715) Bump @nextcloud/babel-config from 1.0.0-beta.1 to 1.0.0
* [privacy#718](https://github.com/nextcloud/privacy/pull/718) Bump @babel/core from 7.13.15 to 7.13.16
* [privacy#721](https://github.com/nextcloud/privacy/pull/721) Bump eslint-import-resolver-webpack from 0.13.0 to 0.13.2
* [privacy#724](https://github.com/nextcloud/privacy/pull/724) Bump babel-loader from 8.2.2 to 8.2.3
* [privacy#731](https://github.com/nextcloud/privacy/pull/731) Bump sass from 1.32.10 to 1.32.13
* [privacy#732](https://github.com/nextcloud/privacy/pull/732) Bump vue and vue-template-compiler
* [privacy#733](https://github.com/nextcloud/privacy/pull/733) Bump eslint-config-standard from 16.0.2 to 16.0.3
* [privacy#734](https://github.com/nextcloud/privacy/pull/734) Bump node-polyfill-webpack-plugin from 1.1.0 to 1.1.4
* [privacy#738](https://github.com/nextcloud/privacy/pull/738) Bump eslint-webpack-plugin from 2.5.3 to 2.5.4
* [text#2147](https://github.com/nextcloud/text/pull/2147) Add index for last_contact in text_sessions table
* [text#2150](https://github.com/nextcloud/text/pull/2150) Use file.path to track EditorWrapper instances more accurately
* [text#2159](https://github.com/nextcloud/text/pull/2159) Build(deps): bump prosemirror-transform from 1.3.3 to 1.3.4
* [text#2195](https://github.com/nextcloud/text/pull/2195) Fix: only apply bullet style to ul > li
* [text#2207](https://github.com/nextcloud/text/pull/2207) Build(deps): bump prosemirror-view from 1.23.6 to 1.23.7
* [text#2208](https://github.com/nextcloud/text/pull/2208) Fix: update psalm baseline to account for changes in server
* [text#2210](https://github.com/nextcloud/text/pull/2210) Derpgon cz fix/stable23/image data urls
* [text#2228](https://github.com/nextcloud/text/pull/2228) Display content first and then load menus
* [viewer#1171](https://github.com/nextcloud/viewer/pull/1171) Build(deps-dev): bump @babel/plugin-proposal-class-properties from 7.16.0 to 7.16.7
* [viewer#1174](https://github.com/nextcloud/viewer/pull/1174) Build(deps-dev): bump @nextcloud/webpack-vue-config from 4.1.0 to 4.1.4
* [viewer#1175](https://github.com/nextcloud/viewer/pull/1175) Build(deps): bump camelcase from 6.2.0 to 6.2.1
* [viewer#1176](https://github.com/nextcloud/viewer/pull/1176) Build(deps): bump @nextcloud/event-bus from 2.1.0 to 2.1.1
* [viewer#1178](https://github.com/nextcloud/viewer/pull/1178) Build(deps-dev): bump @cypress/browserify-preprocessor from 3.0.1 to 3.0.2
* [viewer#1179](https://github.com/nextcloud/viewer/pull/1179) Build(deps-dev): bump @nextcloud/eslint-config from 6.1.0 to 6.1.2
* [viewer#1180](https://github.com/nextcloud/viewer/pull/1180) Build(deps-dev): bump wait-on from 6.0.0 to 6.0.1
