### PR TITLE
Add matrix for psalm baseline update job

### DIFF
--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -3,15 +3,23 @@ name: Update Psalm baseline
 on:
   workflow_dispatch:
   schedule:
-    - cron: '5 4 * * *'
+    - cron: "5 4 * * *"
 
 jobs:
   update-psalm-baseline:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        branches: ["master", "stable24", "stable23", "stable22"]
+
+    name: update-psalm-baseline-${{ matrix.branches }}
+
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ matrix.branches }}
           submodules: true
 
       - name: Set up php7.4
@@ -41,10 +49,8 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>
           signoff: true
-          branch: automated/noid/psalm-baseline-update
-          # Make sure we can open multiple PRs
-          branch-suffix: timestamp
-          title: '[Automated] Update psalm-baseline.xml'
+          branch: automated/noid/${{ matrix.branches }}-update-psalm-baseline
+          title: "[${{ matrix.branches }}] Update psalm-baseline.xml"
           body: |
             Auto-generated update psalm-baseline.xml with fixed psalm warnings
           labels: |


### PR DESCRIPTION
Blocked by https://github.com/nextcloud/server/pull/32727

I noticed that the psalm baseline for stable* is never updated. It seems that schedule workflows always run on the default branch but not on other branches (cf. https://github.community/t/on-schedule-per-branch/17525, https://stackoverflow.com/questions/58798886/github-actions-schedule-operation-on-branch).

This PR adds a matrix to update the psalm-baseline for master, stable24, stable23 and stable22. 

Example run: https://github.com/kesselb/server/actions/runs/2444405480

- https://github.com/kesselb/server/pull/5
- https://github.com/kesselb/server/pull/4
- https://github.com/kesselb/server/pull/6