### PR TITLE
Don't inject Bruteforce capability info in the webui

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -133,6 +133,7 @@ return array(
     'OCP\\Calendar\\Room\\IRoom' => $baseDir . '/lib/public/Calendar/Room/IRoom.php',
     'OCP\\Calendar\\Room\\IRoomMetadata' => $baseDir . '/lib/public/Calendar/Room/IRoomMetadata.php',
     'OCP\\Capabilities\\ICapability' => $baseDir . '/lib/public/Capabilities/ICapability.php',
+    'OCP\\Capabilities\\IInitialStateExcludedCapability' => $baseDir . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
     'OCP\\Capabilities\\IPublicCapability' => $baseDir . '/lib/public/Capabilities/IPublicCapability.php',
     'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => $baseDir . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',
     'OCP\\Collaboration\\AutoComplete\\IManager' => $baseDir . '/lib/public/Collaboration/AutoComplete/IManager.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -162,6 +162,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Calendar\\Room\\IRoom' => __DIR__ . '/../../..' . '/lib/public/Calendar/Room/IRoom.php',
         'OCP\\Calendar\\Room\\IRoomMetadata' => __DIR__ . '/../../..' . '/lib/public/Calendar/Room/IRoomMetadata.php',
         'OCP\\Capabilities\\ICapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/ICapability.php',
+        'OCP\\Capabilities\\IInitialStateExcludedCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
         'OCP\\Capabilities\\IPublicCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IPublicCapability.php',
         'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',
         'OCP\\Collaboration\\AutoComplete\\IManager' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/IManager.php',

--- a/lib/private/CapabilitiesManager.php
+++ b/lib/private/CapabilitiesManager.php
@@ -31,6 +31,7 @@ namespace OC;
 use OCP\AppFramework\QueryException;
 use OCP\Capabilities\ICapability;
 use OCP\Capabilities\IPublicCapability;
+use OCP\Capabilities\IInitialStateExcludedCapability;
 use Psr\Log\LoggerInterface;
 
 class CapabilitiesManager {
@@ -52,7 +53,7 @@ class CapabilitiesManager {
 	 * @throws \InvalidArgumentException
 	 * @return array
 	 */
-	public function getCapabilities(bool $public = false) : array {
+	public function getCapabilities(bool $public = false, bool $initialState = false) : array {
 		$capabilities = [];
 		foreach ($this->capabilities as $capability) {
 			try {
@@ -66,6 +67,11 @@ class CapabilitiesManager {
 
 			if ($c instanceof ICapability) {
 				if (!$public || $c instanceof IPublicCapability) {
+					if ($initialState && ($c instanceof IInitialStateExcludedCapability)) {
+						// Remove less important capabilities information that are expensive to query
+						// that we would otherwise inject to every page load
+						continue;
+					}
 					$capabilities = array_replace_recursive($capabilities, $c->getCapabilities());
 				}
 			} else {

--- a/lib/private/Security/Bruteforce/Capabilities.php
+++ b/lib/private/Security/Bruteforce/Capabilities.php
@@ -28,9 +28,10 @@ declare(strict_types=1);
 namespace OC\Security\Bruteforce;
 
 use OCP\Capabilities\IPublicCapability;
+use OCP\Capabilities\IInitialStateExcludedCapability;
 use OCP\IRequest;
 
-class Capabilities implements IPublicCapability {
+class Capabilities implements IPublicCapability, IInitialStateExcludedCapability {
 	/** @var IRequest */
 	private $request;
 

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -187,7 +187,7 @@ class JSConfigHelper {
 			$lastConfirmTimestamp = 0;
 		}
 
-		$capabilities = $this->capabilitiesManager->getCapabilities();
+		$capabilities = $this->capabilitiesManager->getCapabilities(false, true);
 
 		$config = [
 			'session_lifetime' => min($this->config->getSystemValue('session_lifetime', $this->iniWrapper->getNumeric('session.gc_maxlifetime')), $this->iniWrapper->getNumeric('session.gc_maxlifetime')),

--- a/lib/public/Capabilities/IInitialStateExcludedCapability.php
+++ b/lib/public/Capabilities/IInitialStateExcludedCapability.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\Capabilities;
+
+/**
+ * Indicate that a capability should not be injected in the initial state
+ * of the page as it might be expensive to query and not useful for the
+ * webui.
+ *
+ * @since 24.0.0
+ */
+interface IInitialStateExcludedCapability {
+}


### PR DESCRIPTION
This capability do DB access and as far I know is not used by the webui.
This removes one DB query for each page load.