### PR TITLE
Optimize Node::getParent and usage in previews

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -119,10 +119,11 @@ class Folder extends Node implements \OCP\Files\Folder {
 		} else {
 			$isDir = $info->getType() === FileInfo::TYPE_FOLDER;
 		}
+		$parent = dirname($path) === $this->getPath() ? $this : null;
 		if ($isDir) {
-			return new Folder($this->root, $this->view, $path, $info);
+			return new Folder($this->root, $this->view, $path, $info, $parent);
 		} else {
-			return new File($this->root, $this->view, $path, $info);
+			return new File($this->root, $this->view, $path, $info, $parent);
 		}
 	}
 
@@ -163,7 +164,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 			if (!$this->view->mkdir($fullPath)) {
 				throw new NotPermittedException('Could not create folder');
 			}
-			$node = new Folder($this->root, $this->view, $fullPath, null, $this);
+			$parent = dirname($fullPath) === $this->getPath() ? $this : null;
+			$node = new Folder($this->root, $this->view, $fullPath, null, $parent);
 			$this->sendHooks(['postWrite', 'postCreate'], [$node]);
 			return $node;
 		} else {

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -101,9 +101,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 		return array_map(function (FileInfo $info) {
 			if ($info->getMimetype() === FileInfo::MIMETYPE_FOLDER) {
-				return new Folder($this->root, $this->view, $info->getPath(), $info);
+				return new Folder($this->root, $this->view, $info->getPath(), $info, $this);
 			} else {
-				return new File($this->root, $this->view, $info->getPath(), $info);
+				return new File($this->root, $this->view, $info->getPath(), $info, $this);
 			}
 		}, $folderContent);
 	}
@@ -163,7 +163,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			if (!$this->view->mkdir($fullPath)) {
 				throw new NotPermittedException('Could not create folder');
 			}
-			$node = new Folder($this->root, $this->view, $fullPath);
+			$node = new Folder($this->root, $this->view, $fullPath, null, $this);
 			$this->sendHooks(['postWrite', 'postCreate'], [$node]);
 			return $node;
 		} else {
@@ -193,7 +193,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			if ($result === false) {
 				throw new NotPermittedException('Could not create path');
 			}
-			$node = new File($this->root, $this->view, $fullPath);
+			$node = new File($this->root, $this->view, $fullPath, null, $this);
 			$this->sendHooks(['postWrite', 'postCreate'], [$node]);
 			return $node;
 		}

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -62,16 +62,22 @@ class Node implements \OCP\Files\Node {
 	protected $fileInfo;
 
 	/**
+	 * @var Node|null
+	 */
+	protected $parent;
+
+	/**
 	 * @param \OC\Files\View $view
 	 * @param \OCP\Files\IRootFolder $root
 	 * @param string $path
 	 * @param FileInfo $fileInfo
 	 */
-	public function __construct($root, $view, $path, $fileInfo = null) {
+	public function __construct($root, $view, $path, $fileInfo = null, ?Node $parent = null) {
 		$this->view = $view;
 		$this->root = $root;
 		$this->path = $path;
 		$this->fileInfo = $fileInfo;
+		$this->parent = $parent;
 	}
 
 	/**
@@ -278,11 +284,16 @@ class Node implements \OCP\Files\Node {
 	 * @return Node
 	 */
 	public function getParent() {
-		$newPath = dirname($this->path);
-		if ($newPath === '' || $newPath === '.' || $newPath === '/') {
-			return $this->root;
+		if ($this->parent === null) {
+			$newPath = dirname($this->path);
+			if ($newPath === '' || $newPath === '.' || $newPath === '/') {
+				return $this->root;
+			}
+
+			$this->parent = $this->root->get($newPath);
 		}
-		return $this->root->get($newPath);
+
+		return $this->parent;
 	}
 
 	/**

--- a/lib/private/Preview/ProviderV1Adapter.php
+++ b/lib/private/Preview/ProviderV1Adapter.php
@@ -55,7 +55,7 @@ class ProviderV1Adapter implements IProviderV2 {
 	}
 
 	private function getViewAndPath(File $file) {
-		$view = new View($file->getParent()->getPath());
+		$view = new View(dirname($file->getPath()));
 		$path = $file->getName();
 
 		return [$view, $path];

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -178,7 +178,7 @@ class FolderTest extends NodeTest {
 			->willReturn(true);
 
 		$node = new Folder($root, $view, '/bar/foo');
-		$child = new Folder($root, $view, '/bar/foo/asd');
+		$child = new Folder($root, $view, '/bar/foo/asd', null, $node);
 		$result = $node->newFolder('asd');
 		$this->assertEquals($child, $result);
 	}
@@ -228,7 +228,7 @@ class FolderTest extends NodeTest {
 			->willReturn(true);
 
 		$node = new Folder($root, $view, '/bar/foo');
-		$child = new \OC\Files\Node\File($root, $view, '/bar/foo/asd');
+		$child = new \OC\Files\Node\File($root, $view, '/bar/foo/asd', null, $node);
 		$result = $node->newFile('asd');
 		$this->assertEquals($child, $result);
 	}


### PR DESCRIPTION
`Node::getParent` does not need to query the database again if the parent node was already used before for constructing the child node. In those cases it is now passed to the child node and can be reused.

The second commit avoids using the getParent call on preview generation which saves one query.

Found in Collectives where there are similar optimisations, but this would be a generic use to help prevent this for users of getParent()