### PR TITLE
Remove leading "minus"

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -306,7 +306,7 @@ class Server {
 						\OC::$server->getShareManager(),
 						$view
 					));
--					$logger = \OC::$server->get(LoggerInterface::class);
+					$logger = \OC::$server->get(LoggerInterface::class);
 					$this->server->addPlugin(
 						new BulkUploadPlugin($userFolder, $logger)
 					);


### PR DESCRIPTION
A '-' has been added by mistake in `apps/dav/lib/Server.php` which makes it crash because this operand does not apply to PsrLoggerAdapter:
```
Unsupported operand types: OC\\Log\\PsrLoggerAdapter * int
```
