### PR TITLE
fix exif metadata provider

### DIFF
--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -17,7 +17,7 @@ class ExifProvider implements IMetadataProvider {
 
 	public function execute(File $file): array {
 		$fileDescriptor = $file->fopen('rb');
-		$data = @exif_read_data($fileDescriptor, 'ANY_TAG', true);
+		$data = exif_read_data($fileDescriptor, 'COMPUTED', true);
 
 		$size = new FileMetadata();
 		$size->setGroupName('size');


### PR DESCRIPTION
With `ANY_TAG` it seems to always just return `false`