### PR TITLE
Rename user-agent used by the Webcal Refresh Service

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
@@ -192,7 +192,7 @@ class RefreshWebcalService {
 		$handlerStack->push(Middleware::mapRequest(function (RequestInterface $request) {
 			return $request
 				->withHeader('Accept', 'text/calendar, application/calendar+json, application/calendar+xml')
-				->withHeader('User-Agent', 'Nextcloud Webcal Crawler');
+				->withHeader('User-Agent', 'Nextcloud Webcal Service');
 		}));
 		$handlerStack->push(Middleware::mapResponse(function (ResponseInterface $response) use (&$didBreak301Chain, &$latestLocation) {
 			if (!$didBreak301Chain) {


### PR DESCRIPTION
Some services don't like the "crawler" inside the previous user-agent.

Closes https://github.com/nextcloud/calendar/issues/4232

Copying my comment from the issue here:
> We could even expose some other information like some software often do %InstanceName% Webcal Service (Nextcloud/25.0.1; +https://nextcloud-instance.domain), but some of that might be sensitive.

This could help more service providers identifying where the request comes from, but it's also giving away potentially sensitive information.