### PR TITLE
cache the verification of the share mountpoint

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -34,6 +34,7 @@ use OCA\Files_Sharing\Event\ShareMountedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
@@ -59,6 +60,9 @@ class MountProvider implements IMountProvider {
 	/** @var IEventDispatcher */
 	protected $eventDispatcher;
 
+	/** @var ICacheFactory */
+	protected $cacheFactory;
+
 	/**
 	 * @param \OCP\IConfig $config
 	 * @param IManager $shareManager
@@ -68,12 +72,14 @@ class MountProvider implements IMountProvider {
 		IConfig $config,
 		IManager $shareManager,
 		ILogger $logger,
-		IEventDispatcher $eventDispatcher
+		IEventDispatcher $eventDispatcher,
+		ICacheFactory $cacheFactory
 	) {
 		$this->config = $config;
 		$this->shareManager = $shareManager;
 		$this->logger = $logger;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->cacheFactory = $cacheFactory;
 	}
 
 
@@ -136,7 +142,8 @@ class MountProvider implements IMountProvider {
 					$view,
 					$foldersExistCache,
 					$this->eventDispatcher,
-					$user
+					$user,
+					$this->cacheFactory->createLocal('share-valid-mountpoint')
 				);
 
 				$event = new ShareMountedEvent($mount);

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -29,10 +29,12 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Memcache\NullCache;
 use OCA\Files_Sharing\MountProvider;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
@@ -72,8 +74,11 @@ class MountProviderTest extends \Test\TestCase {
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createLocal')
+			->willReturn(new NullCache());
 
-		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher);
+		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher, $cacheFactory);
 	}
 
 	private function makeMockShare($id, $nodeId, $owner = 'user2', $target = null, $permissions = 31) {


### PR DESCRIPTION
after the initial verification this can only really be invalidated by a system mount (external/group/etc) being created at the share target since any normal file/folder creation will already conflict with the share

Signed-off-by: Robin Appelman <robin@icewind.nl>