### PR TITLE
Make X-HAS-{MD5/SHA256} opt-in

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -215,15 +215,26 @@ class File extends Node implements IFile {
 				$data = $tmpData;
 			}
 
-			$data = HashWrapper::wrap($data, 'md5', function ($hash) {
-				$this->header('X-Hash-MD5: ' . $hash);
-			});
-			$data = HashWrapper::wrap($data, 'sha1', function ($hash) {
-				$this->header('X-Hash-SHA1: ' . $hash);
-			});
-			$data = HashWrapper::wrap($data, 'sha256', function ($hash) {
-				$this->header('X-Hash-SHA256: ' . $hash);
-			});
+			if ($this->request->getHeader('X-HASH') !== '') {
+				$hash = $this->request->getHeader('X-HASH');
+				if ($hash === 'all' || $hash === 'md5') {
+					$data = HashWrapper::wrap($data, 'md5', function ($hash) {
+						$this->header('X-Hash-MD5: ' . $hash);
+					});
+				}
+
+				if ($hash === 'all' || $hash === 'sha1') {
+					$data = HashWrapper::wrap($data, 'sha1', function ($hash) {
+						$this->header('X-Hash-SHA1: ' . $hash);
+					});
+				}
+
+				if ($hash === 'all' || $hash === 'sha256') {
+					$data = HashWrapper::wrap($data, 'sha256', function ($hash) {
+						$this->header('X-Hash-SHA256: ' . $hash);
+					});
+				}
+			}
 
 			if ($partStorage->instanceOfStorage(Storage\IWriteStreamStorage::class)) {
 				$isEOF = false;


### PR DESCRIPTION
This is not always needed and slow down the upload

@tobiasKaminsky do you know if the X-HASH HTTP headers are used by the clients? I doesn't look like this from a github search but I might have missed something. 