### PR TITLE
fix mounts mounted at the users home

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -380,13 +380,9 @@ class SetupManager {
 			return;
 		}
 
-		// for the user's home folder, it's always the home mount
-		if (rtrim($path) === "/" . $user->getUID() . "/files") {
-			if ($includeChildren) {
-				$this->setupForUser($user);
-			} else {
-				$this->oneTimeUserSetup($user);
-			}
+		// for the user's home folder, and includes children we need everything always
+		if (rtrim($path) === "/" . $user->getUID() . "/files" && $includeChildren) {
+			$this->setupForUser($user);
 			return;
 		}
 


### PR DESCRIPTION
this fixes external storages with `/` as mountpoint

it lessens the performance improvement a bit, in the future we can look at only disabling this optimization if there is an external storage with a `/` mountpoint.

Fixes https://github.com/nextcloud/server/issues/32367