### PR TITLE
Revert use the nextcloud certificate bundle for s3

### DIFF
--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -30,7 +30,6 @@ class S3 implements IObjectStore {
 	use S3ObjectTrait;
 
 	public function __construct($parameters) {
-		$parameters['primary_storage'] = true;
 		$this->parseParams($parameters);
 	}
 

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -38,7 +38,6 @@ use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
-use OCP\ICertificateManager;
 use Psr\Log\LoggerInterface;
 
 trait S3ConnectionTrait {
@@ -121,9 +120,6 @@ trait S3ConnectionTrait {
 			)
 		);
 
-		/** @var ICertificateManager $certManager */
-		$certManager = \OC::$server->get(ICertificateManager::class);
-
 		$options = [
 			'version' => isset($this->params['version']) ? $this->params['version'] : 'latest',
 			'credentials' => $provider,
@@ -133,10 +129,9 @@ trait S3ConnectionTrait {
 			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
 			'csm' => false,
 			'use_arn_region' => false,
-			'http' => ['verify' => $certManager->getAbsoluteBundlePath()],
 		];
 		if ($this->getProxy()) {
-			$options['http']['proxy'] = $this->getProxy();
+			$options['http'] = ['proxy' => $this->getProxy()];
 		}
 		if (isset($this->params['legacy_auth']) && $this->params['legacy_auth']) {
 			$options['signature_version'] = 'v2';

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -121,14 +121,8 @@ trait S3ConnectionTrait {
 			)
 		);
 
-		// since we store the certificate bundles on the primary storage, we can't get the bundle while setting up the primary storage
-		if (!isset($this->params['primary_storage'])) {
-			/** @var ICertificateManager $certManager */
-			$certManager = \OC::$server->get(ICertificateManager::class);
-			$certPath = $certManager->getAbsoluteBundlePath();
-		} else {
-			$certPath = \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
-		}
+		/** @var ICertificateManager $certManager */
+		$certManager = \OC::$server->get(ICertificateManager::class);
 
 		$options = [
 			'version' => isset($this->params['version']) ? $this->params['version'] : 'latest',
@@ -139,7 +133,7 @@ trait S3ConnectionTrait {
 			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
 			'csm' => false,
 			'use_arn_region' => false,
-			'http' => ['verify' => $certPath],
+			'http' => ['verify' => $certManager->getAbsoluteBundlePath()],
 		];
 		if ($this->getProxy()) {
 			$options['http']['proxy'] = $this->getProxy();


### PR DESCRIPTION
Reverts 194a21f374ac81d98f3fb70e6917cf6bd6199d89
Reverts 1156214a269572b4460d8aa8a599076520f26b58

By default the aws sdk validates certificate against the default CA bundle provided by the operating system: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#config-http

https://github.com/nextcloud/server/pull/31574 changed the behavior to use our internal certificate manager or the CA bundle shipped with Nextcloud. When you added a self signed certificate to the CA bundle provided by the operating system connections to your object store now fails. Using an internal CA is a common use case for enterprises. 

I guess our best option for now is to restore the old behavior and look for a better approach. Maybe a configuration option to expose the verify option like suggested here: https://github.com/nextcloud/server/issues/32726 