### PR TITLE
Fix "Required parameter $logger follows optional parameter $principal…

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarRoot.php
+++ b/apps/dav/lib/CalDAV/CalendarRoot.php
@@ -34,7 +34,7 @@ class CalendarRoot extends \Sabre\CalDAV\CalendarRoot {
 	/** @var LoggerInterface */
 	private $logger;
 
-	public function __construct(PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $caldavBackend, $principalPrefix = 'principals', LoggerInterface $logger) {
+	public function __construct(PrincipalBackend\BackendInterface $principalBackend, Backend\BackendInterface $caldavBackend, $principalPrefix, LoggerInterface $logger) {
 		parent::__construct($principalBackend, $caldavBackend, $principalPrefix);
 		$this->logger = $logger;
 	}


### PR DESCRIPTION
…Prefix"

### Steps
1. Open workflow admin settings with files_retention or files_automatedtagging enabled
2. Find this in the log:
```json
{
  "reqId": "…",
  "level": 3,
  "time": "2022-04-12T23:53:46+02:00",
  "remoteAddr": "…",
  "user": "admin",
  "app": "PHP",
  "method": "PROPFIND",
  "url": "/remote.php/dav/systemtags/",
  "message": "Required parameter $logger follows optional parameter $principalPrefix at …/apps/dav/lib/CalDAV/CalendarRoot.php#37",
  "userAgent": "…",
  "version": "24.0.0.8"
}
```

Introduced by 0745fc50126e92406ec95265ef1ff5d4b5575d3e cc @miaulalala 