### PR TITLE
fix bitwise check on permissions

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -342,7 +342,7 @@ class Manager implements IManager {
 		}
 
 		// Check that we do not share with more permissions than we have
-		if ($share->getPermissions() & ~$permissions) {
+		if (($share->getPermissions() & ~$permissions) !== 0) {
 			$path = $userFolder->getRelativePath($share->getNode()->getPath());
 			$message_t = $this->l->t('Cannot increase permissions of %s', [$path]);
 			throw new GenericShareException($message_t, $message_t, 404);


### PR DESCRIPTION
might fix 2 known use-cases:

usecase 1:
- create testuser and testuser1
- login as testuser
- create usergroup testgroup and add testuser1 to this group
- create testfolder and share that with testgroup - readonly!
- create subfolder in testfolder
- share subfolder with testuser1 with edit/reshare rights enabled
- login as testuser1
->testuser1 now can't reshare subfolder

usecase 2: this is the one of my original support request!!
- create testuser, testuser1 and testuser2
- login as testuser
- create usergroup testgroup and add testuser2 to this group
- create testfolder and share that with testuser1 with edit/reshare rights enabled
- login as testuser1
- create subfolder  in testfolder and share subfolder with testgroup readonly!
- create a subsubfolder in subfolder and share that with testuser2 with edit/reshare rights enabled
- login as testuser2
- testuser2 cannot reshare subsubfolder, that gives an error 
