### PR TITLE
Fix carddav activities

### DIFF
--- a/apps/dav/lib/CardDAV/Activity/Backend.php
+++ b/apps/dav/lib/CardDAV/Activity/Backend.php
@@ -129,7 +129,7 @@ class Backend {
 		$event = $this->activityManager->generateEvent();
 		$event->setApp('dav')
 			->setObject('addressbook', (int) $addressbookData['id'])
-			->setType('addressbook')
+			->setType('contacts')
 			->setAuthor($currentUser);
 
 		$changedVisibleInformation = array_intersect([
@@ -188,7 +188,7 @@ class Backend {
 		$event = $this->activityManager->generateEvent();
 		$event->setApp('dav')
 			->setObject('addressbook', (int) $addressbookData['id'])
-			->setType('addressbook')
+			->setType('contacts')
 			->setAuthor($currentUser);
 
 		foreach ($remove as $principal) {
@@ -433,7 +433,7 @@ class Backend {
 		$event = $this->activityManager->generateEvent();
 		$event->setApp('dav')
 			->setObject('addressbook', (int) $addressbookData['id'])
-			->setType('card')
+			->setType('contacts')
 			->setAuthor($currentUser);
 
 		$users = $this->getUsersForShares($shares);

--- a/apps/dav/lib/CardDAV/Activity/Provider/Addressbook.php
+++ b/apps/dav/lib/CardDAV/Activity/Provider/Addressbook.php
@@ -72,7 +72,7 @@ class Addressbook extends Base {
 	 * @throws \InvalidArgumentException
 	 */
 	public function parse($language, IEvent $event, IEvent $previousEvent = null): IEvent {
-		if ($event->getApp() !== 'dav' || $event->getType() !== 'addressbook') {
+		if ($event->getApp() !== 'dav' || $event->getType() !== 'contacts') {
 			throw new \InvalidArgumentException();
 		}
 

--- a/apps/dav/lib/CardDAV/Activity/Provider/Card.php
+++ b/apps/dav/lib/CardDAV/Activity/Provider/Card.php
@@ -74,7 +74,7 @@ class Card extends Base {
 	 * @throws \InvalidArgumentException
 	 */
 	public function parse($language, IEvent $event, IEvent $previousEvent = null): IEvent {
-		if ($event->getApp() !== 'dav' || $event->getType() !== 'card') {
+		if ($event->getApp() !== 'dav' || $event->getType() !== 'contacts') {
 			throw new \InvalidArgumentException();
 		}
 

--- a/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
@@ -226,7 +226,7 @@ class BackendTest extends TestCase {
 				->willReturnSelf();
 			$event->expects($this->once())
 				->method('setType')
-				->with('addressbook')
+				->with('contacts')
 				->willReturnSelf();
 			$event->expects($this->once())
 				->method('setAuthor')
@@ -396,7 +396,7 @@ class BackendTest extends TestCase {
 				->willReturnSelf();
 			$event->expects($this->once())
 				->method('setType')
-				->with('card')
+				->with('contacts')
 				->willReturnSelf();
 			$event->expects($this->once())
 				->method('setAuthor')


### PR DESCRIPTION
The settings where combined last minute but at the same time the activities
where not adjusted to map an existing setting so the filter was not possible
to even limit it to the types that the activities had.

Unluckily this is not retro-active

Fix https://github.com/nextcloud/activity/issues/856