### PR TITLE
only register mounts that are new from providers that are new during a full setup

### DIFF
--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -234,4 +234,8 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		$this->homeProviders = [];
 		$this->rootProviders = [];
 	}
+
+	public function getProviders(): array {
+		return $this->providers;
+	}
 }


### PR DESCRIPTION
this fixes cases where during the (partial) setup of a shared mount a full setup is triggered

Signed-off-by: Robin Appelman <robin@icewind.nl>