### PR TITLE
fix filelist not loading after refresh in firefox

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -791,7 +791,7 @@
 			if (e && _.isString(e.dir)) {
 				var currentDir = this.getCurrentDirectory();
 				// this._currentDirectory is NULL when fileList is first initialised
-				if( (this._currentDirectory || this.$el.find('#dir').val()) && currentDir === e.dir) {
+				if(this._currentDirectory && currentDir === e.dir) {
 					return;
 				}
 				this.changeDirectory(e.dir, true, true, undefined, true);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -3442,6 +3442,7 @@ describe('OCA.Files.FileList tests', function() {
 
 		beforeEach(function() {
 			fileListStub = sinon.stub(OCA.Files.FileList.prototype, 'changeDirectory');
+			fileList._currentDirectory = '/subdir';
 		});
 		afterEach(function() {
 			fileListStub.restore();


### PR DESCRIPTION
For some reason I can't find `$('#dir').val()` gets set to `/` before this check when reloading the page in firefox, causing the file list not to be loaded