### PR TITLE
Fix creation of new user and display the correct error message

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -426,7 +426,14 @@ class UsersController extends AUserData {
 			}
 
 			if ($displayName !== '') {
-				$this->editUser($userid, self::USER_FIELD_DISPLAYNAME, $displayName);
+				try {
+					$this->editUser($userid, self::USER_FIELD_DISPLAYNAME, $displayName);
+				} catch (OCSException $e) {
+					if ($newUser instanceof IUser) {
+						$newUser->delete();
+					}
+					throw $e;
+				}
 			}
 
 			if ($quota !== '') {
@@ -837,8 +844,10 @@ class UsersController extends AUserData {
 		switch ($key) {
 			case self::USER_FIELD_DISPLAYNAME:
 			case IAccountManager::PROPERTY_DISPLAYNAME:
-				if (!$targetUser->setDisplayName($value)) {
-					throw new OCSException('Invalid displayname', 102);
+				try {
+					$targetUser->setDisplayName($value);
+				} catch (InvalidArgumentException $e) {
+					throw new OCSException($e->getMessage(), 101);
 				}
 				break;
 			case self::USER_FIELD_QUOTA:

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -212,11 +212,13 @@ class Database extends ABackend implements
 	 * @param string $displayName The new display name
 	 * @return bool
 	 *
+	 * @throws \InvalidArgumentException
+	 *
 	 * Change the display name of a user
 	 */
 	public function setDisplayName(string $uid, string $displayName): bool {
 		if (mb_strlen($displayName) > 64) {
-			return false;
+			throw new \InvalidArgumentException('Invalid displayname');
 		}
 
 		$this->fixDI();

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -154,6 +154,9 @@ class User implements IUser {
 	 *
 	 * @param string $displayName
 	 * @return bool
+	 *
+	 * @since 25.0.0 Throw InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function setDisplayName($displayName) {
 		$displayName = trim($displayName);

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -58,6 +58,9 @@ interface IUser {
 	 * @param string $displayName
 	 * @return bool
 	 * @since 8.0.0
+	 *
+	 * @since 25.0.0 Throw InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function setDisplayName($displayName);
 

--- a/lib/public/User/Backend/ISetDisplayNameBackend.php
+++ b/lib/public/User/Backend/ISetDisplayNameBackend.php
@@ -36,6 +36,9 @@ interface ISetDisplayNameBackend {
 	 * @param string $uid The username
 	 * @param string $displayName The new display name
 	 * @return bool
+	 *
+	 * @since 25.0.0 Throw InvalidArgumentException
+	 * @throws \InvalidArgumentException
 	 */
 	public function setDisplayName(string $uid, string $displayName): bool;
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/33572

- [x] Fix creation of new user (either with the same or different values entered for Username and Display name)
- [x] Rollback user creation on invalid displayname
- [x] Display the correct error message

### Out-of-scope
Rollback user creation on other exceptions