### PR TITLE
Fix handling of internal errors when uploading theming files

### DIFF
--- a/apps/theming/js/settings-admin.js
+++ b/apps/theming/js/settings-admin.js
@@ -127,7 +127,8 @@ window.addEventListener('DOMContentLoaded', function () {
 		},
 		fail: function (e, response){
 			var $form = $(e.target).closest('form');
-			OC.msg.finishedError('#theming_settings_msg', response._response.jqXHR.responseJSON.data.message);
+			const responseJSON = response._response.jqXHR.responseJSON;
+			OC.msg.finishedError('#theming_settings_msg', responseJSON && responseJSON.data && responseJSON.data.message ? responseJSON.data.message : t('theming', 'Error uploading the file'));
 			$form.find('label.button').addClass('icon-upload').removeClass('icon-loading-small');
 			$('#theming_settings_loading').hide();
 		}


### PR DESCRIPTION
When a file can not be uploaded in the Theming app due to an expected error (like an invalid mime type) [the response contains a `data.message` field](https://github.com/nextcloud/server/blob/d1dfdfe7998a3c77a22ebba01be90747744c8ac9/apps/theming/lib/Controller/ThemingController.php#L209-L217). However, if the upload fails due to an unexpected error (like an internal error, for example if the `mime_content_type` function is disabled) there is no such field, so it should not be used.

## How to test

- For simplicity, just force an internal error by adding `throw new \Exception();` to [`ThemingController::updateImage`](https://github.com/nextcloud/server/blob/d1dfdfe7998a3c77a22ebba01be90747744c8ac9/apps/theming/lib/Controller/ThemingController.php#L187)
- Log in to Nextcloud as an admin
- Open the Theming section in the Adminstration settings
- Upload a logo

### Result with this pull request

_Error uploading the file_ is shown and the spinner on the upload button is replaced again with the upload icon

### Result without this pull request

No error message is shown and the spinner on the upload button never ends
