### PR TITLE
Do not redirect if requested font, style or script can not be found

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1055,6 +1055,15 @@ class OC {
 			return;
 		}
 
+		// Handle resources that can't be found
+		// This prevents browsers from redirecting to the default page and then
+		// attempting to parse HTML as CSS and similar.
+		$destinationHeader = $request->getHeader('Sec-Fetch-Dest');
+		if (in_array($destinationHeader, ['font', 'script', 'style'])) {
+			http_response_code(404);
+			return;
+		}
+
 		// Someone is logged in
 		if (\OC::$server->getUserSession()->isLoggedIn()) {
 			OC_App::loadApps();


### PR DESCRIPTION
If a page in Nextcloud requests a font, stylesheet or script that doesn't exist we currently redirect to the default page. This comes with the following consequences
* The redirect causes one additional HTTP request per page load
* The request to the default page causes server load
* The requested default page causes traffic
* The browser requests a font, CSS or JavaScript and gets HTML. This causes a parsing error, e.g. ``The stylesheet https://localhost/apps/dashboard/ was not loaded because its MIME type, “text/html”, is not “text/css”.`` 

User routing is not affected by this. If you navigate to ``<domain>/apps/phpmymailapp`` Nextcloud still redirects to the default page. That behavior is desired.

Tested with FF and Chromium.

Ref https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest