### PR TITLE
Avoid libxml_entity_loader errors on PHP8+

### DIFF
--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -95,12 +95,12 @@ class VersionCheck {
 		}
 
 		if ($xml) {
-			if (\LIBXML_VERSION < 20900) {
+			if ((PHP_VERSION_ID < 80000)) {
 				$loadEntities = libxml_disable_entity_loader(true);
-				$data = @simplexml_load_string($xml);
+				$data = simplexml_load_string($xml);
 				libxml_disable_entity_loader($loadEntities);
 			} else {
-				$data = @simplexml_load_string($xml);
+				$data = simplexml_load_string($xml);
 			}
 			if ($data !== false) {
 				$tmp['version'] = (string)$data->version;


### PR DESCRIPTION
Check against PHP version instead of LIBXML version.
Same fix as https://github.com/nextcloud/server/blob/master/lib/private/App/InfoParser.php#L64

```
"url": "/settings/admin/overview",
  "message": "Function libxml_disable_entity_loader() is deprecated at /app/lib/private/Updater/VersionCheck.php#100",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.115 Safari/537.36",
  "version": "23.0.6.1",
  "exception": {
    "Exception": "Error",
    "Message": "Function libxml_disable_entity_loader() is deprecated at /app/lib/private/Updater/VersionCheck.php#100",
    "Code": 0,
    "Trace": [
      {
        "file": "/app/lib/private/Updater/VersionCheck.php",
        "line": 100,
        "function": "onError",
        "class": "OC\\Log\\ErrorHandler",
        "type": "::",
        "args": [
          8192,
          "Function libxml_disable_entity_loader() is deprecated",
          "/app/lib/private/Updater/VersionCheck.php",
          100
        ]
      },
```