### PR TITLE
[Psalm] Fix spelling for return type

### DIFF
--- a/lib/public/FullTextSearch/Model/ISearchRequest.php
+++ b/lib/public/FullTextSearch/Model/ISearchRequest.php
@@ -193,7 +193,7 @@ interface ISearchRequest {
 	 *
 	 * @return ISearchRequest
 	 */
-	public function setMetaTags(array $tags): IsearchRequest;
+	public function setMetaTags(array $tags): ISearchRequest;
 
 
 	/**


### PR DESCRIPTION
```
  <file src="lib/public/FullTextSearch/Model/ISearchRequest.php">
    <InvalidClass occurrences="1">
      <code>IsearchRequest</code>
    </InvalidClass>
  </file>
```