### PR TITLE
Fixes the undefined index error with the DAV property getlastmodified

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -587,7 +587,7 @@ class DAV extends Common {
 				return false;
 			}
 			return [
-				'mtime' => isset($response['{DAV:getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : false,
+				'mtime' => isset($response['{DAV:}getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : false,
 				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 			];
 		} catch (\Exception $e) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -587,7 +587,7 @@ class DAV extends Common {
 				return false;
 			}
 			return [
-				'mtime' => isset($response['{DAV:}getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : false,
+				'mtime' => isset($response['{DAV:}getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : null,
 				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 			];
 		} catch (\Exception $e) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -588,7 +588,7 @@ class DAV extends Common {
 			}
 			return [
 				'mtime' => isset($response['{DAV:}getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : null,
-				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
+				'size' => (int)($response['{DAV:}getcontentlength'] ?? 0),
 			];
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -587,7 +587,7 @@ class DAV extends Common {
 				return false;
 			}
 			return [
-				'mtime' => strtotime($response['{DAV:}getlastmodified']),
+				'mtime' => isset($response['{DAV:getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : false,
 				'size' => (int)isset($response['{DAV:}getcontentlength']) ? $response['{DAV:}getcontentlength'] : 0,
 			];
 		} catch (\Exception $e) {
@@ -804,9 +804,12 @@ class DAV extends Common {
 				} else {
 					return false;
 				}
-			} else {
+			} elseif (isset($response['{DAV:}getlastmodified'])) {
 				$remoteMtime = strtotime($response['{DAV:}getlastmodified']);
 				return $remoteMtime > $time;
+			} else {
+				// neither `getetag` nor `getlastmodified` is set
+				return false;
 			}
 		} catch (ClientHttpException $e) {
 			if ($e->getHttpStatus() === 405) {


### PR DESCRIPTION
This PR fixes the undefined index {DAV:}getlastmodified error, which can occur in the `DAV.php` file.

The return value in the else clause is false if neither `getetag` nor `getlastmodified` is set. At least, I would argue that it should return false because false is returned if there is no response (`$response === false`), and in the exceptions, too.

It resolves some errors from issue #15363.
