### PR TITLE
Check background job type

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -311,6 +311,10 @@ class JobList implements IJobList {
 				}
 			}
 
+			if (!($job instanceof IJob)) {
+				// This most likely means an invalid job was enqueued. We can ignore it.
+				return null;
+			}
 			$job->setId((int) $row['id']);
 			$job->setLastRun((int) $row['last_run']);
 			$job->setArgument(json_decode($row['argument'], true));


### PR DESCRIPTION
It is assumed that a job class loaded from the jobs table is an IJob,
but due to programming error the job might be of another type. Then the
setters will most likely fail.

This patch adds an interface type check so only correct jobs are used,
anything else is ignored.

Fixes 

```
Error: Call to undefined method OCA\Files\Command\TransferOwnership::setId() in /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php:314
Stack trace:
#0 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(241): OC\BackgroundJob\JobList->buildJob(Array)
#1 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#2 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#3 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#4 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#5 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#6 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#7 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#8 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#9 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#10 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#11 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#12 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#13 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#14 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#15 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#16 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#17 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#18 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#19 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#20 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#21 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#22 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#23 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#24 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#25 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#26 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#27 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#28 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#29 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#30 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#31 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#32 /home/christoph/workspace/nextcloud/lib/private/BackgroundJob/JobList.php(253): OC\BackgroundJob\JobList->getNext(false)
#33 /home/christoph/workspace/nextcloud/cron.php(144): OC\BackgroundJob\JobList->getNext(false)
#34 {main}
``` 