### PR TITLE
remove trailing space(s) from `var_export`

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -257,7 +257,7 @@ class Config {
 		// Create a php file ...
 		$content = "<?php\n";
 		$content .= '$CONFIG = ';
-		$content .= var_export($this->cache, true);
+		$content .= preg_replace('/\s+$/m', '', var_export($this->cache, true));
 		$content .= ";\n";
 
 		touch($this->configFilePath);


### PR DESCRIPTION
https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_whitespace
```diff
-  'enabledPreviewProviders' => 
+  'enabledPreviewProviders' =>
```