### PR TITLE
Remove at() matcher in files_sharing tests

### DIFF
--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -186,19 +186,15 @@ class CleanupRemoteStoragesTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		//
-
 		// parent folder, `files`, ´test` and `welcome.txt` => 4 elements
 
-		$at = 0;
 		$output
-			->expects($this->at($at++))
+			->expects($this->any())
 			->method('writeln')
-			->with('5 remote storage(s) need(s) to be checked');
-		$output
-			->expects($this->at($at++))
-			->method('writeln')
-			->with('5 remote share(s) exist');
+			->withConsecutive(
+				['5 remote storage(s) need(s) to be checked'],
+				['5 remote share(s) exist'],
+			);
 
 		$this->cloudIdManager
 			->expects($this->any())

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -263,10 +263,17 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
 		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects($this->exactly(3))
 			->method('linkToRouteAbsolute')
-			->with('files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename])
-			->willReturn('downloadURL');
+			->withConsecutive(
+				['files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename]],
+				['files_sharing.sharecontroller.showShare', ['token' => 'token']],
+				['files_sharing.PublicPreview.getPreview', ['token' => 'token', 'x' => 200, 'y' => 200, 'file' => '/'.$filename]],
+			)->willReturnOnConsecutiveCalls(
+				'downloadURL',
+				'shareUrl',
+				'previewImage',
+			);
 
 		$this->previewManager->method('isMimeSupported')->with('text/plain')->willReturn(true);
 
@@ -343,8 +350,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'hideFileList' => false,
 			'shareOwner' => 'ownerDisplay',
 			'disclaimer' => 'My disclaimer text',
-			'shareUrl' => null,
-			'previewImage' => null,
+			'shareUrl' => 'shareUrl',
+			'previewImage' => 'previewImage',
 			'previewURL' => 'downloadURL',
 			'note' => $note,
 			'hideDownload' => false,
@@ -414,10 +421,17 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
 		$this->session->method('get')->with('public_link_authenticated')->willReturn('42');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects($this->exactly(3))
 			->method('linkToRouteAbsolute')
-			->with('files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename])
-			->willReturn('downloadURL');
+			->withConsecutive(
+				['files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename]],
+				['files_sharing.sharecontroller.showShare', ['token' => 'token']],
+				['files_sharing.PublicPreview.getPreview', ['token' => 'token', 'x' => 200, 'y' => 200, 'file' => '/'.$filename]],
+			)->willReturnOnConsecutiveCalls(
+				'downloadURL',
+				'shareUrl',
+				'previewImage',
+			);
 
 		$this->previewManager->method('isMimeSupported')->with('text/plain')->willReturn(true);
 
@@ -494,8 +508,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'hideFileList' => false,
 			'shareOwner' => '',
 			'disclaimer' => 'My disclaimer text',
-			'shareUrl' => null,
-			'previewImage' => null,
+			'shareUrl' => 'shareUrl',
+			'previewImage' => 'previewImage',
 			'previewURL' => 'downloadURL',
 			'note' => $note,
 			'hideDownload' => false,
@@ -569,10 +583,17 @@ class ShareControllerTest extends \Test\TestCase {
 		// Even if downloads are disabled the "downloadURL" parameter is
 		// provided to the template, as it is needed to preview audio and GIF
 		// files.
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects($this->exactly(3))
 			->method('linkToRouteAbsolute')
-			->with('files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename])
-			->willReturn('downloadURL');
+			->withConsecutive(
+				['files_sharing.sharecontroller.downloadShare', ['token' => 'token', 'filename' => $filename]],
+				['files_sharing.sharecontroller.showShare', ['token' => 'token']],
+				['files_sharing.PublicPreview.getPreview', ['token' => 'token', 'x' => 200, 'y' => 200, 'file' => '/'.$filename]],
+			)->willReturnOnConsecutiveCalls(
+				'downloadURL',
+				'shareUrl',
+				'previewImage',
+			);
 
 		$this->previewManager->method('isMimeSupported')->with('text/plain')->willReturn(true);
 
@@ -645,8 +666,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'hideFileList' => false,
 			'shareOwner' => 'ownerDisplay',
 			'disclaimer' => 'My disclaimer text',
-			'shareUrl' => null,
-			'previewImage' => null,
+			'shareUrl' => 'shareUrl',
+			'previewImage' => 'previewImage',
 			'previewURL' => 'downloadURL',
 			'note' => $note,
 			'hideDownload' => true,

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -231,8 +231,14 @@ class ManagerTest extends TestCase {
 		if ($isGroup) {
 			$this->manager->expects($this->never())->method('tryOCMEndPoint');
 		} else {
-			$this->manager->expects($this->at(0))->method('tryOCMEndPoint')->with('http://localhost', 'token1', '2342', 'accept')->willReturn(false);
-			$this->manager->expects($this->at(1))->method('tryOCMEndPoint')->with('http://localhost', 'token3', '2342', 'decline')->willReturn(false);
+			$this->manager->expects($this->any())->method('tryOCMEndPoint')
+				->withConsecutive(
+					['http://localhost', 'token1', '2342', 'accept'],
+					['http://localhost', 'token3', '2342', 'decline'],
+				)->willReturnOnConsecutiveCalls(
+					false,
+					false,
+				);
 		}
 
 		// Add a share for "user"
@@ -375,12 +381,12 @@ class ManagerTest extends TestCase {
 				->disableOriginalConstructor()->getMock();
 			$client2 = $this->getMockBuilder('OCP\Http\Client\IClient')
 				->disableOriginalConstructor()->getMock();
-			$this->clientService->expects($this->at(0))
+			$this->clientService->expects($this->exactly(2))
 				->method('newClient')
-				->willReturn($client1);
-			$this->clientService->expects($this->at(1))
-				->method('newClient')
-				->willReturn($client2);
+				->willReturnOnConsecutiveCalls(
+					$client1,
+					$client2,
+				);
 			$response = $this->createMock(IResponse::class);
 			$response->method('getBody')
 				->willReturn(json_encode([
@@ -656,7 +662,7 @@ class ManagerTest extends TestCase {
 		$user2Shares = $manager2->getOpenShares();
 		$this->assertCount(2, $user2Shares);
 
-		$this->manager->expects($this->at(0))->method('tryOCMEndPoint')->with('http://localhost', 'token1', '2342', 'decline')->willReturn([]);
+		$this->manager->expects($this->once())->method('tryOCMEndPoint')->with('http://localhost', 'token1', '2342', 'decline')->willReturn([]);
 		$this->manager->removeUserShares($this->uid);
 
 		$user1Shares = $this->manager->getOpenShares();

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -141,26 +141,21 @@ class MountProviderTest extends \Test\TestCase {
 		$this->user->expects($this->any())
 			->method('getUID')
 			->willReturn('user1');
-		$this->shareManager->expects($this->at(0))
+		$this->shareManager->expects($this->exactly(5))
 			->method('getSharedWith')
-			->with('user1', IShare::TYPE_USER)
-			->willReturn($userShares);
-		$this->shareManager->expects($this->at(1))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_GROUP, null, -1)
-			->willReturn($groupShares);
-		$this->shareManager->expects($this->at(2))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_CIRCLE, null, -1)
-			->willReturn($circleShares);
-		$this->shareManager->expects($this->at(3))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_ROOM, null, -1)
-			->willReturn($roomShares);
-		$this->shareManager->expects($this->at(4))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_DECK, null, -1)
-			->willReturn($deckShares);
+			->withConsecutive(
+				['user1', IShare::TYPE_USER],
+				['user1', IShare::TYPE_GROUP, null, -1],
+				['user1', IShare::TYPE_CIRCLE, null, -1],
+				['user1', IShare::TYPE_ROOM, null, -1],
+				['user1', IShare::TYPE_DECK, null, -1],
+			)->willReturnOnConsecutiveCalls(
+				$userShares,
+				$groupShares,
+				$circleShares,
+				$roomShares,
+				$deckShares,
+			);
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->willReturnCallback(function () use ($rootFolder, $userManager) {
@@ -362,26 +357,21 @@ class MountProviderTest extends \Test\TestCase {
 		$circleShares = [];
 		$roomShares = [];
 		$deckShares = [];
-		$this->shareManager->expects($this->at(0))
+		$this->shareManager->expects($this->exactly(5))
 			->method('getSharedWith')
-			->with('user1', IShare::TYPE_USER)
-			->willReturn($userShares);
-		$this->shareManager->expects($this->at(1))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_GROUP, null, -1)
-			->willReturn($groupShares);
-		$this->shareManager->expects($this->at(2))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_CIRCLE, null, -1)
-			->willReturn($circleShares);
-		$this->shareManager->expects($this->at(3))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_ROOM, null, -1)
-			->willReturn($roomShares);
-		$this->shareManager->expects($this->at(4))
-			->method('getSharedWith')
-			->with('user1', IShare::TYPE_DECK, null, -1)
-			->willReturn($deckShares);
+			->withConsecutive(
+				['user1', IShare::TYPE_USER],
+				['user1', IShare::TYPE_GROUP, null, -1],
+				['user1', IShare::TYPE_CIRCLE, null, -1],
+				['user1', IShare::TYPE_ROOM, null, -1],
+				['user1', IShare::TYPE_DECK, null, -1],
+			)->willReturnOnConsecutiveCalls(
+				$userShares,
+				$groupShares,
+				$circleShares,
+				$roomShares,
+				$deckShares,
+			);
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->willReturnCallback(function () use ($rootFolder, $userManager) {


### PR DESCRIPTION
- [ ] Find out how to get rid of the one left in `OCA\Files_Sharing\Tests\External\ManagerTest::testAddUserShare`

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>