### PR TITLE
Expose Doctrine support for persistent connections in PDO in Nextcloud settings

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -138,6 +138,12 @@ $CONFIG = [
  */
 'dbtableprefix' => '',
 
+/**
+ *  Enable persistent connexions to the database.
+ *  This setting uses the "persistent" option from doctrine dbal, wich in turns 
+ *  uses the PDO::ATTR_PERSISTENT option from de pdo driver.
+ */
+'dbpersistent' => '',
 
 /**
  * Indicates whether the Nextcloud instance was installed successfully; ``true``

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -233,7 +233,7 @@ class ConnectionFactory {
 			];
 		}
 
-		if ($this->config->getValue('db.persistent', false)) {
+		if ($this->config->getValue('dbpersistent', false)) {
 			$connectionParams['persistent'] = true;
 		}
 

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -233,6 +233,10 @@ class ConnectionFactory {
 			];
 		}
 
+		if ($this->config->getValue('persistent', false)) {
+			$connectionParams['persistent'] = true;
+		}
+
 		return $connectionParams;
 	}
 

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -233,7 +233,7 @@ class ConnectionFactory {
 			];
 		}
 
-		if ($this->config->getValue('persistent', false)) {
+		if ($this->config->getValue('db.persistent', false)) {
 			$connectionParams['persistent'] = true;
 		}
 


### PR DESCRIPTION
This is a very naive PR to expose [Doctrine support for persistent connections in PDO](https://github.com/doctrine/dbal/pull/3515) doctrine/dbal#2315  in Netxcloud settings.

This setting enable the use of [PDO::ATTR_PERSISTENT in the PDO driver ](https://www.php.net/manual/en/pdo.connections.php#example-1015). 

This, with the various "persistent" options suggested in [the docs](https://docs.nextcloud.com/server/latest/admin_manual/configuration_database/linux_database_configuration.html)  allow for  php-fpm to keep open and reuse connexion to the backend database. Not unlike a pool of connexion we can encounter in other languages.

I am personally using this modification, with a postresql database and pgsql.allow_persistent = On for a small nextcloud shared between friends and haven't seen anything weird yet. Although my use case is fairly small and problems may arise on larger instances

