### PR TITLE
Do not update _lastChanged on auto-detected attributes

### DIFF
--- a/apps/user_ldap/lib/Command/CreateEmptyConfig.php
+++ b/apps/user_ldap/lib/Command/CreateEmptyConfig.php
@@ -59,6 +59,7 @@ class CreateEmptyConfig extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configPrefix = $this->helper->getNextServerConfigurationPrefix();
 		$configHolder = new Configuration($configPrefix);
+		$configHolder->ldapConfigurationActive = false;
 		$configHolder->saveConfiguration();
 
 		$prose = '';

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -257,6 +257,7 @@ class Configuration {
 	 */
 	public function saveConfiguration(): void {
 		$cta = array_flip($this->getConfigTranslationArray());
+		$changed = false;
 		foreach ($this->unsavedChanges as $key) {
 			$value = $this->config[$key];
 			switch ($key) {
@@ -286,9 +287,12 @@ class Configuration {
 			if (is_null($value)) {
 				$value = '';
 			}
+			$changed = true;
 			$this->saveValue($cta[$key], $value);
 		}
-		$this->saveValue('_lastChange', (string)time());
+		if ($changed) {
+			$this->saveValue('_lastChange', (string)time());
+		}
 		$this->unsavedChanges = [];
 	}
 

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -56,10 +56,9 @@ class Configuration {
 	 */
 	protected $configRead = false;
 	/**
-	 * @var string[] pre-filled with one reference key so that at least one entry is written on save request and
-	 *               the config ID is registered
+	 * @var string[]
 	 */
-	protected $unsavedChanges = ['ldapConfigurationActive' => 'ldapConfigurationActive'];
+	protected array $unsavedChanges = [];
 
 	/**
 	 * @var array<string, mixed> settings

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -118,6 +118,7 @@ class ConfigAPIController extends OCSController {
 		try {
 			$configPrefix = $this->ldapHelper->getNextServerConfigurationPrefix();
 			$configHolder = new Configuration($configPrefix);
+			$configHolder->ldapConfigurationActive = false;
 			$configHolder->saveConfiguration();
 		} catch (\Exception $e) {
 			$this->logger->logException($e);


### PR DESCRIPTION
- [x] Does not work yet, because ldapConfigurationActive is always set and that count as a change.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>