### PR TITLE
Fix metadata extraction

### DIFF
--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -101,7 +101,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		$this->data = $data;
 		$this->mount = $mount;
 		$this->owner = $owner;
-		if (isset($this->data['unencrypted_size'])) {
+		if (isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] !== 0) {
 			$this->rawSize = $this->data['unencrypted_size'];
 		} else {
 			$this->rawSize = $this->data['size'] ?? 0;


### PR DESCRIPTION
The metadata extraction only happens when the size is not equal to 0,
but due to a regression in FileInfo the size is always zero.

This fix the regression.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>