### PR TITLE
Fix update when viewer is not installed

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -56,7 +56,6 @@
     "oauth2",
     "settings",
     "twofactor_backupcodes",
-    "viewer",
     "workflowengine"
   ]
 }


### PR DESCRIPTION
Since the viewer app is not shipped with server, currently with a fresh clone of
the server repo it is impossible to do an update.