### PR TITLE
Fix plural translation without %n usage in string

### DIFF
--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -27,6 +27,8 @@
  */
 namespace OC\L10N;
 
+use function strpos;
+
 class L10NString implements \JsonSerializable {
 	/** @var L10N */
 	protected $l10n;
@@ -74,11 +76,11 @@ class L10NString implements \JsonSerializable {
 			return 'Can not use pipe character in translations';
 		}
 
-		$beforeIdentity = $identity;
 		$identity = str_replace('%n', '%count%', $identity);
 
 		$parameters = [];
-		if ($beforeIdentity !== $identity) {
+		// Make sure to pass the count parameter to Symfony for all plural strings
+		if (strpos($identity, '|')) {
 			$parameters = ['%count%' => $this->count];
 		}
 

--- a/tests/data/l10n/de.json
+++ b/tests/data/l10n/de.json
@@ -1,6 +1,7 @@
 {
 	"translations" : {
 		"_%n file_::_%n files_": ["%n Datei", "%n Dateien"],
+		"_%s user found_::_%s users found_" : ["%s Benutzer gefunden","%s Benutzer gefunden"],
 		"Ordered placeholders one %s two %s": "Placeholder one %s two %s",
 		"Reordered placeholders one %s two %s": "Placeholder two %2$s one %1$s",
 		"Reordered placeholders one %1$s two %2$s": "Placeholder two %2$s one %1$s"

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -50,6 +50,14 @@ class L10nTest extends TestCase {
 		$this->assertEquals('2 Dateien', (string) $l->n('%n file', '%n files', 2));
 	}
 
+	public function testGermanPluralTranslationsWithoutPluralUsage() {
+		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/de.json';
+		$l = new L10N($this->getFactory(), 'test', 'de', 'de_AT', [$transFile]);
+
+		$this->assertEquals('1 Benutzer gefunden', (string) $l->n('%s user found', '%s users found', 1, [1]));
+		$this->assertEquals('> 1000 Benutzer gefunden', (string) $l->n('%s user found', '%s users found', 2000, ['> 1000']));
+	}
+
 	public function testRussianPluralTranslations() {
 		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/ru.json';
 		$l = new L10N($this->getFactory(), 'test', 'ru', 'ru_UA', [$transFile]);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/32745.

The issue is that the translation string `_%s user found_::_%s users found_` doesn't contain a `%n`, so it was wrongly assumed that this isn't a plural string and so the counter didn't get passed to Symfony. Symfony then didn't bother to split the plural string at `|` and the final text passed to `vsprintf` contained *two* `%s`.

The code now uses the `|` as indicator for a plural string.

Test added to reproduce the issue and confirm the fix.

Ref https://github.com/nextcloud/server/pull/26375
Ref https://github.com/nextcloud/server/pull/32155