### PR TITLE
Add integration tests for getting folder sizes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1027,6 +1027,31 @@ trigger:
 
 ---
 kind: pipeline
+name: integration-files
+
+steps:
+- name: submodules
+  image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
+  commands:
+    - git submodule update --init
+- name: integration-files
+  image: ghcr.io/nextcloud/continuous-integration-integration-php7.4:latest
+  commands:
+    - bash tests/drone-run-integration-tests.sh || exit 0
+    - ./occ maintenance:install --admin-pass=admin --data-dir=/dev/shm/nc_int
+    - cd build/integration
+    - ./run.sh features/files.feature
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
 name: integration-provisioning-v2
 
 steps:

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -116,6 +116,9 @@ default:
               - admin
               - admin
             regular_user_password: 123456
+        - CommandLineContext:
+            baseUrl: http://localhost:8080
+            ocPath: ../../
         - RemoteContext:
             remote:  http://localhost:8080
   extensions:

--- a/build/integration/features/bootstrap/CommandLine.php
+++ b/build/integration/features/bootstrap/CommandLine.php
@@ -42,21 +42,27 @@ trait CommandLine {
 	 * Invokes an OCC command
 	 *
 	 * @param []string $args OCC command, the part behind "occ". For example: "files:transfer-ownership"
+	 * @param []string $phpArgs optional PHP command arguments. For example: "--define apc.enable_cli=1"
 	 * @return int exit code
 	 */
-	public function runOcc($args = []) {
+	public function runOcc($args = [], $phpArgs = []) {
 		$args = array_map(function ($arg) {
 			return escapeshellarg($arg);
 		}, $args);
 		$args[] = '--no-ansi';
 		$args = implode(' ', $args);
 
+		$phpArgs = array_map(function ($phpArg) {
+			return escapeshellarg($phpArg);
+		}, $phpArgs);
+		$phpArgs = implode(' ', $phpArgs);
+
 		$descriptor = [
 			0 => ['pipe', 'r'],
 			1 => ['pipe', 'w'],
 			2 => ['pipe', 'w'],
 		];
-		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, $this->ocPath);
+		$process = proc_open('php ' . $phpArgs . ' console.php ' . $args, $descriptor, $pipes, $this->ocPath);
 		$this->lastStdOut = stream_get_contents($pipes[1]);
 		$this->lastStdErr = stream_get_contents($pipes[2]);
 		$this->lastCode = proc_close($process);

--- a/build/integration/features/bootstrap/FeatureContext.php
+++ b/build/integration/features/bootstrap/FeatureContext.php
@@ -34,6 +34,7 @@ require __DIR__ . '/../../vendor/autoload.php';
  */
 class FeatureContext implements Context, SnippetAcceptingContext {
 	use ContactsMenu;
+	use Files;
 	use Search;
 	use WebDav;
 	use Trashbin;

--- a/build/integration/features/bootstrap/Files.php
+++ b/build/integration/features/bootstrap/Files.php
@@ -29,6 +29,21 @@ trait Files {
 
 	// BasicStructure trait is expected to be used in the class that uses this
 	// trait.
+	// CommandLineContext is expected to be loaded in the Behat suite where this
+	// trait is used.
+
+	/**
+	 * @AfterScenario
+	 */
+	public function disableMemcacheLocal(AfterScenarioScope $scope) {
+		$environment = $scope->getEnvironment();
+		$commandLineContext = $environment->getContext('CommandLineContext');
+
+		// If APCu was set APC needs to be enabled for the CLI when running OCC;
+		// otherwise OC\Memcache\APCu is not available and OCC command fails,
+		// even if it is just trying to disable the memcache.
+		$commandLineContext->runOcc(['config:system:delete', 'memcache.local'], ['--define', 'apc.enable_cli=1']);
+	}
 
 	/**
 	 * @When logged in user gets storage stats of folder :folder

--- a/build/integration/features/bootstrap/Files.php
+++ b/build/integration/features/bootstrap/Files.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use PHPUnit\Framework\Assert;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+trait Files {
+
+	// BasicStructure trait is expected to be used in the class that uses this
+	// trait.
+
+	/**
+	 * @When logged in user gets storage stats of folder :folder
+	 *
+	 * @param string $folder
+	 */
+	public function loggedInUserGetsStorageStatsOfFolder(string $folder) {
+		$this->loggedInUserGetsStorageStatsOfFolderWith($folder, '200');
+	}
+
+	/**
+	 * @When logged in user gets storage stats of folder :folder with :statusCode
+	 *
+	 * @param string $folder
+	 */
+	public function loggedInUserGetsStorageStatsOfFolderWith(string $folder, string $statusCode) {
+		$this->sendingAToWithRequesttoken('GET', '/index.php/apps/files/ajax/getstoragestats?dir=' . $folder);
+		$this->theHTTPStatusCodeShouldBe($statusCode);
+	}
+
+	/**
+	 * @Then the storage stats match with
+	 *
+	 * @param Behat\Gherkin\Node\TableNode $body
+	 */
+	public function theStorageStatsMatchWith(Behat\Gherkin\Node\TableNode $body) {
+		$storageStats = json_decode($this->response->getBody()->getContents(), $asAssociativeArray = true);
+		$storageStats = $storageStats['data'];
+
+		foreach ($body->getRowsHash() as $expectedField => $expectedValue) {
+			if (!array_key_exists($expectedField, $storageStats)) {
+				Assert::fail("$expectedField was not found in response");
+			}
+
+			Assert::assertEquals($expectedValue, $storageStats[$expectedField], "Field '$expectedField' does not match ({$storageStats[$expectedField]})");
+		}
+	}
+}

--- a/build/integration/features/files.feature
+++ b/build/integration/features/files.feature
@@ -91,3 +91,14 @@ Feature: files
       | used | 0 |
 
   # End of counterpart scenarios
+
+  Scenario: Retrieving storage stats after a file was uploaded when using APCu
+    Given using old dav path
+    And invoking occ with "config:system:set memcache.local --value \OC\Memcache\APCu --type string"
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/test.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/"
+    Then the storage stats match with
+      | used | 447 |

--- a/build/integration/features/files.feature
+++ b/build/integration/features/files.feature
@@ -1,0 +1,93 @@
+Feature: files
+
+  # Counterpart scenarios for getting the folder size in webdav-related.feature
+
+  Scenario: Retrieving storage stats after a file was uploaded
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/test.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/"
+    Then the storage stats match with
+      | used | 447 |
+
+  Scenario: Retrieving storage stats after a file was uploaded to a folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/"
+    Then the storage stats match with
+      | used | 447 |
+
+  Scenario: Retrieving storage stats for folder after a file was uploaded to that folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/FOLDER/"
+    Then the storage stats match with
+      | used | 108 |
+
+  Scenario: Retrieving storage stats after a file was deleted from a folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 23 bytes to "/FOLDER/test1.txt"
+    And user "user0" adds a file of 42 bytes to "/FOLDER/test2.txt"
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test3.txt"
+    And User "user0" deletes file "/FOLDER/test2.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/"
+    Then the storage stats match with
+      | used | 470 |
+
+  Scenario: Retrieving storage stats for folder after a file was deleted from that folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 23 bytes to "/FOLDER/test1.txt"
+    And user "user0" adds a file of 42 bytes to "/FOLDER/test2.txt"
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test3.txt"
+    And User "user0" deletes file "/FOLDER/test2.txt"
+    When Logging in using web as "user0"
+    And logged in user gets storage stats of folder "/FOLDER/"
+    Then the storage stats match with
+      | used | 131 |
+
+  Scenario: Retrieving storage stats after the last file was deleted from a folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+    And Logging in using web as "user0"
+    # Get the size after uploading the file to ensure that the size after the
+    # deletion is not just a size cached before the upload.
+    And logged in user gets storage stats of folder "/"
+    And the storage stats match with
+      | used | 447 |
+    And User "user0" deletes file "/FOLDER/test.txt"
+    When logged in user gets storage stats of folder "/"
+    Then the storage stats match with
+      | used | 339 |
+
+  Scenario: Retrieving storage stats for folder after the last file was deleted from that folder
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+    And Logging in using web as "user0"
+    # Get the size after uploading the file to ensure that the size after the
+    # deletion is not just a size cached before the upload.
+    And logged in user gets storage stats of folder "/"
+    And the storage stats match with
+      | used | 447 |
+    And User "user0" deletes file "/FOLDER/test.txt"
+    When logged in user gets storage stats of folder "/FOLDER/"
+    Then the storage stats match with
+      | used | 0 |
+
+  # End of counterpart scenarios

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -223,6 +223,91 @@ Feature: webdav-related
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "685"
 
+	# Counterpart scenarios for getting the storage stats in files.feature
+
+	Scenario: Retrieving root folder size after a file was uploaded
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 108 bytes to "/test.txt"
+		When as "user0" gets properties of folder "/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "447"
+
+	Scenario: Retrieving root folder size after a file was uploaded to a folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+		When as "user0" gets properties of folder "/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "447"
+
+	Scenario: Retrieving folder size after a file was uploaded to that folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+		When as "user0" gets properties of folder "/FOLDER/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "108"
+
+	Scenario: Retrieving root folder size after a file was deleted from a folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 23 bytes to "/FOLDER/test1.txt"
+		And user "user0" adds a file of 42 bytes to "/FOLDER/test2.txt"
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test3.txt"
+		And User "user0" deletes file "/FOLDER/test2.txt"
+		When as "user0" gets properties of folder "/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "470"
+
+	Scenario: Retrieving folder size after a file was deleted from that folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 23 bytes to "/FOLDER/test1.txt"
+		And user "user0" adds a file of 42 bytes to "/FOLDER/test2.txt"
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test3.txt"
+		And User "user0" deletes file "/FOLDER/test2.txt"
+		When as "user0" gets properties of folder "/FOLDER/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "131"
+
+	Scenario: Retrieving root folder size after the last file was deleted from a folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+		# Get the size after uploading the file to ensure that the size after the
+		# deletion is not just a size cached before the upload.
+		And as "user0" gets properties of folder "/" with
+		  |{http://owncloud.org/ns}size|
+		And the single response should contain a property "{http://owncloud.org/ns}size" with value "447"
+		And User "user0" deletes file "/FOLDER/test.txt"
+		When as "user0" gets properties of folder "/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "339"
+
+	Scenario: Retrieving folder size after the last file was deleted from that folder
+		Given using old dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" adds a file of 108 bytes to "/FOLDER/test.txt"
+		# Get the size after uploading the file to ensure that the size after the
+		# deletion is not just a size cached before the upload.
+		And as "user0" gets properties of folder "/FOLDER/" with
+		  |{http://owncloud.org/ns}size|
+		And the single response should contain a property "{http://owncloud.org/ns}size" with value "108"
+		And User "user0" deletes file "/FOLDER/test.txt"
+		When as "user0" gets properties of folder "/FOLDER/" with
+		  |{http://owncloud.org/ns}size|
+		Then the single response should contain a property "{http://owncloud.org/ns}size" with value "0"
+
+	# End of counterpart scenarios
+
 	Scenario: download a public shared file with range
 		Given user "user0" exists
 		And As an "user0"


### PR DESCRIPTION
The integration tests pass in latest 23 (v23.0.8rc1), but fail in latest master and 24. Due to that this pull request is kept as _Developing_ until that is clarified.

These are the regressions:
- Root folder size returned by WebDAV is off by 1 byte since #31843 (specifically, 151c80039751bbe74042d7f6f5d58e9f115064e4)
- ~~Storage stats size after deleting the last file in a folder is wrong in 24, but not in master. The breaking PR in 24 was #32708, which is a backport of #31966 without interface changes. Due to the interface changes 32708 is going to be reverted and replaced by #32943, which also makes the integration tests fail.~~ - Fixed in latest #32943 and #33562
- Storage stats size when APCu is enabled can be outdated since #32048 I do not know if it is acceptable (which may require documenting it) or if the cache needs to be invalidated, for example, when a file is uploaded.

If the tests are run in older commits note that `getstoragestats.php` may need to be used in [`features/bootstrap/Files.php`](https://github.com/nextcloud/server/commit/14919971f9930dee2b1e6020a1224d36f5894e39#diff-18a86337dea4924ad81521a168bc99ea1bfb6db6e18bf2b23f1472feb5b75435R48) instead of just `getstoragestats` (see #32962, #33113 and #33116).

@PVince81 @icewind1991 