### PR TITLE
Fix @since comment in IManager

### DIFF
--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -458,7 +458,7 @@ interface IManager {
 	 * Check if the search should match the email
 	 *
 	 * @return bool
-	 * @since 25.0.0
+	 * @since 24.0.1
 	 */
 	public function matchEmail(): bool;
 
@@ -466,7 +466,7 @@ interface IManager {
 	 * Check if the search should ignore the second in parentheses display name if there is any
 	 *
 	 * @return bool
-	 * @since 25.0.0
+	 * @since 24.0.1
 	 */
 	public function ignoreSecondDisplayName(): bool;
 


### PR DESCRIPTION
The methods will be backported to 23 and 22 but PR are still pending. I'll create a new PR to update the `@since` when they get merged.