### PR TITLE
fix using FSEEK_END with SeekableHttpStream to get file size

### DIFF
--- a/tests/lib/Files/ObjectStore/AzureTest.php
+++ b/tests/lib/Files/ObjectStore/AzureTest.php
@@ -35,4 +35,8 @@ class AzureTest extends ObjectStoreTest {
 
 		return new Azure($config['arguments']);
 	}
+
+	public function testFseekSize() {
+		$this->markTestSkipped('azure does not support seeking at the moment');
+	}
 }

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -143,4 +143,19 @@ abstract class ObjectStoreTest extends TestCase {
 
 		$this->assertEquals('foobar', stream_get_contents($instance->readObject('target')));
 	}
+
+	public function testFseekSize() {
+		$instance = $this->getInstance();
+
+		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
+		$size = filesize($textFile);
+		$instance->writeObject('source', fopen($textFile, 'r'));
+
+		$fh = $instance->readObject('source');
+
+		fseek($fh, 0, SEEK_END);
+		$pos = ftell($fh);
+
+		$this->assertEquals($size, $pos);
+	}
 }

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -664,4 +664,18 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertStringEqualsFile($textFile, $storage->file_get_contents('test.txt'));
 		$this->assertEquals('resource (closed)', gettype($source));
 	}
+
+	public function testFseekSize() {
+		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
+		$this->instance->file_put_contents('bar.txt', file_get_contents($textFile));
+
+		$size = $this->instance->filesize('bar.txt');
+		$this->assertEquals(filesize($textFile), $size);
+		$fh = $this->instance->fopen('bar.txt', 'r');
+
+		fseek($fh, 0, SEEK_END);
+		$pos = ftell($fh);
+
+		$this->assertEquals($size, $pos);
+	}
 }


### PR DESCRIPTION
Delays the reconnect on `fseek` to allow `fseek(0, FSEEK_END)` to return successfully.

This is used by some libraries to get the filesize from stream.

Adds tests to ensure that this method can be used for all storage backends.