### PR TITLE
improve optimization for SharedStorage::instanceOfStorage(Common)

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -35,8 +35,11 @@ namespace OCA\Files_Sharing;
 use OC\Files\Cache\FailedCache;
 use OC\Files\Cache\NullWatcher;
 use OC\Files\Cache\Watcher;
+use OC\Files\ObjectStore\HomeObjectStoreStorage;
 use OC\Files\Storage\Common;
+use OC\Files\Storage\Home;
 use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
 use OCP\Files\Node;
 use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Wrapper\PermissionsMask;
@@ -186,7 +189,14 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		if ($class === '\OC\Files\Storage\Common' || $class == Common::class) {
 			return true;
 		}
-		if (in_array($class, ['\OC\Files\Storage\Home', '\OC\Files\ObjectStore\HomeObjectStoreStorage', '\OCP\Files\IHomeStorage'])) {
+		if (in_array($class, [
+			'\OC\Files\Storage\Home',
+			'\OC\Files\ObjectStore\HomeObjectStoreStorage',
+			'\OCP\Files\IHomeStorage',
+			Home::class,
+			HomeObjectStoreStorage::class,
+			IHomeStorage::class
+		])) {
 			return false;
 		}
 		return parent::instanceOfStorage($class);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -35,6 +35,7 @@ namespace OCA\Files_Sharing;
 use OC\Files\Cache\FailedCache;
 use OC\Files\Cache\NullWatcher;
 use OC\Files\Cache\Watcher;
+use OC\Files\Storage\Common;
 use OCP\Files\Folder;
 use OCP\Files\Node;
 use OC\Files\Storage\FailedStorage;
@@ -182,7 +183,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	 * @inheritdoc
 	 */
 	public function instanceOfStorage($class): bool {
-		if ($class === '\OC\Files\Storage\Common') {
+		if ($class === '\OC\Files\Storage\Common' || $class == Common::class) {
 			return true;
 		}
 		if (in_array($class, ['\OC\Files\Storage\Home', '\OC\Files\ObjectStore\HomeObjectStoreStorage', '\OCP\Files\IHomeStorage'])) {


### PR DESCRIPTION
The `::class` doesn't have a leading slash I believe