### PR TITLE
Don't use hash to check if binding worked

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -128,7 +128,7 @@ class Connection extends LDAPUtility {
 	protected $ignoreValidation = false;
 
 	/**
-	 * @var array{dn?: mixed, hash?: string, result?: bool}
+	 * @var array{sum?: string, result?: bool}
 	 */
 	protected $bindResult = [];
 
@@ -672,11 +672,7 @@ class Connection extends LDAPUtility {
 
 		if (
 			count($this->bindResult) !== 0
-			&& $this->bindResult['dn'] === $this->configuration->ldapAgentName
-			&& \OC::$server->getHasher()->verify(
-				$this->configPrefix . $this->configuration->ldapAgentPassword,
-				$this->bindResult['hash']
-			)
+			&& $this->bindResult['sum'] === md5($this->configuration->ldapAgentName . $this->configPrefix . $this->configuration->ldapAgentPassword)
 		) {
 			// don't attempt to bind again with the same data as before
 			// bind might have been invoked via getConnectionResource(),
@@ -689,8 +685,7 @@ class Connection extends LDAPUtility {
 										$this->configuration->ldapAgentPassword);
 
 		$this->bindResult = [
-			'dn' => $this->configuration->ldapAgentName,
-			'hash' => \OC::$server->getHasher()->hash($this->configPrefix . $this->configuration->ldapAgentPassword),
+			'sum' => md5($this->configuration->ldapAgentName . $this->configPrefix . $this->configuration->ldapAgentPassword),
 			'result' => $ldapLogin,
 		];
 


### PR DESCRIPTION
using password_hash is expensive and should be used for hashing
passwords when saving them in the database. Here we just want to see if
the bind was already done with the given password.

Time spent on testing.nextcloud.com for password hashing 160ms:

![image](https://user-images.githubusercontent.com/23653902/166315485-3ccff8db-5986-4992-babe-887d87da40e8.png)

