### PR TITLE
Fix mistake in db query to delete a user config value

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -353,8 +353,8 @@ class AllConfig implements IConfig {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('preferences')
 			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)))
-			->where($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
-			->where($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($appName, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key, IQueryBuilder::PARAM_STR)))
 			->executeStatement();
 
 		if (isset($this->userCache[$userId][$appName])) {


### PR DESCRIPTION
The key value was deleted for all users and all apps. :boom:  :grin: