### PR TITLE
[S3] Add option to specify an SSE-C customer provided key

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -231,4 +231,34 @@ trait S3ConnectionTrait {
 			return null;
 		}
 	}
+
+	protected function getSSECKey(): ?string {
+		if (isset($this->params['sse_c_key'])) {
+			return $this->params['sse_c_key'];
+		}
+
+		return null;
+	}
+
+	protected function getSSECParameters(bool $copy = false): array {
+		$key = $this->getSSECKey();
+
+		if ($key === null) {
+			return [];
+		}
+
+		$rawKey = base64_decode($key);
+		if ($copy) {
+			return [
+				'CopySourceSSECustomerAlgorithm' => 'AES256',
+				'CopySourceSSECustomerKey' => $rawKey,
+				'CopySourceSSECustomerKeyMD5' => md5($rawKey, true)
+			];
+		}
+		return [
+			'SSECustomerAlgorithm' => 'AES256',
+			'SSECustomerKey' => $rawKey,
+			'SSECustomerKeyMD5' => md5($rawKey, true)
+		];
+	}
 }

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -44,6 +44,7 @@ trait S3ObjectTrait {
 	abstract protected function getConnection();
 
 	abstract protected function getCertificateBundlePath(): ?string;
+	abstract protected function getSSECParameters(bool $copy = false): array;
 
 	/**
 	 * @param string $urn the unified resource name used to identify the object
@@ -58,7 +59,7 @@ trait S3ObjectTrait {
 				'Bucket' => $this->bucket,
 				'Key' => $urn,
 				'Range' => 'bytes=' . $range,
-			]);
+			] + $this->getSSECParameters());
 			$request = \Aws\serialize($command);
 			$headers = [];
 			foreach ($request->getHeaders() as $key => $values) {
@@ -106,7 +107,7 @@ trait S3ObjectTrait {
 			'ACL' => 'private',
 			'ContentType' => $mimetype,
 			'StorageClass' => $this->storageClass,
-		]);
+		] + $this->getSSECParameters());
 	}
 
 
@@ -126,7 +127,7 @@ trait S3ObjectTrait {
 			'params' => [
 				'ContentType' => $mimetype,
 				'StorageClass' => $this->storageClass,
-			],
+			] + $this->getSSECParameters(),
 		]);
 
 		try {
@@ -181,10 +182,12 @@ trait S3ObjectTrait {
 	}
 
 	public function objectExists($urn) {
-		return $this->getConnection()->doesObjectExist($this->bucket, $urn);
+		return $this->getConnection()->doesObjectExist($this->bucket, $urn, $this->getSSECParameters());
 	}
 
 	public function copyObject($from, $to) {
-		$this->getConnection()->copy($this->getBucket(), $from, $this->getBucket(), $to);
+		$this->getConnection()->copy($this->getBucket(), $from, $this->getBucket(), $to, 'private', [
+			'params' => $this->getSSECParameters() + $this->getSSECParameters(true)
+		]);
 	}
 }


### PR DESCRIPTION
- [x] Document sse_c_key to provide the 256-bit encryption key for Amazon S3 to use to encrypt or decrypt your data.
  - Requires a base64 encoded value e.g. generated with `openssl rand 32 | base64`
  - `'sse_c_key' => 'o9d3Q9tHcPMv6TIpH53MSXaUmY91YheZRwuIhwCFRSs=',`
  - https://github.com/nextcloud/documentation/pull/9414
- [x] Needs more testing, especially large file upload, copy

https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#specifying-s3-c-encryption