### PR TITLE
Use share setting in DAV search

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -271,6 +271,7 @@ class Principal implements BackendInterface {
 		$limitEnumerationPhone = $this->shareManager->limitEnumerationToPhone();
 		$allowEnumerationFullMatch = $this->shareManager->allowEnumerationFullMatch();
 		$ignoreSecondDisplayName = $this->shareManager->ignoreSecondDisplayName();
+		$matchEmail = $this->shareManager->matchEmail();
 
 		// If sharing is restricted to group members only,
 		// return only members that have groups in common
@@ -299,7 +300,7 @@ class Principal implements BackendInterface {
 			switch ($prop) {
 				case '{http://sabredav.org/ns}email-address':
 					if (!$allowEnumeration) {
-						if ($allowEnumerationFullMatch) {
+						if ($allowEnumerationFullMatch && $matchEmail) {
 							$users = $this->userManager->getByEmail($value);
 						} else {
 							$users = [];

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -270,6 +270,7 @@ class Principal implements BackendInterface {
 		$limitEnumerationGroup = $this->shareManager->limitEnumerationToGroups();
 		$limitEnumerationPhone = $this->shareManager->limitEnumerationToPhone();
 		$allowEnumerationFullMatch = $this->shareManager->allowEnumerationFullMatch();
+		$ignoreSecondDisplayName = $this->shareManager->ignoreSecondDisplayName();
 
 		// If sharing is restricted to group members only,
 		// return only members that have groups in common
@@ -349,8 +350,9 @@ class Principal implements BackendInterface {
 						if ($allowEnumerationFullMatch) {
 							$lowerSearch = strtolower($value);
 							$users = $this->userManager->searchDisplayName($value, $searchLimit);
-							$users = \array_filter($users, static function (IUser $user) use ($lowerSearch) {
-								return strtolower($user->getDisplayName()) === $lowerSearch;
+							$users = \array_filter($users, static function (IUser $user) use ($lowerSearch, $ignoreSecondDisplayName) {
+								$lowerDisplayName = strtolower($user->getDisplayName());
+								return $lowerDisplayName === $lowerSearch || ($ignoreSecondDisplayName && trim(preg_replace('/ \(.*\)$/', '', $lowerDisplayName)) === $lowerSearch);
 							});
 						} else {
 							$users = [];

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -662,6 +662,10 @@ class PrincipalTest extends TestCase {
 			->method('allowEnumerationFullMatch')
 			->willReturn(true);
 
+		$this->shareManager->expects($this->once())
+			->method('matchEmail')
+			->willReturn(true);
+
 		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$user2->method('getDisplayName')->willReturn('User 2');

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1963,6 +1963,10 @@ class Manager implements IManager {
 		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
 	}
 
+	public function matchEmail(): bool {
+		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_email', 'yes') === 'yes';
+	}
+
 	public function ignoreSecondDisplayName(): bool {
 		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_display_name', 'no') === 'yes';
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1963,6 +1963,10 @@ class Manager implements IManager {
 		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
 	}
 
+	public function ignoreSecondDisplayName(): bool {
+		return $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_display_name', 'no') === 'yes';
+	}
+
 	public function currentUserCanEnumerateTargetUser(?IUser $currentUser, IUser $targetUser): bool {
 		if ($this->allowEnumerationFullMatch()) {
 			return true;

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -455,6 +455,14 @@ interface IManager {
 	public function allowEnumerationFullMatch(): bool;
 
 	/**
+	 * Check if the search should ignore the second in parentheses display name if there is any
+	 *
+	 * @return bool
+	 * @since 24.0.0
+	 */
+	public function ignoreSecondDisplayName(): bool;
+
+	/**
 	 * Check if the current user can enumerate the target user
 	 *
 	 * @param IUser|null $currentUser

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -455,10 +455,18 @@ interface IManager {
 	public function allowEnumerationFullMatch(): bool;
 
 	/**
+	 * Check if the search should match the email
+	 *
+	 * @return bool
+	 * @since 25.0.0
+	 */
+	public function matchEmail(): bool;
+
+	/**
 	 * Check if the search should ignore the second in parentheses display name if there is any
 	 *
 	 * @return bool
-	 * @since 24.0.0
+	 * @since 25.0.0
 	 */
 	public function ignoreSecondDisplayName(): bool;
 


### PR DESCRIPTION
`shareapi_restrict_user_enumeration_full_match_ignore_second_display_name` was introduced in https://github.com/nextcloud/server/pull/31932 to ignore second display name during search from the Share panel. But this setting was not respected by search from the calendar application. This fix it.

Same with `shareapi_restrict_user_enumeration_full_match_email` in https://github.com/nextcloud/server/pull/31964.