### PR TITLE
Move \OC\User\NoUserException to OCP

### DIFF
--- a/apps/dashboard/lib/Service/BackgroundService.php
+++ b/apps/dashboard/lib/Service/BackgroundService.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 namespace OCA\Dashboard\Service;
 
 use InvalidArgumentException;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\Files\File;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
@@ -143,7 +143,7 @@ class BackgroundService {
 	 * @throws NotPermittedException
 	 * @throws LockedException
 	 * @throws PreConditionNotMetException
-	 * @throws NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	public function setFileBackground($path): void {
 		$this->config->setUserValue($this->userId, 'dashboard', 'background', 'custom');

--- a/apps/dav/lib/BackgroundJob/EventReminderJob.php
+++ b/apps/dav/lib/BackgroundJob/EventReminderJob.php
@@ -54,7 +54,7 @@ class EventReminderJob extends TimedJob {
 	/**
 	 * @throws \OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException
 	 * @throws \OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	public function run($argument):void {
 		if ($this->config->getAppValue('dav', 'sendEventReminders', 'yes') !== 'yes') {

--- a/apps/dav/lib/BackgroundJob/UploadCleanup.php
+++ b/apps/dav/lib/BackgroundJob/UploadCleanup.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\BackgroundJob;
 
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;

--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -329,7 +329,7 @@ class UserHooks implements IHook {
 	 * init mount points for given user
 	 *
 	 * @param string $user
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	protected function initMountPoints($user) {
 		Filesystem::initMountPoints($user);

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -93,7 +93,7 @@ class OwnershipTransferService {
 	 * @param OutputInterface|null $output
 	 * @param bool $move
 	 * @throws TransferOwnershipException
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	public function transfer(IUser $sourceUser,
 							 IUser $destinationUser,

--- a/apps/files_external/lib/Command/Create.php
+++ b/apps/files_external/lib/Command/Create.php
@@ -26,7 +26,7 @@ namespace OCA\Files_External\Command;
 
 use OC\Core\Command\Base;
 use OC\Files\Filesystem;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\DefinitionParameter;

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -25,7 +25,7 @@
 namespace OCA\Files_External\Command;
 
 use OC\Core\Command\Base;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -26,7 +26,7 @@
 namespace OCA\Files_External\Command;
 
 use OC\Core\Command\Base;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -44,7 +44,7 @@ use OCP\Files\IHomeStorage;
 use OCP\Files\Node;
 use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Wrapper\PermissionsMask;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -95,7 +95,7 @@ class Trashbin {
 	 *
 	 * @param string $filename
 	 * @return array
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	public static function getUidAndFilename($filename) {
 		$uid = Filesystem::getOwner($filename);

--- a/apps/files_versions/lib/Sabre/VersionHome.php
+++ b/apps/files_versions/lib/Sabre/VersionHome.php
@@ -23,7 +23,7 @@
  */
 namespace OCA\Files_Versions\Sabre;
 
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\Files\IRootFolder;
 use OCP\IUserManager;

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -105,7 +105,7 @@ class Storage {
 	 *
 	 * @param string $filename
 	 * @return array
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	public static function getUidAndFilename($filename) {
 		$uid = Filesystem::getOwner($filename);
@@ -755,7 +755,7 @@ class Storage {
 			$user = \OC::$server->get(IUserManager::class)->get($uid);
 			if (is_null($user)) {
 				$logger->error('Backends provided no user object for ' . $uid, ['app' => 'files_versions']);
-				throw new \OC\User\NoUserException('Backends provided no user object for ' . $uid);
+				throw new \OCP\User\NoUserException('Backends provided no user object for ' . $uid);
 			}
 
 			\OC_Util::setupFS($uid);

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -629,7 +629,7 @@ class VersioningTest extends \Test\TestCase {
 
 
 	public function testExpireNonexistingUser() {
-		$this->expectException(\OC\User\NoUserException::class);
+		$this->expectException(\OCP\User\NoUserException::class);
 
 		$this->logout();
 		// needed to have a FS setup (the background job does this)

--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -33,7 +33,7 @@ namespace OCA\Provisioning_API\Controller;
 
 use OC\Group\Manager;
 use OC\User\Backend;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OC_Helper;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\PropertyDoesNotExistException;

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -31,7 +31,7 @@ namespace OCA\Provisioning_API\Tests\Controller;
 
 use OC\Group\Manager;
 use OC\SubAdmin;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Provisioning_API\Controller\GroupsController;
 use OCP\Accounts\IAccountManager;
 use OCP\IConfig;

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -42,7 +42,7 @@ namespace OCA\ShareByMail;
 
 use OC\Share20\Exception\InvalidShare;
 use OC\Share20\Share;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\ShareByMail\Settings\SettingsManager;
 use OCP\Activity\IManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;

--- a/apps/testing/lib/Controller/LockingController.php
+++ b/apps/testing/lib/Controller/LockingController.php
@@ -23,7 +23,7 @@
 namespace OCA\Testing\Controller;
 
 use OC\Lock\DBLockingProvider;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\Testing\Locking\FakeDBLockingProvider;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -40,7 +40,7 @@ namespace OCA\User_LDAP;
 
 use OC\ServerNotAvailableException;
 use OC\User\Backend;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCA\User_LDAP\Exceptions\NotOnLDAP;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
@@ -429,7 +429,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 *
 	 * @param string $uid the username
 	 * @return bool|string
-	 * @throws NoUserException
+	 * @throws \OCP\User\NoUserException
 	 * @throws \Exception
 	 */
 	public function getHome($uid) {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -616,6 +616,7 @@ return array(
     'OCP\\User\\Events\\UserLoggedInWithCookieEvent' => $baseDir . '/lib/public/User/Events/UserLoggedInWithCookieEvent.php',
     'OCP\\User\\Events\\UserLoggedOutEvent' => $baseDir . '/lib/public/User/Events/UserLoggedOutEvent.php',
     'OCP\\User\\GetQuotaEvent' => $baseDir . '/lib/public/User/GetQuotaEvent.php',
+    'OCP\\User\\NoUserException' => $baseDir . '/lib/public/User/NoUserException.php',
     'OCP\\Util' => $baseDir . '/lib/public/Util.php',
     'OCP\\WorkflowEngine\\EntityContext\\IContextPortation' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IContextPortation.php',
     'OCP\\WorkflowEngine\\EntityContext\\IDisplayName' => $baseDir . '/lib/public/WorkflowEngine/EntityContext/IDisplayName.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -649,6 +649,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\User\\Events\\UserLoggedInWithCookieEvent' => __DIR__ . '/../../..' . '/lib/public/User/Events/UserLoggedInWithCookieEvent.php',
         'OCP\\User\\Events\\UserLoggedOutEvent' => __DIR__ . '/../../..' . '/lib/public/User/Events/UserLoggedOutEvent.php',
         'OCP\\User\\GetQuotaEvent' => __DIR__ . '/../../..' . '/lib/public/User/GetQuotaEvent.php',
+        'OCP\\User\\NoUserException' => __DIR__ . '/../../..' . '/lib/public/User/NoUserException.php',
         'OCP\\Util' => __DIR__ . '/../../..' . '/lib/public/Util.php',
         'OCP\\WorkflowEngine\\EntityContext\\IContextPortation' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IContextPortation.php',
         'OCP\\WorkflowEngine\\EntityContext\\IDisplayName' => __DIR__ . '/../../..' . '/lib/public/WorkflowEngine/EntityContext/IDisplayName.php',

--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -37,7 +37,7 @@ namespace OC\Avatar;
 
 use OC\KnownUser\KnownUserService;
 use OC\User\Manager;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\Files\IAppData;

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -45,7 +45,7 @@ class File implements ICache {
 	 *
 	 * @return \OC\Files\View cache storage
 	 * @throws \OC\ForbiddenException
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	protected function getStorage() {
 		if ($this->storage !== null) {

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -31,7 +31,7 @@ use OC\Encryption\Util;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\ServerNotAvailableException;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\Encryption\Keys\IStorage;
 use OCP\IConfig;
 use OCP\Security\ICrypto;

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -39,7 +39,7 @@ namespace OC\Files;
 
 use OCP\Cache\CappedMemoryCache;
 use OC\Files\Mount\MountPoint;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
 use OCP\Files\NotFoundException;
@@ -366,7 +366,7 @@ class Filesystem {
 	 * Initialize system and personal mount points for a user
 	 *
 	 * @param string|IUser|null $user
-	 * @throws \OC\User\NoUserException if the user is not available
+	 * @throws \OCP\User\NoUserException if the user is not available
 	 */
 	public static function initMountPoints($user = '') {
 		/** @var IUserManager $userManager */

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -39,7 +39,7 @@ use OC\Files\Mount\MountPoint;
 use OC\Files\Utils\PathHelper;
 use OC\Files\View;
 use OC\Hooks\PublicEmitter;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
@@ -358,7 +358,7 @@ class Root extends Folder implements IRootFolder {
 	 *
 	 * @param string $userId user ID
 	 * @return \OCP\Files\Folder
-	 * @throws NoUserException
+	 * @throws \OCP\User\NoUserException
 	 * @throws NotPermittedException
 	 */
 	public function getUserFolder($userId) {

--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -186,7 +186,7 @@ class TemplateManager implements ITemplateManager {
 	 * @return Folder
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 */
 	private function getTemplateFolder(): Node {
 		if ($this->getTemplatePath() !== '') {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2155,7 +2155,7 @@ class View {
 	/**
 	 * @param string $filename
 	 * @return array
-	 * @throws \OC\User\NoUserException
+	 * @throws \OCP\User\NoUserException
 	 * @throws NotFoundException
 	 */
 	public function getUidAndFilename($filename) {

--- a/lib/private/User/NoUserException.php
+++ b/lib/private/User/NoUserException.php
@@ -22,5 +22,6 @@
  */
 namespace OC\User;
 
-class NoUserException extends \Exception {
+/** @depreacted 25.0.0 */
+class NoUserException extends \OCP\User\NoUserException {
 }

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -322,7 +322,7 @@ class Session implements IUserSession, Emitter {
 		$currentUser = $this->getUser();
 
 		if ($currentUser === null) {
-			throw new \OC\User\NoUserException();
+			throw new \OCP\User\NoUserException();
 		}
 		$this->session->set('oldUserId', $currentUser->getUID());
 	}

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -25,7 +25,7 @@
 namespace OCP\Files;
 
 use OC\Hooks\Emitter;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 
 /**
  * Interface IRootFolder

--- a/lib/public/User/NoUserException.php
+++ b/lib/public/User/NoUserException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCP\User;
+
+/**
+ * @since 25.0.0
+ */
+class NoUserException extends \Exception {
+}

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -24,7 +24,7 @@ namespace Test\Files;
 
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
-use OC\User\NoUserException;
+use OCP\User\NoUserException;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
@@ -340,16 +340,16 @@ class FilesystemTest extends \Test\TestCase {
 	 *
 	 */
 	public function testLocalMountWhenUserDoesNotExist() {
-		$this->expectException(\OC\User\NoUserException::class);
+		$this->expectException(\OCP\User\NoUserException::class);
 
 		$userId = $this->getUniqueID('user_');
 
 		\OC\Files\Filesystem::initMountPoints($userId);
 	}
 
-	
+
 	public function testNullUserThrows() {
-		$this->expectException(\OC\User\NoUserException::class);
+		$this->expectException(\OCP\User\NoUserException::class);
 
 		\OC\Files\Filesystem::initMountPoints(null);
 	}

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -210,7 +210,7 @@ class RootTest extends \Test\TestCase {
 
 
 	public function testGetUserFolderWithNoUserObj() {
-		$this->expectException(\OC\User\NoUserException::class);
+		$this->expectException(\OCP\User\NoUserException::class);
 		$this->expectExceptionMessage('Backends provided no user object');
 
 		$root = new \OC\Files\Node\Root(


### PR DESCRIPTION
The NoUserException might be useful for apps and is already used quite a lot as `IRootFolder::getUserFolder` may throw it.

First commit is the new class, second refactors the server usages.