### PR TITLE
Add skip content buttons to the public page layout

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -31,6 +31,11 @@
 <?php foreach ($_['initialStates'] as $app => $initialState) { ?>
 	<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
 <?php }?>
+	<div id="skip-actions">
+		<?php if ($_['id-app-content'] !== null) { ?><a href="<?php p($_['id-app-content']); ?>" class="button primary skip-navigation skip-content"><?php p($l->t('Skip to main content')); ?></a><?php } ?>
+		<?php if ($_['id-app-navigation'] !== null) { ?><a href="<?php p($_['id-app-navigation']); ?>" class="button primary skip-navigation"><?php p($l->t('Skip to navigation of app')); ?></a><?php } ?>
+	</div>
+
 	<div id="notification-container">
 		<div id="notification"></div>
 	</div>

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -282,8 +282,8 @@ class TemplateLayout extends \OC_Template {
 
 		$this->assign('initialStates', $this->initialState->getInitialStates());
 
-		$this->assign('id-app-content', '#app-content');
-		$this->assign('id-app-navigation', '#app-navigation');
+		$this->assign('id-app-content', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-content' : '#content');
+		$this->assign('id-app-navigation', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-navigation' : null);
 	}
 
 	/**


### PR DESCRIPTION
Add the skip to navigation/content buttons to public pages as well. For the other layouts it didn't seem to be that useful as there is no navigation with apps or additional buttons in the right header section that are necessary to be skippable.

Follow up to https://github.com/nextcloud/server/pull/33247

For public pages the app-navigation skip button is disabled by default as it is more likely that there is none with non-vue apps like for files_sharing and public share links.
