### PR TITLE
Improve container return type annotations

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -840,6 +840,7 @@
     </RedundantCondition>
     <TypeDoesNotContainType occurrences="2">
       <code>get_class($res) === 'OpenSSLAsymmetricKey'</code>
+      <code>is_object($res)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="apps/encryption/lib/Crypto/EncryptAll.php">
@@ -3159,7 +3160,6 @@
       <code>bool</code>
       <code>int</code>
       <code>string</code>
-      <code>string</code>
     </InvalidReturnType>
     <InvalidScalarArgument occurrences="5">
       <code>$lastChunkPos</code>
@@ -3619,6 +3619,9 @@
       <code>\OCP\Calendar\Room\IManager</code>
       <code>\OCP\Files\Folder|null</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="1">
+      <code>new GenericEvent($user)</code>
+    </InvalidArgument>
     <InvalidCatch occurrences="1"/>
     <UndefinedDocblockClass occurrences="1">
       <code>\OC\OCSClient</code>

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -53,6 +53,15 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 		$this->container = new Container();
 	}
 
+	/**
+	 * @template T
+	 * @param class-string<T>|string $id
+	 * @return T|mixed
+	 * @psalm-template S as class-string<T>|string
+	 * @psalm-param S $id
+	 * @psalm-return (S is class-string<T> ? T : mixed)
+	 * @throws QueryException
+	 */
 	public function get(string $id) {
 		return $this->query($id);
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -155,6 +155,7 @@ use OC\Template\JSCombiner;
 use OC\User\DisplayNameCache;
 use OC\User\Listeners\BeforeUserDeletedListener;
 use OC\User\Listeners\UserChangedListener;
+use OC\User\Session;
 use OCA\Theming\ImageManager;
 use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
@@ -1672,7 +1673,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @deprecated 20.0.0
 	 */
 	public function getSession() {
-		return $this->get(IUserSession::class)->getSession();
+		return $this->get(Session::class)->getSession();
 	}
 
 	/**
@@ -1680,7 +1681,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function setSession(\OCP\ISession $session) {
 		$this->get(SessionStorage::class)->setSession($session);
-		$this->get(IUserSession::class)->setSession($session);
+		$this->get(Session::class)->setSession($session);
 		$this->get(Store::class)->setSession($session);
 	}
 

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -127,6 +127,13 @@ class ServerContainer extends SimpleContainer {
 	}
 
 	/**
+	 * @template T
+	 * @param class-string<T>|string $name
+	 * @return T|mixed
+	 * @psalm-template S as class-string<T>|string
+	 * @psalm-param S $name
+	 * @psalm-return (S is class-string<T> ? T : mixed)
+	 * @throws QueryException
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */
 	public function query(string $name, bool $autoload = true) {

--- a/lib/public/Server.php
+++ b/lib/public/Server.php
@@ -41,9 +41,11 @@ use Psr\Container\NotFoundExceptionInterface;
 final class Server {
 	/**
 	 * @template T
-	 * @template S as class-string<T>|string
-	 * @param S $serviceName
-	 * @return (S is class-string<T> ? T : mixed)
+	 * @param class-string<T>|string $serviceName
+	 * @return T|mixed
+	 * @psalm-template S as class-string<T>|string
+	 * @psalm-param S $serviceName
+	 * @psalm-return (S is class-string<T> ? T : mixed)
 	 * @throws ContainerExceptionInterface
 	 * @throws NotFoundExceptionInterface
 	 * @since 25.0.0


### PR DESCRIPTION
Some IDEs currently do not support conditional return type annotations as we use it, so this makes sure that the get/query methods still provide some useful type in those cases. The `@psalm-` prefixed annotations will ensure that psalm still handles the conditional.

Ref https://youtrack.jetbrains.com/issue/WI-66465/Support-parsing-of-PhpStans-conditional-return-types

With this change PHPStorm can for example properly indicate the types of:

```php
$s1 = \OCP\Server::get(\OCP\IUserSession::class);
$s2 = \OC::$server->get(\OCP\IUserSession::class);
$s3 = \OC::$server->query(\OCP\IUserSession::class);
```