### PR TITLE
Make appName of TemplateResponse accessible in BeforeTemplateRendered…

### DIFF
--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -139,6 +139,15 @@ class TemplateResponse extends Response {
 
 
 	/**
+	 * @return string the app id of the used template
+	 * @since 25.0.0
+	 */
+	public function getApp(): string {
+		return $this->appName;
+	}
+
+
+	/**
 	 * Used for accessing the name of the set template
 	 * @return string the name of the used template
 	 * @since 6.0.0


### PR DESCRIPTION
…Event

Currently Talk + Guests have to work around this:
https://github.com/nextcloud/spreed/pull/7399/files#diff-70e5309fcd3311d771b3db9c93490ea270fd5894769093765ec37edb68e5dd9bR255-R257
https://github.com/nextcloud/guests/pull/892/files#diff-0d8f2d87512e1e2607e0d1b3433fa74d674eda5df7d001b6733cb1738bf0dcc9R44-R47