### PR TITLE
Use {$var} instead of ${var} for PHP 8.2 compatibility

### DIFF
--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -201,7 +201,7 @@ class Backend {
 		while ($row = $result->fetch()) {
 			$p = $this->principalBackend->getPrincipalByPath($row['principaluri']);
 			$shares[] = [
-				'href' => "principal:${row['principaluri']}",
+				'href' => "principal:{$row['principaluri']}",
 				'commonName' => isset($p['{DAV:}displayname']) ? $p['{DAV:}displayname'] : '',
 				'status' => 1,
 				'readOnly' => (int) $row['access'] === self::ACCESS_READ,

--- a/apps/files/lib/Command/RepairTree.php
+++ b/apps/files/lib/Command/RepairTree.php
@@ -68,7 +68,7 @@ class RepairTree extends Command {
 			->where($query->expr()->eq('fileid', $query->createParameter('fileid')));
 
 		foreach ($rows as $row) {
-			$output->writeln("Path of file ${row['fileid']} is ${row['path']} but should be ${row['parent_path']}/${row['name']} based on it's parent", OutputInterface::VERBOSITY_VERBOSE);
+			$output->writeln("Path of file {$row['fileid']} is {$row['path']} but should be {$row['parent_path']}/{$row['name']} based on it's parent", OutputInterface::VERBOSITY_VERBOSE);
 
 			if ($fix) {
 				$fileId = $this->getFileId((int)$row['parent_storage'], $row['parent_path'] . '/' . $row['name']);

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -122,7 +122,7 @@ class L10N implements IL10N {
 	 *
 	 */
 	public function n(string $text_singular, string $text_plural, int $count, array $parameters = []): string {
-		$identifier = "_${text_singular}_::_${text_plural}_";
+		$identifier = "_{$text_singular}_::_{$text_plural}_";
 		if (isset($this->translations[$identifier])) {
 			return (string) new L10NString($this, $identifier, $parameters, $count);
 		}

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -497,7 +497,7 @@ EOF;
 				 */
 				/** @var string $label */
 				$label = ($plainMetaInfo !== false)? $plainMetaInfo : '';
-				$this->plainBody .= sprintf("%${plainIndent}s %s\n",
+				$this->plainBody .= sprintf("%{$plainIndent}s %s\n",
 					$label,
 					str_replace("\n", "\n" . str_repeat(' ', $plainIndent + 1), $plainText));
 			}

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -80,7 +80,7 @@ class MySQL extends AbstractDatabase {
 			$user = $this->dbUser;
 			//we can't use OC_DB functions here because we need to connect as the administrative user.
 			$characterSet = $this->config->getValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
-			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE ${characterSet}_bin;";
+			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE {$characterSet}_bin;";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
 			$this->logger->error('Database creation failed.', [


### PR DESCRIPTION
See https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>