### PR TITLE
Principal search by display name case insensitive

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -347,9 +347,10 @@ class Principal implements BackendInterface {
 
 					if (!$allowEnumeration) {
 						if ($allowEnumerationFullMatch) {
+							$lowerSearch = strtolower($value);
 							$users = $this->userManager->searchDisplayName($value, $searchLimit);
-							$users = \array_filter($users, static function (IUser $user) use ($value) {
-								return $user->getDisplayName() === $value;
+							$users = \array_filter($users, static function (IUser $user) use ($lowerSearch) {
+								return strtolower($user->getDisplayName()) === $lowerSearch;
 							});
 						} else {
 							$users = [];


### PR DESCRIPTION
Adjust principal search to be case insensitive even with exact match.
This aligns the behavior to how the search also works in
Collaborators/UserPlugin

This aligns the behavior with https://github.com/nextcloud/server/blob/bugfix/noid/principal-search-case-insensitive-dn/lib/private/Collaboration/Collaborators/UserPlugin.php#L180

To test:
1. Disable share autocomplete to trigger exact match mode
2. Create an event
3. Type in the exact display name of a user, but with different casing

Before the fix: no results
After the fix: one result found
