### PR TITLE
fix social sharing buttons

### DIFF
--- a/apps/federatedfilesharing/css/settings-personal.scss
+++ b/apps/federatedfilesharing/css/settings-personal.scss
@@ -30,13 +30,14 @@
 
 .social-diaspora {
 	@include icon-color('social-diaspora', 'federatedfilesharing', $color-black);
-	padding-left: 26px;
 }
 .social-twitter {
     @include icon-color('social-twitter', 'federatedfilesharing', $color-black);
-	padding-left: 26px;
 }
 .social-facebook {
 	@include icon-color('social-facebook', 'federatedfilesharing', $color-black);
-	padding-left: 26px;
+}
+
+.social_sharing_buttons {
+	padding-left: 30px !important;
 }

--- a/apps/federatedfilesharing/templates/settings-personal.php
+++ b/apps/federatedfilesharing/templates/settings-personal.php
@@ -22,15 +22,15 @@ style('federatedfilesharing', 'settings-personal');
 
 	<p>
 		<?php p($l->t('Share it so your friends can share files with you:')); ?><br>
-		<button class="social-facebook pop-up"
+		<button class="social-facebook pop-up social_sharing_buttons"
 				data-url='https://www.facebook.com/sharer/sharer.php?u=<?php p(urlencode($_['reference'])); ?>'>
 			Facebook
 		</button>
-		<button class="social-twitter pop-up"
+		<button class="social-twitter pop-up social_sharing_buttons"
 			data-url='https://twitter.com/intent/tweet?text=<?php p(urlencode($_['message_with_URL'])); ?>'>
 			Twitter
 		</button>
-		<button class="social-diaspora pop-up"
+		<button class="social-diaspora pop-up social_sharing_buttons"
 				data-url='https://share.diasporafoundation.org/?title=<?php p($_['message_without_URL']); ?>&url=<?php p(urlencode($_['reference'])); ?>'>
 			Diaspora
 		</button>


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/31970

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/165126616-7f925c8d-45f7-4788-b769-ac4f89c80188.png) | ![image](https://user-images.githubusercontent.com/42591237/165126466-89e9b89f-7643-4804-87a4-d7ba46fbc5a8.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=fix/31970/fix-social-sharing-buttons \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>