### PR TITLE
Cleanup temporary files after finishing the write to object storage

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -335,6 +335,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				$handle = fopen($tmpFile, $mode);
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
 					$this->writeBack($tmpFile, $path);
+					unlink($tmpFile);
 				});
 			case 'a':
 			case 'ab':
@@ -352,6 +353,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 				$handle = fopen($tmpFile, $mode);
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
 					$this->writeBack($tmpFile, $path);
+					unlink($tmpFile);
 				});
 		}
 		return false;


### PR DESCRIPTION
This makes sure that temp files get cleaned up immediately which helps to not occupy space on /tmp for too long, especially when there are file operations happening in a cron run, as there they would only get cleaned up after an hour.