### PR TITLE
Fix warning about optional parameter before required one

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarRoot.php
+++ b/apps/dav/lib/CalDAV/CalendarRoot.php
@@ -30,11 +30,14 @@ use Sabre\CalDAV\Backend;
 use Sabre\DAVACL\PrincipalBackend;
 
 class CalendarRoot extends \Sabre\CalDAV\CalendarRoot {
+	private LoggerInterface $logger;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $caldavBackend, $principalPrefix = 'principals', LoggerInterface $logger) {
+	public function __construct(
+		PrincipalBackend\BackendInterface $principalBackend,
+		Backend\BackendInterface $caldavBackend,
+		$principalPrefix,
+		LoggerInterface $logger
+	) {
 		parent::__construct($principalBackend, $caldavBackend, $principalPrefix);
 		$this->logger = $logger;
 	}


### PR DESCRIPTION
Fixes this warning:
PHP Deprecated:  Required parameter $logger follows optional parameter $principalPrefix in /var/www/html/apps/dav/lib/CalDAV/CalendarRoot.php on line 37

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>