### PR TITLE
[stable22] Ignore vendor-bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ clover.xml
 tests/acceptance/vendor/
 
 composer.phar
+/lib/composer/bin
+/vendor-bin/**/vendor


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/30826 is partly a backport of https://github.com/nextcloud/server/pull/28507 but did not add the vendor-bin directory to `.gitignore`.

