### PR TITLE
Handle the move operation properly between shared calendars

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -209,6 +209,7 @@ return array(
     'OCA\\DAV\\Events\\CalendarMovedToTrashEvent' => $baseDir . '/../lib/Events/CalendarMovedToTrashEvent.php',
     'OCA\\DAV\\Events\\CalendarObjectCreatedEvent' => $baseDir . '/../lib/Events/CalendarObjectCreatedEvent.php',
     'OCA\\DAV\\Events\\CalendarObjectDeletedEvent' => $baseDir . '/../lib/Events/CalendarObjectDeletedEvent.php',
+    'OCA\\DAV\\Events\\CalendarObjectMovedEvent' => $baseDir . '/../lib/Events/CalendarObjectMovedEvent.php',
     'OCA\\DAV\\Events\\CalendarObjectMovedToTrashEvent' => $baseDir . '/../lib/Events/CalendarObjectMovedToTrashEvent.php',
     'OCA\\DAV\\Events\\CalendarObjectRestoredEvent' => $baseDir . '/../lib/Events/CalendarObjectRestoredEvent.php',
     'OCA\\DAV\\Events\\CalendarObjectUpdatedEvent' => $baseDir . '/../lib/Events/CalendarObjectUpdatedEvent.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -224,6 +224,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Events\\CalendarMovedToTrashEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarMovedToTrashEvent.php',
         'OCA\\DAV\\Events\\CalendarObjectCreatedEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectCreatedEvent.php',
         'OCA\\DAV\\Events\\CalendarObjectDeletedEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectDeletedEvent.php',
+        'OCA\\DAV\\Events\\CalendarObjectMovedEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectMovedEvent.php',
         'OCA\\DAV\\Events\\CalendarObjectMovedToTrashEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectMovedToTrashEvent.php',
         'OCA\\DAV\\Events\\CalendarObjectRestoredEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectRestoredEvent.php',
         'OCA\\DAV\\Events\\CalendarObjectUpdatedEvent' => __DIR__ . '/..' . '/../lib/Events/CalendarObjectUpdatedEvent.php',

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -57,6 +57,7 @@ use OCA\DAV\Events\CalendarDeletedEvent;
 use OCA\DAV\Events\CalendarMovedToTrashEvent;
 use OCA\DAV\Events\CalendarObjectCreatedEvent;
 use OCA\DAV\Events\CalendarObjectDeletedEvent;
+use OCA\DAV\Events\CalendarObjectMovedEvent;
 use OCA\DAV\Events\CalendarObjectMovedToTrashEvent;
 use OCA\DAV\Events\CalendarObjectRestoredEvent;
 use OCA\DAV\Events\CalendarObjectUpdatedEvent;
@@ -154,6 +155,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectDeletedEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectDeletedEvent::class, CalendarObjectReminderUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectMovedEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectMovedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectRestoredEvent::class, ActivityUpdaterListener::class);

--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -40,6 +40,7 @@ use OCP\L10N\IFactory;
 class Event extends Base {
 	public const SUBJECT_OBJECT_ADD = 'object_add';
 	public const SUBJECT_OBJECT_UPDATE = 'object_update';
+	public const SUBJECT_OBJECT_MOVE = 'object_move';
 	public const SUBJECT_OBJECT_MOVE_TO_TRASH = 'object_move_to_trash';
 	public const SUBJECT_OBJECT_RESTORE = 'object_restore';
 	public const SUBJECT_OBJECT_DELETE = 'object_delete';
@@ -145,6 +146,10 @@ class Event extends Base {
 			$subject = $this->l->t('{actor} updated event {event} in calendar {calendar}');
 		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_UPDATE . '_event_self') {
 			$subject = $this->l->t('You updated event {event} in calendar {calendar}');
+		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE . '_event') {
+			$subject = $this->l->t('{actor} moved event {event} from calendar {sourceCalendar} to calendar {targetCalendar}');
+		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE . '_event_self') {
+			$subject = $this->l->t('You moved event {event} from calendar {sourceCalendar} to calendar {targetCalendar}');
 		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE_TO_TRASH . '_event') {
 			$subject = $this->l->t('{actor} deleted event {event} from calendar {calendar}');
 		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE_TO_TRASH . '_event_self') {
@@ -193,6 +198,24 @@ class Event extends Base {
 				case self::SUBJECT_OBJECT_RESTORE . '_event_self':
 					return [
 						'calendar' => $this->generateCalendarParameter($parameters['calendar'], $this->l),
+						'event' => $this->generateClassifiedObjectParameter($parameters['object']),
+					];
+			}
+		}
+
+		if (isset($parameters['sourceCalendar']) && isset($parameters['targetCalendar'])) {
+			switch ($subject) {
+				case self::SUBJECT_OBJECT_MOVE . '_event':
+					return [
+						'actor' => $this->generateUserParameter($parameters['actor']),
+						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
+						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
+						'event' => $this->generateClassifiedObjectParameter($parameters['object']),
+					];
+				case self::SUBJECT_OBJECT_MOVE . '_event_self':
+					return [
+						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
+						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
 						'event' => $this->generateClassifiedObjectParameter($parameters['object']),
 					];
 			}

--- a/apps/dav/lib/CalDAV/Activity/Provider/Todo.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Todo.php
@@ -69,6 +69,10 @@ class Todo extends Event {
 			$subject = $this->l->t('{actor} reopened todo {todo} in list {calendar}');
 		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_UPDATE . '_todo_needs_action_self') {
 			$subject = $this->l->t('You reopened todo {todo} in list {calendar}');
+		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE . '_todo') {
+			$subject = $this->l->t('{actor} moved todo {todo} from list {sourceCalendar} to list {targetCalendar}');
+		} elseif ($event->getSubject() === self::SUBJECT_OBJECT_MOVE . '_todo_self') {
+			$subject = $this->l->t('You moved todo {todo} from list {sourceCalendar} to list {targetCalendar}');
 		} else {
 			throw new \InvalidArgumentException();
 		}
@@ -109,6 +113,24 @@ class Todo extends Event {
 				case self::SUBJECT_OBJECT_UPDATE . '_todo_needs_action_self':
 					return [
 						'calendar' => $this->generateCalendarParameter($parameters['calendar'], $this->l),
+						'todo' => $this->generateObjectParameter($parameters['object']),
+					];
+			}
+		}
+
+		if (isset($parameters['sourceCalendar']) && isset($parameters['targetCalendar'])) {
+			switch ($subject) {
+				case self::SUBJECT_OBJECT_MOVE . '_todo':
+					return [
+						'actor' => $this->generateUserParameter($parameters['actor']),
+						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
+						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
+						'todo' => $this->generateObjectParameter($parameters['object']),
+					];
+				case self::SUBJECT_OBJECT_MOVE . '_todo_self':
+					return [
+						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
+						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
 						'todo' => $this->generateObjectParameter($parameters['object']),
 					];
 			}

--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -450,7 +450,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 		}
 
 		try {
-			return $this->caldavBackend->moveCalendarObject($sourceNode->getCalendarId(), (int)$this->calendarInfo['id'], $sourceNode->getId(), $sourceNode->getPrincipalUri());
+			return $this->caldavBackend->moveCalendarObject($sourceNode->getCalendarId(), (int)$this->calendarInfo['id'], $sourceNode->getId(), $sourceNode->getOwner(), $this->getOwner());
 		} catch (Exception $e) {
 			$this->logger->error('Could not move calendar object: ' . $e->getMessage(), ['exception' => $e]);
 			return false;

--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -162,4 +162,11 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 	public function getPrincipalUri(): string {
 		return $this->calendarInfo['principaluri'];
 	}
+
+	public function getOwner(): ?string {
+		if (isset($this->calendarInfo['{http://owncloud.org/ns}owner-principal'])) {
+			return $this->calendarInfo['{http://owncloud.org/ns}owner-principal'];
+		}
+		return parent::getOwner();
+	}
 }

--- a/apps/dav/lib/Events/CalendarObjectMovedEvent.php
+++ b/apps/dav/lib/Events/CalendarObjectMovedEvent.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2020, Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\DAV\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Class CalendarObjectMovedEvent
+ *
+ * @package OCA\DAV\Events
+ * @since 25.0.0
+ */
+class CalendarObjectMovedEvent extends Event {
+	private int $sourceCalendarId;
+	private array $sourceCalendarData;
+	private int $targetCalendarId;
+	private array $targetCalendarData;
+	private array $sourceShares;
+	private array $targetShares;
+	private array $objectData;
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function __construct(int $sourceCalendarId,
+								array $sourceCalendarData,
+								int $targetCalendarId,
+								array $targetCalendarData,
+								array $sourceShares,
+								array $targetShares,
+								array $objectData) {
+		parent::__construct();
+		$this->sourceCalendarId = $sourceCalendarId;
+		$this->sourceCalendarData = $sourceCalendarData;
+		$this->targetCalendarId = $targetCalendarId;
+		$this->targetCalendarData = $targetCalendarData;
+		$this->sourceShares = $sourceShares;
+		$this->targetShares = $targetShares;
+		$this->objectData = $objectData;
+	}
+
+	/**
+	 * @return int
+	 * @since 25.0.0
+	 */
+	public function getSourceCalendarId(): int {
+		return $this->sourceCalendarId;
+	}
+
+	/**
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getSourceCalendarData(): array {
+		return $this->sourceCalendarData;
+	}
+
+	/**
+	 * @return int
+	 * @since 25.0.0
+	 */
+	public function getTargetCalendarId(): int {
+		return $this->targetCalendarId;
+	}
+
+	/**
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getTargetCalendarData(): array {
+		return $this->targetCalendarData;
+	}
+
+	/**
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getSourceShares(): array {
+		return $this->sourceShares;
+	}
+
+	/**
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getTargetShares(): array {
+		return $this->targetShares;
+	}
+
+	/**
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getObjectData(): array {
+		return $this->objectData;
+	}
+}

--- a/apps/dav/lib/Listener/ActivityUpdaterListener.php
+++ b/apps/dav/lib/Listener/ActivityUpdaterListener.php
@@ -32,6 +32,7 @@ use OCA\DAV\Events\CalendarDeletedEvent;
 use OCA\DAV\Events\CalendarMovedToTrashEvent;
 use OCA\DAV\Events\CalendarObjectCreatedEvent;
 use OCA\DAV\Events\CalendarObjectDeletedEvent;
+use OCA\DAV\Events\CalendarObjectMovedEvent;
 use OCA\DAV\Events\CalendarObjectMovedToTrashEvent;
 use OCA\DAV\Events\CalendarObjectRestoredEvent;
 use OCA\DAV\Events\CalendarObjectUpdatedEvent;
@@ -173,7 +174,26 @@ class ActivityUpdaterListener implements IEventListener {
 				);
 
 				$this->logger->debug(
-					sprintf('Activity generated for deleted calendar object %d', $event->getCalendarId())
+					sprintf('Activity generated for updated calendar object in calendar %d', $event->getCalendarId())
+				);
+			} catch (Throwable $e) {
+				// Any error with activities shouldn't abort the calendar deletion, so we just log it
+				$this->logger->error('Error generating activity for a deleted calendar object: ' . $e->getMessage(), [
+					'exception' => $e,
+				]);
+			}
+		} elseif ($event instanceof CalendarObjectMovedEvent) {
+			try {
+				$this->activityBackend->onMovedCalendarObject(
+					$event->getSourceCalendarData(),
+					$event->getTargetCalendarData(),
+					$event->getSourceShares(),
+					$event->getTargetShares(),
+					$event->getObjectData()
+				);
+
+				$this->logger->debug(
+					sprintf('Activity generated for moved calendar object from calendar %d to calendar %d', $event->getSourceCalendarId(), $event->getTargetCalendarId())
 				);
 			} catch (Throwable $e) {
 				// Any error with activities shouldn't abort the calendar deletion, so we just log it


### PR DESCRIPTION
`CalDAVBackend`'s `moveCalendarObject` method failed when moving from a calendar to shared calendar (or reverse) because the owner is not the same before and after. Now we consider this properly.

- Introduce a new CalendarObjectMovedEvent typed event dedicated for this operation
- Handle the event in the activity backend and add new appropriate activity subjects

A little refactoring in `apps/dav/lib/CalDAV/Activity/Backend.php` would help too.