### PR TITLE
Fix file public link permissions if public upload is not enabled

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -650,7 +650,7 @@ class Manager implements IManager {
 		}
 
 		// Check if public upload is allowed
-		if (!$this->shareApiLinkAllowPublicUpload() &&
+		if ($share->getNodeType() === 'folder' && !$this->shareApiLinkAllowPublicUpload() &&
 			($share->getPermissions() & (\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE))) {
 			throw new \InvalidArgumentException('Public upload is not allowed');
 		}
@@ -1544,7 +1544,7 @@ class Manager implements IManager {
 		 * Reduce the permissions for link or email shares if public upload is not enabled
 		 */
 		if (($share->getShareType() === IShare::TYPE_LINK || $share->getShareType() === IShare::TYPE_EMAIL)
-			&& !$this->shareApiLinkAllowPublicUpload()) {
+			&& $share->getNodeType() === 'folder' && !$this->shareApiLinkAllowPublicUpload()) {
 			$share->setPermissions($share->getPermissions() & ~(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE));
 		}
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1915,13 +1915,31 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 
-	public function testLinkCreateChecksNoPublicUpload() {
+	public function testFileLinkCreateChecksNoPublicUpload() {
+		$share = $this->manager->newShare();
+
+		$share->setPermissions(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		$share->setNodeType('file');
+
+		$this->config
+			->method('getAppValue')
+			->willReturnMap([
+				['core', 'shareapi_allow_links', 'yes', 'yes'],
+				['core', 'shareapi_allow_public_upload', 'yes', 'no']
+			]);
+
+		self::invokePrivate($this->manager, 'linkCreateChecks', [$share]);
+		$this->addToAssertionCount(1);
+	}
+
+	public function testFolderLinkCreateChecksNoPublicUpload() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Public upload is not allowed');
 
 		$share = $this->manager->newShare();
 
 		$share->setPermissions(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		$share->setNodeType('folder');
 
 		$this->config
 			->method('getAppValue')
@@ -1937,6 +1955,9 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 
 		$share->setPermissions(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		$share->setSharedWith('sharedWith');
+		$folder = $this->createMock(\OC\Files\Node\Folder::class);
+		$share->setNode($folder);
 
 		$this->config
 			->method('getAppValue')
@@ -1953,6 +1974,9 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 
 		$share->setPermissions(\OCP\Constants::PERMISSION_READ);
+		$share->setSharedWith('sharedWith');
+		$folder = $this->createMock(\OC\Files\Node\Folder::class);
+		$share->setNode($folder);
 
 		$this->config
 			->method('getAppValue')
@@ -2947,6 +2971,9 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 		$share->setShareType(IShare::TYPE_LINK)
 			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE);
+		$share->setSharedWith('sharedWith');
+		$folder = $this->createMock(\OC\Files\Node\Folder::class);
+		$share->setNode($folder);
 
 		$this->config
 			->expects($this->at(1))


### PR DESCRIPTION
When "Administration -> Share -> Public upload" admin setting is disabled:
* We refuse to
    * create a share with update permissions
    * add update permissions to an existing share
* We remove PERMISSION_CREATE and PERMISSION_UPDATE when getting the share permissions

It makes perfect sense when sharing a directory but not when sharing a file which can then only be accessed in read-only by Text, NC Office and OnlyOffice.

If this is the intended behaviour, we should at least make it very explicit in the admin settings.