### PR TITLE
Don't scan children from created directory

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1182,7 +1182,7 @@ class View {
 				if ($result && in_array('delete', $hooks)) {
 					$this->removeUpdate($storage, $internalPath);
 				}
-				if ($result && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
+				if ($result && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch' && $operation !== 'mkdir') {
 					$this->writeUpdate($storage, $internalPath);
 				}
 				if ($result && in_array('touch', $hooks)) {


### PR DESCRIPTION
We already know what there is no children so the size = 0 and we don't
need to propagate the new size to the children because x + 0 is still
equal to x

Remove some queries when doing a MKCOL