### PR TITLE
Fix translation of home breadcrumb

### DIFF
--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -220,7 +220,7 @@
 			});
 			// root part
 			crumbs.push({
-				name: t('core', 'Home'),
+				name: t('files', 'Home'),
 				dir: '/',
 				class: 'crumbhome',
 				linkclass: rootIcon || 'icon-home'


### PR DESCRIPTION
The existing translations were not being used e.g. https://github.com/nextcloud/server/blob/ec465bf247ec2e9fd3df13f6a289ecc5fb6e4e2a/apps/files/l10n/sv.json#L9