### PR TITLE
Improve user migration api

### DIFF
--- a/apps/dav/lib/UserMigration/CalendarMigratorException.php
+++ b/apps/dav/lib/UserMigration/CalendarMigratorException.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\UserMigration;
 
-use Exception;
+use OCP\UserMigration\UserMigrationException;
 
-class CalendarMigratorException extends Exception {
+class CalendarMigratorException extends UserMigrationException {
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -549,6 +549,7 @@ return array(
     'OCP\\UserMigration\\IImportSource' => $baseDir . '/lib/public/UserMigration/IImportSource.php',
     'OCP\\UserMigration\\IMigrator' => $baseDir . '/lib/public/UserMigration/IMigrator.php',
     'OCP\\UserMigration\\TMigratorBasicVersionHandling' => $baseDir . '/lib/public/UserMigration/TMigratorBasicVersionHandling.php',
+    'OCP\\UserMigration\\UserMigrationException' => $baseDir . '/lib/public/UserMigration/UserMigrationException.php',
     'OCP\\UserStatus\\IManager' => $baseDir . '/lib/public/UserStatus/IManager.php',
     'OCP\\UserStatus\\IProvider' => $baseDir . '/lib/public/UserStatus/IProvider.php',
     'OCP\\UserStatus\\IUserStatus' => $baseDir . '/lib/public/UserStatus/IUserStatus.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -578,6 +578,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\UserMigration\\IImportSource' => __DIR__ . '/../../..' . '/lib/public/UserMigration/IImportSource.php',
         'OCP\\UserMigration\\IMigrator' => __DIR__ . '/../../..' . '/lib/public/UserMigration/IMigrator.php',
         'OCP\\UserMigration\\TMigratorBasicVersionHandling' => __DIR__ . '/../../..' . '/lib/public/UserMigration/TMigratorBasicVersionHandling.php',
+        'OCP\\UserMigration\\UserMigrationException' => __DIR__ . '/../../..' . '/lib/public/UserMigration/UserMigrationException.php',
         'OCP\\UserStatus\\IManager' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IManager.php',
         'OCP\\UserStatus\\IProvider' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IProvider.php',
         'OCP\\UserStatus\\IUserStatus' => __DIR__ . '/../../..' . '/lib/public/UserStatus/IUserStatus.php',

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -32,6 +32,7 @@ use OCP\Files\Folder;
  * @since 24.0.0
  */
 interface IImportSource {
+	public const PATH_USER = 'user.json';
 
 	/**
 	 * Reads a file from the export
@@ -95,6 +96,13 @@ interface IImportSource {
 	 * @since 24.0.0
 	 */
 	public function getMigratorVersion(string $migrator): ?int;
+
+	/**
+	 * Get original uid of the imported account
+	 *
+	 * @since 24.0.0
+	 */
+	public function getOriginalUid(): string;
 
 	/**
 	 * Called after import is complete

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -64,6 +64,13 @@ interface IImportSource {
 	public function getFolderListing(string $path): array;
 
 	/**
+	 * Test if a path exists
+	 *
+	 * @since 24.0.0
+	 */
+	public function pathExists(string $path): bool;
+
+	/**
 	 * Copy files from the export to a Folder
 	 *
 	 * Folder $destination folder to copy into

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -65,7 +65,7 @@ interface IImportSource {
 	public function getFolderListing(string $path): array;
 
 	/**
-	 * Test if a path exists
+	 * Test if a path exists, which may be a file or a folder
 	 *
 	 * @since 24.0.0
 	 */

--- a/lib/public/UserMigration/IMigrator.php
+++ b/lib/public/UserMigration/IMigrator.php
@@ -38,6 +38,7 @@ interface IMigrator {
 	/**
 	 * Export user data
 	 *
+	 * @throws UserMigrationException
 	 * @since 24.0.0
 	 */
 	public function export(
@@ -49,6 +50,7 @@ interface IMigrator {
 	/**
 	 * Import user data
 	 *
+	 * @throws UserMigrationException
 	 * @since 24.0.0
 	 */
 	public function import(

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -28,6 +28,7 @@ namespace OCP\UserMigration;
 
 /**
  * Basic version handling: we can import older versions but not newer ones
+ * @since 24.0.0
  */
 trait TMigratorBasicVersionHandling {
 	protected int $version = 1;

--- a/lib/public/UserMigration/UserMigrationException.php
+++ b/lib/public/UserMigration/UserMigrationException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\UserMigration;
+
+class UserMigrationException extends \Exception {
+}

--- a/lib/public/UserMigration/UserMigrationException.php
+++ b/lib/public/UserMigration/UserMigrationException.php
@@ -26,5 +26,8 @@ declare(strict_types=1);
 
 namespace OCP\UserMigration;
 
+/**
+ * @since 24.0.0
+ */
 class UserMigrationException extends \Exception {
 }


### PR DESCRIPTION
- Add base exception class to be used by migrators and add appropriate `@throws` documentation
- Add pathExists method to have an efficient way to test if a folder or a file exists (previously one had to use `in_array($path, $importSource->getFolderListing('parent/'))`)
- Add getOriginalUid as single point of truth to get the original uid of the imported account, which may differ from the uid of the imported account in the end. This is useful information for instance to detect files comment which are from the imported user.