### PR TITLE
Avoid locking the php session

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -257,6 +257,17 @@ $CONFIG = [
 'session_lifetime' => 60 * 60 * 24,
 
 /**
+ * `true` enabled a relaxed session timeout, where the session timeout would no longer be
+ * handled by Nextcloud but by either the PHP garbage collection or the expiration of
+ * potential other session backends like redis.
+ *
+ * This may lead to sessions being available for longer than what session_lifetime uses but
+ * comes with performance benefits as sessions are no longer a locking operation for concurrent
+ * requests.
+ */
+'session_relaxed_expiry' => false,
+
+/**
  * Enable or disable session keep-alive when a user is logged in to the Web UI.
  * Enabling this sends a "heartbeat" to the server to keep it from timing out.
  *

--- a/lib/base.php
+++ b/lib/base.php
@@ -445,7 +445,9 @@ class OC {
 			die();
 		}
 
+		//try to set the session lifetime
 		$sessionLifeTime = self::getSessionLifeTime();
+		@ini_set('gc_maxlifetime', (string)$sessionLifeTime);
 
 		// session timeout
 		if ($session->exists('LAST_ACTIVITY') && (time() - $session->get('LAST_ACTIVITY') > $sessionLifeTime)) {
@@ -717,9 +719,6 @@ class OC {
 				$config->deleteAppValue('core', 'cronErrors');
 			}
 		}
-		//try to set the session lifetime
-		$sessionLifeTime = self::getSessionLifeTime();
-		@ini_set('gc_maxlifetime', (string)$sessionLifeTime);
 
 		// User and Groups
 		if (!$systemConfig->getValue("installed", false)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -456,6 +456,7 @@ class OC {
 		}
 
 		$session->set('LAST_ACTIVITY', time());
+		$session->close();
 	}
 
 	/**

--- a/lib/base.php
+++ b/lib/base.php
@@ -455,7 +455,9 @@ class OC {
 			\OC::$server->getUserSession()->logout();
 		}
 
-		$session->set('LAST_ACTIVITY', time());
+		if (!self::hasSessionRelaxedExpiry()) {
+			$session->set('LAST_ACTIVITY', time());
+		}
 		$session->close();
 	}
 
@@ -464,6 +466,13 @@ class OC {
 	 */
 	private static function getSessionLifeTime() {
 		return \OC::$server->getConfig()->getSystemValue('session_lifetime', 60 * 60 * 24);
+	}
+
+	/**
+	 * @return bool true if the session expiry should only be done by gc instead of an explicit timeout
+	 */
+	public static function hasSessionRelaxedExpiry(): bool {
+		return \OC::$server->getConfig()->getSystemValue('session_relaxed_expiry', false);
 	}
 
 	/**

--- a/lib/private/AppFramework/Middleware/SessionMiddleware.php
+++ b/lib/private/AppFramework/Middleware/SessionMiddleware.php
@@ -51,8 +51,8 @@ class SessionMiddleware extends Middleware {
 	 */
 	public function beforeController($controller, $methodName) {
 		$useSession = $this->reflector->hasAnnotation('UseSession');
-		if (!$useSession) {
-			$this->session->close();
+		if ($useSession) {
+			$this->session->reopen();
 		}
 	}
 

--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -97,8 +97,17 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * @param mixed $value
 	 */
 	public function set(string $key, $value) {
+		if ($this->get($key) === $value) {
+			// Do not write the session if the value hasn't changed to avoid reopening
+			return;
+		}
+
+		$reopened = $this->reopen();
 		$this->sessionValues[$key] = $value;
 		$this->isModified = true;
+		if ($reopened) {
+			$this->close();
+		}
 	}
 
 	/**
@@ -131,9 +140,13 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * @param string $key
 	 */
 	public function remove(string $key) {
+		$reopened = $this->reopen();
 		$this->isModified = true;
 		unset($this->sessionValues[$key]);
 		$this->session->remove(self::encryptedSessionName);
+		if ($reopened) {
+			$this->close();
+		}
 	}
 
 	/**
@@ -147,6 +160,10 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 		}
 		$this->isModified = true;
 		$this->session->clear();
+	}
+
+	public function reopen(): bool {
+		return $this->session->reopen();
 	}
 
 	/**

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -178,7 +178,7 @@ class Internal extends Session {
 	 */
 	public function reopen(): bool {
 		if ($this->sessionClosed) {
-			$this->startSession();
+			$this->startSession(false, false);
 			$this->sessionClosed = false;
 			return true;
 		}
@@ -225,7 +225,11 @@ class Internal extends Session {
 		}
 	}
 
-	private function startSession(bool $silence = false) {
-		$this->invoke('session_start', [['cookie_samesite' => 'Lax']], $silence);
+	private function startSession(bool $silence = false, bool $readAndClose = true) {
+		$sessionParams = ['cookie_samesite' => 'Lax'];
+		if (\OC::hasSessionRelaxedExpiry()) {
+			$sessionParams['read_and_close'] = $readAndClose;
+		}
+		$this->invoke('session_start', [$sessionParams], $silence);
 	}
 }

--- a/lib/private/Session/Memory.php
+++ b/lib/private/Session/Memory.php
@@ -53,7 +53,6 @@ class Memory extends Session {
 	 * @param integer $value
 	 */
 	public function set(string $key, $value) {
-		$this->validateSession();
 		$this->data[$key] = $value;
 	}
 
@@ -80,7 +79,6 @@ class Memory extends Session {
 	 * @param string $key
 	 */
 	public function remove(string $key) {
-		$this->validateSession();
 		unset($this->data[$key]);
 	}
 
@@ -110,8 +108,10 @@ class Memory extends Session {
 	/**
 	 * Helper function for PHPUnit execution - don't use in non-test code
 	 */
-	public function reopen() {
+	public function reopen(): bool {
+		$reopened = $this->sessionClosed;
 		$this->sessionClosed = false;
+		return $reopened;
 	}
 
 	/**

--- a/lib/public/ISession.php
+++ b/lib/public/ISession.php
@@ -84,6 +84,14 @@ interface ISession {
 	public function clear();
 
 	/**
+	 * Reopen a session for writing again
+	 *
+	 * @return bool true if the session was actually reopened, otherwise false
+	 * @since 25.0.0
+	 */
+	public function reopen(): bool;
+
+	/**
 	 * Close the session and release the lock
 	 * @since 7.0.0
 	 */


### PR DESCRIPTION
Slightly different approach about has the same target as https://github.com/nextcloud/server/issues/29356 to reduce the time that request might need to wait for locked sessions.

We already try to write and close the session  early but on multiple concurrent requests that is still not fast enough to not have noticeable wait time on the lock. To my knowledge we don't write anything into the session that would be critical in terms of using already read value that has been updated by another request, so I think this approach should be fine from the potential race condition perspective, especially with reopening the session we would read again.

Impact on page load can be tested by adding a sleep for specific routes:

```diff
diff --git a/lib/private/Session/Internal.php b/lib/private/Session/Internal.php
index 1dfec8d71e..db9002f8be 100644
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -233,5 +233,8 @@ class Internal extends Session {
                        $sessionParams['read_and_close'] = $readAndClose;
                }
                $this->invoke('session_start', [$sessionParams], $silence);
+               if (strpos(\OC::$server->getRequest()->getRequestUri(), '/ocs/v2.php/search/providers') === 0) {
+                       sleep(10);
+               }
        }
 }
```

Currently every request writes to the session https://github.com/nextcloud/server/blob/d42911c4869ecb7a9a55d1e1d77ae22d95a1c53b/lib/base.php#L455 so we always need to at least open once for reading and that write, so second commit implements what was described in https://github.com/nextcloud/server/issues/29356 but requires that we do no longer invalidate sessions on the Nextcloud side, but rely on the PHP garbage collection for it.

I decided to go for a config flag for this, as for most setups having a session timeout that is happening at the exact second might not be really needed. If that is not used, PHP may clean up the session at a later point depending on the session garbage collection configuration. If using redis, the session lifetime will be set anyways on redis, so redis would take care of the deletion using configured key eviction policy.