### PR TITLE
cache storage id mapping both ways

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -126,19 +126,9 @@ class Storage {
 	 * @param int $numericId
 	 * @return string|null either the storage id string or null if the numeric id is not known
 	 */
-	public static function getStorageId($numericId) {
-		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$query->select('id')
-			->from('storages')
-			->where($query->expr()->eq('numeric_id', $query->createNamedParameter($numericId)));
-		$result = $query->execute();
-		$row = $result->fetch();
-		$result->closeCursor();
-		if ($row) {
-			return $row['id'];
-		} else {
-			return null;
-		}
+	public static function getStorageId(int $numericId): ?string {
+		$storage = self::getGlobalCache()->getStorageInfoByNumericId($numericId);
+		return $storage['id'] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
No need to query the numeric id by storage id  if we've just queried it the other way around.