### PR TITLE
fix updating cached mounts that didn't have their mount provider set previously

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -90,7 +90,12 @@ class UserMountCache implements IUserMountCache {
 
 		$cachedMounts = $this->getMountsForUser($user);
 		if (is_array($mountProviderClasses)) {
-			$cachedMounts = array_filter($cachedMounts, function (ICachedMountInfo $mountInfo) use ($mountProviderClasses) {
+			$cachedMounts = array_filter($cachedMounts, function (ICachedMountInfo $mountInfo) use ($mountProviderClasses, $newMounts) {
+				// for existing mounts that didn't have a mount provider set
+				// we still want the ones that map to new mounts
+				if ($mountInfo->getMountProvider() === '' && isset($newMounts[$mountInfo->getRootId()])) {
+					return true;
+				}
 				return in_array($mountInfo->getMountProvider(), $mountProviderClasses);
 			});
 		}

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -507,4 +507,29 @@ class UserMountCacheTest extends TestCase {
 		$result = $this->cache->getUsedSpaceForUsers([$user1, $user2]);
 		$this->assertEquals(['u1' => 100], $result);
 	}
+
+
+	public function testMigrateMountProvider() {
+		$user1 = $this->userManager->get('u1');
+
+		[$storage1, $rootId] = $this->getStorage(2);
+		$rootId = $this->createCacheEntry('', 2);
+		$mount1 = new MountPoint($storage1, '/foo/');
+		$this->cache->registerMounts($user1, [$mount1]);
+
+		$this->clearCache();
+
+		$cachedMounts = $this->cache->getMountsForUser($user1);
+		$this->assertCount(1, $cachedMounts);
+		$this->assertEquals('', $cachedMounts[0]->getMountProvider());
+
+		$mount1 = new MountPoint($storage1, '/foo/', null, null, null, null, 'dummy');
+		$this->cache->registerMounts($user1, [$mount1], ['dummy']);
+
+		$this->clearCache();
+
+		$cachedMounts = $this->cache->getMountsForUser($user1);
+		$this->assertCount(1, $cachedMounts);
+		$this->assertEquals('dummy', $cachedMounts[0]->getMountProvider());
+	}
 }


### PR DESCRIPTION
When a cached mount info has no mount provider set, but it's rootId matches one of the newly registered providers, we might be hitting in a migration case with existing pre-24 mountpoints. So it should be taken in consideration even if it doesn't match the registered mount provider types.