### PR TITLE
Modernize contacts menu backend

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2818,14 +2818,6 @@
       <code>$this-&gt;application</code>
     </UndefinedThisPropertyFetch>
   </file>
-  <file src="lib/private/Contacts/ContactsMenu/Manager.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>IEntry</code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement occurrences="1">
-      <code>$entry</code>
-    </NullableReturnStatement>
-  </file>
   <file src="lib/private/ContactsManager.php">
     <InvalidNullableReturnType occurrences="3">
       <code>IAddressBook</code>

--- a/core/Controller/ContactsMenuController.php
+++ b/core/Controller/ContactsMenuController.php
@@ -24,6 +24,7 @@
  */
 namespace OC\Core\Controller;
 
+use Exception;
 use OC\Contacts\ContactsMenu\Manager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -32,18 +33,9 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 class ContactsMenuController extends Controller {
+	private Manager $manager;
+	private IUserSession $userSession;
 
-	/** @var Manager */
-	private $manager;
-
-	/** @var IUserSession */
-	private $userSession;
-
-	/**
-	 * @param IRequest $request
-	 * @param IUserSession $userSession
-	 * @param Manager $manager
-	 */
 	public function __construct(IRequest $request, IUserSession $userSession, Manager $manager) {
 		parent::__construct('core', $request);
 		$this->userSession = $userSession;
@@ -53,21 +45,20 @@ class ContactsMenuController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param string|null filter
 	 * @return \JsonSerializable[]
+	 * @throws Exception
 	 */
-	public function index($filter = null) {
+	public function index(?string $filter = null): array {
 		return $this->manager->getEntries($this->userSession->getUser(), $filter);
 	}
 
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param integer $shareType
-	 * @param string $shareWith
 	 * @return JSONResponse|\JsonSerializable
+	 * @throws Exception
 	 */
-	public function findOne($shareType, $shareWith) {
+	public function findOne(int $shareType, string $shareWith) {
 		$contact = $this->manager->findOne($this->userSession->getUser(), $shareType, $shareWith);
 
 		if ($contact) {

--- a/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
+++ b/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
@@ -38,15 +38,9 @@ use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class ActionProviderStore {
-
-	/** @var IServerContainer */
-	private $serverContainer;
-
-	/** @var AppManager */
-	private $appManager;
-
-	/** @var LoggerInterface */
-	private $logger;
+	private IServerContainer $serverContainer;
+	private AppManager $appManager;
+	private LoggerInterface $logger;
 
 	public function __construct(IServerContainer $serverContainer, AppManager $appManager, LoggerInterface $logger) {
 		$this->serverContainer = $serverContainer;
@@ -67,7 +61,7 @@ class ActionProviderStore {
 
 		foreach ($allClasses as $class) {
 			try {
-				$providers[] = $this->serverContainer->query($class);
+				$providers[] = $this->serverContainer->get($class);
 			} catch (QueryException $ex) {
 				$this->logger->error(
 					'Could not load contacts menu action provider ' . $class,

--- a/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
+++ b/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
@@ -25,73 +25,44 @@ namespace OC\Contacts\ContactsMenu\Actions;
 use OCP\Contacts\ContactsMenu\ILinkAction;
 
 class LinkAction implements ILinkAction {
-
-	/** @var string */
-	private $icon;
-
-	/** @var string */
-	private $name;
-
-	/** @var string */
-	private $href;
-
-	/** @var int */
-	private $priority = 10;
-
-	/** @var string */
-	private $appId;
+	private string $icon = '';
+	private string $name = '';
+	private string $href = '';
+	private int $priority = 10;
+	private string $appId = '';
 
 	/**
 	 * @param string $icon absolute URI to an icon
 	 */
-	public function setIcon($icon) {
+	public function setIcon(string $icon) {
 		$this->icon = $icon;
 	}
 
-	/**
-	 * @param string $name
-	 */
-	public function setName($name) {
+	public function setName(string $name) {
 		$this->name = $name;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->name;
 	}
 
-	/**
-	 * @param int $priority
-	 */
-	public function setPriority($priority) {
+	public function setPriority(int $priority) {
 		$this->priority = $priority;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getPriority() {
+	public function getPriority(): int {
 		return $this->priority;
 	}
 
-	/**
-	 * @param string $href
-	 */
-	public function setHref($href) {
+	public function setHref(string $href) {
 		$this->href = $href;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getHref() {
+	public function getHref(): string {
 		return $this->href;
 	}
 
 	/**
-	 * @param string $appId
 	 * @since 23.0.0
 	 */
 	public function setAppId(string $appId) {
@@ -99,7 +70,6 @@ class LinkAction implements ILinkAction {
 	}
 
 	/**
-	 * @return string
 	 * @since 23.0.0
 	 */
 	public function getAppId(): string {

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -44,30 +44,14 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 
 class ContactsStore implements IContactsStore {
-
-	/** @var IManager */
-	private $contactsManager;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var ProfileManager */
-	private $profileManager;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var IGroupManager */
-	private $groupManager;
-
-	/** @var KnownUserService */
-	private $knownUserService;
-
-	/** @var IL10NFactory */
-	private $l10nFactory;
+	private IManager $contactsManager;
+	private IConfig $config;
+	private ProfileManager $profileManager;
+	private IUserManager $userManager;
+	private IURLGenerator $urlGenerator;
+	private IGroupManager $groupManager;
+	private KnownUserService $knownUserService;
+	private IL10NFactory $l10nFactory;
 
 	public function __construct(
 		IManager $contactsManager,
@@ -90,11 +74,9 @@ class ContactsStore implements IContactsStore {
 	}
 
 	/**
-	 * @param IUser $user
-	 * @param string|null $filter
 	 * @return IEntry[]
 	 */
-	public function getContacts(IUser $user, $filter, ?int $limit = null, ?int $offset = null) {
+	public function getContacts(IUser $user, ?string $filter, ?int $limit = null, ?int $offset = null): array {
 		$options = [
 			'enumeration' => $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes',
 			'fullmatch' => $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes',
@@ -152,8 +134,8 @@ class ContactsStore implements IContactsStore {
 	private function filterContacts(
 		IUser $self,
 		array $entries,
-		$filter
-	) {
+		?string $filter
+	): array {
 		$disallowEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes';
 		$restrictEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$restrictEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
@@ -168,7 +150,7 @@ class ContactsStore implements IContactsStore {
 		$selfGroups = $this->groupManager->getUserGroupIds($self);
 
 		if ($excludedGroups) {
-			$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
+			$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list');
 			$decodedExcludeGroups = json_decode($excludedGroups, true);
 			$excludeGroupsList = $decodedExcludeGroups ?? [];
 
@@ -253,13 +235,7 @@ class ContactsStore implements IContactsStore {
 		}));
 	}
 
-	/**
-	 * @param IUser $user
-	 * @param integer $shareType
-	 * @param string $shareWith
-	 * @return IEntry|null
-	 */
-	public function findOne(IUser $user, $shareType, $shareWith) {
+	public function findOne(IUser $user, int $shareType, string $shareWith): ?IEntry {
 		switch ($shareType) {
 			case 0:
 			case 6:
@@ -305,11 +281,7 @@ class ContactsStore implements IContactsStore {
 		return $match;
 	}
 
-	/**
-	 * @param array $contact
-	 * @return Entry
-	 */
-	private function contactArrayToEntry(array $contact) {
+	private function contactArrayToEntry(array $contact): Entry {
 		$entry = new Entry();
 
 		if (isset($contact['id'])) {

--- a/lib/private/Contacts/ContactsMenu/Entry.php
+++ b/lib/private/Contacts/ContactsMenu/Entry.php
@@ -35,51 +35,34 @@ class Entry implements IEntry {
 	/** @var string|int|null */
 	private $id = null;
 
-	/** @var string */
-	private $fullName = '';
+	private string $fullName = '';
 
 	/** @var string[] */
-	private $emailAddresses = [];
+	private array $emailAddresses = [];
 
-	/** @var string|null */
-	private $avatar;
+	private ?string $avatar = null;
 
-	/** @var string|null */
-	private $profileTitle;
+	private ?string $profileTitle = null;
 
-	/** @var string|null */
-	private $profileUrl;
+	private ?string $profileUrl = null;
 
 	/** @var IAction[] */
-	private $actions = [];
+	private array $actions = [];
 
-	/** @var array */
-	private $properties = [];
+	private array $properties = [];
 
-	/**
-	 * @param string $id
-	 */
 	public function setId(string $id): void {
 		$this->id = $id;
 	}
 
-	/**
-	 * @param string $displayName
-	 */
 	public function setFullName(string $displayName): void {
 		$this->fullName = $displayName;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getFullName(): string {
 		return $this->fullName;
 	}
 
-	/**
-	 * @param string $address
-	 */
 	public function addEMailAddress(string $address): void {
 		$this->emailAddresses[] = $address;
 	}
@@ -91,51 +74,30 @@ class Entry implements IEntry {
 		return $this->emailAddresses;
 	}
 
-	/**
-	 * @param string $avatar
-	 */
 	public function setAvatar(string $avatar): void {
 		$this->avatar = $avatar;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAvatar(): ?string {
 		return $this->avatar;
 	}
 
-	/**
-	 * @param string $profileTitle
-	 */
 	public function setProfileTitle(string $profileTitle): void {
 		$this->profileTitle = $profileTitle;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getProfileTitle(): ?string {
 		return $this->profileTitle;
 	}
 
-	/**
-	 * @param string $profileUrl
-	 */
 	public function setProfileUrl(string $profileUrl): void {
 		$this->profileUrl = $profileUrl;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getProfileUrl(): ?string {
 		return $this->profileUrl;
 	}
 
-	/**
-	 * @param IAction $action
-	 */
 	public function addAction(IAction $action): void {
 		$this->actions[] = $action;
 		$this->sortActions();

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -25,6 +25,7 @@
  */
 namespace OC\Contacts\ContactsMenu;
 
+use Exception;
 use OCP\App\IAppManager;
 use OCP\Constants;
 use OCP\Contacts\ContactsMenu\IEntry;
@@ -32,24 +33,11 @@ use OCP\IConfig;
 use OCP\IUser;
 
 class Manager {
+	private ContactsStore $store;
+	private ActionProviderStore $actionProviderStore;
+	private IAppManager $appManager;
+	private IConfig $config;
 
-	/** @var ContactsStore */
-	private $store;
-
-	/** @var ActionProviderStore */
-	private $actionProviderStore;
-
-	/** @var IAppManager */
-	private $appManager;
-
-	/** @var IConfig */
-	private $config;
-
-	/**
-	 * @param ContactsStore $store
-	 * @param ActionProviderStore $actionProviderStore
-	 * @param IAppManager $appManager
-	 */
 	public function __construct(ContactsStore $store, ActionProviderStore $actionProviderStore, IAppManager $appManager, IConfig $config) {
 		$this->store = $store;
 		$this->actionProviderStore = $actionProviderStore;
@@ -61,10 +49,11 @@ class Manager {
 	 * @param IUser $user
 	 * @param string|null $filter
 	 * @return array
+	 * @throws Exception
 	 */
-	public function getEntries(IUser $user, $filter) {
+	public function getEntries(IUser $user, ?string $filter): array {
 		$maxAutocompleteResults = max(0, $this->config->getSystemValueInt('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT));
-		$minSearchStringLength = $this->config->getSystemValueInt('sharing.minSearchStringLength', 0);
+		$minSearchStringLength = $this->config->getSystemValueInt('sharing.minSearchStringLength');
 		$topEntries = [];
 		if (strlen($filter ?? '') >= $minSearchStringLength) {
 			$entries = $this->store->getContacts($user, $filter, $maxAutocompleteResults);
@@ -82,12 +71,9 @@ class Manager {
 	}
 
 	/**
-	 * @param IUser $user
-	 * @param integer $shareType
-	 * @param string $shareWith
-	 * @return IEntry
+	 * @throws Exception
 	 */
-	public function findOne(IUser $user, $shareType, $shareWith) {
+	public function findOne(IUser $user, int $shareType, string $shareWith): ?IEntry {
 		$entry = $this->store->findOne($user, $shareType, $shareWith);
 		if ($entry) {
 			$this->processEntries([$entry], $user);
@@ -100,7 +86,7 @@ class Manager {
 	 * @param IEntry[] $entries
 	 * @return IEntry[]
 	 */
-	private function sortEntries(array $entries) {
+	private function sortEntries(array $entries): array {
 		usort($entries, function (IEntry $entryA, IEntry $entryB) {
 			return strcasecmp($entryA->getFullName(), $entryB->getFullName());
 		});
@@ -110,6 +96,7 @@ class Manager {
 	/**
 	 * @param IEntry[] $entries
 	 * @param IUser $user
+	 * @throws Exception
 	 */
 	private function processEntries(array $entries, IUser $user) {
 		$providers = $this->actionProviderStore->getProviders($user);

--- a/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
@@ -28,17 +28,9 @@ use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IURLGenerator;
 
 class EMailProvider implements IProvider {
+	private IActionFactory $actionFactory;
+	private IURLGenerator $urlGenerator;
 
-	/** @var IActionFactory */
-	private $actionFactory;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/**
-	 * @param IActionFactory $actionFactory
-	 * @param IURLGenerator $urlGenerator
-	 */
 	public function __construct(IActionFactory $actionFactory, IURLGenerator $urlGenerator) {
 		$this->actionFactory = $actionFactory;
 		$this->urlGenerator = $urlGenerator;

--- a/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
@@ -33,29 +33,12 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 
 class ProfileProvider implements IProvider {
+	private IActionFactory $actionFactory;
+	private ProfileManager $profileManager;
+	private IL10NFactory $l10nFactory;
+	private IURLGenerator $urlGenerator;
+	private IUserManager $userManager;
 
-	/** @var IActionFactory */
-	private $actionFactory;
-
-	/** @var ProfileManager */
-	private $profileManager;
-
-	/** @var IL10NFactory */
-	private $l10nFactory;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/**
-	 * @param IActionFactory $actionFactory
-	 * @param ProfileManager $profileManager
-	 * @param IL10NFactory $l10nFactory
-	 * @param IURLGenerator $urlGenerator
-	 * @param IUserManager $userManager
-	 */
 	public function __construct(
 		IActionFactory $actionFactory,
 		ProfileManager $profileManager,

--- a/lib/public/Contacts/ContactsMenu/IAction.php
+++ b/lib/public/Contacts/ContactsMenu/IAction.php
@@ -35,31 +35,31 @@ interface IAction extends JsonSerializable {
 	 * @param string $icon absolute URI to an icon
 	 * @since 12.0
 	 */
-	public function setIcon($icon);
+	public function setIcon(string $icon);
 
 	/**
 	 * @return string localized action name, e.g. 'Call'
 	 * @since 12.0
 	 */
-	public function getName();
+	public function getName(): string;
 
 	/**
 	 * @param string $name localized action name, e.g. 'Call'
 	 * @since 12.0
 	 */
-	public function setName($name);
+	public function setName(string $name);
 
 	/**
 	 * @param int $priority priorize actions, high order ones are shown on top
 	 * @since 12.0
 	 */
-	public function setPriority($priority);
+	public function setPriority(int $priority);
 
 	/**
 	 * @return int priority to priorize actions, high order ones are shown on top
 	 * @since 12.0
 	 */
-	public function getPriority();
+	public function getPriority(): int;
 
 	/**
 	 * @param string $appId

--- a/lib/public/Contacts/ContactsMenu/IContactsStore.php
+++ b/lib/public/Contacts/ContactsMenu/IContactsStore.php
@@ -34,21 +34,17 @@ interface IContactsStore {
 
 	/**
 	 * @param IUser $user
-	 * @param string $filter
-	 * @param int $limit added 19.0.2
-	 * @param int $offset added 19.0.2
+	 * @param string|null $filter
+	 * @param int|null $limit added 19.0.2
+	 * @param int|null $offset added 19.0.2
 	 * @return IEntry[]
 	 * @since 13.0.0
 	 */
-	public function getContacts(IUser $user, $filter, ?int $limit = null, ?int $offset = null);
+	public function getContacts(IUser $user, ?string $filter, ?int $limit = null, ?int $offset = null): array;
 
 	/**
 	 * @brief finds a contact by specifying the property to search on ($shareType) and the value ($shareWith)
-	 * @param IUser $user
-	 * @param integer $shareType
-	 * @param string $shareWith
-	 * @return IEntry|null
 	 * @since 13.0.0
 	 */
-	public function findOne(IUser $user, $shareType, $shareWith);
+	public function findOne(IUser $user, int $shareType, string $shareWith): ?IEntry;
 }

--- a/lib/public/Contacts/ContactsMenu/ILinkAction.php
+++ b/lib/public/Contacts/ContactsMenu/ILinkAction.php
@@ -28,14 +28,14 @@ namespace OCP\Contacts\ContactsMenu;
 interface ILinkAction extends IAction {
 
 	/**
-	 * @since 12.0
 	 * @param string $href the target URL of the action
+	 * @since 12.0
 	 */
-	public function setHref($href);
+	public function setHref(string $href);
 
 	/**
 	 * @since 12.0
 	 * @return string
 	 */
-	public function getHref();
+	public function getHref(): string;
 }

--- a/tests/Core/Controller/ContactsMenuControllerTest.php
+++ b/tests/Core/Controller/ContactsMenuControllerTest.php
@@ -30,30 +30,27 @@ use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ContactsMenuControllerTest extends TestCase {
 
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserSession|MockObject */
 	private $userSession;
 
-	/** @var Manager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Manager|MockObject */
 	private $contactsManager;
 
-	/** @var ContactsMenuController */
-	private $controller;
+	private ContactsMenuController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->request = $this->createMock(IRequest::class);
+		$request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->contactsManager = $this->createMock(Manager::class);
 
-		$this->controller = new ContactsMenuController($this->request, $this->userSession, $this->contactsManager);
+		$this->controller = new ContactsMenuController($request, $this->userSession, $this->contactsManager);
 	}
 
 	public function testIndex() {

--- a/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionFactoryTest.php
@@ -29,9 +29,7 @@ use OCP\Contacts\ContactsMenu\IAction;
 use Test\TestCase;
 
 class ActionFactoryTest extends TestCase {
-
-	/** @var ActionFactory */
-	private $actionFactory;
+	private ActionFactory $actionFactory;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ActionProviderStoreTest.php
@@ -33,31 +33,28 @@ use OCP\AppFramework\QueryException;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IServerContainer;
 use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ActionProviderStoreTest extends TestCase {
 
-	/** @var IServerContainer|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IServerContainer|MockObject */
 	private $serverContainer;
 
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IAppManager|MockObject */
 	private $appManager;
 
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
-
-	/** @var ActionProviderStore */
-	private $actionProviderStore;
+	private ActionProviderStore $actionProviderStore;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->serverContainer = $this->createMock(IServerContainer::class);
 		$this->appManager = $this->createMock(AppManager::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$logger = $this->createMock(LoggerInterface::class);
 
-		$this->actionProviderStore = new ActionProviderStore($this->serverContainer, $this->appManager, $this->logger);
+		$this->actionProviderStore = new ActionProviderStore($this->serverContainer, $this->appManager, $logger);
 	}
 
 	public function testGetProviders() {
@@ -79,11 +76,11 @@ class ActionProviderStoreTest extends TestCase {
 				],
 			]);
 		$this->serverContainer->expects($this->exactly(3))
-			->method('query')
+			->method('get')
 			->willReturnMap([
-				[ProfileProvider::class, true, $provider1],
-				[EMailProvider::class, true, $provider2],
-				['OCA\Contacts\Provider1', true, $provider3]
+				[ProfileProvider::class, $provider1],
+				[EMailProvider::class, $provider2],
+				['OCA\Contacts\Provider1', $provider3]
 			]);
 
 		$providers = $this->actionProviderStore->getProviders($user);
@@ -107,10 +104,10 @@ class ActionProviderStoreTest extends TestCase {
 			->with('contacts')
 			->willReturn([/* Empty info.xml */]);
 		$this->serverContainer->expects($this->exactly(2))
-			->method('query')
+			->method('get')
 			->willReturnMap([
-				[ProfileProvider::class, true, $provider1],
-				[EMailProvider::class, true, $provider2],
+				[ProfileProvider::class, $provider1],
+				[EMailProvider::class, $provider2],
 			]);
 
 		$providers = $this->actionProviderStore->getProviders($user);
@@ -130,7 +127,7 @@ class ActionProviderStoreTest extends TestCase {
 			->with($user)
 			->willReturn([]);
 		$this->serverContainer->expects($this->once())
-			->method('query')
+			->method('get')
 			->willThrowException(new QueryException());
 
 		$this->actionProviderStore->getProviders($user);

--- a/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Actions/LinkActionTest.php
@@ -28,7 +28,7 @@ use OC\Contacts\ContactsMenu\Actions\LinkAction;
 use Test\TestCase;
 
 class LinkActionTest extends TestCase {
-	private $action;
+	private LinkAction $action;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,7 +49,7 @@ class LinkActionTest extends TestCase {
 	public function testGetSetName() {
 		$name = 'Jane Doe';
 
-		$this->assertNull($this->action->getName());
+		$this->assertEmpty($this->action->getName());
 		$this->action->setName($name);
 		$this->assertEquals($name, $this->action->getName());
 	}
@@ -67,7 +67,7 @@ class LinkActionTest extends TestCase {
 
 		$json = $this->action->jsonSerialize();
 		$this->assertArrayHasKey('hyperlink', $json);
-		$this->assertEquals($json['hyperlink'], '/some/url');
+		$this->assertEquals('/some/url', $json['hyperlink']);
 	}
 
 	public function testJsonSerialize() {

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -39,19 +39,18 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ContactsStoreTest extends TestCase {
-	/** @var ContactsStore */
-	private $contactsStore;
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	private ContactsStore $contactsStore;
+	/** @var IManager|MockObject */
 	private $contactsManager;
 	/** @var ProfileManager */
 	private $profileManager;
-	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserManager|MockObject */
 	private $userManager;
 	/** @var IURLGenerator */
 	private $urlGenerator;
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IGroupManager|MockObject */
 	private $groupManager;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 	/** @var KnownUserService|MockObject */
 	private $knownUserService;
@@ -82,7 +81,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testGetContactsWithoutFilter() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -112,7 +111,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testGetContactsHidesOwnEntry() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -139,7 +138,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testGetContactsWithoutBinaryImage() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -168,7 +167,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testGetContactsWithoutAvatarURI() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -208,7 +207,7 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_exclude_groups_list', '', '["group1", "group5", "group6"]'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
@@ -251,44 +250,39 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'yes'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
-			->method('getUserGroupIds')
-			->with($this->equalTo($currentUser))
-			->willReturn(['group1', 'group2', 'group3']);
-
 		$user1 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('user1')
-			->willReturn($user1);
-		$this->groupManager->expects($this->at(1))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user1))
-			->willReturn(['group1']);
 		$user2 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(1))
-			->method('get')
-			->with('user2')
-			->willReturn($user2);
-		$this->groupManager->expects($this->at(2))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user2))
-			->willReturn(['group2', 'group3']);
 		$user3 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(2))
-			->method('get')
-			->with('user3')
-			->willReturn($user3);
-		$this->groupManager->expects($this->at(3))
+
+		$this->groupManager->expects($this->exactly(4))
 			->method('getUserGroupIds')
-			->with($this->equalTo($user3))
-			->willReturn(['group8', 'group9']);
+			->withConsecutive(
+				[$this->equalTo($currentUser)],
+				[$this->equalTo($user1)],
+				[$this->equalTo($user2)],
+				[$this->equalTo($user3)]
+			)
+			->willReturnOnConsecutiveCalls(
+				['group1', 'group2', 'group3'],
+				['group1'],
+				['group2', 'group3'],
+				['group8', 'group9']
+			);
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(
+				['user1'],
+				['user2'],
+				['user3']
+			)
+			->willReturnOnConsecutiveCalls($user1, $user2, $user3);
 
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -330,44 +324,39 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'yes'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
-			->method('getUserGroupIds')
-			->with($this->equalTo($currentUser))
-			->willReturn(['group1', 'group2', 'group3']);
-
 		$user1 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('user1')
-			->willReturn($user1);
-		$this->groupManager->expects($this->at(1))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user1))
-			->willReturn(['group1']);
 		$user2 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(1))
-			->method('get')
-			->with('user2')
-			->willReturn($user2);
-		$this->groupManager->expects($this->at(2))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user2))
-			->willReturn(['group2', 'group3']);
 		$user3 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(2))
-			->method('get')
-			->with('user3')
-			->willReturn($user3);
-		$this->groupManager->expects($this->at(3))
+
+		$this->groupManager->expects($this->exactly(4))
 			->method('getUserGroupIds')
-			->with($this->equalTo($user3))
-			->willReturn(['group8', 'group9']);
+			->withConsecutive(
+				[$this->equalTo($currentUser)],
+				[$this->equalTo($user1)],
+				[$this->equalTo($user2)],
+				[$this->equalTo($user3)]
+			)
+			->willReturnOnConsecutiveCalls(
+				['group1', 'group2', 'group3'],
+				['group1'],
+				['group2', 'group3'],
+				['group8', 'group9']
+			);
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(
+				['user1'],
+				['user2'],
+				['user3']
+			)
+			->willReturn($user1, $user2, $user3);
 
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -409,13 +398,13 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'no'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
+		$this->groupManager->expects($this->once())
 			->method('getUserGroupIds')
 			->with($this->equalTo($currentUser))
 			->willReturn(['group1', 'group2', 'group3']);
@@ -467,44 +456,39 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'yes'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
-			->method('getUserGroupIds')
-			->with($this->equalTo($currentUser))
-			->willReturn(['group1', 'group2', 'group3']);
-
 		$user1 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('user1')
-			->willReturn($user1);
-		$this->groupManager->expects($this->at(1))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user1))
-			->willReturn(['group1']);
 		$user2 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(1))
-			->method('get')
-			->with('user2')
-			->willReturn($user2);
-		$this->groupManager->expects($this->at(2))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user2))
-			->willReturn(['group2', 'group3']);
 		$user3 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(2))
-			->method('get')
-			->with('user3')
-			->willReturn($user3);
-		$this->groupManager->expects($this->at(3))
+
+		$this->groupManager->expects($this->exactly(4))
 			->method('getUserGroupIds')
-			->with($this->equalTo($user3))
-			->willReturn(['group8', 'group9']);
+			->withConsecutive(
+				[$this->equalTo($currentUser)],
+				[$this->equalTo($user1)],
+				[$this->equalTo($user2)],
+				[$this->equalTo($user3)]
+			)
+			->willReturnOnConsecutiveCalls(
+				['group1', 'group2', 'group3'],
+				['group1'],
+				['group2', 'group3'],
+				['group8', 'group9']
+			);
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(
+				['user1'],
+				['user2'],
+				['user3']
+			)
+			->willReturnOnConsecutiveCalls($user1, $user2, $user3);
 
 		$this->knownUserService->method('isKnownToUser')
 			->willReturnMap([
@@ -553,26 +537,29 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'no'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
-			->method('getUserGroupIds')
-			->with($this->equalTo($currentUser))
-			->willReturn(['group1', 'group2', 'group3']);
-
 		$user1 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
+
+		$this->groupManager->expects($this->exactly(2))
+			->method('getUserGroupIds')
+			->withConsecutive(
+				[$this->equalTo($currentUser)],
+				[$this->equalTo($user1)]
+			)
+			->willReturnOnConsecutiveCalls(
+				['group1', 'group2', 'group3'],
+				['group1']
+			);
+
+		$this->userManager->expects($this->once())
 			->method('get')
 			->with('user1')
 			->willReturn($user1);
-		$this->groupManager->expects($this->at(1))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user1))
-			->willReturn(['group1']);
 
 		$this->knownUserService->method('isKnownToUser')
 			->willReturnMap([
@@ -622,44 +609,39 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_only_share_with_group_members', 'no', 'yes'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $currentUser */
+		/** @var IUser|MockObject $currentUser */
 		$currentUser = $this->createMock(IUser::class);
 		$currentUser->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('user001');
 
-		$this->groupManager->expects($this->at(0))
-			->method('getUserGroupIds')
-			->with($this->equalTo($currentUser))
-			->willReturn(['group1', 'group2', 'group3']);
-
 		$user1 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(0))
-			->method('get')
-			->with('user1')
-			->willReturn($user1);
-		$this->groupManager->expects($this->at(1))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user1))
-			->willReturn(['group1']);
 		$user2 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(1))
-			->method('get')
-			->with('user2')
-			->willReturn($user2);
-		$this->groupManager->expects($this->at(2))
-			->method('getUserGroupIds')
-			->with($this->equalTo($user2))
-			->willReturn(['group2', 'group3']);
 		$user3 = $this->createMock(IUser::class);
-		$this->userManager->expects($this->at(2))
-			->method('get')
-			->with('user3')
-			->willReturn($user3);
-		$this->groupManager->expects($this->at(3))
+
+		$this->groupManager->expects($this->exactly(4))
 			->method('getUserGroupIds')
-			->with($this->equalTo($user3))
-			->willReturn(['group8', 'group9']);
+			->withConsecutive(
+				[$this->equalTo($currentUser)],
+				[$this->equalTo($user1)],
+				[$this->equalTo($user2)],
+				[$this->equalTo($user3)]
+			)
+			->willReturnOnConsecutiveCalls(
+				['group1', 'group2', 'group3'],
+				['group1'],
+				['group2', 'group3'],
+				['group8', 'group9']
+			);
+
+		$this->userManager->expects($this->exactly(3))
+			->method('get')
+			->withConsecutive(
+				['user1'],
+				['user2'],
+				['user3']
+			)
+			->willReturnOnConsecutiveCalls($user1, $user2, $user3);
 
 		$this->knownUserService->method('isKnownToUser')
 			->willReturnMap([
@@ -705,7 +687,7 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_restrict_user_enumeration_full_match', 'yes', 'yes'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->any())
 			->method('search')
@@ -792,7 +774,7 @@ class ContactsStoreTest extends TestCase {
 				['core', 'shareapi_restrict_user_enumeration_full_match', 'yes', 'no'],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->any())
 			->method('search')
@@ -869,11 +851,18 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testFindOneUser() {
-		$this->config->expects($this->at(0))->method('getAppValue')
-			->with($this->equalTo('core'), $this->equalTo('shareapi_allow_share_dialog_user_enumeration'), $this->equalTo('yes'))
-			->willReturn('yes');
+		$this->config
+			->method('getAppValue')
+			->willReturnMap([
+				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
+				['core', 'shareapi_restrict_user_enumeration_to_group', 'no', 'no'],
+				['core', 'shareapi_restrict_user_enumeration_to_phone', 'no', 'no'],
+				['core', 'shareapi_restrict_user_enumeration_full_match', 'yes', 'yes'],
+				['core', 'shareapi_exclude_groups', 'no', 'yes'],
+				['core', 'shareapi_only_share_with_group_members', 'no', 'no'],
+			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -904,7 +893,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testFindOneEMail() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')
@@ -935,7 +924,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testFindOneNotSupportedType() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 
 		$entry = $this->contactsStore->findOne($user, 42, 'darren@roner.au');
@@ -944,7 +933,7 @@ class ContactsStoreTest extends TestCase {
 	}
 
 	public function testFindOneNoMatches() {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$this->contactsManager->expects($this->once())
 			->method('search')

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -29,9 +29,7 @@ use OC\Contacts\ContactsMenu\Entry;
 use Test\TestCase;
 
 class EntryTest extends TestCase {
-
-	/** @var Entry */
-	private $entry;
+	private Entry $entry;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Contacts/ContactsMenu/ManagerTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ManagerTest.php
@@ -33,24 +33,24 @@ use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IConfig;
 use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
 
-	/** @var ContactsStore|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ContactsStore|MockObject */
 	private $contactsStore;
 
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IAppManager|MockObject */
 	private $appManager;
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var ActionProviderStore|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ActionProviderStore|MockObject */
 	private $actionProviderStore;
 
-	/** @var Manager */
-	private $manager;
+	private Manager $manager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -63,7 +63,7 @@ class ManagerTest extends TestCase {
 		$this->manager = new Manager($this->contactsStore, $this->actionProviderStore, $this->appManager, $this->config);
 	}
 
-	private function generateTestEntries() {
+	private function generateTestEntries(): array {
 		$entries = [];
 		foreach (range('Z', 'A') as $char) {
 			$entry = $this->createMock(IEntry::class);
@@ -81,14 +81,13 @@ class ManagerTest extends TestCase {
 		$entries = $this->generateTestEntries();
 		$provider = $this->createMock(IProvider::class);
 
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValueInt')
-			->with('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT)
-			->willReturn(25);
-		$this->config->expects($this->at(1))
-			->method('getSystemValueInt')
-			->with('sharing.minSearchStringLength', 0)
-			->willReturn(0);
+			->withConsecutive(
+				['sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT],
+				['sharing.minSearchStringLength', 0]
+			)
+			->willReturnOnConsecutiveCalls(25, 0);
 		$this->contactsStore->expects($this->once())
 			->method('getContacts')
 			->with($user, $filter)
@@ -119,14 +118,13 @@ class ManagerTest extends TestCase {
 		$entries = $this->generateTestEntries();
 		$provider = $this->createMock(IProvider::class);
 
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValueInt')
-			->with('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT)
-			->willReturn(3);
-		$this->config->expects($this->at(1))
-			->method('getSystemValueInt')
-			->with('sharing.minSearchStringLength', 0)
-			->willReturn(0);
+			->withConsecutive(
+				['sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT],
+				['sharing.minSearchStringLength', 0]
+			)
+			->willReturnOnConsecutiveCalls(3, 0);
 		$this->contactsStore->expects($this->once())
 			->method('getContacts')
 			->with($user, $filter)
@@ -156,14 +154,13 @@ class ManagerTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$provider = $this->createMock(IProvider::class);
 
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValueInt')
-			->with('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT)
-			->willReturn(3);
-		$this->config->expects($this->at(1))
-			->method('getSystemValueInt')
-			->with('sharing.minSearchStringLength', 0)
-			->willReturn(4);
+			->withConsecutive(
+				['sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT],
+				['sharing.minSearchStringLength', 0]
+			)
+			->willReturnOnConsecutiveCalls(3, 4);
 		$this->appManager->expects($this->once())
 			->method('isEnabledForUser')
 			->with($this->equalTo('contacts'), $user)

--- a/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Providers/EMailproviderTest.php
@@ -29,18 +29,18 @@ use OCP\Contacts\ContactsMenu\IActionFactory;
 use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\Contacts\ContactsMenu\ILinkAction;
 use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class EMailproviderTest extends TestCase {
 
-	/** @var IActionFactory|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IActionFactory|MockObject */
 	private $actionFactory;
 
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 
-	/** @var EMailProvider */
-	private $provider;
+	private EMailProvider $provider;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -80,7 +80,6 @@ class EMailproviderTest extends TestCase {
 
 	public function testProcessEmptyAddress() {
 		$entry = $this->createMock(IEntry::class);
-		$action = $this->createMock(ILinkAction::class);
 		$iconUrl = 'https://example.com/img/actions/icon.svg';
 		$this->urlGenerator->expects($this->once())
 			->method('imagePath')


### PR DESCRIPTION
The only signature changes due to added types in OCP shouldn't break anything as all apps that I could find only use the `IActionFactory` methods which are already typed.