### PR TITLE
[files app]: Fix dark color mode detection for filelist

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1787,8 +1787,11 @@
 			td.append(linkElem);
 			tr.append(td);
 
-			var enabledThemes = window.OCA?.Theming?.enabledThemes || []
-			var isDarkTheme = enabledThemes.join('').indexOf('dark') !== -1
+			const enabledThemes = window.OCA?.Theming?.enabledThemes || []
+			// Check enabled themes, if system default is selected check the browser
+			const isDarkTheme = (enabledThemes.length === 0 || enabledThemes[0] === 'default')
+				? window.matchMedia('(prefers-color-scheme: dark)').matches
+				: enabledThemes.join('').indexOf('dark') !== -1
 
 			try {
 				var maxContrastHex = window.getComputedStyle(document.documentElement)


### PR DESCRIPTION
* This fixes #33298

The color of the file list entries is dynamically calculated, but clipped to readable values.
This clipping is currently broken when using the system color theme and the system is using a dark color theme.

When system default color theme is selected for theming, the `enabledThemes` array
is empty or just contains one entry `'default'`, in this case the color theme has
to be retrieved from the browser to ensure text like the modified date is readable.

**Before**:
![Color theme detection broken](https://user-images.githubusercontent.com/1855448/180043779-1e1c5815-978a-46b5-8f67-140700d11bf4.png)

**After:**
![Readable file list as the colortheme detection is fixed](https://user-images.githubusercontent.com/1855448/180045062-57c1c4b3-d4dd-41d5-b921-7c33db0d5c45.png)
