### PR TITLE
allow apps to specify methods carrying sensitive parameters

### DIFF
--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -121,6 +121,9 @@ class RegistrationContext {
 	/** @var ServiceRegistration<ICalendarProvider>[] */
 	private $calendarProviders = [];
 
+	/** @var ParameterRegistration[] */
+	private $sensitiveMethods = [];
+
 	/** @var LoggerInterface */
 	private $logger;
 
@@ -304,6 +307,14 @@ class RegistrationContext {
 					$migratorClass
 				);
 			}
+
+			public function registerSensitiveMethods(string $class, array $methods): void {
+				$this->context->registerSensitiveMethods(
+					$this->appId,
+					$class,
+					$methods
+				);
+			}
 		};
 	}
 
@@ -428,6 +439,11 @@ class RegistrationContext {
 	 */
 	public function registerUserMigrator(string $appId, string $migratorClass): void {
 		$this->userMigrators[] = new ServiceRegistration($appId, $migratorClass);
+	}
+
+	public function registerSensitiveMethods(string $appId, string $class, array $methods): void {
+		$methods = array_filter($methods, 'is_string');
+		$this->sensitiveMethods[] = new ParameterRegistration($appId, $class, $methods);
 	}
 
 	/**
@@ -711,5 +727,12 @@ class RegistrationContext {
 	 */
 	public function getUserMigrators(): array {
 		return $this->userMigrators;
+	}
+
+	/**
+	 * @return ParameterRegistration[]
+	 */
+	public function getSensitiveMethods(): array {
+		return $this->sensitiveMethods;
 	}
 }

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -109,7 +109,7 @@ class ExceptionSerializer {
 		$this->systemConfig = $systemConfig;
 	}
 
-	public const methodsWithSensitiveParametersByClass = [
+	protected array $methodsWithSensitiveParametersByClass = [
 		SetupController::class => [
 			'run',
 			'display',
@@ -190,8 +190,8 @@ class ExceptionSerializer {
 		$sensitiveValues = [];
 		$trace = array_map(function (array $traceLine) use (&$sensitiveValues) {
 			$className = $traceLine['class'] ?? '';
-			if ($className && isset(self::methodsWithSensitiveParametersByClass[$className])
-				&& in_array($traceLine['function'], self::methodsWithSensitiveParametersByClass[$className], true)) {
+			if ($className && isset($this->methodsWithSensitiveParametersByClass[$className])
+				&& in_array($traceLine['function'], $this->methodsWithSensitiveParametersByClass[$className], true)) {
 				return $this->editTrace($sensitiveValues, $traceLine);
 			}
 			foreach (self::methodsWithSensitiveParameters as $sensitiveMethod) {
@@ -288,5 +288,12 @@ class ExceptionSerializer {
 		}
 
 		return $data;
+	}
+
+	public function enlistSensitiveMethods(string $class, array $methods): void {
+		if (!isset($this->methodsWithSensitiveParametersByClass[$class])) {
+			$this->methodsWithSensitiveParametersByClass[$class] = [];
+		}
+		$this->methodsWithSensitiveParametersByClass[$class] = array_merge($this->methodsWithSensitiveParametersByClass[$class], $methods);
 	}
 }

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -306,4 +306,15 @@ interface IRegistrationContext {
 	 * @since 24.0.0
 	 */
 	public function registerUserMigrator(string $migratorClass): void;
+
+	/**
+	 * Announce methods of classes that may contain sensitive values, which
+	 * should be obfuscated before being logged.
+	 *
+	 * @param string $class
+	 * @param string[] $methods
+	 * @return void
+	 * @since 25.0.0
+	 */
+	public function registerSensitiveMethods(string $class, array $methods): void;
 }


### PR DESCRIPTION
… in order to remove them from logging.

Apps are empowered to enlist those methods by class through the `IRegistrationContext`. Since we need to get  those values in the Logger, we need to manoeuver around dependencies. The `ExceptionSerializer` was already being instantiated before every time logging an exception. 

What do you think?

When this approach is agreeable, I would further propose to backport. With `IRegistrationContext.php` an API is extended, however it is not being implemented outside of server.