### PR TITLE
Inject theming css if theming app is available and loaded

### DIFF
--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -38,6 +38,7 @@
  *
  */
 use OC\TemplateLayout;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Util;
 
@@ -283,10 +284,25 @@ class OC_Template extends \OC\Template\Base {
 	 * @suppress PhanAccessMethodInternal
 	 */
 	public static function printErrorPage($error_msg, $hint = '', $statusCode = 500) {
-		if (\OC::$server->getAppManager()->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
-			\OC_App::loadApp('theming');
-		}
+		if (\OC::$server->getAppManager()->isEnabledForUser('theming')) {
+			if (!\OC_App::isAppLoaded('theming')) {
+				\OC_App::loadApp('theming');
+			}
 
+			$linkToCSS = \OC::$server->getURLGenerator()->linkToRoute(
+				'theming.Theming.getStylesheet',
+				[
+					'v' =>1,
+				]
+			);
+			\OCP\Util::addHeader(
+				'link',
+				[
+					'rel' => 'stylesheet',
+					'href' => $linkToCSS,
+				]
+			);
+		}
 
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.


### PR DESCRIPTION
We made sure to load the theming app with https://github.com/nextcloud/server/pull/4719
But the logic behind https://github.com/nextcloud/server/blob/dd7bf0f902570d4561c07237ea9072f4fc1d3edc/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php#L64-L78 is not implemented.

The code is not acceptable of course, so it's only here for POC.

@juliushaertl, I was thinking we could have a dedicated CssInject service or method somewhere in theming for that purpose only? Firing a `BeforeTemplateRendered` event works of course, but I am afraid other apps might pick it up as well and create further issues.

Mayve split the js/css logic of the Theming app in two Listeners?


cc @vanpertsch @nickvergessen 