### PR TITLE
Fix User profile picture when performing the search

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -284,8 +284,11 @@ class ContactsStore implements IContactsStore {
 	private function contactArrayToEntry(array $contact): Entry {
 		$entry = new Entry();
 
-		if (isset($contact['id'])) {
-			$entry->setId($contact['id']);
+		if (isset($contact['UID'])) {
+			$entry->setId($contact['UID']);
+			$uid = $contact['UID'];
+			$avatar = "/index.php/avatar/$uid/64";
+			$entry->setAvatar($avatar);
 		}
 
 		if (isset($contact['FN'])) {

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -287,7 +287,7 @@ class ContactsStore implements IContactsStore {
 		if (isset($contact['UID'])) {
 			$entry->setId($contact['UID']);
 			$uid = $contact['UID'];
-			$avatar = $this->urlGenerator->linkToRoute('core.getAvatar', ['userId' => $uid, 'size' => 64]);
+			$avatar = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $uid, 'size' => 64]);
 			$entry->setAvatar($avatar);
 		}
 

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -285,8 +285,8 @@ class ContactsStore implements IContactsStore {
 		$entry = new Entry();
 
 		if (isset($contact['UID'])) {
-			$entry->setId($contact['UID']);
 			$uid = $contact['UID'];
+			$entry->setId($uid);
 			$avatar = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $uid, 'size' => 64]);
 			$entry->setAvatar($avatar);
 		}

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -287,7 +287,7 @@ class ContactsStore implements IContactsStore {
 		if (isset($contact['UID'])) {
 			$entry->setId($contact['UID']);
 			$uid = $contact['UID'];
-			$avatar = "/index.php/avatar/$uid/64";
+			$avatar = $this->urlGenerator->linkToRoute('core.getAvatar', ['userId' => $uid, 'size' => 64]);
 			$entry->setAvatar($avatar);
 		}
 

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -140,6 +140,10 @@ class ContactsStoreTest extends TestCase {
 	public function testGetContactsWithoutBinaryImage() {
 		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
+		$this->urlGenerator->expects($this->any())
+			->method('linkToRouteAbsolute')
+			->with('core.avatar.getAvatar', $this->anything())
+			->willReturn('https://urlToNcAvatar.test');
 		$this->contactsManager->expects($this->once())
 			->method('search')
 			->with($this->equalTo(''), $this->equalTo(['FN', 'EMAIL']))
@@ -163,7 +167,7 @@ class ContactsStoreTest extends TestCase {
 		$entries = $this->contactsStore->getContacts($user, '');
 
 		$this->assertCount(2, $entries);
-		$this->assertNull($entries[1]->getAvatar());
+		$this->assertSame('https://urlToNcAvatar.test', $entries[1]->getAvatar());
 	}
 
 	public function testGetContactsWithoutAvatarURI() {


### PR DESCRIPTION
Signed-off-by: Andy Xheli <axheli@axtsolutions.com>

Before 
![image](https://user-images.githubusercontent.com/59488153/140980158-b9108161-57ab-48b4-ae6f-98ec4e72775a.png)

After
![2022-05-27 14_47_23-Dashboard - AXTSolutions Cloud](https://user-images.githubusercontent.com/59488153/170780178-9cb19a84-f24b-4b2b-aacb-b4ec80576819.png)




Fix for #31065