### PR TITLE
Do not update passwords if nothing changed

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -409,9 +409,12 @@ class PublicKeyTokenProvider implements IProvider {
 		$tokens = $this->mapper->getTokenByUser($uid);
 		foreach ($tokens as $t) {
 			$publicKey = $t->getPublicKey();
-			$t->setPassword($this->encryptPassword($password, $publicKey));
-			$t->setPasswordInvalid(false);
-			$this->updateToken($t);
+			$encryptedPassword = $this->encryptPassword($password, $publicKey);
+			if ($t->getPassword() !== $encryptedPassword) {
+				$t->setPassword($encryptedPassword);
+				$t->setPasswordInvalid(false);
+				$this->updateToken($t);
+			}
 		}
 	}
 


### PR DESCRIPTION
This would avoid updating the password on all authtokens if nothing has changed.

It may especially result in heavy requests when using the user password to authenticate through basic auth, where then every request would trigger an update of all tokens.

![Screenshot 2022-08-08 at 17 45 54](https://user-images.githubusercontent.com/3404133/183458682-9a354317-628b-4340-981a-5af0cf0283c5.png)


## Todo

- [x] Check if an additional transation might be worth to add
- [x] Check if we can otherwise batch the operation or perform filtering upfront (e.g. for passwordless tokens)
