### PR TITLE
Run performance testing in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -34,16 +34,19 @@ jobs:
 
           php -S localhost:8080 &
       - name: Apply blueprint
-        uses: icewind1991/blueprint@v0.1.1
+        uses: icewind1991/blueprint@v0.1.2
         with:
-          blueprint: apps/blueprint/blueprints/small.toml
-
+          blueprint: tests/blueprints/basic.toml
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Run before measurements
-        uses: nextcloud/profiler@44befceb459ca489ba17a14c3f17683ab7206660
+        uses: nextcloud/profiler@fa03a1e6864fcb63fb92b8940fa72f5191baffbe
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
             curl -s -u test:test http://localhost:8080/remote.php/dav/files/test/test.txt
+            curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test/many_files
+            curl -s -u test:test -T README.md http://localhost:8080/remote.php/dav/files/test/new_file.txt
+            curl -s -u test:test -X DELETE http://localhost:8080/remote.php/dav/files/test/new_file.txt
           output: before.json
 
       - name: Apply PR
@@ -56,11 +59,14 @@ jobs:
 
       - name: Run after measurements
         id: compare
-        uses: nextcloud/profiler@44befceb459ca489ba17a14c3f17683ab7206660
+        uses: nextcloud/profiler@fa03a1e6864fcb63fb92b8940fa72f5191baffbe
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
             curl -s -u test:test http://localhost:8080/remote.php/dav/files/test/test.txt
+            curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test/many_files
+            curl -s -u test:test -T README.md http://localhost:8080/remote.php/dav/files/test/new_file.txt
+            curl -s -u test:test -X DELETE http://localhost:8080/remote.php/dav/files/test/new_file.txt
           output: after.json
           compare-with: before.json
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -32,34 +32,20 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
 
-          cd apps
-          git clone https://github.com/icewind1991/blueprint
-          cd blueprint
-          composer install
-          cd ..
-
-          git clone -b cli https://github.com/nextcloud/profiler
-          cd ..
-
-          ./occ app:enable --force blueprint
-          ./occ app:enable --force profiler
-
-          ./occ profiler:enable
-          ./occ blueprint:enable
-          ./occ blueprint:apply apps/blueprint/blueprints/small.toml
-
           php -S localhost:8080 &
-      - name: Run warmup
-        run: |
-          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+      - name: Apply blueprint
+        uses: icewind1991/blueprint@v0.1.1
+        with:
+          blueprint: apps/blueprint/blueprints/small.toml
+
       - name: Run before measurements
-        run: |
-          rm -rf data/profiler
+        uses: nextcloud/profiler@44befceb459ca489ba17a14c3f17683ab7206660
+        with:
+          run: |
+            curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+            curl -s -u test:test http://localhost:8080/remote.php/dav/files/test/test.txt
+          output: before.json
 
-          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
-
-          ./occ profiler:list
-          ./occ profiler:export > before.json
       - name: Apply PR
         run: |
           git fetch origin ${{ github.event.pull_request.head.ref }}
@@ -67,16 +53,19 @@ jobs:
           git submodule update
 
           ./occ upgrade
+
       - name: Run after measurements
-        run: |
-          rm -rf data/profiler
-
-          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
-
-          ./occ profiler:list
-          ./occ profiler:export > after.json
+        id: compare
+        uses: nextcloud/profiler@44befceb459ca489ba17a14c3f17683ab7206660
+        with:
+          run: |
+            curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+            curl -s -u test:test http://localhost:8080/remote.php/dav/files/test/test.txt
+          output: after.json
+          compare-with: before.json
 
       - name: Upload profiles
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: profiles
@@ -84,11 +73,6 @@ jobs:
             before.json
             after.json
 
-      - name: Compare measurements
-        uses: mathiasvr/command-output@v1
-        id: compare
-        with:
-          run: ./occ profiler:compare before.json after.json
       - uses: actions/github-script@v5
         if: failure() && steps.compare.outcome == 'failure'
         with:
@@ -98,7 +82,7 @@ jobs:
             comment += `<details><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.compare.outputs.stdout }}
+            ${{ steps.compare.outputs.compare }}
             \`\`\`
 
             </details>`;

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,111 @@
+name: Performance testing
+on:
+  pull_request:
+
+jobs:
+  performance-testing:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.0']
+
+    name: performance-${{ matrix.php-versions }}
+
+    steps:
+      - name: Checkout server before PR
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: phpunit
+          extensions: mbstring, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
+
+      - name: Set up Nextcloud
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
+
+          cd apps
+          git clone https://github.com/icewind1991/blueprint
+          cd blueprint
+          composer install
+          cd ..
+
+          git clone -b cli https://github.com/nextcloud/profiler
+          cd ..
+
+          ./occ app:enable --force blueprint
+          ./occ app:enable --force profiler
+
+          ./occ profiler:enable
+          ./occ blueprint:enable
+          ./occ blueprint:apply apps/blueprint/blueprints/small.toml
+
+          php -S localhost:8080 &
+      - name: Run warmup
+        run: |
+          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+      - name: Run before measurements
+        run: |
+          rm -rf data/profiler
+
+          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+
+          ./occ profiler:list
+          ./occ profiler:export > before.json
+      - name: Apply PR
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+          git submodule update
+
+          ./occ upgrade
+      - name: Run after measurements
+        run: |
+          rm -rf data/profiler
+
+          curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
+
+          ./occ profiler:list
+          ./occ profiler:export > after.json
+
+      - name: Upload profiles
+        uses: actions/upload-artifact@v2
+        with:
+          name: profiles
+          path: |
+            before.json
+            after.json
+
+      - name: Compare measurements
+        uses: mathiasvr/command-output@v1
+        id: compare
+        with:
+          run: ./occ profiler:compare before.json after.json
+      - uses: actions/github-script@v5
+        if: failure() && steps.compare.outcome == 'failure'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            let comment = `Possible performance regression detected\n`;
+            comment += `<details><summary>Show Output</summary>
+
+            \`\`\`
+            ${{ steps.compare.outputs.stdout }}
+            \`\`\`
+
+            </details>`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            })

--- a/tests/blueprints/basic.toml
+++ b/tests/blueprints/basic.toml
@@ -1,0 +1,20 @@
+[[user]]
+id = "test"
+groups = ["test_group"]
+files = [
+	"test.txt",
+	"foo/sub.png",
+	"empty",
+]
+
+[[user]]
+id = "test2"
+groups = ["test"]
+files = [
+	"many_files/file_[1..100].txt"
+]
+
+[[share]]
+from = "test2"
+to = "test"
+file = "many_files"


### PR DESCRIPTION
Runs a set of queries before and after applying the PR and compare the queries used by the requests

Example of output when a regression is detected: https://github.com/icewind1991/server/pull/1#issuecomment-1171197170

Besides the comment when a regression is detected, the action uploads the exported profiles to ease investigation into the cause of the regression

Future work:

- [ ] improved way for defining the queries to run
- [ ] also show report if the number of queries is reduced
- [ ] allow viewing the exported profiles in the profiler app