### PR TITLE
fix loading legacy app.php with multi app dir

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -183,7 +183,7 @@ class OC_App {
 				'app' => $app,
 			]);
 			try {
-				self::requireAppFile($app);
+				self::requireAppFile($appPath);
 			} catch (Throwable $ex) {
 				if ($ex instanceof ServerNotAvailableException) {
 					throw $ex;


### PR DESCRIPTION
Scenarion: two app dirs are configured in config.php, and in both dirs is a copy of a file, with different versions. The business logic should only load from the location with the highest version.

The issue in a screenshot:

![Screenshot_20220718_200729](https://user-images.githubusercontent.com/2184312/179576911-f117d093-d580-4394-9852-9c4678a8a1ea.png)

- requireAppFile() only appends /appinfo/app.php
- without the absolute path, require_once looks into include_path
- the first match in inlcude_path however migth be different from appPath
- fixed by providing the tested(!), full path to the app

contributes to fixing https://github.com/nextcloud/server/issues/8929

