### PR TITLE
Remove legacy #dir element in files list

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -231,6 +231,7 @@
 		 * @param options.dragOptions drag options, disabled by default
 		 * @param options.folderDropOptions folder drop options, disabled by default
 		 * @param options.scrollTo name of file to scroll to after the first load
+		 * @param [options.dir='/'] current directory
 		 * @param {OC.Files.Client} [options.filesClient] files API client
 		 * @param {OC.Backbone.Model} [options.filesConfig] files app configuration
 		 * @private
@@ -412,6 +413,10 @@
 				this.$fileList.one('updated', function() {
 					self.scrollTo(options.scrollTo);
 				});
+			}
+
+			if (!_.isUndefined(options.dir)) {
+				this._setCurrentDir(options.dir || '/', false);
 			}
 
 			if(options.openFile) {
@@ -2049,7 +2054,7 @@
 		 * @return current directory
 		 */
 		getCurrentDirectory: function(){
-			return this._currentDirectory || this.$el.find('#dir').val() || '/';
+			return this._currentDirectory || '/';
 		},
 		/**
 		 * Returns the directory permissions
@@ -2130,9 +2135,6 @@
 				targetDir = '/' + targetDir;
 			}
 			this._currentDirectory = targetDir;
-
-			// legacy stuff
-			this.$el.find('#dir').val(targetDir);
 
 			if (changeUrl !== false) {
 				var params = {

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -71,7 +71,6 @@
 	</tfoot>
 </table>
 <div class="filelist-footer"></div>
-<input type="hidden" name="dir" id="dir" value="" />
 <div class="hiddenuploadfield">
 	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]" />
 </div>

--- a/apps/files/templates/recentlist.php
+++ b/apps/files/templates/recentlist.php
@@ -2,8 +2,6 @@
 
 <div class="emptyfilelist emptycontent hidden"></div>
 
-<input type="hidden" name="dir" value="" id="dir">
-
 <div class="nofilterresults emptycontent hidden">
 	<div class="icon-search"></div>
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>

--- a/apps/files/templates/simplelist.php
+++ b/apps/files/templates/simplelist.php
@@ -4,8 +4,6 @@
 	<p><?php p($l->t('Files and folders you mark as favorite will show up here')); ?></p>
 </div>
 
-<input type="hidden" name="dir" value="" id="dir">
-
 <div class="nofilterresults emptycontent hidden">
 	<div class="icon-search"></div>
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>

--- a/apps/files/tests/js/favoritesfilelistspec.js
+++ b/apps/files/tests/js/favoritesfilelistspec.js
@@ -30,7 +30,6 @@ describe('OCA.Files.FavoritesFileList tests', function() {
 		$('#testArea').append(
 			'<div id="app-content-container">' +
 			// init horrible parameters
-			'<input type="hidden" id="dir" value="/"></input>' +
 			'<input type="hidden" id="permissions" value="31"></input>' +
 			// dummy controls
 			'<div class="files-controls">' +

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -33,7 +33,6 @@ describe('OCA.Files.FileActions tests', function() {
 		clock = sinon.useFakeTimers();
 		// init horrible parameters
 		var $body = $('#testArea');
-		$body.append('<input type="hidden" id="dir" value="/subdir"></input>');
 		$body.append('<input type="hidden" id="permissions" value="31"></input>');
 		$body.append('<table class="files-filestable list-container view-grid"><tbody class="files-fileList"></tbody></table>');
 		// dummy files table
@@ -66,13 +65,14 @@ describe('OCA.Files.FileActions tests', function() {
 		fileList = new OCA.Files.FileList($body, {
 			fileActions: fileActions
 		});
+		fileList.changeDirectory('/subdir', false, true);
 	});
 	afterEach(function() {
 		fileActions = null;
 		fileList.destroy();
 		fileList = undefined;
 		clock.restore();
-		$('#dir, #permissions, .files-filestable').remove();
+		$('#permissions, .files-filestable').remove();
 	});
 	it('calling clear() clears file actions', function() {
 		fileActions.clear();

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -31,7 +31,6 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 	beforeEach(function() {
 		// init horrible parameters
 		var $body = $('#testArea');
-		$body.append('<input type="hidden" id="dir" value="/subdir"></input>');
 		$body.append('<input type="hidden" id="permissions" value="31"></input>');
 		// dummy files table
 		actionStub = sinon.stub();
@@ -39,6 +38,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 		fileList = new OCA.Files.FileList($body, {
 			fileActions: fileActions
 		});
+		fileList.changeDirectory('/subdir', false, true);
 
 		fileActions.registerAction({
 			name: 'Testdropdown',
@@ -100,7 +100,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 		fileList.destroy();
 		fileList = undefined;
 		menu.remove();
-		$('#dir, #permissions, .files-filestable').remove();
+		$('#permissions, .files-filestable').remove();
 	});
 
 	describe('rendering', function() {

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -584,7 +584,7 @@ OCA.Files_External.StatusManager.Utils = {
 	isCorrectViewAndRootFolder: function () {
 		// correct views = files & extstoragemounts
 		if (OCA.Files.App.getActiveView() === 'files' || OCA.Files.App.getActiveView() === 'extstoragemounts') {
-			return OCA.Files.App.getCurrentAppContainer().find('#dir').val() === '/';
+			return OCA.Files.App.currentFileList.getCurrentDirectory() === '/';
 		}
 		return false;
 	},

--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -8,8 +8,6 @@
 	<h2><?php p($l->t('No external storage configured or you don\'t have the permission to configure them')); ?></h2>
 </div>
 
-<input type="hidden" name="dir" value="" id="dir">
-
 <table class="files-filestable list-container <?php p($_['showgridview'] ? 'view-grid' : '') ?>">
 	<thead>
 		<tr>

--- a/apps/files_external/tests/js/mountsfilelistSpec.js
+++ b/apps/files_external/tests/js/mountsfilelistSpec.js
@@ -33,7 +33,6 @@ describe('OCA.Files_External.FileList tests', function() {
 		$('#testArea').append(
 			'<div id="app-content-container">' +
 			// init horrible parameters
-			'<input type="hidden" id="dir" value="/"></input>' +
 			'<input type="hidden" id="permissions" value="31"></input>' +
 			// dummy controls
 			'<div class="files-controls">' +

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -45,7 +45,8 @@ OCA.Sharing.PublicApp = {
 		OCA.Files.fileActions = fileActions;
 
 		this._initialized = true;
-		this.initialDir = $('#dir').val();
+		var urlParams = OC.Util.History.parseUrlQuery();
+		this.initialDir = urlParams.path || '/';
 
 		var token = $('#sharingToken').val();
 		var hideDownload = $('#hideDownload').val();

--- a/apps/files_sharing/templates/list.php
+++ b/apps/files_sharing/templates/list.php
@@ -2,8 +2,6 @@
 
 <div class="emptyfilelist emptycontent hidden"></div>
 
-<input type="hidden" name="dir" value="" id="dir">
-
 <div class="nofilterresults emptycontent hidden">
 	<div class="icon-search"></div>
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -10,7 +10,6 @@
 <input type="hidden" id="sharingUserId" value="<?php p($_['owner']) ?>">
 <input type="hidden" id="filesApp" name="filesApp" value="1">
 <input type="hidden" id="isPublic" name="isPublic" value="1">
-<input type="hidden" name="dir" value="<?php p($_['dir']) ?>" id="dir">
 <?php if (!$_['hideDownload']): ?>
 	<input type="hidden" name="downloadURL" value="<?php p($_['downloadURL']) ?>" id="downloadURL">
 <?php endif; ?>
@@ -140,7 +139,6 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 <?php } ?>
 
 <?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] !== true)): ?>
-	<input type="hidden" name="dir" id="dir" value="" />
 	<div class="hiddenuploadfield">
 		<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"
 			   data-url="<?php p(\OC::$server->getURLGenerator()->linkTo('files', 'ajax/upload.php')); ?>" />

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -51,12 +51,12 @@ describe('OCA.Sharing.PublicApp tests', function() {
 	});
 
 	describe('File list', function() {
+		var parseUrlQueryStub
 		// TODO: this should be moved to a separate file once the PublicFileList is extracted from public.js
 		beforeEach(function() {
 			$preview.append(
 				'<div id="app-content-files">' +
 				// init horrible parameters
-				'<input type="hidden" id="dir" value="/subdir"/>' +
 				'<input type="hidden" id="permissions" value="31"/>' +
 				// dummy controls
 				'<div class="files-controls">' +
@@ -88,10 +88,13 @@ describe('OCA.Sharing.PublicApp tests', function() {
 				'</div>'
 			);
 
+			parseUrlQueryStub = sinon.stub(OC.Util.History, 'parseUrlQuery');
+			parseUrlQueryStub.returns({path: '/subdir'});
 			App.initialize($('#preview'));
 		});
 		afterEach(function() {
 			App._initialized = false;
+			parseUrlQueryStub.restore();
 		});
 
 		it('Uses public webdav endpoint', function() {

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -9,8 +9,6 @@
 	<p><?php p($l->t('You will be able to recover deleted files from here')); ?></p>
 </div>
 
-<input type="hidden" name="dir" value="" id="dir">
-
 <div class="nofilterresults emptycontent hidden">
 	<div class="icon-search"></div>
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -43,8 +43,6 @@ describe('OCA.Trashbin.FileList tests', function () {
 		// init parameters and test table elements
 		$('#testArea').append(
 			'<div id="app-content-trashbin">' +
-			// init horrible parameters
-			'<input type="hidden" id="dir" value="/"></input>' +
 			// set this but it shouldn't be used (could be the one from the
 			// files app)
 			'<input type="hidden" id="permissions" value="31"></input>' +
@@ -129,7 +127,6 @@ describe('OCA.Trashbin.FileList tests', function () {
 		fileList.destroy();
 		fileList = undefined;
 
-		$('#dir').remove();
 		notificationStub.restore();
 		alertStub.restore();
 	});
@@ -174,7 +171,6 @@ describe('OCA.Trashbin.FileList tests', function () {
 	describe('Rendering rows', function () {
 		it('renders rows with the correct data when in root', function () {
 			// dir listing is false when in root
-			$('#dir').val('/');
 			fileList.setFiles(testFiles);
 			var $rows = fileList.$el.find('tbody tr');
 			var $tr = $rows.eq(0);
@@ -195,7 +191,6 @@ describe('OCA.Trashbin.FileList tests', function () {
 		});
 		it('renders rows with the correct data when in root after calling setFiles with the same data set', function () {
 			// dir listing is false when in root
-			$('#dir').val('/');
 			fileList.setFiles(testFiles);
 			fileList.setFiles(fileList.files);
 			var $rows = fileList.$el.find('tbody tr');
@@ -216,9 +211,6 @@ describe('OCA.Trashbin.FileList tests', function () {
 			expect(fileList.findFileEl('One.txt.d11111')[0]).toEqual($tr[0]);
 		});
 		it('renders rows with the correct data when in subdirectory', function () {
-			// dir listing is true when in a subdir
-			$('#dir').val('/subdir');
-
 			fileList.setFiles(testFiles.map(function (file) {
 				file.name = file.displayName;
 				return file;

--- a/apps/systemtags/templates/list.php
+++ b/apps/systemtags/templates/list.php
@@ -34,5 +34,4 @@
 	<tfoot>
 	</tfoot>
 </table>
-<input type="hidden" name="dir" id="dir" value="" />
 

--- a/apps/systemtags/tests/js/systemtagsfilelistSpec.js
+++ b/apps/systemtags/tests/js/systemtagsfilelistSpec.js
@@ -30,7 +30,6 @@ describe('OCA.SystemTags.FileList tests', function() {
 		$('#testArea').append(
 			'<div id="app-content-container">' +
 			// init horrible parameters
-			'<input type="hidden" id="dir" value="/"></input>' +
 			'<input type="hidden" id="permissions" value="31"></input>' +
 			'<div class="files-controls"></div>' +
 			// dummy table


### PR DESCRIPTION
Removed legacy "#dir" input element in the DOM.

Apps should use OCA.Files.App.currentFileList or
OCA.Sharing.PublicApp.fileList and call getCurrentDirectory() to
retrieve the current directory and changeDirectory() to change it.

### Reasons
- accessibility tools are unhappy about duplicate ids in the code.
- this is a really really old (OC <= 5) and dirty way for managing state

### Affected apps from the release bundle
- [ ] richdocuments: https://github.com/nextcloud/richdocuments/pull/2337

### Todos
- [x] update https://github.com/nextcloud/server/issues/32117 after merging

### Tests
- [x] TEST: manually tested file list page refresh with root dir
- [x] TEST: manually tested file list page refresh with non-default dir
- [x] TEST: manually tested public link page refresh with root dir
- [x] TEST: manually tested public link page refresh with non-default dir
