### PR TITLE
[stable22] Fix listeners declaration in case of occ usage

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -727,6 +727,8 @@ class OC {
 		// Make sure that the application class is not loaded before the database is setup
 		if ($systemConfig->getValue("installed", false)) {
 			OC_App::loadApp('settings');
+			/* Build core application to make sure that listeners are registered */
+			self::$server->get(\OC\Core\Application::class);
 		}
 
 		//make sure temporary files are cleaned up


### PR DESCRIPTION
Build OC\Core\Application when running occ or cron to register listeners correctly

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>
(cherry picked from commit 63d7e7c798f6a6cbd56642a287673532b991c5ac)

See https://github.com/nextcloud/server/pull/30889