### PR TITLE
[stable24] logger ignore args of sharepoint-related methods

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -100,6 +100,11 @@ class ExceptionSerializer {
 
 		// Preview providers, don't log big data strings
 		'imagecreatefromstring',
+
+		// Sharepoint, only up to NC24
+		'acquireSecurityToken',
+		'acquireToken',
+		'acquireTokenForUser',
 	];
 
 	/** @var SystemConfig */


### PR DESCRIPTION
For we don't backport https://github.com/nextcloud/server/pull/33398 methods enlisted in https://github.com/nextcloud/sharepoint/pull/143 should be added here at the ExceptionSerializer.

