### PR TITLE
Fix empty address books being exported

### DIFF
--- a/apps/dav/lib/UserMigration/ContactsMigrator.php
+++ b/apps/dav/lib/UserMigration/ContactsMigrator.php
@@ -131,6 +131,10 @@ class ContactsMigrator implements IMigrator, ISizeEstimationMigrator {
 			}
 		}
 
+		if (count($vCards) === 0) {
+			throw new InvalidAddressBookException();
+		}
+
 		return [
 			'name' => $addressBookNode->getName(),
 			'displayName' => $addressBookInfo['{DAV:}displayname'],


### PR DESCRIPTION
This prevents empty `*.vcf` files from being created in `<export_archive_root>/dav/address_books/`