### PR TITLE
don't error if we can't load the ExceptionSerializer for early exceptions

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -308,7 +308,13 @@ class Log implements ILogger, IDataLogger {
 		$app = $context['app'] ?? 'no app in context';
 		$level = $context['level'] ?? ILogger::ERROR;
 
-		$serializer = new ExceptionSerializer($this->config);
+		// if an error is raised before the autoloader is properly setup, we can't serialize exceptions
+		try {
+			$serializer = new ExceptionSerializer($this->config);
+		} catch (\Throwable $e) {
+			$this->error("Failed to load ExceptionSerializer serializer while trying to log " . $exception->getMessage());
+			return;
+		}
 		$data = $serializer->serializeException($exception);
 		$data['CustomMessage'] = $this->interpolateMessage($context, $context['message'] ?? '--');
 


### PR DESCRIPTION
When an exception is thrown very early on (such as when rendering the "access trough non trusted domain" error page) the `ExceptionSerializer` can't be autoloaded