### PR TITLE
Remove at() matcher use from encryption tests

### DIFF
--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -192,15 +192,16 @@ class SettingsControllerTest extends TestCase {
 			->method('get')->with('loginname')->willReturn('testUser');
 
 		$this->userManagerMock
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('checkPassword')
-			->with('testUserUid', 'new')
-			->willReturn(false);
-		$this->userManagerMock
-			->expects($this->at(1))
-			->method('checkPassword')
-			->with('testUser', 'new')
-			->willReturn(true);
+			->withConsecutive(
+				['testUserUid', 'new'],
+				['testUser', 'new'],
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true,
+			);
 
 
 

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -166,9 +166,9 @@ class EncryptAllTest extends TestCase {
 			->getMock();
 
 		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
-		$encryptAll->expects($this->at(0))->method('createKeyPairs')->with();
-		$encryptAll->expects($this->at(1))->method('outputPasswords')->with();
-		$encryptAll->expects($this->at(2))->method('encryptAllUsersFiles')->with();
+		$encryptAll->expects($this->once())->method('createKeyPairs')->with();
+		$encryptAll->expects($this->once())->method('outputPasswords')->with();
+		$encryptAll->expects($this->once())->method('encryptAllUsersFiles')->with();
 
 		$encryptAll->encryptAll($this->inputInterface, $this->outputInterface);
 	}
@@ -196,7 +196,7 @@ class EncryptAllTest extends TestCase {
 		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(true);
 		$encryptAll->expects($this->never())->method('createKeyPairs');
 		$this->keyManager->expects($this->once())->method('validateMasterKey');
-		$encryptAll->expects($this->at(0))->method('encryptAllUsersFiles')->with();
+		$encryptAll->expects($this->once())->method('encryptAllUsersFiles')->with();
 		$encryptAll->expects($this->never())->method('outputPasswords');
 
 		$encryptAll->encryptAll($this->inputInterface, $this->outputInterface);
@@ -277,8 +277,11 @@ class EncryptAllTest extends TestCase {
 		$this->invokePrivate($encryptAll, 'output', [$this->outputInterface]);
 		$this->invokePrivate($encryptAll, 'userPasswords', [['user1' => 'pwd1', 'user2' => 'pwd2']]);
 
-		$encryptAll->expects($this->at(0))->method('encryptUsersFiles')->with('user1');
-		$encryptAll->expects($this->at(1))->method('encryptUsersFiles')->with('user2');
+		$encryptAll->expects($this->exactly(2))->method('encryptUsersFiles')
+			->withConsecutive(
+				['user1'],
+				['user2'],
+			);
 
 		$this->invokePrivate($encryptAll, 'encryptAllUsersFiles');
 	}
@@ -305,16 +308,15 @@ class EncryptAllTest extends TestCase {
 
 		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
-		$this->view->expects($this->at(0))->method('getDirectoryContent')
-			->with('/user1/files')->willReturn(
+		$this->view->expects($this->exactly(2))->method('getDirectoryContent')
+			->withConsecutive(
+				['/user1/files'],
+				['/user1/files/foo'],
+			)->willReturnOnConsecutiveCalls(
 				[
 					['name' => 'foo', 'type' => 'dir'],
 					['name' => 'bar', 'type' => 'file'],
-				]
-			);
-
-		$this->view->expects($this->at(3))->method('getDirectoryContent')
-			->with('/user1/files/foo')->willReturn(
+				],
 				[
 					['name' => 'subfile', 'type' => 'file']
 				]
@@ -330,8 +332,11 @@ class EncryptAllTest extends TestCase {
 				}
 			);
 
-		$encryptAll->expects($this->at(1))->method('encryptFile')->with('/user1/files/bar');
-		$encryptAll->expects($this->at(2))->method('encryptFile')->with('/user1/files/foo/subfile');
+		$encryptAll->expects($this->exactly(2))->method('encryptFile')
+			->withConsecutive(
+				['/user1/files/bar'],
+				['/user1/files/foo/subfile'],
+			);
 
 		$this->outputInterface->expects($this->any())
 			->method('getFormatter')

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -287,8 +287,11 @@ class KeyManagerTest extends TestCase {
 		$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn($useMasterKey);
 
-		$this->sessionMock->expects($this->at(0))->method('setStatus')
-			->with(Session::INIT_EXECUTED);
+		$this->sessionMock->expects($this->exactly(2))->method('setStatus')
+			->withConsecutive(
+				[Session::INIT_EXECUTED],
+				[Session::INIT_SUCCESSFUL],
+			);
 
 		$instance->expects($this->any())->method('getMasterKeyId')->willReturn('masterKeyId');
 		$instance->expects($this->any())->method('getMasterKeyPassword')->willReturn('masterKeyPassword');
@@ -404,15 +407,16 @@ class KeyManagerTest extends TestCase {
 
 		$this->invokePrivate($this->instance, 'masterKeyId', ['masterKeyId']);
 
-		$this->keyStorageMock->expects($this->at(0))
+		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getFileKey')
-			->with($path, 'fileKey', 'OC_DEFAULT_MODULE')
-			->willReturn(true);
-
-		$this->keyStorageMock->expects($this->at(1))
-			->method('getFileKey')
-			->with($path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE')
-			->willReturn(true);
+			->withConsecutive(
+				[$path, 'fileKey', 'OC_DEFAULT_MODULE'],
+				[$path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE'],
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				true,
+			);
 
 		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')
 			->willReturn($isMasterKeyEnabled);


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>