### PR TITLE
Fix imaginary with rotated exif images

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -89,18 +89,26 @@ class Imaginary extends ProviderV2 {
 				$mimeType = 'jpeg';
 		}
 
-		$parameters = [
-			'width' => $maxX,
-			'height' => $maxY,
-			'stripmeta' => 'true',
-			'type' => $mimeType,
+		$operations = [
+			[
+				'operation' => 'autorotate',
+			],
+			[
+				'operation' => ($crop ? 'smartcrop' : 'fit'),
+				'params' => [
+					'width' => $maxX,
+					'height' => $maxY,
+					'stripmeta' => 'true',
+					'type' => $mimeType,
+					'norotation' => 'true',
+				]
+			]
 		];
-
 
 		try {
 			$response = $httpClient->post(
-				$imaginaryUrl . ($crop ? '/smartcrop' : '/fit'), [
-					'query' => $parameters,
+				$imaginaryUrl . '/pipeline', [
+					'query' => ['operations' => json_encode($operations)],
 					'stream' => true,
 					'content-type' => $file->getMimeType(),
 					'body' => $stream,


### PR DESCRIPTION
Now do the operation in two steps:

1. Rotate the image according the exif data
2. Do the actual operation

This should only have a performance impact on image with exif rotation
data to do the rotation. For all the other images the autorotate steps
should be almost instant.
