### PR TITLE
Fix 404 handling of requested JSON/XML

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1048,6 +1048,13 @@ class OC {
 			return;
 		}
 
+		// Handle requests for JSON or XML
+		$acceptHeader = $request->getHeader('Accept');
+		if (in_array($acceptHeader, ['application/json', 'application/xml'], true)) {
+			http_response_code(404);
+			return;
+		}
+
 		// Someone is logged in
 		if (\OC::$server->getUserSession()->isLoggedIn()) {
 			OC_App::loadApps();


### PR DESCRIPTION
If front-end or an application requests JSON/XML, there is no point in
redirecting to the default page if that response doesn't exist. In the
worst case that would just cause another request, therefore server load,
traffic and a response that is meaningless to the requester.

Tested with

```js
axios.get('/apps/mail/nothing', {
	headers: {
		Accept: 'application/json',
	},
})
``` 