### PR TITLE
Fix passing null to strlen

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -107,7 +107,7 @@ class ContactsStore implements IContactsStore {
 		}
 
 		$allContacts = $this->contactsManager->search(
-			$filter ?: '',
+			$filter ?? '',
 			[
 				'FN',
 				'EMAIL'
@@ -146,7 +146,7 @@ class ContactsStore implements IContactsStore {
 	 *
 	 * @param IUser $self
 	 * @param Entry[] $entries
-	 * @param string $filter
+	 * @param string|null $filter
 	 * @return Entry[] the filtered contacts
 	 */
 	private function filterContacts(

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -59,14 +59,14 @@ class Manager {
 
 	/**
 	 * @param IUser $user
-	 * @param string $filter
+	 * @param string|null $filter
 	 * @return array
 	 */
 	public function getEntries(IUser $user, $filter) {
 		$maxAutocompleteResults = max(0, $this->config->getSystemValueInt('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT));
 		$minSearchStringLength = $this->config->getSystemValueInt('sharing.minSearchStringLength', 0);
 		$topEntries = [];
-		if (strlen($filter) >= $minSearchStringLength) {
+		if (strlen($filter ?? '') >= $minSearchStringLength) {
 			$entries = $this->store->getContacts($user, $filter, $maxAutocompleteResults);
 
 			$sortedEntries = $this->sortEntries($entries);


### PR DESCRIPTION
`$filter` can be null as it's the default value passed in ContactsMenuController.

On PHP 8.1:
```
strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```
