### PR TITLE
Minor improvement to diagnostics - log user name in setupForUserWith

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -311,7 +311,7 @@ class SetupManager {
 			$this->oneTimeUserSetup($user);
 		}
 
-		$this->eventLogger->start('setup_fs', 'Setup filesystem');
+		$this->eventLogger->start('setup_fs', 'Setup user filesystem for: ' . $user->getUID());
 
 		if ($this->lockdownManager->canAccessFilesystem()) {
 			$mountCallback();


### PR DESCRIPTION
While investigating [slow loading of chat messages](https://github.com/nextcloud/talk-android/issues/2228) in Talk/Android I have been struggling with understanding why setup_fs is called many times during a single request.

It turned out that the **setupForUserWith** method is called for all participants of the chat who shared images in the chat.

The proposed change makes this analysis a bit easier.