### PR TITLE
tell mysql to ignore the sort index for search queries

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1113,7 +1113,7 @@ class QueryBuilder implements IQueryBuilder {
 	/**
 	 * Adds an ordering to the query results.
 	 *
-	 * @param string $sort The ordering expression.
+	 * @param string|ILiteral|IParameter|IQueryFunction $sort The ordering expression.
 	 * @param string $order The ordering direction.
 	 *
 	 * @return $this This QueryBuilder instance.

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -232,6 +232,17 @@ class SearchBuilder {
 			if ($field === 'fileid') {
 				$field = 'file.fileid';
 			}
+
+			// Mysql really likes to pick an index for sorting if it can't fully satisfy the where
+			// filter with an index, since search queries pretty much never are fully filtered by index
+			// mysql often picks an index for sorting instead of the much more useful index for filtering.
+			//
+			// By changing the order by to an expression, mysql isn't smart enough to see that it could still
+			// use the index, so it instead picks an index for the filtering
+			if ($field === 'mtime') {
+				$field = $query->func()->add($field, $query->createNamedParameter(0));
+			}
+
 			$query->addOrderBy($field, $order->getDirection());
 		}
 	}

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -834,7 +834,7 @@ interface IQueryBuilder {
 	/**
 	 * Adds an ordering to the query results.
 	 *
-	 * @param string $sort The ordering expression.
+	 * @param string|ILiteral|IParameter|IQueryFunction $sort The ordering expression.
 	 * @param string $order The ordering direction.
 	 *
 	 * @return $this This QueryBuilder instance.


### PR DESCRIPTION
Cleaner version of https://github.com/nextcloud/server/pull/29300 (ab)using mysql's inability to use an index for sorting by function.

> mysql really likes to pick an index for sorting if it can't fully satisfy the where
filter with an index, since search queries pretty much never are fully filtered by index
mysql often picks an index for sorting instead of the much more useful index for filtering.