### PR TITLE
Add API to change preferences

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -73,6 +73,12 @@ return [
 		['name' => 'AppConfig#getValue', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'GET'],
 		['name' => 'AppConfig#setValue', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'POST'],
 		['name' => 'AppConfig#deleteKey', 'url' => '/api/v1/config/apps/{app}/{key}', 'verb' => 'DELETE'],
+
+		// Preferences
+		['name' => 'Preferences#setPreference', 'url' => '/api/v1/config/users/{appId}/{configKey}', 'verb' => 'POST'],
+		['name' => 'Preferences#setMultiplePreferences', 'url' => '/api/v1/config/users/{appId}', 'verb' => 'POST'],
+		['name' => 'Preferences#deletePreference', 'url' => '/api/v1/config/users/{appId}/{configKey}', 'verb' => 'DELETE'],
+		['name' => 'Preferences#deleteMultiplePreference', 'url' => '/api/v1/config/users/{appId}', 'verb' => 'DELETE'],
 	],
 	'routes' => [
 		// Verification

--- a/apps/provisioning_api/composer/composer/autoload_classmap.php
+++ b/apps/provisioning_api/composer/composer/autoload_classmap.php
@@ -13,6 +13,7 @@ return array(
     'OCA\\Provisioning_API\\Controller\\AppConfigController' => $baseDir . '/../lib/Controller/AppConfigController.php',
     'OCA\\Provisioning_API\\Controller\\AppsController' => $baseDir . '/../lib/Controller/AppsController.php',
     'OCA\\Provisioning_API\\Controller\\GroupsController' => $baseDir . '/../lib/Controller/GroupsController.php',
+    'OCA\\Provisioning_API\\Controller\\PreferencesController' => $baseDir . '/../lib/Controller/PreferencesController.php',
     'OCA\\Provisioning_API\\Controller\\UsersController' => $baseDir . '/../lib/Controller/UsersController.php',
     'OCA\\Provisioning_API\\Controller\\VerificationController' => $baseDir . '/../lib/Controller/VerificationController.php',
     'OCA\\Provisioning_API\\FederatedShareProviderFactory' => $baseDir . '/../lib/FederatedShareProviderFactory.php',

--- a/apps/provisioning_api/composer/composer/autoload_static.php
+++ b/apps/provisioning_api/composer/composer/autoload_static.php
@@ -28,6 +28,7 @@ class ComposerStaticInitProvisioning_API
         'OCA\\Provisioning_API\\Controller\\AppConfigController' => __DIR__ . '/..' . '/../lib/Controller/AppConfigController.php',
         'OCA\\Provisioning_API\\Controller\\AppsController' => __DIR__ . '/..' . '/../lib/Controller/AppsController.php',
         'OCA\\Provisioning_API\\Controller\\GroupsController' => __DIR__ . '/..' . '/../lib/Controller/GroupsController.php',
+        'OCA\\Provisioning_API\\Controller\\PreferencesController' => __DIR__ . '/..' . '/../lib/Controller/PreferencesController.php',
         'OCA\\Provisioning_API\\Controller\\UsersController' => __DIR__ . '/..' . '/../lib/Controller/UsersController.php',
         'OCA\\Provisioning_API\\Controller\\VerificationController' => __DIR__ . '/..' . '/../lib/Controller/VerificationController.php',
         'OCA\\Provisioning_API\\FederatedShareProviderFactory' => __DIR__ . '/..' . '/../lib/FederatedShareProviderFactory.php',

--- a/apps/provisioning_api/lib/Controller/PreferencesController.php
+++ b/apps/provisioning_api/lib/Controller/PreferencesController.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Provisioning_API\Controller;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\Config\BeforePreferenceDeletedEvent;
+use OCP\Config\BeforePreferenceSetEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class PreferencesController extends OCSController {
+
+	private IConfig $config;
+	private IUserSession $userSession;
+	private IEventDispatcher $eventDispatcher;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IConfig $config,
+		IUserSession $userSession,
+		IEventDispatcher $eventDispatcher
+	) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+		$this->userSession = $userSession;
+		$this->eventDispatcher = $eventDispatcher;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 */
+	public function setMultiplePreferences(string $appId, array $configs): DataResponse {
+		$userId = $this->userSession->getUser()->getUID();
+
+		foreach ($configs as $configKey => $configValue) {
+			$event = new BeforePreferenceSetEvent(
+				$userId,
+				$appId,
+				$configKey,
+				$configValue
+			);
+
+			$this->eventDispatcher->dispatchTyped($event);
+
+			if (!$event->isValid()) {
+				// No listener validated that the preference can be set (to this value)
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
+		}
+
+		foreach ($configs as $configKey => $configValue) {
+			$this->config->setUserValue(
+				$userId,
+				$appId,
+				$configKey,
+				$configValue
+			);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 */
+	public function setPreference(string $appId, string $configKey, string $configValue): DataResponse {
+		$userId = $this->userSession->getUser()->getUID();
+
+		$event = new BeforePreferenceSetEvent(
+			$userId,
+			$appId,
+			$configKey,
+			$configValue
+		);
+
+		$this->eventDispatcher->dispatchTyped($event);
+
+		if (!$event->isValid()) {
+			// No listener validated that the preference can be set (to this value)
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		$this->config->setUserValue(
+			$userId,
+			$appId,
+			$configKey,
+			$configValue
+		);
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 */
+	public function deleteMultiplePreference(string $appId, array $configKeys): DataResponse {
+		$userId = $this->userSession->getUser()->getUID();
+
+		foreach ($configKeys as $configKey) {
+			$event = new BeforePreferenceDeletedEvent(
+				$userId,
+				$appId,
+				$configKey
+			);
+
+			$this->eventDispatcher->dispatchTyped($event);
+
+			if (!$event->isValid()) {
+				// No listener validated that the preference can be deleted
+				return new DataResponse([], Http::STATUS_BAD_REQUEST);
+			}
+		}
+
+		foreach ($configKeys as $configKey) {
+			$this->config->deleteUserValue(
+				$userId,
+				$appId,
+				$configKey
+			);
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 */
+	public function deletePreference(string $appId, string $configKey): DataResponse {
+		$userId = $this->userSession->getUser()->getUID();
+
+		$event = new BeforePreferenceDeletedEvent(
+			$userId,
+			$appId,
+			$configKey
+		);
+
+		$this->eventDispatcher->dispatchTyped($event);
+
+		if (!$event->isValid()) {
+			// No listener validated that the preference can be deleted
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		$this->config->deleteUserValue(
+			$userId,
+			$appId,
+			$configKey
+		);
+
+		return new DataResponse();
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -160,6 +160,8 @@ return array(
     'OCP\\Comments\\IllegalIDChangeException' => $baseDir . '/lib/public/Comments/IllegalIDChangeException.php',
     'OCP\\Comments\\MessageTooLongException' => $baseDir . '/lib/public/Comments/MessageTooLongException.php',
     'OCP\\Comments\\NotFoundException' => $baseDir . '/lib/public/Comments/NotFoundException.php',
+    'OCP\\Config\\BeforePreferenceDeletedEvent' => $baseDir . '/lib/public/Config/BeforePreferenceDeletedEvent.php',
+    'OCP\\Config\\BeforePreferenceSetEvent' => $baseDir . '/lib/public/Config/BeforePreferenceSetEvent.php',
     'OCP\\Console\\ConsoleEvent' => $baseDir . '/lib/public/Console/ConsoleEvent.php',
     'OCP\\Constants' => $baseDir . '/lib/public/Constants.php',
     'OCP\\Contacts\\ContactsMenu\\IAction' => $baseDir . '/lib/public/Contacts/ContactsMenu/IAction.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -189,6 +189,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Comments\\IllegalIDChangeException' => __DIR__ . '/../../..' . '/lib/public/Comments/IllegalIDChangeException.php',
         'OCP\\Comments\\MessageTooLongException' => __DIR__ . '/../../..' . '/lib/public/Comments/MessageTooLongException.php',
         'OCP\\Comments\\NotFoundException' => __DIR__ . '/../../..' . '/lib/public/Comments/NotFoundException.php',
+        'OCP\\Config\\BeforePreferenceDeletedEvent' => __DIR__ . '/../../..' . '/lib/public/Config/BeforePreferenceDeletedEvent.php',
+        'OCP\\Config\\BeforePreferenceSetEvent' => __DIR__ . '/../../..' . '/lib/public/Config/BeforePreferenceSetEvent.php',
         'OCP\\Console\\ConsoleEvent' => __DIR__ . '/../../..' . '/lib/public/Console/ConsoleEvent.php',
         'OCP\\Constants' => __DIR__ . '/../../..' . '/lib/public/Constants.php',
         'OCP\\Contacts\\ContactsMenu\\IAction' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IAction.php',

--- a/lib/public/Config/BeforePreferenceDeletedEvent.php
+++ b/lib/public/Config/BeforePreferenceDeletedEvent.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Config;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 25.0.0
+ */
+class BeforePreferenceDeletedEvent extends Event {
+	protected string $userId;
+	protected string $appId;
+	protected string $configKey;
+	protected bool $valid = false;
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function __construct(string $userId, string $appId, string $configKey) {
+		parent::__construct();
+		$this->userId = $userId;
+		$this->appId = $appId;
+		$this->configKey = $configKey;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getUserId(): string {
+		return $this->userId;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getAppId(): string {
+		return $this->appId;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getConfigKey(): string {
+		return $this->configKey;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function isValid(): bool {
+		return $this->valid;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function setValid(bool $valid): void {
+		$this->valid = $valid;
+	}
+}

--- a/lib/public/Config/BeforePreferenceSetEvent.php
+++ b/lib/public/Config/BeforePreferenceSetEvent.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Config;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 25.0.0
+ */
+class BeforePreferenceSetEvent extends Event {
+	protected string $userId;
+	protected string $appId;
+	protected string $configKey;
+	protected string $configValue;
+	protected bool $valid = false;
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function __construct(string $userId, string $appId, string $configKey, string $configValue) {
+		parent::__construct();
+		$this->userId = $userId;
+		$this->appId = $appId;
+		$this->configKey = $configKey;
+		$this->configValue = $configValue;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getUserId(): string {
+		return $this->userId;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getAppId(): string {
+		return $this->appId;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getConfigKey(): string {
+		return $this->configKey;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function getConfigValue(): string {
+		return $this->configValue;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function isValid(): bool {
+		return $this->valid;
+	}
+
+	/**
+	 * @since 25.0.0
+	 */
+	public function setValid(bool $valid): void {
+		$this->valid = $valid;
+	}
+}


### PR DESCRIPTION
As per chat:
> It seems we currently don't have an public API endpoint to manage oc_preferences
I would tend to go for something like https://github.com/nextcloud/server/blob/0dee717c94468afeb139d9e8d9322b5fd26974b6/apps/provisioning_api/appinfo/routes.php#L70-L75 instead of implementing it yet another time in a new app.
Would come with an event and only when a listener makes the validation pass it would be allowed, to prevent e.g. overwriting lastLogin and other things.

Will be used for https://github.com/nextcloud/spreed/issues/7321