### PR TITLE
Added parameter to disable "Add to your nextcloud" option in public shares

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
@@ -572,7 +573,7 @@ class ShareController extends AuthPublicShareController {
 				$responseComposer[] = $download;
 			}
 			$responseComposer[] = $directLink;
-			if ($this->federatedShareProvider->isOutgoingServer2serverShareEnabled()) {
+			if ($this->federatedShareProvider->isOutgoingServer2serverShareEnabled() && ($this->config->getAppValue('files_sharing', 'showExternalShareOption', 'yes') === 'yes')) {
 				$responseComposer[] = $externalShare;
 			}
 


### PR DESCRIPTION
Added app `files_sharing` parameter `showExternalShareOption` to allow one to hide
"Add to your nextcloud" option in public shares (shown by default). Use
```
occ config:app:set files_sharing showExternalShareOption --value='no'
```
to hide and
```
occ config:app:set files_sharing showExternalShareOption --value='yes'
```
to restore.

Related: https://github.com/nextcloud/server/issues/12395
Author-Change-Id: IB#1123210
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>