### PR TITLE
Always log errors from sending federation api requests to ease debugging

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -199,6 +199,7 @@ class RequestHandlerController extends Controller {
 				$e->getCode()
 			);
 		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse(
 				['message' => 'Internal error at ' . $this->urlGenerator->getBaseUrl()],
 				Http::STATUS_BAD_REQUEST

--- a/lib/private/Federation/CloudFederationProviderManager.php
+++ b/lib/private/Federation/CloudFederationProviderManager.php
@@ -150,11 +150,12 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 				return (is_array($result)) ? $result : [];
 			}
 		} catch (\Exception $e) {
+			$this->logger->debug($e->getMessage(), ['exception' => $e]);
+
 			// if flat re-sharing is not supported by the remote server
 			// we re-throw the exception and fall back to the old behaviour.
 			// (flat re-shares has been introduced in Nextcloud 9.1)
 			if ($e->getCode() === Http::STATUS_INTERNAL_SERVER_ERROR) {
-				$this->logger->debug($e->getMessage(), ['exception' => $e]);
 				throw $e;
 			}
 		}


### PR DESCRIPTION
Just cost me ~1h to find a stupid mistake when working on Talk federation https://github.com/nextcloud/spreed/pull/7464