### PR TITLE
Avoid calendar & addressbook activities being created on user being deleted

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Backend.php
+++ b/apps/dav/lib/CalDAV/Activity/Backend.php
@@ -34,6 +34,7 @@ use OCP\App\IAppManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use Sabre\VObject\Reader;
 
@@ -56,11 +57,15 @@ class Backend {
 	/** @var IAppManager */
 	protected $appManager;
 
-	public function __construct(IActivityManager $activityManager, IGroupManager $groupManager, IUserSession $userSession, IAppManager $appManager) {
+	/** @var IUserManager */
+	protected $userManager;
+
+	public function __construct(IActivityManager $activityManager, IGroupManager $groupManager, IUserSession $userSession, IAppManager $appManager, IUserManager $userManager) {
 		$this->activityManager = $activityManager;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->appManager = $appManager;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -165,6 +170,11 @@ class Backend {
 		}
 
 		foreach ($users as $user) {
+			if ($action === Calendar::SUBJECT_DELETE && !$this->userManager->userExists($user)) {
+				// Avoid creating calendar_delete activities for deleted users
+				continue;
+			}
+
 			$event->setAffectedUser($user)
 				->setSubject(
 					$user === $currentUser ? $action . '_self' : $action,

--- a/apps/dav/lib/CardDAV/Activity/Backend.php
+++ b/apps/dav/lib/CardDAV/Activity/Backend.php
@@ -32,6 +32,7 @@ use OCP\App\IAppManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use Sabre\CardDAV\Plugin;
 use Sabre\VObject\Reader;
@@ -50,14 +51,19 @@ class Backend {
 	/** @var IAppManager */
 	protected $appManager;
 
+	/** @var IUserManager */
+	protected $userManager;
+
 	public function __construct(IActivityManager $activityManager,
 								IGroupManager $groupManager,
 								IUserSession $userSession,
-								IAppManager $appManager) {
+								IAppManager $appManager,
+								IUserManager $userManager) {
 		$this->activityManager = $activityManager;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->appManager = $appManager;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -139,6 +145,11 @@ class Backend {
 		}
 
 		foreach ($users as $user) {
+			if ($action === Addressbook::SUBJECT_DELETE && !$this->userManager->userExists($user)) {
+				// Avoid creating addressbook_delete activities for deleted users
+				continue;
+			}
+
 			$event->setAffectedUser($user)
 				->setSubject(
 					$user === $currentUser ? $action . '_self' : $action,


### PR DESCRIPTION
Addressbooks and Calendar data are destroyed through hook `OC_User::post_deleteUser` (legacy stuff), which when it reaches the CardDAV/CalDAV backends sends `AddressBookDeletedEvent`/`CalendarDeletedEvent` typed events, which in turns generates activities that aren't deleted until they expire.

This can probably lead to old activities being visible for a new user created with the same uid.

Another way to avoid adding this call to `IUserManager::userExists` would be to have server make sure the activities table is correctly emptied at the end of `OC/User::delete`, but there's no event like `AfterUserDeletedEvent` that would allow the activity app to hook in.

Another possibility is another activity background job that cleans activity entries for users which don't exist anymore, but that's dirty.