### PR TITLE
Add CSP policy merge priority for booleans

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -246,6 +246,13 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function isStrictDynamicAllowed(): bool {
+		return $this->strictDynamicAllowed;
+	}
+
+	/**
 	 * @param boolean $strictDynamicAllowed
 	 */
 	public function setStrictDynamicAllowed(bool $strictDynamicAllowed) {

--- a/lib/private/Security/CSP/ContentSecurityPolicyManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyManager.php
@@ -82,7 +82,12 @@ class ContentSecurityPolicyManager implements IContentSecurityPolicyManager {
 				$currentValues = \is_array($defaultPolicy->$getter()) ? $defaultPolicy->$getter() : [];
 				$defaultPolicy->$setter(array_values(array_unique(array_merge($currentValues, $value))));
 			} elseif (\is_bool($value)) {
-				$defaultPolicy->$setter($value);
+				$getter = 'is'.ucfirst($name);
+				$currentValue = $defaultPolicy->$getter();
+				// true wins over false
+				if ($value > $currentValue) {
+					$defaultPolicy->$setter($value);
+				}
 			}
 		}
 

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -45,7 +45,7 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	/** @var bool Whether eval in JS scripts is allowed */
 	protected $evalScriptAllowed = false;
 	/** @var bool Whether strict-dynamic should be set */
-	protected $strictDynamicAllowed = null;
+	protected $strictDynamicAllowed = false;
 	/** @var array Domains from which scripts can get loaded */
 	protected $allowedScriptDomains = [
 		'\'self\'',

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -87,6 +87,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 			$policy->addAllowedFontDomain('mydomain.com');
 			$policy->addAllowedImageDomain('anotherdomain.de');
 			$policy->useStrictDynamic(true);
+			$policy->allowEvalScript(true);
 
 			$e->addPolicy($policy);
 		});
@@ -96,7 +97,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 			$policy->addAllowedFontDomain('example.com');
 			$policy->addAllowedImageDomain('example.org');
 			$policy->allowInlineScript(true);
-			$policy->allowEvalScript(true);
+			$policy->allowEvalScript(false);
 			$e->addPolicy($policy);
 		});
 


### PR DESCRIPTION
When two booleans conflict when merging CSP policies, true will win.

This is based on the assumption that everything is blocked by default and apps are only interested in allowing more and not adding more blocks.

Beware: this can be considered a change of behavior because apps might need to adjust