### PR TITLE
Add QBMapper::findById

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -83,6 +83,26 @@ abstract class QBMapper {
 		return $this->tableName;
 	}
 
+	/**
+	 * Locate one row by its primary key and throw when nothing is found
+	 *
+	 * @param IQueryBuilder $query
+	 * @return Entity the result
+	 * @psalm-return T the result
+	 * @throws DoesNotExistException if the item does not exist
+	 *
+	 * @since 25.0.0
+	 */
+	public function findById(int $id): Entity {
+		$qb = $this->db->getQueryBuilder();
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
+			);
+		return $this->findEntity($select);
+	}
+
 
 	/**
 	 * Deletes an entity from the table


### PR DESCRIPTION
As of Nextcloud 24 / https://github.com/nextcloud/server/pull/31513 it is a requirement that all tables have a primary
key. This allows us to make an assumption about what a findById looks
like.

This is a kind-of breaking change due to the *fragile base class*
problem. Therefore we need to give app devs a heads-up before this is
added. E.g. by telling them to rename their existing findById methods if
they want to support wider ranges of Nextcloud or drop theirs in favor
of the new base class method.

I would plan to add this only for Nextcloud 25.

In the same sense we could also add `deleteById` in addition to `delete` so that rows can be deleted without a prior retrieval.

Todo
- [x] Implementation
- [ ] Documentation