### PR TITLE
Allow to expire comments of multiple objects with one call

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -1650,14 +1650,18 @@ class Manager implements ICommentsManager {
 	/**
 	 * @inheritDoc
 	 */
-	public function deleteMessageExpiredAtObject(string $objectType, string $objectId): bool {
+	public function deleteCommentsExpiredAtObject(string $objectType, string $objectId = ''): bool {
 		$qb = $this->dbConn->getQueryBuilder();
-		$affectedRows = $qb->delete('comments')
+		$qb->delete('comments')
 			->where($qb->expr()->lt('expire_date',
 				$qb->createNamedParameter($this->timeFactory->getDateTime(), IQueryBuilder::PARAM_DATE)))
-			->andWhere($qb->expr()->eq('object_type', $qb->createNamedParameter($objectType)))
-			->andWhere($qb->expr()->eq('object_id', $qb->createNamedParameter($objectId)))
-			->executeStatement();
+			->andWhere($qb->expr()->eq('object_type', $qb->createNamedParameter($objectType)));
+
+		if ($objectId !== '') {
+			$qb->andWhere($qb->expr()->eq('object_id', $qb->createNamedParameter($objectId)));
+		}
+
+		$affectedRows = $qb->executeStatement();
 
 		$this->commentsCache = [];
 

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -488,9 +488,9 @@ interface ICommentsManager {
 	 * Only will delete the message related with the object.
 	 *
 	 * @param string $objectType the object type (e.g. 'files')
-	 * @param string $objectId e.g. the file id
+	 * @param string $objectId e.g. the file id, leave empty to expire on all objects of this type
 	 * @return boolean true if at least one row was deleted
 	 * @since 25.0.0
 	 */
-	public function deleteMessageExpiredAtObject(string $objectType, string $objectId): bool;
+	public function deleteCommentsExpiredAtObject(string $objectType, string $objectId = ''): bool;
 }

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -142,7 +142,7 @@ class FakeManager implements ICommentsManager {
 		return [];
 	}
 
-	public function deleteMessageExpiredAtObject(string $objectType, string $objectId): bool {
+	public function deleteCommentsExpiredAtObject(string $objectType, string $objectId = ''): bool {
 		return true;
 	}
 }


### PR DESCRIPTION
Also adjusting the method names to refer to comments and not (talks wording) messages