### PR TITLE
Add a public replacement for OC::$server->get

### DIFF
--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -6,6 +6,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Carl Schwan <carl@carlschwan.eu>
  *
  * @license AGPL-3.0
  *
@@ -24,37 +25,42 @@
  */
 namespace OCA\Files;
 
+use OC\NavigationManager;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\INavigationManager;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\L10N\IFactory;
+use OCP\Server;
+
 class App {
-	/**
-	 * @var \OCP\INavigationManager
-	 */
-	private static $navigationManager;
+	private static ?INavigationManager $navigationManager = null;
 
 	/**
 	 * Returns the app's navigation manager
-	 *
-	 * @return \OCP\INavigationManager
 	 */
-	public static function getNavigationManager() {
+	public static function getNavigationManager(): INavigationManager {
 		// TODO: move this into a service in the Application class
 		if (self::$navigationManager === null) {
-			self::$navigationManager = new \OC\NavigationManager(
-				\OC::$server->getAppManager(),
-				\OC::$server->getURLGenerator(),
-				\OC::$server->getL10NFactory(),
-				\OC::$server->getUserSession(),
-				\OC::$server->getGroupManager(),
-				\OC::$server->getConfig()
+			self::$navigationManager = new NavigationManager(
+				Server::get(IAppManager::class),
+				Server::get(IUrlGenerator::class),
+				Server::get(IFactory::class),
+				Server::get(IUserSession::class),
+				Server::get(IGroupManager::class),
+				Server::get(IConfig::class)
 			);
 			self::$navigationManager->clear(false);
 		}
 		return self::$navigationManager;
 	}
 
-	public static function extendJsConfig($settings) {
+	public static function extendJsConfig($settings): void {
 		$appConfig = json_decode($settings['array']['oc_appconfig'], true);
 
-		$maxChunkSize = (int)\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', 10 * 1024 * 1024);
+		$maxChunkSize = (int)Server::get(IConfig::class)->getAppValue('files', 'max_chunk_size', (string)(10 * 1024 * 1024));
 		$appConfig['files'] = [
 			'max_chunk_size' => $maxChunkSize
 		];

--- a/apps/files/lib/Collaboration/Resources/Listener.php
+++ b/apps/files/lib/Collaboration/Resources/Listener.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files\Collaboration\Resources;
 
+use OCP\Server;
 use OCP\Collaboration\Resources\IManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -37,9 +38,9 @@ class Listener {
 
 	public static function shareModification(): void {
 		/** @var IManager $resourceManager */
-		$resourceManager = \OC::$server->query(IManager::class);
+		$resourceManager = Server::get(IManager::class);
 		/** @var ResourceProvider $resourceProvider */
-		$resourceProvider = \OC::$server->query(ResourceProvider::class);
+		$resourceProvider = Server::get(ResourceProvider::class);
 
 		$resourceManager->invalidateAccessCacheForProvider($resourceProvider);
 	}

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -23,12 +23,15 @@
  *
  */
 use OCP\Share\IManager;
+use OCP\Server;
+use OCP\IConfig;
+use OCP\IUserSession;
 
-$config = \OC::$server->getConfig();
-$userSession = \OC::$server->getUserSession();
+$config = Server::get(IConfig::class);
+$userSession = Server::get(IUserSession::class);
 // TODO: move this to the generated config.js
 /** @var IManager $shareManager */
-$shareManager = \OC::$server->get(IManager::class);
+$shareManager = Server::get(IManager::class);
 $publicUploadEnabled = $shareManager->shareApiLinkAllowPublicUpload() ? 'yes' : 'no';
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -53,6 +53,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
 use OCP\ICacheFactory;
 use OCP\IMemcache;
+use OCP\Server;
 
 class AmazonS3 extends \OC\Files\Storage\Common {
 	use S3ConnectionTrait;
@@ -87,9 +88,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$this->objectCache = new CappedMemoryCache();
 		$this->directoryCache = new CappedMemoryCache();
 		$this->filesCache = new CappedMemoryCache();
-		$this->mimeDetector = \OC::$server->get(IMimeTypeDetector::class);
+		$this->mimeDetector = Server::get(IMimeTypeDetector::class);
 		/** @var ICacheFactory $cacheFactory */
-		$cacheFactory = \OC::$server->get(ICacheFactory::class);
+		$cacheFactory = Server::get(ICacheFactory::class);
 		$this->memCache = $cacheFactory->createLocal('s3-external');
 	}
 

--- a/build/psalm-baseline-ocp.xml
+++ b/build/psalm-baseline-ocp.xml
@@ -21,6 +21,11 @@
       <code>$this-&gt;request-&gt;server</code>
     </NoInterfaceProperties>
   </file>
+  <file src="lib/public/Server.php">
+    <InvalidThrow occurrences="2">
+      <code>ContainerExceptionInterface</code>
+    </InvalidThrow>
+  </file>
   <file src="lib/public/AppFramework/App.php">
     <InternalMethod occurrences="1">
       <code>new RouteConfig($this-&gt;container, $router, $routes)</code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1153,11 +1153,6 @@
       <code>$this-&gt;fileIsEncrypted</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="apps/files/lib/App.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>10 * 1024 * 1024</code>
-    </InvalidScalarArgument>
-  </file>
   <file src="apps/files/lib/Command/Scan.php">
     <NullArgument occurrences="1">
       <code>null</code>
@@ -4574,6 +4569,11 @@
       <code>is_bool($setting[1])</code>
       <code>is_int($expected)</code>
     </TypeDoesNotContainType>
+  </file>
+  <file src="lib/public/Server.php">
+    <InvalidThrow occurrences="2">
+      <code>ContainerExceptionInterface</code>
+    </InvalidThrow>
   </file>
   <file src="lib/public/AppFramework/ApiController.php">
     <NoInterfaceProperties occurrences="1">

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -515,6 +515,7 @@ return array(
     'OCP\\Security\\ITrustedDomainHelper' => $baseDir . '/lib/public/Security/ITrustedDomainHelper.php',
     'OCP\\Security\\VerificationToken\\IVerificationToken' => $baseDir . '/lib/public/Security/VerificationToken/IVerificationToken.php',
     'OCP\\Security\\VerificationToken\\InvalidTokenException' => $baseDir . '/lib/public/Security/VerificationToken/InvalidTokenException.php',
+    'OCP\\Server' => $baseDir . '/lib/public/Server.php',
     'OCP\\Session\\Exceptions\\SessionNotAvailableException' => $baseDir . '/lib/public/Session/Exceptions/SessionNotAvailableException.php',
     'OCP\\Settings\\IDelegatedSettings' => $baseDir . '/lib/public/Settings/IDelegatedSettings.php',
     'OCP\\Settings\\IIconSection' => $baseDir . '/lib/public/Settings/IIconSection.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -544,6 +544,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Security\\ITrustedDomainHelper' => __DIR__ . '/../../..' . '/lib/public/Security/ITrustedDomainHelper.php',
         'OCP\\Security\\VerificationToken\\IVerificationToken' => __DIR__ . '/../../..' . '/lib/public/Security/VerificationToken/IVerificationToken.php',
         'OCP\\Security\\VerificationToken\\InvalidTokenException' => __DIR__ . '/../../..' . '/lib/public/Security/VerificationToken/InvalidTokenException.php',
+        'OCP\\Server' => __DIR__ . '/../../..' . '/lib/public/Server.php',
         'OCP\\Session\\Exceptions\\SessionNotAvailableException' => __DIR__ . '/../../..' . '/lib/public/Session/Exceptions/SessionNotAvailableException.php',
         'OCP\\Settings\\IDelegatedSettings' => __DIR__ . '/../../..' . '/lib/public/Settings/IDelegatedSettings.php',
         'OCP\\Settings\\IIconSection' => __DIR__ . '/../../..' . '/lib/public/Settings/IIconSection.php',

--- a/lib/public/AppFramework/IAppContainer.php
+++ b/lib/public/AppFramework/IAppContainer.php
@@ -38,6 +38,7 @@ use Psr\Container\ContainerInterface;
  * thus this interface won't extend it anymore once that was removed. So migrate to the ContainerInterface
  * only.
  *
+ * @deprecated 20.0.0
  * @since 6.0.0
  */
 interface IAppContainer extends ContainerInterface, IContainer {

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -55,6 +55,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * thus this interface won't extend it anymore once that was removed. So migrate to the ContainerInterface
  * only.
  *
+ * @deprecated 20.0.0
+ *
  * @since 6.0.0
  */
 interface IServerContainer extends ContainerInterface, IContainer {

--- a/lib/public/Server.php
+++ b/lib/public/Server.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Class allowing to inject services into your application. You should
+ * use whenever possible dependency injections instead.
+ *
+ * ```php
+ * use OCP\Server;
+ *
+ * $tagManager = Server::get(ITagManager::class);
+ * ```
+ *
+ * @since 25.0.0
+ */
+final class Server {
+	/**
+	 * @template T
+	 * @param class-string<T>|string $serviceName
+	 * @return T|mixed
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 * @since 25.0.0
+	 */
+	public static function get(string $serviceName) {
+		/** @psalm-suppress UndefinedClass */
+		return \OC::$server->get($serviceName);
+	}
+}


### PR DESCRIPTION
Currently, most app are using OC::$sever->get, a private API to load some services. While apps should be migrating to dependency injections, this is not always possible. This PR adds a nicer public API to load services.

<s>Potentially we should expose IServerContainer too and just have `Server::get` has a nice alias for `Server::getServerContainer()->get`</s>