### PR TITLE
Fix listening for circle events in SetupManager

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -554,10 +554,10 @@ class SetupManager {
 		});
 
 		$genericEvents = [
-			'\OCA\Circles::onCircleCreation',
-			'\OCA\Circles::onCircleDestruction',
-			'\OCA\Circles::onMemberNew',
-			'\OCA\Circles::onMemberLeaving',
+			'OCA\Circles\Events\CreatingCircleEvent',
+			'OCA\Circles\Events\DestroyingCircleEvent',
+			'OCA\Circles\Events\AddingCircleMemberEvent',
+			'OCA\Circles\Events\RemovingCircleMemberEvent',
 		];
 
 		foreach ($genericEvents as $genericEvent) {


### PR DESCRIPTION
So far, SetupManager listened for deprecated events that are no longer
triggered. Instead, use the circle events that actually get triggered
when adding or removing a circle or circle member. Also, these events
get triggered on each instance of a globalscale setup.

Fixes: #33210

Signed-off-by: Jonas <jonas@freesources.org>