### PR TITLE
Optimize autoloader level 2

### DIFF
--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -19,7 +19,7 @@ REPODIR=`git rev-parse --show-toplevel`
 #Redump the main autoloader
 echo
 echo "Regenerating main autoloader"
-$COMPOSER_COMMAND dump-autoload -d $REPODIR
+$COMPOSER_COMMAND dump-autoload --apcu -d $REPODIR
 
 for app in ${REPODIR}/apps/*; do
     if [[ -d $app ]]; then

--- a/lib/composer/composer/autoload_real.php
+++ b/lib/composer/composer/autoload_real.php
@@ -29,6 +29,7 @@ class ComposerAutoloaderInit53792487c5a8370acc0b06b1a864ff4c
         require __DIR__ . '/autoload_static.php';
         call_user_func(\Composer\Autoload\ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c::getInitializer($loader));
 
+        $loader->setApcuPrefix('RWXoiKA0E8o6hrCf46Wc1');
         $loader->register(true);
 
         return $loader;


### PR DESCRIPTION
This is using the APCu cache approache since because we load dynamically
other apps that don't include a composer autoloader file the authoritative
class maps approach is not possible.

See
https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-b-apcu-cache

**Test plan:**

1. Enable it
2. Browse a few pages, nothing unusual happens