### PR TITLE
perform onetime setup earlier to ensure wrappers are registered on time

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -403,6 +403,10 @@ class SetupManager {
 			return;
 		}
 
+		if (!$this->isSetupStarted($user)) {
+			$this->oneTimeUserSetup($user);
+		}
+
 		$mounts = [];
 		if (!in_array($cachedMount->getMountProvider(), $setupProviders)) {
 			$setupProviders[] = $cachedMount->getMountProvider();


### PR DESCRIPTION
this fixes an issue with wrappers like encryption not always being applied to mountpoint that create the storage object directly (such as external storage)