### PR TITLE
Use bigger slice in share provider

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -954,8 +954,8 @@ class DefaultShareProvider implements IShareProvider {
 
 			$start = 0;
 			while (true) {
-				$groups = array_slice($allGroups, $start, 100);
-				$start += 100;
+				$groups = array_slice($allGroups, $start, 1000);
+				$start += 1000;
 
 				if ($groups === []) {
 					break;


### PR DESCRIPTION
Probably won't make a big difference as it is unlikely a user has > 100
shares but this make sure we use the same code in spreed where the
change has a bigger impact.

See https://github.com/nextcloud/spreed/pull/7749