### PR TITLE
Extract GPS data from EXIF

### DIFF
--- a/lib/private/Metadata/MetadataManager.php
+++ b/lib/private/Metadata/MetadataManager.php
@@ -21,27 +21,19 @@ namespace OC\Metadata;
 
 use OC\Metadata\Provider\ExifProvider;
 use OCP\Files\File;
-use OCP\IConfig;
-use Psr\Log\LoggerInterface;
 
 class MetadataManager implements IMetadataManager {
 	/** @var array<string, IMetadataProvider> */
 	private array $providers;
 	private array $providerClasses;
 	private FileMetadataMapper $fileMetadataMapper;
-	private IConfig $config;
-	private LoggerInterface $logger;
 
 	public function __construct(
-		FileMetadataMapper $fileMetadataMapper,
-		IConfig $config,
-		LoggerInterface $logger
+		FileMetadataMapper $fileMetadataMapper
 	) {
 		$this->providers = [];
 		$this->providerClasses = [];
 		$this->fileMetadataMapper = $fileMetadataMapper;
-		$this->config = $config;
-		$this->logger = $logger;
 
 		// TODO move to another place, where?
 		$this->registerProvider(ExifProvider::class);

--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -5,10 +5,19 @@ namespace OC\Metadata\Provider;
 use OC\Metadata\FileMetadata;
 use OC\Metadata\IMetadataProvider;
 use OCP\Files\File;
+use Psr\Log\LoggerInterface;
 
 class ExifProvider implements IMetadataProvider {
+	private LoggerInterface $logger;
+
+	public function __construct(
+		LoggerInterface $logger
+	) {
+		$this->logger = $logger;
+	}
+
 	public static function groupsProvided(): array {
-		return ['size'];
+		return ['size', 'gps'];
 	}
 
 	public static function isAvailable(): bool {
@@ -16,8 +25,21 @@ class ExifProvider implements IMetadataProvider {
 	}
 
 	public function execute(File $file): array {
+		$exifData = [];
 		$fileDescriptor = $file->fopen('rb');
-		$data = exif_read_data($fileDescriptor, 'COMPUTED', true);
+
+		$data = null;
+		try {
+			// Needed to make reading exif data reliable.
+			// This is to trigger this condition: https://github.com/php/php-src/blob/d64aa6f646a7b5e58359dc79479860164239580a/main/streams/streams.c#L710
+			// But I don't understand why 1 as a special meaning.
+			// Revert right after reading the exif data.
+			$oldBufferSize = stream_set_chunk_size($fileDescriptor, 1);
+			$data = exif_read_data($fileDescriptor, 'ANY_TAG', true);
+			stream_set_chunk_size($fileDescriptor, $oldBufferSize);
+		} catch (\Exception $ex) {
+			$this->logger->warning("Couldn't extract metadata for ".$file->getId(), ['exception' => $ex]);
+		}
 
 		$size = new FileMetadata();
 		$size->setGroupName('size');
@@ -31,29 +53,65 @@ class ExifProvider implements IMetadataProvider {
 					'width' => $sizeResult[0],
 					'height' => $sizeResult[1],
 				]);
+
+				$exifData['size'] = $size;
 			}
+		} elseif (array_key_exists('COMPUTED', $data)) {
+			if (array_key_exists('Width', $data['COMPUTED']) && array_key_exists('Height', $data['COMPUTED'])) {
+				$size->setMetadata([
+					'width' => $data['COMPUTED']['Width'],
+					'height' => $data['COMPUTED']['Height'],
+				]);
 
-			return [
-				'size' => $size,
-			];
+				$exifData['size'] = $size;
+			}
 		}
 
-		if (array_key_exists('COMPUTED', $data)
-			&& array_key_exists('Width', $data['COMPUTED'])
-			&& array_key_exists('Height', $data['COMPUTED'])
+		if ($data && array_key_exists('GPS', $data)
+			&& array_key_exists('GPSLatitude', $data['GPS']) && array_key_exists('GPSLatitudeRef', $data['GPS'])
+			&& array_key_exists('GPSLongitude', $data['GPS']) && array_key_exists('GPSLongitudeRef', $data['GPS'])
 		) {
-			$size->setMetadata([
-				'width' => $data['COMPUTED']['Width'],
-				'height' => $data['COMPUTED']['Height'],
+			$gps = new FileMetadata();
+			$gps->setGroupName('gps');
+			$gps->setId($file->getId());
+			$gps->setMetadata([
+				'latitude' => $this->gpsDegreesToDecimal($data['GPS']['GPSLatitude'], $data['GPS']['GPSLatitudeRef']),
+				'longitude' => $this->gpsDegreesToDecimal($data['GPS']['GPSLongitude'], $data['GPS']['GPSLongitudeRef']),
 			]);
+
+			$exifData['gps'] = $gps;
 		}
 
-		return [
-			'size' => $size,
-		];
+		return $exifData;
 	}
 
 	public static function getMimetypesSupported(): string {
 		return '/image\/.*/';
+	}
+
+	/**
+	 * @param array|string $coordinates
+	 */
+	private static function gpsDegreesToDecimal($coordinates, ?string $hemisphere): float {
+		if (is_string($coordinates)) {
+			$coordinates = array_map("trim", explode(",", $coordinates));
+		}
+
+		if (count($coordinates) !== 3) {
+			throw new \Exception('Invalid coordinate format: ' . json_encode($coordinates));
+		}
+
+		[$degrees, $minutes, $seconds] = array_map(function (string $rawDegree) {
+			$parts = explode('/', $rawDegree);
+
+			if ($parts[1] === '0') {
+				return 0;
+			}
+
+			return floatval($parts[0]) / floatval($parts[1] ?? 1);
+		}, $coordinates);
+
+		$sign = ($hemisphere === 'W' || $hemisphere === 'S') ? -1 : 1;
+		return $sign * ($degrees + $minutes / 60 + $seconds / 3600);
 	}
 }

--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -1,5 +1,25 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * @copyright Copyright 2022 Carl Schwan <carl@carlschwan.eu>
+ * @copyright Copyright 2022 Louis Chmn <louis@chmn.me>
+ * @license AGPL-3.0-or-later
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
 namespace OC\Metadata\Provider;
 
 use OC\Metadata\FileMetadata;
@@ -24,6 +44,7 @@ class ExifProvider implements IMetadataProvider {
 		return extension_loaded('exif');
 	}
 
+	/** @return array{'gps': FileMetadata, 'size': FileMetadata} */
 	public function execute(File $file): array {
 		$exifData = [];
 		$fileDescriptor = $file->fopen('rb');


### PR DESCRIPTION
I had to do a workaround to read EXIF data properly:

~~Some work has been done by @CarlSchwan [here](https://github.com/nextcloud/server/pull/31839/files#diff-696d573a441e273811747c682474b6b94c726470441f35092a30824bdb7553f9R18).~~

~~But the `exif_read_data` call does not work, and probably never worked. One possible explanation is that the resource is wrapped. From [the README](https://github.com/icewind1991/streams):~~

~~> Note: due to php's internal stream buffering the $count passed to the read callback will be equal to php's internal buffer size (8192 on default) an not the number of bytes requested by fopen()~~

~~As it works when the stream is not wrapped, it might be an explanation for why the `exif_read_data` call fails.~~

~~To make it work, I copy the stream into a tmp stream without wrappers before passing it to exif_read_data.~~

:heavy_check_mark: I found a workaround by calling `stream_set_chunk_size($fileDescriptor, 1);` before we read the stream. No idea why it works, but it does, and I am reverting it right after to prevent any side effect outside our use case.

I also cherry-picked @CarlSchwan PR that adds a CLI command to extract metadata https://github.com/nextcloud/server/pull/32309