### PR TITLE
[Psalm] Rename $userName to $username  to align with child classes

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -141,9 +141,9 @@ abstract class AbstractDatabase {
 	}
 
 	/**
-	 * @param string $userName
+	 * @param string $username
 	 */
-	abstract public function setupDatabase($userName);
+	abstract public function setupDatabase($username);
 
 	public function runMigrations() {
 		if (!is_dir(\OC::$SERVERROOT."/core/Migrations")) {

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -135,9 +135,8 @@ class MySQL extends AbstractDatabase {
 	/**
 	 * @param $username
 	 * @param IDBConnection $connection
-	 * @return array
 	 */
-	private function createSpecificUser($username, $connection) {
+	private function createSpecificUser($username, $connection): void {
 		try {
 			//user already specified in config
 			$oldUser = $this->config->getValue('dbuser', false);


### PR DESCRIPTION
```
  <file src="lib/private/Setup/MySQL.php">
    <InvalidReturnType occurrences="1">
      <code>array</code>
    </InvalidReturnType>
    <ParamNameMismatch occurrences="1">
      <code>$username</code>
    </ParamNameMismatch>
  </file>
  <file src="lib/private/Setup/OCI.php">
    <ParamNameMismatch occurrences="1">
      <code>$username</code>
    </ParamNameMismatch>
  </file>
  <file src="lib/private/Setup/PostgreSQL.php">
    <ParamNameMismatch occurrences="1">
      <code>$username</code>
    </ParamNameMismatch>
  </file>
  <file src="lib/private/Setup/Sqlite.php">
    <ParamNameMismatch occurrences="1">
      <code>$username</code>
    </ParamNameMismatch>
  </file>
```