### PR TITLE
FilePicker: Hide `newButton` outline if only picking is allowed

### DIFF
--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -321,7 +321,7 @@ const Dialogs = {
 
 			var newButton = self.$filePicker.find('.actions.creatable .button-add')
 			if (type === self.FILEPICKER_TYPE_CHOOSE && !options.allowDirectoryChooser) {
-				newButton.hide()
+				self.$filePicker.find('.actions.creatable').hide()
 			}
 			newButton.on('focus', function() {
 				self.$filePicker.ocdialog('setEnterCallback', function(event) {


### PR DESCRIPTION
* Fixes: #33142

If the filepicker mode is set to `FILEPICKER_TYPE_CHOOSE`
currently only the button but not the outline of it is hidden.

This changes the behavior to also hide the outline.