### PR TITLE
Search without join on filecache_extended

### DIFF
--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -41,12 +41,16 @@ class CacheQueryBuilder extends QueryBuilder {
 		parent::__construct($connection, $systemConfig, $logger);
 	}
 
-	public function selectFileCache(string $alias = null) {
+	public function selectFileCache(string $alias = null, bool $joinExtendedCache = true) {
 		$name = $alias ? $alias : 'filecache';
 		$this->select("$name.fileid", 'storage', 'path', 'path_hash', "$name.parent", "$name.name", 'mimetype', 'mimepart', 'size', 'mtime',
-			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'metadata_etag', 'creation_time', 'upload_time', 'unencrypted_size')
-			->from('filecache', $name)
-			->leftJoin($name, 'filecache_extended', 'fe', $this->expr()->eq("$name.fileid", 'fe.fileid'));
+			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'unencrypted_size')
+			->from('filecache', $name);
+
+		if ($joinExtendedCache) {
+			$this->addSelect('metadata_etag', 'creation_time', 'upload_time');
+			$this->leftJoin($name, 'filecache_extended', 'fe', $this->expr()->eq("$name.fileid", 'fe.fileid'));
+		}
 
 		$this->alias = $name;
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -103,7 +103,7 @@ class QuerySearchHelper {
 
 		$builder = $this->getQueryBuilder();
 
-		$query = $builder->selectFileCache('file');
+		$query = $builder->selectFileCache('file', false);
 
 		if ($this->searchBuilder->shouldJoinTags($searchQuery->getSearchOperation())) {
 			$user = $searchQuery->getUser();


### PR DESCRIPTION
A search query is already very heavy, so don't join it with filecache_extended since the data contained in that table is not required to display the search result.