### PR TITLE
Make it possible to get the appdata folder using the public API

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -236,6 +236,7 @@ return array(
     'OCP\\Federation\\ICloudIdManager' => $baseDir . '/lib/public/Federation/ICloudIdManager.php',
     'OCP\\Files' => $baseDir . '/lib/public/Files.php',
     'OCP\\Files\\AlreadyExistsException' => $baseDir . '/lib/public/Files/AlreadyExistsException.php',
+    'OCP\\Files\\AppData\\IAppDataFactory' => $baseDir . '/lib/public/Files/AppData/IAppDataFactory.php',
     'OCP\\Files\\Cache\\AbstractCacheEvent' => $baseDir . '/lib/public/Files/Cache/AbstractCacheEvent.php',
     'OCP\\Files\\Cache\\CacheEntryInsertedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntryInsertedEvent.php',
     'OCP\\Files\\Cache\\CacheEntryRemovedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntryRemovedEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -265,6 +265,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Federation\\ICloudIdManager' => __DIR__ . '/../../..' . '/lib/public/Federation/ICloudIdManager.php',
         'OCP\\Files' => __DIR__ . '/../../..' . '/lib/public/Files.php',
         'OCP\\Files\\AlreadyExistsException' => __DIR__ . '/../../..' . '/lib/public/Files/AlreadyExistsException.php',
+        'OCP\\Files\\AppData\\IAppDataFactory' => __DIR__ . '/../../..' . '/lib/public/Files/AppData/IAppDataFactory.php',
         'OCP\\Files\\Cache\\AbstractCacheEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/AbstractCacheEvent.php',
         'OCP\\Files\\Cache\\CacheEntryInsertedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntryInsertedEvent.php',
         'OCP\\Files\\Cache\\CacheEntryRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntryRemovedEvent.php',

--- a/lib/private/Files/AppData/Factory.php
+++ b/lib/private/Files/AppData/Factory.php
@@ -27,17 +27,16 @@ declare(strict_types=1);
 namespace OC\Files\AppData;
 
 use OC\SystemConfig;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
 
-class Factory {
+class Factory implements IAppDataFactory {
+	private IRootFolder $rootFolder;
+	private SystemConfig $config;
 
-	/** @var IRootFolder */
-	private $rootFolder;
-
-	/** @var SystemConfig */
-	private $config;
-
-	private $folders = [];
+	/** @var array<string, IAppData> */
+	private array $folders = [];
 
 	public function __construct(IRootFolder $rootFolder,
 								SystemConfig $systemConfig) {
@@ -45,11 +44,7 @@ class Factory {
 		$this->config = $systemConfig;
 	}
 
-	/**
-	 * @param string $appId
-	 * @return AppData
-	 */
-	public function get(string $appId): AppData {
+	public function get(string $appId): IAppData {
 		if (!isset($this->folders[$appId])) {
 			$this->folders[$appId] = new AppData($this->rootFolder, $this->config, $appId);
 		}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1439,6 +1439,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(IMetadataManager::class, MetadataManager::class);
 
+		$this->registerAlias(\OCP\Files\AppData\IAppDataFactory::class, \OC\Files\AppData\Factory::class);
+
 		$this->connectDispatcher();
 	}
 
@@ -2300,7 +2302,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 	/**
 	 * @return \OCP\Files\IAppData
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 Use get(\OCP\Files\AppData\IAppDataFactory::class)->get($app) instead
 	 */
 	public function getAppDataDir($app) {
 		/** @var \OC\Files\AppData\Factory $factory */

--- a/lib/public/Files/AppData/IAppDataFactory.php
+++ b/lib/public/Files/AppData/IAppDataFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OCP\Files\AppData;
+
+use OCP\Files\IAppData;
+
+/**
+ * A factory allows you to get the AppData folder for an application.
+ *
+ * @since 25.0.0
+ */
+interface IAppDataFactory {
+
+	/**
+	 * Get the AppData folder for the specified $appId
+	 * @param string $appId
+	 * @return IAppData
+	 * @since 25.0.0
+	 */
+	public function get(string $appId): IAppData;
+}


### PR DESCRIPTION
Can be helpful to port away from the IServerContainer::getAppDataDir

Needed for:

- [ ] https://github.com/nextcloud/social/pull/1415