### PR TITLE
Allow installing unstable app versions based on channel and with `--allow-unstable` just like on updates

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -56,6 +56,12 @@ class Install extends Command {
 				InputOption::VALUE_NONE,
 				'install the app regardless of the Nextcloud version requirement'
 			)
+			->addOption(
+				'allow-unstable',
+				null,
+				InputOption::VALUE_NONE,
+				'allow installing an unstable releases'
+			)
 		;
 	}
 
@@ -71,7 +77,7 @@ class Install extends Command {
 		try {
 			/** @var Installer $installer */
 			$installer = \OC::$server->query(Installer::class);
-			$installer->downloadApp($appId);
+			$installer->downloadApp($appId, $input->getOption('allow-unstable'));
 			$result = $installer->installApp($appId, $forceEnable);
 		} catch (\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -183,7 +183,9 @@ class AppFetcher extends Fetcher {
 
 
 	public function get($allowUnstable = false) {
-		$apps = parent::get($allowUnstable);
+		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily';
+
+		$apps = parent::get($allowPreReleases);
 		$allowList = $this->config->getSystemValue('appsallowlist');
 
 		// If the admin specified a allow list, filter apps from the appstore

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -90,8 +90,8 @@ class AppFetcher extends Fetcher {
 			return [];
 		}
 
-		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily';
-		$allowNightly = $allowUnstable || $this->getChannel() === 'daily';
+		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
+		$allowNightly = $allowUnstable || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
 
 		foreach ($response['data'] as $dataKey => $app) {
 			$releases = [];
@@ -183,7 +183,7 @@ class AppFetcher extends Fetcher {
 
 
 	public function get($allowUnstable = false) {
-		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily';
+		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
 
 		$apps = parent::get($allowPreReleases);
 		$allowList = $this->config->getSystemValue('appsallowlist');

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -1854,15 +1854,21 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->registry = $this->createMock(IRegistry::class);
 
-		$this->fetcher = new AppFetcher(
-			$factory,
-			$this->clientService,
-			$this->timeFactory,
-			$this->config,
-			$this->compareVersion,
-			$this->logger,
-			$this->registry
-		);
+		$this->fetcher = $this->getMockBuilder(AppFetcher::class)
+			->setMethods(['getChannel'])
+			->setConstructorArgs([
+				$factory,
+				$this->clientService,
+				$this->timeFactory,
+				$this->config,
+				$this->compareVersion,
+				$this->logger,
+				$this->registry,
+			])
+			->getMock();
+
+		$this->fetcher->method('getChannel')
+			->willReturn('stable');
 	}
 
 	public function testGetWithFilter() {


### PR DESCRIPTION
cc @danielroehrig

Same parameter existed for updating apps already:
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/core/Command/App/Update.php#L79-L85