### PR TITLE
Allow compatibility wrapper on local external storage

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -147,7 +147,7 @@ class SetupManager {
 		});
 
 		Filesystem::addStorageWrapper('oc_encoding', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
-			if ($mount->getOption('encoding_compatibility', false) && !$storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage') && !$storage->isLocal()) {
+			if ($mount->getOption('encoding_compatibility', false) && !$storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 				return new Encoding(['storage' => $storage]);
 			}
 			return $storage;


### PR DESCRIPTION
The check was likely in place to prevent adding the wrapper on the root
and home storage, which is not possible anyway since the encoding option cannot
be set on that mount.

Fixes https://github.com/nextcloud/server/issues/32151