### PR TITLE
Fix psalm issues related to the user backend

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2310,11 +2310,6 @@
       <code>searchCollections</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="core/Controller/SvgController.php">
-    <TypeDoesNotContainNull occurrences="1">
-      <code>$svg === null</code>
-    </TypeDoesNotContainNull>
-  </file>
   <file src="core/Controller/UnifiedSearchController.php">
     <NullArgument occurrences="1">
       <code>null</code>
@@ -4354,28 +4349,11 @@
     <FalsableReturnStatement occurrences="1">
       <code>false</code>
     </FalsableReturnStatement>
-    <ImplicitToStringCast occurrences="1">
-      <code>$query-&gt;func()-&gt;lower('displayname')</code>
-    </ImplicitToStringCast>
   </file>
   <file src="lib/private/User/Manager.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>array|int</code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
-      <code>$callback</code>
-    </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
-      <code>bool|IUser</code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement occurrences="2">
-      <code>$this-&gt;createUserFromBackend($uid, $password, $backend)</code>
-      <code>$this-&gt;createUserFromBackend($uid, $password, $backend)</code>
-    </NullableReturnStatement>
-    <UndefinedInterfaceMethod occurrences="5">
-      <code>checkPassword</code>
-      <code>checkPassword</code>
-      <code>countUsers</code>
+    <ImplementedReturnTypeMismatch occurrences="1"/>
+    <InvalidArgument occurrences="1"/>
+    <UndefinedInterfaceMethod occurrences="2">
       <code>createUser</code>
       <code>getUsersForUserValueCaseInsensitive</code>
     </UndefinedInterfaceMethod>
@@ -4387,23 +4365,13 @@
     <InvalidArgument occurrences="1">
       <code>IUser::class . '::firstLogin'</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="2">
-      <code>$this-&gt;timeFactory-&gt;getTime()</code>
-      <code>$this-&gt;timeFactory-&gt;getTime()</code>
-    </InvalidScalarArgument>
     <NoInterfaceProperties occurrences="2">
       <code>$request-&gt;server</code>
       <code>$request-&gt;server</code>
     </NoInterfaceProperties>
-    <NullableReturnStatement occurrences="1">
-      <code>null</code>
-    </NullableReturnStatement>
     <TooManyArguments occurrences="1">
       <code>dispatch</code>
     </TooManyArguments>
-    <UndefinedMethod occurrences="1">
-      <code>getByEmail</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/private/User/User.php">
     <InvalidArgument occurrences="5">
@@ -4413,22 +4381,6 @@
       <code>IUser::class . '::preDelete'</code>
       <code>IUser::class . '::preSetPassword'</code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
-      <code>getBackend</code>
-    </InvalidNullableReturnType>
-    <InvalidReturnStatement occurrences="1">
-      <code>$image</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>IImage|null</code>
-    </InvalidReturnType>
-    <InvalidScalarArgument occurrences="2">
-      <code>$quota</code>
-      <code>$this-&gt;lastLogin</code>
-    </InvalidScalarArgument>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;backend</code>
-    </NullableReturnStatement>
     <TooManyArguments occurrences="5">
       <code>dispatch</code>
       <code>dispatch</code>
@@ -4436,13 +4388,6 @@
       <code>dispatch</code>
       <code>dispatch</code>
     </TooManyArguments>
-    <UndefinedInterfaceMethod occurrences="5">
-      <code>canChangeAvatar</code>
-      <code>deleteUserAvatar</code>
-      <code>getHome</code>
-      <code>setDisplayName</code>
-      <code>setPassword</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/legacy/OC_API.php">
     <InvalidNullableReturnType occurrences="1">

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1096,7 +1096,7 @@ class QueryBuilder implements IQueryBuilder {
 	 * Specifies an ordering for the query results.
 	 * Replaces any previously specified orderings, if any.
 	 *
-	 * @param string $sort The ordering expression.
+	 * @param string|IQueryFunction|ILiteral|IParameter $sort The ordering expression.
 	 * @param string $order The ordering direction.
 	 *
 	 * @return $this This QueryBuilder instance.

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -275,7 +275,7 @@ class Database extends ABackend implements
 			->setMaxResults($limit)
 			->setFirstResult($offset);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$displayNames = [];
 		while ($row = $result->fetch()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -25,6 +25,7 @@ namespace OC\User;
 
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\UserInterface;
 
 class LazyUser implements IUser {
 	private ?IUser $user = null;
@@ -83,7 +84,7 @@ class LazyUser implements IUser {
 		return $this->getUser()->getBackendClassName();
 	}
 
-	public function getBackend() {
+	public function getBackend(): ?UserInterface {
 		return $this->getUser()->getBackend();
 	}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -90,7 +90,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class Session implements IUserSession, Emitter {
 
-	/** @var Manager|PublicEmitter $manager */
+	/** @var Manager $manager */
 	private $manager;
 
 	/** @var ISession $session */
@@ -288,9 +288,9 @@ class Session implements IUserSession, Emitter {
 	}
 
 	/**
-	 * get the login name of the current user
+	 * Get the login name of the current user
 	 *
-	 * @return string
+	 * @return ?string
 	 */
 	public function getLoginName() {
 		if ($this->activeUser) {
@@ -870,7 +870,7 @@ class Session implements IUserSession, Emitter {
 		// replace successfully used token with a new one
 		$this->config->deleteUserValue($uid, 'login_token', $currentToken);
 		$newToken = $this->random->generate(32);
-		$this->config->setUserValue($uid, 'login_token', $newToken, $this->timeFactory->getTime());
+		$this->config->setUserValue($uid, 'login_token', $newToken, (string)$this->timeFactory->getTime());
 
 		try {
 			$sessionId = $this->session->getId();
@@ -905,7 +905,7 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function createRememberMeToken(IUser $user) {
 		$token = $this->random->generate(32);
-		$this->config->setUserValue($user->getUID(), 'login_token', $token, $this->timeFactory->getTime());
+		$this->config->setUserValue($user->getUID(), 'login_token', $token, (string)$this->timeFactory->getTime());
 		$this->setMagicInCookie($user->getUID(), $token);
 	}
 

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -820,7 +820,7 @@ interface IQueryBuilder {
 	 * Specifies an ordering for the query results.
 	 * Replaces any previously specified orderings, if any.
 	 *
-	 * @param string $sort The ordering expression.
+	 * @param string|IQueryFunction $sort The ordering expression.
 	 * @param string $order The ordering direction.
 	 *
 	 * @return $this This QueryBuilder instance.

--- a/lib/public/IAvatar.php
+++ b/lib/public/IAvatar.php
@@ -38,7 +38,7 @@ interface IAvatar {
 	/**
 	 * get the users avatar
 	 * @param int $size size in px of the avatar, avatars are square, defaults to 64, -1 can be used to not scale the image
-	 * @return boolean|\OCP\IImage containing the avatar or false if there's no image
+	 * @return false|\OCP\IImage containing the avatar or false if there's no image
 	 * @since 6.0.0 - size of -1 was added in 9.0.0
 	 */
 	public function get($size = 64);

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -113,10 +113,9 @@ interface IUser {
 	/**
 	 * Get the backend for the current user object
 	 *
-	 * @return UserInterface
 	 * @since 15.0.0
 	 */
-	public function getBackend();
+	public function getBackend(): ?UserInterface;
 
 	/**
 	 * check if the backend allows the user to change his avatar on Personal page

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -98,7 +98,7 @@ interface IUserManager {
 	 *
 	 * @param string $loginName
 	 * @param string $password
-	 * @return mixed the User object on success, false otherwise
+	 * @return IUser|false the User object on success, false otherwise
 	 * @since 8.0.0
 	 */
 	public function checkPassword($loginName, $password);
@@ -141,7 +141,7 @@ interface IUserManager {
 	 * @param string $uid
 	 * @param string $password
 	 * @throws \InvalidArgumentException
-	 * @return bool|\OCP\IUser the created user or false
+	 * @return false|\OCP\IUser the created user or false
 	 * @since 8.0.0
 	 */
 	public function createUser($uid, $password);
@@ -157,9 +157,9 @@ interface IUserManager {
 	public function createUserFromBackend($uid, $password, UserInterface $backend);
 
 	/**
-	 * returns how many users per backend exist (if supported by backend)
+	 * Get how many users per backend exist (if supported by backend)
 	 *
-	 * @return array an array of backend class as key and count number as value
+	 * @return array<string, int> an array of backend class name as key and count number as value
 	 * @since 8.0.0
 	 */
 	public function countUsers();

--- a/lib/public/User/Backend/ICheckPasswordBackend.php
+++ b/lib/public/User/Backend/ICheckPasswordBackend.php
@@ -35,7 +35,7 @@ interface ICheckPasswordBackend {
 	 *
 	 * @param string $loginName The loginname
 	 * @param string $password The password
-	 * @return string|bool The uid on success false on failure
+	 * @return string|false The uid on success false on failure
 	 */
 	public function checkPassword(string $loginName, string $password);
 }

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -609,7 +609,7 @@ class ManagerTest extends TestCase {
 	public function testCountUsersOnlySeen() {
 		$manager = \OC::$server->getUserManager();
 		// count other users in the db before adding our own
-		$countBefore = $manager->countUsers(true);
+		$countBefore = $manager->countSeenUsers();
 
 		//Add test users
 		$user1 = $manager->createUser('testseencount1', 'testseencount1');
@@ -623,7 +623,7 @@ class ManagerTest extends TestCase {
 		$user4 = $manager->createUser('testseencount4', 'testseencount4');
 		$user4->updateLastLoginTimestamp();
 
-		$this->assertEquals($countBefore + 3, $manager->countUsers(true));
+		$this->assertEquals($countBefore + 3, $manager->countSeenUsers());
 
 		//cleanup
 		$user1->delete();


### PR DESCRIPTION
- Reflect the actual return value returned by the implementation in the
  the interface. E.g. IUser|bool -> IUser|false
- Remove $hasLoggedIn parameter from private countUser implementation.
  Replace the two call with the equivalent countSeenUser
- getBackend is nuallable, add this to the interface
- Use backend interface to make psalm happy about call to undefined
  methods. Also helps with getting rid at some point of the old
  implementActions

# Test plan

1. Psalm is now happier
2. Unit tests work locally
3. Webui and users interactions also seems to work normally without regressions