### PR TITLE
22.2.6 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 2, 5, 2];
+$OC_Version = [22, 2, 6, 0];
 
 // The human readable string
-$OC_VersionString = '22.2.5';
+$OC_VersionString = '22.2.6 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #29565
* #30851
* #30958
* #30966
* #30968
* #31002
* #31025
* #31051
* #31060
* #31085
* #31119
* #31122
* #31136
* #31182
* #31185
* #31203
* #31210
* #31243
* #31254
* #31256
* #31263
* #31298
* #31305
* #31307
* #31314
* #31351
* #31370
* #31400
* #31403
* #31411
* #31413
* #31428
* #31433
* #31440
* #31441
* #31443
* #31446
* #31451
* #31458
* #31480
* #31482
* #31486
* #31497
* [3rdparty#1005](https://github.com/nextcloud/3rdparty/pull/1005) Bump aws/aws-sdk-php from 3.184.6 to 3.212.2
* [activity#730](https://github.com/nextcloud/activity/pull/730) Make background job time insensitive
* [activity#736](https://github.com/nextcloud/activity/pull/736) Allow specify a config prefix for another database connection
* [activity#740](https://github.com/nextcloud/activity/pull/740) Adjust nextcloud lib version
* [circles#933](https://github.com/nextcloud/circles/pull/933) Fix cached circle returning bool before being parsed as JSON
* [circles#935](https://github.com/nextcloud/circles/pull/935) MembershipsService -> membershipService
* [circles#937](https://github.com/nextcloud/circles/pull/937) Block/force circle types
* [circles#939](https://github.com/nextcloud/circles/pull/939) Set member as INVITED only if not external
* [circles#945](https://github.com/nextcloud/circles/pull/945) Allow configuration of one single password per circle
* [circles#948](https://github.com/nextcloud/circles/pull/948) Display spent time on request
* [photos#1044](https://github.com/nextcloud/photos/pull/1044) Bump url-parse from 1.5.4 to 1.5.10
* [privacy#710](https://github.com/nextcloud/privacy/pull/710) Fix privacy UI with subscription
* [privacy#714](https://github.com/nextcloud/privacy/pull/714) Bump sass from 1.32.10 to 1.32.13
* [privacy#717](https://github.com/nextcloud/privacy/pull/717) Bump eslint-webpack-plugin from 2.5.3 to 2.5.4
* [privacy#723](https://github.com/nextcloud/privacy/pull/723) Bump @nextcloud/babel-config from 1.0.0-beta.1 to 1.0.0
* [privacy#726](https://github.com/nextcloud/privacy/pull/726) Bump @babel/core from 7.13.15 to 7.13.16
* [privacy#727](https://github.com/nextcloud/privacy/pull/727) Bump babel-loader from 8.2.2 to 8.2.3
* [privacy#728](https://github.com/nextcloud/privacy/pull/728) Bump eslint-config-standard from 16.0.2 to 16.0.3
* [privacy#729](https://github.com/nextcloud/privacy/pull/729) Bump vue and vue-template-compiler
* [privacy#730](https://github.com/nextcloud/privacy/pull/730) Bump @nextcloud/vue from 2.6.5 to 2.6.9
* [privacy#737](https://github.com/nextcloud/privacy/pull/737) Bump node-polyfill-webpack-plugin from 1.1.0 to 1.1.4
* [text#2148](https://github.com/nextcloud/text/pull/2148) Add index for last_contact in text_sessions table
* [text#2151](https://github.com/nextcloud/text/pull/2151) Use file.path to track more accurately EditorWrapper instances
* [text#2160](https://github.com/nextcloud/text/pull/2160) Build(deps): bump prosemirror-transform from 1.3.3 to 1.3.4
* [text#2197](https://github.com/nextcloud/text/pull/2197) Fix: only apply bullet style to ul > li
* [text#2212](https://github.com/nextcloud/text/pull/2212) Fix: dependabot template comment