### PR TITLE
More meaningfull message when a public authenticated share's password is wrong or has expired.

### DIFF
--- a/core/templates/publicshareauth.php
+++ b/core/templates/publicshareauth.php
@@ -17,7 +17,7 @@
 			<div class="warning-info"><?php p($l->t('This share is password-protected')); ?></div>
 		<?php endif; ?>
 		<?php if (isset($_['wrongpw'])): ?>
-			<div class="warning"><?php p($l->t('The password is wrong. Try again.')); ?></div>
+			<div class="warning wrongPasswordMsg"><?php p($l->t('The password is wrong or expired. Please try again or request a new one.')); ?></div>
 		<?php endif; ?>
 		<p>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>

--- a/tests/acceptance/features/bootstrap/PublicShareContext.php
+++ b/tests/acceptance/features/bootstrap/PublicShareContext.php
@@ -48,7 +48,7 @@ class PublicShareContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function wrongPasswordMessage() {
-		return Locator::forThe()->xpath("//*[@class = 'warning' and normalize-space() = 'The password is wrong. Try again.']")->
+		return Locator::forThe()->css(".warning .wrongPasswordMsg")->
 				describedAs("Wrong password message in Authenticate page");
 	}
 


### PR DESCRIPTION
Fixes #31952

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>