### PR TITLE
Fix `Undefined array key "enabledThemes"` on layout.user.php

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -107,6 +107,7 @@ class TemplateLayout extends \OC_Template {
 			Util::addScript('core', 'unified-search', 'core');
 
 			// Set body data-theme
+			$this->assign('enabledThemes', []);
 			if (\OC::$server->getAppManager()->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
 				/** @var \OCA\Theming\Service\ThemesService */
 				$themesService = \OC::$server->get(\OCA\Theming\Service\ThemesService::class);


### PR DESCRIPTION
```json
{
  "reqId": "DCgh4WWJzTHSVXPlVsaj",
  "level": 3,
  "time": "2022-04-28T06:53:17+00:00",
  "remoteAddr": "172.18.0.1",
  "user": "admin",
  "app": "PHP",
  "method": "GET",
  "url": "/apps/dashboard/",
  "message": "Undefined array key \"enabledThemes\" at /var/www/nextcloud/core/templates/layout.user.php#43",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36",
  "version": "25.0.0.1",
  "exception": {
    "Exception": "Error",
    "Message": "Undefined array key \"enabledThemes\" at /var/www/nextcloud/core/templates/layout.user.php#43",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/core/templates/layout.user.php",
        "line": 43,
        "function": "onAll",
        "class": "OC\\Log\\ErrorHandler",
        "type": "::",
        "args": [
          2,
          "Undefined array key \"enabledThemes\"",
          "/var/www/nextcloud/core/templates/layout.user.php",
          43
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Template/Base.php",
        "line": 180,
        "args": [
          "/var/www/nextcloud/core/templates/layout.user.php"
        ],
        "function": "include"
      },
      {
        "file": "/var/www/nextcloud/lib/private/Template/Base.php",
        "line": 150,
        "function": "load",
        "class": "OC\\Template\\Base",
        "type": "->",
        "args": [
          "/var/www/nextcloud/core/templates/layout.user.php",
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Template.php",
        "line": 182,
        "function": "fetchPage",
        "class": "OC\\Template\\Base",
        "type": "->",
        "args": [
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Template.php",
        "line": 213,
        "function": "fetchPage",
        "class": "OC_Template",
        "type": "->",
        "args": [
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Http/TemplateResponse.php",
        "line": 204,
        "function": "fetchPage",
        "class": "OC_Template",
        "type": "->",
        "args": [
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 178,
        "function": "render",
        "class": "OCP\\AppFramework\\Http\\TemplateResponse",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 172,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Dashboard\\Controller\\DashboardController"
          },
          "index"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 298,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Dashboard\\Controller\\DashboardController",
          "index",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "_route": "dashboard.dashboard.index"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1023,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/dashboard/"
        ]
      },
      {
        "file": "/var/www/nextcloud/index.php",
        "line": 36,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/nextcloud/lib/private/Log/ErrorHandler.php",
    "Line": 99,
    "CustomMessage": "--"
  }
}
```