### PR TITLE
Update expire_date column of table comments

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -1351,7 +1351,8 @@ class Manager implements ICommentsManager {
 			->set('creation_timestamp', $qb->createNamedParameter($comment->getCreationDateTime(), 'datetime'))
 			->set('latest_child_timestamp', $qb->createNamedParameter($comment->getLatestChildDateTime(), 'datetime'))
 			->set('object_type', $qb->createNamedParameter($comment->getObjectType()))
-			->set('object_id', $qb->createNamedParameter($comment->getObjectId()));
+			->set('object_id', $qb->createNamedParameter($comment->getObjectId()))
+			->set('expire_date', $qb->createNamedParameter($comment->getExpireDate(), 'datetime'));
 
 		if ($tryWritingReferenceId) {
 			$qb->set('reference_id', $qb->createNamedParameter($comment->getReferenceId()));

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -516,15 +516,41 @@ class ManagerTest extends TestCase {
 			->setActor('users', 'alice')
 			->setObject('files', 'file64')
 			->setMessage('very beautiful, I am impressed!')
-			->setVerb('comment');
+			->setVerb('comment')
+			->setExpireDate(new \DateTime('+2 hours'));
 
-		$manager->save($comment);
-
-		$comment->setMessage('very beautiful, I am really so much impressed!');
 		$manager->save($comment);
 
 		$loadedComment = $manager->get($comment->getId());
+		// Compare current object with database values
 		$this->assertSame($comment->getMessage(), $loadedComment->getMessage());
+		$this->assertSame(
+			$comment->getExpireDate()->format('Y-m-d H:i:s'),
+			$loadedComment->getExpireDate()->format('Y-m-d H:i:s')
+		);
+
+		// Preserve the original comment to compare after update
+		$original = clone $comment;
+
+		// Update values
+		$comment->setMessage('very beautiful, I am really so much impressed!')
+			->setExpireDate(new \DateTime('+1 hours'));
+		$manager->save($comment);
+
+		$loadedComment = $manager->get($comment->getId());
+		// Compare current object with database values
+		$this->assertSame($comment->getMessage(), $loadedComment->getMessage());
+		$this->assertSame(
+			$comment->getExpireDate()->format('Y-m-d H:i:s'),
+			$loadedComment->getExpireDate()->format('Y-m-d H:i:s')
+		);
+
+		// Compare original object with database values
+		$this->assertNotSame($original->getMessage(), $loadedComment->getMessage());
+		$this->assertNotSame(
+			$original->getExpireDate()->format('Y-m-d H:i:s'),
+			$loadedComment->getExpireDate()->format('Y-m-d H:i:s')
+		);
 	}
 
 


### PR DESCRIPTION
The Talk app started to use this column but we didn't implemented the update feature to change the expire date of a specific comment.

We need to have this at server side, as talk is not the only thing using comments and the API should work for all things.