### PR TITLE
remove storage wrappers when deleting the user storage

### DIFF
--- a/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OC\Authentication\Listeners;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Config\IMountProviderCollection;
@@ -56,6 +57,13 @@ class UserDeletedFilesCleanupListener implements IEventListener {
 			if (!$storage) {
 				throw new \Exception("User has no home storage");
 			}
+
+			// remove all wrappers, so we do the delete directly on the home storage bypassing any wrapper
+			while ($storage->instanceOfStorage(Wrapper::class)) {
+				/** @var Wrapper $storage */
+				$storage = $storage->getWrapperStorage();
+			}
+
 			$this->homeStorageCache[$event->getUser()->getUID()] = $storage;
 		}
 		if ($event instanceof UserDeletedEvent) {


### PR DESCRIPTION
This mostly matters for stable23 and lower since with 24 the filesystem setup doesn't get triggered by most(?) code paths that trigger the user delete so no wrappers are there in the first place.

To test:
- setup nc23
- enable encryption
- create user, and upload a file
- `occ user:delete` the user

Should fix #32251