### PR TITLE
Cleanup tempfiles after each cron job run

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -64,13 +64,14 @@ try {
 
 	$logger = \OC::$server->getLogger();
 	$config = \OC::$server->getConfig();
+	$tempManager = \OC::$server->getTempManager();
 
 	// Don't do anything if Nextcloud has not been installed
 	if (!$config->getSystemValue('installed', false)) {
 		exit(0);
 	}
 
-	\OC::$server->getTempManager()->cleanOld();
+	$tempManager->cleanOld();
 
 	// Exit if background jobs are disabled!
 	$appMode = $config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
@@ -149,8 +150,10 @@ try {
 
 			$logger->debug('CLI cron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
 			$job->execute($jobList, $logger);
+
 			// clean up after unclean jobs
 			\OC_Util::tearDownFS();
+			$tempManager->clean();
 
 			$jobList->setLastJob($job);
 			$executedJobs[$job->getId()] = true;


### PR DESCRIPTION
Similar to https://github.com/nextcloud/server/pull/32662 but catches other cases where a job might leave temp files around which would otherwise only get cleaned up an hour later by the initial cleanOld call:
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/TempManager.php#L189-L203