### PR TITLE
Always free the DB result in QBMapper::findEntities

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -334,16 +334,15 @@ abstract class QBMapper {
 	 */
 	protected function findEntities(IQueryBuilder $query): array {
 		$result = $query->executeQuery();
-
-		$entities = [];
-
-		while ($row = $result->fetch()) {
-			$entities[] = $this->mapRowToEntity($row);
+		try {
+			$entities = [];
+			while ($row = $result->fetch()) {
+				$entities[] = $this->mapRowToEntity($row);
+			}
+			return $entities;
+		} finally {
+			$result->closeCursor();
 		}
-
-		$result->closeCursor();
-
-		return $entities;
 	}
 
 


### PR DESCRIPTION
Without this patch it only happened if the code ran through without any
errors. Now the result is also freed in the case of an error.