### PR TITLE
Remove "needs info" label when the issue is not stale anymore

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ jobs:
           for your contributions.
         stale-issue-label: 'stale'
         only-labels: 'needs info'
+        labels-to-remove-when-unstale: 'needs info,stale'
         exempt-issue-labels: '1. to develop,2. developing,3. to review,4. to release,security'
         days-before-stale: 30
         days-before-close: 14


### PR DESCRIPTION
Ref https://github.com/actions/stale#labels-to-remove-when-unstale