### PR TITLE
Use custom PHP runtime for PHPUnit execution in autotest

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -395,8 +395,8 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
-	echo "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	"${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	echo "$PHP" "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"$PHP" "${PHPUNIT[@]}" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
 	RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then


### PR DESCRIPTION
If you run `PHP_EXE=/usr/bin/php7 NOCOVERAGE=1 ./autotest.sh sqlite` the script would still run PHPUnit with the global `php` or whatever PHPUnit found. Now it uses the PHP_EXE specified runtime.