### PR TITLE
Improve psalm annotation to make it stricter

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1371,7 +1371,6 @@
     </InvalidReturnType>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SMB.php">
-    <InvalidPropertyAssignmentValue occurrences="1"/>
     <InvalidScalarArgument occurrences="7">
       <code>$e-&gt;getCode()</code>
       <code>$e-&gt;getCode()</code>

--- a/lib/public/Server.php
+++ b/lib/public/Server.php
@@ -41,8 +41,9 @@ use Psr\Container\NotFoundExceptionInterface;
 final class Server {
 	/**
 	 * @template T
-	 * @param class-string<T>|string $serviceName
-	 * @return T|mixed
+	 * @template S as class-string<T>|string
+	 * @param S $serviceName
+	 * @return (S is class-string<T> ? T : mixed)
 	 * @throws ContainerExceptionInterface
 	 * @throws NotFoundExceptionInterface
 	 * @since 25.0.0


### PR DESCRIPTION
Now using class-string<T> as input will only return T, and any other
string will return mixed

Signed-off-by: Carl Schwan <carl@carlschwan.eu>