### PR TITLE
Properly calculate primary element based on background luminance

### DIFF
--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -71,8 +71,10 @@ class DarkTheme extends DefaultTheme implements ITheme {
 
 			'--color-primary-hover' => $this->util->mix($this->primaryColor, $colorMainBackground, 60),
 			'--color-primary-light' => $this->util->mix($this->primaryColor, $colorMainBackground, -80),
-			'--color-primary-element-hover' => $this->util->mix($this->util->elementColor($this->primaryColor), $colorMainBackground, 80),
-			'--color-primary-element-lighter' => $this->util->mix($this->util->elementColor($this->primaryColor), $colorMainBackground, -70),
+			'--color-primary-element' => $this->util->elementColor($this->primaryColor, false),
+			'--color-primary-element-hover' => $this->util->mix($this->util->elementColor($this->primaryColor, false), $colorMainBackground, 80),
+			'--color-primary-element-light' => $this->util->lighten($this->util->elementColor($this->primaryColor, false), 15),
+			'--color-primary-element-lighter' => $this->util->mix($this->util->elementColor($this->primaryColor, false), $colorMainBackground, -70),
 
 			'--color-text-maxcontrast' => $this->util->darken($colorMainText, 30),
 			'--color-text-light' => $this->util->darken($colorMainText, 10),


### PR DESCRIPTION
| Dark primary with dark theme | Bright primary on light theme |
|:---------:|:------:|
|![2022-05-20_08-41](https://user-images.githubusercontent.com/14975046/169469487-4455bba9-0d1f-4b37-bb4a-197b623d8f5c.png)|![2022-05-20_08-41_1](https://user-images.githubusercontent.com/14975046/169469491-3eb7af48-4888-4cae-87ef-de2d3c12e75c.png)|
|![2022-05-20_08-45_1](https://user-images.githubusercontent.com/14975046/169469494-7e169023-969c-4185-b278-bf1d73600d1f.png)|![2022-05-20_08-45](https://user-images.githubusercontent.com/14975046/169469492-2f476f10-5e77-4d74-9d0b-5115c219c56d.png)|

supersede #32500 
closes https://github.com/nextcloud/server/pull/32500