### PR TITLE
Revert "Remove inefficient fed share scanner"

### DIFF
--- a/apps/files_sharing/lib/External/Scanner.php
+++ b/apps/files_sharing/lib/External/Scanner.php
@@ -29,10 +29,28 @@ use OC\ForbiddenException;
 use OCP\Files\NotFoundException;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Http\Client\LocalServerException;
+use Psr\Log\LoggerInterface;
 
 class Scanner extends \OC\Files\Cache\Scanner {
 	/** @var \OCA\Files_Sharing\External\Storage */
 	protected $storage;
+
+	/** {@inheritDoc} */
+	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
+		try {
+			if (!$this->storage->remoteIsOwnCloud()) {
+				return parent::scan($path, $recursive, $reuse, $lock);
+			}
+		} catch (LocalServerException $e) {
+			// Scanner doesn't have dependency injection
+			\OC::$server->get(LoggerInterface::class)
+				->warning('Trying to scan files inside invalid external storage: ' . $this->storage->getRemote() . ' for mountpoint ' . $this->storage->getMountPoint() . ' and id ' . $this->storage->getId());
+			return;
+		}
+
+		$this->scanAll();
+	}
 
 	/**
 	 * Scan a single file and store it in the cache.
@@ -61,6 +79,58 @@ class Scanner extends \OC\Files\Cache\Scanner {
 			$this->storage->checkStorageAvailability();
 		} catch (StorageNotAvailableException $e) {
 			$this->storage->checkStorageAvailability();
+		}
+	}
+
+	/**
+	 * Checks the remote share for changes.
+	 * If changes are available, scan them and update
+	 * the cache.
+	 * @throws NotFoundException
+	 * @throws StorageInvalidException
+	 * @throws \Exception
+	 */
+	public function scanAll() {
+		try {
+			$data = $this->storage->getShareInfo();
+		} catch (\Exception $e) {
+			$this->storage->checkStorageAvailability();
+			throw new \Exception(
+				'Error while scanning remote share: "' .
+				$this->storage->getRemote() . '" ' .
+				$e->getMessage()
+			);
+		}
+		if ($data['status'] === 'success') {
+			$this->addResult($data['data'], '');
+		} else {
+			throw new \Exception(
+				'Error while scanning remote share: "' .
+				$this->storage->getRemote() . '"'
+			);
+		}
+	}
+
+	/**
+	 * @param array $data
+	 * @param string $path
+	 */
+	private function addResult($data, $path) {
+		$id = $this->cache->put($path, $data);
+		if (isset($data['children'])) {
+			$children = [];
+			foreach ($data['children'] as $child) {
+				$children[$child['name']] = true;
+				$this->addResult($child, ltrim($path . '/' . $child['name'], '/'));
+			}
+
+			$existingCache = $this->cache->getFolderContentsById($id);
+			foreach ($existingCache as $existingChild) {
+				// if an existing child is not in the new data, remove it
+				if (!isset($children[$existingChild['name']])) {
+					$this->cache->remove(ltrim($path . '/' . $existingChild['name'], '/'));
+				}
+			}
 		}
 	}
 }

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -50,6 +50,18 @@ class ScannerTest extends TestCase {
 		$this->scanner = new Scanner($this->storage);
 	}
 
+	public function testScanAll() {
+		$this->storage->expects($this->any())
+			->method('getShareInfo')
+			->willReturn(['status' => 'success', 'data' => []]);
+
+		// FIXME add real tests, we are currently only checking for
+		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
+		// compatible with OC\Files\Cache\Scanner::*()
+		$this->scanner->scanAll();
+		$this->addToAssertionCount(1);
+	}
+
 	public function testScan() {
 		$this->storage->expects($this->any())
 			->method('getShareInfo')


### PR DESCRIPTION
This reverts commit ce319143142e2ee998ef4794b04ad684c4ffa911. This is causing some issue.

> "files/xxxxxxxxxxxxxxxxxxxxxxxxx"("shared::xxxxxxxxxxxxxxxxxxxxxxxxxx::a-file.deb") is locked, existing lock on file: exclusive

Signed-off-by: Carl Schwan <carl@carlschwan.eu>