### PR TITLE
load dashboard widgets of enabled apps only

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -151,7 +151,7 @@ class Coordinator {
 		 */
 		$this->registrationContext->delegateCapabilityRegistrations($apps);
 		$this->registrationContext->delegateCrashReporterRegistrations($apps, $this->registry);
-		$this->registrationContext->delegateDashboardPanelRegistrations($apps, $this->dashboardManager);
+		$this->registrationContext->delegateDashboardPanelRegistrations($this->dashboardManager);
 		$this->registrationContext->delegateEventListenerRegistrations($this->eventDispatcher);
 		$this->registrationContext->delegateContainerRegistrations($apps);
 		$this->registrationContext->delegateMiddlewareRegistrations($apps);

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -475,10 +475,10 @@ class RegistrationContext {
 	/**
 	 * @param App[] $apps
 	 */
-	public function delegateDashboardPanelRegistrations(array $apps, IManager $dashboardManager): void {
+	public function delegateDashboardPanelRegistrations(IManager $dashboardManager): void {
 		while (($panel = array_shift($this->dashboardPanels)) !== null) {
 			try {
-				$dashboardManager->lazyRegisterWidget($panel->getService());
+				$dashboardManager->lazyRegisterWidget($panel->getService(), $panel->getAppId());
 			} catch (Throwable $e) {
 				$appId = $panel->getAppId();
 				$this->logger->error("Error during dashboard registration of $appId: " . $e->getMessage(), [

--- a/lib/private/Dashboard/Manager.php
+++ b/lib/private/Dashboard/Manager.php
@@ -27,10 +27,11 @@ declare(strict_types=1);
 namespace OC\Dashboard;
 
 use InvalidArgumentException;
-use OCP\AppFramework\QueryException;
+use OCP\App\IAppManager;
 use OCP\Dashboard\IManager;
 use OCP\Dashboard\IWidget;
-use OCP\IServerContainer;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Throwable;
 use Psr\Log\LoggerInterface;
 
@@ -42,11 +43,12 @@ class Manager implements IManager {
 	/** @var IWidget[] */
 	private $widgets = [];
 
-	/** @var IServerContainer */
-	private $serverContainer;
+	private ContainerInterface $serverContainer;
+	private IAppManager $appManager;
 
-	public function __construct(IServerContainer $serverContainer) {
+	public function __construct(ContainerInterface $serverContainer, IAppManager $appManager) {
 		$this->serverContainer = $serverContainer;
+		$this->appManager = $appManager;
 	}
 
 	private function registerWidget(IWidget $widget): void {
@@ -57,17 +59,22 @@ class Manager implements IManager {
 		$this->widgets[$widget->getId()] = $widget;
 	}
 
-	public function lazyRegisterWidget(string $widgetClass): void {
-		$this->lazyWidgets[] = $widgetClass;
+	public function lazyRegisterWidget(string $widgetClass, string $appId): void {
+		$this->lazyWidgets[] = ['class' => $widgetClass, 'appId' => $appId];
 	}
 
 	public function loadLazyPanels(): void {
-		$classes = $this->lazyWidgets;
-		foreach ($classes as $class) {
+		$services = $this->lazyWidgets;
+		foreach ($services as $service) {
+			/** @psalm-suppress InvalidCatch */
 			try {
+				if (!$this->appManager->isEnabledForUser($service['appId'])) {
+					// all apps are registered, but some may not be enabled for the user
+					continue;
+				}
 				/** @var IWidget $widget */
-				$widget = $this->serverContainer->query($class);
-			} catch (QueryException $e) {
+				$widget = $this->serverContainer->get($service['class']);
+			} catch (ContainerExceptionInterface $e) {
 				/*
 				 * There is a circular dependency between the logger and the registry, so
 				 * we can not inject it. Thus the static call.
@@ -90,7 +97,7 @@ class Manager implements IManager {
 				 */
 				\OC::$server->get(LoggerInterface::class)->critical(
 					'Could not register lazy dashboard widget: ' . $e->getMessage(),
-					['excepiton' => $e]
+					['exception' => $e]
 				);
 			}
 
@@ -111,7 +118,7 @@ class Manager implements IManager {
 			} catch (Throwable $e) {
 				\OC::$server->get(LoggerInterface::class)->critical(
 					'Error during dashboard widget loading: ' . $e->getMessage(),
-					['excepiton' => $e]
+					['exception' => $e]
 				);
 			}
 		}

--- a/lib/private/Dashboard/Manager.php
+++ b/lib/private/Dashboard/Manager.php
@@ -44,11 +44,10 @@ class Manager implements IManager {
 	private $widgets = [];
 
 	private ContainerInterface $serverContainer;
-	private IAppManager $appManager;
+	private ?IAppManager $appManager = null;
 
-	public function __construct(ContainerInterface $serverContainer, IAppManager $appManager) {
+	public function __construct(ContainerInterface $serverContainer) {
 		$this->serverContainer = $serverContainer;
-		$this->appManager = $appManager;
 	}
 
 	private function registerWidget(IWidget $widget): void {
@@ -64,6 +63,9 @@ class Manager implements IManager {
 	}
 
 	public function loadLazyPanels(): void {
+		if ($this->appManager === null) {
+			$this->appManager = $this->serverContainer->get(IAppManager::class);
+		}
 		$services = $this->lazyWidgets;
 		foreach ($services as $service) {
 			/** @psalm-suppress InvalidCatch */

--- a/lib/public/Dashboard/IManager.php
+++ b/lib/public/Dashboard/IManager.php
@@ -36,7 +36,7 @@ interface IManager {
 	 * @param string $widgetClass
 	 * @since 20.0.0
 	 */
-	public function lazyRegisterWidget(string $widgetClass): void;
+	public function lazyRegisterWidget(string $widgetClass, string $appId): void;
 
 	/**
 	 * @since 20.0.0


### PR DESCRIPTION
- per design, all enabled apps have their registration run
- limitations, e.g. enabled by group, are not considered in that state, because we do not have a session (and might need apps?)
- before instantiation of widget it has to be checked whether the providing app is actually enabled for the logged in user.
- a public interface is being changed, but it is not meant to be implemented or used outside of the core handling. Therefore save to   backport.

fixes #32887 (check it also for reproduction steps)

