### PR TITLE
ignore - Only resize a background img if it reduces filesize

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -254,17 +254,17 @@ class ImageManager {
 		$newImage = @imagecreatefromstring(file_get_contents($originalTmpFile));
 
 			// Preserve transparency
-			imagesavealpha($newImage, true);
-			imagealphablending($newImage, true);
+		imagesavealpha($newImage, true);
+		imagealphablending($newImage, true);
 
 		$newImageTmpFile = $this->tempManager->getTemporaryFile();
-			$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
-			$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
-			$outputImage = imagescale($newImage, $newWidth, $newHeight);
+		$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
+		$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
+		$outputImage = imagescale($newImage, $newWidth, $newHeight);
 
-			imageinterlace($outputImage, 1);
-			imagepng($outputImage, $tmpFile, 8);
-			imagedestroy($outputImage);
+		imageinterlace($outputImage, 1);
+		imagepng($outputImage, $newImageTmpFile, 8);
+		imagedestroy($outputImage);
 
 		// only actually use the image if it is an improvement
 		$newImageIsSmaller = filesize($newImageTmpFile) <= filesize($originalTmpFile);


### PR DESCRIPTION
Made to fix [issue 32779.](https://github.com/nextcloud/server/issues/32779)

Current default behaviour (for the last 2 years at least, or more) has been that any background file that is 'not an SVG or a GIF'
will be resized *and stored as a PNG*. When uploading a large compressed (e.g. webp or jpg) image this default results in (relatively) huge (1 MB+) background images, as per the issue I raised, as it then recompresses this e.g. 151kb jpg file to a 1MB png file. This is counterproductive as (per the original comments in the code) the intent of this function is to reduce file size.

With this change, only if the resulting image has a smaller file size than the original file, the new file is used.