### PR TITLE
Fix logger overwriting vars in some circumstances

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -208,14 +208,16 @@ class ExceptionSerializer {
 	}
 
 	private function removeValuesFromArgs($args, $values) {
-		foreach ($args as &$arg) {
+		$workArgs = [];
+		foreach ($args as $arg) {
 			if (in_array($arg, $values, true)) {
 				$arg = '*** sensitive parameter replaced ***';
 			} elseif (is_array($arg)) {
 				$arg = $this->removeValuesFromArgs($arg, $values);
 			}
+			$workArgs[] = $arg;
 		}
-		return $args;
+		return $workArgs;
 	}
 
 	private function encodeTrace($trace) {

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -42,6 +42,8 @@ use OCA\Encryption\Session;
 use OCP\HintException;
 
 class ExceptionSerializer {
+	public const SENSITIVE_VALUE_PLACEHOLDER = '*** sensitive parameters replaced ***';
+
 	public const methodsWithSensitiveParameters = [
 		// Session/User
 		'completeLogin',
@@ -180,7 +182,7 @@ class ExceptionSerializer {
 		if (isset($traceLine['args'])) {
 			$sensitiveValues = array_merge($sensitiveValues, $traceLine['args']);
 		}
-		$traceLine['args'] = ['*** sensitive parameters replaced ***'];
+		$traceLine['args'] = [self::SENSITIVE_VALUE_PLACEHOLDER];
 		return $traceLine;
 	}
 
@@ -211,7 +213,7 @@ class ExceptionSerializer {
 		$workArgs = [];
 		foreach ($args as $arg) {
 			if (in_array($arg, $values, true)) {
-				$arg = '*** sensitive parameter replaced ***';
+				$arg = self::SENSITIVE_VALUE_PLACEHOLDER;
 			} elseif (is_array($arg)) {
 				$arg = $this->removeValuesFromArgs($arg, $values);
 			}

--- a/tests/lib/Log/ExceptionSerializerTest.php
+++ b/tests/lib/Log/ExceptionSerializerTest.php
@@ -62,7 +62,7 @@ class ExceptionSerializerTest extends TestCase {
 		} catch (\Exception $e) {
 			$serializedData = $this->serializer->serializeException($e);
 			$this->assertSame(['Secret'], $secret);
-			$this->assertSame('*** sensitive parameters replaced ***', $serializedData['Trace'][0]['args'][0]);
+			$this->assertSame(ExceptionSerializer::SENSITIVE_VALUE_PLACEHOLDER, $serializedData['Trace'][0]['args'][0]);
 		}
 	}
 }

--- a/tests/lib/Log/ExceptionSerializerTest.php
+++ b/tests/lib/Log/ExceptionSerializerTest.php
@@ -60,8 +60,9 @@ class ExceptionSerializerTest extends TestCase {
 			$secret = ['Secret'];
 			$this->emit([&$secret]);
 		} catch (\Exception $e) {
-			$this->serializer->serializeException($e);
+			$serializedData = $this->serializer->serializeException($e);
 			$this->assertSame(['Secret'], $secret);
+			$this->assertSame('*** sensitive parameters replaced ***', $serializedData['Trace'][0]['args'][0]);
 		}
 	}
 }

--- a/tests/lib/Log/ExceptionSerializerTest.php
+++ b/tests/lib/Log/ExceptionSerializerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2021 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace lib\Log;
+
+use OC\Log\ExceptionSerializer;
+use OC\SystemConfig;
+use Test\TestCase;
+
+class ExceptionSerializerTest extends TestCase {
+	private ExceptionSerializer $serializer;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$config = $this->createMock(SystemConfig::class);
+		$this->serializer = new ExceptionSerializer($config);
+	}
+
+	private function emit($arguments) {
+		\call_user_func_array([$this, 'bind'], $arguments);
+	}
+
+	private function bind(array &$myValues): void {
+		throw new \Exception('my exception');
+	}
+
+	/**
+	 * this test ensures that the serializer does not overwrite referenced
+	 * variables. It is crafted after a scenario we experienced: the DAV server
+	 * emitting the "validateTokens" event, of which later on a handled
+	 * exception was passed to the logger. The token was replaced, the original
+	 * variable overwritten.
+	 */
+	public function testSerializer() {
+		try {
+			$secret = ['Secret'];
+			$this->emit([&$secret]);
+		} catch (\Exception $e) {
+			$this->serializer->serializeException($e);
+			$this->assertSame(['Secret'], $secret);
+		}
+	}
+}


### PR DESCRIPTION
We were investigating one case, indicated by the error `foreach() argument must be of type array|object, string given`

This can be reproduce like this:

1.) in php.ini, zend.exception_ignore_args is set to "Off" (PHP default, check distro in doubt)
2.) app files_lock enabled
3.) use an addressbook client (like KAddressbook)
4.) there, add a new contact

You will see an exception like:

```json
{
  "Exception": "Error",
  "Message": "Invalid argument supplied for foreach() at /srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php#1454",
  "Code": 0,
  "Trace": [
    {
      "file": "/srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php",
      "line": 1454,
      "function": "onAll",
      "class": "OC\\Log\\ErrorHandler",
      "type": "::",
      "args": [
        2,
        "Invalid argument supplied for foreach()",
        "/srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php",
        1454,
        {
          "request": {
            "__class__": "Sabre\\HTTP\\Request"
          },
          "response": {
            "__class__": "Sabre\\HTTP\\Response"
          },
          "path": "addressbooks/users/stable24/contacts/1655379707.R254.vcf",
          "node": null,
          "lastMod": null,
          "etag": null,
          "ifMatch": null,
          "e": {
            "__class__": "Sabre\\DAV\\Exception\\NotFound"
          },
          "ifNoneMatch": "*",
          "nodeExists": false,
          "ifUnmodifiedSince": null,
          "ifConditions": "*** sensitive parameter replaced ***"
        }
      ]
    },
    {
      "file": "/srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php",
      "line": 466,
      "function": "checkPreconditions",
      "class": "Sabre\\DAV\\Server",
      "type": "->",
      "args": [
        {
          "__class__": "Sabre\\HTTP\\Request"
        },
        {
          "__class__": "Sabre\\HTTP\\Response"
        }
      ]
    },
    {
      "file": "/srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php",
      "line": 253,
      "function": "invokeMethod",
      "class": "Sabre\\DAV\\Server",
      "type": "->",
      "args": [
        {
          "__class__": "Sabre\\HTTP\\Request"
        },
        {
          "__class__": "Sabre\\HTTP\\Response"
        }
      ]
    },
    {
      "file": "/srv/http/nextcloud/stable24/3rdparty/sabre/dav/lib/DAV/Server.php",
      "line": 321,
      "function": "start",
      "class": "Sabre\\DAV\\Server",
      "type": "->",
      "args": []
    },
    {
      "file": "/srv/http/nextcloud/stable24/apps/dav/lib/Server.php",
      "line": 352,
      "function": "exec",
      "class": "Sabre\\DAV\\Server",
      "type": "->",
      "args": []
    },
    {
      "file": "/srv/http/nextcloud/stable24/apps/dav/appinfo/v2/remote.php",
      "line": 35,
      "function": "exec",
      "class": "OCA\\DAV\\Server",
      "type": "->",
      "args": []
    },
    {
      "file": "/srv/http/nextcloud/stable24/remote.php",
      "line": 166,
      "args": [
        "/srv/http/nextcloud/stable24/apps/dav/appinfo/v2/remote.php"
      ],
      "function": "require_once"
    }
  ],
  "File": "/srv/http/nextcloud/stable24/lib/private/Log/ErrorHandler.php",
  "Line": 99,
  "CustomMessage": "--"
}
```

The hidden issue is that a variable, passed by reference, was overwritten. I used to be an array and was turned into a string `*** sensitive parameter replaced ***`.

Now we have a test to reproduce the issue and the fix. 

This problem popped up in a related scenario, where we committed a temporary fix: https://github.com/nextcloud/server/pull/32685 