### PR TITLE
only setup home mount when getting home folder

### DIFF
--- a/apps/files/lib/Controller/AjaxController.php
+++ b/apps/files/lib/Controller/AjaxController.php
@@ -40,7 +40,6 @@ class AjaxController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public function getStorageStats(string $dir = '/'): JSONResponse {
-		\OC_Util::setupFS();
 		try {
 			return new JSONResponse([
 				'status' => 'success',

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -367,6 +367,12 @@ class SetupManager {
 			return;
 		}
 
+		// for the user's home folder, it's always the home mount
+		if (rtrim($path) === "/" . $user->getUID() . "/files" && !$includeChildren) {
+			$this->oneTimeUserSetup($user);
+			return;
+		}
+
 		if (!isset($this->setupUserMountProviders[$user->getUID()])) {
 			$this->setupUserMountProviders[$user->getUID()] = [];
 		}


### PR DESCRIPTION
The mount provider for `/<uid>/files` is always known

Also removes an unneeded force-setup

Saves some more queries