### PR TITLE
Uses IShare::TYPE_... in Server.php rather than the obsolete Constants

### DIFF
--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -106,7 +106,7 @@ class Search implements ISearch {
 	}
 
 	public function registerPlugin(array $pluginInfo) {
-		$shareType = constant(Share::class . '::' . $pluginInfo['shareType']);
+		$shareType = $pluginInfo['shareType'];
 		if ($shareType === null) {
 			throw new \InvalidArgumentException('Provided ShareType is invalid');
 		}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -238,6 +238,7 @@ use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Security\ITrustedDomainHelper;
 use OCP\Security\VerificationToken\IVerificationToken;
+use OCP\Share\IShare;
 use OCP\Share\IShareHelper;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
@@ -1313,11 +1314,11 @@ class Server extends ServerContainer implements IServerContainer {
 			$instance = new Collaboration\Collaborators\Search($c);
 
 			// register default plugins
-			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_USER', 'class' => UserPlugin::class]);
-			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_GROUP', 'class' => GroupPlugin::class]);
-			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_EMAIL', 'class' => MailPlugin::class]);
-			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE', 'class' => RemotePlugin::class]);
-			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE_GROUP', 'class' => RemoteGroupPlugin::class]);
+			$instance->registerPlugin(['shareType' => IShare::TYPE_USER, 'class' => UserPlugin::class]);
+			$instance->registerPlugin(['shareType' => IShare::TYPE_GROUP, 'class' => GroupPlugin::class]);
+			$instance->registerPlugin(['shareType' => IShare::TYPE_EMAIL, 'class' => MailPlugin::class]);
+			$instance->registerPlugin(['shareType' => IShare::TYPE_REMOTE, 'class' => RemotePlugin::class]);
+			$instance->registerPlugin(['shareType' => IShare::TYPE_REMOTE_GROUP, 'class' => RemoteGroupPlugin::class]);
 
 			return $instance;
 		});


### PR DESCRIPTION
It doesn't look like those search plugins are used somewhere else....

hmmm.... Here might be another attention point though:

https://github.com/nextcloud/server/blob/5a12e8f906ea5075193d88963cbdf805a097f626/lib/private/legacy/OC_App.php#L257


Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>