### PR TITLE
Set special header for 503 maintenance mode

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -295,6 +295,7 @@ class OC {
 		if (((bool) $systemConfig->getValue('maintenance', false)) && OC::$SUBURI != '/core/ajax/update.php') {
 			// send http status 503
 			http_response_code(503);
+			header('X-Nextcloud-Maintenance-Mode: 1');
 			header('Retry-After: 120');
 
 			// render error page


### PR DESCRIPTION
This removes ambiguity with a 503 returned by Nextcloud maintenance mode, some app's code, web server, proxy or
similar. Front-end and clients can then handle this state accordingly.

This will be helpful for https://github.com/nextcloud/mail/issues/5714.