### PR TITLE
Fix psalm warning for zip response due wrong type

### DIFF
--- a/lib/public/AppFramework/Http/ZipResponse.php
+++ b/lib/public/AppFramework/Http/ZipResponse.php
@@ -37,11 +37,11 @@ use OCP\IRequest;
  * @since 15.0.0
  */
 class ZipResponse extends Response implements ICallbackResponse {
-	/** @var resource[] Files to be added to the zip response */
-	private $resources = [];
+	/** @var array{internalName: string, resource: string, size: int, time: int}[] Files to be added to the zip response */
+	private array $resources = [];
 	/** @var string Filename that the zip file should have */
-	private $name;
-	private $request;
+	private string $name;
+	private IRequest $request;
 
 	/**
 	 * @since 15.0.0


### PR DESCRIPTION
```
  <file src="lib/public/AppFramework/Http/ZipResponse.php">
    <InvalidArrayAccess occurrences="5">
      <code>$resource['internalName']</code>
      <code>$resource['resource']</code>
      <code>$resource['size']</code>
      <code>$resource['size']</code>
      <code>$resource['time']</code>
    </InvalidArrayAccess>
    <InvalidPropertyAssignmentValue occurrences="1">
      <code>$this-&gt;resources</code>
    </InvalidPropertyAssignmentValue>
  </file>
```