### PR TITLE
Fix detection of firefox in ContentSecurityPolicyNonceManager

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -80,10 +80,8 @@ class ContentSecurityPolicyNonceManager {
 	public function browserSupportsCspV3(): bool {
 		$browserWhitelist = [
 			Request::USER_AGENT_CHROME,
-			// Firefox 45+
-			'/^Mozilla\/5\.0 \([^)]+\) Gecko\/[0-9.]+ Firefox\/(4[5-9]|[5-9][0-9])\.[0-9.]+$/',
-			// Safari 12+
-			'/^Mozilla\/5\.0 \([^)]+\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\) Version\/(?:1[2-9]|[2-9][0-9])\.[0-9]+(?:\.[0-9]+)? Safari\/[0-9.A-Z]+$/',
+			Request::USER_AGENT_FIREFOX,
+			Request::USER_AGENT_SAFARI,
 		];
 
 		if ($this->request->isUserAgent($browserWhitelist)) {


### PR DESCRIPTION
Reuse Request::USER_AGENT_FIREFOX, and also update the safari detection
since safari < 12 is not supported anymore and we can remove a bit of
code duplication

Thanks @fancycode for the finding

Fix #33045