### PR TITLE
Remove more legacy ids

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2475,7 +2475,7 @@
 		 * @param show true for enabling, false for disabling
 		 */
 		showActions: function(show){
-			this.$el.find('.actions,#file_action_panel').toggleClass('hidden', !show);
+			this.$el.find('.actions').toggleClass('hidden', !show);
 			if (show){
 				// make sure to display according to permissions
 				var permissions = this.getDirectoryPermissions();

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -306,9 +306,6 @@
 		initialize: function() {
 			Files.bindKeyboardShortcuts(document, $);
 
-			// TODO: move file list related code (upload) to OCA.Files.FileList
-			$('#file_action_panel').attr('activeAction', false);
-
 			// drag&drop support using jquery.fileupload
 			// TODO use OC.dialogs
 			$(document).bind('drop dragover', function (e) {

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -3,7 +3,6 @@
 			<div id="uploadprogresswrapper">
 			</div>
 		</div>
-		<div id="file_action_panel"></div>
 		<div class="notCreatable notPublic hidden">
 			<div class="icon-alert-outline"></div>
 			<?php p($l->t('You do not have permission to upload or create files here'))?>

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -141,7 +141,7 @@ describe('OC.Upload tests', function() {
 				'<th class="hidden column-name">' +
 				'<input type="checkbox" id="select_all_files" class="select-all">' +
 				'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
-				'<span id="selectedActionsList" class="selectedActions hidden">' +
+				'<span class="selectedActions hidden">' +
 				'<a href class="download"><img src="actions/download.svg">Download</a>' +
 				'<a href class="delete-selected">Delete</a></span>' +
 				'</th>' +

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -119,7 +119,7 @@ describe('OCA.Files.FileList tests', function() {
 			'<th class="hidden column-name">' +
 			'<input type="checkbox" id="select_all_files" class="select-all checkbox">' +
 			'<a class="name columntitle" href="#" onclick="event.preventDefault()" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
-			'<span id="selectedActionsList" class="selectedActions hidden">' +
+			'<span class="selectedActions hidden">' +
 			'<a class="actions-selected" href="#" onclick="event.preventDefault()"><span class="icon icon-more"></span><span>Actions</span></a>' +
 			'</th>' +
 			'<th class="hidden column-size"><a class="columntitle" href="#" onclick="event.preventDefault()" data-sort="size"><span class="sort-indicator"></span></a></th>' +

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -307,7 +307,6 @@ OCA.Sharing.PublicApp = {
 			});
 
 			if (hideDownload === 'true') {
-				this.fileList.$el.find('#headerSelection').remove();
 				this.fileList.$el.find('.summary').find('td:first-child').remove();
 			}
 		}


### PR DESCRIPTION
Remove more unused legacy ids from early ownCloud times.

This reduces the number of duplicate ids in the DOM.

