### PR TITLE
Run php tests when 3rdparty changed

### DIFF
--- a/tests/drone-run-php-tests.sh
+++ b/tests/drone-run-php-tests.sh
@@ -22,4 +22,6 @@ echo "========================="
 
 [[ $(git diff --name-only origin/$DRONE_TARGET_BRANCH...$DRONE_COMMIT_SHA | grep -c "/tests/") -gt 0 ]] && echo "PHP test files of an app are modified" && exit 0
 
+[[ $(git diff --name-only origin/$DRONE_TARGET_BRANCH...$DRONE_COMMIT_SHA | grep -c "3rdparty") -gt 0 ]] && echo "3rdparty is modified" && exit 0
+
 exit 1


### PR DESCRIPTION
`tests/drone-run-php-tests.sh` is there to reduce CI load a bit. The idea to skip for example the php tests when only vue/js is touched. Screenshot below is from a dependency update. As we don't have a check for 3rdparty the php tests are skipped and CI is happy. But we didn't run the unit tests for the dependency update :see_no_evil: 

![image](https://user-images.githubusercontent.com/3902676/173062170-258aeba6-281e-4854-ad25-09c9568fac63.png)

Example to test the condition: 

```[[ $(git diff --name-only 51c61d3194a306c68daab34537742f476408cfe3...aee4d39aa974431bbe473829fc44e7084b43e809 | grep -c "3rdparty") -gt 0 ]] && echo "3rdparty is modified"; ```
