### PR TITLE
Fix default toast message for failed uploads with HTTP/2

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1134,7 +1134,7 @@ OC.Uploader.prototype = _.extend({
 							}
 						}
 						console.error(e, data, response)
-						OC.Notification.show(message || data.errorThrown, {type: 'error'});
+						OC.Notification.show(message || data.errorThrown || t('files', 'File could not be uploaded'), {type: 'error'});
 					}
 
 					if (upload) {


### PR DESCRIPTION
When an upload fails a toast is shown with either a specific message or just the textual part of the HTTP error code (which comes from the [upload failure handler and set by `jQuery.ajax()`](https://github.com/nextcloud/server/blob/742703c92fe708b4fec0ac815e646a4f60bb96ea/apps/files/js/jquery.fileupload.js#L909-L912)). However, if there is neither a message nor an error then the toast will show [the default message from the Toastify-js library](https://github.com/apvarun/toastify-js/tree/1.11.2#api), which is an undescriptive "Hi there!".

When HTTP/2 is used Chromium does not provide the textual part of the HTTP error code, so when an upload fails the toast can receive an empty message and thus just show "Hi there!". Now an explicit message is provided as a fallback to prevent that.

## How to reproduce

- Setup HTTP/2 (you will need HTTPS too, as browsers seem to ignore HTTP/2 when using plain HTTP)
- Open the files app
- Share a folder with another user
- Remove share permission for _Allow editing_
- Log in as that user in Chromium (Firefox works as expected)
- Open the shared folder
- Upload a file
- Upload the same file again
- In the conflict dialog, keep the new file

### Result with this pull request

An error toast is shown with the message _File could not be uploaded_

### Result without this pull request

An error toast is shown with the message _Hi there!_
