### PR TITLE
Fix opening Help page throwing Exception

### DIFF
--- a/apps/settings/lib/Controller/HelpController.php
+++ b/apps/settings/lib/Controller/HelpController.php
@@ -79,7 +79,7 @@ class HelpController extends Controller {
 		}
 
 		$documentationUrl = $this->urlGenerator->getAbsoluteURL(
-			$this->urlGenerator->linkTo('core', 'doc/' . $mode . '/index.html')
+			$this->urlGenerator->linkTo('', 'core/doc/' . $mode . '/index.html')
 		);
 
 		$urlUserDocs = $this->urlGenerator->linkToRoute('settings.Help.help', ['mode' => 'user']);

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -146,7 +146,7 @@ class URLGenerator implements IURLGenerator {
 		if ($appName !== '') {
 			$app_path = $this->getAppManager()->getAppPath($appName);
 			// Check if the app is in the app folder
-			if ($app_path && file_exists($app_path . '/' . $file)) {
+			if (file_exists($app_path . '/' . $file)) {
 				if (substr($file, -3) === 'php') {
 					$urlLinkTo = \OC::$WEBROOT . '/index.php/apps/' . $appName;
 					if ($frontControllerActive) {


### PR DESCRIPTION
To reproduce:

On master, open the "Help" page via drop-down menu on the upper right. You would expect that the page opens, instead you are faced with a server error.

Details:

- Commit 458c2fa2971e6595a18a289b0afeb4a79ea0e0d3 provoked the error,
  because the "core" "app" was not found. Previously, false was
  returned, but now an AppPathNotFoundException
- IUrlGenerator::linkTo() accepts an empty app argument however, moving
  the "core" portion to the path solves it and avoids apps lookup

This caused one scenarion of user_saml integration tests to fail 😃
