### PR TITLE
Get not only time-sensitive next job from list but any when not in cron-mode

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -147,6 +147,7 @@ try {
 				break;
 			}
 
+			$logger->debug('CLI cron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
 			$job->execute($jobList, $logger);
 			// clean up after unclean jobs
 			\OC_Util::tearDownFS();
@@ -169,6 +170,7 @@ try {
 			$jobList = \OC::$server->getJobList();
 			$job = $jobList->getNext();
 			if ($job != null) {
+				$logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
 				$job->execute($jobList, $logger);
 				$jobList->setLastJob($job);
 			}

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -203,7 +203,7 @@ class JobList implements IJobList {
 	 * @param bool $onlyTimeSensitive
 	 * @return IJob|null
 	 */
-	public function getNext(bool $onlyTimeSensitive = true): ?IJob {
+	public function getNext(bool $onlyTimeSensitive = false): ?IJob {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -78,7 +78,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	 * @param bool $onlyTimeSensitive
 	 * @return IJob|null
 	 */
-	public function getNext(bool $onlyTimeSensitive = true): ?IJob {
+	public function getNext(bool $onlyTimeSensitive = false): ?IJob {
 		if (count($this->jobs) > 0) {
 			if ($this->last < (count($this->jobs) - 1)) {
 				$i = $this->last + 1;


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/31725
Fix https://github.com/nextcloud/server/issues/30899

Before the change webcron used to select
**only** time-sensitive tasks.

Signed-off-by: Kirill Popov <kirill.s.popov@gmail.com>