### PR TITLE
only log diagnostic events if a treshhold is set

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1791,7 +1791,7 @@ $CONFIG = [
 
 /**
  * Enforce the user theme. This will disable the user theming settings
- * This must be a valid ITheme ID. 
+ * This must be a valid ITheme ID.
  * E.g. light, dark, highcontrast, dark-highcontrast...
  */
 'enforce_theme' => '',
@@ -2146,6 +2146,8 @@ $CONFIG = [
 
 /**
  * Limit diagnostics event logging to events longer than the configured threshold in ms
+ *
+ * when set to 0 no diagnostics events will be logged
  */
 'diagnostics.logging.threshold' => 0,
 

--- a/lib/private/Diagnostics/EventLogger.php
+++ b/lib/private/Diagnostics/EventLogger.php
@@ -126,7 +126,7 @@ class EventLogger implements IEventLogger {
 			$timeInMs = round($duration * 1000, 4);
 
 			$loggingMinimum = (int)$this->config->getValue('diagnostics.logging.threshold', 0);
-			if ($loggingMinimum > 0 && $timeInMs < $loggingMinimum) {
+			if ($loggingMinimum === 0 || $timeInMs < $loggingMinimum) {
 				return;
 			}
 


### PR DESCRIPTION
this prevents log spam and it's rare that you actually want to very short events logged anyway

Signed-off-by: Robin Appelman <robin@icewind.nl>