### PR TITLE
[Stable23] Logging, updating status for general error in federation

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -99,9 +99,11 @@ class SyncService {
 			if ($ex->getCode() === Http::STATUS_UNAUTHORIZED) {
 				// remote server revoked access to the address book, remove it
 				$this->backend->deleteAddressBook($addressBookId);
-				$this->logger->info('Authorization failed, remove address book: ' . $url, ['app' => 'dav']);
-				throw $ex;
+				$this->logger->error('Authorization failed, remove address book: ' . $url, ['app' => 'dav']);
+			} else {
+				$this->logger->error('Client exception:', ['app' => 'dav', 'exception' => $ex]);
 			}
+			throw $ex;
 		}
 
 		// 3. apply changes

--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -26,21 +26,20 @@
 namespace OCA\Federation;
 
 use OC\BackgroundJob\TimedJob;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class SyncJob extends TimedJob {
 
 	/** @var SyncFederationAddressBooks */
 	protected $syncService;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	protected $logger;
 
 	/**
 	 * @param SyncFederationAddressBooks $syncService
-	 * @param ILogger $logger
 	 */
-	public function __construct(SyncFederationAddressBooks $syncService, ILogger $logger) {
+	public function __construct(SyncFederationAddressBooks $syncService, LoggerInterface $logger) {
 		// Run once a day
 		$this->setInterval(24 * 60 * 60);
 		$this->syncService = $syncService;
@@ -50,11 +49,11 @@ class SyncJob extends TimedJob {
 	protected function run($argument) {
 		$this->syncService->syncThemAll(function ($url, $ex) {
 			if ($ex instanceof \Exception) {
-				$this->logger->logException($ex, [
-					'message' => "Error while syncing $url.",
-					'level' => ILogger::INFO,
-					'app' => 'fed-sync',
-				]);
+				$this->logger->error("Error while syncing $url.",
+					[
+						'exception' => $ex
+					]
+				);
 			}
 		});
 	}

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -31,14 +31,19 @@ namespace OCA\Federation\Tests;
 use OC\OCS\DiscoveryService;
 use OCA\Federation\DbHandler;
 use OCA\Federation\SyncFederationAddressBooks;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 	/** @var array */
 	private $callBacks = [];
 
-	/** @var  \PHPUnit\Framework\MockObject\MockObject | DiscoveryService */
+	/** @var  MockObject | DiscoveryService */
 	private $discoveryService;
+
+	/** @var MockObject|LoggerInterface  */
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -46,10 +51,11 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		$this->discoveryService = $this->getMockBuilder(DiscoveryService::class)
 			->disableOriginalConstructor()->getMock();
 		$this->discoveryService->expects($this->any())->method('discover')->willReturn([]);
+		$this->logger = $this->createMock(LoggerInterface::class);
 	}
 
 	public function testSync() {
-		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $dbHandler */
+		/** @var DbHandler | MockObject $dbHandler */
 		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')->
 			disableOriginalConstructor()->
 			getMock();
@@ -62,8 +68,8 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 					'sync_token' => '0'
 				]
 			]);
-		$dbHandler->expects($this->once())->method('setServerStatus')->
-			with('https://cloud.drop.box', 1, '1');
+		$dbHandler->expects($this->once())->method('setServerStatus')
+			->with('https://cloud.drop.box', 1, '1');
 		$syncService = $this->getMockBuilder('OCA\DAV\CardDAV\SyncService')
 			->disableOriginalConstructor()
 			->getMock();
@@ -71,7 +77,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 			->willReturn(1);
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
-		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService);
+		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
 		$s->syncThemAll(function ($url, $ex) {
 			$this->callBacks[] = [$url, $ex];
 		});
@@ -79,7 +85,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 	}
 
 	public function testException() {
-		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $dbHandler */
+		/** @var DbHandler | MockObject $dbHandler */
 		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')->
 		disableOriginalConstructor()->
 		getMock();
@@ -99,7 +105,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 			->willThrowException(new \Exception('something did not work out'));
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
-		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService);
+		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
 		$s->syncThemAll(function ($url, $ex) {
 			$this->callBacks[] = [$url, $ex];
 		});


### PR DESCRIPTION
Add some more logging and logging at the appropriate level. Also, the sync status was only updated for a specific error case when the server revoked access but not on general failure. This has been added too.

Manual backport of https://github.com/nextcloud/server/pull/33104