### PR TITLE
Add $extraParams for setUserStatus OCP to handle extra user status attributes

### DIFF
--- a/apps/user_status/lib/Connector/UserStatusProvider.php
+++ b/apps/user_status/lib/Connector/UserStatusProvider.php
@@ -57,8 +57,22 @@ class UserStatusProvider implements IProvider, ISettableProvider {
 		return $userStatuses;
 	}
 
-	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup): void {
-		$this->service->setUserStatus($userId, $status, $messageId, $createBackup);
+	/**
+	 * Set a new status for the selected user.
+	 *
+	 * The following $extraParams keys are supported:
+	 * - clearAt When to clear this user status
+	 * - customIcon A custom icon for the user status
+	 * - customMessage A custom message for the user status
+	 *
+	 * @param string $userId The user for which we want to update the status.
+	 * @param string $messageId The new message id.
+	 * @param string $status The new status.
+	 * @param bool $createBackup If true, this will store the old status so that it is possible to revert it later (e.g. after a call).
+	 * @param array{clearAt?: \DateTime|int|null, customIcon?: string|null, customMessage?: string|null} $extraParams Pass extra parameters to the user status implementation provider. Added in 25.0.0
+	 */
+	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup, array $extraParams = []): void {
+		$this->service->setUserStatus($userId, $status, $messageId, $createBackup, $extraParams);
 	}
 
 	public function revertUserStatus(string $userId, string $messageId, string $status): void {

--- a/lib/private/UserStatus/ISettableProvider.php
+++ b/lib/private/UserStatus/ISettableProvider.php
@@ -39,8 +39,9 @@ interface ISettableProvider extends IProvider {
 	 * @param string $messageId The new message id.
 	 * @param string $status The new status.
 	 * @param bool $createBackup If true, this will store the old status so that it is possible to revert it later (e.g. after a call).
+	 * @param array $extraParams Pass extra parameters to the user status implementation provider. Refer to the provider implementation to determine which keys are supported. Added in 25.0.0
 	 */
-	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup): void;
+	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup, array $extraParams = []): void;
 
 	/**
 	 * Revert an automatically set user status. For example after leaving a call,

--- a/lib/private/UserStatus/Manager.php
+++ b/lib/private/UserStatus/Manager.php
@@ -105,13 +105,13 @@ class Manager implements IManager {
 		$this->provider = $provider;
 	}
 
-	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup = false): void {
+	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup = false, array $extraParams = []): void {
 		$this->setupProvider();
 		if (!$this->provider || !($this->provider instanceof ISettableProvider)) {
 			return;
 		}
 
-		$this->provider->setUserStatus($userId, $messageId, $status, $createBackup);
+		$this->provider->setUserStatus($userId, $messageId, $status, $createBackup, $extraParams);
 	}
 
 	public function revertUserStatus(string $userId, string $messageId, string $status): void {

--- a/lib/public/UserStatus/IManager.php
+++ b/lib/public/UserStatus/IManager.php
@@ -53,9 +53,10 @@ interface IManager {
 	 * @param string $messageId The id of the predefined message.
 	 * @param string $status The status to assign
 	 * @param bool $createBackup If true, this will store the old status so that it is possible to revert it later (e.g. after a call).
+	 * @param array $extraParams Pass extra parameters to the user status implementation provider. Refer to the provider implementation to determine which keys are supported. Added in 25.0.0
 	 * @since 23.0.0
 	 */
-	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup = false): void;
+	public function setUserStatus(string $userId, string $messageId, string $status, bool $createBackup = false, array $extraParams = []): void;
 
 	/**
 	 * Revert an automatically set user status. For example after leaving a call,


### PR DESCRIPTION
Allows to pass extra params to the UserStatus provider through OCP, here used to:
* clear status after a while
* set custom icon
* set custom message