### PR TITLE
getUnjailedPath() fix for duplicated parts

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -58,6 +58,9 @@ class Jail extends Wrapper {
 	}
 
 	public function getUnjailedPath($path) {
+		if (strpos($path, $this->rootPath) === 0) {
+			return trim(Filesystem::normalizePath($path), '/');
+		}
 		return trim(Filesystem::normalizePath($this->rootPath . '/' . $path), '/');
 	}
 


### PR DESCRIPTION
See https://github.com/nextcloud/server/issues/32178 for complete context.
PR for fix submitted at https://github.com/nextcloud/server/issues/32178#issuecomment-1118648018 for review/CI tests.

It fixed those problems for everyone (me including).
Fix https://github.com/nextcloud/server/issues/32178