### PR TITLE
23.0.4 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [23, 0, 3, 2];
+$OC_Version = [23, 0, 4, 0];
 
 // The human readable string
-$OC_VersionString = '23.0.3';
+$OC_VersionString = '23.0.4 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #31453
* #31514
* #31518
* #31521
* #31536
* #31540
* #31624
* #31634
* #31641
* #31656
* #31666
* #31678
* #31705
* #31721
* #31730
* #31733
* #31740
* #31748
* #31774
* #31785
* #31804
* #31821
* #31831
* #31835
* #31836
* #31846
* #31856
* #31862
* #31878
* #31880
* #31882
* #31913
* #31923
* #31940
* #31946
* #31949
* #31955
* #31968
* [3rdparty#1016](https://github.com/nextcloud/3rdparty/pull/1016) Bump guzzlehttp/psr7 from 1.8.3 to 1.8.5
* [activity#781](https://github.com/nextcloud/activity/pull/781) Fallback to the admin settings if the user did not configure it
* [circles#1001](https://github.com/nextcloud/circles/pull/1001) Bypass/limit permissions
* [circles#1007](https://github.com/nextcloud/circles/pull/1007) Update memberships on path change
* [circles#1010](https://github.com/nextcloud/circles/pull/1010) Check owner attendance
* [circles#1015](https://github.com/nextcloud/circles/pull/1015) Remove child shares
* [circles#1017](https://github.com/nextcloud/circles/pull/1017) Update displayName
* [circles#978](https://github.com/nextcloud/circles/pull/978) Oracle support
* [circles#982](https://github.com/nextcloud/circles/pull/982) Limit some feature when Circles is managed by an app
* [circles#985](https://github.com/nextcloud/circles/pull/985) Use stable23 for oci tests
* [circles#995](https://github.com/nextcloud/circles/pull/995) Missing $prec
* [circles#997](https://github.com/nextcloud/circles/pull/997) Update population
* [firstrunwizard#693](https://github.com/nextcloud/firstrunwizard/pull/693) Disable social recommendation
* [firstrunwizard#697](https://github.com/nextcloud/firstrunwizard/pull/697) Fix settings navigation order
* [privacy#752](https://github.com/nextcloud/privacy/pull/752) Bump babel-loader from 8.2.3 to 8.2.4
* [text#2233](https://github.com/nextcloud/text/pull/2233) Build(deps): bump prosemirror-view from 1.23.7 to 1.23.9
* [text#2259](https://github.com/nextcloud/text/pull/2259) Build(deps): bump prosemirror-view from 1.23.9 to 1.23.10
* [text#2274](https://github.com/nextcloud/text/pull/2274) Build(deps): bump prosemirror-view from 1.23.10 to 1.23.11
* [text#2277](https://github.com/nextcloud/text/pull/2277) Fix: menu bubble size at the end of the line
* [text#2286](https://github.com/nextcloud/text/pull/2286) Build(deps): bump prosemirror-view from 1.23.11 to 1.23.12
* [viewer#1208](https://github.com/nextcloud/viewer/pull/1208) Properly cancel and reset ongoing streams when unmounting