### PR TITLE
Only resize an image if it results in a smaller image size

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -232,29 +232,47 @@ class ImageManager {
 		}
 
 		if ($key === 'background' && strpos($detectedMimeType, 'image/svg') === false && strpos($detectedMimeType, 'image/gif') === false) {
-			// Optimize the image since some people may upload images that will be
-			// either to big or are not progressive rendering.
-			$newImage = @imagecreatefromstring(file_get_contents($tmpFile));
-
-			// Preserve transparency
-			imagesavealpha($newImage, true);
-			imagealphablending($newImage, true);
-
-			$tmpFile = $this->tempManager->getTemporaryFile();
-			$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
-			$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
-			$outputImage = imagescale($newImage, $newWidth, $newHeight);
-
-			imageinterlace($outputImage, 1);
-			imagepng($outputImage, $tmpFile, 8);
-			imagedestroy($outputImage);
-
-			$target->putContent(file_get_contents($tmpFile));
-		} else {
-			$target->putContent(file_get_contents($tmpFile));
+			$tmpFile = $this->getResizedImagePathIfResizeIsSmaller($tmpFile);
 		}
 
+		$target->putContent(file_get_contents($tmpFile));
 		return $detectedMimeType;
+	}
+
+	/**
+	 * Returns the file path of the file stored as a png and resized to be 
+	 * a maximum of 4096 pixels wide (preserving aspect ratio), but only if the resizing
+	 * results in an image that has a smaller file size than the uploaded file.
+	 *
+	 * @param string $originalTmpFile The image key, e.g. "favicon"
+	 * @return string Location of the resized file, or the original
+	 */
+	private function getResizedImagePathIfResizeIsSmaller(string $originalTmpFile): string
+	{
+			// Optimize the image since some people may upload images that will be
+			// either to big or are not progressive rendering.
+		$newImage = @imagecreatefromstring(file_get_contents($originalTmpFile));
+
+			// Preserve transparency
+		imagesavealpha($newImage, true);
+		imagealphablending($newImage, true);
+
+		$newImageTmpFile = $this->tempManager->getTemporaryFile();
+		$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
+		$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
+		$outputImage = imagescale($newImage, $newWidth, $newHeight);
+
+		imageinterlace($outputImage, 1);
+		imagepng($outputImage, $newImageTmpFile, 8);
+		imagedestroy($outputImage);
+
+		// only actually use the image if it is an improvement
+		$newImageIsSmaller = filesize($newImageTmpFile) <= filesize($originalTmpFile);
+		if ($newImageIsSmaller) {
+			return $newImageTmpFile;
+		} else {
+			return $originalTmpFile;
+		}
 	}
 
 	/**

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -244,7 +244,7 @@ class ImageManager {
 	 * a maximum of 4096 pixels wide (preserving aspect ratio), but only if the resizing
 	 * results in an image that has a smaller file size than the uploaded file.
 	 *
-	 * @param string $originalTmpFile The image key, e.g. "favicon"
+	 * @param string $originalTmpFile The tmpFile(path) as uploaded by the user
 	 * @return string Location of the resized file, or the original
 	 */
 	private function getResizedImagePathIfResizeIsSmaller(string $originalTmpFile): string


### PR DESCRIPTION
Made to fix [issue 32779.](https://github.com/nextcloud/server/issues/32779)

Current default behaviour (for the last 2 years at least, or more) has been that any background file that is 'not an SVG or a GIF'
will be resized *and stored as a PNG*. When uploading a large compressed (e.g. webp or jpg) image this default results in (relatively) huge (1 MB+) background images, as per the issue I raised, as it then recompresses this e.g. 151kb jpg file to a 1MB png file. This is counterproductive as (per the original comments in the code) the intent of this function is to reduce file size.

With this change, only if the resulting image has a smaller file size than the original file, the new file is used.

Signed-off-by: JelleV <3942301+jcjveraa@users.noreply.github.com>