### PR TITLE
Remove redundant events

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -46,6 +46,7 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -294,6 +295,7 @@ class ViewController extends Controller {
 			];
 		}
 
+		$this->eventDispatcher->dispatchTyped(new ResourcesLoadAdditionalScriptsEvent());
 		$event = new LoadAdditionalScriptsEvent();
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->eventDispatcher->dispatchTyped(new LoadSidebar());
@@ -301,6 +303,7 @@ class ViewController extends Controller {
 		if (class_exists(LoadViewer::class)) {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
+
 		$this->initialState->provideInitialState('templates_path', $this->templateManager->hasTemplateDirectory() ? $this->templateManager->getTemplatePath() : false);
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 

--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -23,18 +23,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-use OCA\Files\Event\LoadAdditionalScriptsEvent;
-use OCA\Files\Event\LoadSidebar;
-use OCA\Viewer\Event\LoadViewer;
-use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IUserSession;
 use OCP\Server;
 
 $config = Server::get(IConfig::class);
 $userSession = Server::get(IUserSession::class);
-$eventDispatcher = Server::get(IEventDispatcher::class);
 
 $showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
 
@@ -42,15 +36,5 @@ $tmpl = new OCP\Template('files_sharing', 'list', '');
 
 // gridview not available for ie
 $tmpl->assign('showgridview', $showgridview);
-
-// fire script events
-$eventDispatcher->dispatchTyped(new ResourcesLoadAdditionalScriptsEvent());
-$eventDispatcher->dispatchTyped(new LoadAdditionalScriptsEvent());
-$eventDispatcher->dispatchTyped(new LoadSidebar());
-
-// Load Viewer scripts
-if (class_exists(LoadViewer::class)) {
-	$eventDispatcher->dispatchTyped(new LoadViewer());
-}
 
 $tmpl->printPage();


### PR DESCRIPTION
The events that were removed here actually already existed in ViewController.

Tested with the Talk sidebar tab after sharing a file, still works.

Fixes https://github.com/nextcloud/server/issues/33547

With Talk enabled and reloading the page twice.

Before: 33 DB queries
After: 27 DB queries