### PR TITLE
Move CappedMemoryCache to OCP

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -44,7 +44,7 @@ use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\ObjectStore\S3ConnectionTrait;
 use OC\Files\ObjectStore\S3ObjectTrait;

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -54,7 +54,7 @@ use Icewind\SMB\ServerFactory;
 use Icewind\SMB\System;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
 use OCA\Files_External\Lib\Notify\SMBNotifyHandler;

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -200,7 +200,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 		$this->params = $params;
 		// FIXME: private class...
-		$this->objectCache = new \OC\Cache\CappedMemoryCache();
+		$this->objectCache = new \OCP\Cache\CappedMemoryCache();
 		$this->connectionFactory = new SwiftFactory(
 			\OC::$server->getMemCacheFactory()->createDistributed('swift/'),
 			$this->params,

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -28,7 +28,7 @@
  */
 namespace OCA\Files_Sharing;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\View;
 use OCA\Files_Sharing\Event\ShareMountedEvent;
 use OCP\EventDispatcher\IEventDispatcher;

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -29,7 +29,7 @@
 
 namespace OCA\Files_Sharing;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Mount\MoveableMount;

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -45,7 +45,7 @@ namespace OCA\User_LDAP;
 use Closure;
 use Exception;
 use OC;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\ServerNotAvailableException;
 use OCP\Group\Backend\IGetDisplayNameBackend;
 use OCP\Group\Backend\IDeleteGroupBackend;

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -29,7 +29,7 @@
  */
 namespace OCA\User_LDAP;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -28,7 +28,7 @@
  */
 namespace OCA\User_LDAP\User;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\FilesystemHelper;
 use OCP\IAvatarManager;

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -30,7 +30,7 @@
 namespace OCA\WorkflowEngine;
 
 use Doctrine\DBAL\Exception;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCA\WorkflowEngine\AppInfo\Application;
 use OCA\WorkflowEngine\Check\FileMimeType;
 use OCA\WorkflowEngine\Check\FileName;

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -116,6 +116,7 @@ return array(
     'OCP\\BackgroundJob\\QueuedJob' => $baseDir . '/lib/public/BackgroundJob/QueuedJob.php',
     'OCP\\BackgroundJob\\TimedJob' => $baseDir . '/lib/public/BackgroundJob/TimedJob.php',
     'OCP\\Broadcast\\Events\\IBroadcastEvent' => $baseDir . '/lib/public/Broadcast/Events/IBroadcastEvent.php',
+    'OCP\\Cache\\CappedMemoryCache' => $baseDir . '/lib/public/Cache/CappedMemoryCache.php',
     'OCP\\Calendar\\BackendTemporarilyUnavailableException' => $baseDir . '/lib/public/Calendar/BackendTemporarilyUnavailableException.php',
     'OCP\\Calendar\\Exceptions\\CalendarException' => $baseDir . '/lib/public/Calendar/Exceptions/CalendarException.php',
     'OCP\\Calendar\\ICalendar' => $baseDir . '/lib/public/Calendar/ICalendar.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -149,6 +149,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\BackgroundJob\\QueuedJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/QueuedJob.php',
         'OCP\\BackgroundJob\\TimedJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/TimedJob.php',
         'OCP\\Broadcast\\Events\\IBroadcastEvent' => __DIR__ . '/../../..' . '/lib/public/Broadcast/Events/IBroadcastEvent.php',
+        'OCP\\Cache\\CappedMemoryCache' => __DIR__ . '/../../..' . '/lib/public/Cache/CappedMemoryCache.php',
         'OCP\\Calendar\\BackendTemporarilyUnavailableException' => __DIR__ . '/../../..' . '/lib/public/Calendar/BackendTemporarilyUnavailableException.php',
         'OCP\\Calendar\\Exceptions\\CalendarException' => __DIR__ . '/../../..' . '/lib/public/Calendar/Exceptions/CalendarException.php',
         'OCP\\Calendar\\ICalendar' => __DIR__ . '/../../..' . '/lib/public/Calendar/ICalendar.php',

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -42,7 +42,7 @@ use libphonenumber\PhoneNumber;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 use OC\Profile\TProfileHelper;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCA\Settings\BackgroundJobs\VerifyUserData;
 use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -32,7 +32,7 @@
  */
 namespace OC;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -34,7 +34,7 @@ use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\TokenPasswordExpiredException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Exceptions\WipeTokenException;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;

--- a/lib/private/Diagnostics/QueryLogger.php
+++ b/lib/private/Diagnostics/QueryLogger.php
@@ -24,7 +24,7 @@
  */
 namespace OC\Diagnostics;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCP\Diagnostics\IQueryLogger;
 
 class QueryLogger implements IQueryLogger {

--- a/lib/private/Encryption/File.php
+++ b/lib/private/Encryption/File.php
@@ -27,7 +27,7 @@
  */
 namespace OC\Encryption;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;

--- a/lib/private/Files/AppData/AppData.php
+++ b/lib/private/Files/AppData/AppData.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
  */
 namespace OC\Files\AppData;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\SimpleFS\SimpleFolder;
 use OC\SystemConfig;
 use OCP\Files\Folder;

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -28,7 +28,7 @@
  */
 namespace OC\Files\Config;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCA\Files_Sharing\SharedMount;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Config\ICachedMountFileInfo;

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -37,7 +37,7 @@
  */
 namespace OC\Files;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Mount\MountPoint;
 use OC\User\NoUserException;
 use OCP\EventDispatcher\IEventDispatcher;

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 
 namespace OC\Files\Mount;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\SetupManager;
 use OC\Files\SetupManagerFactory;

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -32,7 +32,7 @@
 
 namespace OC\Files\Node;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\FileInfo;
 use OC\Files\Mount\Manager;
 use OC\Files\Mount\MountPoint;

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -28,7 +28,7 @@
  */
 namespace OC\Files\Storage\Wrapper;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OCP\Files\Storage\IStorage;
 use OCP\ICache;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -41,7 +41,7 @@
  */
 namespace OC\Share20;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\KnownUser\KnownUserService;
 use OC\Share20\Exception\ProviderException;

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -45,7 +45,7 @@ declare(strict_types=1);
  */
 namespace OC\User;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;

--- a/lib/public/Cache/CappedMemoryCache.php
+++ b/lib/public/Cache/CappedMemoryCache.php
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Cache;
+namespace OCP\Cache;
 
 use OCP\ICache;
 
@@ -27,33 +27,45 @@ use OCP\ICache;
  * In-memory cache with a capacity limit to keep memory usage in check
  *
  * Uses a simple FIFO expiry mechanism
+ *
+ * @since 25.0.0
  * @template T
- * @deprecated use OCP\Cache\CappedMemoryCache instead
  */
 class CappedMemoryCache implements ICache, \ArrayAccess {
-	private $capacity;
+	private int $capacity;
 	/** @var T[] */
-	private $cache = [];
+	private array $cache = [];
 
-	public function __construct($capacity = 512) {
+	/**
+	 * @inheritdoc
+	 * @since 25.0.0
+	 */
+	public function __construct(int $capacity = 512) {
 		$this->capacity = $capacity;
 	}
 
+	/**
+	 * @inheritdoc
+	 * @since 25.0.0
+	 */
 	public function hasKey($key): bool {
 		return isset($this->cache[$key]);
 	}
 
 	/**
 	 * @return ?T
+	 * @since 25.0.0
 	 */
 	public function get($key) {
 		return $this->cache[$key] ?? null;
 	}
 
 	/**
+	 * @inheritdoc
 	 * @param string $key
 	 * @param T $value
 	 * @param int $ttl
+	 * @since 25.0.0
 	 * @return bool
 	 */
 	public function set($key, $value, $ttl = 0): bool {
@@ -66,22 +78,34 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 		return true;
 	}
 
-	public function remove($key) {
+	/**
+	 * @since 25.0.0
+	 */
+	public function remove($key): bool {
 		unset($this->cache[$key]);
 		return true;
 	}
 
-	public function clear($prefix = '') {
+	/**
+	 * @inheritdoc
+	 * @since 25.0.0
+	 */
+	public function clear($prefix = ''): bool {
 		$this->cache = [];
 		return true;
 	}
 
+	/**
+	 * @since 25.0.0
+	 */
 	public function offsetExists($offset): bool {
 		return $this->hasKey($offset);
 	}
 
 	/**
+	 * @inheritdoc
 	 * @return T
+	 * @since 25.0.0
 	 */
 	#[\ReturnTypeWillChange]
 	public function &offsetGet($offset) {
@@ -89,27 +113,36 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	}
 
 	/**
+	 * @inheritdoc
 	 * @param string $offset
 	 * @param T $value
-	 * @return void
+	 * @since 25.0.0
 	 */
 	public function offsetSet($offset, $value): void {
 		$this->set($offset, $value);
 	}
 
+	/**
+	 * @inheritdoc
+	 * @since 25.0.0
+	 */
 	public function offsetUnset($offset): void {
 		$this->remove($offset);
 	}
 
 	/**
 	 * @return T[]
+	 * @since 25.0.0
 	 */
-	public function getData() {
+	public function getData(): array {
 		return $this->cache;
 	}
 
 
-	private function garbageCollect() {
+	/**
+	 * @since 25.0.0
+	 */
+	private function garbageCollect(): void {
 		while (count($this->cache) > $this->capacity) {
 			reset($this->cache);
 			$key = key($this->cache);
@@ -117,6 +150,10 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 		}
 	}
 
+	/**
+	 * @inheritdoc
+	 * @since 25.0.0
+	 */
 	public static function isAvailable(): bool {
 		return true;
 	}

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -11,15 +11,15 @@ namespace Test\App;
 use OC;
 use OC\App\InfoParser;
 use Test\TestCase;
+use OCP\Cache\CappedMemoryCache;
 
 class InfoParserTest extends TestCase {
-	/** @var OC\Cache\CappedMemoryCache */
+	/** @var OCP\Cache\CappedMemoryCache */
 	private static $cache;
 
 	public static function setUpBeforeClass(): void {
-		self::$cache = new OC\Cache\CappedMemoryCache();
+		self::$cache = new CappedMemoryCache();
 	}
-
 
 	public function parserTest($expectedJson, $xmlFile, $cache = null) {
 		$parser = new InfoParser($cache);

--- a/tests/lib/Cache/CappedMemoryCacheTest.php
+++ b/tests/lib/Cache/CappedMemoryCacheTest.php
@@ -30,11 +30,11 @@ namespace Test\Cache;
 class CappedMemoryCacheTest extends TestCache {
 	protected function setUp(): void {
 		parent::setUp();
-		$this->instance = new \OC\Cache\CappedMemoryCache();
+		$this->instance = new \OCP\Cache\CappedMemoryCache();
 	}
 
 	public function testSetOverCap() {
-		$instance = new \OC\Cache\CappedMemoryCache(3);
+		$instance = new \OCP\Cache\CappedMemoryCache(3);
 
 		$instance->set('1', 'a');
 		$instance->set('2', 'b');

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -11,7 +11,7 @@ namespace Test\Files\Config;
 use OC\DB\QueryBuilder\Literal;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Storage;
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\User\Manager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\ICachedMountInfo;

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -8,7 +8,7 @@
 
 namespace Test\Files\Node;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\FileInfo;
 use OC\Files\Mount\Manager;
 use OC\Files\Node\Folder;

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -7,7 +7,7 @@
 
 namespace Test\Files;
 
-use OC\Cache\CappedMemoryCache;
+use OCP\Cache\CappedMemoryCache;
 use OC\Files\Cache\Watcher;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;


### PR DESCRIPTION
This is an helpful helper that should be used in more place than just
server and this is already the case with groupfodlers, deck, user_oidc
and more using it, so let's make it public

## how to port your app

```
find lib -iname '*.php' -exec sed -i 's/OC\\Cache\\Capped/OCP\\Cache\\Capped/g' {} \;
```