### PR TITLE
Deduplicate storage ids in list before reusing

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -240,6 +240,7 @@ class Storage {
 				->from('mounts')
 				->where($query->expr()->eq('mount_id', $query->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
 			$storageIds = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+			$storageIds = array_unique($storageIds);
 
 			$query = $db->getQueryBuilder();
 			$query->delete('filecache')


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>