### PR TITLE
Fixes for quota text in navigation bar

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2633,7 +2633,10 @@
 						self.showFileBusyState($tr, false);
 					});
 			};
-			return this.reportOperationProgress(fileNames, moveFileFunction, callback);
+			return this.reportOperationProgress(fileNames, moveFileFunction, callback).then(function() {
+				self.updateStorageStatistics();
+				self.updateStorageQuotas();
+			});
 		},
 
 		_reflect: function (promise){
@@ -2813,7 +2816,10 @@
 						}
 					});
 			};
-			return this.reportOperationProgress(fileNames, copyFileFunction, callback);
+			return this.reportOperationProgress(fileNames, copyFileFunction, callback).then(function() {
+				self.updateStorageStatistics();
+				self.updateStorageQuotas();
+			});
 		},
 
 		/**

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -103,9 +103,9 @@
 				if (response.data.quota > 0) {
 					$('#quota').attr('data-original-title', Math.floor(response.data.used/response.data.quota*1000)/10 + '%');
 					$('#quota progress').val(response.data.usedSpacePercent);
-					$('#quotatext').text(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanQuota}));
+					$('#quotatext').html(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanQuota}));
 				} else {
-					$('#quotatext').text(t('files', '{used} used', {used: humanUsed}));
+					$('#quotatext').html(t('files', '{used} used', {used: humanUsed}));
 				}
 				if (response.data.usedSpacePercent > 80) {
 					$('#quota progress').addClass('warn');

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -12,7 +12,7 @@
 		<?php if ($_['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED): ?>
 			<li id="quota" class="pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>">
 				<a href="#" class="icon-quota svg">
-					<p><?php p($l->t('%s used', [$_['usage']])); ?></p>
+					<p id="quotatext"><?php p($l->t('%s used', [$_['usage']])); ?></p>
 				</a>
 			</li>
 		<?php else: ?>


### PR DESCRIPTION
This pull request fixes a regression introduced in f310b964d453ed0192661d005e5f575918bda2c7 (not updating the usage on updates when no quota is set), as well as wrongly escaped text and not updating the quota when copying or moving files.

All issues were present already in Nextcloud 22. As it is a regression the fix will be backported to 22, 23 and 24.

## How to reproduce (scenario 1)

- Ensure that the [default skeleton files for development](https://github.com/nextcloud/server/blob/bbc7c0f3dd446ea668229b4544c2161e0f4a8bbb/core/skeleton/welcome.txt) are used, so only "Welcome.txt" is created in the user directory when a new user is created
- Create a new user and set a quota of 1 GB
- Log in as that user
- Open the Files app
- Create a folder
- Delete the folder

### Result with this pull request

The quota text in the navigation bar is updated and set to `< 1 KB of 1 GB used`

### Result without this pull request

The quota text in the navigation bar is updated and set to `&lt; 1 KB of 1 GB used`


## How to reproduce (scenario 2)

- Create a new user with unlimited quota (the default)
- Log in as that user
- Open the Files app
- Upload a file

### Result with this pull request

The quota text in the navigation bar is updated

### Result without this pull request

The quota text in the navigation bar is not updated


## How to reproduce (scenario 3)

- Open the Files app
- Copy an existing file

### Result with this pull request

The quota text in the navigation bar is updated

### Result without this pull request

The quota text in the navigation bar is not updated


## How to reproduce (scenario 4)

- Share a folder with another user
- Log in as that user
- Open the Files app
- Move an existing file to the shared folder

### Result with this pull request

The quota text in the navigation bar is updated

### Result without this pull request

The quota text in the navigation bar is not updated
