### PR TITLE
WIP: Allow admins to select installed app version

### DIFF
--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -50,7 +50,7 @@ return [
 		['name' => 'AppSettings#enableApps', 'url' => '/settings/apps/enable', 'verb' => 'POST' , 'root' => ''],
 		['name' => 'AppSettings#disableApp', 'url' => '/settings/apps/disable/{appId}', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'AppSettings#disableApps', 'url' => '/settings/apps/disable', 'verb' => 'POST' , 'root' => ''],
-		['name' => 'AppSettings#updateApp', 'url' => '/settings/apps/update/{appId}', 'verb' => 'GET' , 'root' => ''],
+		['name' => 'AppSettings#updateApp', 'url' => '/settings/apps/update/{appId}/{version}', 'verb' => 'GET' , 'defaults' => ['appId' => '', 'version' => ''],'root' => ''],
 		['name' => 'AppSettings#uninstallApp', 'url' => '/settings/apps/uninstall/{appId}', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'AppSettings#viewApps', 'url' => '/settings/apps/{category}', 'verb' => 'GET', 'defaults' => ['category' => ''] , 'root' => ''],
 		['name' => 'AppSettings#viewApps', 'url' => '/settings/apps/{category}/{id}', 'verb' => 'GET', 'defaults' => ['category' => '', 'id' => ''] , 'root' => ''],

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -527,12 +527,12 @@ class AppSettingsController extends Controller {
 	 * @param string $appId
 	 * @return JSONResponse
 	 */
-	public function updateApp(string $appId): JSONResponse {
+	public function updateApp(string $appId, string $version = ''): JSONResponse {
 		$appId = OC_App::cleanAppId($appId);
 
 		$this->config->setSystemValue('maintenance', true);
 		try {
-			$result = $this->installer->updateAppstoreApp($appId);
+			$result = $this->installer->updateAppstoreApp($appId, false, $version);
 			$this->config->setSystemValue('maintenance', false);
 		} catch (\Exception $ex) {
 			$this->config->setSystemValue('maintenance', false);

--- a/apps/settings/src/mixins/AppManagement.js
+++ b/apps/settings/src/mixins/AppManagement.js
@@ -135,8 +135,8 @@ export default {
 				.then((response) => { rebuildNavigation() })
 				.catch((error) => { showError(error) })
 		},
-		update(appId) {
-			this.$store.dispatch('updateApp', { appId })
+		update(appId, version = '') {
+			this.$store.dispatch('updateApp', { appId, version })
 				.then((response) => { rebuildNavigation() })
 				.catch((error) => { showError(error) })
 		},

--- a/apps/settings/src/store/apps.js
+++ b/apps/settings/src/store/apps.js
@@ -283,15 +283,15 @@ const actions = {
 		}).catch((error) => context.commit('API_FAILURE', { appId, error }))
 	},
 
-	updateApp(context, { appId }) {
+	updateApp(context, { appId, version }) {
 		return api.requireAdmin().then((response) => {
 			context.commit('startLoading', appId)
 			context.commit('startLoading', 'install')
-			return api.get(generateUrl(`settings/apps/update/${appId}`))
+			return api.get(generateUrl(`settings/apps/update/${appId}/${version}`))
 				.then((response) => {
 					context.commit('stopLoading', 'install')
 					context.commit('stopLoading', appId)
-					context.commit('updateApp', appId)
+					context.commit('updateApp', appId, version)
 					return true
 				})
 				.catch((error) => {

--- a/apps/settings/src/views/Apps.vue
+++ b/apps/settings/src/views/Apps.vue
@@ -125,12 +125,12 @@
 				icon="icon-category-organization"
 				:name="t('settings', 'Versions')"
 				:order="1">
-				<div v-for="release in app.appstoreData.allreleases" :key="release.version" class="app-sidebar-tabs__release">
+				<div v-for="release in app.appstoreData.allreleases" class="app-sidebar-tabs__release">
 					<input
-					class="update primary"
-					type="button"
-					:value="release.version"
-					@click="update(app.id, release.version)">
+						class="update primary"
+						type="button"
+						:value="'Install ' + release.version"
+						@click="update(app.id, release.version)">
 				</div>
 			</AppSidebarTab>
 		</AppSidebar>

--- a/apps/settings/src/views/Apps.vue
+++ b/apps/settings/src/views/Apps.vue
@@ -125,9 +125,9 @@
 				icon="icon-category-organization"
 				:name="t('settings', 'Changelog')"
 				:order="1">
-				<div v-for="release in app.releases" :key="release.version" class="app-sidebar-tabs__release">
+				<div v-for="release in app.appstoreData.allreleases" :key="release.version" class="app-sidebar-tabs__release">
 					<h2>{{ release.version }}</h2>
-					<Markdown v-if="changelog(release)" :text="changelog(release)" />
+					<!--<Markdown v-if="changelog(release)" :text="changelog(release)" />-->
 				</div>
 			</AppSidebarTab>
 		</AppSidebar>

--- a/apps/settings/src/views/Apps.vue
+++ b/apps/settings/src/views/Apps.vue
@@ -123,11 +123,14 @@
 			<AppSidebarTab v-if="app.appstoreData && app.releases[0].translations.en.changelog"
 				id="desca"
 				icon="icon-category-organization"
-				:name="t('settings', 'Changelog')"
+				:name="t('settings', 'Versions')"
 				:order="1">
 				<div v-for="release in app.appstoreData.allreleases" :key="release.version" class="app-sidebar-tabs__release">
-					<h2>{{ release.version }}</h2>
-					<!--<Markdown v-if="changelog(release)" :text="changelog(release)" />-->
+					<input
+					class="update primary"
+					type="button"
+					:value="release.version"
+					@click="update(app.id, release.version)">
 				</div>
 			</AppSidebarTab>
 		</AppSidebar>

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -164,6 +164,8 @@ class AppFetcher extends Fetcher {
 					}
 				}
 			}
+
+			$response['data'][$dataKey]['allreleases'] = $releases;
 		}
 
 		$response['data'] = array_values(array_filter($response['data']));

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -316,7 +316,7 @@ class Installer {
 				}
 				else {
 					$client->get($app['releases'][0]['download'], ['sink' => $tempFile, 'timeout' => $timeout]);
-					
+
 					// Check if the signature actually matches the downloaded content
 					$verified = (bool)openssl_verify(file_get_contents($tempFile), base64_decode($app['releases'][0]['signature']), $certificate, OPENSSL_ALGO_SHA512);
 				}
@@ -373,18 +373,20 @@ class Installer {
 					}
 
 					// Check if the version is lower than before
-					// $currentVersion = OC_App::getAppVersion($appId);
-					// $newVersion = (string)$xml->version;
-					// if (version_compare($currentVersion, $newVersion) === 1) {
-					// 	throw new \Exception(
-					// 		sprintf(
-					// 			'App for id %s has version %s and tried to update to lower version %s',
-					// 			$appId,
-					// 			$currentVersion,
-					// 			$newVersion
-					// 		)
-					// 	);
-					// }
+					if ($targetVersion === '') {
+						$currentVersion = OC_App::getAppVersion($appId);
+						$newVersion = (string)$xml->version;
+						if (version_compare($currentVersion, $newVersion) === 1) {
+							throw new \Exception(
+								sprintf(
+									'App for id %s has version %s and tried to update to lower version %s',
+									$appId,
+									$currentVersion,
+									$newVersion
+								)
+							);
+						}
+					}
 
 					$baseDir = OC_App::getInstallPath() . '/' . $appId;
 					// Remove old app with the ID if existent


### PR DESCRIPTION
This PR allows admins to select the version of apps via web UI. Currently, only the latest version can be installed. This is especially painful when new app versions come with regressions. With this change, admins can roll back to any previous version without using CLI (esp. relevant for managed instances).

![grafik](https://user-images.githubusercontent.com/56191773/158544089-2f635619-ef15-4aa9-83dc-857416eb6dbe.png)

Current implementation status:
:x: cleanly implemented
:x: nicely designed
:heavy_check_mark: sketches the concept

If there is interest, I can follow up. Otherwise, feel free to close it.

Closes #31564