### PR TITLE
Revert "Revert "Remove inefficient fed share scanner""

### DIFF
--- a/apps/files_sharing/lib/External/Scanner.php
+++ b/apps/files_sharing/lib/External/Scanner.php
@@ -34,6 +34,11 @@ class Scanner extends \OC\Files\Cache\Scanner {
 	/** @var \OCA\Files_Sharing\External\Storage */
 	protected $storage;
 
+	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
+		// Disable locking for federated shares
+		parent::scan($path, $recursive, $reuse, false);
+	}
+
 	/**
 	 * Scan a single file and store it in the cache.
 	 * If an exception happened while accessing the external storage,

--- a/apps/files_sharing/lib/External/Scanner.php
+++ b/apps/files_sharing/lib/External/Scanner.php
@@ -54,7 +54,7 @@ class Scanner extends \OC\Files\Cache\Scanner {
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null) {
 		try {
-			return parent::scanFile($file, $reuseExisting);
+			return parent::scanFile($file, $reuseExisting, $parentId, $cacheData, $lock, $data);
 		} catch (ForbiddenException $e) {
 			$this->storage->checkStorageAvailability();
 		} catch (NotFoundException $e) {

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -50,18 +50,6 @@ class ScannerTest extends TestCase {
 		$this->scanner = new Scanner($this->storage);
 	}
 
-	public function testScanAll() {
-		$this->storage->expects($this->any())
-			->method('getShareInfo')
-			->willReturn(['status' => 'success', 'data' => []]);
-
-		// FIXME add real tests, we are currently only checking for
-		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
-		// compatible with OC\Files\Cache\Scanner::*()
-		$this->scanner->scanAll();
-		$this->addToAssertionCount(1);
-	}
-
 	public function testScan() {
 		$this->storage->expects($this->any())
 			->method('getShareInfo')


### PR DESCRIPTION
This reverts commit 6667007bf235b90a7dd105c881cf5802b2a3f83e.

See context in https://github.com/nextcloud/server/pull/32806, this is breaking things 

- [x] investigate locking issue: https://github.com/nextcloud/server/issues/31554

Fixes https://github.com/nextcloud/server/issues/31554
