### PR TITLE
Fix: files_versions store

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -194,7 +194,9 @@ class Storage {
 
 		$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 		$fileInfo = $files_view->getFileInfo($filename);
-		if ($fileInfo === false) return false;
+		if ($fileInfo === false) {
+			return false;
+		}
 		$id = $fileInfo->getId();
 		$nodes = \OC::$server->get(IRootFolder::class)->getUserFolder($uid)->getById($id);
 		foreach ($nodes as $node) {

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -194,6 +194,7 @@ class Storage {
 
 		$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 		$fileInfo = $files_view->getFileInfo($filename);
+		if ($fileInfo === false) return false;
 		$id = $fileInfo->getId();
 		$nodes = \OC::$server->get(IRootFolder::class)->getUserFolder($uid)->getById($id);
 		foreach ($nodes as $node) {


### PR DESCRIPTION
In version 7.5.2 of [Nextcloud ONLYOFFICE integration app](https://github.com/ONLYOFFICE/onlyoffice-nextcloud) we have changed file saving (https://github.com/ONLYOFFICE/onlyoffice-nextcloud/commit/1468eff4e4b9c54f3a037314698b5c484d0f568a):
we call `\OC_Util::setupFS` with the owner of the file
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/f77c15953d9956a74f45cd0a5acef215d495a2ab/controller/callbackcontroller.php#L498

and call `\OC_User::setUserId` with the author of the changes
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/f77c15953d9956a74f45cd0a5acef215d495a2ab/controller/callbackcontroller.php#L468

In general, the save is successful. But an error occurs when editing a shared file from a group folder or from external storage. And in the logs there is an error from the File Versions application
ONLYOFFICE/onlyoffice-nextcloud#660

This fix makes the save work.

Hi @juliushaertl @PVince81 
can you help?

Signed-off-by: Sergey Linnik <sergey.linnik@onlyoffice.com>

Thanks