### PR TITLE
Add OCS-APIRequest to list of allowed CORS headers

### DIFF
--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -61,7 +61,7 @@ abstract class OCSController extends ApiController {
 	public function __construct($appName,
 								IRequest $request,
 								$corsMethods = 'PUT, POST, GET, DELETE, PATCH',
-								$corsAllowedHeaders = 'Authorization, Content-Type, Accept',
+								$corsAllowedHeaders = 'Authorization, Content-Type, Accept, OCS-APIRequest',
 								$corsMaxAge = 1728000) {
 		parent::__construct($appName, $request, $corsMethods,
 							$corsAllowedHeaders, $corsMaxAge);


### PR DESCRIPTION
Adding the `OCS-APIRequest` header to the list of allowed headers

This makes the OCS API usable by external web apps via XMLHttpRequest:
Otherwise the access to the resource is either blocked by the OCS API (missing `OCS-APIRequest: true` header) or by the browser (`OCS-APIRequest: true` header not allowed by CORS).

See Feature Request #31694 