### PR TITLE
Add event to load additional scripts for projects

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -56,6 +56,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProviderCollection;
@@ -131,11 +132,11 @@ class Application extends App implements IBootstrap {
 		$dispatcher->addServiceListener(BeforeTemplateRenderedEvent::class, LegacyBeforeTemplateRenderedListener::class);
 		$dispatcher->addServiceListener(LoadSidebar::class, LoadSidebarListener::class);
 		$dispatcher->addServiceListener(ShareCreatedEvent::class, ShareInteractionListener::class);
-		$dispatcher->addListener('\OCP\Collaboration\Resources::loadAdditionalScripts', function () {
-			\OCP\Util::addScript('files_sharing', 'collaboration');
-		});
 		$dispatcher->addServiceListener(ShareCreatedEvent::class, UserShareAcceptanceListener::class);
 		$dispatcher->addServiceListener(UserAddedEvent::class, UserAddedToGroupListener::class);
+		$dispatcher->addListener(ResourcesLoadAdditionalScriptsEvent::class, function () {
+			\OCP\Util::addScript('files_sharing', 'collaboration');
+		});
 
 		// notifications api to accept incoming user shares
 		$oldDispatcher->addListener('OCP\Share::postShare', function (GenericEvent $event) {

--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -26,13 +26,15 @@
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files\Event\LoadSidebar;
 use OCA\Viewer\Event\LoadViewer;
-use OCP\EventDispatcher\GenericEvent;
+use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IUserSession;
+use OCP\Server;
 
-$config = \OC::$server->getConfig();
-$userSession = \OC::$server->getUserSession();
-$legacyEventDispatcher = \OC::$server->getEventDispatcher();
-/** @var \OCP\EventDispatcher\IEventDispatcher $eventDispatcher */
-$eventDispatcher = \OC::$server->get(OCP\EventDispatcher\IEventDispatcher::class);
+$config = Server::get(IConfig::class);
+$userSession = Server::get(IUserSession::class);
+$eventDispatcher = Server::get(IEventDispatcher::class);
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
 
@@ -42,7 +44,7 @@ $tmpl = new OCP\Template('files_sharing', 'list', '');
 $tmpl->assign('showgridview', $showgridview);
 
 // fire script events
-$legacyEventDispatcher->dispatch('\OCP\Collaboration\Resources::loadAdditionalScripts', new GenericEvent());
+$eventDispatcher->dispatchTyped(new ResourcesLoadAdditionalScriptsEvent());
 $eventDispatcher->dispatchTyped(new LoadAdditionalScriptsEvent());
 $eventDispatcher->dispatchTyped(new LoadSidebar());
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -62,9 +62,11 @@
  *
  */
 
+use OC\EventDispatcher\SymfonyAdapter;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
+use OCP\Server;
 use OCP\Share;
 use OC\Encryption\HookManager;
 use OC\Files\Filesystem;
@@ -881,7 +883,7 @@ class OC {
 	}
 
 	private static function registerResourceCollectionHooks() {
-		\OC\Collaboration\Resources\Listener::register(\OC::$server->getEventDispatcher());
+		\OC\Collaboration\Resources\Listener::register(Server::get(SymfonyAdapter::class), Server::get(IEventDispatcher::class));
 	}
 
 	/**

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -148,6 +148,7 @@ return array(
     'OCP\\Collaboration\\Resources\\IProvider' => $baseDir . '/lib/public/Collaboration/Resources/IProvider.php',
     'OCP\\Collaboration\\Resources\\IProviderManager' => $baseDir . '/lib/public/Collaboration/Resources/IProviderManager.php',
     'OCP\\Collaboration\\Resources\\IResource' => $baseDir . '/lib/public/Collaboration/Resources/IResource.php',
+    'OCP\\Collaboration\\Resources\\LoadAdditionalScriptsEvent' => $baseDir . '/lib/public/Collaboration/Resources/LoadAdditionalScriptsEvent.php',
     'OCP\\Collaboration\\Resources\\ResourceException' => $baseDir . '/lib/public/Collaboration/Resources/ResourceException.php',
     'OCP\\Command\\IBus' => $baseDir . '/lib/public/Command/IBus.php',
     'OCP\\Command\\ICommand' => $baseDir . '/lib/public/Command/ICommand.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -177,6 +177,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OCP\\Collaboration\\Resources\\IProvider' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Resources/IProvider.php',
         'OCP\\Collaboration\\Resources\\IProviderManager' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Resources/IProviderManager.php',
         'OCP\\Collaboration\\Resources\\IResource' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Resources/IResource.php',
+        'OCP\\Collaboration\\Resources\\LoadAdditionalScriptsEvent' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Resources/LoadAdditionalScriptsEvent.php',
         'OCP\\Collaboration\\Resources\\ResourceException' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Resources/ResourceException.php',
         'OCP\\Command\\IBus' => __DIR__ . '/../../..' . '/lib/public/Command/IBus.php',
         'OCP\\Command\\ICommand' => __DIR__ . '/../../..' . '/lib/public/Command/ICommand.php',

--- a/lib/public/Collaboration/Resources/LoadAdditionalScriptsEvent.php
+++ b/lib/public/Collaboration/Resources/LoadAdditionalScriptsEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Collaboration\Resources;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is used by apps to register their own frontend scripts for integrating
+ * projects in their app. Apps also need to dispatch the event in order to load
+ * scripts during page load
+ *
+ * @see https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/projects.html
+ * @since 25.0.0
+ */
+class LoadAdditionalScriptsEvent extends Event {
+}


### PR DESCRIPTION
This adds a public event for apps to listen or register for additional scripts when using the projects feature (OCP\Collaboration\Resources). Previously this was only possible using a static string through the SymfonyAdapter.

A fallback for the old event has been added, so we should mark the old event as deprecated in the developer notes and drop it then 3 versions later.

- [x] Add to https://github.com/nextcloud/server/issues/32117 once merged
- [x] Documentation https://github.com/nextcloud/documentation/pull/8302