### PR TITLE
[24] make groupfolders use system wide encryption keys

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -34,6 +34,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\GlobalStoragesService;
+use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCP\Encryption\IEncryptionModule;
 use OCP\IConfig;
 use OCP\IUser;
@@ -299,6 +300,15 @@ class Util {
 	 * @return boolean
 	 */
 	public function isSystemWideMountPoint($path, $uid) {
+		$mount = Filesystem::getMountManager()->find('/' . $uid . $path);
+
+		/**
+		 * @psalm-suppress UndefinedClass
+		 */
+		if ($mount instanceof GroupMountPoint) {
+			return true;
+		}
+
 		if (\OCP\App::isEnabled("files_external")) {
 			/** @var GlobalStoragesService $storageService */
 			$storageService = \OC::$server->get(GlobalStoragesService::class);


### PR DESCRIPTION
Backported alternative of https://github.com/nextcloud/server/pull/33500

Doesn't do anything without https://github.com/nextcloud/groupfolders/pull/2068 to enable encryption for groupfolders