### PR TITLE
Make sure activities are not created when a deleted calendar object expires

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1139,7 +1139,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 */
 	public function getCalendarObject($calendarId, $objectUri, int $calendarType = self::CALENDAR_TYPE_CALENDAR) {
 		$query = $this->db->getQueryBuilder();
-		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'calendardata', 'componenttype', 'classification'])
+		$query->select(['id', 'uri', 'lastmodified', 'etag', 'calendarid', 'size', 'calendardata', 'componenttype', 'classification', 'deleted_at'])
 			->from('calendarobjects')
 			->where($query->expr()->eq('calendarid', $query->createNamedParameter($calendarId)))
 			->andWhere($query->expr()->eq('uri', $query->createNamedParameter($objectUri)))
@@ -1161,7 +1161,8 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			'size' => (int)$row['size'],
 			'calendardata' => $this->readBlob($row['calendardata']),
 			'component' => strtolower($row['componenttype']),
-			'classification' => (int)$row['classification']
+			'classification' => (int)$row['classification'],
+			'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_NEXTCLOUD . '}deleted-at' => $row['deleted_at'] === null ? $row['deleted_at'] : (int) $row['deleted_at'],
 		];
 	}
 

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -35,6 +35,7 @@ use DateTime;
 use DateTimeZone;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\DAV\Sharing\Plugin as SharingPlugin;
 use OCA\DAV\Events\CalendarDeletedEvent;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -232,13 +233,13 @@ EOD;
 			->method('dispatchTyped');
 		$this->backend->createCalendarObject($calendarId, $uri, $calData);
 
-		// get all the cards
+		// get all the calendar objects
 		$calendarObjects = $this->backend->getCalendarObjects($calendarId);
 		$this->assertCount(1, $calendarObjects);
 		$this->assertEquals($calendarId, $calendarObjects[0]['calendarid']);
 		$this->assertArrayHasKey('classification', $calendarObjects[0]);
 
-		// get the cards
+		// get the calendar objects
 		$calendarObject = $this->backend->getCalendarObject($calendarId, $uri);
 		$this->assertNotNull($calendarObject);
 		$this->assertArrayHasKey('id', $calendarObject);
@@ -247,6 +248,7 @@ EOD;
 		$this->assertArrayHasKey('etag', $calendarObject);
 		$this->assertArrayHasKey('size', $calendarObject);
 		$this->assertArrayHasKey('classification', $calendarObject);
+		$this->assertArrayHasKey('{' . SharingPlugin::NS_NEXTCLOUD . '}deleted-at', $calendarObject);
 		$this->assertEquals($calData, $calendarObject['calendardata']);
 
 		// update the card

--- a/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
+++ b/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2022 Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @author Thomas Citharel <nextcloud@tcit.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\DAV\Tests\Unit\Listener;
+
+use OCA\DAV\CalDAV\Activity\Backend as ActivityBackend;
+use OCA\DAV\CalDAV\Activity\Provider\Event;
+use OCA\DAV\DAV\Sharing\Plugin as SharingPlugin;
+use OCA\DAV\Events\CalendarDeletedEvent;
+use OCA\DAV\Events\CalendarObjectDeletedEvent;
+use OCA\DAV\Listener\ActivityUpdaterListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class ActivityUpdaterListenerTest extends TestCase {
+
+	/** @var ActivityBackend|MockObject */
+	private $activityBackend;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+	/** @var ActivityUpdaterListener */
+	private ActivityUpdaterListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->activityBackend = $this->createMock(ActivityBackend::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new ActivityUpdaterListener(
+			$this->activityBackend,
+			$this->logger
+		);
+	}
+
+	/**
+	 * @dataProvider dataForTestHandleCalendarObjectDeletedEvent
+	 */
+	public function testHandleCalendarObjectDeletedEvent(int $calendarId, array $calendarData, array $shares, array $objectData, bool $createsActivity): void {
+		$event = new CalendarObjectDeletedEvent($calendarId, $calendarData, $shares, $objectData);
+		$this->logger->expects($this->once())->method('debug')->with(
+			$createsActivity ? "Activity generated for deleted calendar object in calendar $calendarId" : "Calendar object in calendar $calendarId was already in trashbin, skipping deletion activity"
+		);
+		$this->activityBackend->expects($createsActivity ? $this->once() : $this->never())->method('onTouchCalendarObject')->with(
+			Event::SUBJECT_OBJECT_DELETE,
+			$calendarData,
+			$shares,
+			$objectData
+		);
+		$this->listener->handle($event);
+	}
+
+	public function dataForTestHandleCalendarObjectDeletedEvent(): array {
+		return [
+			[1, [], [], [], true],
+			[1, [], [], ['{' . SharingPlugin::NS_NEXTCLOUD . '}deleted-at' => 120], false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataForTestHandleCalendarDeletedEvent
+	 */
+	public function testHandleCalendarDeletedEvent(int $calendarId, array $calendarData, array $shares, bool $createsActivity): void {
+		$event = new CalendarDeletedEvent($calendarId, $calendarData, $shares);
+		$this->logger->expects($this->once())->method('debug')->with(
+			$createsActivity ? "Activity generated for deleted calendar $calendarId" : "Calendar $calendarId was already in trashbin, skipping deletion activity"
+		);
+		$this->activityBackend->expects($createsActivity ? $this->once() : $this->never())->method('onCalendarDelete')->with(
+			$calendarData,
+			$shares
+		);
+		$this->listener->handle($event);
+	}
+
+	public function dataForTestHandleCalendarDeletedEvent(): array {
+		return [
+			[1, [], [], true],
+			[1, ['{' . SharingPlugin::NS_NEXTCLOUD . '}deleted-at' => 120], [], false],
+		];
+	}
+}


### PR DESCRIPTION
The `deleted_at` property was not being fetched in `getCalendarObject` and then passed into the `CalendarObjectDeletedEvent`, so the handling in `ActivityUpdaterListener` didn't work properly.

Added a small assertion in `CalDavBackendTest` to make sure the key is present. And you get a test for free in `ActivityUpdaterListener`.

Closes https://github.com/nextcloud/activity/issues/784