### PR TITLE
Remove call to already default php.ini values

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -141,7 +141,7 @@ class OC {
 	public static function initPaths() {
 		if (defined('PHPUNIT_CONFIG_DIR')) {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
-		} elseif (defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
+		} elseif (defined('PHPUNIT_RUN') && PHPUNIT_RUN && is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
 		} elseif ($dir = getenv('NEXTCLOUD_CONFIG_DIR')) {
 			self::$configDir = rtrim($dir, '/') . '/';
@@ -463,14 +463,6 @@ class OC {
 	}
 
 	/**
-	 * Try to set some values to the required Nextcloud default
-	 */
-	public static function setRequiredIniValues() {
-		@ini_set('default_charset', 'UTF-8');
-		@ini_set('gd.jpeg_ignore_warning', '1');
-	}
-
-	/**
 	 * Send the same site cookies
 	 */
 	private static function sendSameSiteCookies() {
@@ -634,7 +626,6 @@ class OC {
 		@ini_set('max_execution_time', '3600');
 		@ini_set('max_input_time', '3600');
 
-		self::setRequiredIniValues();
 		self::handleAuthHeaders();
 		$systemConfig = \OC::$server->get(\OC\SystemConfig::class);
 		self::registerAutoloaderCache($systemConfig);


### PR DESCRIPTION
These values are already the default on supported PHP versions.
I suggest to remove these calls.

https://www.php.net/manual/en/ini.core.php#ini.default-charset
https://www.php.net/manual/en/image.configuration.php#ini.gd.jpeg-ignore-warning