### PR TITLE
dont re-query fileinfo when getting dav quota

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -327,8 +327,7 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 			return $this->quotaInfo;
 		}
 		try {
-			$info = $this->fileView->getFileInfo($this->path, false);
-			$storageInfo = \OC_Helper::getStorageInfo($this->info->getPath(), $info);
+			$storageInfo = \OC_Helper::getStorageInfo($this->info->getPath(), $this->info, false);
 			if ($storageInfo['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				$free = \OCP\Files\FileInfo::SPACE_UNLIMITED;
 			} else {

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -299,10 +299,6 @@ class DirectoryTest extends \Test\TestCase {
 			->method('getMountPoint')
 			->willReturn($mountPoint);
 
-		$this->view->expects($this->once())
-			->method('getFileInfo')
-			->willReturn($this->info);
-
 		$mountPoint->method('getMountPoint')
 			->willReturn('/user/files/mymountpoint');
 
@@ -343,10 +339,6 @@ class DirectoryTest extends \Test\TestCase {
 
 		$mountPoint->method('getMountPoint')
 			->willReturn('/user/files/mymountpoint');
-
-		$this->view->expects($this->once())
-			->method('getFileInfo')
-			->willReturn($this->info);
 
 		$dir = new Directory($this->view, $this->info);
 		$this->assertEquals([200, 800], $dir->getQuotaInfo()); //200 used, 800 free

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -485,7 +485,7 @@ class OC_Helper {
 	 * @return array
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	public static function getStorageInfo($path, $rootInfo = null) {
+	public static function getStorageInfo($path, $rootInfo = null, $includeMountPoints = true) {
 		// return storage info without adding mount points
 		$includeExtStorage = \OC::$server->getSystemConfig()->getValue('quota_include_external_storage', false);
 
@@ -495,7 +495,7 @@ class OC_Helper {
 		if (!$rootInfo instanceof \OCP\Files\FileInfo) {
 			throw new \OCP\Files\NotFoundException();
 		}
-		$used = $rootInfo->getSize();
+		$used = $rootInfo->getSize($includeMountPoints);
 		if ($used < 0) {
 			$used = 0;
 		}


### PR DESCRIPTION
Instead of re-querying the fileinfo to get the raw size without sub mounts, use the raw size that is already in the fileinfo

Saves a query per folder when doing `PROPFIND `

See https://github.com/nextcloud/server/pull/19436