### PR TITLE
Fix assignment of the LDAP Wizard connection

### DIFF
--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -1331,7 +1331,7 @@ class Wizard extends LDAPUtility {
 								 $this->configuration->ldapAgentName,
 								 $this->configuration->ldapAgentPassword);
 		if ($lo === true) {
-			$this->$cr = $cr;
+			$this->cr = $cr;
 			return $cr;
 		}
 


### PR DESCRIPTION
PHP<8.1 allowed this and serialized the connection object into a string. That means the connection wasn't actually remembered, `$this->cr` would still be null after the assignment of `$this->$cr`.