### PR TITLE
allow use of rememberme cookies for IApacheAuth backends

### DIFF
--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -179,6 +179,7 @@ class OC_User {
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();
 				$userSession->createSessionToken($request, $uid, $uid);
+				$userSession->createRememberMeToken($userSession->getUser());
 				// setup the filesystem
 				OC_Util::setupFS($uid);
 				// first call the post_login hooks, the login-process needs to be


### PR DESCRIPTION
- e.g. enables it for SAML backend. Fixes https://github.com/nextcloud/user_saml/issues/609

