### PR TITLE
Document pitfalls when building production assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build-js:
 	npm run dev
 
 build-js-production:
+	@echo Using node version $(shell node -v) and npm version $(shell npm -v)
+	@echo Please make sure you are using the same version as recommended in the README.md
+	@echo
 	npm run build
 
 watch-js:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Otherwise, git checkouts can be handled the same as release archives, by using t
 
 #### Pre-requisites
 
+##### Node JS
+
 You will need Node.js and npm to be able to build assets during development and for checking in.
 
 One way to do this is by [setting up nvm](https://github.com/nvm-sh/nvm#install--update-script) and then running the following commands:
@@ -69,6 +71,13 @@ nvm install 14.20.0
 
 npm i -g npm@"^7.0.0"
 ```
+
+##### App folders
+
+If you are using additional apps that are not present in this repository, please make sure that they are checked out in a separate folder "apps-extra" (or similar).
+Otherwise the build script for production assets will include styles and icons from unrelated apps and this will result in a asset mismatches causing a failure in CI.
+
+See the `apps_paths` [config.php setting](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html) for further details.
 
 #### Building
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Otherwise, git checkouts can be handled the same as release archives, by using t
 
 ### Working with front-end code 🏗
 
+#### Pre-requisites
+
+You will need Node.js and npm to be able to build assets during development and for checking in.
+
+One way to do this is by [setting up nvm](https://github.com/nvm-sh/nvm#install--update-script) and then running the following commands:
+```
+# install and select node version
+nvm install 14.20.0
+
+npm i -g npm@"^7.0.0"
+```
+
 #### Building
 
 We are moving more and more towards using Vue.js in the frontend, starting with Settings. For building the code on changes, use these terminal commands in the root folder:


### PR DESCRIPTION
Otherwise building assets for production will fail CI due to
differences.

Because it's super annoying to get CI fails despite having been nice enough to run `make build-js-production` (example: https://github.com/nextcloud/server/pull/33321)
