### PR TITLE
Fix cropped image generated when not asked

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -144,6 +144,7 @@ class Generator {
 			&& ($specifications[0]['width'] <= 256 || $specifications[0]['height'] <= 256)
 			&& preg_match(Imaginary::supportedMimeTypes(), $mimeType)
 			&& $this->config->getSystemValueString('preview_imaginary_url', 'invalid') !== 'invalid') {
+
 			$crop = $specifications[0]['crop'] ?? false;
 			$preview = $this->getSmallImagePreview($previewFolder, $file, $mimeType, $previewVersion, $crop);
 
@@ -255,7 +256,7 @@ class Generator {
 					continue;
 				}
 
-				$preview = $this->helper->getThumbnail($provider, $file, 256, 256, true);
+				$preview = $this->helper->getThumbnail($provider, $file, 256, 256, $crop);
 
 				if (!($preview instanceof IImage)) {
 					continue;


### PR DESCRIPTION
The $crop parameter was not propagated to the imaginary pipeline and
instead it used the smartcrop algorithm always