### PR TITLE
Fix export of shared calendars

### DIFF
--- a/apps/dav/lib/UserMigration/CalendarMigrator.php
+++ b/apps/dav/lib/UserMigration/CalendarMigrator.php
@@ -108,14 +108,7 @@ class CalendarMigrator implements IMigrator {
 	 */
 	private function getCalendarExportData(IUser $user, ICalendar $calendar, OutputInterface $output): array {
 		$userId = $user->getUID();
-		$calendarId = $calendar->getKey();
-		$calendarInfo = $this->calDavBackend->getCalendarById($calendarId);
-
-		if (empty($calendarInfo)) {
-			throw new CalendarMigratorException("Invalid info for calendar ID $calendarId");
-		}
-
-		$uri = $calendarInfo['uri'];
+		$uri = $calendar->getUri();
 		$path = CalDAVPlugin::CALENDAR_ROOT . "/$userId/$uri";
 
 		/**
@@ -227,12 +220,12 @@ class CalendarMigrator implements IMigrator {
 
 		try {
 			/**
-			* @var string $name
-			* @var VCalendar $vCalendar
-			*/
+			 * @var string $name
+			 * @var VCalendar $vCalendar
+			 */
 			foreach ($calendarExports as ['name' => $name, 'vCalendar' => $vCalendar]) {
-				// Set filename to sanitized calendar name appended with the date
-				$filename = preg_replace('/[^a-zA-Z0-9-_ ]/um', '', $name) . '_' . date('Y-m-d') . CalendarMigrator::FILENAME_EXT;
+				// Set filename to sanitized calendar name
+				$filename = preg_replace('/[^a-z0-9-_]/iu', '', $name) . CalendarMigrator::FILENAME_EXT;
 				$exportPath = CalendarMigrator::EXPORT_ROOT . $filename;
 
 				$exportDestination->addFileContents($exportPath, $vCalendar->serialize());
@@ -445,11 +438,11 @@ class CalendarMigrator implements IMigrator {
 				throw new CalendarMigratorException("Invalid calendar data contained in \"$importPath\"");
 			}
 
-			$splitFilename = explode('_', $filename, 2);
+			$splitFilename = explode('.', $filename, 2);
 			if (count($splitFilename) !== 2) {
-				throw new CalendarMigratorException("Invalid filename \"$filename\", expected filename of the format \"<calendar_name>_YYYY-MM-DD" . CalendarMigrator::FILENAME_EXT . '"');
+				throw new CalendarMigratorException("Invalid filename \"$filename\", expected filename of the format \"<calendar_name>" . CalendarMigrator::FILENAME_EXT . '"');
 			}
-			[$initialCalendarUri, $suffix] = $splitFilename;
+			[$initialCalendarUri, $ext] = $splitFilename;
 
 			try {
 				$this->importCalendar(

--- a/apps/dav/lib/UserMigration/ContactsMigrator.php
+++ b/apps/dav/lib/UserMigration/ContactsMigrator.php
@@ -168,7 +168,7 @@ class ContactsMigrator implements IMigrator {
 		}
 
 		$existingAddressBookUris = array_map(
-			fn (array $addressBookInfo) => $addressBookInfo['uri'],
+			fn (array $addressBookInfo): string => $addressBookInfo['uri'],
 			$this->cardDavBackend->getAddressBooksForUser($principalUri),
 		);
 

--- a/apps/dav/lib/UserMigration/ContactsMigrator.php
+++ b/apps/dav/lib/UserMigration/ContactsMigrator.php
@@ -207,14 +207,14 @@ class ContactsMigrator implements IMigrator {
 
 		try {
 			/**
-			* @var string $name
-			* @var string $displayName
-			* @var ?string $description
-			* @var VCard[] $vCards
-			*/
+			 * @var string $name
+			 * @var string $displayName
+			 * @var ?string $description
+			 * @var VCard[] $vCards
+			 */
 			foreach ($addressBookExports as ['name' => $name, 'displayName' => $displayName, 'description' => $description, 'vCards' => $vCards]) {
-				// Set filename to sanitized address book name appended with the date
-				$basename = preg_replace('/[^a-zA-Z0-9-_ ]/um', '', $name) . '_' . date('Y-m-d');
+				// Set filename to sanitized address book name
+				$basename = preg_replace('/[^a-z0-9-_]/iu', '', $name);
 				$exportPath = ContactsMigrator::PATH_ROOT . $basename . '.' . ContactsMigrator::FILENAME_EXT;
 				$metadataExportPath = ContactsMigrator::PATH_ROOT . $basename . '.' . ContactsMigrator::METADATA_EXT;
 
@@ -340,11 +340,11 @@ class ContactsMigrator implements IMigrator {
 				$vCards[] = $vCard;
 			}
 
-			$splitFilename = explode('_', $addressBookFilename, 2);
+			$splitFilename = explode('.', $addressBookFilename, 2);
 			if (count($splitFilename) !== 2) {
-				throw new ContactsMigratorException("Invalid filename \"$addressBookFilename\", expected filename of the format \"<address_book_name>_YYYY-MM-DD." . ContactsMigrator::FILENAME_EXT . '"');
+				throw new ContactsMigratorException("Invalid filename \"$addressBookFilename\", expected filename of the format \"<address_book_name>." . ContactsMigrator::FILENAME_EXT . '"');
 			}
-			[$initialAddressBookUri, $suffix] = $splitFilename;
+			[$initialAddressBookUri, $ext] = $splitFilename;
 
 			/** @var array{displayName: string, description?: string} $metadata */
 			$metadata = json_decode($importSource->getFileContents($metadataImportPath), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Use the correct `<calendar_name>_shared_by_<user>` uri, e.g. `work_shared_by_tim`, instead of just `work` (returned by `getCalendarById()`) which will throw as SabreDAV will try to look for the potentially non-existent or mistake it with the user's own `calendars/me/work` path rather than the correct `calendars/me/work_shared_by_tim` path

> Note: Contacts export already uses the correct uri

The date is removed from the filename as well as the export zip itself is timestamped, and the underscore no longer has special meaning as a separator