### PR TITLE
Add explicit return if getSmallImagePreview fails

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -115,7 +115,7 @@ class Generator {
 	 * Generates previews of a file
 	 *
 	 * @param File $file
-	 * @param array $specifications
+	 * @param non-empty-array $specifications
 	 * @param string $mimeType
 	 * @return ISimpleFile the last preview that was generated
 	 * @throws NotFoundException
@@ -213,6 +213,7 @@ class Generator {
 				throw new NotFoundException('Cached preview size 0, invalid!');
 			}
 		}
+		assert($preview !== null);
 
 		// Free memory being used by the embedded image resource.  Without this the image is kept in memory indefinitely.
 		// Garbage Collection does NOT free this memory.  We have to do it ourselves.
@@ -226,8 +227,10 @@ class Generator {
 	/**
 	 * Generate a small image straight away without generating a max preview first
 	 * Preview generated is 256x256
+	 *
+	 * @throws NotFoundException
 	 */
-	private function getSmallImagePreview(ISimpleFolder $previewFolder, File $file, string $mimeType, string $prefix, bool $crop) {
+	private function getSmallImagePreview(ISimpleFolder $previewFolder, File $file, string $mimeType, string $prefix, bool $crop): ISimpleFile {
 		$nodes = $previewFolder->getDirectoryListing();
 
 		foreach ($nodes as $node) {
@@ -284,6 +287,8 @@ class Generator {
 				return $file;
 			}
 		}
+
+		throw new NotFoundException('No provider successfully handled the preview generation');
 	}
 
 	/**


### PR DESCRIPTION
In case the imaginary service is unreachable (e.g. if the container is stopped) the connect exception would be logged and then would move to the next available preview provider in https://github.com/nextcloud/server/blob/35bd74de0563067bb2fd944d446ca02e8868d1bd/lib/private/Preview/Generator.php#L267

However if only Imaginary is available due to the configuration this will with an unexpected Call to a member function getSize() on null in file '/var/www/nextcloud/lib/private/Preview/Generator.php' line 149

https://sentry.io/share/issue/a96487fb502e478cb071847fed6375b0/
