### PR TITLE
directly build the search filter for shared storage instead of setting up the source cache

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -183,16 +183,18 @@ class Cache extends CacheJail {
 	}
 
 	public function getQueryFilterForStorage(): ISearchOperator {
+		$storageFilter = \OC\Files\Cache\Cache::getQueryFilterForStorage();
+
 		// Do the normal jail behavior for non files
 		if ($this->storage->getItemType() !== 'file') {
-			return parent::getQueryFilterForStorage();
+			return $this->addJailFilterQuery($storageFilter);
 		}
 
 		// for single file shares we don't need to do the LIKE
 		return new SearchBinaryOperator(
 			ISearchBinaryOperator::OPERATOR_AND,
 			[
-				\OC\Files\Cache\Cache::getQueryFilterForStorage(),
+				$storageFilter,
 				new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
 			]
 		);

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -306,10 +306,14 @@ class CacheJail extends CacheWrapper {
 	}
 
 	public function getQueryFilterForStorage(): ISearchOperator {
+		return $this->addJailFilterQuery($this->getCache()->getQueryFilterForStorage());
+	}
+
+	protected function addJailFilterQuery(ISearchOperator $filter): ISearchOperator {
 		if ($this->getGetUnjailedRoot() !== '' && $this->getGetUnjailedRoot() !== '/') {
 			return new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND,
 				[
-					$this->getCache()->getQueryFilterForStorage(),
+					$filter,
 					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR,
 						[
 							new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
@@ -319,7 +323,7 @@ class CacheJail extends CacheWrapper {
 				]
 			);
 		} else {
-			return $this->getCache()->getQueryFilterForStorage();
+			return $filter;
 		}
 	}
 


### PR DESCRIPTION
This way we only need to setup the source cache once we post-process any results from the shares.