### PR TITLE
Ensure schema change before checking OracleConstraints

### DIFF
--- a/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
+++ b/apps/user_ldap/lib/Migration/Version1120Date20210917155206.php
@@ -129,7 +129,7 @@ class Version1120Date20210917155206 extends SimpleMigrationStep {
 		$qb = $this->dbc->getQueryBuilder();
 		$qb->select('owncloud_name', 'directory_uuid')
 			->from($table)
-			->where($qb->expr()->gt($qb->func()->octetLength('owncloud_name'), '64', IQueryBuilder::PARAM_INT));
+			->where($qb->expr()->gt($qb->func()->octetLength('owncloud_name'), $qb->createNamedParameter('64'), IQueryBuilder::PARAM_INT));
 		return $qb;
 	}
 

--- a/apps/user_ldap/lib/Migration/Version1141Date20220323143801.php
+++ b/apps/user_ldap/lib/Migration/Version1141Date20220323143801.php
@@ -51,7 +51,7 @@ class Version1141Date20220323143801 extends SimpleMigrationStep {
 			$qb = $this->dbc->getQueryBuilder();
 			$qb->select('ldap_dn')
 				->from($tableName)
-				->where($qb->expr()->gt($qb->func()->octetLength('ldap_dn'), '4000', IQueryBuilder::PARAM_INT));
+				->where($qb->expr()->gt($qb->func()->octetLength('ldap_dn'), $qb->createNamedParameter('4000'), IQueryBuilder::PARAM_INT));
 
 			$dnsTooLong = [];
 			$result = $qb->executeQuery();

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -582,17 +582,17 @@ class MigrationService {
 			}
 
 			foreach ($table->getColumns() as $thing) {
-				// If the table doesn't exists OR if the column doesn't exists in the table
+				// If the table doesn't exist OR if the column doesn't exist in the table
 				if (!$sourceTable instanceof Table || !$sourceTable->hasColumn($thing->getName())) {
 					if (\strlen($thing->getName()) > 30) {
 						throw new \InvalidArgumentException('Column name "' . $table->getName() . '"."' . $thing->getName() . '" is too long.');
 					}
-	
+
 					if ($thing->getNotnull() && $thing->getDefault() === ''
 						&& $sourceTable instanceof Table && !$sourceTable->hasColumn($thing->getName())) {
 						throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is NotNull, but has empty string or null as default.');
 					}
-	
+
 					if ($thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
 						throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is type Bool and also NotNull, so it can not store "false".');
 					}
@@ -601,7 +601,7 @@ class MigrationService {
 				} else {
 					$sourceColumn = $sourceTable->getColumn($thing->getName());
 				}
-				
+
 				// If the column was just created OR the length changed OR the type changed
 				// we will NOT detect invalid length if the column is not modified
 				if (($sourceColumn === null || $sourceColumn->getLength() !== $thing->getLength() || $sourceColumn->getType()->getName() !== Types::STRING)

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -27,7 +27,6 @@
  */
 namespace OC\DB;
 
-use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\Index;
@@ -424,10 +423,10 @@ class MigrationService {
 		foreach ($toBeExecuted as $version) {
 			try {
 				$this->executeStep($version, $schemaOnly);
-			} catch (DriverException $e) {
+			} catch (\Exception $e) {
 				// The exception itself does not contain the name of the migration,
 				// so we wrap it here, to make debugging easier.
-				throw new \Exception('Database error when running migration ' . $to . ' for app ' . $this->getApp(), 0, $e);
+				throw new \Exception('Database error when running migration ' . $version . ' for app ' . $this->getApp() . PHP_EOL. $e->getMessage(), 0, $e);
 			}
 		}
 	}
@@ -607,7 +606,6 @@ class MigrationService {
 				// we will NOT detect invalid length if the column is not modified
 				if (($sourceColumn === null || $sourceColumn->getLength() !== $thing->getLength() || $sourceColumn->getType()->getName() !== Types::STRING)
 					&& $thing->getLength() > 4000 && $thing->getType()->getName() === Types::STRING) {
-						var_dump($sourceColumn === null, $sourceColumn->getLength(), $thing->getLength(),  $sourceColumn->getName());
 					throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is type String, but exceeding the 4.000 length limit.');
 				}
 			}


### PR DESCRIPTION
- Fix the oracle constraints check
- Fix ldap migration parametters
- Improve error logging
  ```bash
  $ php80 occ upgrade
  Nextcloud or one of the apps require upgrade - only a limited number of commands are available
  You may use your browser or the occ upgrade command to do the upgrade
  Setting log level to debug
  Updating database schema
  Updated database
  Updating <user_ldap> ...
  Exception: Database error when running migration 1142Date20220410143802 for app user_ldap
  Column "oc_ldap_group_mapping"."ldap_dn" is type String, but exceeding the 4.000 length limit.
  Update failed
  Maintenance mode is kept active
  Resetting log level
  ```