### PR TITLE
Fix preview generator trying to recreate an existing folder

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -31,6 +31,7 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\Files\IAppData;
+use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -549,12 +550,19 @@ class Generator {
 	 *
 	 * @param File $file
 	 * @return ISimpleFolder
+	 *
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 */
 	private function getPreviewFolder(File $file) {
+		// Obtain file id outside of try catch block to prevent the creation of an existing folder
+		$fileId = (string)$file->getId();
+
 		try {
-			$folder = $this->appData->getFolder($file->getId());
+			$folder = $this->appData->getFolder($fileId);
 		} catch (NotFoundException $e) {
-			$folder = $this->appData->newFolder($file->getId());
+			$folder = $this->appData->newFolder($fileId);
 		}
 
 		return $folder;


### PR DESCRIPTION
Fix https://github.com/nextcloud/previewgenerator/issues/289

The call to `$file->getId()` might throw a `NotFoundException` which is interpreted as a missing directory in the try/catch block. The catch block then tried to recreate the directory even though it's already existing.

This patch was tested by the community via https://github.com/nextcloud/previewgenerator/issues/289#issuecomment-1111043125 and https://github.com/nextcloud/previewgenerator/issues/289#issuecomment-1120908271