### PR TITLE
Do not send display name twice for saving

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -837,7 +837,9 @@ class UsersController extends AUserData {
 		switch ($key) {
 			case self::USER_FIELD_DISPLAYNAME:
 			case IAccountManager::PROPERTY_DISPLAYNAME:
-				$targetUser->setDisplayName($value);
+				if (!$targetUser->setDisplayName($value)) {
+					throw new OCSException('Invalid displayname', 102);
+				}
 				break;
 			case self::USER_FIELD_QUOTA:
 				$quota = $value;

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1486,7 +1486,8 @@ class UsersControllerTest extends TestCase {
 		$targetUser
 			->expects($this->once())
 			->method('setDisplayName')
-			->with('NewDisplayName');
+			->with('NewDisplayName')
+			->willReturn(true);
 		$targetUser
 			->expects($this->any())
 			->method('getUID')

--- a/apps/settings/js/federationsettingsview.js
+++ b/apps/settings/js/federationsettingsview.js
@@ -128,7 +128,8 @@
 			_.each(this._inputFields, function(field) {
 				if (
 					field === 'avatar' ||
-					field === 'email'
+					field === 'email' ||
+					field === 'displayname'
 				) {
 					return;
 				}

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -215,6 +215,10 @@ class Database extends ABackend implements
 	 * Change the display name of a user
 	 */
 	public function setDisplayName(string $uid, string $displayName): bool {
+		if (mb_strlen($displayName) > 64) {
+			return false;
+		}
+
 		$this->fixDI();
 
 		if ($this->userExists($uid)) {


### PR DESCRIPTION
Additionally prevents a duplicate request to set the displayname