### PR TITLE
fix: add moveFromStorage for objectstorage to fix transfer ownership on s3

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -611,4 +611,17 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			throw $e;
 		}
 	}
+
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		while ($sourceStorage->instanceOfStorage(Jail::class)) {
+			/**
+			 * @var Jail $sourceStorage
+			 */
+			$sourceInternalPath = $sourceStorage->getUnjailedPath($sourceInternalPath);
+			$sourceStorage = $sourceStorage->getUnjailedStorage();
+		}
+		
+		$this->getCache()->moveFromCache($sourceStorage->getCache(), $sourceInternalPath, $targetInternalPath);
+		return true;
+	}
 }


### PR DESCRIPTION
This PR fixes https://github.com/nextcloud/server/issues/25693 and https://github.com/nextcloud/server/issues/31870

When transferring ownership on s3 primary storage it was doing a copy and delete leading to shares being linked to non-existing files and failing to transfer

Implementing `moveFromStorage` in `lib/private/Files/ObjectStore/ObjectStoreStorage.php` fixes it. 

It doesn't fix the `isSameStorage` (https://github.com/nextcloud/server/blob/e56a072fa73ec6dc717569a169c532e07443d782/lib/private/Files/Storage/Common.php#L678) that should return true as mentioned in https://github.com/nextcloud/server/issues/31870 which anyway leads to another issue. If this condition passes it then goes to `rename` which only works for renaming a folder/files in the same user storage. 

