### PR TITLE
Add hit information to profiler

### DIFF
--- a/lib/private/Memcache/ProfilerWrapperCache.php
+++ b/lib/private/Memcache/ProfilerWrapperCache.php
@@ -69,6 +69,7 @@ class ProfilerWrapperCache extends AbstractDataCollector implements IMemcacheTTL
 			'start' => $start,
 			'end' => microtime(true),
 			'op' => $this->getPrefix() . '::get::' . $key,
+			'hit' => $ret !== null,
 		];
 		return $ret;
 	}


### PR DESCRIPTION
This might be helpful later on for the cache profiler UI that is worked on in
https://github.com/nextcloud/profiler/pull/21 so that we know which cache
requests resulted in a cache miss.