### PR TITLE
IConfig: PHP 7.4, global default values

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -30,6 +30,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OC;
 
 use OC\Cache\CappedMemoryCache;
@@ -37,13 +38,20 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\PreConditionNotMetException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class to combine all the configuration options ownCloud offers
  */
 class AllConfig implements IConfig {
+
+	const USER_KEY_LIMIT = 64;
+	const APP_KEY_LIMIT = 64;
+
+
 	private SystemConfig $systemConfig;
 	private ?IDBConnection $connection = null;
+	private LoggerInterface $logger;
 
 	/**
 	 * 3 dimensional array with the following structure:
@@ -66,6 +74,10 @@ class AllConfig implements IConfig {
 	 * @var CappedMemoryCache $userCache
 	 */
 	private CappedMemoryCache $userCache;
+	private array $appDefaultValues = [];
+	private array $userDefaultValues = [];
+	private array $systemDefaultValues = [];
+
 
 	public function __construct(SystemConfig $systemConfig) {
 		$this->userCache = new CappedMemoryCache();
@@ -91,13 +103,31 @@ class AllConfig implements IConfig {
 		}
 	}
 
+
+	/**
+	 * @param string $appName
+	 * @param array $default
+	 */
+	public function setAppDefaultValues(string $appName, array $default): void {
+		$this->appDefaultValues[$appName] = $default;
+	}
+
+	public function setUserDefaultValues(string $appName, array $default): void {
+		$this->userDefaultValues[$appName] = $default;
+	}
+
+	public function setSystemDefaultValues(array $default): void {
+		$this->systemDefaultValues = $default;
+	}
+
+
 	/**
 	 * Sets and deletes system wide values
 	 *
 	 * @param array $configs Associative array with `key => value` pairs
 	 *                       If value is null, the config key will be deleted
 	 */
-	public function setSystemValues(array $configs) {
+	public function setSystemValues(array $configs): void {
 		$this->systemConfig->setValues($configs);
 	}
 
@@ -107,15 +137,26 @@ class AllConfig implements IConfig {
 	 * @param string $key the key of the value, under which will be saved
 	 * @param mixed $value the value that should be stored
 	 */
-	public function setSystemValue($key, $value) {
+	public function setSystemValue(string $key, $value): void {
 		$this->systemConfig->setValue($key, $value);
 	}
+
+	public function setSystemValueInt(string $key, int $value): void {
+	}
+
+	public function setSystemValueBool(string $key, bool $value): void {
+	}
+
+	public function setSystemValueArray(string $key, array $value): void {
+	}
+
 
 	/**
 	 * Looks up a system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return mixed the value or $default
 	 */
 	public function getSystemValue($key, $default = '') {
@@ -133,7 +174,7 @@ class AllConfig implements IConfig {
 	 * @since 16.0.0
 	 */
 	public function getSystemValueBool(string $key, bool $default = false): bool {
-		return (bool) $this->getSystemValue($key, $default);
+		return (bool)$this->getSystemValue($key, $default);
 	}
 
 	/**
@@ -147,7 +188,7 @@ class AllConfig implements IConfig {
 	 * @since 16.0.0
 	 */
 	public function getSystemValueInt(string $key, int $default = 0): int {
-		return (int) $this->getSystemValue($key, $default);
+		return (int)$this->getSystemValue($key, $default);
 	}
 
 	/**
@@ -161,7 +202,7 @@ class AllConfig implements IConfig {
 	 * @since 16.0.0
 	 */
 	public function getSystemValueString(string $key, string $default = ''): string {
-		return (string) $this->getSystemValue($key, $default);
+		return (string)$this->getSystemValue($key, $default);
 	}
 
 	/**
@@ -169,9 +210,10 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return mixed the value or $default
 	 */
-	public function getFilteredSystemValue($key, $default = '') {
+	public function getFilteredSystemValue(string $key, $default = '') {
 		return $this->systemConfig->getFilteredValue($key, $default);
 	}
 
@@ -180,7 +222,7 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 */
-	public function deleteSystemValue($key) {
+	public function deleteSystemValue(string $key) {
 		$this->systemConfig->deleteValue($key);
 	}
 
@@ -188,9 +230,10 @@ class AllConfig implements IConfig {
 	 * Get all keys stored for an app
 	 *
 	 * @param string $appName the appName that we stored the value under
+	 *
 	 * @return string[] the keys stored for the app
 	 */
-	public function getAppKeys($appName) {
+	public function getAppKeys(string $appName): array {
 		return \OC::$server->get(AppConfig::class)->getKeys($appName);
 	}
 
@@ -201,9 +244,60 @@ class AllConfig implements IConfig {
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string|float|int $value the value that should be stored
 	 */
-	public function setAppValue($appName, $key, $value) {
+	public function setAppValue(string $appName, string $key, $value): void {
+		if (!is_string($value)) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning(
+							'Value used in setAppValue() with config key ' . $key
+							. ' is not a string. Please use the suitable method.'
+						);
+		}
+
 		\OC::$server->get(AppConfig::class)->setValue($appName, $key, $value);
 	}
+
+	/**
+	 * @param string $appName
+	 * @param string $key
+	 * @param int $value
+	 */
+	public function setAppValueInt(string $appName, string $key, int $value): void {
+		if (strlen($key) > self::APP_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key is too long: ' . $key . ' - limit is ' . self::APP_KEY_LIMIT);
+		}
+
+		\OC::$server->get(AppConfig::class)->setValueInt($appName, $key, $value);
+	}
+
+	/**
+	 * @param string $appName
+	 * @param string $key
+	 * @param bool $value
+	 */
+	public function setAppValueBool(string $appName, string $key, bool $value): void {
+		if (strlen($key) > self::APP_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key is too long: ' . $key . ' - limit is ' . self::APP_KEY_LIMIT);
+		}
+
+		\OC::$server->get(AppConfig::class)->setValueBool($appName, $key, $value);
+	}
+
+	/**
+	 * @param string $appName
+	 * @param string $key
+	 * @param array $value
+	 */
+	public function setAppValueArray(string $appName, string $key, array $value): void {
+		if (strlen($key) > self::APP_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key is too long: ' . $key . ' - limit is ' . self::APP_KEY_LIMIT);
+		}
+
+		\OC::$server->get(AppConfig::class)->setValueArray($appName, $key, $value);
+	}
+
 
 	/**
 	 * Looks up an app wide defined value
@@ -211,11 +305,33 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
 	 * @param string $default the default value to be returned if the value isn't set
+	 *
 	 * @return string the saved value
 	 */
-	public function getAppValue($appName, $key, $default = '') {
+	public function getAppValue(string $appName, string $key, $default = '') {
 		return \OC::$server->get(AppConfig::class)->getValue($appName, $key, $default);
 	}
+
+
+	public function getAppValueInt(string $appName, string $key, ?int $default = null): int {
+		$default = (int)($default ?? $this->appDefaultValues[$appName][$key] ?? 0);
+
+		return \OC::$server->get(AppConfig::class)->getValueInt($appName, $key, $default);
+	}
+
+	public function getAppValueBool(string $appName, string $key, ?bool $default = null): bool {
+		$default = (bool)($default ?? $this->appDefaultValues[$appName][$key] ?? false);
+
+		return \OC::$server->get(AppConfig::class)->getValueBool($appName, $key, $default);
+	}
+
+	public function getAppValueArray(string $appName, string $key, ?array $default = null): array {
+		$default = $default ?? $this->appDefaultValues[$appName][$key] ?? [];
+		$default = (is_array($default)) ? $default : [];
+
+		return \OC::$server->get(AppConfig::class)->getValueArray($appName, $key, $default);
+	}
+
 
 	/**
 	 * Delete an app wide defined value
@@ -244,21 +360,33 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param string|float|int $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
+	 * @param string $preCondition only update if the config value was previously the value passed as
+	 *     $preCondition
+	 *
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null) {
+	public function setUserValue(string $userId, string $appName, string $key, $value, $preCondition = null) {
 		if (!is_int($value) && !is_float($value) && !is_string($value)) {
 			throw new \UnexpectedValueException('Only integers, floats and strings are allowed as value');
+		}
+
+		if (!is_string($value)) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning(
+							'Value used in setUserValue() with config key ' . $key
+							. ' is not a string. Please use the suitable method.'
+						);
 		}
 
 		// TODO - FIXME
 		$this->fixDIInit();
 
+		// can it be moved ?
 		if ($appName === 'settings' && $key === 'email') {
-			$value = strtolower((string) $value);
+			$value = strtolower((string)$value);
 		}
+
 
 		$prevValue = $this->getUserValue($userId, $appName, $key, null);
 
@@ -270,13 +398,14 @@ class AllConfig implements IConfig {
 			} else {
 				$qb = $this->connection->getQueryBuilder();
 				$qb->update('preferences')
-					->set('configvalue', $qb->createNamedParameter($value))
-					->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId)))
-					->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($appName)))
-					->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
+				   ->set('configvalue', $qb->createNamedParameter($value))
+				   ->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId)))
+				   ->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($appName)))
+				   ->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
 				$qb->executeStatement();
 
 				$this->userCache[$userId][$appName][$key] = (string)$value;
+
 				return;
 			}
 		}
@@ -293,8 +422,8 @@ class AllConfig implements IConfig {
 			'appid' => $appName,
 			'configkey' => $key,
 		], [
-			'configvalue' => $value,
-		], $preconditionArray);
+										 'configvalue' => $value,
+									 ], $preconditionArray);
 
 		// only add to the cache if we already loaded data for the user
 		if (isset($this->userCache[$userId])) {
@@ -305,6 +434,96 @@ class AllConfig implements IConfig {
 		}
 	}
 
+
+	/**
+	 * @throws PreConditionNotMetException
+	 */
+	public function setUserValueInt(
+		string $userId,
+		string $appName,
+		string $key,
+		int $value,
+		?int $preCondition = null
+	) {
+		if (strlen($key) > self::USER_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key ' . $key . ' is too long; limit is ' . self::USER_KEY_LIMIT);
+		}
+
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$prevValue = $this->getUserValueInt($userId, $appName, $key);
+		if (!is_null($preCondition) && $prevValue !== $preCondition) {
+			throw new PreConditionNotMetException();
+		}
+
+		if ($prevValue === $value) {
+			return;
+		}
+
+		$this->prepareInsertOrUpdatePreference($userId, $appName, $key)
+			 ->setParameter('configValue', $value, IQueryBuilder::PARAM_INT)
+			 ->executeStatement();
+
+		if ($this->isUserCacheInitiated($userId, $appName)) {
+			$this->userCache[$userId][$appName][$key] = $value;
+		}
+	}
+
+
+	public function setUserValueBool(
+		string $userId,
+		string $appName,
+		string $key,
+		bool $value
+	) {
+		if (strlen($key) > self::USER_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key ' . $key . ' is too long; limit is ' . self::USER_KEY_LIMIT);
+		}
+
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$prevValue = $this->getUserValueBool($userId, $appName, $key);
+		if ($prevValue === $value) {
+			return;
+		}
+
+		$this->prepareInsertOrUpdatePreference($userId, $appName, $key)
+			 ->setParameter('configValue', $value, IQueryBuilder::PARAM_BOOL)
+			 ->executeStatement();
+
+		if ($this->isUserCacheInitiated($userId, $appName)) {
+			$this->userCache[$userId][$appName][$key] = $value;
+		}
+	}
+
+	public function setUserValueArray(string $userId, string $appName, string $key, array $value) {
+		if (strlen($key) > self::USER_KEY_LIMIT) {
+			\OC::$server->get(LoggerInterface::class)
+						->warning('key ' . $key . ' is too long; limit is ' . self::USER_KEY_LIMIT);
+		}
+
+		// TODO - FIXME
+		$this->fixDIInit();
+
+		$prevValue = $this->getUserValueArray($userId, $appName, $key);
+		if ($prevValue === $value) {
+			return;
+		}
+
+		$this->prepareInsertOrUpdatePreference($userId, $appName, $key)
+			 ->setParameter('configValue', json_encode($value), IQueryBuilder::PARAM_STR)
+			 ->executeStatement();
+
+		if ($this->isUserCacheInitiated($userId, $appName)) {
+			$this->userCache[$userId][$appName][$key] = $value;
+		}
+	}
+
+
 	/**
 	 * Getting a user defined value
 	 *
@@ -312,6 +531,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return string
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '') {
@@ -323,11 +543,65 @@ class AllConfig implements IConfig {
 		}
 	}
 
+
+	public function getUserValueInt(
+		string $userId,
+		string $appName,
+		string $key,
+		?int $default = null
+	): int {
+		$data = $this->getAllUserValues($userId);
+
+		return (int)($data[$appName][$key] ?? $default ?? $this->userDefaultValues[$key] ?? 0);
+	}
+
+	public function getUserValueBool(
+		string $userId,
+		string $appName,
+		string $key,
+		?bool $default = null
+	): bool {
+		$data = $this->getAllUserValues($userId);
+
+		$value = $data[$appName][$key] ?? $default ?? $this->userDefaultValues[$key] ?? false;
+		if (is_bool($value)) {
+			return $value;
+		}
+
+		if (is_string($value) && in_array(strtolower($value), ['0', '1', 'true', 'false'])) {
+			return ($value === '1' || strtolower($value) === 'true');
+		}
+
+		if (is_numeric($value) && in_array($value, [0, 1])) {
+			return ($value === 1);
+		}
+
+		return false;
+	}
+
+	public function getUserValueArray(
+		string $userId,
+		string $appName,
+		string $key,
+		?array $default = null
+	): array {
+		$data = $this->getAllUserValues($userId);
+
+		$value = $data[$appName][$key] ?? $default ?? $this->userDefaultValues[$key] ?? [];
+		if (is_string($value)) {
+			$value = json_decode($value, true);
+		}
+
+		return (is_array($value)) ? $value : [];
+	}
+
+
 	/**
 	 * Get the keys of all stored by an app for the user
 	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
+	 *
 	 * @return string[]
 	 */
 	public function getUserKeys($userId, $appName) {
@@ -352,10 +626,10 @@ class AllConfig implements IConfig {
 
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('preferences')
-			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
-			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
-			->where($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
-			->executeStatement();
+		   ->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
+		   ->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
+		   ->where($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
+		   ->executeStatement();
 
 		if (isset($this->userCache[$userId][$appName])) {
 			unset($this->userCache[$userId][$appName][$key]);
@@ -372,8 +646,8 @@ class AllConfig implements IConfig {
 		$this->fixDIInit();
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('preferences')
-			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
-			->executeStatement();
+		   ->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
+		   ->executeStatement();
 
 		unset($this->userCache[$userId]);
 	}
@@ -389,8 +663,8 @@ class AllConfig implements IConfig {
 
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('preferences')
-			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
-			->executeStatement();
+		   ->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
+		   ->executeStatement();
 
 		foreach ($this->userCache as &$userCache) {
 			unset($userCache[$appName]);
@@ -401,6 +675,7 @@ class AllConfig implements IConfig {
 	 * Returns all user configs sorted by app of one user
 	 *
 	 * @param ?string $userId the user ID to get the app configs from
+	 *
 	 * @psalm-return array<string, array<string, string>>
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
@@ -413,6 +688,7 @@ class AllConfig implements IConfig {
 		}
 		if ($userId === null || $userId === '') {
 			$this->userCache[''] = [];
+
 			return $this->userCache[''];
 		}
 
@@ -423,9 +699,13 @@ class AllConfig implements IConfig {
 
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb->select('appid', 'configkey', 'configvalue')
-			->from('preferences')
-			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
-			->executeQuery();
+					 ->from('preferences')
+					 ->where(
+						 $qb->expr()->eq(
+							 'userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)
+						 )
+					 )
+					 ->executeQuery();
 		while ($row = $result->fetch()) {
 			$appId = $row['appid'];
 			if (!isset($data[$appId])) {
@@ -434,6 +714,7 @@ class AllConfig implements IConfig {
 			$data[$appId][$row['configkey']] = $row['configvalue'];
 		}
 		$this->userCache[$userId] = $data;
+
 		return $data;
 	}
 
@@ -443,6 +724,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName app to get the value for
 	 * @param string $key the key to get the value for
 	 * @param array $userIds the user IDs to fetch the values for
+	 *
 	 * @return array Mapped values: userId => value
 	 */
 	public function getUserValueForUsers($appName, $key, $userIds) {
@@ -457,10 +739,10 @@ class AllConfig implements IConfig {
 
 		$qb = $this->connection->getQueryBuilder();
 		$qb->select('userid', 'configvalue')
-			->from('preferences')
-			->where($qb->expr()->eq('appid', $qb->createParameter('appName')))
-			->andWhere($qb->expr()->eq('configkey', $qb->createParameter('configKey')))
-			->andWhere($qb->expr()->in('userid', $qb->createParameter('userIds')));
+		   ->from('preferences')
+		   ->where($qb->expr()->eq('appid', $qb->createParameter('appName')))
+		   ->andWhere($qb->expr()->eq('configkey', $qb->createParameter('configKey')))
+		   ->andWhere($qb->expr()->in('userid', $qb->createParameter('userIds')));
 
 		$userValues = [];
 		foreach ($chunkedUsers as $chunk) {
@@ -483,6 +765,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
+	 *
 	 * @return array of user IDs
 	 */
 	public function getUsersForUserValue($appName, $key, $value) {
@@ -491,14 +774,24 @@ class AllConfig implements IConfig {
 
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb->select('userid')
-			->from('preferences')
-			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
-			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
-			->andWhere($qb->expr()->eq(
-				$qb->expr()->castColumn('configvalue', IQueryBuilder::PARAM_STR),
-				$qb->createNamedParameter($value, IQueryBuilder::PARAM_STR))
-			)->orderBy('userid')
-			->executeQuery();
+					 ->from('preferences')
+					 ->where(
+						 $qb->expr()->eq(
+							 'appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)
+						 )
+					 )
+					 ->andWhere(
+						 $qb->expr()->eq(
+							 'configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)
+						 )
+					 )
+					 ->andWhere(
+						 $qb->expr()->eq(
+							 $qb->expr()->castColumn('configvalue', IQueryBuilder::PARAM_STR),
+							 $qb->createNamedParameter($value, IQueryBuilder::PARAM_STR)
+						 )
+					 )->orderBy('userid')
+					 ->executeQuery();
 
 		$userIDs = [];
 		while ($row = $result->fetch()) {
@@ -514,6 +807,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
+	 *
 	 * @return array of user IDs
 	 */
 	public function getUsersForUserValueCaseInsensitive($appName, $key, $value) {
@@ -526,14 +820,26 @@ class AllConfig implements IConfig {
 		}
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb->select('userid')
-			->from('preferences')
-			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
-			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
-			->andWhere($qb->expr()->eq(
-				$qb->func()->lower($qb->expr()->castColumn('configvalue', IQueryBuilder::PARAM_STR)),
-				$qb->createNamedParameter(strtolower($value), IQueryBuilder::PARAM_STR))
-			)->orderBy('userid')
-			->executeQuery();
+					 ->from('preferences')
+					 ->where(
+						 $qb->expr()->eq(
+							 'appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)
+						 )
+					 )
+					 ->andWhere(
+						 $qb->expr()->eq(
+							 'configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)
+						 )
+					 )
+					 ->andWhere(
+						 $qb->expr()->eq(
+							 $qb->func()->lower(
+								 $qb->expr()->castColumn('configvalue', IQueryBuilder::PARAM_STR)
+							 ),
+							 $qb->createNamedParameter(strtolower($value), IQueryBuilder::PARAM_STR)
+						 )
+					 )->orderBy('userid')
+					 ->executeQuery();
 
 		$userIDs = [];
 		while ($row = $result->fetch()) {
@@ -545,5 +851,78 @@ class AllConfig implements IConfig {
 
 	public function getSystemConfig() {
 		return $this->systemConfig;
+	}
+
+
+	/**
+	 * returns if config key is already known
+	 */
+	private function hasUserValue(string $userId, string $appName, string $key): bool {
+		$data = $this->getAllUserValues($userId);
+
+		return !is_null($data[$appName][$key]);
+	}
+
+
+	/**
+	 * Prepare the IQueryBuilder based on user value is already known in database or creation is needed
+	 *
+	 * The IQueryBuilder only prepare the request and will require the parameter 'configValue' to be set:
+	 *
+	 *       $this->prepareInsertOrUpdatePreference($userId, $appName, $key)
+	 *            ->setParameter('configValue', $value)
+	 *            ->executeStatement();
+	 *
+	 *
+	 * @param string $userId
+	 * @param string $appName
+	 * @param string $key
+	 *
+	 * @return IQueryBuilder
+	 */
+	private function prepareInsertOrUpdatePreference(
+		string $userId,
+		string $appName,
+		string $key
+	): IQueryBuilder {
+		$qb = $this->connection->getQueryBuilder();
+
+		if (!$this->hasUserValue($userId, $appName, $key)) {
+			$qb->insert('preferences')
+			   ->setValue('configvalue', $qb->createParameter('configValue'))
+			   ->setValue('userid', $qb->createNamedParameter($userId))
+			   ->setValue('appid', $qb->createNamedParameter($appName))
+			   ->setValue('configkey', $qb->createNamedParameter($key));
+		} else {
+			$qb->update('preferences')
+			   ->set('configvalue', $qb->createParameter('configValue'))
+			   ->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId)))
+			   ->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($appName)))
+			   ->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
+		}
+
+		return $qb;
+	}
+
+
+	/**
+	 * Returns true if userCache is initiated for $userId
+	 * if $appName is provided, will initiate the array if it does not exist yet
+	 *
+	 * @param string $userId
+	 * @param string $appName
+	 *
+	 * @return bool
+	 */
+	private function isUserCacheInitiated(string $userId, string $appName = ''): bool {
+		if (!isset($this->userCache[$userId])) {
+			return false;
+		}
+
+		if ($appName !== '' && !isset($this->userCache[$userId][$appName])) {
+			$this->userCache[$userId][$appName] = [];
+		}
+
+		return true;
 	}
 }

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -224,6 +224,46 @@ class AppConfig implements IAppConfig {
 		return $default;
 	}
 
+
+
+	public function getValueInt(string $app, string $key, int $default = 0): int {
+		$this->loadConfigValues();
+
+		return (int) ($this->cache[$app][$key] ?? $default);
+	}
+
+	public function getValueBool(string $app, string $key, bool $default = false): bool {
+		$this->loadConfigValues();
+
+		$value = $this->cache[$app][$key] ?? $default;
+		if (is_bool($value)) {
+			return $value;
+		}
+
+		if (is_string($value) && in_array(strtolower($value), ['0', '1', 'true', 'false'])) {
+			return ($value === '1' || strtolower($value) === 'true');
+		}
+
+		if (is_numeric($value) && in_array($value, [0, 1])) {
+			return ($value === 1);
+		}
+
+		return $default;
+	}
+
+
+	public function getValueArray(string $app, string $key, array $default = []): array {
+		$this->loadConfigValues();
+
+		$value = $this->cache[$app][$key] ?? $default;
+		if (is_string($value)) {
+			$value = json_decode($value, true);
+		}
+
+		return (is_array($value)) ? $value : $default;
+	}
+
+
 	/**
 	 * check if a key is set in the appconfig
 	 *

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Maxence Lange <maxence@artificial-owl.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -31,11 +32,9 @@ use OCP\IConfig;
 
 class AppConfig implements IAppConfig {
 
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
+	private string $appName;
 
-	/** @var string */
-	private $appName;
 
 	public function __construct(IConfig $config, string $appName) {
 		$this->config = $config;
@@ -46,13 +45,50 @@ class AppConfig implements IAppConfig {
 		return $this->config->getAppKeys($this->appName);
 	}
 
+	public function setAppDefaultValues(array $default): void {
+		$this->config->setAppDefaultValues($this->appName, $default);
+	}
+
+	public function setUserDefaultValues(array $default): void {
+		$this->config->setUserDefaultValues($this->appName, $default);
+	}
+
+
 	public function setAppValue(string $key, string $value): void {
 		$this->config->setAppValue($this->appName, $key, $value);
 	}
 
+	public function setAppValueInt(string $key, int $value): void {
+		$this->config->setAppValueInt($this->appName, $key, $value);
+	}
+
+	public function setAppValueBool(string $key, bool $value): void {
+		$this->config->setAppValueBool($this->appName, $key, $value);
+	}
+
+	public function setAppValueArray(string $key, array $value): void {
+		$this->config->setAppValueArray($this->appName, $key, $value);
+	}
+
+
+
+
 	public function getAppValue(string $key, string $default = ''): string {
 		return $this->config->getAppValue($this->appName, $key, $default);
 	}
+
+	public function getAppValueInt(string $key, ?int $default = null): int {
+		return $this->config->getAppValueInt($this->appName, $key, $default);
+	}
+
+	public function getAppValueBool(string $key): bool {
+	}
+
+	public function getAppValueArray(string $key): array {
+	}
+
+
+
 
 	public function deleteAppValue(string $key): void {
 		$this->config->deleteAppValue($this->appName, $key);
@@ -62,13 +98,51 @@ class AppConfig implements IAppConfig {
 		$this->config->deleteAppValues($this->appName);
 	}
 
-	public function setUserValue(string $userId, string $key, string $value, ?string $preCondition = null): void {
+
+
+	public function setUserValue(
+		string $userId,
+		string $key,
+		string $value,
+		?string $preCondition = null
+	): void {
 		$this->config->setUserValue($userId, $this->appName, $key, $value, $preCondition);
+	}
+
+	public function setUserValueInt(
+		string $userId,
+		string $key,
+		int $value,
+		?int $preCondition = null
+	): void {
+		$this->config->setUserValueInt($userId, $this->appName, $key, $value, $preCondition);
+	}
+
+	public function setUserValueBool(
+		string $userId,
+		string $key,
+		bool $value,
+		?bool $preCondition = null
+	): void {
+	}
+
+	public function setUserValueArray(string $userId, string $key, array $value, ?array $preCondition = null
+	): void {
 	}
 
 	public function getUserValue(string $userId, string $key, string $default = ''): string {
 		return $this->config->getUserValue($userId, $this->appName, $key, $default);
 	}
+
+	public function getUserValueInt(string $userId, string $key): int {
+	}
+
+	public function getUserValueBool(string $userId, string $key): bool {
+	}
+
+	public function getUserValueArray(string $userId, string $key): array {
+	}
+
 
 	public function deleteUserValue(string $userId, string $key): void {
 		$this->config->deleteUserValue($userId, $this->appName, $key);

--- a/lib/public/AppFramework/Services/IAppConfig.php
+++ b/lib/public/AppFramework/Services/IAppConfig.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Maxence Lange <maxence@artificial-owl.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -23,6 +24,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+
 namespace OCP\AppFramework\Services;
 
 /**
@@ -31,38 +34,124 @@ namespace OCP\AppFramework\Services;
  * @since 20.0.0
  */
 interface IAppConfig {
+
 	/**
 	 * Get all keys stored for this app
 	 *
 	 * @return string[] the keys stored for the app
 	 * @since 20.0.0
 	 */
-	public function getAppKeys(): array ;
+	public function getAppKeys(): array;
+
+//
+//	/**
+//	 * set default values for any config values related to your app
+//	 *
+//	 * @param array $default
+//	 *
+//	 * @since 25.0.0
+//	 */
+//	public function setAppDefaultValues(array $default): void;
+//
+//	/**
+//	 * set default values for any config values related to users
+//	 *
+//	 * @param array $default
+//	 *
+//	 * @since 25.0.0
+//	 */
+//	public function setUserDefaultValues(array $default): void;
+
 
 	/**
 	 * Writes a new app wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
+	 *
 	 * @return void
 	 * @since 20.0.0
 	 */
 	public function setAppValue(string $key, string $value): void;
 
 	/**
+	 * store an app wide value as integer
+	 *
+	 * @param string $key
+	 * @param int $value
+	 *
+	 * @since 25.0.0
+	 */
+	public function setAppValueInt(string $key, int $value): void;
+
+	/**
+	 * store an app wide value as bool
+	 *
+	 * @param string $key
+	 * @param bool $value
+	 *
+	 * @since 25.0.0
+	 */
+	public function setAppValueBool(string $key, bool $value): void;
+
+	/**
+	 * store an app wide value as array
+	 *
+	 * @param string $key
+	 * @param array $value
+	 *
+	 * @since 25.0.0
+	 */
+	public function setAppValueArray(string $key, array $value): void;
+
+	/**
 	 * Looks up an app wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the saved value
+	 *
+	 * string $default is deprecated since 25.0.0:
+	 * @see setAppDefaultValues();
+	 *
 	 * @since 20.0.0
 	 */
 	public function getAppValue(string $key, string $default = ''): string;
 
 	/**
+	 * looks up app wide defined value as integer
+	 *
+	 * @param string $key
+	 *
+	 * @return int
+	 * @since 25.0.0
+	 */
+	public function getAppValueInt(string $key): int;
+
+	/**
+	 * looks up app wide defined value as bool
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 * @since 25.0.0
+	 */
+	public function getAppValueBool(string $key): bool;
+
+	/**
+	 * looks up app wide defined value as array
+	 *
+	 * @param string $key
+	 *
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getAppValueArray(string $key): array;
+
+	/**
 	 * Delete an app wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
+	 *
 	 * @return void
 	 * @since 20.0.0
 	 */
@@ -82,12 +171,68 @@ interface IAppConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param string $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
+	 * @param string $preCondition only update if the config value was previously the value passed as
+	 *     $preCondition
+	 *
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 20.0.0
 	 */
-	public function setUserValue(string $userId, string $key, string $value, ?string $preCondition = null): void;
+	public function setUserValue(
+		string $userId,
+		string $key,
+		string $value,
+		?string $preCondition = null
+	): void;
+
+	/**
+	 * Set a user defined value as integer
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 * @param int $value
+	 * @param int|null $preCondition if current user config value for $key from database is not the one
+	 * specified as $preCondition, the method will fail silently
+	 *
+	 * @since 25.0.0
+	 */
+	public function setUserValueInt(
+		string $userId,
+		string $key,
+		int $value,
+		?int $preCondition = null
+	): void;
+
+	/**
+	 * Set a user defined value as bool
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 * @param bool $value
+	 * @param bool|null $preCondition
+	 */
+	public function setUserValueBool(
+		string $userId,
+		string $key,
+		bool $value,
+		?bool $preCondition = null
+	): void;
+
+	/**
+	 * Set a user defined value as array
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 * @param array $value
+	 * @param array|null $preCondition
+	 */
+	public function setUserValueArray(
+		string $userId,
+		string $key,
+		array $value,
+		?array $preCondition = null
+	): void;
+
 
 	/**
 	 * Shortcut for getting a user defined value
@@ -95,16 +240,54 @@ interface IAppConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
+	 * string $default is deprecated since 25.0.0:
+	 * @see setUserDefaultValues();
+	 *
 	 * @return string
 	 * @since 20.0.0
 	 */
 	public function getUserValue(string $userId, string $key, string $default = ''): string;
 
 	/**
+	 * get user defined value as integer
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 *
+	 * @return int
+	 * @since 25.0.0
+	 */
+	public function getUserValueInt(string $userId, string $key): int;
+
+	/**
+	 * get user defined value as integer
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 *
+	 * @return bool
+	 * @since 25.0.0
+	 */
+	public function getUserValueBool(string $userId, string $key): bool;
+
+	/**
+	 * get user defined value as integer
+	 *
+	 * @param string $userId
+	 * @param string $key
+	 *
+	 * @return array
+	 * @since 25.0.0
+	 */
+	public function getUserValueArray(string $userId, string $key): array;
+
+	/**
 	 * Delete a user value
 	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $key the key under which the value is being stored
+	 *
 	 * @since 20.0.0
 	 */
 	public function deleteUserValue(string $userId, string $key): void;

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -11,6 +11,7 @@
  * @author Robin Appelman <robin@icewind.nl>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Maxence Lange <maxence@artificial-owl.com>
  *
  * @license AGPL-3.0
  *
@@ -34,6 +35,7 @@ namespace OCP;
 
 /**
  * Access to all the configuration options Nextcloud offers.
+ *
  * @since 6.0.0
  */
 interface IConfig {
@@ -47,56 +49,69 @@ interface IConfig {
 	 *
 	 * @param array $configs Associative array with `key => value` pairs
 	 *                       If value is null, the config key will be deleted
+	 *
 	 * @throws HintException if config file is read-only
 	 * @since 8.0.0
 	 */
-	public function setSystemValues(array $configs);
+	public function setSystemValues(array $configs): void;
 
 	/**
 	 * Sets a new system wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved
 	 * @param mixed $value the value that should be stored
+	 *
 	 * @throws HintException if config file is read-only
 	 * @since 8.0.0
 	 */
-	public function setSystemValue($key, $value);
+	public function setSystemValue(string $key, $value): void;
+
+	public function setSystemValueInt(string $key, int $value): void;
+
+	public function setSystemValueBool(string $key, bool $value): void;
+
+	public function setSystemValueArray(string $key, array $value): void;
+
 
 	/**
 	 * Looks up a system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return mixed the value or $default
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getSystemValue($key, $default = '');
-
-	/**
-	 * Looks up a boolean system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param bool $default the default value to be returned if the value isn't set
-	 * @return bool the value or $default
-	 * @since 16.0.0
-	 */
-	public function getSystemValueBool(string $key, bool $default = false): bool;
+	public function getSystemValue(string $key, $default = '');
 
 	/**
 	 * Looks up an integer system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param int $default the default value to be returned if the value isn't set
+	 *
 	 * @return int the value or $default
 	 * @since 16.0.0
 	 */
 	public function getSystemValueInt(string $key, int $default = 0): int;
 
 	/**
+	 * Looks up a boolean system wide defined value
+	 *
+	 * @param string $key the key of the value, under which it was saved
+	 * @param bool $default the default value to be returned if the value isn't set
+	 *
+	 * @return bool the value or $default
+	 * @since 16.0.0
+	 */
+	public function getSystemValueBool(string $key, bool $default = false): bool;
+
+	/**
 	 * Looks up a string system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param string $default the default value to be returned if the value isn't set
+	 *
 	 * @return string the value or $default
 	 * @since 16.0.0
 	 */
@@ -107,27 +122,44 @@ interface IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return mixed the value or $default
 	 * @since 8.2.0
 	 */
-	public function getFilteredSystemValue($key, $default = '');
+	public function getFilteredSystemValue(string $key, $default = '');
 
 	/**
 	 * Delete a system wide defined value
 	 *
 	 * @param string $key the key of the value, under which it was saved
+	 *
 	 * @since 8.0.0
 	 */
-	public function deleteSystemValue($key);
+	public function deleteSystemValue(string $key);
 
 	/**
 	 * Get all keys stored for an app
 	 *
 	 * @param string $appName the appName that we stored the value under
+	 *
 	 * @return string[] the keys stored for the app
 	 * @since 8.0.0
 	 */
-	public function getAppKeys($appName);
+	public function getAppKeys(string $appName);
+
+
+	/**
+	 * @param string $appName
+	 * @param array $default
+	 *
+	 * @since 25.0.0
+	 */
+	public function setAppDefaultValues(string $appName, array $default): void;
+
+	public function setUserDefaultValues(string $appName, array $default): void;
+
+	public function setSystemDefaultValues(array $default): void;
+
 
 	/**
 	 * Writes a new app wide value
@@ -135,10 +167,20 @@ interface IConfig {
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string|float|int $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
+	 *
 	 * @return void
 	 * @since 6.0.0
+	 *
+	 * Note: this method might be used for mixed type of $value.
+	 * since 25.0.0, a warning is logged if this is the case.
 	 */
-	public function setAppValue($appName, $key, $value);
+	public function setAppValue(string $appName, string $key, $value): void;
+
+	public function setAppValueInt(string $appName, string $key, int $value): void;
+
+	public function setAppValueBool(string $appName, string $key, bool $value): void;
+
+	public function setAppValueArray(string $appName, string $key, array $value): void;
 
 	/**
 	 * Looks up an app wide defined value
@@ -146,16 +188,24 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
 	 * @param string $default the default value to be returned if the value isn't set
+	 *
 	 * @return string the saved value
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getAppValue($appName, $key, $default = '');
+	public function getAppValue(string $appName, string $key, $default = '');
+
+	public function getAppValueInt(string $appName, string $key, ?int $default = null): int;
+
+	public function getAppValueBool(string $appName, string $key, ?bool $default = null): bool;
+
+	public function getAppValueArray(string $appName, string $key, ?array $default = null): array;
 
 	/**
 	 * Delete an app wide defined value
 	 *
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
+	 *
 	 * @since 8.0.0
 	 */
 	public function deleteAppValue($appName, $key);
@@ -164,6 +214,7 @@ interface IConfig {
 	 * Removes all keys in appconfig belonging to the app
 	 *
 	 * @param string $appName the appName the configs are stored under
+	 *
 	 * @since 8.0.0
 	 */
 	public function deleteAppValues($appName);
@@ -176,12 +227,43 @@ interface IConfig {
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param string $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
+	 * @param string $preCondition only update if the config value was previously the value passed as
+	 *     $preCondition
+	 *
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
+	public function setUserValue(
+		string $userId,
+		string $appName,
+		string $key,
+		$value,
+		$preCondition = null
+	);
+
+	public function setUserValueInt(
+		string $userId,
+		string $appName,
+		string $key,
+		int $value,
+		?int $preCondition = null
+	);
+
+	public function setUserValueBool(
+		string $userId,
+		string $appName,
+		string $key,
+		bool $value
+	);
+
+	public function setUserValueArray(
+		string $userId,
+		string $appName,
+		string $key,
+		array $value
+	);
+
 
 	/**
 	 * Shortcut for getting a user defined value
@@ -190,10 +272,33 @@ interface IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 * @param mixed $default the default value to be returned if the value isn't set
+	 *
 	 * @return string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
 	public function getUserValue($userId, $appName, $key, $default = '');
+
+	public function getUserValueInt(
+		string $userId,
+		string $appName,
+		string $key,
+		?int $default = null
+	): int;
+
+	public function getUserValueBool(
+		string $userId,
+		string $appName,
+		string $key,
+		?bool $default = null
+	): bool;
+
+	public function getUserValueArray(
+		string $userId,
+		string $appName,
+		string $key,
+		?array $default = null
+	): array;
+
 
 	/**
 	 * Fetches a mapped list of userId -> value, for a specified app and key and a list of user IDs.
@@ -201,6 +306,7 @@ interface IConfig {
 	 * @param string $appName app to get the value for
 	 * @param string $key the key to get the value for
 	 * @param array $userIds the user IDs to fetch the values for
+	 *
 	 * @return array Mapped values: userId => value
 	 * @since 8.0.0
 	 */
@@ -211,6 +317,7 @@ interface IConfig {
 	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
+	 *
 	 * @return string[]
 	 * @since 8.0.0
 	 */
@@ -220,6 +327,7 @@ interface IConfig {
 	 * Get all user configs sorted by app of one user
 	 *
 	 * @param string $userId the userId of the user that we want to get all values from
+	 *
 	 * @psalm-return array<string, array<string, string>>
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
@@ -235,6 +343,7 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
+	 *
 	 * @since 8.0.0
 	 */
 	public function deleteUserValue($userId, $appName, $key);
@@ -243,6 +352,7 @@ interface IConfig {
 	 * Delete all user values
 	 *
 	 * @param string $userId the userId of the user that we want to remove all values from
+	 *
 	 * @since 8.0.0
 	 */
 	public function deleteAllUserValues($userId);
@@ -251,6 +361,7 @@ interface IConfig {
 	 * Delete all user related values of one app
 	 *
 	 * @param string $appName the appName of the app that we want to remove all values from
+	 *
 	 * @since 8.0.0
 	 */
 	public function deleteAppFromAllUsers($appName);
@@ -261,6 +372,7 @@ interface IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
+	 *
 	 * @return array of user IDs
 	 * @since 8.0.0
 	 */


### PR DESCRIPTION
**WIP**

- [ ] migrating code to PHP 7.4
- [ ] adding `setAppDefaultValues()`, `setUserDefaultValues()`, `setSystemDefaultValues()`
- [ ] adding `setAppValueInt()`, `setAppValueBool()`, `setAppValueArray()`
- [ ] adding `getAppValueInt()`, `getAppValueBool()`, `getAppValueArray()`
- [ ] adding `setUserValueInt()`, `setUserValueBool()`, `setUserAppValueArray()`
- [ ] adding `getUserValueInt()`, `getUserValueBool()`, `getUserAppValueArray()`
- [ ] warning in logs for long, too long, keys
- [ ] warning in logs to enforce the use of the correct `setValue()` method