### PR TITLE
Fix replacing external storage password during debug log

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -100,7 +100,7 @@ class Store implements IStore {
 		} catch (SessionNotAvailableException $ex) {
 			$this->logger->debug('could not get login credentials because session is unavailable', ['app' => 'core', 'exception' => $ex]);
 		} catch (InvalidTokenException $ex) {
-			$this->logger->debug('could not get login credentials because the token is invalid: ' . $ex->getMessage(), ['app' => 'core', 'exception' => $ex]);
+			$this->logger->debug('could not get login credentials because the token is invalid: ' . $ex->getMessage(), ['app' => 'core']);
 			$trySession = true;
 		} catch (PasswordlessTokenException $ex) {
 			$this->logger->debug('could not get login credentials because the token has no password', ['app' => 'core', 'exception' => $ex]);


### PR DESCRIPTION
This is untested and unverified. Apparently the logging replaces the password.

Ref https://github.com/nextcloud/server/issues/32598#issuecomment-1143269327

Fixes https://github.com/nextcloud/server/issues/32598

Regression of https://github.com/nextcloud/server/pull/31826