### PR TITLE
Reset user status based on message ID only

### DIFF
--- a/apps/user_status/lib/Connector/UserStatusProvider.php
+++ b/apps/user_status/lib/Connector/UserStatusProvider.php
@@ -62,10 +62,10 @@ class UserStatusProvider implements IProvider, ISettableProvider {
 	}
 
 	public function revertUserStatus(string $userId, string $messageId, string $status): void {
-		$this->service->revertUserStatus($userId, $messageId, $status);
+		$this->service->revertUserStatus($userId, $messageId);
 	}
 
 	public function revertMultipleUserStatus(array $userIds, string $messageId, string $status): void {
-		$this->service->revertMultipleUserStatus($userIds, $messageId, $status);
+		$this->service->revertMultipleUserStatus($userIds, $messageId);
 	}
 }

--- a/apps/user_status/lib/Db/UserStatusMapper.php
+++ b/apps/user_status/lib/Db/UserStatusMapper.php
@@ -160,15 +160,13 @@ class UserStatusMapper extends QBMapper {
 	 *
 	 * @param string $userId
 	 * @param string $messageId
-	 * @param string $status
 	 * @return bool True if an entry was deleted
 	 */
-	public function deleteCurrentStatusToRestoreBackup(string $userId, string $messageId, string $status): bool {
+	public function deleteCurrentStatusToRestoreBackup(string $userId, string $messageId): bool {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
 			->andWhere($qb->expr()->eq('message_id', $qb->createNamedParameter($messageId)))
-			->andWhere($qb->expr()->eq('status', $qb->createNamedParameter($status)))
 			->andWhere($qb->expr()->eq('is_backup', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
 		return $qb->executeStatement() > 0;
 	}

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -496,7 +496,7 @@ class StatusService {
 		}
 	}
 
-	public function revertUserStatus(string $userId, string $messageId, string $status): void {
+	public function revertUserStatus(string $userId, string $messageId): void {
 		try {
 			/** @var UserStatus $userStatus */
 			$backupUserStatus = $this->mapper->findByUserId($userId, true);
@@ -505,7 +505,7 @@ class StatusService {
 			return;
 		}
 
-		$deleted = $this->mapper->deleteCurrentStatusToRestoreBackup($userId, $messageId, $status);
+		$deleted = $this->mapper->deleteCurrentStatusToRestoreBackup($userId, $messageId);
 		if (!$deleted) {
 			// Another status is set automatically or no status, do nothing
 			return;
@@ -517,7 +517,7 @@ class StatusService {
 		$this->mapper->update($backupUserStatus);
 	}
 
-	public function revertMultipleUserStatus(array $userIds, string $messageId, string $status): void {
+	public function revertMultipleUserStatus(array $userIds, string $messageId): void {
 		// Get all user statuses and the backups
 		$findById = $userIds;
 		foreach ($userIds as $userId) {
@@ -528,8 +528,7 @@ class StatusService {
 		$backups = $restoreIds = $statuesToDelete = [];
 		foreach ($userStatuses as $userStatus) {
 			if (!$userStatus->getIsBackup()
-				&& $userStatus->getMessageId() === $messageId
-				&& $userStatus->getStatus() === $status) {
+				&& $userStatus->getMessageId() === $messageId) {
 				$statuesToDelete[$userStatus->getUserId()] = $userStatus->getId();
 			} else if ($userStatus->getIsBackup()) {
 				$backups[$userStatus->getUserId()] = $userStatus->getId();

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -795,24 +795,34 @@ class StatusServiceTest extends TestCase {
 		$backupOnly->setUserId('_backuponly');
 		$backupOnly->setIsBackup(true);
 
+		$noBackupDND = new UserStatus();
+		$noBackupDND->setId(5);
+		$noBackupDND->setStatus(IUserStatus::DND);
+		$noBackupDND->setStatusTimestamp(1337);
+		$noBackupDND->setIsUserDefined(false);
+		$noBackupDND->setMessageId('call');
+		$noBackupDND->setUserId('nobackupanddnd');
+		$noBackupDND->setIsBackup(false);
+
 		$this->mapper->expects($this->once())
 			->method('findByUserIds')
-			->with(['john', 'nobackup', 'backuponly', '_john', '_nobackup', '_backuponly'])
+			->with(['john', 'nobackup', 'backuponly', 'nobackupanddnd', '_john', '_nobackup', '_backuponly', '_nobackupanddnd'])
 			->willReturn([
 				$john,
 				$johnBackup,
 				$noBackup,
 				$backupOnly,
+				$noBackupDND,
 			]);
 
 		$this->mapper->expects($this->once())
 			->method('deleteByIds')
-			->with([1, 3]);
+			->with([1, 3, 5]);
 
 		$this->mapper->expects($this->once())
 			->method('restoreBackupStatuses')
 			->with([2]);
 
-		$this->service->revertMultipleUserStatus(['john', 'nobackup', 'backuponly'], 'call', IUserStatus::AWAY);
+		$this->service->revertMultipleUserStatus(['john', 'nobackup', 'backuponly', 'nobackupanddnd'], 'call');
 	}
 }


### PR DESCRIPTION
Since some statuses (call) can occure with different status
(away and dnd) we need to reset only based on the message id.
But as it can not be set by the user this is still save and okay.

Fix #33314 