### PR TITLE
Make sure app menu text opacity matches the icons

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -529,7 +529,7 @@ nav[role=navigation] {
   transform: translateY(-7px);
 }
 #appmenu:hover li span {
-  opacity: 0.6;
+  opacity: 1;
   bottom: 2px;
   z-index: -1;
   /* fix clickability issue - otherwise we need to move the span into the link */

--- a/core/css/header.scss
+++ b/core/css/header.scss
@@ -527,7 +527,7 @@ nav[role='navigation'] {
 
 			/* Show app title */
 			span {
-				opacity: .6;
+				opacity: 1;
 				bottom: 2px;
 				z-index: -1; /* fix clickability issue - otherwise we need to move the span into the link */
 			}

--- a/core/css/server.css
+++ b/core/css/server.css
@@ -2810,7 +2810,7 @@ nav[role=navigation] {
   transform: translateY(-7px);
 }
 #appmenu:hover li span {
-  opacity: 0.6;
+  opacity: 1;
   bottom: 2px;
   z-index: -1;
   /* fix clickability issue - otherwise we need to move the span into the link */


### PR DESCRIPTION
Otherwise the text has a lower opacity than the icons and doesn't match the expected 3:1 contrast ratio