### PR TITLE
Fix: #32543 Update zh_CN.js

### DIFF
--- a/apps/files_sharing/l10n/zh_CN.js
+++ b/apps/files_sharing/l10n/zh_CN.js
@@ -194,7 +194,7 @@ OC.L10N.register(
     "{shareWith} by {initiator}" : "由 {initiator} 通过 {shareWith} 共享",
     "Shared via link by {initiator}" : "由 {initiator} 通过链接共享",
     "Mail share ({label})" : "邮件分享 ({label})",
-    "Share link ({label})" : "分享链接({标签})",
+    "Share link ({label})" : "分享链接({label})",
     "Share link" : "共享链接",
     "Error, please enter proper password and/or expiration date" : "错误，请输入正确的密码和/或过期日期",
     "No recommendations. Start typing." : "没有推荐。开始输入。",


### PR DESCRIPTION
Fix the bug about dispaying in share-link label  in Chinese mode.

before:
![](https://i.bmp.ovh/imgs/2022/05/24/2f279ffc8747904e.png)
after:
![](https://i.bmp.ovh/imgs/2022/05/24/a1f935d619a55062.png)

Signed-off-by: wangvic21<wangvic21@126.com>