### PR TITLE
Fix risky test without assertion

### DIFF
--- a/apps/updatenotification/tests/ResetTokenBackgroundJobTest.php
+++ b/apps/updatenotification/tests/ResetTokenBackgroundJobTest.php
@@ -65,13 +65,11 @@ class ResetTokenBackgroundJobTest extends TestCase {
 
 	public function testRunWithExpiredToken() {
 		$this->timeFactory
-			->expects($this->at(0))
 			->method('getTime')
-			->willReturn(1455131633);
-		$this->timeFactory
-			->expects($this->at(1))
-			->method('getTime')
-			->willReturn(1455045234);
+			->willReturnOnConsecutiveCalls(
+				1455131633,
+				1455045234
+			);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
  */
 namespace OCA\UpdateNotification\Tests\Settings;
 
+use OC\User\Backend;
 use OCA\UpdateNotification\Settings\Admin;
 use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -36,13 +37,18 @@ use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IGroup;
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\L10N\ILanguageIterator;
 use OCP\Support\Subscription\IRegistry;
+use OCP\User\Backend\ICountUsersBackend;
+use OCP\UserInterface;
 use OCP\Util;
-use Test\TestCase;
-use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+interface UserInterfaceAwareICountUsersBackend extends UserInterface, ICountUsersBackend {
+}
 
 class AdminTest extends TestCase {
 	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
@@ -77,11 +83,11 @@ class AdminTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->admin = new Admin(
-			$this->config, 
-			$this->updateChecker, 
-			$this->groupManager, 
-			$this->dateTimeFormatter, 
-			$this->l10nFactory, 
+			$this->config,
+			$this->updateChecker,
+			$this->groupManager,
+			$this->dateTimeFormatter,
+			$this->l10nFactory,
 			$this->subscriptionRegistry,
 			$this->userManager,
 			$this->logger
@@ -89,9 +95,9 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdate() {
-		$backend1 = $this->createMock(UserInterface::class);
-		$backend2 = $this->createMock(UserInterface::class);
-		$backend3 = $this->createMock(UserInterface::class);
+		$backend1 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend2 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend3 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
 		$backend1
 			->expects($this->once())
 			->method('implementsActions')
@@ -213,9 +219,9 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdateAndChangedUpdateServer() {
-		$backend1 = $this->createMock(UserInterface::class);
-		$backend2 = $this->createMock(UserInterface::class);
-		$backend3 = $this->createMock(UserInterface::class);
+		$backend1 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend2 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend3 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
 		$backend1
 			->expects($this->once())
 			->method('implementsActions')
@@ -337,9 +343,9 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdateAndCustomersUpdateServer() {
-		$backend1 = $this->createMock(UserInterface::class);
-		$backend2 = $this->createMock(UserInterface::class);
-		$backend3 = $this->createMock(UserInterface::class);
+		$backend1 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend2 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
+		$backend3 = $this->createMock(UserInterfaceAwareICountUsersBackend::class);
 		$backend1
 			->expects($this->once())
 			->method('implementsActions')

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -37,6 +37,7 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\Encryption\IEncryptionModule;
 use OCP\IConfig;
 use OCP\IUser;
+use OCP\App\IAppManager;
 
 class Util {
 	public const HEADER_START = 'HBEGIN';
@@ -299,7 +300,8 @@ class Util {
 	 * @return boolean
 	 */
 	public function isSystemWideMountPoint($path, $uid) {
-		if (\OCP\App::isEnabled("files_external")) {
+		$appManager = \OC::$server->get(IAppManager::class);
+		if ($appManager->isEnabledForUser('files_external', null)) {
 			/** @var GlobalStoragesService $storageService */
 			$storageService = \OC::$server->get(GlobalStoragesService::class);
 			$storages = $storageService->getAllStorages();

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -18,7 +18,6 @@ function enableApp($app) {
 
 enableApp('files_sharing');
 enableApp('files_trashbin');
-enableApp('files_external');
 enableApp('encryption');
 enableApp('user_ldap');
 enableApp('files_versions');

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -18,6 +18,7 @@ function enableApp($app) {
 
 enableApp('files_sharing');
 enableApp('files_trashbin');
+enableApp('files_external');
 enableApp('encryption');
 enableApp('user_ldap');
 enableApp('files_versions');

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -40,11 +40,11 @@ class UtilTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userManager = $this->getMockBuilder('OC\User\Manager')
+		$this->userManager = $this->getMockBuilder(\OC\User\Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->groupManager = $this->getMockBuilder('OC\Group\Manager')
+		$this->groupManager = $this->getMockBuilder(\OC\Group\Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -105,11 +105,14 @@ class FolderTest extends NodeTest {
 			->method('getUser')
 			->willReturn($this->user);
 
+		$expected = $this->createMock(Node::class);
 		$root->method('get')
-			->with('/bar/foo/asd');
+			->with('/bar/foo/asd')
+			->willReturn($expected);
 
 		$node = new Folder($root, $view, '/bar/foo');
-		$node->get('asd');
+		$return = $node->get('asd');
+		self::assertEquals($expected, $return);
 	}
 
 	public function testNodeExists() {

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 bootstrap="bootstrap.php"
 		 verbose="true"
+		 failOnRisky="true"
 		 backupGlobals="false"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -3,6 +3,7 @@
 		 bootstrap="bootstrap.php"
 		 verbose="true"
 		 failOnRisky="true"
+		 failOnWarning="true"
 		 backupGlobals="false"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"


### PR DESCRIPTION
Before:
```
There was 1 risky test:

1) Test\Files\Node\FolderTest::testGet
This test did not perform any assertions

/home/nickv/Nextcloud/25/server/tests/lib/Files/Node/FolderTest.php:95

phpvfscomposer:///home/nickv/Tools/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 64, Assertions: 144, Risky: 1.
```