### PR TITLE
Do not dispatch postSetPassword when setPassword fails

### DIFF
--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -109,7 +109,10 @@ class ChangePasswordController extends Controller {
 		try {
 			if ($newpassword === null || $user->setPassword($newpassword) === false) {
 				return new JSONResponse([
-					'status' => 'error'
+					'status' => 'error',
+					'data' => [
+						'message' => $this->l->t('Unable to change personal password'),
+					],
 				]);
 			}
 			// password policy app throws exception

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -320,13 +320,17 @@ class User implements IUser {
 		}
 		if ($this->backend->implementsActions(Backend::SET_PASSWORD)) {
 			$result = $this->backend->setPassword($this->uid, $password);
-			$this->legacyDispatcher->dispatch(IUser::class . '::postSetPassword', new GenericEvent($this, [
-				'password' => $password,
-				'recoveryPassword' => $recoveryPassword,
-			]));
-			if ($this->emitter) {
-				$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
+
+			if ($result !== false) {
+				$this->legacyDispatcher->dispatch(IUser::class . '::postSetPassword', new GenericEvent($this, [
+					'password' => $password,
+					'recoveryPassword' => $recoveryPassword,
+				]));
+				if ($this->emitter) {
+					$this->emitter->emit('\OC\User', 'postSetPassword', [$this, $password, $recoveryPassword]);
+				}
 			}
+
 			return !($result === false);
 		} else {
 			return false;

--- a/tests/Core/Controller/ChangePasswordControllerTest.php
+++ b/tests/Core/Controller/ChangePasswordControllerTest.php
@@ -138,6 +138,9 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 
 		$expects = [
 			'status' => 'error',
+			'data' => [
+				'message' => 'Unable to change personal password',
+			],
 		];
 
 		$res = $this->controller->changePersonalPassword('old');
@@ -163,6 +166,9 @@ class ChangePasswordControllerTest extends \Test\TestCase {
 
 		$expects = new JSONResponse([
 			'status' => 'error',
+			'data' => [
+				'message' => 'Unable to change personal password',
+			],
 		]);
 
 		$actual = $this->controller->changePersonalPassword('old', 'new');


### PR DESCRIPTION
When the call to `setPassword` fails, `dispatch` and `emit` are still called. That means that the user will receive a password change confirmation.

This PR makes sure that we only dispatch in case of success.

It also adds an error message when `setPassword` fails.