### PR TITLE
Use JSON_THROW_ON_ERROR instead of custom error handling

### DIFF
--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -64,13 +64,7 @@ class JSONResponse extends Response {
 	 * @throws \Exception If data could not get encoded
 	 */
 	public function render() {
-		$response = json_encode($this->data, JSON_HEX_TAG);
-		if ($response === false) {
-			throw new \Exception(sprintf('Could not json_encode due to invalid ' .
-				'non UTF-8 characters in the array: %s', var_export($this->data, true)));
-		}
-
-		return $response;
+		return json_encode($this->data, JSON_HEX_TAG | JSON_THROW_ON_ERROR);
 	}
 
 	/**

--- a/tests/lib/AppFramework/Http/JSONResponseTest.php
+++ b/tests/lib/AppFramework/Http/JSONResponseTest.php
@@ -88,10 +88,10 @@ class JSONResponseTest extends \Test\TestCase {
 		$this->assertEquals($expected, $this->json->render());
 	}
 
-	
+
 	public function testRenderWithNonUtf8Encoding() {
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Could not json_encode due to invalid non UTF-8 characters in the array: array (');
+		$this->expectException(\JsonException::class);
+		$this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
 
 		$params = ['test' => hex2bin('e9')];
 		$this->json->setData($params);


### PR DESCRIPTION
This way we can rely on json_encode for the actual error message, as there [might be more](https://www.php.net/manual/en/function.json-last-error.php) than just malformed UTF8 characters and avoid to always dump the full response data into the logs.

Source of the recent report that this happened with text are addressed separately in https://github.com/nextcloud/text/pull/2385