### PR TITLE
Use getLengthExpression to measure field length instead of like

### DIFF
--- a/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
+++ b/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
@@ -127,10 +127,9 @@ class Version1120Date20210917155206 extends SimpleMigrationStep {
 
 	protected function getSelectQuery(string $table): IQueryBuilder {
 		$qb = $this->dbc->getQueryBuilder();
-		$lengthExpr = $this->dbc->getDatabasePlatform()->getLengthExpression('owncloud_name');
 		$qb->select('owncloud_name', 'directory_uuid')
 			->from($table)
-			->where($qb->expr()->gt($qb->createFunction($lengthExpr), '64', IQueryBuilder::PARAM_INT));
+			->where($qb->expr()->gt($qb->func()->octetLength('owncloud_name'), '64', IQueryBuilder::PARAM_INT));
 		return $qb;
 	}
 

--- a/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
+++ b/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
@@ -127,9 +127,10 @@ class Version1120Date20210917155206 extends SimpleMigrationStep {
 
 	protected function getSelectQuery(string $table): IQueryBuilder {
 		$qb = $this->dbc->getQueryBuilder();
+		$lengthExpr = $this->dbc->getDatabasePlatform()->getLengthExpression('owncloud_name');
 		$qb->select('owncloud_name', 'directory_uuid')
 			->from($table)
-			->where($qb->expr()->like('owncloud_name', $qb->createNamedParameter(str_repeat('_', 65) . '%'), Types::STRING));
+			->where($qb->expr()->gt($qb->createFunction($lengthExpr), '64', IQueryBuilder::PARAM_INT));
 		return $qb;
 	}
 

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -94,6 +94,18 @@ class FunctionBuilder implements IFunctionBuilder {
 		return new QueryFunction('COUNT(' . $quotedName . ')' . $alias);
 	}
 
+	public function octetLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTHB(' . $quotedName . ')' . $alias);
+	}
+
+	public function charLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTH(' . $quotedName . ')' . $alias);
+	}
+
 	public function max($field): IQueryFunction {
 		return new QueryFunction('MAX(' . $this->helper->quoteColumnName($field) . ')');
 	}

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -103,7 +103,7 @@ class FunctionBuilder implements IFunctionBuilder {
 	public function charLength($field, $alias = ''): IQueryFunction {
 		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
 		$quotedName = $this->helper->quoteColumnName($field);
-		return new QueryFunction('LENGTH(' . $quotedName . ')' . $alias);
+		return new QueryFunction('CHAR_LENGTH(' . $quotedName . ')' . $alias);
 	}
 
 	public function max($field): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -97,7 +97,7 @@ class FunctionBuilder implements IFunctionBuilder {
 	public function octetLength($field, $alias = ''): IQueryFunction {
 		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
 		$quotedName = $this->helper->quoteColumnName($field);
-		return new QueryFunction('LENGTHB(' . $quotedName . ')' . $alias);
+		return new QueryFunction('OCTET_LENGTH(' . $quotedName . ')' . $alias);
 	}
 
 	public function charLength($field, $alias = ''): IQueryFunction {

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -91,4 +91,10 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		$separator = $this->connection->quote($separator);
 		return new QueryFunction('LISTAGG(' . $this->helper->quoteColumnName($expr) . ', ' . $separator . ')' . $orderByClause);
 	}
+
+	public function octetLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTHB(' . $quotedName . ')' . $alias);
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -97,4 +97,10 @@ class OCIFunctionBuilder extends FunctionBuilder {
 		$quotedName = $this->helper->quoteColumnName($field);
 		return new QueryFunction('LENGTHB(' . $quotedName . ')' . $alias);
 	}
+
+	public function charLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTH(' . $quotedName . ')' . $alias);
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -54,4 +54,10 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 		$quotedName = $this->helper->quoteColumnName($field);
 		return new QueryFunction('LENGTH(CAST(' . $quotedName . ' as BLOB))' . $alias);
 	}
+
+	public function charLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTH(' . $quotedName . ')' . $alias);
+	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/SqliteFunctionBuilder.php
@@ -48,4 +48,10 @@ class SqliteFunctionBuilder extends FunctionBuilder {
 	public function least($x, $y): IQueryFunction {
 		return new QueryFunction('MIN(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
+
+	public function octetLength($field, $alias = ''): IQueryFunction {
+		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
+		$quotedName = $this->helper->quoteColumnName($field);
+		return new QueryFunction('LENGTH(CAST(' . $quotedName . ' as BLOB))' . $alias);
+	}
 }

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -124,6 +124,24 @@ interface IFunctionBuilder {
 	public function count($count = '', $alias = ''): IQueryFunction;
 
 	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $field The input to be measured
+	 * @param string $alias Alias for the length
+	 *
+	 * @return IQueryFunction
+	 * @since 24.0.0
+	 */
+	public function octetLength($field, $alias = ''): IQueryFunction;
+
+	/**
+	 * @param string|ILiteral|IParameter|IQueryFunction $field The input to be measured
+	 * @param string $alias Alias for the length
+	 *
+	 * @return IQueryFunction
+	 * @since 24.0.0
+	 */
+	public function charLength($field, $alias = ''): IQueryFunction;
+
+	/**
 	 * Takes the maximum of all rows in a column
 	 *
 	 * If you want to get the maximum value of multiple columns in the same row, use `greatest` instead

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -336,6 +336,52 @@ class FunctionBuilderTest extends TestCase {
 		$this->assertGreaterThan(1, $column);
 	}
 
+	public function octetLengthProvider() {
+		return [
+			['', 0],
+			['foobar', 6],
+			['fé', 3],
+			['šđčćž', 10],
+		];
+	}
+
+	/**
+	 * @dataProvider octetLengthProvider
+	 */
+	public function testOctetLength(string $str, int $bytes) {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->octetLength($query->createNamedParameter($str, IQueryBuilder::PARAM_STR)));
+
+		$result = $query->execute();
+		$column = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertEquals($bytes, $column);
+	}
+
+	public function charLengthProvider() {
+		return [
+			['', 0],
+			['foobar', 6],
+			['fé', 2],
+			['šđčćž', 5],
+		];
+	}
+
+	/**
+	 * @dataProvider charLengthProvider
+	 */
+	public function testCharLength(string $str, int $bytes) {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->charLength($query->createNamedParameter($str, IQueryBuilder::PARAM_STR)));
+
+		$result = $query->execute();
+		$column = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertEquals($bytes, $column);
+	}
+
 	private function setUpMinMax($value) {
 		$query = $this->connection->getQueryBuilder();
 

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -352,6 +352,8 @@ class FunctionBuilderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 
 		$query->select($query->func()->octetLength($query->createNamedParameter($str, IQueryBuilder::PARAM_STR)));
+		$query->from('appconfig')
+			->setMaxResults(1);
 
 		$result = $query->execute();
 		$column = $result->fetchOne();
@@ -375,6 +377,8 @@ class FunctionBuilderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 
 		$query->select($query->func()->charLength($query->createNamedParameter($str, IQueryBuilder::PARAM_STR)));
+		$query->from('appconfig')
+			->setMaxResults(1);
 
 		$result = $query->execute();
 		$column = $result->fetchOne();


### PR DESCRIPTION
The use of the LIKE with _ does not work on oracle as it measure length in chars instead of bytes.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>