### PR TITLE
Improve frontend-building related Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,18 @@ npm-update:
 	npm update
 
 # Building
-build-js:
+build-js: build-css
 	npm run dev
 
 build-js-production:
 	npm run build
 
-watch-js:
-	npm run watch
+watch-js: build-css
+	npm run watch &
+	npm run sass:watch
+
+build-css:
+	npm run sass:icons
 
 # Linting
 lint-fix:

--- a/core/src/icons.js
+++ b/core/src/icons.js
@@ -332,4 +332,5 @@ css += generateVariablesAliases(true)
 css += '}'
 
 // WRITE CSS
+fs.mkdir('dist', (err) => { if (err) { console.info('Directory dist/ already exists') } })
 fs.writeFileSync(path.join(__dirname, '../../dist', 'icons.css'), sass.compileString(css).css)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
+    "postbuild": "npm run sass && npm run sass:icons",
     "dev": "NODE_ENV=development webpack --progress --config webpack.dev.js",
     "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js",
     "lint": "eslint '**/src/**/*.{vue,js}'",


### PR DESCRIPTION
Currently it's necessary to run `npm run sass:icons` in addition to `make dev-setup` and `make build-js`, to have the icons on your development server.

This PR improves the frontend-building related Makefile rules to make this additional manual action unneeded anymore

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>