### PR TITLE
Add --if-present flag to prevent error when sass script does not exists

### DIFF
--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -87,10 +87,10 @@ jobs:
           npm run build --if-present
 
       - name: Build css
-        run: npm run sass
+        run: npm run --if-present sass
 
       - name: Build icons css
-        run: npm run sass:icons
+        run: npm run --if-present sass:icons
 
       - name: Commit and push default
         if: ${{ needs.init.outputs.arg1 != 'fixup' && needs.init.outputs.arg1 != 'amend' }}


### PR DESCRIPTION
`sass` and `sass:icons` script were only [recently introduced](https://github.com/nextcloud/server/commit/3e29e0ad13b427b6ba4b62c7a35497e9a75de976). But we made it mandatory for the [compile bot command](https://github.com/nextcloud/server/commit/da49e3f3e07158e3aec22efec26ff758c0f04598).

This PR prevents the compile command to [fail](https://github.com/nextcloud/server/runs/6675037997?check_suite_focus=true) for branches that do not contain those scripts.
