### PR TITLE
Allow symlinks during webpack build

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -141,7 +141,9 @@ module.exports = {
 		new VueLoaderPlugin(),
 		new webpack.ProvidePlugin({
 			// Provide jQuery to jquery plugins as some are loaded before $ is exposed globally.
-			jQuery: 'jquery',
+			// We need to provide the path to node_moduels as otherwise npm link will fail due
+			// to tribute.js checking for jQuery in @nextcloud/vue
+			jQuery: path.resolve(path.join(__dirname, 'node_modules/jquery')),
 			// Shim ICAL to prevent using the global object (window.ICAL).
 			// The library ical.js heavily depends on instanceof checks which will
 			// break if two separate versions of the library are used (e.g. bundled one

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -155,7 +155,7 @@ module.exports = {
 			handlebars: 'handlebars/runtime',
 		},
 		extensions: ['*', '.js', '.vue'],
-		symlinks: false,
+		symlinks: true,
 		fallback: {
 			stream: require.resolve('stream-browserify'),
 			buffer: require.resolve('buffer'),


### PR DESCRIPTION
Make sure that symlinked node_modules are properly handled by webpack in case of using `npm link`.

There is currently one issue during the watch with `@nextcloud/vue` where it cannot resolve jquery which tributejs is pulling in which then cannot be resolved as the parent node modules of `@nextcloud/vue` do not contain it. This is only an issue if components that use the rich content editor and only during linking as in other cases the jquery dependency would be found in the server node_modules. As a fix we could add jquery to the vue library as a dependency, which shouldn't matter in terms of building as those are marked as external anyways.

While tribute.js doesn't require query it checks for its presence which webpack is trying to fill through the ProvidePlugin:

https://github.com/nextcloud/server/blob/master/webpack.common.js#L144

This causes the following tribute.js code to fail then as it tires to resolve it from the linked path:

```
~/repos/nextcloud/@nextcloud/nextcloud-vue bugfix/noid/popover-focus-trap✦ ➜ rg jQuery node_modules/tributejs/dist/tribute.esm.js
1497:    // Check if it is a jQuery collection
1498:    if (typeof jQuery !== "undefined" && el instanceof jQuery) {
1788:    // Check if it is a jQuery collection
1789:    if (typeof jQuery !== "undefined" && el instanceof jQuery) {
```