### PR TITLE
Fix Uninitialized string offset 0 at GenerateMimetypeFileBuilder.php#39

### DIFF
--- a/core/Command/Maintenance/Mimetype/GenerateMimetypeFileBuilder.php
+++ b/core/Command/Maintenance/Mimetype/GenerateMimetypeFileBuilder.php
@@ -30,17 +30,15 @@ namespace OC\Core\Command\Maintenance\Mimetype;
 class GenerateMimetypeFileBuilder {
 	/**
 	 * Generate mime type list file
-	 * @param $aliases
+	 *
+	 * @param array $aliases
 	 * @return string
 	 */
 	public function generateFile(array $aliases): string {
 		// Remove comments
-		$keys = array_filter(array_keys($aliases), function ($k) {
-			return $k[0] === '_';
-		});
-		foreach ($keys as $key) {
-			unset($aliases[$key]);
-		}
+		$aliases = array_filter($aliases, static function ($key) {
+			return !($key === '' || $key[0] === '_');
+		}, ARRAY_FILTER_USE_KEY);
 
 		// Fetch all files
 		$dir = new \DirectoryIterator(\OC::$SERVERROOT.'/core/img/filetypes');


### PR DESCRIPTION
Fix #31973

Someone added a file `config/mimetypealiases.json` to my instance like below. Key is empty hence the check if the first character of the string is `_` fails.

```
{
	"": "x-office\/document",
	"application\/vnd.openxmlformats-officedocument.wordprocessingml.document.docxf": "x-office\/document",
	"application\/vnd.openxmlformats-officedocument.wordprocessingml.document.oform": "x-office\/document"
}
```
