### PR TITLE
Log why the login token can't be used for credentials

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -98,12 +98,12 @@ class Store implements IStore {
 
 			return new Credentials($uid, $user, $password);
 		} catch (SessionNotAvailableException $ex) {
-			$this->logger->debug('could not get login credentials because session is unavailable', ['app' => 'core']);
+			$this->logger->debug('could not get login credentials because session is unavailable', ['app' => 'core', 'exception' => $ex]);
 		} catch (InvalidTokenException $ex) {
-			$this->logger->debug('could not get login credentials because the token is invalid', ['app' => 'core']);
+			$this->logger->debug('could not get login credentials because the token is invalid: ' . $ex->getMessage(), ['app' => 'core', 'exception' => $ex]);
 			$trySession = true;
 		} catch (PasswordlessTokenException $ex) {
-			$this->logger->debug('could not get login credentials because the token has no password', ['app' => 'core']);
+			$this->logger->debug('could not get login credentials because the token has no password', ['app' => 'core', 'exception' => $ex]);
 			$trySession = true;
 		}
 


### PR DESCRIPTION
And always pass the exception object to the logger.

``\OC\Authentication\Exceptions\InvalidTokenException`` is thrown for different reasons. This makes debugging very hard if you don't see the actual exception's message or trace.