### PR TITLE
don't unjail the path when getting the storage info

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -519,9 +519,6 @@ class OC_Helper {
 		$sourceStorage = $storage;
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
 			$includeExtStorage = false;
-			$internalPath = $storage->getUnjailedPath($rootInfo->getInternalPath());
-		} else {
-			$internalPath = $rootInfo->getInternalPath();
 		}
 		if ($includeExtStorage) {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home')
@@ -545,7 +542,7 @@ class OC_Helper {
 			$quota = $sourceStorage->getQuota();
 		}
 		try {
-			$free = $sourceStorage->free_space($internalPath);
+			$free = $sourceStorage->free_space($rootInfo->getInternalPath());
 		} catch (\Exception $e) {
 			if ($path === "") {
 				throw $e;


### PR DESCRIPTION
the original reason for adding it no longer exist.

This was added with #30985 since then the share source storage was also used, however this was changed with #32076

Fixes https://github.com/nextcloud/server/issues/32178