### PR TITLE
allow disabling object store write check

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -61,6 +61,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 	private $logger;
 
+	/** @var bool */
+	protected $validateWrites = true;
+
 	public function __construct($params) {
 		if (isset($params['objectstore']) && $params['objectstore'] instanceof IObjectStore) {
 			$this->objectStore = $params['objectstore'];
@@ -74,6 +77,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		}
 		if (isset($params['objectPrefix'])) {
 			$this->objectPrefix = $params['objectPrefix'];
+		}
+		if (isset($params['validateWrites'])) {
+			$this->validateWrites = (bool)$params['validateWrites'];
 		}
 		//initialize cache with root directory in cache
 		if (!$this->is_dir('/')) {
@@ -522,7 +528,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if ($exists) {
 			$this->getCache()->update($fileId, $stat);
 		} else {
-			if ($this->objectStore->objectExists($urn)) {
+			if (!$this->validateWrites || $this->objectStore->objectExists($urn)) {
 				$this->getCache()->move($uploadPath, $path);
 			} else {
 				$this->getCache()->remove($uploadPath);

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageOverwrite.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageOverwrite.php
@@ -37,4 +37,8 @@ class ObjectStoreStorageOverwrite extends ObjectStoreStorage {
 	public function getObjectStore(): IObjectStore {
 		return $this->objectStore;
 	}
+
+	public function setValidateWrites(bool $validate) {
+		$this->validateWrites = $validate;
+	}
 }

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -181,6 +181,15 @@ class ObjectStoreStorageTest extends Storage {
 		$this->assertFalse($this->instance->file_exists('test.txt'));
 	}
 
+	public function testWriteObjectSilentFailureNoCheck() {
+		$objectStore = $this->instance->getObjectStore();
+		$this->instance->setObjectStore(new FailWriteObjectStore($objectStore));
+		$this->instance->setValidateWrites(false);
+
+		$this->instance->file_put_contents('test.txt', 'foo');
+		$this->assertTrue($this->instance->file_exists('test.txt'));
+	}
+
 	public function testDeleteObjectFailureKeepCache() {
 		$objectStore = $this->instance->getObjectStore();
 		$this->instance->setObjectStore(new FailDeleteObjectStore($objectStore));


### PR DESCRIPTION
In clustered setups replication delay means that trying to read the object directly after writing it can fail.

This allows disabling the check by setting `'validateWrites' => false` under the object store `arguments` in config.php