### PR TITLE
Detect leading spaces in config files

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -231,6 +231,14 @@ class Config {
 
 			unset($CONFIG);
 			include $file;
+			if (!defined('PHPUNIT_RUN') && headers_sent()) {
+				// syntax issues in the config file like leading spaces causing PHP to send output
+				$errorMessage = sprintf('Config file has leading content, please remove everything before "<?php" in %s', basename($file));
+				if (!defined('OC_CONSOLE')) {
+					print(\OCP\Util::sanitizeHTML($errorMessage));
+				}
+				throw new \Exception($errorMessage);
+			}
 			if (isset($CONFIG) && is_array($CONFIG)) {
 				$this->cache = array_merge($this->cache, $CONFIG);
 			}


### PR DESCRIPTION
Because those will cause PHP to output to stdout and will cause
unrelated error messages.

Steps to reproduce:

1. Create a config file "config/app.config.php" and add your apps_paths section (or anything else)
2. In that config file, add spaces in front of `<?php`
3. Open Nextcloud

Before: internal server error with mysterious errors in the log about ini settings that cannot be set at this stage

After: explicit error about the invalid file, both in occ and web UI

Background: I lost some time with this, believing that an app was broken. In my setup I have a bash script that generates the sidecar config files using `cat <<` and I mistakenly indented the contents of the file