### PR TITLE
Support iMIP invitations from Mail

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1864,6 +1864,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			}
 		}
 
+		if(isset($options['uid'])) {
+			$outerQuery->andWhere($outerQuery->expr()->eq('uid', $outerQuery->createNamedParameter($options['uid'])));
+		}
+
 		if (!empty($options['types'])) {
 			$or = $outerQuery->expr()->orX();
 			foreach ($options['types'] as $type) {

--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -206,7 +206,6 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		return $this->caldavBackend->calendarSearch($principalUri, $filters, $limit, $offset);
 	}
 
-
 	public function enableCachedSubscriptionsForThisRequest() {
 		$this->returnCachedSubscriptions = true;
 	}

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV;
 
 use OCP\Calendar\ICalendarProvider;
+use OCP\Calendar\ICreateFromString;
 use OCP\IConfig;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;

--- a/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
@@ -25,9 +25,13 @@
  */
 namespace OCA\DAV\Tests\unit\CalDAV;
 
+use OCA\DAV\CalDAV\Auth\CustomPrincipalPlugin;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\CalendarImpl;
+use OCA\DAV\CalDAV\InvitationResponse\InvitationResponseServer;
+use OCA\DAV\CalDAV\Schedule\Plugin;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class CalendarImplTest extends \Test\TestCase {
 
@@ -51,6 +55,7 @@ class CalendarImplTest extends \Test\TestCase {
 			'id' => 'fancy_id_123',
 			'{DAV:}displayname' => 'user readable name 123',
 			'{http://apple.com/ns/ical/}calendar-color' => '#AABBCC',
+			'uri' => '/this/is/a/uri'
 		];
 		$this->backend = $this->createMock(CalDavBackend::class);
 
@@ -124,5 +129,79 @@ class CalendarImplTest extends \Test\TestCase {
 			]);
 
 		$this->assertEquals(31, $this->calendarImpl->getPermissions());
+	}
+
+	public function testHandleImipMessage(): void {
+		$invitationResponseServer = $this->createConfiguredMock(InvitationResponseServer::class, [
+			'server' => $this->createConfiguredMock(CalDavBackend::class, [
+				'getPlugin' => [
+					'auth' => $this->createMock(CustomPrincipalPlugin::class),
+					'schedule' => $this->createMock(Plugin::class)
+				]
+			])
+		]);
+
+		$message = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//Nextcloud/Nextcloud CalDAV Server//EN
+METHOD:REPLY
+VERSION:2.0
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=mailto:lewis@stardew-tent-living.com:ACCEPTED
+ORGANIZER:mailto:pierre@generalstore.com
+UID:aUniqueUid
+SEQUENCE:2
+REQUEST-STATUS:2.0;Success
+%sEND:VEVENT
+END:VCALENDAR
+EOF;
+
+		/** @var CustomPrincipalPlugin|MockObject $authPlugin */
+		$authPlugin = $invitationResponseServer->server->getPlugin('auth');
+		$authPlugin->expects(self::once())
+			->method('setPrincipalUri')
+			->with($this->calendar->getPrincipalURI());
+
+		/** @var Plugin|MockObject $schedulingPlugin */
+		$schedulingPlugin = $invitationResponseServer->server->getPlugin('caldav-schedule');
+		$schedulingPlugin->expects(self::once())
+			->method('setPathOfCalendarObjectChange')
+			->with('fullcalendarname');
+	}
+
+	public function testHandleImipMessageNoCalendarUri(): void {
+		$invitationResponseServer = $this->createConfiguredMock(InvitationResponseServer::class, [
+			'server' => $this->createConfiguredMock(CalDavBackend::class, [
+				'getPlugin' => [
+					'auth' => $this->createMock(CustomPrincipalPlugin::class),
+					'schedule' => $this->createMock(Plugin::class)
+				]
+			])
+		]);
+
+		$message = <<<EOF
+BEGIN:VCALENDAR
+PRODID:-//Nextcloud/Nextcloud CalDAV Server//EN
+METHOD:REPLY
+VERSION:2.0
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=mailto:lewis@stardew-tent-living.com:ACCEPTED
+ORGANIZER:mailto:pierre@generalstore.com
+UID:aUniqueUid
+SEQUENCE:2
+REQUEST-STATUS:2.0;Success
+%sEND:VEVENT
+END:VCALENDAR
+EOF;
+
+		/** @var CustomPrincipalPlugin|MockObject $authPlugin */
+		$authPlugin = $invitationResponseServer->server->getPlugin('auth');
+		$authPlugin->expects(self::once())
+			->method('setPrincipalUri')
+			->with($this->calendar->getPrincipalURI());
+
+		unset($this->calendarInfo['uri']);
+		$this->expectException('CalendarException');
+		$this->calendarImpl->handleIMipMessage('filename.ics', $message);
 	}
 }

--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -27,12 +27,19 @@ declare(strict_types=1);
 namespace OC\Calendar;
 
 use OC\AppFramework\Bootstrap\Coordinator;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Calendar\Exceptions\CalendarException;
 use OCP\Calendar\ICalendar;
 use OCP\Calendar\ICalendarProvider;
 use OCP\Calendar\ICalendarQuery;
+use OCP\Calendar\ICreateFromString;
 use OCP\Calendar\IManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Component\VEvent;
+use Sabre\VObject\Property\VCard\DateTime;
+use Sabre\VObject\Reader;
 use Throwable;
 use function array_map;
 use function array_merge;
@@ -58,12 +65,17 @@ class Manager implements IManager {
 	/** @var LoggerInterface */
 	private $logger;
 
+	private ITimeFactory $timeFactory;
+
+
 	public function __construct(Coordinator $coordinator,
 								ContainerInterface $container,
-								LoggerInterface $logger) {
+								LoggerInterface $logger,
+								ITimeFactory $timeFactory) {
 		$this->coordinator = $coordinator;
 		$this->container = $container;
 		$this->logger = $logger;
+		$this->timeFactory = $timeFactory;
 	}
 
 	/**
@@ -167,6 +179,11 @@ class Manager implements IManager {
 		$this->calendarLoaders = [];
 	}
 
+	/**
+	 * @param string $principalUri
+	 * @param array $calendarUris
+	 * @return ICreateFromString[]
+	 */
 	public function getCalendarsForPrincipal(string $principalUri, array $calendarUris = []): array {
 		$context = $this->coordinator->getRegistrationContext();
 		if ($context === null) {
@@ -198,7 +215,6 @@ class Manager implements IManager {
 		);
 
 		$results = [];
-		/** @var ICalendar $calendar */
 		foreach ($calendars as $calendar) {
 			$r = $calendar->search(
 				$query->getSearchPattern() ?? '',
@@ -218,5 +234,138 @@ class Manager implements IManager {
 
 	public function newQuery(string $principalUri): ICalendarQuery {
 		return new CalendarQuery($principalUri);
+	}
+
+	/**
+	 * @throws \OCP\DB\Exception
+	 */
+	public function handleIMipReply(string $principalUri, string $sender, string $recipient, string $calendarData): bool {
+		/** @var VCalendar $vObject */
+		$vObject = Reader::read($calendarData);
+		/** @var VEvent $vEvent */
+		$vEvent = $vObject->{'VEVENT'};
+
+		// First, we check if the correct method is passed to us
+		if (strcasecmp('REPLY', $vObject->{'METHOD'}->getValue()) !== 0) {
+			$this->logger->warning('Wrong method provided for processing');
+			return false;
+		}
+
+		// check if mail recipient and organizer are one and the same
+		$organizer = substr($vEvent->{'ORGANIZER'}->getValue(), 7);
+
+		if (strcasecmp($recipient, $organizer) !== 0) {
+			$this->logger->warning('Recipient and ORGANIZER must be identical');
+			return false;
+		}
+
+		//check if the event is in the future
+		/** @var DateTime $eventTime */
+		$eventTime = $vEvent->{'DTSTART'};
+		if ($eventTime->getDateTime()->getTimeStamp() < $this->timeFactory->getTime()) { // this might cause issues with recurrences
+			$this->logger->warning('Only events in the future are processed');
+			return false;
+		}
+
+		$calendars = $this->getCalendarsForPrincipal($principalUri);
+		if (empty($calendars)) {
+			$this->logger->warning('Could not find any calendars for principal ' . $principalUri);
+			return false;
+		}
+
+		$found = null;
+		// if the attendee has been found in at least one calendar event with the UID of the iMIP event
+		// we process it.
+		// Benefit: no attendee lost
+		// Drawback: attendees that have been deleted will still be able to update their partstat
+		foreach ($calendars as $calendar) {
+			// We should not search in writable calendars
+			if ($calendar instanceof ICreateFromString) {
+				$o = $calendar->search($sender, ['ATTENDEE'], ['uid' => $vEvent->{'UID'}->getValue()]);
+				if (!empty($o)) {
+					$found = $calendar;
+					$name = $o[0]['uri'];
+					break;
+				}
+			}
+		}
+
+		if (empty($found)) {
+			$this->logger->info('Event not found in any calendar for principal ' . $principalUri . 'and UID' . $vEvent->{'UID'}->getValue());
+			return false;
+		}
+
+		try {
+			$found->handleIMipMessage($name, $calendarData); // sabre will handle the scheduling behind the scenes
+		} catch (CalendarException $e) {
+			$this->logger->error('Could not update calendar for iMIP processing', ['exception' => $e]);
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @since 25.0.0
+	 * @throws \OCP\DB\Exception
+	 */
+	public function handleIMipCancel(string $principalUri, string $sender, ?string $replyTo, string $recipient, string $calendarData): bool {
+		$vObject = Reader::read($calendarData);
+		/** @var VEvent $vEvent */
+		$vEvent = $vObject->{'VEVENT'};
+
+		// First, we check if the correct method is passed to us
+		if (strcasecmp('CANCEL', $vObject->{'METHOD'}->getValue()) !== 0) {
+			$this->logger->warning('Wrong method provided for processing');
+			return false;
+		}
+
+		$attendee = substr($vEvent->{'ATTENDEE'}->getValue(), 7);
+		if (strcasecmp($recipient, $attendee) !== 0) {
+			$this->logger->warning('Recipient must be an ATTENDEE of this event');
+			return false;
+		}
+
+		// Thirdly, we need to compare the email address the CANCEL is coming from (in Mail)
+		// or the Reply- To Address submitted with the CANCEL email
+		// to the email address in the ORGANIZER.
+		// We don't want to accept a CANCEL request from just anyone
+		$organizer = substr($vEvent->{'ORGANIZER'}->getValue(), 7);
+		if (strcasecmp($sender, $organizer) !== 0 && strcasecmp($replyTo, $organizer) !== 0) {
+			$this->logger->warning('Sender must be the ORGANIZER of this event');
+			return false;
+		}
+
+		$calendars = $this->getCalendarsForPrincipal($principalUri);
+		$found = null;
+		// if the attendee has been found in at least one calendar event with the UID of the iMIP event
+		// we process it.
+		// Benefit: no attendee lost
+		// Drawback: attendees that have been deleted will still be able to update their partstat
+		foreach ($calendars as $calendar) {
+			// We should not search in writable calendars
+			if ($calendar instanceof ICreateFromString) {
+				$o = $calendar->search($recipient, ['ATTENDEE'], ['uid' => $vEvent->{'UID'}->getValue()]);
+				if (!empty($o)) {
+					$found = $calendar;
+					$name = $o[0]['uri'];
+					break;
+				}
+			}
+		}
+
+		if (empty($found)) {
+			$this->logger->info('Event not found in any calendar for principal ' . $principalUri . 'and UID' . $vEvent->{'UID'}->getValue());
+			// this is a safe operation
+			// we can ignore events that have been cancelled but were not in the calendar anyway
+			return true;
+		}
+
+		try {
+			$found->handleIMipMessage($name, $calendarData); // sabre will handle the scheduling behind the scenes
+			return true;
+		} catch (CalendarException $e) {
+			$this->logger->error('Could not update calendar for iMIP processing', ['exception' => $e]);
+			return false;
+		}
 	}
 }

--- a/lib/public/Calendar/ICreateFromString.php
+++ b/lib/public/Calendar/ICreateFromString.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright 2021 Anna Larch <anna.larch@gmx.net>
  *
@@ -38,4 +40,11 @@ interface ICreateFromString extends ICalendar {
 	 * @throws CalendarException
 	 */
 	public function createFromString(string $name, string $calendarData): void;
+
+	/**
+	 * @since 25.0.0
+	 *
+	 * @throws CalendarException
+	 */
+	public function handleIMipMessage(string $name, string $calendarData): void;
 }

--- a/lib/public/Calendar/IManager.php
+++ b/lib/public/Calendar/IManager.php
@@ -156,4 +156,18 @@ interface IManager {
 	 * @since 23.0.0
 	 */
 	public function newQuery(string $principalUri) : ICalendarQuery;
+
+	/**
+	 * Handle a iMip REPLY message
+	 *
+	 * @since 25.0.0
+	 */
+	public function handleIMipReply(string $principalUri, string $sender, string $recipient, string $calendarData): bool;
+
+	/**
+	 * Handle a iMip CANCEL message
+	 *
+	 * @since 25.0.0
+	 */
+	public function handleIMipCancel(string $principalUri, string $sender, ?string $replyTo, string $recipient, string $calendarData): bool;
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6803
Fixes #19144
Fixes #22532
To Do:

- [x] Write updated or accepted calendar events to CalDAV
- [x] Tests


Don't do  "Fix CANCEL method for emails that are updated from UI (https://github.com/nextcloud/server/issues/33008) - the STATUS CANCELLED should also lead to an iMIP message with method CANCEL, not reply" as we're using a systemwide email address which could lead to cancellation email addresses not being processed by other mail clients.

Considerations:

- Extend the CalendarImpl to handle these requests
- Preconditions as specified in the RFC must be met, and the VEVENT that should be written needs to be compared to the original for both ORGANIZER and ATTENDEE
- CANCEL requests must be from the right email address and the right organiser or they shouldn't be processed. (but what if we send them from NC from the system email? Will that work? maybe accepting the system email as a secondary email address as specified in the RFC could work.)
