### PR TITLE
Trim mount point before matching in encryption code

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -304,7 +304,7 @@ class Util {
 			$storageService = \OC::$server->get(GlobalStoragesService::class);
 			$storages = $storageService->getAllStorages();
 			foreach ($storages as $storage) {
-				if (strpos($path, '/files/' . $storage->getMountPoint()) === 0) {
+				if (strpos($path, '/files/' . ltrim($storage->getMountPoint(), '/')) === 0) {
 					if ($this->isMountPointApplicableToUser($storage, $uid)) {
 						return true;
 					}

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -4,6 +4,8 @@ namespace Test\Encryption;
 
 use OC\Encryption\Util;
 use OC\Files\View;
+use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\Encryption\IEncryptionModule;
 use OCP\IConfig;
 use Test\TestCase;
@@ -187,5 +189,44 @@ class UtilTest extends TestCase {
 			['/foo/test.txt.ocTransferId7567846853.part', '/foo/test.txt'],
 			['/foo/test.txt.ocTransferId7567.part', '/foo/test.txt'],
 		];
+	}
+
+	public function dataTestIsSystemWideMountPoint() {
+		return [
+			[false, 'non-matching mount point name', [], [], '/mp_another'],
+			[true, 'applicable to all', [], []],
+			[true, 'applicable to user directly', ['user1'], []],
+			[true, 'applicable to group directly', [], ['group1']],
+			[false, 'non-applicable to current user', ['user2'], []],
+			[false, 'non-applicable to current user\'s group', [], ['group2']],
+			[true, 'mount point without leading slash', [], [], 'mp'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestIsSystemWideMountPoint
+	 */
+	public function testIsSystemWideMountPoint($expectedResult, $expectationText, $applicableUsers, $applicableGroups, $mountPointName = '/mp') {
+		$this->groupManager->method('isInGroup')
+			 ->will($this->returnValueMap([
+			 	['user1', 'group1', true], // user is only in group1
+			 	['user1', 'group2', false],
+			 ]));
+
+		$storages = [];
+
+		$storageConfig = $this->createMock(StorageConfig::class);
+		$storageConfig->method('getMountPoint')->willReturn($mountPointName);
+		$storageConfig->method('getApplicableUsers')->willReturn($applicableUsers);
+		$storageConfig->method('getApplicableGroups')->willReturn($applicableGroups);
+		$storages[] = $storageConfig;
+
+		$storagesServiceMock = $this->createMock(GlobalStoragesService::class);
+		$storagesServiceMock->expects($this->atLeastOnce())->method('getAllStorages')
+			->willReturn($storages);
+
+		$this->overwriteService(GlobalStoragesService::class, $storagesServiceMock);
+
+		$this->assertEquals($expectedResult, $this->util->isSystemWideMountPoint('/files/mp', 'user1'), 'Test case: ' . $expectationText);
 	}
 }


### PR DESCRIPTION
Often times the mount point has a leading slash.
This fix sanitizes it to make sure matching works.

- [x] add unit test for this function