### PR TITLE
improve hidedownload

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -51,6 +51,18 @@ thead {
 	left: 0 !important;
 }
 
+// blur page when focus is removed
+.blur_body { 
+	filter: blur(5px); 
+}
+
+// disable printing
+@media print { 
+	.disable_print { 
+		display: none 
+	}
+}
+
 #data-upload-form {
 	position: relative;
 	right: 0;

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -50,13 +50,55 @@ OCA.Sharing.PublicApp = {
 		var token = $('#sharingToken').val();
 		var hideDownload = $('#hideDownload').val();
 
-		// Prevent all right-click options if hideDownload is enabled
 		if (hideDownload === 'true') {
+			// Prevent all right-click options
 			window.oncontextmenu = function(event) {
 				event.preventDefault();
 				event.stopPropagation();
 				return false;
 		   };
+
+			// Prevent printing
+			document.body.classList.add('disable_print');
+			window.addEventListener('keydown', (event) => {
+				if (event.key === "PrintScreen") {
+					event.preventDefault();
+					event.stopPropagation();
+					return false;
+				}
+			});
+			window.addEventListener('keydown', (event) => {
+				if (event.key === "p" && event.ctrlKey === true) {
+					event.preventDefault();
+					event.stopPropagation();
+					return false;
+				}
+			});
+
+			// Prevent saving
+			window.addEventListener('keydown', (event) => {
+				if (event.key === "Save") {
+					event.preventDefault();
+					event.stopPropagation();
+					return false;
+				}
+			});
+			window.addEventListener('keydown', (event) => {
+				if (event.key === "s" && event.ctrlKey === true) {
+					event.preventDefault();
+					event.stopPropagation();
+					return false;
+				}
+			});
+
+			// Blur elements when window has no focus in order to make screenshots harder
+			setInterval(function () {
+				if (document.hasFocus()) {
+					document.body.classList.remove('blur_body');
+				} else {
+					document.body.classList.add('blur_body');
+				}
+			}, 300);
 		}
 
 		// file list mode ?


### PR DESCRIPTION
With this change getting the original previews and files gets again much more complicated. We are now pretty near the goal of only being able to get the files using the browser inspector, an external tool or a screenshot tool.

What works in my testing:
- [x] printing is disabled when using the shortcut and the browser option
- [x] saving of the site is disabled when using the shortcut; the browser option now does no longer download all assets into an separate folder and only save the html and thus link to the preview but not the preview itself
- [x] enable blur when the focus moves away from the tab; ~~not sure if this makes sense at all because some screenshot tools might be able to be activated without moving the focus away from the tab.~~ Seems to make sense indeed.

TODO:
- [ ] discuss if we really do this
- [ ] discuss if it should be encapsulated in a different sharing option or e.g. be enabled by a config.php switch

Signed-off-by: szaimen <szaimen@e.mail.de>

