### PR TITLE
Fix reading blob data as resource

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -113,6 +113,9 @@ abstract class Entity {
 				$type = $this->_fieldTypes[$name];
 				if ($type === 'blob') {
 					// (B)LOB is treated as string when we read from the DB
+					if (is_resource($args[0])) {
+						$args[0] = stream_get_contents($args[0]);
+					}
 					$type = 'string';
 				}
 

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -43,6 +43,8 @@ use PHPUnit\Framework\Constraint\IsType;
  * @method bool getAnotherBool()
  * @method bool isAnotherBool()
  * @method void setAnotherBool(bool $anotherBool)
+ * @method string getLongText()
+ * @method void setLongText(string $longText)
  */
 class TestEntity extends Entity {
 	protected $name;
@@ -51,11 +53,13 @@ class TestEntity extends Entity {
 	protected $preName;
 	protected $trueOrFalse;
 	protected $anotherBool;
+	protected $longText;
 
 	public function __construct($name = null) {
 		$this->addType('testId', 'integer');
 		$this->addType('trueOrFalse', 'bool');
 		$this->addType('anotherBool', 'boolean');
+		$this->addType('longText', 'blob');
 		$this->name = $name;
 	}
 }
@@ -210,6 +214,18 @@ class EntityTest extends \Test\TestCase {
 		$this->assertSame(null, $entity->getId());
 	}
 
+	public function testSetterConvertsResourcesToStringProperly() {
+		$string = 'Definitely a string';
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, $string);
+		rewind($stream);
+
+		$entity = new TestEntity();
+		$entity->setLongText($stream);
+		fclose($stream);
+		$this->assertSame($string, $entity->getLongText());
+	}
+
 
 	public function testGetFieldTypes() {
 		$entity = new TestEntity();
@@ -218,6 +234,7 @@ class EntityTest extends \Test\TestCase {
 			'testId' => 'integer',
 			'trueOrFalse' => 'bool',
 			'anotherBool' => 'boolean',
+			'longText' => 'blob',
 		], $entity->getFieldTypes());
 	}
 


### PR DESCRIPTION
PostgreSQL returns data as resource when using `IQueryBuilder::PARAM_LOB` (which is used for QBMapper).

Previously we just converted this resource using `settype`, which produced things like `"Resource id #14"` instead of the actual resource data.

Now we read the stream correctly if the returned data is a resource

See context at #22472

Fixes #22439
