### PR TITLE
Fix user status not resetting correctly after a call

### DIFF
--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -295,7 +295,7 @@ class StatusService {
 
 		$userStatus->setStatus($status);
 		$userStatus->setStatusTimestamp($this->timeFactory->getTime());
-		$userStatus->setIsUserDefined(false);
+		$userStatus->setIsUserDefined(true);
 		$userStatus->setIsBackup(false);
 		$userStatus->setMessageId($messageId);
 		$userStatus->setCustomIcon(null);


### PR DESCRIPTION
Only happens when the user navigated away and came back,
so the heartbeat updates the status to "Online + In a call"
After that resetting away from "Away + In a call" does not match anymore
and the previous status sticks

See https://github.com/nextcloud/server/issues/31532#issuecomment-1065048937 for in-depth analysis

Fix #31532 