### PR TITLE
Don't try to purge objects from the birthday calendar when it doesn't exist

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -273,6 +273,9 @@ class BirthdayService {
 	public function resetForUser(string $user):void {
 		$principal = 'principals/users/'.$user;
 		$calendar = $this->calDavBackEnd->getCalendarByUri($principal, self::BIRTHDAY_CALENDAR_URI);
+		if (!$calendar) {
+			return; // The user's birthday calendar doesn't exist, no need to purge it
+		}
 		$calendarObjects = $this->calDavBackEnd->getCalendarObjects($calendar['id'], CalDavBackend::CALENDAR_TYPE_CALENDAR);
 
 		foreach ($calendarObjects as $calendarObject) {


### PR DESCRIPTION
Doesn't matter much as it's been recreated afterwards (with `ensureCalendarExists`).

Closes #29617
