### PR TITLE
Get access list share by email recipients

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -1098,7 +1098,7 @@ class ShareByMailProvider implements IShareProvider {
 		}
 
 		$qb = $this->dbConnection->getQueryBuilder();
-		$qb->select('share_with', 'file_source')
+		$qb->select('share_with', 'file_source', 'token')
 			->from('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_EMAIL)))
 			->andWhere($qb->expr()->in('file_source', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
@@ -1114,7 +1114,8 @@ class ShareByMailProvider implements IShareProvider {
 				$mail[] = $row['share_with'];
 			} else {
 				$mail[$row['share_with']] = [
-					'node_id' => $row['file_source']
+					'node_id' => $row['file_source'],
+					'token' => $row['token']
 				];
 			}
 		}

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -1108,6 +1108,7 @@ class ShareByMailProvider implements IShareProvider {
 			));
 		$cursor = $qb->executeQuery();
 
+		$public = $cursor->rowCount() > 0;
 		$mail = [];
 		while ($row = $cursor->fetch()) {
 			if ($currentAccess === false) {
@@ -1121,7 +1122,7 @@ class ShareByMailProvider implements IShareProvider {
 		}
 		$cursor->closeCursor();
 
-		return ['public' => $mail];
+		return ['public' => $public, 'mail' => $mail];
 	}
 
 	public function getAllShares(): iterable {

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -1108,9 +1108,10 @@ class ShareByMailProvider implements IShareProvider {
 			));
 		$cursor = $qb->executeQuery();
 
-		$public = $cursor->rowCount() > 0;
+		$public = false;
 		$mail = [];
 		while ($row = $cursor->fetch()) {
+			$public = true;
 			if ($currentAccess === false) {
 				$mail[] = $row['share_with'];
 			} else {

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -1108,7 +1108,7 @@ class ShareByMailProvider implements IShareProvider {
 			));
 		$cursor = $qb->executeQuery();
 
-		$mail = array();
+		$mail = [];
 		while ($row = $cursor->fetch()) {
 			if ($currentAccess === false) {
 				$mail[] = $row['share_with'];

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1690,8 +1690,8 @@ class Manager implements IManager {
 	 *  ],
 	 *  public => bool
 	 *  mail => [
-         *      'email1@maildomain1' => ['node_id' => 42],
-         *      'email2@maildomain2' => ['node_id' => 23],
+         *      'email1@maildomain1' => ['node_id' => 42, 'token' => 'aBcDeFg'],
+         *      'email2@maildomain2' => ['node_id' => 23, 'token' => 'hIjKlMn'],
          *  ]
 	 * ]
 	 *

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1690,9 +1690,9 @@ class Manager implements IManager {
 	 *  ],
 	 *  public => bool
 	 *  mail => [
-         *      'email1@maildomain1' => ['node_id' => 42, 'token' => 'aBcDeFg'],
-         *      'email2@maildomain2' => ['node_id' => 23, 'token' => 'hIjKlMn'],
-         *  ]
+	 *      'email1@maildomain1' => ['node_id' => 42, 'token' => 'aBcDeFg'],
+	 *      'email2@maildomain2' => ['node_id' => 23, 'token' => 'hIjKlMn'],
+	 *  ]
 	 * ]
 	 *
 	 * The access list to '/folder1/folder2/fileA' **without** $currentAccess is:

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1672,9 +1672,10 @@ class Manager implements IManager {
 	 *  |-folder2 (32)
 	 *   |-fileA (42)
 	 *
-	 * fileA is shared with user1 and user1@server1
+	 * fileA is shared with user1 and user1@server1 and email1@maildomain1
 	 * folder2 is shared with group2 (user4 is a member of group2)
 	 * folder1 is shared with user2 (renamed to "folder (1)") and user2@server2
+	 *                        and email2@maildomain2
 	 *
 	 * Then the access list to '/folder1/folder2/fileA' with $currentAccess is:
 	 * [
@@ -1688,7 +1689,10 @@ class Manager implements IManager {
 	 *      'user2@server2' => ['node_id' => 23, 'token' => 'FooBaR'],
 	 *  ],
 	 *  public => bool
-	 *  mail => bool
+	 *  mail => [
+         *      'email1@maildomain1' => ['node_id' => 42],
+         *      'email2@maildomain2' => ['node_id' => 23],
+         *  ]
 	 * ]
 	 *
 	 * The access list to '/folder1/folder2/fileA' **without** $currentAccess is:
@@ -1696,7 +1700,7 @@ class Manager implements IManager {
 	 *  users  => ['user1', 'user2', 'user4'],
 	 *  remote => bool,
 	 *  public => bool
-	 *  mail => bool
+	 *  mail => ['email1@maildomain1', 'email2@maildomain2']
 	 * ]
 	 *
 	 * This is required for encryption/activity
@@ -1716,9 +1720,9 @@ class Manager implements IManager {
 		$owner = $owner->getUID();
 
 		if ($currentAccess) {
-			$al = ['users' => [], 'remote' => [], 'public' => false];
+			$al = ['users' => [], 'remote' => [], 'public' => false, 'mail' => []];
 		} else {
-			$al = ['users' => [], 'remote' => false, 'public' => false];
+			$al = ['users' => [], 'remote' => false, 'public' => false, 'mail' => []];
 		}
 		if (!$this->userManager->userExists($owner)) {
 			return $al;

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -256,9 +256,10 @@ interface IManager {
 	 *  |-folder2 (32)
 	 *   |-fileA (42)
 	 *
-	 * fileA is shared with user1 and user1@server1
+	 * fileA is shared with user1 and user1@server1 email1@maildomain1
 	 * folder2 is shared with group2 (user4 is a member of group2)
 	 * folder1 is shared with user2 (renamed to "folder (1)") and user2@server2
+	 *                        and email2@maildomain2
 	 *
 	 * Then the access list to '/folder1/folder2/fileA' with $currentAccess is:
 	 * [
@@ -272,7 +273,9 @@ interface IManager {
 	 *      'user2@server2' => ['node_id' => 23, 'token' => 'FooBaR'],
 	 *  ],
 	 *  public => bool
-	 *  mail => bool
+	 *  mail => [
+	 *      'email1@maildomain1' => ['node_id' => 42],
+	 *      'email2@maildomain2' => ['node_id' => 23],
 	 * ]
 	 *
 	 * The access list to '/folder1/folder2/fileA' **without** $currentAccess is:
@@ -280,7 +283,7 @@ interface IManager {
 	 *  users  => ['user1', 'user2', 'user4'],
 	 *  remote => bool,
 	 *  public => bool
-	 *  mail => bool
+	 *  mail => ['email1@maildomain1', 'email2@maildomain2']
 	 * ]
 	 *
 	 * This is required for encryption/activity

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -256,7 +256,7 @@ interface IManager {
 	 *  |-folder2 (32)
 	 *   |-fileA (42)
 	 *
-	 * fileA is shared with user1 and user1@server1 email1@maildomain1
+	 * fileA is shared with user1 and user1@server1 and email1@maildomain1
 	 * folder2 is shared with group2 (user4 is a member of group2)
 	 * folder1 is shared with user2 (renamed to "folder (1)") and user2@server2
 	 *                        and email2@maildomain2
@@ -274,9 +274,9 @@ interface IManager {
 	 *  ],
 	 *  public => bool
 	 *  mail => [
-	 *      'email1@maildomain1' => ['node_id' => 42],
-	 *      'email2@maildomain2' => ['node_id' => 23],
-	 * ]
+	 *      'email1@maildomain1' => ['node_id' => 42, 'token' => 'aBcDeFg'],
+	 *      'email2@maildomain2' => ['node_id' => 23, 'token' => 'hIjKlMn'],
+	 *  ]
 	 *
 	 * The access list to '/folder1/folder2/fileA' **without** $currentAccess is:
 	 * [


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/32629

## Summary: 

Return the recipients for an email share. 

We already have `mail`, but it's unused / broken.

The backstory: 

In https://github.com/nextcloud/server/pull/2834 `mail => bool` was documented but not implemented. 

![image](https://github.com/nextcloud/server/assets/3902676/218004c3-3fb8-4900-9f02-5175c52a7853)


Commit to change mail to public: https://github.com/nextcloud/server/pull/2834/commits/cab41118f67e6a4743bac2cfcfa69a4bee28f2a3

