### PR TITLE
Remove broken function resetStorage from test cases

### DIFF
--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -106,8 +106,6 @@ abstract class TestCase extends \Test\TestCase {
 			}
 		}
 
-		self::resetStorage();
-
 		\OC_Util::tearDownFS();
 		\OC::$server->getUserSession()->setUser(null);
 		\OC\Files\Filesystem::tearDown();
@@ -115,16 +113,5 @@ abstract class TestCase extends \Test\TestCase {
 		\OC::$server->getUserFolder($user);
 
 		\OC_Util::setupFS($user);
-	}
-
-	/**
-	 * reset init status for the share storage
-	 */
-	protected static function resetStorage() {
-		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
-		$isInitialized = $storage->getProperty('initialized');
-		$isInitialized->setAccessible(true);
-		$isInitialized->setValue($storage, false);
-		$isInitialized->setAccessible(false);
 	}
 }

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -201,8 +201,6 @@ abstract class TestCase extends \Test\TestCase {
 			}
 		}
 
-		self::resetStorage();
-
 		\OC_Util::tearDownFS();
 		\OC\Files\Cache\Storage::getGlobalCache()->clearCache();
 		\OC::$server->getUserSession()->setUser(null);
@@ -211,17 +209,6 @@ abstract class TestCase extends \Test\TestCase {
 		\OC::$server->getUserFolder($user);
 
 		\OC_Util::setupFS($user);
-	}
-
-	/**
-	 * reset init status for the share storage
-	 */
-	protected static function resetStorage() {
-		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
-		$isInitialized = $storage->getProperty('initialized');
-		$isInitialized->setAccessible(true);
-		$isInitialized->setValue($storage, false);
-		$isInitialized->setAccessible(false);
 	}
 
 	/**


### PR DESCRIPTION
The method resetStorage does not work as it does not say on which instance of `\OCA\Files_Sharing\SharedStorage` it sets the property `initialized`. It tries to set it on the `ReflectionClass` instance, which makes no sense.
Spotted by PHP 8.2.

Function came from https://github.com/nextcloud/server/commit/391fab35f078bd37d7b432eaf6a1c6fab701dff4

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>