### PR TITLE
24.0.0 beta 3

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [24, 0, 0, 7];
+$OC_Version = [24, 0, 0, 8];
 
 // The human readable string
-$OC_VersionString = '24.0.0 beta 2';
+$OC_VersionString = '24.0.0 beta 3';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
**This is the last beta before the first release candidate**

* #25747
* #28935
* #29510
* #30438
* #30550
* #30823
* #30939
* #31194
* #31594
* #31661
* #31673
* #31684
* #31687
* #31713
* #31734
* #31750
* #31754
* #31773
* #31776
* #31779
* #31782
* #31796
* #31797
* #31798
* #31799
* #31800
* #31811
* #31816
* #31820
* #31825
* #31827
* #31828
* #31829
* #31832
* #31833
* #31841
* #31843
* #31844
* #31845
* #31847
* #31849
* #31850
* #31852
* #31853
* #31864
* #31872
* #31876
* #31877
* [3rdparty#1013](https://github.com/nextcloud/3rdparty/pull/1013) Bump guzzlehttp/psr7 from 1.8.3 to 1.8.5
* [activity#772](https://github.com/nextcloud/activity/pull/772) Bump @nextcloud/vue from 5.2.1 to 5.3.0
* [activity#774](https://github.com/nextcloud/activity/pull/774) Bump phpunit/phpunit from 9.5.19 to 9.5.20
* [activity#776](https://github.com/nextcloud/activity/pull/776) Update master php testing versions
* [activity#779](https://github.com/nextcloud/activity/pull/779) Fallback to the admin settings if the user did not configure it
* [activity#780](https://github.com/nextcloud/activity/pull/780) Update master php testing versions
* [circles#1005](https://github.com/nextcloud/circles/pull/1005) Update master php testing versions
* [circles#972](https://github.com/nextcloud/circles/pull/972) Cache getSharedWith() result
* [circles#976](https://github.com/nextcloud/circles/pull/976) Bypass/limit permissions
* [circles#986](https://github.com/nextcloud/circles/pull/986) Use master to test oci
* [circles#988](https://github.com/nextcloud/circles/pull/988) Use master for oci tests
* [circles#990](https://github.com/nextcloud/circles/pull/990) Missing $prec
* [circles#991](https://github.com/nextcloud/circles/pull/991) Update population
* [circles#994](https://github.com/nextcloud/circles/pull/994) Update master php testing versions
* [files_pdfviewer#584](https://github.com/nextcloud/files_pdfviewer/pull/584) Bump phpunit/phpunit from 9.5.19 to 9.5.20
* [files_pdfviewer#585](https://github.com/nextcloud/files_pdfviewer/pull/585) Bump minimist from 1.2.5 to 1.2.6
* [files_pdfviewer#586](https://github.com/nextcloud/files_pdfviewer/pull/586) Update master php testing versions
* [files_pdfviewer#588](https://github.com/nextcloud/files_pdfviewer/pull/588) Update master php testing versions
* [files_videoplayer#264](https://github.com/nextcloud/files_videoplayer/pull/264) Updating node.yml workflow from template
* [files_videoplayer#265](https://github.com/nextcloud/files_videoplayer/pull/265) Updating lint-eslint.yml workflow from template
* [files_videoplayer#266](https://github.com/nextcloud/files_videoplayer/pull/266) Updating command-compile.yml workflow from template
* [files_videoplayer#267](https://github.com/nextcloud/files_videoplayer/pull/267) Updating command-rebase.yml workflow from template
* [firstrunwizard#680](https://github.com/nextcloud/firstrunwizard/pull/680) Updating command-compile.yml workflow from template
* [firstrunwizard#681](https://github.com/nextcloud/firstrunwizard/pull/681) Updating command-rebase.yml workflow from template
* [firstrunwizard#682](https://github.com/nextcloud/firstrunwizard/pull/682) Updating lint-eslint.yml workflow from template
* [firstrunwizard#683](https://github.com/nextcloud/firstrunwizard/pull/683) Updating node.yml workflow from template
* [firstrunwizard#687](https://github.com/nextcloud/firstrunwizard/pull/687) Update master php testing versions
* [firstrunwizard#688](https://github.com/nextcloud/firstrunwizard/pull/688) Bump minimist from 1.2.5 to 1.2.6
* [firstrunwizard#690](https://github.com/nextcloud/firstrunwizard/pull/690) Update master php testing versions
* [firstrunwizard#691](https://github.com/nextcloud/firstrunwizard/pull/691) Make the buttons round
* [logreader#690](https://github.com/nextcloud/logreader/pull/690) Update master php testing versions
* [logreader#691](https://github.com/nextcloud/logreader/pull/691) Update master php testing versions
* [nextcloud_announcements#99](https://github.com/nextcloud/nextcloud_announcements/pull/99) Update master php testing versions
* [notifications#1174](https://github.com/nextcloud/notifications/pull/1174) Move to button component
* [notifications#1179](https://github.com/nextcloud/notifications/pull/1179) Update master php testing versions
* [notifications#1182](https://github.com/nextcloud/notifications/pull/1182) Update master php testing versions
* [password_policy#336](https://github.com/nextcloud/password_policy/pull/336) Bump minimist from 1.2.5 to 1.2.6
* [password_policy#340](https://github.com/nextcloud/password_policy/pull/340) Update master php testing versions
* [password_policy#342](https://github.com/nextcloud/password_policy/pull/342) Update master php testing versions
* [photos#1045](https://github.com/nextcloud/photos/pull/1045) Unify preview urls with the files app
* [photos#1069](https://github.com/nextcloud/photos/pull/1069) Bump phpunit/phpunit from 9.5.19 to 9.5.20
* [photos#1071](https://github.com/nextcloud/photos/pull/1071) Bump node-forge from 1.2.1 to 1.3.1
* [photos#1072](https://github.com/nextcloud/photos/pull/1072) Update master php testing versions
* [photos#1073](https://github.com/nextcloud/photos/pull/1073) Fix grammar in readme
* [privacy#754](https://github.com/nextcloud/privacy/pull/754) Bump phpunit/phpunit from 9.5.19 to 9.5.20
* [privacy#755](https://github.com/nextcloud/privacy/pull/755) Update master php testing versions
* [privacy#756](https://github.com/nextcloud/privacy/pull/756) Update master php testing versions
* [recommendations#504](https://github.com/nextcloud/recommendations/pull/504) Bump sass from 1.49.4 to 1.49.10
* [recommendations#505](https://github.com/nextcloud/recommendations/pull/505) Bump babel-loader from 8.2.3 to 8.2.4
* [recommendations#508](https://github.com/nextcloud/recommendations/pull/508) Bump @babel/core from 7.17.5 to 7.17.8
* [recommendations#509](https://github.com/nextcloud/recommendations/pull/509) Update master php testing versions
* [recommendations#510](https://github.com/nextcloud/recommendations/pull/510) Do less DB requests when fetching parent path
* [recommendations#511](https://github.com/nextcloud/recommendations/pull/511) Fix a compatibility issue with php 8.1
* [serverinfo#217](https://github.com/nextcloud/serverinfo/pull/217) Use OS::getMemory for information about memory and swap.
* [serverinfo#271](https://github.com/nextcloud/serverinfo/pull/271) FreeBSD Gateway IP fix and add ipv6
* [serverinfo#329](https://github.com/nextcloud/serverinfo/pull/329) List php extensions
* [serverinfo#365](https://github.com/nextcloud/serverinfo/pull/365) Add psalm ci
* [text#2244](https://github.com/nextcloud/text/pull/2244) Fix participant popover design
* [text#2268](https://github.com/nextcloud/text/pull/2268) Fix broken file links
* [text#2270](https://github.com/nextcloud/text/pull/2270) Build(deps-dev): bump cypress from 9.5.2 to 9.5.3
* [text#2271](https://github.com/nextcloud/text/pull/2271) Build(deps): bump prosemirror-view from 1.23.10 to 1.23.11
* [text#2272](https://github.com/nextcloud/text/pull/2272) Build(deps): bump @nextcloud/vue from 5.2.1 to 5.3.0
* [text#2273](https://github.com/nextcloud/text/pull/2273) Build(deps): bump prosemirror-transform from 1.4.0 to 1.4.1
* [text#2281](https://github.com/nextcloud/text/pull/2281) Update master php testing versions
* [updater#411](https://github.com/nextcloud/updater/pull/411) Expect dist directory
* [updater#412](https://github.com/nextcloud/updater/pull/412) Add dist folder to index.php as well
* [viewer#1196](https://github.com/nextcloud/viewer/pull/1196) Build(deps-dev): bump phpunit/phpunit from 9.5.19 to 9.5.20
* [viewer#1197](https://github.com/nextcloud/viewer/pull/1197) Build(deps): bump plist from 3.0.4 to 3.0.5
* [viewer#1198](https://github.com/nextcloud/viewer/pull/1198) Build(deps): bump minimist from 1.2.5 to 1.2.6
* [viewer#1199](https://github.com/nextcloud/viewer/pull/1199) Build(deps): bump node-forge from 1.2.1 to 1.3.1
* [viewer#1200](https://github.com/nextcloud/viewer/pull/1200) Update master php testing versions
* [viewer#1202](https://github.com/nextcloud/viewer/pull/1202) Let header buttons properly adapt to the viewer handler theme
