### PR TITLE
22.2.8 RC1

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [22, 2, 7, 1];
+$OC_Version = [22, 2, 8, 0];
 
 // The human readable string
-$OC_VersionString = '22.2.7';
+$OC_VersionString = '22.2.8 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
* #31977
* #31980
* #32015
* #32070
* #32125
* #32130
* #32136
* #32158
* #32161
* #32175
* #32183
* #32248
* #32283
* #32324
* #32331
* #32421
* #32430
* #32433
* [circles#1028](https://github.com/nextcloud/circles/pull/1028) Fix array key on import()
* [circles#1044](https://github.com/nextcloud/circles/pull/1044) Switch to getOption()
* [files_pdfviewer#601](https://github.com/nextcloud/files_pdfviewer/pull/601) Update phpunit workflows
* [files_videoplayer#277](https://github.com/nextcloud/files_videoplayer/pull/277) Prevent video file downloads when there is a download limit
* [password_policy#359](https://github.com/nextcloud/password_policy/pull/359) Fix password generation
* [privacy#763](https://github.com/nextcloud/privacy/pull/763) Bump babel-loader from 8.2.4 to 8.2.5
* [text#2327](https://github.com/nextcloud/text/pull/2327) Build(deps-dev): bump babel-loader from 8.2.4 to 8.2.5
* [text#2360](https://github.com/nextcloud/text/pull/2360) Fix: use node workflow from template
* [viewer#1215](https://github.com/nextcloud/viewer/pull/1215) Build(deps-dev): bump @nextcloud/eslint-config from 6.1.0 to 6.1.2
* [viewer#1233](https://github.com/nextcloud/viewer/pull/1233) Improve preloading