### PR TITLE
Fix profiler trying to serialize invalid utf8

### DIFF
--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -320,7 +320,15 @@ class LDAP implements ILDAPWrapper {
 		$this->curArgs = $args;
 
 		if ($this->dataCollector !== null) {
-			$args = array_map(fn ($item) => (!$this->isResource($item) ? $item : '(resource)'), $this->curArgs);
+			$args = array_map(function ($item) {
+				if ($this->isResource($item)) {
+					return '(resource)';
+				}
+				if (isset($item[0]['value']['cookie']) && $item[0]['value']['cookie'] !== "") {
+					$item[0]['value']['cookie'] = "*opaque cookie*";
+				}
+				return $item;
+			}, $this->curArgs);
 
 			$this->dataCollector->startLdapRequest($this->curFunc, $args);
 		}


### PR DESCRIPTION
The cookie value contains invalid utf8 characters most of the time so
let's just ignore it as it is also not that interesting to analyse.