### PR TITLE
Limit missing primary key fail to new tables and comment out for now

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -634,8 +634,8 @@ class MigrationService {
 				if ($isUsingDefaultName && \strlen($table->getName()) - $prefixLength >= 23) {
 					throw new \InvalidArgumentException('Primary index name on "' . $table->getName() . '" is too long.');
 				}
-			} elseif (!$primaryKey instanceof Index && !$sourceTable instanceof Table) {
-				throw new \InvalidArgumentException('Table "' . $table->getName() . '" has no primary key and therefor will not behave sane in clustered setups.');
+				// } elseif (!$primaryKey instanceof Index && !$sourceTable instanceof Table) {
+				// throw new \InvalidArgumentException('Table "' . $table->getName() . '" has no primary key and therefor will not behave sane in clustered setups.');
 			}
 		}
 

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -634,7 +634,7 @@ class MigrationService {
 				if ($isUsingDefaultName && \strlen($table->getName()) - $prefixLength >= 23) {
 					throw new \InvalidArgumentException('Primary index name on "' . $table->getName() . '" is too long.');
 				}
-			} elseif (!$primaryKey instanceof Index) {
+			} elseif (!$primaryKey instanceof Index && !$sourceTable instanceof Table) {
 				throw new \InvalidArgumentException('Table "' . $table->getName() . '" has no primary key and therefor will not behave sane in clustered setups.');
 			}
 		}


### PR DESCRIPTION
This will work on CI so devs notice it when they install the app for testing,
and at the same time existing faulty tables don't break the upgrade to 24

Regression from #31513 