### PR TITLE
invalidate mount cache after accepting or renaming federated share

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -374,6 +374,7 @@ class Manager {
 				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
 				$event = new FederatedShareAddedEvent($share['remote']);
 				$this->eventDispatcher->dispatchTyped($event);
+				$this->eventDispatcher->dispatchTyped(new Files\Events\InvalidateMountCacheEvent($this->userManager->get($this->uid)));
 				$result = true;
 			}
 		}
@@ -595,6 +596,8 @@ class Manager {
 			AND `user` = ?
 		');
 		$result = (bool)$query->execute([$target, $targetHash, $sourceHash, $this->uid]);
+
+		$this->eventDispatcher->dispatchTyped(new Files\Events\InvalidateMountCacheEvent($this->userManager->get($this->uid)));
 
 		return $result;
 	}


### PR DESCRIPTION
Ensures that new federated shares show up directly

This only really impacts the first federated share a user receives, so testing should be done with an account that doesn't already have incoming federated shares