### PR TITLE
Delete comments that expired now

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -1652,7 +1652,7 @@ class Manager implements ICommentsManager {
 	public function deleteCommentsExpiredAtObject(string $objectType, string $objectId = ''): bool {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('comments')
-			->where($qb->expr()->lt('expire_date',
+			->where($qb->expr()->lte('expire_date',
 				$qb->createNamedParameter($this->timeFactory->getDateTime(), IQueryBuilder::PARAM_DATE)))
 			->andWhere($qb->expr()->eq('object_type', $qb->createNamedParameter($objectType)));
 

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -753,6 +753,9 @@ class ManagerTest extends TestCase {
 		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file1', new \DateTime('-2 hours'));
 		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file2', new \DateTime('-2 hours'));
 		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file3', new \DateTime('-2 hours'));
+		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file3', new \DateTime());
+		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file3', new \DateTime());
+		$ids[] = $this->addDatabaseEntry(0, 0, null, null, 'file3', new \DateTime());
 
 		$manager = new Manager(
 			$this->connection,
@@ -777,7 +780,7 @@ class ManagerTest extends TestCase {
 			}
 		}
 		$this->assertSame($exists, 0);
-		$this->assertSame($deleted, 3);
+		$this->assertSame($deleted, 6);
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back


### PR DESCRIPTION
**Problem**: Now, the method that delete expired messages use `<` and, if the message expire exactly in the same time of now, the message won't be deleted.

**Solution**: I changed the comparison from `<` to `<=` to delete messages expired now.

fix: https://github.com/nextcloud/spreed/pull/7629

Previous pr: #32863 