### PR TITLE
Unify initial and updated quota display

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -98,14 +98,15 @@
 			}
 			if (response.data !== undefined
 			 && response.data.quota !== undefined
+			 && response.data.total !== undefined
 			 && response.data.used !== undefined
 			 && response.data.usedSpacePercent !== undefined) {
 				var humanUsed = OC.Util.humanFileSize(response.data.used, true);
-				var humanQuota = OC.Util.humanFileSize(response.data.quota, true);
+				var humanTotal = OC.Util.humanFileSize(response.data.total, true);
 				if (response.data.quota > 0) {
 					$('#quota').attr('data-original-title', Math.floor(response.data.used/response.data.quota*1000)/10 + '%');
 					$('#quota progress').val(response.data.usedSpacePercent);
-					$('#quotatext').html(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanQuota}));
+					$('#quotatext').html(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanTotal}));
 				} else {
 					$('#quotatext').html(t('files', '{used} used', {used: humanUsed}));
 				}

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -104,7 +104,7 @@
 				var humanUsed = OC.Util.humanFileSize(response.data.used, true);
 				var humanTotal = OC.Util.humanFileSize(response.data.total, true);
 				if (response.data.quota > 0) {
-					$('#quota').attr('data-original-title', Math.floor(response.data.used/response.data.quota*1000)/10 + '%');
+					$('#quota').attr('data-original-title', t('files', '{used}%', {used: Math.round(response.data.usedSpacePercent)}));
 					$('#quota progress').val(response.data.usedSpacePercent);
 					$('#quotatext').html(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanTotal}));
 				} else {

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -60,7 +60,7 @@ class Helper {
 			'quota' => $storageInfo['quota'],
 			'total' => $storageInfo['total'],
 			'used' => $storageInfo['used'],
-			'usedSpacePercent' => (int)$storageInfo['relative'],
+			'usedSpacePercent' => $storageInfo['relative'],
 			'owner' => $storageInfo['owner'],
 			'ownerDisplayName' => $storageInfo['ownerDisplayName'],
 			'mountType' => $storageInfo['mountType'],

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -58,6 +58,7 @@ class Helper {
 			'maxHumanFilesize' => $maxHumanFileSize,
 			'freeSpace' => $storageInfo['free'],
 			'quota' => $storageInfo['quota'],
+			'total' => $storageInfo['total'],
 			'used' => $storageInfo['used'],
 			'usedSpacePercent' => (int)$storageInfo['relative'],
 			'owner' => $storageInfo['owner'],

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -17,7 +17,7 @@
 			</li>
 		<?php else: ?>
 			<li id="quota" class="has-tooltip pinned <?php p($pinned === 0 ? 'first-pinned ' : '') ?>"
-				title="<?php p($l->t('%s%% of %s used', [$_['usage_relative'], $_['total_space']])); ?>">
+				title="<?php p($l->t('%s%%', [round($_['usage_relative'])])); ?>">
 				<a href="#" class="icon-quota svg quota-navigation-item">
 					<p id="quotatext" class="quota-navigation-item__text"><?php p($l->t('%1$s of %2$s used', [$_['usage'], $_['total_space']])); ?></p>
 					<div class="quota-navigation-item__container">


### PR DESCRIPTION
Unlike the initial quota display, the updated quota display used the quota rather than the total available space. Due to this there was a "jump" in the quota when the display was updated if the quota is larger than the total available space. [The relative usage is based on the total available space](https://github.com/nextcloud/server/blob/53169890d6dccfcc48d80930e33824084d68aa1c/lib/private/legacy/OC_Helper.php#L567), so the updated quota display was changed to also use the total available space.

The tooltip was also inconsistent between the initial quota display and the updated quota display. It was unified to use only the relative usage percenteage, as showing again the total available space in the tooltip was redundant, and to round the value to make it consistent also with [the quota display in the personal information page](https://github.com/nextcloud/server/blob/1fc0b4320c8921ad59bf4d41a88bf9936e1f653d/apps/settings/lib/Settings/Personal/PersonalInfo.php#L145). Unfortunately this change requires new translation strings, but they just show a percenteage symbol after a number, so even if untranslated they should be fine in a lot of languages.

## How to test

- Configure a quota for a user larger than the available space
- Log in as that user
- Open the Files app
- Upload a file

### Expected result

The updated quota display still shows the total available space. The tooltip with the usage percenteage matches the usage bar below.

### Actual result

The updated quota display now shows the quota rather than the total available space. The tooltip with the usage percenteage matches the proportion between the used space and the quota, although it is different from the usage bar below.
