### PR TITLE
Avoid size changes on web ui update

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -625,7 +625,7 @@ p.info {
 
 /* Update */
 .update {
-	width: inherit;
+	width: calc(100% - 32px);
 	text-align: center;
 }
 .update .appList {


### PR DESCRIPTION
Otherwise the container size jumps around during the update
