### PR TITLE
trigger a rescan when trying to fopen a file that exists in cache but not on disk

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1151,7 +1151,7 @@ class FileTest extends TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
-			'type' => FileInfo::TYPE_FOLDER,
+			'type' => FileInfo::TYPE_FILE,
 		], null);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
@@ -1172,7 +1172,7 @@ class FileTest extends TestCase {
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
-			'type' => FileInfo::TYPE_FOLDER,
+			'type' => FileInfo::TYPE_FILE,
 		], null);
 
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -166,6 +166,9 @@ class Local extends \OC\Files\Storage\Common {
 	public function stat($path) {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
+		if (!file_exists($fullPath)) {
+			return false;
+		}
 		$statResult = @stat($fullPath);
 		if (PHP_INT_SIZE === 4 && $statResult && !$this->is_dir($path)) {
 			$filesize = $this->filesize($path);
@@ -388,11 +391,15 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function fopen($path, $mode) {
+		$sourcePath = $this->getSourcePath($path);
+		if (!file_exists($sourcePath) && $mode === 'r') {
+			return false;
+		}
 		$oldMask = umask($this->defUMask);
 		if (($mode === 'w' || $mode === 'w+') && $this->unlinkOnTruncate) {
 			$this->unlink($path);
 		}
-		$result = fopen($this->getSourcePath($path), $mode);
+		$result = @fopen($sourcePath, $mode);
 		umask($oldMask);
 		return $result;
 	}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2709,4 +2709,23 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals(25, $info->getUploadTime());
 		$this->assertEquals(0, $info->getCreationTime());
 	}
+
+	public function testFopenGone() {
+		$storage = new Temporary([]);
+		$scanner = $storage->getScanner();
+		$storage->file_put_contents('foo.txt', 'bar');
+		$scanner->scan('');
+		$cache = $storage->getCache();
+
+		Filesystem::mount($storage, [], '/test/');
+		$view = new View('/test');
+
+		$storage->unlink('foo.txt');
+
+		$this->assertTrue($cache->inCache('foo.txt'));
+
+		$this->assertFalse($view->fopen('foo.txt', 'r'));
+
+		$this->assertFalse($cache->inCache('foo.txt'));
+	}
 }


### PR DESCRIPTION
When the file index gets out of sync, any attempt by client to open a deleted (but still in cache) file will result in errors until an admin manually triggers a scan to repair it.

Rather than letting clients loop in errors forever we can just detect this error condition and repair the file index ourselves.

Note that this has no effect on primary object store as there `file_exists` will check the cache.