### PR TITLE
Fix occ user:add-app-password

### DIFF
--- a/apps/settings/lib/Activity/Provider.php
+++ b/apps/settings/lib/Activity/Provider.php
@@ -115,7 +115,11 @@ class Provider implements IProvider {
 		} elseif ($event->getSubject() === self::EMAIL_CHANGED) {
 			$subject = $this->l->t('Your email address was changed by an administrator');
 		} elseif ($event->getSubject() === self::APP_TOKEN_CREATED) {
-			$subject = $this->l->t('You created app password "{token}"');
+			if ($event->getAffectedUser() === $event->getAuthor()) {
+				$subject = $this->l->t('You created app password "{token}"');
+			} else {
+				$subject = $this->l->t('An administrator created app password "{token}"');
+			}
 		} elseif ($event->getSubject() === self::APP_TOKEN_DELETED) {
 			$subject = $this->l->t('You deleted app password "{token}"');
 		} elseif ($event->getSubject() === self::APP_TOKEN_RENAMED) {

--- a/apps/settings/lib/Listener/AppPasswordCreatedActivityListener.php
+++ b/apps/settings/lib/Listener/AppPasswordCreatedActivityListener.php
@@ -31,6 +31,7 @@ use OCA\Settings\Activity\Provider;
 use OCP\Activity\IManager as IActivityManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -40,12 +41,17 @@ class AppPasswordCreatedActivityListener implements IEventListener {
 	/** @var IActivityManager */
 	private $activityManager;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(IActivityManager $activityManager,
+								IUserSession $userSession,
 								LoggerInterface $logger) {
 		$this->activityManager = $activityManager;
+		$this->userSession = $userSession;
 		$this->logger = $logger;
 	}
 
@@ -58,7 +64,7 @@ class AppPasswordCreatedActivityListener implements IEventListener {
 		$activity->setApp('settings')
 			->setType('security')
 			->setAffectedUser($event->getToken()->getUID())
-			->setAuthor($event->getToken()->getUID())
+			->setAuthor($this->userSession->getUser() ? $this->userSession->getUser()->getUID() : '')
 			->setSubject(Provider::APP_TOKEN_CREATED, ['name' => $event->getToken()->getName()])
 			->setObject('app_token', $event->getToken()->getId());
 

--- a/core/Command/User/AddAppPassword.php
+++ b/core/Command/User/AddAppPassword.php
@@ -109,8 +109,10 @@ class AddAppPassword extends Command {
 			return 1;
 		}
 
-		$output->writeln('<info>The password is not validated so what you provide is what gets recorded in the token</info>');
-
+		if (!$this->userManager->checkPassword($user->getUID(), $password)) {
+			$output->writeln('<error>The provided password is invalid</error>');
+			return 1;
+		}
 
 		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS);
 		$generatedToken = $this->tokenProvider->generateToken(

--- a/core/Command/User/AddAppPassword.php
+++ b/core/Command/User/AddAppPassword.php
@@ -23,10 +23,11 @@
  */
 namespace OC\Core\Command\User;
 
+use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUserManager;
-use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -44,17 +45,17 @@ class AddAppPassword extends Command {
 	protected $tokenProvider;
 	/** @var ISecureRandom */
 	private $random;
-	/** @var ICrypto */
-	private $crypto;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
 
 	public function __construct(IUserManager $userManager,
 								IProvider $tokenProvider,
 								ISecureRandom $random,
-								ICrypto $crypto) {
+								IEventDispatcher $eventDispatcher) {
 		$this->tokenProvider = $tokenProvider;
 		$this->userManager = $userManager;
 		$this->random = $random;
-		$this->crypto = $crypto;
+		$this->eventDispatcher = $eventDispatcher;
 		parent::__construct();
 	}
 
@@ -112,7 +113,7 @@ class AddAppPassword extends Command {
 
 
 		$token = $this->random->generate(72, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_LOWER.ISecureRandom::CHAR_DIGITS);
-		$this->tokenProvider->generateToken(
+		$generatedToken = $this->tokenProvider->generateToken(
 			$token,
 			$user->getUID(),
 			$user->getUID(),
@@ -120,6 +121,10 @@ class AddAppPassword extends Command {
 			'cli',
 			IToken::PERMANENT_TOKEN,
 			IToken::DO_NOT_REMEMBER
+		);
+
+		$this->eventDispatcher->dispatchTyped(
+			new AppPasswordCreatedEvent($generatedToken)
 		);
 
 		$output->writeln('app password:');

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -187,7 +187,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\AddAppPassword(\OC::$server->get(\OCP\IUserManager::class), \OC::$server->get(\OC\Authentication\Token\IProvider::class), \OC::$server->get(\OCP\Security\ISecureRandom::class), \OC::$server->get(\OCP\Security\ICrypto::class)));
+	$application->add(new OC\Core\Command\User\AddAppPassword(\OC::$server->get(\OCP\IUserManager::class), \OC::$server->get(\OC\Authentication\Token\IProvider::class), \OC::$server->get(\OCP\Security\ISecureRandom::class), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class)));
 
 	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));


### PR DESCRIPTION
### Steps
Create an app-password via all 3 methods and check the differences:

* occ user:add-app-password admin
* curl -k -u admin:admin https://nextcloud.local/ocs/v2.php/core/getapppassword -H "OCS-APIRequest: true"
* https://nextcloud.local/index.php/settings/user/security