### PR TITLE
Properly import maintenance script

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -297,8 +297,8 @@ class OC {
 
 			// render error page
 			$template = new OC_Template('', 'update.user', 'guest');
-			OC_Util::addScript('maintenance');
-			OC_Util::addStyle('core', 'guest');
+			\OCP\Util::addScript('core', 'maintenance');
+			\OCP\Util::addStyle('core', 'guest');
 			$template->printPage();
 			die();
 		}


### PR DESCRIPTION
Make sure that the core maintenance script is properly loaded instead of logging an error:

`[jsresourceloader] Could not find resource js/maintenance.js to load`
