### PR TITLE
Fix Ldap search for attributes with no substr matching rule

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1537,14 +1537,19 @@ class Access extends LDAPUtility {
 			}
 		}
 
+		$originalSearch = $search;
 		$search = $this->prepareSearchTerm($search);
 		if (!is_array($searchAttributes) || count($searchAttributes) === 0) {
 			if ($fallbackAttribute === '') {
 				return '';
 			}
+			// wildcards don't work with some attributes
+			$filter[] = $fallbackAttribute . '=' . $originalSearch;
 			$filter[] = $fallbackAttribute . '=' . $search;
 		} else {
 			foreach ($searchAttributes as $attribute) {
+				// wildcards don't work with some attributes
+				$filter[] = $attribute . '=' . $originalSearch;
 				$filter[] = $attribute . '=' . $search;
 			}
 		}


### PR DESCRIPTION
Wildcards are not supported when used in search filters for the `entryUUID` attribute. I guess it's the same for some other attributes as well.

IMO we can make an exact search filter in this case.

Is there a cleaner way to address that issue?