### PR TITLE
Fix crop condition

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -144,7 +144,6 @@ class Generator {
 			&& ($specifications[0]['width'] <= 256 || $specifications[0]['height'] <= 256)
 			&& preg_match(Imaginary::supportedMimeTypes(), $mimeType)
 			&& $this->config->getSystemValueString('preview_imaginary_url', 'invalid') !== 'invalid') {
-
 			$crop = $specifications[0]['crop'] ?? false;
 			$preview = $this->getSmallImagePreview($previewFolder, $file, $mimeType, $previewVersion, $crop);
 
@@ -233,9 +232,17 @@ class Generator {
 
 		foreach ($nodes as $node) {
 			$name = $node->getName();
-			if (($prefix === '' || strpos($name, $prefix) === 0)
-				&& (str_starts_with($name, '256-256-crop') && $crop || str_starts_with($name, '256-256') && !$crop)) {
-				return $node;
+			if (($prefix === '' || str_starts_with($name, $prefix))) {
+				// Prefix match
+				if (str_starts_with($name, $prefix . '256-256-crop') && $crop) {
+					// Cropped image
+					return $node;
+				}
+
+				if (str_starts_with($name, $prefix . '256-256.') && !$crop) {
+					// Uncropped image
+					return $node;
+				}
 			}
 		}
 


### PR DESCRIPTION
Make sure that when fetching the image from the cache we don't
accidentally fetch the cropped image just because it also start with
256-256