### PR TITLE
further pre-filter search result before setting up share source cache

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -197,4 +197,12 @@ class Cache extends CacheJail {
 			]
 		);
 	}
+
+	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {
+		if ($rawEntry->getStorageId() === $this->getNumericStorageId()) {
+			return parent::getCacheEntryFromSearchResult($rawEntry);
+		} else {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
Further reduce the number of shares we need to initialize when doing search