### PR TITLE
Allow to estimate free space when using object storage

### DIFF
--- a/lib/private/Files/ObjectStore/Azure.php
+++ b/lib/private/Files/ObjectStore/Azure.php
@@ -25,6 +25,7 @@ namespace OC\Files\ObjectStore;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
 use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
+use OCP\Files\FileInfo;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class Azure implements IObjectStore {
@@ -132,5 +133,18 @@ class Azure implements IObjectStore {
 
 	public function copyObject($from, $to) {
 		$this->getBlobClient()->copyBlob($this->containerName, $to, $this->containerName, $from);
+	}
+
+	public function bytesUsed(): int {
+		// The only way to get the bytes used is by listing every object
+		// in the blob and sum their size
+		return FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function bytesQuota(): int {
+		// Azure doesn't have a way to set a quota on a specific blob container,
+		// only on a storage account
+		// https://learn.microsoft.com/en-us/answers/questions/627442/blob-general-v2-container-quota.html
+		return FileInfo::SPACE_UNLIMITED;
 	}
 }

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -27,8 +27,9 @@ namespace OC\Files\ObjectStore;
 
 use OC\User\User;
 use OCP\IUser;
+use OCP\Files\IHomeStorage;
 
-class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IHomeStorage {
+class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage {
 	/**
 	 * The home user storage requires a user object to create a unique storage id
 	 * @param array $params
@@ -60,7 +61,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 
 	/**
 	 * @param string $path, optional
-	 * @return \OC\User\User
+	 * @return User
 	 */
 	public function getUser($path = null): IUser {
 		return $this->user;

--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -25,6 +25,7 @@ namespace OC\Files\ObjectStore;
 
 use Aws\Result;
 use Exception;
+use OCP\Files\FileInfo;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 
@@ -109,5 +110,17 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 			'Key' => $urn,
 			'UploadId' => $uploadId
 		]);
+	}
+
+	public function bytesUsed(): int {
+		// The only way to get the bytes used is by listing every object
+		// in the bucket and sum their size
+		return FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function bytesQuota(): int {
+		// The quota is not obtainable through the S3 API, only through the
+		// specific Amazon Service Quotas API
+		return FileInfo::SPACE_UNLIMITED;
 	}
 }

--- a/lib/private/Files/ObjectStore/StorageObjectStore.php
+++ b/lib/private/Files/ObjectStore/StorageObjectStore.php
@@ -23,6 +23,7 @@
  */
 namespace OC\Files\ObjectStore;
 
+use OCP\Files\FileInfo;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\Storage\IStorage;
 use function is_resource;
@@ -90,5 +91,13 @@ class StorageObjectStore implements IObjectStore {
 
 	public function copyObject($from, $to) {
 		$this->storage->copy($from, $to);
+	}
+
+	public function bytesUsed(): int {
+		return FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function bytesQuota(): int {
+		return FileInfo::SPACE_UNLIMITED;
 	}
 }

--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -29,6 +29,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Utils;
 use Icewind\Streams\RetryWrapper;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\StorageAuthException;
@@ -151,5 +152,13 @@ class Swift implements IObjectStore {
 		$this->getContainer()->getObject($from)->copy([
 			'destination' => $this->getContainer()->name . '/' . $to
 		]);
+	}
+
+	public function bytesUsed(): int {
+		return $this->getContainer()->bytesUsed;
+	}
+
+	public function bytesQuota(): int {
+		return $this->getContainer()->getMetadata()['Quota-Bytes'] ?? FileInfo::SPACE_UNLIMITED;
 	}
 }

--- a/lib/public/Files/ObjectStore/IObjectStore.php
+++ b/lib/public/Files/ObjectStore/IObjectStore.php
@@ -80,4 +80,18 @@ interface IObjectStore {
 	 * @since 21.0.0
 	 */
 	public function copyObject($from, $to);
+
+	/**
+	 * Returns the number of bytes used in the object store
+	 *
+	 * @since 26.0.0
+	 */
+	public function bytesUsed(): int;
+
+	/**
+	 * Returns the eventual quota of the object store, in bytes
+	 *
+	 * @since 26.0.0
+	 */
+	public function bytesQuota(): int;
 }

--- a/tests/lib/Files/ObjectStore/FailDeleteObjectStore.php
+++ b/tests/lib/Files/ObjectStore/FailDeleteObjectStore.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Test\Files\ObjectStore;
 
+use OCP\Files\FileInfo;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class FailDeleteObjectStore implements IObjectStore {
@@ -54,5 +55,13 @@ class FailDeleteObjectStore implements IObjectStore {
 
 	public function copyObject($from, $to) {
 		$this->objectStore->copyObject($from, $to);
+	}
+
+	public function bytesUsed(): int {
+		return FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function bytesQuota(): int {
+		return FileInfo::SPACE_UNLIMITED;
 	}
 }

--- a/tests/lib/Files/ObjectStore/FailWriteObjectStore.php
+++ b/tests/lib/Files/ObjectStore/FailWriteObjectStore.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Test\Files\ObjectStore;
 
+use OCP\Files\FileInfo;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class FailWriteObjectStore implements IObjectStore {
@@ -55,5 +56,13 @@ class FailWriteObjectStore implements IObjectStore {
 
 	public function copyObject($from, $to) {
 		$this->objectStore->copyObject($from, $to);
+	}
+
+	public function bytesUsed(): int {
+		return FileInfo::SPACE_UNKNOWN;
+	}
+
+	public function bytesQuota(): int {
+		return FileInfo::SPACE_UNLIMITED;
 	}
 }


### PR DESCRIPTION
With ObjectStorage there's no way to determine the free space for a bucket with a limited storage quota, so it's hard to detect when you have a space issue (there's nothing like `disk_free_space`).

It would be better if the object storage provider would provide us this information, but at least for S3 it's hard or impossible to get this information easily, so this can be an appropriate workaround in the meanwhile.

~~Using an AppConfig instead of a SystemConfig might be more flexible for admins to change the value, but it might also introduce a database overhead.~~

When using the `Local` storage regular `disk_free_space` is used instead.

Still need to check if and how this affects external storages.