### PR TITLE
Remove at() matcher from tests in federatedfilesharing

### DIFF
--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -548,11 +548,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
-		$this->addressHandler->expects($this->at(0))->method('splitUserRemote')
-			->willReturn(['user', 'server.com']);
-
-		$this->addressHandler->expects($this->at(1))->method('splitUserRemote')
-			->willReturn(['user2', 'server.com']);
+		$this->addressHandler->expects($this->never())->method('splitUserRemote');
 
 		$this->addressHandler->method('generateRemoteURL')
 			->willReturn('remoteurl.com');


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>