### PR TITLE
 Fix federated cloud share icons overlap in button

### DIFF
--- a/apps/federatedfilesharing/css/settings-personal.scss
+++ b/apps/federatedfilesharing/css/settings-personal.scss
@@ -30,10 +30,13 @@
 
 .social-diaspora {
 	@include icon-color('social-diaspora', 'federatedfilesharing', $color-black);
+	padding-left: 26px;
 }
 .social-twitter {
     @include icon-color('social-twitter', 'federatedfilesharing', $color-black);
+	padding-left: 26px;
 }
 .social-facebook {
 	@include icon-color('social-facebook', 'federatedfilesharing', $color-black);
+	padding-left: 26px;
 }


### PR DESCRIPTION
Added margin right the the icon to avoid overlap over the write

Fix #30819