### PR TITLE
Only load direct editing capabilities when required

### DIFF
--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -40,6 +40,7 @@ return array(
     'OCA\\Files\\Controller\\ViewController' => $baseDir . '/../lib/Controller/ViewController.php',
     'OCA\\Files\\Db\\TransferOwnership' => $baseDir . '/../lib/Db/TransferOwnership.php',
     'OCA\\Files\\Db\\TransferOwnershipMapper' => $baseDir . '/../lib/Db/TransferOwnershipMapper.php',
+    'OCA\\Files\\DirectEditingCapabilities' => $baseDir . '/../lib/DirectEditingCapabilities.php',
     'OCA\\Files\\Event\\LoadAdditionalScriptsEvent' => $baseDir . '/../lib/Event/LoadAdditionalScriptsEvent.php',
     'OCA\\Files\\Event\\LoadSidebar' => $baseDir . '/../lib/Event/LoadSidebar.php',
     'OCA\\Files\\Exception\\TransferOwnershipException' => $baseDir . '/../lib/Exception/TransferOwnershipException.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -55,6 +55,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Controller\\ViewController' => __DIR__ . '/..' . '/../lib/Controller/ViewController.php',
         'OCA\\Files\\Db\\TransferOwnership' => __DIR__ . '/..' . '/../lib/Db/TransferOwnership.php',
         'OCA\\Files\\Db\\TransferOwnershipMapper' => __DIR__ . '/..' . '/../lib/Db/TransferOwnershipMapper.php',
+        'OCA\\Files\\DirectEditingCapabilities' => __DIR__ . '/..' . '/../lib/DirectEditingCapabilities.php',
         'OCA\\Files\\Event\\LoadAdditionalScriptsEvent' => __DIR__ . '/..' . '/../lib/Event/LoadAdditionalScriptsEvent.php',
         'OCA\\Files\\Event\\LoadSidebar' => __DIR__ . '/..' . '/../lib/Event/LoadSidebar.php',
         'OCA\\Files\\Exception\\TransferOwnershipException' => __DIR__ . '/..' . '/../lib/Exception/TransferOwnershipException.php',

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -39,6 +39,7 @@ use OCA\Files\Capabilities;
 use OCA\Files\Collaboration\Resources\Listener;
 use OCA\Files\Collaboration\Resources\ResourceProvider;
 use OCA\Files\Controller\ApiController;
+use OCA\Files\DirectEditingCapabilities;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files\Event\LoadSidebar;
 use OCA\Files\Listener\LegacyLoadAdditionalScriptsAdapter;
@@ -111,6 +112,7 @@ class Application extends App implements IBootstrap {
 		 * Register capabilities
 		 */
 		$context->registerCapability(Capabilities::class);
+		$context->registerCapability(DirectEditingCapabilities::class);
 
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LegacyLoadAdditionalScriptsAdapter::class);
 		$context->registerEventListener(LoadSidebar::class, LoadSidebarListener::class);

--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -25,36 +25,15 @@
  */
 namespace OCA\Files;
 
-use OCA\Files\Service\DirectEditingService;
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
-use OCP\IURLGenerator;
 
-/**
- * Class Capabilities
- *
- * @package OCA\Files
- */
 class Capabilities implements ICapability {
 
-	/** @var IConfig */
-	protected $config;
+	protected IConfig $config;
 
-	/** @var DirectEditingService */
-	protected $directEditingService;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/**
-	 * Capabilities constructor.
-	 *
-	 * @param IConfig $config
-	 */
-	public function __construct(IConfig $config, DirectEditingService $directEditingService, IURLGenerator $urlGenerator) {
+	public function __construct(IConfig $config) {
 		$this->config = $config;
-		$this->directEditingService = $directEditingService;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -66,11 +45,7 @@ class Capabilities implements ICapability {
 		return [
 			'files' => [
 				'bigfilechunking' => true,
-				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
-				'directEditing' => [
-					'url' => $this->urlGenerator->linkToOCSRouteAbsolute('files.DirectEditing.info'),
-					'etag' => $this->directEditingService->getDirectEditingETag()
-				]
+				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess'])
 			],
 		];
 	}

--- a/apps/files/lib/DirectEditingCapabilities.php
+++ b/apps/files/lib/DirectEditingCapabilities.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Files;
+
+use OCA\Files\Service\DirectEditingService;
+use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IInitialStateExcludedCapability;
+use OCP\IURLGenerator;
+
+class DirectEditingCapabilities implements ICapability, IInitialStateExcludedCapability {
+
+	protected DirectEditingService $directEditingService;
+	protected IURLGenerator $urlGenerator;
+
+	public function __construct(DirectEditingService $directEditingService, IURLGenerator $urlGenerator) {
+		$this->directEditingService = $directEditingService;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getCapabilities() {
+		return [
+			'files' => [
+				'directEditing' => [
+					'url' => $this->urlGenerator->linkToOCSRouteAbsolute('files.DirectEditing.info'),
+					'etag' => $this->directEditingService->getDirectEditingETag()
+				]
+			],
+		];
+	}
+}


### PR DESCRIPTION
As we only need those for the clients they can be moved out and excluded from the initial state.


ref https://github.com/nextcloud/server/issues/32345