### PR TITLE
Filesystem setup tweaks

### DIFF
--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OC\Files\Node;
 
 use OC\Files\Utils\PathHelper;
@@ -310,6 +311,9 @@ class LazyFolder implements \OCP\Files\Folder {
 	 * @inheritDoc
 	 */
 	public function getMimetype() {
+		if (isset($this->data['mimetype'])) {
+			return $this->data['mimetype'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -317,6 +321,10 @@ class LazyFolder implements \OCP\Files\Folder {
 	 * @inheritDoc
 	 */
 	public function getMimePart() {
+		if (isset($this->data['mimetype'])) {
+			[$part,] = explode('/', $this->data['mimetype']);
+			return $part;
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -331,6 +339,9 @@ class LazyFolder implements \OCP\Files\Folder {
 	 * @inheritDoc
 	 */
 	public function getType() {
+		if (isset($this->data['type'])) {
+			return $this->data['type'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/LazyUserFolder.php
+++ b/lib/private/Files/Node/LazyUserFolder.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OC\Files\Node;
 
+use OCP\Files\FileInfo;
 use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -49,6 +50,8 @@ class LazyUserFolder extends LazyFolder {
 		}, [
 			'path' => $this->path,
 			'permissions' => Constants::PERMISSION_ALL,
+			'type' => FileInfo::TYPE_FOLDER,
+			'mimetype' => FileInfo::MIMETYPE_FOLDER,
 		]);
 	}
 

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -368,8 +368,12 @@ class SetupManager {
 		}
 
 		// for the user's home folder, it's always the home mount
-		if (rtrim($path) === "/" . $user->getUID() . "/files" && !$includeChildren) {
-			$this->oneTimeUserSetup($user);
+		if (rtrim($path) === "/" . $user->getUID() . "/files") {
+			if ($includeChildren) {
+				$this->setupForUser($user);
+			} else {
+				$this->oneTimeUserSetup($user);
+			}
 			return;
 		}
 

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -460,6 +460,7 @@ class SetupManager {
 
 		if (in_array('', $providers)) {
 			$this->setupForUser($user);
+			return;
 		}
 		$setupProviders = $this->setupUserMountProviders[$user->getUID()] ?? [];
 


### PR DESCRIPTION
- Fix cached mountpoints without mount provider set being removed when getting a file by fileid (fixes https://github.com/nextcloud/server/issues/31858)
- Always perform a full setup when loading the home folder with submounts included
  
  This does undo some of the performance improvements when a user has unused mount providers (i.e. groupfolders enabled, but the none configured) but does improve the reliability of handing apps that aren't adjusted to emit the events to refresh the cached mounts. Further tweaking can be done in the future

Might also https://github.com/nextcloud/server/issues/31896 but I don't have the setup to run the `richdocuments` integration tests atm