### PR TITLE
fix `Add to your Nextcloud`

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -560,7 +560,7 @@ class ShareController extends AuthPublicShareController {
 			$downloadAll = new SimpleMenuAction('download', $this->l10n->t('Download all files'), 'icon-download', $shareTmpl['downloadURL'], 10, $shareTmpl['fileSize']);
 			$directLink = new LinkMenuAction($this->l10n->t('Direct link'), 'icon-public', $shareTmpl['previewURL']);
 			// TRANSLATORS The placeholder refers to the software product name as in 'Add to your Nextcloud'
-			$externalShare = new ExternalShareMenuAction($this->l10n->t('Add to your %s', [$this->defaults->getProductName()]), 'icon-external', $shareTmpl['owner'], $shareTmpl['shareOwner'], $shareTmpl['filename']);
+			$externalShare = new ExternalShareMenuAction($this->l10n->t('Add to your Nextcloud'), 'icon-external', $shareTmpl['owner'], $shareTmpl['shareOwner'], $shareTmpl['filename']);
 
 			$responseComposer = [];
 


### PR DESCRIPTION
See https://help.nextcloud.com/t/label-add-to-your-nextcloud-hanssonit-vm-is-confusing-people/142101/12

Signed-off-by: szaimen <szaimen@e.mail.de>