### PR TITLE
Respect user settings in php.ini if they are big enough

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -628,17 +628,17 @@ class OC {
 		//this doesn´t work always depending on the webserver and php configuration.
 		//Let´s try to overwrite some defaults if they are smaller than 1 hour
 
-		if (intval(@ini_get('max_execution_time')?? 0) < 3600) {
+		if (intval(@ini_get('max_execution_time') ?? 0) < 3600) {
 			@ini_set('max_execution_time', strval(3600));
 		}
 
-		if (intval(@ini_get('max_input_time')?? 0) < 3600) {
+		if (intval(@ini_get('max_input_time') ?? 0) < 3600) {
 			@ini_set('max_input_time', strval(3600));
 		}
 
 		//try to set the maximum execution time to the largest time limit we have
 		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
-			@set_time_limit(strval(max(intval(@ini_get('max_execution_time')),intval(@ini_get('max_input_time')))));
+			@set_time_limit(max(intval(@ini_get('max_execution_time')), intval(@ini_get('max_input_time'))));
 		}
 
 		self::setRequiredIniValues();

--- a/lib/base.php
+++ b/lib/base.php
@@ -627,27 +627,18 @@ class OC {
 		//try to configure php to enable big file uploads.
 		//this doesn´t work always depending on the webserver and php configuration.
 		//Let´s try to overwrite some defaults if they are smaller than 1 hour
-		// One hour is 3600 seconds
-		$time_limit = 3600;
 
-		$max_execution_time_from_ini = @ini_get('max_execution_time');
-		$biggest_max_execution_time = $time_limit;
-		if (isset($max_execution_time_from_ini)) {
-			$biggest_max_execution_time = max($time_limit, intval($max_execution_time_from_ini));
+		if (intval(@ini_get('max_execution_time')?? 0) < 3600) {
+			@ini_set('max_execution_time', strval(3600));
 		}
-		@ini_set('max_execution_time', strval($biggest_max_execution_time));
 
-		$max_input_time_from_ini = @ini_get('max_input_time');
-		$biggest_max_input_time = $time_limit;
-		if (isset($max_input_time_from_ini)) {
-			$biggest_max_input_time = max($time_limit, intval($max_input_time_from_ini));
+		if (intval(@ini_get('max_input_time')?? 0) < 3600) {
+			@ini_set('max_input_time', strval(3600));
 		}
-		@ini_set('max_input_time', strval($biggest_max_input_time));
 
 		//try to set the maximum execution time to the largest time limit we have
 		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
-			$biggest_time_limit = max($time_limit, $biggest_max_execution_time, $biggest_max_input_time);
-			@set_time_limit($biggest_time_limit);
+			@set_time_limit(strval(max(intval(@ini_get('max_execution_time')),intval(@ini_get('max_input_time')))));
 		}
 
 		self::setRequiredIniValues();

--- a/lib/base.php
+++ b/lib/base.php
@@ -623,16 +623,32 @@ class OC {
 			throw new \RuntimeException('Could not set timezone to UTC');
 		}
 
-		//try to configure php to enable big file uploads.
-		//this doesn´t work always depending on the web server and php configuration.
-		//Let´s try to overwrite some defaults anyway
 
-		//try to set the maximum execution time to 60min
-		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
-			@set_time_limit(3600);
+		//try to configure php to enable big file uploads.
+		//this doesn´t work always depending on the webserver and php configuration.
+		//Let´s try to overwrite some defaults if they are smaller than 1 hour
+		// One hour is 3600 seconds
+		$time_limit = 3600;
+
+		$max_execution_time_from_ini = @ini_get('max_execution_time');
+		$biggest_max_execution_time = $time_limit;
+		if (isset($max_execution_time_from_ini)) {
+			$biggest_max_execution_time = max($time_limit, intval($max_execution_time_from_ini));
 		}
-		@ini_set('max_execution_time', '3600');
-		@ini_set('max_input_time', '3600');
+		@ini_set('max_execution_time', strval($biggest_max_execution_time));
+
+		$max_input_time_from_ini = @ini_get('max_input_time');
+		$biggest_max_input_time = $time_limit;
+		if (isset($max_input_time_from_ini)) {
+			$biggest_max_input_time = max($time_limit, intval($max_input_time_from_ini));
+		}
+		@ini_set('max_input_time', strval($biggest_max_input_time));
+
+		//try to set the maximum execution time to the largest time limit we have
+		if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+			$biggest_time_limit = max($time_limit, $biggest_max_execution_time, $biggest_max_input_time);
+			@set_time_limit($biggest_time_limit);
+		}
 
 		self::setRequiredIniValues();
 		self::handleAuthHeaders();


### PR DESCRIPTION
In the admin guide:
* https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/big_file_upload_configuration.html

Fix https://github.com/nextcloud/server/issues/32209

it is mentioned that you can tweek:
* max_input_time
* max_execution_time

in order to enable larger file uploads. However, the current codebase
will hard code these values to one hour, no matter what the user sets in
php.ini.

This patch will allow the user to set these settings in php.ini and they
will be respected, if and only if, they are set to something bigger than
3600 seconds.