### PR TITLE
Fix: Birthday calendar issue with shared calendars

### DIFF
--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -184,7 +184,7 @@ class Backend {
 				'status' => 1,
 				'readOnly' => (int) $row['access'] === self::ACCESS_READ,
 				'{http://owncloud.org/ns}principal' => (string)$row['principaluri'],
-				'{http://owncloud.org/ns}group-share' => is_null($p)
+				'{http://owncloud.org/ns}group-share' => isset($p['uri']) ? str_starts_with($p['uri'], 'principals/groups') : false
 			];
 		}
 


### PR DESCRIPTION
Fixes [#3914](https://github.com/nextcloud/calendar/issues/3914) in nextcloud/calendar.

My understanding is that `{http://owncloud.org/ns}group-share` is wrongly assigned. It is `false` although an address book is shared with a group.

This leads the BirthdayService to not update birthday calendars of group members. See
https://github.com/nextcloud/server/blob/d2289519a3284f89f264de4d14aed565b66c46d7/apps/dav/lib/CalDAV/BirthdayService.php#L356

I must admit that I don't really understand the rationale of `{http://owncloud.org/ns}group-share`. So please review carefully :)