### PR TITLE
[stable24] Handle one time and large passwords

### DIFF
--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -107,7 +107,7 @@ class ChangePasswordController extends Controller {
 		}
 
 		try {
-			if ($newpassword === null || $user->setPassword($newpassword) === false) {
+			if ($newpassword === null || strlen($newpassword) > 469 || $user->setPassword($newpassword) === false) {
 				return new JSONResponse([
 					'status' => 'error'
 				]);
@@ -154,6 +154,16 @@ class ChangePasswordController extends Controller {
 				],
 			]);
 		}
+
+		if (strlen($password) > 469) {
+			return new JSONResponse([
+				'status' => 'error',
+				'data' => [
+					'message' => $this->l->t('Unable to change password. Password too long.'),
+				],
+			]);
+		}
+
 
 		$currentUser = $this->userSession->getUser();
 		$targetUser = $this->userManager->get($username);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -309,6 +309,21 @@ $CONFIG = [
 'auth.webauthn.enabled' => true,
 
 /**
+ * Whether encrypted password should be stored in the database
+ *
+ * The passwords are only decrypted using the login token stored uniquely in the
+ * clients and allow to connect to external storages, autoconfigure mail account in
+ * the mail app and periodically check if the password it still valid.
+ *
+ * This might be desirable to disable this functionality when using one time
+ * passwords or when having a password policy enforcing long passwords (> 300
+ * characters).
+ *
+ * By default the passwords are stored encrypted in the database.
+ */
+'auth.storeCryptedPassword' => true,
+
+/**
  * By default the login form is always available. There are cases (SSO) where an
  * admin wants to avoid users entering their credentials to the system if the SSO
  * app is unavailable.

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -346,7 +346,7 @@ class PublicKeyTokenProvider implements IProvider {
 
 		$config = array_merge([
 			'digest_alg' => 'sha512',
-			'private_key_bits' => 2048,
+			'private_key_bits' => $password !== null && strlen($password) > 250 ? 4096 : 2048,
 		], $this->config->getSystemValue('openssl', []));
 
 		// Generate new key
@@ -368,7 +368,10 @@ class PublicKeyTokenProvider implements IProvider {
 		$dbToken->setPublicKey($publicKey);
 		$dbToken->setPrivateKey($this->encrypt($privateKey, $token));
 
-		if (!is_null($password)) {
+		if (!is_null($password) && $this->config->getSystemValueBool('auth.storeCryptedPassword', true)) {
+			if (strlen($password) > 469) {
+				throw new \RuntimeException('Trying to save a password with more than 469 characters is not supported. If you want to use big passwords, disable the auth.storeCryptedPassword option in config.php');
+			}
 			$dbToken->setPassword($this->encryptPassword($password, $publicKey));
 		}
 
@@ -398,7 +401,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->clear();
 
 		// prevent setting an empty pw as result of pw-less-login
-		if ($password === '') {
+		if ($password === '' || !$this->config->getSystemValueBool('auth.storeCryptedPassword', true)) {
 			return;
 		}
 


### PR DESCRIPTION
This adds an option to disable storing passwords in the database. This
might be desirable when using single-use token as passwords or very
large passwords.

For passwords bigger than 250 characters, use a bigger key since the
performance impact is minor (around one second to encrypt the password).

For passwords bigger than 470 characters, give up earlier and throw
exception recommending admin to either enable the previously enabled
configuration or use smaller passwords.