### PR TITLE
Remove .php from url

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -99,7 +99,7 @@ $application->registerRoutes(
 			],
 			[
 				'name' => 'ajax#getStorageStats',
-				'url' => '/ajax/getstoragestats.php',
+				'url' => '/ajax/getstoragestats',
 				'verb' => 'GET',
 			],
 			[

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -25,7 +25,7 @@
 				state.call.abort();
 			}
 			state.dir = currentDir;
-			state.call = $.getJSON(OC.filePath('files','ajax','getstoragestats.php') + '?dir=' + encodeURIComponent(currentDir),function(response) {
+			state.call = $.getJSON(OC.filePath('files','ajax','getstoragestats') + '?dir=' + encodeURIComponent(currentDir),function(response) {
 				state.dir = null;
 				state.call = null;
 				Files.updateMaxUploadFilesize(response);
@@ -37,7 +37,7 @@
 		},
 		_updateStorageQuotas: function() {
 			var state = Files.updateStorageQuotas;
-			state.call = $.getJSON(OC.filePath('files','ajax','getstoragestats.php'),function(response) {
+			state.call = $.getJSON(OC.filePath('files','ajax','getstoragestats'),function(response) {
 				Files.updateQuota(response);
 			});
 		},


### PR DESCRIPTION
Probably here for legacy reasons, but it is a bit weird to call an .php
endpoint that doesn't correspond to a .php file

Signed-off-by: Carl Schwan <carl@carlschwan.eu>