### PR TITLE
Remove legacy Internet Explorer headers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,9 +24,6 @@
     Header onsuccess unset X-Content-Type-Options
     Header always set X-Content-Type-Options "nosniff"
 
-    Header onsuccess unset X-Download-Options
-    Header always set X-Download-Options "noopen"
-
     Header onsuccess unset X-Frame-Options
     Header always set X-Frame-Options "SAMEORIGIN"
 

--- a/build/integration/features/carddav.feature
+++ b/build/integration/features/carddav.feature
@@ -44,7 +44,6 @@ Feature: carddav
         |Content-Type|text/vcard; charset=utf-8|
         |Content-Security-Policy|default-src 'none';|
         |X-Content-Type-Options |nosniff|
-        |X-Download-Options|noopen|
         |X-Frame-Options|SAMEORIGIN|
         |X-Permitted-Cross-Domain-Policies|none|
         |X-Robots-Tag|none|
@@ -59,7 +58,6 @@ Feature: carddav
       |Content-Type|image/jpeg|
       |Content-Security-Policy|default-src 'none';|
       |X-Content-Type-Options |nosniff|
-      |X-Download-Options|noopen|
       |X-Frame-Options|SAMEORIGIN|
       |X-Permitted-Cross-Domain-Policies|none|
       |X-Robots-Tag|none|

--- a/build/integration/features/dav-v2.feature
+++ b/build/integration/features/dav-v2.feature
@@ -25,7 +25,6 @@ Feature: dav-v2
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
-			|X-Download-Options|noopen|
 			|X-Frame-Options|SAMEORIGIN|
 			|X-Permitted-Cross-Domain-Policies|none|
 			|X-Robots-Tag|none|

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -249,7 +249,6 @@ Feature: webdav-related
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
 			|X-Content-Type-Options |nosniff|
-			|X-Download-Options|noopen|
 			|X-Frame-Options|SAMEORIGIN|
 			|X-Permitted-Cross-Domain-Policies|none|
 			|X-Robots-Tag|none|

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -658,7 +658,6 @@
 					'X-Content-Type-Options': ['nosniff'],
 					'X-Robots-Tag': ['none'],
 					'X-Frame-Options': ['SAMEORIGIN', 'DENY'],
-					'X-Download-Options': ['noopen'],
 					'X-Permitted-Cross-Domain-Policies': ['none'],
 				};
 				for (var header in securityHeaders) {

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -1492,12 +1492,8 @@ describe('OC.SetupChecks tests', function() {
 				}, {
 					msg: 'The "X-Robots-Tag" HTTP header is not set to "none". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-
 				}, {
 					msg: 'The "X-Frame-Options" HTTP header is not set to "SAMEORIGIN". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.',
-					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-				}, {
-					msg: 'The "X-Download-Options" HTTP header is not set to "noopen". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}, {
 					msg: 'The "X-Permitted-Cross-Domain-Policies" HTTP header is not set to "none". This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.',
@@ -1524,7 +1520,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
 					'Strict-Transport-Security': 'max-age=15768000;preload',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				}
@@ -1556,7 +1551,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
 					'Strict-Transport-Security': 'max-age=15768000',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer'
 				}
@@ -1579,7 +1573,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				});
@@ -1600,7 +1593,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				});
@@ -1621,7 +1613,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				});
@@ -1647,7 +1638,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				});
@@ -1675,7 +1665,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer',
 				});
@@ -1696,7 +1685,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'no-referrer-when-downgrade',
 				});
@@ -1717,7 +1705,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'strict-origin',
 				});
@@ -1738,7 +1725,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'strict-origin-when-cross-origin',
 				});
@@ -1759,7 +1745,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'same-origin',
 				});
@@ -1780,7 +1765,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'origin',
 				});
@@ -1806,7 +1790,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'origin-when-cross-origin',
 				});
@@ -1832,7 +1815,6 @@ describe('OC.SetupChecks tests', function() {
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
-					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
 					'Referrer-Policy': 'unsafe-url',
 				});
@@ -1860,7 +1842,6 @@ describe('OC.SetupChecks tests', function() {
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
-				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
 				'Referrer-Policy': 'no-referrer',
 			}
@@ -1907,7 +1888,6 @@ describe('OC.SetupChecks tests', function() {
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
-				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
 				'Referrer-Policy': 'no-referrer',
 			}
@@ -1933,7 +1913,6 @@ describe('OC.SetupChecks tests', function() {
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
-				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
 				'Referrer-Policy': 'no-referrer',
 			}
@@ -1959,7 +1938,6 @@ describe('OC.SetupChecks tests', function() {
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
-				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
 				'Referrer-Policy': 'no-referrer',
 			}
@@ -1984,7 +1962,6 @@ describe('OC.SetupChecks tests', function() {
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
 			'X-Permitted-Cross-Domain-Policies': 'none',
 			'Referrer-Policy': 'no-referrer',
 		});
@@ -2005,7 +1982,6 @@ describe('OC.SetupChecks tests', function() {
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
 			'X-Permitted-Cross-Domain-Policies': 'none',
 			'Referrer-Policy': 'no-referrer',
 		});
@@ -2026,7 +2002,6 @@ describe('OC.SetupChecks tests', function() {
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
 			'X-Permitted-Cross-Domain-Policies': 'none',
 			'Referrer-Policy': 'no-referrer',
 		});
@@ -2047,7 +2022,6 @@ describe('OC.SetupChecks tests', function() {
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
 			'X-Permitted-Cross-Domain-Policies': 'none',
 			'Referrer-Policy': 'no-referrer',
 		});

--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -5,7 +5,6 @@
 		<title>
 		<?php p($theme->getTitle()); ?>
 		</title>
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">
 		<link rel="icon" href="<?php print_unescaped(image_path('', 'favicon.ico')); /* IE11+ supports png */ ?>">

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -9,7 +9,6 @@
 		<title>
 		<?php p($theme->getTitle()); ?>
 		</title>
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<?php if ($theme->getiTunesAppId() !== '') { ?>
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -8,7 +8,6 @@
 		p($theme->getTitle());
 		?>
 	</title>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 	<?php if ($theme->getiTunesAppId() !== '') { ?>
 	<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -22,7 +22,6 @@ $getUserAvatar = static function (int $size) use ($_): string {
 				p($theme->getTitle());
 			?>
 		</title>
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<?php if ($theme->getiTunesAppId() !== '') { ?>
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">

--- a/lib/private/legacy/OC_Response.php
+++ b/lib/private/legacy/OC_Response.php
@@ -97,7 +97,6 @@ class OC_Response {
 		if (getenv('modHeadersAvailable') !== 'true') {
 			header('Referrer-Policy: no-referrer'); // https://www.w3.org/TR/referrer-policy/
 			header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
-			header('X-Download-Options: noopen'); // https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
 			header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
 			header('X-Permitted-Cross-Domain-Policies: none'); // https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
 			header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag


### PR DESCRIPTION
`X-UA-Compatible` and `X-Download-Options` headers are interpreted or relevant for Internet Explorer only. With the deprecation of Internet Explorer support in Nextcloud 20 and planned support removal already in Nextcloud 22, these became obsolete and are hereby removed, including their removal from setup checks.