### PR TITLE
Feature: Add loglevel exported JS OC.config object

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -889,6 +889,15 @@ $CONFIG = [
 'loglevel' => 2,
 
 /**
+ * Loglevel used by the frontend to start logging at. The same values as
+ * for ``loglevel`` can be used. If not set it defaults to the value
+ * configured for ``loglevel`` or Warning if that is not set either.
+ *
+ * Defaults to ``2``
+ */
+'loglevel_frontend' => 2,
+
+/**
  * If you maintain different instances and aggregate the logs, you may want
  * to distinguish between them. ``syslog_tag`` can be set per instance
  * with a unique id. Only available if ``log_type`` is set to ``syslog`` or

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -47,6 +47,7 @@ use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\ISession;
 use OCP\IURLGenerator;
+use OCP\ILogger;
 use OCP\IUser;
 use OCP\User\Backend\IPasswordConfirmationBackend;
 use OCP\Util;
@@ -176,6 +177,9 @@ class JSConfigHelper {
 			'sharing.maxAutocompleteResults' => max(0, $this->config->getSystemValueInt('sharing.maxAutocompleteResults', Constants::SHARING_MAX_AUTOCOMPLETE_RESULTS_DEFAULT)),
 			'sharing.minSearchStringLength' => $this->config->getSystemValueInt('sharing.minSearchStringLength', 0),
 			'blacklist_files_regex' => FileInfo::BLACKLIST_FILES_REGEX,
+			'loglevel' => $this->config->getSystemValue('loglevel_frontend',
+				$this->config->getSystemValue('loglevel', ILogger::WARN)
+			),
 		];
 
 		$array = [


### PR DESCRIPTION
This allows using the configured logging level for the backend also on the frontend.

As requested for the `@nextcloud/logger` package  in nextcloud/nextcloud-logger#141 (and required for the associated SR nextcloud/nextcloud-logger#345)