### PR TITLE
Require Primary Keys in all SQL tables

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -306,6 +306,7 @@ services:
     MYSQL_DATABASE: oc_autotest
   command:
     - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+    - --innodb_force_primary_key=ON
   tmpfs:
     - /var/lib/mysql
 
@@ -344,6 +345,7 @@ services:
     MYSQL_DATABASE: oc_autotest
   command:
     - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+    - --innodb_force_primary_key=ON
   tmpfs:
     - /var/lib/mysql
 
@@ -382,6 +384,7 @@ services:
     MYSQL_DATABASE: oc_autotest
   command:
     - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+    - --innodb_force_primary_key=ON
   tmpfs:
     - /var/lib/mysql
 
@@ -416,6 +419,7 @@ services:
   command:
     - --default-authentication-plugin=mysql_native_password
     - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+    - --sql_require_primary_key=ON
   environment:
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: oc_autotest


### PR DESCRIPTION
Force the existence of PK on all MySQL/MariaDB tables.
https://vettabase.com/blog/why-tables-need-a-primary-key-in-mariadb-and-mysql/