### PR TITLE
Use Migrators id instead of class names

### DIFF
--- a/apps/dav/lib/UserMigration/CalendarMigrator.php
+++ b/apps/dav/lib/UserMigration/CalendarMigrator.php
@@ -414,7 +414,7 @@ class CalendarMigrator implements IMigrator {
 	 * @throws CalendarMigratorException
 	 */
 	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
-		if ($importSource->getMigratorVersion(static::class) === null) {
+		if ($importSource->getMigratorVersion($this->getId()) === null) {
 			$output->writeln('No version for ' . static::class . ', skipping import…');
 			return;
 		}

--- a/apps/dav/lib/UserMigration/ContactsMigrator.php
+++ b/apps/dav/lib/UserMigration/ContactsMigrator.php
@@ -306,7 +306,7 @@ class ContactsMigrator implements IMigrator {
 	 * @throws ContactsMigratorException
 	 */
 	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
-		if ($importSource->getMigratorVersion(static::class) === null) {
+		if ($importSource->getMigratorVersion($this->getId()) === null) {
 			$output->writeln('No version for ' . static::class . ', skipping import…');
 			return;
 		}

--- a/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
+++ b/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
@@ -93,7 +93,7 @@ class TrashbinMigrator implements IMigrator {
 	 * {@inheritDoc}
 	 */
 	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
-		if ($importSource->getMigratorVersion(static::class) === null) {
+		if ($importSource->getMigratorVersion($this->getId()) === null) {
 			$output->writeln('No version for ' . static::class . ', skipping import…');
 			return;
 		}

--- a/apps/settings/lib/UserMigration/AccountMigrator.php
+++ b/apps/settings/lib/UserMigration/AccountMigrator.php
@@ -95,7 +95,7 @@ class AccountMigrator implements IMigrator {
 	 * {@inheritDoc}
 	 */
 	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
-		if ($importSource->getMigratorVersion(static::class) === null) {
+		if ($importSource->getMigratorVersion($this->getId()) === null) {
 			$output->writeln('No version for ' . static::class . ', skipping import…');
 			return;
 		}

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -98,7 +98,7 @@ class AccountMigratorTest extends TestCase {
 		$this->importSource
 			->expects($this->once())
 			->method('getMigratorVersion')
-			->with(AccountMigrator::class)
+			->with($this->migrator->getId())
 			->willReturn(1);
 
 		$this->importSource

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -91,7 +91,7 @@ interface IImportSource {
 	/**
 	 * @return ?int Version for this migrator from the export archive. Null means migrator missing.
 	 *
-	 * @param class-string<IMigrator> $migrator
+	 * @param string $migrator Migrator id (as returned by IMigrator::getId)
 	 *
 	 * @since 24.0.0
 	 */

--- a/lib/public/UserMigration/IMigrator.php
+++ b/lib/public/UserMigration/IMigrator.php
@@ -89,7 +89,7 @@ interface IMigrator {
 
 	/**
 	 * Checks whether it is able to import a version of the export format for this migrator
-	 * Use $importSource->getMigratorVersion(static::class) to get the version from the archive
+	 * Use $importSource->getMigratorVersion($this->getId()) to get the version from the archive
 	 *
 	 * @since 24.0.0
 	 */

--- a/lib/public/UserMigration/TMigratorBasicVersionHandling.php
+++ b/lib/public/UserMigration/TMigratorBasicVersionHandling.php
@@ -50,7 +50,7 @@ trait TMigratorBasicVersionHandling {
 	public function canImport(
 		IImportSource $importSource
 	): bool {
-		$version = $importSource->getMigratorVersion(static::class);
+		$version = $importSource->getMigratorVersion($this->getId());
 		if ($version === null) {
 			return !$this->mandatory;
 		}


### PR DESCRIPTION
This will help with UI and means migrators can move in namespaces
 without changing export format.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>