### PR TITLE
fix external storages access

### DIFF
--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -28,7 +28,6 @@ namespace OC\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Handler\CurlHandler;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
@@ -63,8 +62,7 @@ class ClientService implements IClientService {
 	 * @return Client
 	 */
 	public function newClient(): IClient {
-		$handler = new CurlHandler();
-		$stack = HandlerStack::create($handler);
+		$stack = HandlerStack::create();
 		$stack->push($this->dnsPinMiddleware->addDnsPinning());
 
 		$client = new GuzzleClient(['handler' => $stack]);

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -10,7 +10,6 @@ namespace Test\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Handler\CurlHandler;
 use OC\Http\Client\Client;
 use OC\Http\Client\ClientService;
 use OC\Http\Client\DnsPinMiddleware;
@@ -42,8 +41,7 @@ class ClientServiceTest extends \Test\TestCase {
 			$localAddressChecker
 		);
 
-		$handler = new CurlHandler();
-		$stack = HandlerStack::create($handler);
+		$stack = HandlerStack::create();
 		$stack->push($dnsPinMiddleware->addDnsPinning());
 		$guzzleClient = new GuzzleClient(['handler' => $stack]);
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/30282

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=fix/30282/external-storages \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.130 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>