### PR TITLE
do not forget DB table prefix with truncate query

### DIFF
--- a/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
+++ b/apps/user_ldap/lib/Migration/Version1130Date20211102154716.php
@@ -67,7 +67,7 @@ class Version1130Date20211102154716 extends SimpleMigrationStep {
 			// ldap_group_mapping_backup table. No need to recreate, but it
 			// should be empty.
 			// TRUNCATE is not available from Query Builder, but faster than DELETE FROM.
-			$sql = $this->dbc->getDatabasePlatform()->getTruncateTableSQL('ldap_group_mapping_backup', false);
+			$sql = $this->dbc->getDatabasePlatform()->getTruncateTableSQL('`*PREFIX*ldap_group_mapping_backup`', false);
 			$this->dbc->executeStatement($sql);
 		}
 	}


### PR DESCRIPTION
- as used in LDAP's AbstractMapping::clear() method
- and in Comment's ManagerTest::setUp()
- fixes a DB Exception with Oracle

