### PR TITLE
Only log events when enabled in debug mode

### DIFF
--- a/lib/private/Diagnostics/EventLogger.php
+++ b/lib/private/Diagnostics/EventLogger.php
@@ -60,12 +60,13 @@ class EventLogger implements IEventLogger {
 	}
 
 	public function isLoggingActivated(): bool {
-		if ($this->config->getValue('debug', false)) {
+		$systemValue = (bool)$this->config->getValue('diagnostics.logging', false);
+
+		if ($systemValue && $this->config->getValue('debug', false)) {
 			return true;
 		}
 
 		$isDebugLevel = $this->internalLogger->getLogLevel([]) === Log::DEBUG;
-		$systemValue = (bool)$this->config->getValue('diagnostics.logging', false);
 		return $systemValue && $isDebugLevel;
 	}
 


### PR DESCRIPTION
Avoid heavy log spam on developer instances