### PR TITLE
Accept CSRF on CORS routes

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -87,6 +87,10 @@ class CORSMiddleware extends Middleware {
 			$user = array_key_exists('PHP_AUTH_USER', $this->request->server) ? $this->request->server['PHP_AUTH_USER'] : null;
 			$pass = array_key_exists('PHP_AUTH_PW', $this->request->server) ? $this->request->server['PHP_AUTH_PW'] : null;
 
+			// Allow to use the current session if a CSRF token is provided
+			if ($this->request->passesCSRFCheck()) {
+				return;
+			}
 			$this->session->logout();
 			try {
 				if ($user === null || $pass === null || !$this->session->logClientIn($user, $pass, $this->request, $this->throttler)) {

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -61,7 +61,7 @@ abstract class OCSController extends ApiController {
 	public function __construct($appName,
 								IRequest $request,
 								$corsMethods = 'PUT, POST, GET, DELETE, PATCH',
-								$corsAllowedHeaders = 'Authorization, Content-Type, Accept',
+								$corsAllowedHeaders = 'Authorization, Content-Type, Accept, OCS-APIRequest',
 								$corsMaxAge = 1728000) {
 		parent::__construct($appName, $request, $corsMethods,
 							$corsAllowedHeaders, $corsMaxAge);


### PR DESCRIPTION
On Forms we got the request to allow CORS on our (OCS-)API routes. However, if i add the CORS Annotation to the OCS-Controller Methods, our internal calls to the API (with CSRF) do not work anymore.

This PR now enables to allow both, CSRF and the classical CORS requests on the OCS-routes.

Basically, this PR includes #31698 and takes a part out of #19354, since both is necessary to make it work. The latter imo initially had a similar intention like the current PR, but has been closed due to the discussion on another topic. 😉