### PR TITLE
Remove deprecated at() matcher from settings tests

### DIFF
--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -234,15 +234,12 @@ class CheckSetupControllerTest extends TestCase {
 	}
 
 	public function testIsInternetConnectionWorkingCorrectly() {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
-
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org'])
-			->willReturn(['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']);
+			->withConsecutive(
+				['has_internet_connection', true],
+				['connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']],
+			)->willReturnArgument(1);
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
@@ -263,15 +260,12 @@ class CheckSetupControllerTest extends TestCase {
 	}
 
 	public function testIsInternetConnectionFail() {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
-
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org'])
-			->willReturn(['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']);
+			->withConsecutive(
+				['has_internet_connection', true],
+				['connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']],
+			)->willReturnArgument(1);
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
@@ -432,30 +426,20 @@ class CheckSetupControllerTest extends TestCase {
 	}
 
 	public function testCheck() {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->any())
 			->method('getAppValue')
-			->with('files_external', 'user_certificate_scan', false)
-			->willReturn('["a", "b"]');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('core', 'cronErrors')
-			->willReturn('');
-		$this->config->expects($this->at(3))
+			->willReturnMap([
+				['files_external', 'user_certificate_scan', '', '["a", "b"]'],
+				['core', 'cronErrors', ''],
+			]);
+		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->with('connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org'])
-			->willReturn(['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']);
-		$this->config->expects($this->at(4))
-			->method('getSystemValue')
-			->with('memcache.local', null)
-			->willReturn('SomeProvider');
-		$this->config->expects($this->at(5))
-			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
-		$this->config->expects($this->at(6))
-			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(false);
+			->willReturnMap([
+				['connectivity_check_domains', ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org'], ['www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org']],
+				['memcache.local', null, 'SomeProvider'],
+				['has_internet_connection', true, true],
+				['appstoreenabled', true, false],
+			]);
 
 		$this->request->expects($this->atLeastOnce())
 			->method('getHeader')
@@ -466,22 +450,14 @@ class CheckSetupControllerTest extends TestCase {
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
-		$client->expects($this->at(0))
+		$client->expects($this->exactly(4))
 			->method('get')
-			->with('http://www.nextcloud.com/', [])
-			->will($this->throwException(new \Exception()));
-		$client->expects($this->at(1))
-			->method('get')
-			->with('http://www.startpage.com/', [])
-			->will($this->throwException(new \Exception()));
-		$client->expects($this->at(2))
-			->method('get')
-			->with('http://www.eff.org/', [])
-			->will($this->throwException(new \Exception()));
-		$client->expects($this->at(3))
-			->method('get')
-			->with('http://www.edri.org/', [])
-			->will($this->throwException(new \Exception()));
+			->withConsecutive(
+				['http://www.nextcloud.com/', []],
+				['http://www.startpage.com/', []],
+				['http://www.eff.org/', []],
+				['http://www.edri.org/', []]
+			)->will($this->throwException(new \Exception()));
 		$this->clientService->expects($this->exactly(4))
 			->method('newClient')
 			->willReturn($client);
@@ -740,10 +716,12 @@ class CheckSetupControllerTest extends TestCase {
 
 	public function testIsUsedTlsLibOutdatedWithOlderOpenSslAndWithoutAppstore() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->any())
 			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
+			->willReturnMap([
+				['has_internet_connection', true, true],
+				['appstoreenabled', true, false],
+			]);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
@@ -855,7 +833,7 @@ class CheckSetupControllerTest extends TestCase {
 			->method('getResponse')
 			->willReturn($response);
 
-		$client->expects($this->at(0))
+		$client->expects($this->once())
 			->method('get')
 			->with('https://nextcloud.com/', [])
 			->will($this->throwException($exception));
@@ -889,7 +867,7 @@ class CheckSetupControllerTest extends TestCase {
 			->method('getResponse')
 			->willReturn($response);
 
-		$client->expects($this->at(0))
+		$client->expects($this->once())
 			->method('get')
 			->with('https://nextcloud.com/', [])
 			->will($this->throwException($exception));
@@ -903,7 +881,7 @@ class CheckSetupControllerTest extends TestCase {
 
 	public function testIsUsedTlsLibOutdatedWithInternetDisabled() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
 			->willReturn(false);
@@ -912,25 +890,19 @@ class CheckSetupControllerTest extends TestCase {
 
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingEnabled() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
+			->willReturnMap([
+				['has_internet_connection', true, true],
+				['appstoreenabled', true, false],
+			]);
 		$this->config
-			->expects($this->at(1))
-			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(false);
-		$this->config
-			->expects($this->at(2))
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('files_sharing', 'outgoing_server2server_share_enabled', 'yes')
-			->willReturn('no');
-		$this->config
-			->expects($this->at(3))
-			->method('getAppValue')
-			->with('files_sharing', 'incoming_server2server_share_enabled', 'yes')
-			->willReturn('yes');
+			->willReturnMap([
+				['files_sharing', 'outgoing_server2server_share_enabled', 'yes', 'no'],
+				['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'yes'],
+			]);
 
 		$this->checkSetupController
 			->expects($this->once())
@@ -941,25 +913,19 @@ class CheckSetupControllerTest extends TestCase {
 
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingDisabled() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getSystemValue')
-			->with('has_internet_connection', true)
-			->willReturn(true);
+			->willReturnMap([
+				['has_internet_connection', true, true],
+				['appstoreenabled', true, false],
+			]);
 		$this->config
-			->expects($this->at(1))
-			->method('getSystemValue')
-			->with('appstoreenabled', true)
-			->willReturn(false);
-		$this->config
-			->expects($this->at(2))
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('files_sharing', 'outgoing_server2server_share_enabled', 'yes')
-			->willReturn('no');
-		$this->config
-			->expects($this->at(3))
-			->method('getAppValue')
-			->with('files_sharing', 'incoming_server2server_share_enabled', 'yes')
-			->willReturn('no');
+			->willReturnMap([
+				['files_sharing', 'outgoing_server2server_share_enabled', 'yes', 'no'],
+				['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'no'],
+			]);
 
 		$this->checkSetupController
 			->expects($this->never())

--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -155,17 +155,13 @@ class NewUserMailHelperTest extends TestCase {
 			->method('setUserValue')
 			->with('john', 'core', 'lostpassword', 'TokenCiphertext');
 		$this->urlGenerator
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('linkToRouteAbsolute')
 			->with('core.lost.resetform', ['userId' => 'john', 'token' => 'MySuperLongSecureRandomToken'])
 			->willReturn('https://example.com/resetPassword/MySuperLongSecureRandomToken');
 		$user
 			->expects($this->any())
 			->method('getDisplayName')
-			->willReturn('john');
-		$user
-			->expects($this->at(5))
-			->method('getUID')
 			->willReturn('john');
 		$this->defaults
 			->expects($this->any())
@@ -384,10 +380,12 @@ EOF;
 
 	public function testGenerateTemplateWithoutPasswordResetToken() {
 		$this->urlGenerator
-			->expects($this->at(0))
+			->expects($this->any())
 			->method('getAbsoluteURL')
-			->with('/')
-			->willReturn('https://example.com/');
+			->willReturnMap([
+				['/','https://example.com/'],
+				['myLogo',''],
+			]);
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
@@ -616,10 +614,12 @@ EOF;
 
 	public function testGenerateTemplateWithoutUserId() {
 		$this->urlGenerator
-			->expects($this->at(0))
+			->expects($this->any())
 			->method('getAbsoluteURL')
-			->with('/')
-			->willReturn('https://example.com/');
+			->willReturnMap([
+				['/', 'https://example.com/'],
+				['myLogo', ''],
+			]);
 
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
@@ -837,30 +837,30 @@ EOF;
 		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getEMailAddress')
 			->willReturn('recipient@example.com');
 		$user
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('getDisplayName')
 			->willReturn('John Doe');
 		/** @var IEMailTemplate|\PHPUnit\Framework\MockObject\MockObject $emailTemplate */
 		$emailTemplate = $this->createMock(IEMailTemplate::class);
 		$message = $this->createMock(Message::class);
 		$message
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('setTo')
 			->with(['recipient@example.com' => 'John Doe']);
 		$message
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('setFrom')
 			->with(['no-reply@nextcloud.com' => 'TestCloud']);
 		$message
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('useTemplate')
 			->with($emailTemplate);
 		$this->defaults
-			->expects($this->exactly(1))
+			->expects($this->once())
 			->method('getName')
 			->willReturn('TestCloud');
 		$this->mailer

--- a/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
+++ b/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
@@ -68,15 +68,12 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\NotAdminException::class);
 
 		$this->reflector
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('hasAnnotation')
-			->with('NoSubAdminRequired')
-			->willReturn(false);
-		$this->reflector
-			->expects($this->at(1))
-			->method('hasAnnotation')
-			->with('AuthorizedAdminSetting')
-			->willReturn(false);
+			->withConsecutive(
+				['NoSubAdminRequired'],
+				['AuthorizedAdminSetting'],
+			)->willReturn(false);
 		$this->subadminMiddleware->beforeController($this->controller, 'foo');
 	}
 
@@ -92,15 +89,12 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 
 	public function testBeforeControllerAsSubAdminWithoutExemption() {
 		$this->reflector
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('hasAnnotation')
-			->with('NoSubAdminRequired')
-			->willReturn(false);
-		$this->reflector
-			->expects($this->at(1))
-			->method('hasAnnotation')
-			->with('AuthorizedAdminSetting')
-			->willReturn(false);
+			->withConsecutive(
+				['NoSubAdminRequired'],
+				['AuthorizedAdminSetting'],
+			)->willReturn(false);
 		$this->subadminMiddlewareAsSubAdmin->beforeController($this->controller, 'foo');
 	}
 

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -55,60 +55,21 @@ class MailTest extends TestCase {
 
 	public function testGetForm() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->any())
 			->method('getSystemValue')
-			->with('mail_domain', '')
-			->willReturn('mx.nextcloud.com');
-		$this->config
-			->expects($this->at(1))
-			->method('getSystemValue')
-			->with('mail_from_address', '')
-			->willReturn('no-reply@nextcloud.com');
-		$this->config
-			->expects($this->at(2))
-			->method('getSystemValue')
-			->with('mail_smtpmode', '')
-			->willReturn('smtp');
-		$this->config
-			->expects($this->at(3))
-			->method('getSystemValue')
-			->with('mail_smtpsecure', '')
-			->willReturn(true);
-		$this->config
-			->expects($this->at(4))
-			->method('getSystemValue')
-			->with('mail_smtphost', '')
-			->willReturn('smtp.nextcloud.com');
-		$this->config
-			->expects($this->at(5))
-			->method('getSystemValue')
-			->with('mail_smtpport', '')
-			->willReturn(25);
-		$this->config
-			->expects($this->at(6))
-			->method('getSystemValue')
-			->with('mail_smtpauthtype', '')
-			->willReturn('login');
-		$this->config
-			->expects($this->at(7))
-			->method('getSystemValue')
-			->with('mail_smtpauth', false)
-			->willReturn(true);
-		$this->config
-			->expects($this->at(8))
-			->method('getSystemValue')
-			->with('mail_smtpname', '')
-			->willReturn('smtp.sender.com');
-		$this->config
-			->expects($this->at(9))
-			->method('getSystemValue')
-			->with('mail_smtppassword', '')
-			->willReturn('mypassword');
-		$this->config
-			->expects($this->at(10))
-			->method('getSystemValue')
-			->with('mail_sendmailmode', 'smtp')
-			->willReturn('smtp');
+			->willReturnMap([
+				['mail_domain', '', 'mx.nextcloud.com'],
+				['mail_from_address', '', 'no-reply@nextcloud.com'],
+				['mail_smtpmode', '', 'smtp'],
+				['mail_smtpsecure', '', true],
+				['mail_smtphost', '', 'smtp.nextcloud.com'],
+				['mail_smtpport', '', 25],
+				['mail_smtpauthtype', '', 'login'],
+				['mail_smtpauth', false, true],
+				['mail_smtpname', '', 'smtp.sender.com'],
+				['mail_smtppassword', '', 'mypassword'],
+				['mail_sendmailmode', 'smtp', 'smtp'],
+			]);
 
 		$expected = new TemplateResponse(
 			'settings',

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -93,20 +93,13 @@ class ServerTest extends TestCase {
 			->method('cronMaxAge')
 			->willReturn(1337);
 		$this->config
-			->expects($this->at(0))
+			->expects($this->any())
 			->method('getAppValue')
-			->with('core', 'backgroundjobs_mode', 'ajax')
-			->willReturn('ajax');
-		$this->config
-			->expects($this->at(1))
-			->method('getAppValue')
-			->with('core', 'lastcron', '0')
-			->willReturn('0');
-		$this->config
-			->expects($this->at(2))
-			->method('getAppValue')
-			->with('core', 'cronErrors')
-			->willReturn('');
+			->willReturnMap([
+				['core', 'backgroundjobs_mode', 'ajax', 'ajax'],
+				['core', 'lastcron', '0', '0'],
+				['core', 'cronErrors', ''],
+			]);
 		$this->profileManager
 			->expects($this->exactly(2))
 			->method('isProfileEnabled')

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -96,33 +96,34 @@ class AuthtokensTest extends TestCase {
 			->method('getToken')
 			->with('session123')
 			->willReturn($sessionToken);
-		$this->initialState->expects($this->at(0))
+		$this->initialState->expects($this->exactly(2))
 			->method('provideInitialState')
-			->with('app_tokens', [
+			->withConsecutive(
 				[
-					'id' => 100,
-					'name' => null,
-					'lastActivity' => 0,
-					'type' => 0,
-					'canDelete' => false,
-					'current' => true,
-					'scope' => ['filesystem' => true],
-					'canRename' => false,
+					'app_tokens', [
+						[
+							'id' => 100,
+							'name' => null,
+							'lastActivity' => 0,
+							'type' => 0,
+							'canDelete' => false,
+							'current' => true,
+							'scope' => ['filesystem' => true],
+							'canRename' => false,
+						],
+						[
+							'id' => 200,
+							'name' => null,
+							'lastActivity' => 0,
+							'type' => 0,
+							'canDelete' => true,
+							'scope' => ['filesystem' => true],
+							'canRename' => true,
+						],
+					]
 				],
-				[
-					'id' => 200,
-					'name' => null,
-					'lastActivity' => 0,
-					'type' => 0,
-					'canDelete' => true,
-					'scope' => ['filesystem' => true],
-					'canRename' => true,
-				],
-			]);
-
-		$this->initialState->expects($this->at(1))
-			->method('provideInitialState')
-			->with('can_create_app_token', true);
+				['can_create_app_token', true],
+			);
 
 		$form = $this->section->getForm();
 


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>