### PR TITLE
Fix get avatar authorization

### DIFF
--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -136,20 +136,23 @@ class AvatarManager implements IAvatarManager {
 			$avatarScope = '';
 		}
 
-		if (
+		switch ($avatarScope) {
 			// v2-private scope hides the avatar from public access and from unknown users
-			$avatarScope === IAccountManager::SCOPE_PRIVATE
-			&& (
-				// accessing from public link
-				$requestingUser === null
-				// logged in, but unknown to user
-				|| !$this->knownUserService->isKnownToUser($requestingUser->getUID(), $userId)
-			)) {
-			// use a placeholder avatar which caches the generated images
-			return new PlaceholderAvatar($folder, $user, $this->logger);
+			case IAccountManager::SCOPE_PRIVATE:
+				if ($requestingUser !== null && $this->knownUserService->isKnownToUser($requestingUser->getUID(), $userId)) {
+					return new UserAvatar($folder, $this->l, $user, $this->logger, $this->config);
+				}
+				break;
+			case IAccountManager::SCOPE_LOCAL:
+			case IAccountManager::SCOPE_FEDERATED:
+			case IAccountManager::SCOPE_PUBLISHED:
+				return new UserAvatar($folder, $this->l, $user, $this->logger, $this->config);
+			default:
+				// use a placeholder avatar which caches the generated images
+				return new PlaceholderAvatar($folder, $user, $this->logger);
 		}
 
-		return new UserAvatar($folder, $this->l, $user, $this->logger, $this->config);
+		return new PlaceholderAvatar($folder, $user, $this->logger);
 	}
 
 	/**

--- a/tests/lib/Avatar/AvatarManagerTest.php
+++ b/tests/lib/Avatar/AvatarManagerTest.php
@@ -161,12 +161,32 @@ class AvatarManagerTest extends \Test\TestCase {
 			->method('getUID')
 			->willReturn('valid-user');
 
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData
 			->expects($this->once())
 			->method('getFolder')
 			->with('valid-user')
 			->willReturn($folder);
+
+		$account = $this->createMock(IAccount::class);
+		$this->accountManager->expects($this->once())
+			->method('getAccount')
+			->with($user)
+			->willReturn($account);
+
+		$property = $this->createMock(IAccountProperty::class);
+		$account->expects($this->once())
+			->method('getProperty')
+			->with(IAccountManager::PROPERTY_AVATAR)
+			->willReturn($property);
+
+		$property->expects($this->once())
+			->method('getScope')
+			->willReturn(IAccountManager::SCOPE_FEDERATED);
 
 		$expected = new UserAvatar($folder, $this->l10n, $user, $this->logger, $this->config);
 		$this->assertEquals($expected, $this->avatarManager->getAvatar('vaLid-USER'));

--- a/tests/lib/Avatar/AvatarManagerTest.php
+++ b/tests/lib/Avatar/AvatarManagerTest.php
@@ -192,22 +192,25 @@ class AvatarManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $this->avatarManager->getAvatar('vaLid-USER'));
 	}
 
-	public function knownUnknownProvider() {
+	public function dataGetAvatarScopes() {
 		return [
-			[IAccountManager::SCOPE_LOCAL, false, false, false],
-			[IAccountManager::SCOPE_LOCAL, true, false, false],
-
 			// public access cannot see real avatar
 			[IAccountManager::SCOPE_PRIVATE, true, false, true],
 			// unknown users cannot see real avatar
 			[IAccountManager::SCOPE_PRIVATE, false, false, true],
 			// known users can see real avatar
 			[IAccountManager::SCOPE_PRIVATE, false, true, false],
+			[IAccountManager::SCOPE_LOCAL, false, false, false],
+			[IAccountManager::SCOPE_LOCAL, true, false, false],
+			[IAccountManager::SCOPE_FEDERATED, false, false, false],
+			[IAccountManager::SCOPE_FEDERATED, true, false, false],
+			[IAccountManager::SCOPE_PUBLISHED, false, false, false],
+			[IAccountManager::SCOPE_PUBLISHED, true, false, false],
 		];
 	}
 
 	/**
-	 * @dataProvider knownUnknownProvider
+	 * @dataProvider dataGetAvatarScopes
 	 */
 	public function testGetAvatarScopes($avatarScope, $isPublicCall, $isKnownUser, $expectedPlaceholder) {
 		if ($isPublicCall) {


### PR DESCRIPTION
This is functionally equivalent but explicitly handles all scopes and is slightly more restrictive by returning a placeholder in the single case where a `PropertyDoesNotExistException` is thrown when querying for the avatar account property

### To Do

- [x] Add new test cases
- [x] Fix tests