### PR TITLE
RFC: Cache locally the filecache information

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -111,6 +111,7 @@ class Propagator implements IPropagator {
 
 			$builder->execute();
 		}
+		$this->storage->getCache()->clearInternalCache();
 	}
 
 	protected function getParents($path) {
@@ -195,5 +196,6 @@ class Propagator implements IPropagator {
 		$this->batch = [];
 
 		$this->connection->commit();
+		$this->storage->getCache()->clearInternalCache();
 	}
 }

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -31,6 +31,7 @@ namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\QuerySearchHelper;
+use OC\Cache\CappedMemoryCache;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchOperator;
@@ -50,6 +51,7 @@ class CacheWrapper extends Cache {
 		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->querySearchHelper = \OC::$server->get(QuerySearchHelper::class);
+		$this->internalCache = new CappedMemoryCache();
 	}
 
 	protected function getCache() {

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -217,7 +217,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertFalse($cachedData['encrypted']);
 		$id = $rootView->putFileInfo('/foo.txt', ['encrypted' => true]);
 		$cachedData = $rootView->getFileInfo('/foo.txt');
-		$this->assertTrue($cachedData['encrypted']);
+		$this->assertTrue((bool)$cachedData['encrypted']);
 		$this->assertEquals($cachedData['fileid'], $id);
 
 		$this->assertFalse($rootView->getFileInfo('/non/existing'));


### PR DESCRIPTION
This on one side might improve the performance by doing less requests to
the database but more importantly this decrease the likeliness of read
after write errors in a cluster setup since we don't requests the data
from the database that just got updated

Currently this only cache get/put/insert/update and for
copy/move/propagator this clear the cache.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>