### PR TITLE
Fix photo url generation (add URI type to VCard2Array)

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -273,7 +273,7 @@ class AddressBookImpl implements IAddressBook {
 		];
 
 		foreach ($vCard->children() as $property) {
-			if ($property->name === 'PHOTO' && $property->getValueType() === 'BINARY') {
+			if ($property->name === 'PHOTO' && in_array($property->getValueType(), ['BINARY', 'URI'])) {
 				$url = $this->urlGenerator->getAbsoluteURL(
 					$this->urlGenerator->linkTo('', 'remote.php') . '/dav/');
 				$url .= implode('/', [


### PR DESCRIPTION
Related to https://github.com/nextcloud/mail/pull/6715
Hello! Sometimes the contact photo returns the URI type and this affects the display of the photo in the search (for example, in mail) I added address generation for the URI type, thereby the photos of users in the mail are shown correctly in both cases.
May be it will be useful! Thank you!
![image](https://user-images.githubusercontent.com/3595562/182583789-1b8f5f96-9d5f-459b-85c6-193a826f2c19.png)
![image](https://user-images.githubusercontent.com/3595562/182583942-7ab07ebc-8057-4ab8-b703-e564468578bd.png)

Signed-off-by: Mikhail Sazanov <m@sazanof.ru>