### PR TITLE
Automatically set binlog_format to ROW on connect

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -131,6 +131,8 @@ class ConnectionFactory {
 			case 'mysql':
 				$eventManager->addEventSubscriber(
 					new SQLSessionInit("SET SESSION AUTOCOMMIT=1"));
+				$eventManager->addEventSubscriber(
+					new SQLSessionInit("SET SESSION binlog_format='ROW'"));
 				break;
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);


### PR DESCRIPTION
This automatically sets the binlog_format to ROW for the session in order to make it independant of the configured DB value.

I'm running MariaDB with Nextcloud with the binlog_format MIXED for several years now, maybe that would be a better option when the DBMS can decide whether to use ROW or STATEMENT format.

cf. issue #29911