### PR TITLE
Allow to manually specify a theme to apply to a section of an app

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -331,7 +331,7 @@ class ThemingController extends Controller {
 		} else { 
 			// If not set, we'll rely on the body class
 			$compiler = new Compiler();
-			$compiledCss = $compiler->compileString("body[data-theme-$themeId] { $variables $customCss }");
+			$compiledCss = $compiler->compileString("[data-theme-$themeId] { $variables $customCss }");
 			$css = $compiledCss->getCss();;
 		}
 

--- a/core/src/icons.js
+++ b/core/src/icons.js
@@ -322,12 +322,12 @@ css += generateVariablesAliases(true)
 css += '}}'
 
 // DARK THEME
-css += 'body[data-themes*=light] {'
+css += '[data-themes*=light] {'
 css += generateVariablesAliases()
 css += '}'
 
 // DARK THEME
-css += 'body[data-themes*=dark] {'
+css += '[data-themes*=dark] {'
 css += generateVariablesAliases(true)
 css += '}'
 

--- a/dist/icons.css
+++ b/dist/icons.css
@@ -1585,7 +1585,7 @@ body .nav-icon-systemtagsfilter {
     --icon-view-previous-dark: var(--original-icon-view-previous-white);
   }
 }
-body[data-themes*=light] {
+[data-themes*=light] {
   --icon-add-dark: var(--original-icon-add-dark);
   --icon-add-white: var(--original-icon-add-white);
   --icon-address-dark: var(--original-icon-address-dark);
@@ -1794,7 +1794,7 @@ body[data-themes*=light] {
   --icon-view-previous-white: var(--original-icon-view-previous-white);
 }
 
-body[data-themes*=dark] {
+[data-themes*=dark] {
   --icon-add-white: var(--original-icon-add-dark);
   --icon-add-dark: var(--original-icon-add-white);
   --icon-address-white: var(--original-icon-address-dark);


### PR DESCRIPTION
This allow apps to add `[data-theme-dark]` (or whatever theme they want) to force a specific theme to apply to a section of an app.

e.g, we want to force the image editor to have a dark theme, no matter what current theme the user have. 
Just adding `[data-theme-dark]` to the editor root element will make the entire editor using the dark theme.

https://user-images.githubusercontent.com/14975046/184883561-ff0e7b62-1cfe-425b-ba50-0a8c5c8d1895.mp4

