### PR TITLE
keyboard focus on login input fields

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -241,6 +241,8 @@ input, textarea, select, button, div[contenteditable=true] {
 }
 input,
 input:not([type='range']),
+input:not([type='text']),
+input:not([type='password']),
 a.button {
 	font-size: 20px;
 	margin: 5px;
@@ -285,6 +287,10 @@ input[type='email'] {
 	box-sizing: content-box;
 	border: none;
 	font-weight: normal;
+}
+input[type='text']:focus-visible,
+input[type='password']:focus-visible {
+	outline: var(--color-primary) auto 2px;
 }
 input[type='password'].password-with-toggle, input[type='text'].password-with-toggle {
 	width: 219px;


### PR DESCRIPTION
Better indication of keyboard focus like a clear border (https://github.com/nextcloud-gmbh/server/issues/232)
**Before**

<img width="280" alt="Screenshot 2022-05-10 at 16 33 56" src="https://user-images.githubusercontent.com/38529028/167654071-e80f05bf-525d-4838-b443-da34acfd8e19.png">|<img width="258" alt="Screenshot 2022-05-10 at 16 32 29" src="https://user-images.githubusercontent.com/38529028/167653766-e1ed28e9-a97b-4a82-97bc-7b228c6e1b3d.png">


**After**
<img width="281" alt="Screenshot 2022-05-10 at 16 24 10" src="https://user-images.githubusercontent.com/38529028/167652349-42a25aec-748b-4074-939b-17501c78178f.png">|<img width="270" alt="Screenshot 2022-05-10 at 16 24 20" src="https://user-images.githubusercontent.com/38529028/167652293-4ea1fe01-9c13-403a-884e-e6c0265b009e.png">



Signed-off-by: Vanessa Pertsch <vanessa.pertsch@nextcloud.com>