### PR TITLE
store unencrypted size in the unencrypted_size column

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -114,12 +114,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function comparison($x, string $operator, $y, $type = null): string {
+	public function comparison($x, string $operator, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->comparison($x, $operator, $y);
+		return new QueryFunction($this->expressionBuilder->comparison($x, $operator, $y));
 	}
 
 	/**
@@ -137,12 +137,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function eq($x, $y, $type = null): string {
+	public function eq($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->eq($x, $y);
+		return new QueryFunction($this->expressionBuilder->eq($x, $y));
 	}
 
 	/**
@@ -159,12 +159,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function neq($x, $y, $type = null): string {
+	public function neq($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->neq($x, $y);
+		return new QueryFunction($this->expressionBuilder->neq($x, $y));
 	}
 
 	/**
@@ -181,12 +181,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function lt($x, $y, $type = null): string {
+	public function lt($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->lt($x, $y);
+		return new QueryFunction($this->expressionBuilder->lt($x, $y));
 	}
 
 	/**
@@ -203,12 +203,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function lte($x, $y, $type = null): string {
+	public function lte($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->lte($x, $y);
+		return new QueryFunction($this->expressionBuilder->lte($x, $y));
 	}
 
 	/**
@@ -225,12 +225,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function gt($x, $y, $type = null): string {
+	public function gt($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->gt($x, $y);
+		return new QueryFunction($this->expressionBuilder->gt($x, $y));
 	}
 
 	/**
@@ -247,12 +247,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function gte($x, $y, $type = null): string {
+	public function gte($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->gte($x, $y);
+		return new QueryFunction($this->expressionBuilder->gte($x, $y));
 	}
 
 	/**
@@ -260,11 +260,11 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be restricted by IS NULL.
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function isNull($x): string {
+	public function isNull($x): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
-		return $this->expressionBuilder->isNull($x);
+		return new QueryFunction($this->expressionBuilder->isNull($x));
 	}
 
 	/**
@@ -272,11 +272,11 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be restricted by IS NOT NULL.
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function isNotNull($x): string {
+	public function isNotNull($x): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
-		return $this->expressionBuilder->isNotNull($x);
+		return new QueryFunction($this->expressionBuilder->isNotNull($x));
 	}
 
 	/**
@@ -287,12 +287,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function like($x, $y, $type = null): string {
+	public function like($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->like($x, $y);
+		return new QueryFunction($this->expressionBuilder->like($x, $y));
 	}
 
 	/**
@@ -303,11 +303,11 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 9.0.0
 	 */
-	public function iLike($x, $y, $type = null): string {
-		return $this->expressionBuilder->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y));
+	public function iLike($x, $y, $type = null): IQueryFunction {
+		return new QueryFunction($this->expressionBuilder->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y)));
 	}
 
 	/**
@@ -318,12 +318,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function notLike($x, $y, $type = null): string {
+	public function notLike($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->notLike($x, $y);
+		return new QueryFunction($this->expressionBuilder->notLike($x, $y));
 	}
 
 	/**
@@ -334,12 +334,12 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function in($x, $y, $type = null): string {
+	public function in($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnNames($y);
-		return $this->expressionBuilder->in($x, $y);
+		return new QueryFunction($this->expressionBuilder->in($x, $y));
 	}
 
 	/**
@@ -350,34 +350,34 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 */
-	public function notIn($x, $y, $type = null): string {
+	public function notIn($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnNames($y);
-		return $this->expressionBuilder->notIn($x, $y);
+		return new QueryFunction($this->expressionBuilder->notIn($x, $y));
 	}
 
 	/**
 	 * Creates a $x = '' statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 */
-	public function emptyString($x): string {
-		return $this->eq($x, $this->literal('', IQueryBuilder::PARAM_STR));
+	public function emptyString($x): IQueryFunction {
+		return new QueryFunction($this->eq($x, $this->literal('', IQueryBuilder::PARAM_STR)));
 	}
 
 	/**
 	 * Creates a `$x <> ''` statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 */
-	public function nonEmptyString($x): string {
-		return $this->neq($x, $this->literal('', IQueryBuilder::PARAM_STR));
+	public function nonEmptyString($x): IQueryFunction {
+		return new QueryFunction($this->neq($x, $this->literal('', IQueryBuilder::PARAM_STR)));
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -49,10 +49,10 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
-	public function iLike($x, $y, $type = null): string {
+	public function iLike($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->comparison($x, ' COLLATE ' . $this->collation . ' LIKE', $y);
+		return new QueryFunction($this->expressionBuilder->comparison($x, ' COLLATE ' . $this->collation . ' LIKE', $y));
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -49,101 +49,101 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
-	public function comparison($x, string $operator, $y, $type = null): string {
+	public function comparison($x, string $operator, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->comparison($x, $operator, $y);
+		return new QueryFunction($this->expressionBuilder->comparison($x, $operator, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function eq($x, $y, $type = null): string {
+	public function eq($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->eq($x, $y);
+		return new QueryFunction($this->expressionBuilder->eq($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function neq($x, $y, $type = null): string {
+	public function neq($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->neq($x, $y);
+		return new QueryFunction($this->expressionBuilder->neq($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function lt($x, $y, $type = null): string {
+	public function lt($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->lt($x, $y);
+		return new QueryFunction($this->expressionBuilder->lt($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function lte($x, $y, $type = null): string {
+	public function lte($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->lte($x, $y);
+		return new QueryFunction($this->expressionBuilder->lte($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function gt($x, $y, $type = null): string {
+	public function gt($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->gt($x, $y);
+		return new QueryFunction($this->expressionBuilder->gt($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function gte($x, $y, $type = null): string {
+	public function gte($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->gte($x, $y);
+		return new QueryFunction($this->expressionBuilder->gte($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function in($x, $y, $type = null): string {
+	public function in($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->in($x, $y);
+		return new QueryFunction($this->expressionBuilder->in($x, $y));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function notIn($x, $y, $type = null): string {
+	public function notIn($x, $y, $type = null): IQueryFunction {
 		$x = $this->prepareColumn($x, $type);
 		$y = $this->prepareColumn($y, $type);
 
-		return $this->expressionBuilder->notIn($x, $y);
+		return new QueryFunction($this->expressionBuilder->notIn($x, $y));
 	}
 
 	/**
 	 * Creates a $x = '' statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 */
-	public function emptyString($x): string {
+	public function emptyString($x): IQueryFunction {
 		return $this->isNull($x);
 	}
 
@@ -151,10 +151,10 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	 * Creates a `$x <> ''` statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 */
-	public function nonEmptyString($x): string {
+	public function nonEmptyString($x): IQueryFunction {
 		return $this->isNotNull($x);
 	}
 
@@ -182,14 +182,14 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
-	public function like($x, $y, $type = null): string {
-		return parent::like($x, $y, $type) . " ESCAPE '\\'";
+	public function like($x, $y, $type = null): IQueryFunction {
+		return new QueryFunction(parent::like($x, $y, $type) . " ESCAPE '\\'");
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function iLike($x, $y, $type = null): string {
+	public function iLike($x, $y, $type = null): IQueryFunction {
 		return $this->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y));
 	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
@@ -52,9 +52,9 @@ class PgSqlExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
-	public function iLike($x, $y, $type = null): string {
+	public function iLike($x, $y, $type = null): IQueryFunction {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->comparison($x, 'ILIKE', $y);
+		return new QueryFunction($this->expressionBuilder->comparison($x, 'ILIKE', $y));
 	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/SqliteExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/SqliteExpressionBuilder.php
@@ -23,15 +23,18 @@
  */
 namespace OC\DB\QueryBuilder\ExpressionBuilder;
 
+use OC\DB\QueryBuilder\QueryFunction;
+use OCP\DB\QueryBuilder\IQueryFunction;
+
 class SqliteExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
-	public function like($x, $y, $type = null): string {
-		return parent::like($x, $y, $type) . " ESCAPE '\\'";
+	public function like($x, $y, $type = null): IQueryFunction {
+		return new QueryFunction(parent::like($x, $y, $type) . " ESCAPE '\\'");
 	}
 
-	public function iLike($x, $y, $type = null): string {
-		return $this->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y), $type);
+	public function iLike($x, $y, $type = null): IQueryFunction {
+		return new QueryFunction($this->like($this->functionBuilder->lower($x), $this->functionBuilder->lower($y), $type));
 	}
 }

--- a/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/FunctionBuilder.php
@@ -121,4 +121,15 @@ class FunctionBuilder implements IFunctionBuilder {
 	public function least($x, $y): IQueryFunction {
 		return new QueryFunction('LEAST(' . $this->helper->quoteColumnName($x) . ', ' . $this->helper->quoteColumnName($y) . ')');
 	}
+
+	public function case(array $whens, $else): IQueryFunction {
+		if (count($whens) < 1) {
+			return new QueryFunction($this->helper->quoteColumnName($else));
+		}
+
+		$whenParts = array_map(function (array $when) {
+			return 'WHEN ' . $this->helper->quoteColumnName($when['when']) . ' THEN ' . $this->helper->quoteColumnName($when['then']);
+		}, $whens);
+		return new QueryFunction('CASE ' .  implode(' ', $whenParts) . ' ELSE ' . $this->helper->quoteColumnName($else) . ' END');
+	}
 }

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -715,11 +715,12 @@ class QueryBuilder implements IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function join($fromAlias, $join, $alias, $condition = null) {
+		$condition = $condition !== null ? (string)$condition : null;
 		$this->queryBuilder->join(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
@@ -743,11 +744,12 @@ class QueryBuilder implements IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function innerJoin($fromAlias, $join, $alias, $condition = null) {
+		$condition = $condition !== null ? (string)$condition : null;
 		$this->queryBuilder->innerJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
@@ -771,11 +773,12 @@ class QueryBuilder implements IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function leftJoin($fromAlias, $join, $alias, $condition = null) {
+		$condition = $condition !== null ? (string)$condition : null;
 		$this->queryBuilder->leftJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),
@@ -799,11 +802,12 @@ class QueryBuilder implements IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function rightJoin($fromAlias, $join, $alias, $condition = null) {
+		$condition = $condition !== null ? (string)$condition : null;
 		$this->queryBuilder->rightJoin(
 			$this->quoteAlias($fromAlias),
 			$this->getTableName($join),

--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -132,4 +132,12 @@ class CacheEntry implements ICacheEntry {
 	public function __clone() {
 		$this->data = array_merge([], $this->data);
 	}
+
+	public function getUnencryptedSize(): int {
+		if (isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
+			return $this->data['unencrypted_size'];
+		} else {
+			return $this->data['size'];
+		}
+	}
 }

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -44,7 +44,7 @@ class CacheQueryBuilder extends QueryBuilder {
 	public function selectFileCache(string $alias = null) {
 		$name = $alias ? $alias : 'filecache';
 		$this->select("$name.fileid", 'storage', 'path', 'path_hash', "$name.parent", "$name.name", 'mimetype', 'mimepart', 'size', 'mtime',
-			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'metadata_etag', 'creation_time', 'upload_time')
+			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'metadata_etag', 'creation_time', 'upload_time', 'unencrypted_size')
 			->from('filecache', $name)
 			->leftJoin($name, 'filecache_extended', 'fe', $this->expr()->eq("$name.fileid", 'fe.fileid'));
 

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -101,7 +101,11 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		$this->data = $data;
 		$this->mount = $mount;
 		$this->owner = $owner;
-		$this->rawSize = $this->data['size'] ?? 0;
+		if (isset($this->data['unencrypted_size'])) {
+			$this->rawSize = $this->data['unencrypted_size'];
+		} else {
+			$this->rawSize = $this->data['size'] ?? 0;
+		}
 	}
 
 	public function offsetSet($offset, $value): void {
@@ -208,7 +212,12 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	public function getSize($includeMounts = true) {
 		if ($includeMounts) {
 			$this->updateEntryfromSubMounts();
-			return isset($this->data['size']) ? 0 + $this->data['size'] : 0;
+
+			if (isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
+				return $this->data['unencrypted_size'];
+			} else {
+				return isset($this->data['size']) ? 0 + $this->data['size'] : 0;
+			}
 		} else {
 			return $this->rawSize;
 		}
@@ -386,7 +395,19 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @param string $entryPath full path of the child entry
 	 */
 	public function addSubEntry($data, $entryPath) {
-		$this->data['size'] += isset($data['size']) ? $data['size'] : 0;
+		if (!$data) {
+			return;
+		}
+		$hasUnencryptedSize = isset($data['unencrypted_size']) && $data['unencrypted_size'] > 0;
+		if ($hasUnencryptedSize) {
+			$subSize = $data['unencrypted_size'];
+		} else {
+			$subSize = $data['size'] ?: 0;
+		}
+		$this->data['size'] += $subSize;
+		if ($hasUnencryptedSize) {
+			$this->data['unencrypted_size'] += $subSize;
+		}
 		if (isset($data['mtime'])) {
 			$this->data['mtime'] = max($this->data['mtime'], $data['mtime']);
 		}

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -33,6 +33,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
@@ -41,6 +42,7 @@ use OC\Encryption\Util;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Filesystem;
 use OC\Files\Mount\Manager;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\LocalTempFileTrait;
 use OC\Memcache\ArrayCache;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
@@ -139,28 +141,36 @@ class Encryption extends Wrapper {
 			$size = $this->unencryptedSize[$fullPath];
 			// update file cache
 			if ($info instanceof ICacheEntry) {
-				$info = $info->getData();
 				$info['encrypted'] = $info['encryptedVersion'];
 			} else {
 				if (!is_array($info)) {
 					$info = [];
 				}
 				$info['encrypted'] = true;
+				$info = new CacheEntry($info);
 			}
 
-			$info['size'] = $size;
-			$this->getCache()->put($path, $info);
+			if ($size !== $info->getUnencryptedSize()) {
+				$this->getCache()->update($info->getId(), [
+					'unencrypted_size' => $size
+				]);
+			}
 
 			return $size;
 		}
 
 		if (isset($info['fileid']) && $info['encrypted']) {
-			return $this->verifyUnencryptedSize($path, $info['size']);
+			return $this->verifyUnencryptedSize($path, $info->getUnencryptedSize());
 		}
 
 		return $this->storage->filesize($path);
 	}
 
+	/**
+	 * @param string $path
+	 * @param array $data
+	 * @return array
+	 */
 	private function modifyMetaData(string $path, array $data): array {
 		$fullPath = $this->getFullPath($path);
 		$info = $this->getCache()->get($path);
@@ -170,7 +180,7 @@ class Encryption extends Wrapper {
 			$data['size'] = $this->unencryptedSize[$fullPath];
 		} else {
 			if (isset($info['fileid']) && $info['encrypted']) {
-				$data['size'] = $this->verifyUnencryptedSize($path, $info['size']);
+				$data['size'] = $this->verifyUnencryptedSize($path, $info->getUnencryptedSize());
 				$data['encrypted'] = true;
 			}
 		}
@@ -478,7 +488,7 @@ class Encryption extends Wrapper {
 	 *
 	 * @return int unencrypted size
 	 */
-	protected function verifyUnencryptedSize($path, $unencryptedSize) {
+	protected function verifyUnencryptedSize(string $path, int $unencryptedSize): int {
 		$size = $this->storage->filesize($path);
 		$result = $unencryptedSize;
 
@@ -510,7 +520,7 @@ class Encryption extends Wrapper {
 	 *
 	 * @return int calculated unencrypted size
 	 */
-	protected function fixUnencryptedSize($path, $size, $unencryptedSize) {
+	protected function fixUnencryptedSize(string $path, int $size, int $unencryptedSize): int {
 		$headerSize = $this->getHeaderSize($path);
 		$header = $this->getHeader($path);
 		$encryptionModule = $this->getEncryptionModule($path);
@@ -581,7 +591,9 @@ class Encryption extends Wrapper {
 		$cache = $this->storage->getCache();
 		if ($cache) {
 			$entry = $cache->get($path);
-			$cache->update($entry['fileid'], ['size' => $newUnencryptedSize]);
+			$cache->update($entry['fileid'], [
+				'unencrypted_size' => $newUnencryptedSize
+			]);
 		}
 
 		return $newUnencryptedSize;
@@ -621,7 +633,12 @@ class Encryption extends Wrapper {
 	 * @param bool $preserveMtime
 	 * @return bool
 	 */
-	public function moveFromStorage(Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = true) {
+	public function moveFromStorage(
+		Storage\IStorage $sourceStorage,
+		$sourceInternalPath,
+		$targetInternalPath,
+		$preserveMtime = true
+	) {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
@@ -656,7 +673,13 @@ class Encryption extends Wrapper {
 	 * @param bool $isRename
 	 * @return bool
 	 */
-	public function copyFromStorage(Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false, $isRename = false) {
+	public function copyFromStorage(
+		Storage\IStorage $sourceStorage,
+		$sourceInternalPath,
+		$targetInternalPath,
+		$preserveMtime = false,
+		$isRename = false
+	) {
 
 		// TODO clean this up once the underlying moveFromStorage in OC\Files\Storage\Wrapper\Common is fixed:
 		// - call $this->storage->copyFromStorage() instead of $this->copyBetweenStorage
@@ -676,7 +699,13 @@ class Encryption extends Wrapper {
 	 * @param bool $isRename
 	 * @param bool $keepEncryptionVersion
 	 */
-	private function updateEncryptedVersion(Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $isRename, $keepEncryptionVersion) {
+	private function updateEncryptedVersion(
+		Storage\IStorage $sourceStorage,
+		$sourceInternalPath,
+		$targetInternalPath,
+		$isRename,
+		$keepEncryptionVersion
+	) {
 		$isEncrypted = $this->encryptionManager->isEnabled() && $this->shouldEncrypt($targetInternalPath);
 		$cacheInformation = [
 			'encrypted' => $isEncrypted,
@@ -725,7 +754,13 @@ class Encryption extends Wrapper {
 	 * @return bool
 	 * @throws \Exception
 	 */
-	private function copyBetweenStorage(Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, $isRename) {
+	private function copyBetweenStorage(
+		Storage\IStorage $sourceStorage,
+		$sourceInternalPath,
+		$targetInternalPath,
+		$preserveMtime,
+		$isRename
+	) {
 
 		// for versions we have nothing to do, because versions should always use the
 		// key from the original file. Just create a 1:1 copy and done
@@ -743,7 +778,7 @@ class Encryption extends Wrapper {
 				if (isset($info['encrypted']) && $info['encrypted'] === true) {
 					$this->updateUnencryptedSize(
 						$this->getFullPath($targetInternalPath),
-						$info['size']
+						$info->getUnencryptedSize()
 					);
 				}
 				$this->updateEncryptedVersion($sourceStorage, $sourceInternalPath, $targetInternalPath, $isRename, true);
@@ -808,13 +843,6 @@ class Encryption extends Wrapper {
 		return (bool)$result;
 	}
 
-	/**
-	 * get the path to a local version of the file.
-	 * The local version of the file can be temporary and doesn't have to be persistent across requests
-	 *
-	 * @param string $path
-	 * @return string
-	 */
 	public function getLocalFile($path) {
 		if ($this->encryptionManager->isEnabled()) {
 			$cachedFile = $this->getCachedFile($path);
@@ -825,11 +853,6 @@ class Encryption extends Wrapper {
 		return $this->storage->getLocalFile($path);
 	}
 
-	/**
-	 * Returns the wrapped storage's value for isLocal()
-	 *
-	 * @return bool wrapped storage's isLocal() value
-	 */
 	public function isLocal() {
 		if ($this->encryptionManager->isEnabled()) {
 			return false;
@@ -837,15 +860,11 @@ class Encryption extends Wrapper {
 		return $this->storage->isLocal();
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.stat.php
-	 * only the following keys are required in the result: size and mtime
-	 *
-	 * @param string $path
-	 * @return array
-	 */
 	public function stat($path) {
 		$stat = $this->storage->stat($path);
+		if (!$stat) {
+			return false;
+		}
 		$fileSize = $this->filesize($path);
 		$stat['size'] = $fileSize;
 		$stat[7] = $fileSize;
@@ -853,14 +872,6 @@ class Encryption extends Wrapper {
 		return $stat;
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.hash.php
-	 *
-	 * @param string $type
-	 * @param string $path
-	 * @param bool $raw
-	 * @return string
-	 */
 	public function hash($type, $path, $raw = false) {
 		$fh = $this->fopen($path, 'rb');
 		$ctx = hash_init($type);
@@ -1068,6 +1079,13 @@ class Encryption extends Wrapper {
 		[$count, $result] = \OC_Helper::streamCopy($stream, $target);
 		fclose($stream);
 		fclose($target);
+
+		// object store, stores the size after write and doesn't update this during scan
+		// manually store the unencrypted size
+		if ($result && $this->getWrapperStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
+			$this->getCache()->put($path, ['unencrypted_size' => $count]);
+		}
+
 		return $count;
 	}
 }

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -107,7 +107,7 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
@@ -115,7 +115,7 @@ interface IExpressionBuilder {
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function comparison($x, string $operator, $y, $type = null): string;
+	public function comparison($x, string $operator, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates an equality comparison expression with the given arguments.
@@ -132,14 +132,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function eq($x, $y, $type = null): string;
+	public function eq($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a non equality comparison expression with the given arguments.
@@ -155,14 +155,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function neq($x, $y, $type = null): string;
+	public function neq($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a lower-than comparison expression with the given arguments.
@@ -178,14 +178,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function lt($x, $y, $type = null): string;
+	public function lt($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a lower-than-equal comparison expression with the given arguments.
@@ -201,14 +201,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function lte($x, $y, $type = null): string;
+	public function lte($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a greater-than comparison expression with the given arguments.
@@ -224,14 +224,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function gt($x, $y, $type = null): string;
+	public function gt($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a greater-than-equal comparison expression with the given arguments.
@@ -247,38 +247,38 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function gte($x, $y, $type = null): string;
+	public function gte($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates an IS NULL expression with the given arguments.
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be restricted by IS NULL.
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 */
-	public function isNull($x): string;
+	public function isNull($x): IQueryFunction;
 
 	/**
 	 * Creates an IS NOT NULL expression with the given arguments.
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be restricted by IS NOT NULL.
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 */
-	public function isNotNull($x): string;
+	public function isNotNull($x): IQueryFunction;
 
 	/**
 	 * Creates a LIKE() comparison expression with the given arguments.
@@ -288,14 +288,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function like($x, $y, $type = null): string;
+	public function like($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a NOT LIKE() comparison expression with the given arguments.
@@ -305,14 +305,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function notLike($x, $y, $type = null): string;
+	public function notLike($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a ILIKE() comparison expression with the given arguments.
@@ -322,14 +322,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function iLike($x, $y, $type = null): string;
+	public function iLike($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a IN () comparison expression with the given arguments.
@@ -339,14 +339,14 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function in($x, $y, $type = null): string;
+	public function in($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a NOT IN () comparison expression with the given arguments.
@@ -356,36 +356,36 @@ interface IExpressionBuilder {
 	 * @param mixed|null $type one of the IQueryBuilder::PARAM_* constants
 	 *                  required when comparing text fields for oci compatibility
 	 *
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 8.2.0 - Parameter $type was added in 9.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 * @psalm-taint-sink sql $y
 	 * @psalm-taint-sink sql $type
 	 */
-	public function notIn($x, $y, $type = null): string;
+	public function notIn($x, $y, $type = null): IQueryFunction;
 
 	/**
 	 * Creates a $x = '' statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 */
-	public function emptyString($x): string;
+	public function emptyString($x): IQueryFunction;
 
 	/**
 	 * Creates a `$x <> ''` statement, because Oracle needs a different check
 	 *
 	 * @param string|ILiteral|IParameter|IQueryFunction $x The field in string format to be inspected by the comparison.
-	 * @return string
+	 * @return IQueryFunction
 	 * @since 13.0.0
 	 *
 	 * @psalm-taint-sink sql $x
 	 */
-	public function nonEmptyString($x): string;
+	public function nonEmptyString($x): IQueryFunction;
 
 
 	/**

--- a/lib/public/DB/QueryBuilder/IFunctionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IFunctionBuilder.php
@@ -188,4 +188,16 @@ interface IFunctionBuilder {
 	 * @since 18.0.0
 	 */
 	public function least($x, $y): IQueryFunction;
+
+	/**
+	 * Takes the minimum of multiple values
+	 *
+	 * If you want to get the minimum value of all rows in a column, use `min` instead
+	 *
+	 * @param array<array{"when": string|ILiteral|IParameter|IQueryFunction, "then": string|ILiteral|IParameter|IQueryFunction}> $whens
+	 * @param string|ILiteral|IParameter|IQueryFunction $else
+	 * @return IQueryFunction
+	 * @since 18.0.0
+	 */
+	public function case(array $whens, $else): IQueryFunction;
 }

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -503,7 +503,7 @@ interface IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0
@@ -528,7 +528,7 @@ interface IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0
@@ -553,7 +553,7 @@ interface IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0
@@ -578,7 +578,7 @@ interface IQueryBuilder {
 	 * @param string $fromAlias The alias that points to a from clause.
 	 * @param string $join The table name to join.
 	 * @param string $alias The alias of the join table.
-	 * @param string|ICompositeExpression|null $condition The condition for the join.
+	 * @param string|IQueryFunction|ICompositeExpression|null $condition The condition for the join.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 * @since 8.2.0

--- a/lib/public/Files/Cache/ICacheEntry.php
+++ b/lib/public/Files/Cache/ICacheEntry.php
@@ -162,4 +162,14 @@ interface ICacheEntry extends ArrayAccess {
 	 * @since 18.0.0
 	 */
 	public function getUploadTime(): ?int;
+
+	/**
+	 * Get the unencrypted size
+	 *
+	 * This might be different from the result of getSize
+	 *
+	 * @return int
+	 * @since 25.0.0
+	 */
+	public function getUnencryptedSize(): int;
 }

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -501,4 +501,21 @@ class FunctionBuilderTest extends TestCase {
 		$result->closeCursor();
 		$this->assertEquals(1, $row);
 	}
+
+	public function testCase() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->case([
+			['when' => $query->expr()->gt($query->expr()->literal(1, IQueryBuilder::PARAM_INT), $query->expr()->literal(2, IQueryBuilder::PARAM_INT)), 'then' => $query->expr()->literal('first')],
+			['when' => $query->expr()->lt($query->expr()->literal(1, IQueryBuilder::PARAM_INT), $query->expr()->literal(2, IQueryBuilder::PARAM_INT)), 'then' => $query->expr()->literal('second')],
+			['when' => $query->expr()->eq($query->expr()->literal(1, IQueryBuilder::PARAM_INT), $query->expr()->literal(2, IQueryBuilder::PARAM_INT)), 'then' => $query->expr()->literal('third')],
+		], $query->createNamedParameter('else')));
+		$query->from('appconfig')
+			->setMaxResults(1);
+
+		$result = $query->execute();
+		$row = $result->fetchOne();
+		$result->closeCursor();
+		$this->assertEquals('second', $row);
+	}
 }

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -5,6 +5,7 @@ namespace Test\Files\Storage\Wrapper;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
 use OC\Encryption\Update;
 use OC\Encryption\Util;
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
@@ -259,7 +260,7 @@ class EncryptionTest extends Storage {
 			->method('get')
 			->willReturnCallback(
 				function ($path) use ($encrypted) {
-					return ['encrypted' => $encrypted, 'path' => $path, 'size' => 0, 'fileid' => 1];
+					return new CacheEntry(['encrypted' => $encrypted, 'path' => $path, 'size' => 0, 'fileid' => 1]);
 				}
 			);
 
@@ -332,7 +333,7 @@ class EncryptionTest extends Storage {
 			->disableOriginalConstructor()->getMock();
 		$cache->expects($this->any())
 			->method('get')
-			->willReturn(['encrypted' => true, 'path' => '/test.txt', 'size' => 0, 'fileid' => 1]);
+			->willReturn(new CacheEntry(['encrypted' => true, 'path' => '/test.txt', 'size' => 0, 'fileid' => 1]));
 
 		$this->instance = $this->getMockBuilder('\OC\Files\Storage\Wrapper\Encryption')
 			->setConstructorArgs(
@@ -910,7 +911,7 @@ class EncryptionTest extends Storage {
 		if ($copyResult) {
 			$cache->expects($this->once())->method('get')
 				->with($sourceInternalPath)
-				->willReturn(['encrypted' => $encrypted, 'size' => 42]);
+				->willReturn(new CacheEntry(['encrypted' => $encrypted, 'size' => 42]));
 			if ($encrypted) {
 				$instance->expects($this->once())->method('updateUnencryptedSize')
 					->with($mountPoint . $targetInternalPath, 42);

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -104,6 +104,9 @@ class HelperStorageTest extends \Test\TestCase {
 		$extStorage->file_put_contents('extfile.txt', 'abcdefghijklmnopq');
 		$extStorage->getScanner()->scan(''); // update root size
 
+		$config = \OC::$server->getConfig();
+		$config->setSystemValue('quota_include_external_storage', false);
+
 		\OC\Files\Filesystem::mount($extStorage, [], '/' . $this->user . '/files/ext');
 
 		$storageInfo = \OC_Helper::getStorageInfo('');


### PR DESCRIPTION
*The column is right there*

Store the unencrypted size in the `unencrypted_size` column instead of the `size` column, fixes some issues where other code (object storage) stores the encrypted size in the cache.