### PR TITLE
DB mounts table: Add index for mount_provider_class

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -225,6 +225,13 @@ class Application extends App {
 						$subject->addHintForMissingSubject($table->getName(), 'preferences_app_key');
 					}
 				}
+
+				if ($schema->hasTable('mounts')) {
+					$table = $schema->getTable('mounts');
+					if (!$table->hasIndex('mounts_class_index')) {
+						$subject->addHintForMissingSubject($table->getName(), 'mounts_class_index');
+					}
+				}
 			}
 		);
 

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -444,6 +444,19 @@ class AddMissingIndices extends Command {
 			}
 		}
 
+		$output->writeln('<info>Check indices of the oc_mounts table.</info>');
+		if ($schema->hasTable('mounts')) {
+			$table = $schema->getTable('mounts');
+			if (!$table->hasIndex('mounts_class_index')) {
+				$output->writeln('<info>Adding mounts_class_index index to the oc_mounts table, this can take some time...</info>');
+
+				$table->addIndex(['mount_provider_class'], 'mounts_class_index');
+				$this->connection->migrateToSchema($schema->getWrappedSchema());
+				$updated = true;
+				$output->writeln('<info>oc_mounts table updated successfully.</info>');
+			}
+		}
+
 		if (!$updated) {
 			$output->writeln('<info>Done.</info>');
 		}

--- a/core/Migrations/Version24000Date20220202150027.php
+++ b/core/Migrations/Version24000Date20220202150027.php
@@ -30,6 +30,7 @@ class Version24000Date20220202150027 extends SimpleMigrationStep {
 				'notnull' => false,
 				'length' => 128,
 			]);
+			$table->addIndex(['mount_provider_class'], 'mounts_class_index');
 			return $schema;
 		}
 		return null;


### PR DESCRIPTION
This would be necessary to [select appropriate mount points to crawl files from](https://github.com/nextcloud/recognize/pull/261/files#diff-0b5aa351f3590699c338ea5df8abd34df59597f99ca33b149afdf6796b265a7cR40-R43) in the proposed refactoring for [recognize](https://github.com/nextcloud/recognize) (for photos2.0)