### PR TITLE
Make the order of reactions reliable

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -1269,6 +1269,7 @@ class Manager implements ICommentsManager {
 			->where($totalQuery->expr()->eq('r.parent_id', $qb->createNamedParameter($parentId)))
 			->groupBy('r.reaction')
 			->orderBy('total', 'DESC')
+			->addOrderBy('r.reaction', 'ASC')
 			->setMaxResults(20);
 
 		$jsonQuery = $this->dbConn->getQueryBuilder();


### PR DESCRIPTION
Currently the talk reaction tests are not too reliable. The problem is reactions with the same emoji are not always sorted in the same way as they are only sorted by count so far:
https://drone.nextcloud.com/nextcloud/spreed/7669/7/4 line 440