### PR TITLE
Fix sync errors for card creation with the same uri from different sources

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -47,12 +47,14 @@ class Converter {
 		$userProperties = $this->accountManager->getAccount($user)->getProperties();
 
 		$uid = $user->getUID();
+		$backendClassName = $user->getBackendClassName();
 		$cloudId = $user->getCloudId();
 		$image = $this->getAvatarImage($user);
 
 		$vCard = new VCard();
 		$vCard->VERSION = '3.0';
-		$vCard->UID = $uid;
+		$vCard->UID = md5("$backendClassName:$uid");
+	 	$vCard->add(new Text($vCard, 'X-NEXTCLOUD-UID', $uid));
 
 		$publish = false;
 

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -274,7 +274,7 @@ class SyncService {
 		$allCards = $this->backend->getCards($systemAddressBook['id']);
 		foreach ($allCards as $card) {
 			$vCard = Reader::read($card['carddata']);
-			$uid = $vCard->UID->getValue();
+			$uid = isset($vCard->{'X-NEXTCLOUD-UID'}) ? $vCard->{'X-NEXTCLOUD-UID'}->getValue() : $vCard->UID->getValue();
 			// load backend and see if user exists
 			if (!$this->userManager->userExists($uid)) {
 				$this->deleteUser($card['uri']);


### PR DESCRIPTION
When syncing the system address book,, the email address is used as the uri.

This leads to errors when two different backends are providing the same email addresses and try to create VCards for those entries separately.

Since the code should not be forced to decide which data providing backend is the source of truth, the uri should include the backend identifier to make uris more unique and dependent on their source.