### PR TITLE
Check whether entry is of type ICacheEntry in Cache->remove()

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -540,7 +540,7 @@ class Cache implements ICache {
 	public function remove($file) {
 		$entry = $this->get($file);
 
-		if ($entry) {
+		if ($entry instanceof ICacheEntry) {
 			$query = $this->getQueryBuilder();
 			$query->delete('filecache')
 				->whereFileId($entry->getId());


### PR DESCRIPTION
In some scenarios (file not in cache, but partial data of it in the
object), Cache->get() might return an array, which leads to errors like
"Call to a member function getId() on array".

So check whether the returned entry is of type ICacheEntry before doing
operations on it in Cache->remove().

Fixes: #33023

Supersedes: #22598

Signed-off-by: Jonas <jonas@freesources.org>