### PR TITLE
Mention missing files subdir

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -144,7 +144,7 @@ class Scan extends Base {
 				$scanner->scan($path, $recursive, $homeOnly ? [$this, 'filterHomeMount'] : null);
 			}
 		} catch (ForbiddenException $e) {
-			$output->writeln("<error>Home storage for user $user not writable</error>");
+			$output->writeln("<error>Home storage for user $user not writable or 'files' subdirectory missing</error>");
 			$output->writeln('Make sure you\'re running the scan command only as the user the web server runs as');
 		} catch (InterruptedException $e) {
 			# exit the function if ctrl-c has been pressed


### PR DESCRIPTION
Many users are getting confused by the inaccurate error message "Home storage for user $user not writable" because the storage *is* writable.  The actual issue is a missing files/ subdirectory.  cf. https://help.nextcloud.com/t/home-storage-for-user-not-writable/10831/7
By mentioning the possible cause in the error message, users are going to be able to rapidly solve their problem rather than bang their heads against the screen, Google, and eventually forums to find out that the error message is wrong in their case.
Yes, it would be better to detect and precisely describe the fault, or fix the problem automatically, but until then, be kind to the users for the next however many years.