### PR TITLE
Declare header entries in the order they are displayed

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -133,8 +133,8 @@ $getUserAvatar = static function (int $size) use ($_): string {
 			</div>
 
 			<div class="header-right">
-				<div id="notifications"></div>
 				<div id="unified-search"></div>
+				<div id="notifications"></div>
 				<div id="contactsmenu">
 					<div class="menutoggle" tabindex="0" role="button"
 					aria-haspopup="true" aria-controls="contactsmenu-menu" aria-expanded="false">


### PR DESCRIPTION
The notifications' entry was declared after the search one, but they are rendered in a different order. This PR switch their declarations, so the order they appear in match their order in the DOM.

This also make more sense when navigating with the keyboard.

Before | After
-- | --
![Screencast from 02-06-2022 11:19:51](https://user-images.githubusercontent.com/6653109/171599685-b9bee6c3-38d6-4176-a74f-c2722918733a.gif) | ![Screencast from 02-06-2022 11:19:20](https://user-images.githubusercontent.com/6653109/171599683-106809af-5a68-4b5e-a77e-61f0e6b850a3.gif)




