### PR TITLE
Verify that Talk could be enabled before executing the tests

### DIFF
--- a/build/integration/sharing_features/sharing-v1-video-verification.feature
+++ b/build/integration/sharing_features/sharing-v1-video-verification.feature
@@ -4,6 +4,7 @@ Feature: sharing
     Given using api version "1"
     Given using old dav path
     Given invoking occ with "app:enable spreed"
+    Given the command was successful
 
   Scenario: Creating a link share with send password by Talk
     Given user "user0" exists


### PR DESCRIPTION
This should make the problem clearer if Talk could not be enabled (for example, due to a version mismatch), as otherwise the tests would fail in more cryptic ways.
