### PR TITLE
Recover installation when creating the database user fails and improve password strength

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -141,6 +141,16 @@ class MySQL extends AbstractDatabase {
 		$rootUser = $this->dbUser;
 		$rootPassword = $this->dbPassword;
 
+		//create a random password so we don't need to store the admin password in the config file
+		$saveSymbols = str_replace(['\"', '\\', '\'', '`'], '', ISecureRandom::CHAR_SYMBOLS);
+		$password = $this->random->generate(22, ISecureRandom::CHAR_ALPHANUMERIC . $saveSymbols)
+			. $this->random->generate(2, ISecureRandom::CHAR_UPPER)
+			. $this->random->generate(2, ISecureRandom::CHAR_LOWER)
+			. $this->random->generate(2, ISecureRandom::CHAR_DIGITS)
+			. $this->random->generate(2, $saveSymbols)
+		;
+		$this->dbPassword = str_shuffle($password);
+
 		try {
 			//user already specified in config
 			$oldUser = $this->config->getValue('dbuser', false);
@@ -163,10 +173,6 @@ class MySQL extends AbstractDatabase {
 					if (count($data) === 0) {
 						//use the admin login data for the new database user
 						$this->dbUser = $adminUser;
-
-						//create a random password so we don't need to store the admin password in the config file
-						$this->dbPassword = $this->random->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
-
 						$this->createDBUser($connection);
 
 						break;

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -129,6 +129,7 @@ class MySQL extends AbstractDatabase {
 				'exception' => $ex,
 				'app' => 'mysql.setup',
 			]);
+			throw $ex;
 		}
 	}
 
@@ -137,6 +138,9 @@ class MySQL extends AbstractDatabase {
 	 * @param IDBConnection $connection
 	 */
 	private function createSpecificUser($username, $connection): void {
+		$rootUser = $this->dbUser;
+		$rootPassword = $this->dbPassword;
+
 		try {
 			//user already specified in config
 			$oldUser = $this->config->getValue('dbuser', false);
@@ -179,6 +183,9 @@ class MySQL extends AbstractDatabase {
 				'exception' => $ex,
 				'app' => 'mysql.setup',
 			]);
+			// Restore the original credentials
+			$this->dbUser = $rootUser;
+			$this->dbPassword = $rootPassword;
 		}
 
 		$this->config->setValues([


### PR DESCRIPTION
I reinstalled my setup and ended up with this error on MySQL:
> General error: 1819 Your password does not satisfy the current policy requirements

The problem is the exception was logged and swallowed, so the remaining part of the installation process tried to grant privileges to that user and wrote it to the config files resulting afterwards in:
```
MySQL username and/or password not valid
 -> You need to enter details of an existing account.
Trace: #0 /home/nickv/Nextcloud/25/server/lib/private/Setup.php(353): OC\Setup\MySQL->setupDatabase()
#1 /home/nickv/Nextcloud/25/server/core/Command/Maintenance/Install.php(105): OC\Setup->install()
#2 /home/nickv/Nextcloud/25/server/3rdparty/symfony/console/Command/Command.php(255): OC\Core\Command\Maintenance\Install->execute()
#3 /home/nickv/Nextcloud/25/server/3rdparty/symfony/console/Application.php(1009): Symfony\Component\Console\Command\Command->run()
#4 /home/nickv/Nextcloud/25/server/3rdparty/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand()
#5 /home/nickv/Nextcloud/25/server/3rdparty/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun()
#6 /home/nickv/Nextcloud/25/server/lib/private/Console/Application.php(213): Symfony\Component\Console\Application->run()
#7 /home/nickv/Nextcloud/25/server/console.php(100): OC\Console\Application->run()
#8 /home/nickv/Nextcloud/25/server/occ(11): require_once('...')
#9 {main}
```

As per https://ostechnix.com/fix-mysql-error-1819-hy000-your-password-does-not-satisfy-the-current-policy-requirements/ there are 3 levels of password strength and the new default is medium:
> MEDIUM Length >= 8, numeric, mixed case, and special characters.

So in a second commit instead of reusing the provided root account, I increased the random password strength that hopefully also matches the STRONG rules