### PR TITLE
Fix ETAG returned by bulk upload

### DIFF
--- a/apps/dav/lib/BulkUpload/BulkUploadPlugin.php
+++ b/apps/dav/lib/BulkUpload/BulkUploadPlugin.php
@@ -90,6 +90,7 @@ class BulkUploadPlugin extends ServerPlugin {
 
 				$node = $this->userFolder->newFile($headers['x-file-path'], $content);
 				$node->touch($mtime);
+				$node = $this->userFolder->getById($node->getId())[0];
 
 				$writtenFiles[$headers['x-file-path']] = [
 					"error" => false,


### PR DESCRIPTION
Refresh Node object to get fresh fileinfo data after touch.
Should fix https://github.com/nextcloud/desktop/issues/4243

Problem was that $node->touch updates mtime but not etag. @icewind1991 do you know of a cleaner way to refresh the etag after calling touch?

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>