### PR TITLE
Remove deprecated at matcher in tests/lib part 2

### DIFF
--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -146,20 +146,21 @@ class FactoryTest extends TestCase {
 	public function testFindLanguageWithNotExistingRequestLanguageAndNotExistingStoredUserLanguage(): void {
 		$factory = $this->getFactory(['languageExists'], true);
 		$this->invokePrivate($factory, 'requestLanguage', ['de']);
-		$factory->expects(self::at(0))
-				->method('languageExists')
-				->with('MyApp', 'de')
-				->willReturn(false);
+		$factory->expects($this->exactly(3))
+			->method('languageExists')
+			->willReturnMap([
+				['MyApp', 'de', false],
+				['MyApp', 'jp', false],
+				['MyApp', 'es', true],
+			]);
 		$this->config
-			->expects(self::at(0))
+			->expects($this->exactly(3))
 			->method('getSystemValue')
-			->with('force_language', false)
-			->willReturn(false);
-		$this->config
-				->expects(self::at(1))
-				->method('getSystemValue')
-				->with('installed', false)
-				->willReturn(true);
+			->willReturnMap([
+				['force_language', false, false],
+				['installed', false, true],
+				['default_language', false, 'es']
+			]);
 		$user = $this->getMockBuilder(IUser::class)
 			->getMock();
 		$user->expects(self::once())
@@ -174,19 +175,6 @@ class FactoryTest extends TestCase {
 				->method('getUserValue')
 				->with('MyUserUid', 'core', 'lang', null)
 				->willReturn('jp');
-		$factory->expects(self::at(1))
-				->method('languageExists')
-				->with('MyApp', 'jp')
-				->willReturn(false);
-		$this->config
-				->expects(self::at(3))
-				->method('getSystemValue')
-				->with('default_language', false)
-				->willReturn('es');
-		$factory->expects(self::at(2))
-				->method('languageExists')
-				->with('MyApp', 'es')
-				->willReturn(true);
 
 		self::assertSame('es', $factory->findLanguage('MyApp'));
 	}
@@ -194,20 +182,21 @@ class FactoryTest extends TestCase {
 	public function testFindLanguageWithNotExistingRequestLanguageAndNotExistingStoredUserLanguageAndNotExistingDefault(): void {
 		$factory = $this->getFactory(['languageExists'], true);
 		$this->invokePrivate($factory, 'requestLanguage', ['de']);
-		$factory->expects(self::at(0))
-				->method('languageExists')
-				->with('MyApp', 'de')
-				->willReturn(false);
+		$factory->expects($this->exactly(3))
+			->method('languageExists')
+			->willReturnMap([
+				['MyApp', 'de', false],
+				['MyApp', 'jp', false],
+				['MyApp', 'es', false],
+			]);
 		$this->config
-			->expects(self::at(0))
+			->expects($this->exactly(3))
 			->method('getSystemValue')
-			->with('force_language', false)
-			->willReturn(false);
-		$this->config
-				->expects(self::at(1))
-				->method('getSystemValue')
-				->with('installed', false)
-				->willReturn(true);
+			->willReturnMap([
+				['force_language', false, false],
+				['installed', false, true],
+				['default_language', false, 'es']
+			]);
 		$user = $this->getMockBuilder(IUser::class)
 			->getMock();
 		$user->expects(self::once())
@@ -222,19 +211,6 @@ class FactoryTest extends TestCase {
 				->method('getUserValue')
 				->with('MyUserUid', 'core', 'lang', null)
 				->willReturn('jp');
-		$factory->expects(self::at(1))
-				->method('languageExists')
-				->with('MyApp', 'jp')
-				->willReturn(false);
-		$this->config
-				->expects(self::at(3))
-				->method('getSystemValue')
-				->with('default_language', false)
-				->willReturn('es');
-		$factory->expects(self::at(2))
-				->method('languageExists')
-				->with('MyApp', 'es')
-				->willReturn(false);
 		$this->config
 			->expects(self::never())
 			->method('setUserValue');
@@ -245,20 +221,21 @@ class FactoryTest extends TestCase {
 	public function testFindLanguageWithNotExistingRequestLanguageAndNotExistingStoredUserLanguageAndNotExistingDefaultAndNoAppInScope(): void {
 		$factory = $this->getFactory(['languageExists'], true);
 		$this->invokePrivate($factory, 'requestLanguage', ['de']);
-		$factory->expects(self::at(0))
-				->method('languageExists')
-				->with('MyApp', 'de')
-				->willReturn(false);
+		$factory->expects($this->exactly(3))
+			->method('languageExists')
+			->willReturnMap([
+				['MyApp', 'de', false],
+				['MyApp', 'jp', false],
+				['MyApp', 'es', false],
+			]);
 		$this->config
-			->expects(self::at(0))
+			->expects($this->exactly(3))
 			->method('getSystemValue')
-			->with('force_language', false)
-			->willReturn(false);
-		$this->config
-				->expects(self::at(1))
-				->method('getSystemValue')
-				->with('installed', false)
-				->willReturn(true);
+			->willReturnMap([
+				['force_language', false, false],
+				['installed', false, true],
+				['default_language', false, 'es']
+			]);
 		$user = $this->getMockBuilder(IUser::class)
 			->getMock();
 		$user->expects(self::once())
@@ -273,19 +250,6 @@ class FactoryTest extends TestCase {
 				->method('getUserValue')
 				->with('MyUserUid', 'core', 'lang', null)
 				->willReturn('jp');
-		$factory->expects(self::at(1))
-				->method('languageExists')
-				->with('MyApp', 'jp')
-				->willReturn(false);
-		$this->config
-				->expects(self::at(3))
-				->method('getSystemValue')
-				->with('default_language', false)
-				->willReturn('es');
-		$factory->expects(self::at(2))
-				->method('languageExists')
-				->with('MyApp', 'es')
-				->willReturn(false);
 		$this->config
 				->expects(self::never())
 				->method('setUserValue')
@@ -298,12 +262,12 @@ class FactoryTest extends TestCase {
 	public function testFindLanguageWithForcedLanguage(): void {
 		$factory = $this->getFactory(['languageExists']);
 		$this->config
-			->expects(self::at(0))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('force_language', false)
 			->willReturn('de');
 
-		$factory->expects(self::once())
+		$factory->expects($this->once())
 			->method('languageExists')
 			->with('MyApp', 'de')
 			->willReturn(true);

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -135,7 +135,7 @@ class MailerTest extends TestCase {
 		$message = $this->createMock(Message::class);
 
 		$event = new BeforeMessageSent($message);
-		$this->dispatcher->expects($this->at(0))
+		$this->dispatcher->expects($this->once())
 			->method('dispatchTyped')
 			->with($this->equalTo($event));
 

--- a/tests/lib/OCS/ProviderTest.php
+++ b/tests/lib/OCS/ProviderTest.php
@@ -41,24 +41,14 @@ class ProviderTest extends \Test\TestCase {
 
 	public function testBuildProviderListWithoutAnythingEnabled() {
 		$this->appManager
-			->expects($this->at(0))
+			->expects($this->exactly(4))
 			->method('isEnabledForUser')
-			->with('files_sharing')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(1))
-			->method('isEnabledForUser')
-			->with('federation')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(2))
-			->method('isEnabledForUser')
-			->with('activity')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(3))
-			->method('isEnabledForUser')
-			->with('provisioning_api')
+			->withConsecutive(
+				['files_sharing'],
+				['federation'],
+				['activity'],
+				['provisioning_api']
+			)
 			->willReturn(false);
 
 		$expected = new \OCP\AppFramework\Http\JSONResponse(
@@ -82,25 +72,20 @@ class ProviderTest extends \Test\TestCase {
 
 	public function testBuildProviderListWithSharingEnabled() {
 		$this->appManager
-			->expects($this->at(0))
+			->expects($this->exactly(4))
 			->method('isEnabledForUser')
-			->with('files_sharing')
-			->willReturn(true);
-		$this->appManager
-			->expects($this->at(1))
-			->method('isEnabledForUser')
-			->with('federation')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(2))
-			->method('isEnabledForUser')
-			->with('activity')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(3))
-			->method('isEnabledForUser')
-			->with('provisioning_api')
-			->willReturn(false);
+			->withConsecutive(
+				['files_sharing'],
+				['federation'],
+				['activity'],
+				['provisioning_api']
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				false,
+				false,
+				false
+			);
 
 		$expected = new \OCP\AppFramework\Http\JSONResponse(
 			[
@@ -136,25 +121,20 @@ class ProviderTest extends \Test\TestCase {
 
 	public function testBuildProviderListWithFederationEnabled() {
 		$this->appManager
-			->expects($this->at(0))
+			->expects($this->exactly(4))
 			->method('isEnabledForUser')
-			->with('files_sharing')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(1))
-			->method('isEnabledForUser')
-			->with('federation')
-			->willReturn(true);
-		$this->appManager
-			->expects($this->at(2))
-			->method('isEnabledForUser')
-			->with('activity')
-			->willReturn(false);
-		$this->appManager
-			->expects($this->at(3))
-			->method('isEnabledForUser')
-			->with('provisioning_api')
-			->willReturn(false);
+			->withConsecutive(
+				['files_sharing'],
+				['federation'],
+				['activity'],
+				['provisioning_api']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true,
+				false,
+				false
+			);
 
 		$expected = new \OCP\AppFramework\Http\JSONResponse(
 			[

--- a/tests/lib/Repair/ClearFrontendCachesTest.php
+++ b/tests/lib/Repair/ClearFrontendCachesTest.php
@@ -61,7 +61,7 @@ class ClearFrontendCachesTest extends \Test\TestCase {
 			->with('');
 		$this->jsCombiner->expects($this->once())
 			->method('resetCache');
-		$this->cacheFactory->expects($this->at(0))
+		$this->cacheFactory->expects($this->once())
 			->method('createDistributed')
 			->with('imagePath')
 			->willReturn($imagePathCache);

--- a/tests/lib/Repair/NC11/FixMountStoragesTest.php
+++ b/tests/lib/Repair/NC11/FixMountStoragesTest.php
@@ -70,17 +70,16 @@ class FixMountStoragesTest extends TestCase {
 
 		/** @var IOutput|\PHPUnit\Framework\MockObject\MockObject $output */
 		$output = $this->createMock(IOutput::class);
-		$output->expects($this->at(0))
+		$output->expects($this->exactly(2))
 			->method('info')
-			->with('1 mounts updated');
+			->withConsecutive(
+				['1 mounts updated'],
+				['No mounts updated']
+			);
 
 		$this->repair->run($output);
 		$this->assertStorage($mount1, 42);
 		$this->assertStorage($mount2, 23);
-
-		$output->expects($this->at(0))
-			->method('info')
-			->with('No mounts updated');
 
 		$this->repair->run($output);
 		$this->assertStorage($mount1, 42);

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -163,7 +163,7 @@ class CertificateManagerTest extends \Test\TestCase {
 		$certificateManager->expects($this->any())->method('getFilemtimeOfCaBundle')
 			->willReturn($CaBundleMtime);
 
-		$certificateManager->expects($this->at(0))->method('getCertificateBundle')
+		$certificateManager->expects($this->once())->method('getCertificateBundle')
 			->willReturn('targetBundlePath');
 
 		$view->expects($this->any())->method('file_exists')

--- a/tests/lib/Security/IdentityProof/ManagerTest.php
+++ b/tests/lib/Security/IdentityProof/ManagerTest.php
@@ -117,15 +117,16 @@ class ManagerTest extends TestCase {
 			->with('EncryptedPrivateKey')
 			->willReturn('MyPrivateKey');
 		$folder
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getFile')
-			->with('private')
-			->willReturn($privateFile);
-		$folder
-			->expects($this->at(1))
-			->method('getFile')
-			->with('public')
-			->willReturn($publicFile);
+			->withConsecutive(
+				['private'],
+				['public']
+			)
+			->willReturnOnConsecutiveCalls(
+				$privateFile,
+				$publicFile
+			);
 		$this->appData
 			->expects($this->once())
 			->method('getFolder')
@@ -142,17 +143,12 @@ class ManagerTest extends TestCase {
 			->expects($this->once())
 			->method('getUID')
 			->willReturn('MyUid');
-		$this->appData
-			->expects($this->at(0))
-			->method('getFolder')
-			->with('user-MyUid')
-			->willThrowException(new \Exception());
 		$this->manager
 			->expects($this->once())
 			->method('generateKeyPair')
 			->willReturn(['MyNewPublicKey', 'MyNewPrivateKey']);
 		$this->appData
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('newFolder')
 			->with('user-MyUid');
 		$folder = $this->createMock(ISimpleFolder::class);
@@ -172,20 +168,24 @@ class ManagerTest extends TestCase {
 			->method('putContent')
 			->with('MyNewPublicKey');
 		$folder
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('newFile')
-			->with('private')
-			->willReturn($privateFile);
-		$folder
-			->expects($this->at(1))
-			->method('newFile')
-			->with('public')
-			->willReturn($publicFile);
+			->withConsecutive(
+				['private'],
+				['public']
+			)
+			->willReturnOnConsecutiveCalls(
+				$privateFile,
+				$publicFile
+			);
 		$this->appData
-			->expects($this->at(2))
+			->expects($this->exactly(2))
 			->method('getFolder')
 			->with('user-MyUid')
-			->willReturn($folder);
+			->willReturnOnConsecutiveCalls(
+				$this->throwException(new \Exception()),
+				$folder
+			);
 
 
 		$expected = new Key('MyNewPublicKey', 'MyNewPrivateKey');

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -248,22 +248,18 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->with($share);
 
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->with(
-				'OCP\Share::preUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share) {
-					return $e->getSubject() === $share;
-				})
-			);
-		$this->eventDispatcher->expects($this->at(1))
-			->method('dispatch')
-			->with(
-				'OCP\Share::postUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share) {
-					return $e->getSubject() === $share &&
-						$e->getArgument('deletedShares') === [$share];
-				})
+			->withConsecutive(
+				['OCP\Share::preUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share) {
+						return $e->getSubject() === $share;
+					})],
+				['OCP\Share::postUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share) {
+						return $e->getSubject() === $share &&
+							$e->getArgument('deletedShares') === [$share];
+					})]
 			);
 
 		$manager->deleteShare($share);
@@ -296,22 +292,18 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->with($share);
 
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->with(
-				'OCP\Share::preUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share) {
-					return $e->getSubject() === $share;
-				})
-			);
-		$this->eventDispatcher->expects($this->at(1))
-			->method('dispatch')
-			->with(
-				'OCP\Share::postUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share) {
-					return $e->getSubject() === $share &&
-						$e->getArgument('deletedShares') === [$share];
-				})
+			->withConsecutive(
+				['OCP\Share::preUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share) {
+						return $e->getSubject() === $share;
+					})],
+				['OCP\Share::postUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share) {
+						return $e->getSubject() === $share &&
+							$e->getArgument('deletedShares') === [$share];
+					})]
 			);
 
 		$manager->deleteShare($share);
@@ -365,22 +357,18 @@ class ManagerTest extends \Test\TestCase {
 			->method('delete')
 			->withConsecutive([$share3], [$share2], [$share1]);
 
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->with(
-				'OCP\Share::preUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share1) {
-					return $e->getSubject() === $share1;
-				})
-			);
-		$this->eventDispatcher->expects($this->at(1))
-			->method('dispatch')
-			->with(
-				'OCP\Share::postUnshare',
-				$this->callBack(function (GenericEvent $e) use ($share1, $share2, $share3) {
-					return $e->getSubject() === $share1 &&
-						$e->getArgument('deletedShares') === [$share3, $share2, $share1];
-				})
+			->withConsecutive(
+				['OCP\Share::preUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share1) {
+						return $e->getSubject() === $share1;
+					})],
+				['OCP\Share::postUnshare',
+					$this->callBack(function (GenericEvent $e) use ($share1, $share2, $share3) {
+						return $e->getSubject() === $share1 &&
+							$e->getArgument('deletedShares') === [$share3, $share2, $share1];
+					})]
 			);
 
 		$manager->deleteShare($share1);
@@ -408,7 +396,7 @@ class ManagerTest extends \Test\TestCase {
 			->method('deleteFromSelf')
 			->with($share, $recipientId);
 
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
 			->with(
 				'OCP\Share::postUnshareFromSelf',
@@ -2330,44 +2318,39 @@ class ManagerTest extends \Test\TestCase {
 				return $share->setId(42);
 			});
 
-		// Pre share
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->with(
-				$this->equalTo('OCP\Share::preShare'),
-				$this->callback(function (GenericEvent $e) use ($path, $date) {
-					/** @var IShare $share */
-					$share = $e->getSubject();
+			->withConsecutive(
+				// Pre share
+				[$this->equalTo('OCP\Share::preShare'),
+					$this->callback(function (GenericEvent $e) use ($path, $date) {
+						/** @var IShare $share */
+						$share = $e->getSubject();
 
-					return $share->getShareType() === IShare::TYPE_LINK &&
-						$share->getNode() === $path &&
-						$share->getSharedBy() === 'sharedBy' &&
-						$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
-						$share->getExpirationDate() === $date &&
-						$share->getPassword() === 'hashed' &&
-						$share->getToken() === 'token';
-				})
-			);
+						return $share->getShareType() === IShare::TYPE_LINK &&
+							$share->getNode() === $path &&
+							$share->getSharedBy() === 'sharedBy' &&
+							$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+							$share->getExpirationDate() === $date &&
+							$share->getPassword() === 'hashed' &&
+							$share->getToken() === 'token';
+					})],
+				// Post share
+				[$this->equalTo('OCP\Share::postShare'),
+					$this->callback(function (GenericEvent $e) use ($path, $date) {
+						/** @var IShare $share */
+						$share = $e->getSubject();
 
-		// Post share
-		$this->eventDispatcher->expects($this->at(1))
-			->method('dispatch')
-			->with(
-				$this->equalTo('OCP\Share::postShare'),
-				$this->callback(function (GenericEvent $e) use ($path, $date) {
-					/** @var IShare $share */
-					$share = $e->getSubject();
-
-					return $share->getShareType() === IShare::TYPE_LINK &&
-						$share->getNode() === $path &&
-						$share->getSharedBy() === 'sharedBy' &&
-						$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
-						$share->getExpirationDate() === $date &&
-						$share->getPassword() === 'hashed' &&
-						$share->getToken() === 'token' &&
-						$share->getId() === '42' &&
-						$share->getTarget() === '/target';
-				})
+						return $share->getShareType() === IShare::TYPE_LINK &&
+							$share->getNode() === $path &&
+							$share->getSharedBy() === 'sharedBy' &&
+							$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+							$share->getExpirationDate() === $date &&
+							$share->getPassword() === 'hashed' &&
+							$share->getToken() === 'token' &&
+							$share->getId() === '42' &&
+							$share->getTarget() === '/target';
+					})]
 			);
 
 		/** @var IShare $share */
@@ -2442,44 +2425,37 @@ class ManagerTest extends \Test\TestCase {
 				return $share->setId(42);
 			});
 
-		// Pre share
-		$this->eventDispatcher->expects($this->at(0))
+		$this->eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
-			->with(
-				$this->equalTo('OCP\Share::preShare'),
-				$this->callback(function (GenericEvent $e) use ($path) {
-					/** @var IShare $share */
-					$share = $e->getSubject();
+			->withConsecutive(
+				[$this->equalTo('OCP\Share::preShare'),
+					$this->callback(function (GenericEvent $e) use ($path) {
+						/** @var IShare $share */
+						$share = $e->getSubject();
 
-					return $share->getShareType() === IShare::TYPE_EMAIL &&
-						$share->getNode() === $path &&
-						$share->getSharedBy() === 'sharedBy' &&
-						$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
-						$share->getExpirationDate() === null &&
-						$share->getPassword() === null &&
-						$share->getToken() === 'token';
-				})
-			);
+						return $share->getShareType() === IShare::TYPE_EMAIL &&
+							$share->getNode() === $path &&
+							$share->getSharedBy() === 'sharedBy' &&
+							$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+							$share->getExpirationDate() === null &&
+							$share->getPassword() === null &&
+							$share->getToken() === 'token';
+					})],
+				[$this->equalTo('OCP\Share::postShare'),
+					$this->callback(function (GenericEvent $e) use ($path) {
+						/** @var IShare $share */
+						$share = $e->getSubject();
 
-		// Post share
-		$this->eventDispatcher->expects($this->at(1))
-			->method('dispatch')
-			->with(
-				$this->equalTo('OCP\Share::postShare'),
-				$this->callback(function (GenericEvent $e) use ($path) {
-					/** @var IShare $share */
-					$share = $e->getSubject();
-
-					return $share->getShareType() === IShare::TYPE_EMAIL &&
-						$share->getNode() === $path &&
-						$share->getSharedBy() === 'sharedBy' &&
-						$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
-						$share->getExpirationDate() === null &&
-						$share->getPassword() === null &&
-						$share->getToken() === 'token' &&
-						$share->getId() === '42' &&
-						$share->getTarget() === '/target';
-				})
+						return $share->getShareType() === IShare::TYPE_EMAIL &&
+							$share->getNode() === $path &&
+							$share->getSharedBy() === 'sharedBy' &&
+							$share->getPermissions() === \OCP\Constants::PERMISSION_ALL &&
+							$share->getExpirationDate() === null &&
+							$share->getPassword() === null &&
+							$share->getToken() === 'token' &&
+							$share->getId() === '42' &&
+							$share->getTarget() === '/target';
+					})],
 			);
 
 		/** @var IShare $share */
@@ -2868,23 +2844,21 @@ class ManagerTest extends \Test\TestCase {
 
 		$share = $this->createMock(IShare::class);
 
-		$factory->expects($this->at(0))
+		$factory->expects($this->exactly(2))
 			->method('getProviderForType')
-			->with(IShare::TYPE_LINK)
-			->willReturn($this->defaultProvider);
-		$factory->expects($this->at(1))
-			->method('getProviderForType')
-			->with(IShare::TYPE_REMOTE)
+			->withConsecutive(
+				[IShare::TYPE_LINK],
+				[IShare::TYPE_REMOTE]
+			)
 			->willReturn($this->defaultProvider);
 
-		$this->defaultProvider->expects($this->at(0))
+		$this->defaultProvider->expects($this->exactly(2))
 			->method('getShareByToken')
 			->with('token')
-			->will($this->throwException(new ShareNotFound()));
-		$this->defaultProvider->expects($this->at(1))
-			->method('getShareByToken')
-			->with('token')
-			->willReturn($share);
+			->willReturnOnConsecutiveCalls(
+				$this->throwException(new ShareNotFound()),
+				$share
+			);
 
 		$ret = $manager->getShareByToken('token');
 		$this->assertSame($share, $ret);
@@ -2963,10 +2937,12 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testGetShareByTokenPublicUploadDisabled() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('core', 'shareapi_allow_links', 'yes')
-			->willReturn('yes');
+			->willReturnMap([
+				['core', 'shareapi_allow_links', 'yes', 'yes'],
+				['core', 'shareapi_allow_public_upload', 'yes', 'no'],
+			]);
 
 		$share = $this->manager->newShare();
 		$share->setShareType(IShare::TYPE_LINK)
@@ -2974,13 +2950,6 @@ class ManagerTest extends \Test\TestCase {
 		$share->setSharedWith('sharedWith');
 		$folder = $this->createMock(\OC\Files\Node\Folder::class);
 		$share->setNode($folder);
-
-		$this->config
-			->expects($this->at(1))
-			->method('getAppValue')
-			->willReturnMap([
-				['core', 'shareapi_allow_public_upload', 'yes', 'no'],
-			]);
 
 		$this->defaultProvider->expects($this->once())
 			->method('getShareByToken')

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -59,7 +59,7 @@ class JSCombinerTest extends \Test\TestCase {
 		$this->config = $this->createMock(SystemConfig::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->depsCache = $this->createMock(ICache::class);
-		$this->cacheFactory->expects($this->at(0))
+		$this->cacheFactory->expects($this->atLeastOnce())
 			->method('createDistributed')
 			->willReturn($this->depsCache);
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -85,15 +85,16 @@ class JSCombinerTest extends \Test\TestCase {
 
 	public function testProcessNotInstalled() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getValue')
-			->with('debug')
-			->willReturn(false);
-		$this->config
-			->expects($this->at(1))
-			->method('getValue')
-			->with('installed')
-			->willReturn(false);
+			->withConsecutive(
+				['debug'],
+				['installed']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				false
+			);
 
 		$actual = $this->jsCombiner->process(__DIR__, '/data/combine.json', 'awesomeapp');
 		$this->assertFalse($actual);
@@ -101,15 +102,16 @@ class JSCombinerTest extends \Test\TestCase {
 
 	public function testProcessUncachedFileNoAppDataFolder() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getValue')
-			->with('debug')
-			->willReturn(false);
-		$this->config
-			->expects($this->at(1))
-			->method('getValue')
-			->with('installed')
-			->willReturn(true);
+			->withConsecutive(
+				['debug'],
+				['installed']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true
+			);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willThrowException(new NotFoundException());
 		$this->appData->expects($this->once())->method('newFolder')->with('awesomeapp')->willReturn($folder);
@@ -140,15 +142,16 @@ class JSCombinerTest extends \Test\TestCase {
 
 	public function testProcessUncachedFile() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getValue')
-			->with('debug')
-			->willReturn(false);
-		$this->config
-			->expects($this->at(1))
-			->method('getValue')
-			->with('installed')
-			->willReturn(true);
+			->withConsecutive(
+				['debug'],
+				['installed']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true
+			);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willReturn($folder);
 		$file = $this->createMock(ISimpleFile::class);
@@ -177,15 +180,16 @@ class JSCombinerTest extends \Test\TestCase {
 
 	public function testProcessCachedFile() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getValue')
-			->with('debug')
-			->willReturn(false);
-		$this->config
-			->expects($this->at(1))
-			->method('getValue')
-			->with('installed')
-			->willReturn(true);
+			->withConsecutive(
+				['debug'],
+				['installed']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true
+			);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())->method('getFolder')->with('awesomeapp')->willReturn($folder);
 		$file = $this->createMock(ISimpleFile::class);
@@ -217,15 +221,16 @@ class JSCombinerTest extends \Test\TestCase {
 
 	public function testProcessCachedFileMemcache() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getValue')
-			->with('debug')
-			->willReturn(false);
-		$this->config
-			->expects($this->at(1))
-			->method('getValue')
-			->with('installed')
-			->willReturn(true);
+			->withConsecutive(
+				['debug'],
+				['installed']
+			)
+			->willReturnOnConsecutiveCalls(
+				false,
+				true
+			);
 		$folder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects($this->once())
 			->method('getFolder')
@@ -401,13 +406,23 @@ class JSCombinerTest extends \Test\TestCase {
 		$folder = $this->createMock(ISimpleFolder::class);
 		$file = $this->createMock(ISimpleFile::class);
 		$depsFile = $this->createMock(ISimpleFile::class);
+		$gzFile = $this->createMock(ISimpleFile::class);
 
 		$path = __DIR__ . '/data/';
 
-		$folder->expects($this->at(0))->method('getFile')->with($fileName)->willReturn($file);
-		$folder->expects($this->at(1))->method('getFile')->with($fileName . '.deps')->willReturn($depsFile);
+		$folder->expects($this->exactly(3))
+			->method('getFile')
+			->withConsecutive(
+				[$fileName],
+				[$fileName . '.deps'],
+				[$fileName . '.gzip']
+			)->willReturnOnConsecutiveCalls(
+				$file,
+				$depsFile,
+				$gzFile
+			);
 
-		$file->expects($this->at(0))
+		$file->expects($this->once())
 			->method('putContent')
 			->with('var a = \'hello\';
 
@@ -417,7 +432,7 @@ var b = \'world\';
 
 ');
 		$depsFile
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('putContent')
 			->with($this->callback(
 			function ($content) {
@@ -455,7 +470,7 @@ var b = \'world\';
 			}
 		);
 
-		$file->expects($this->at(0))
+		$file->expects($this->once())
 			->method('putContent')
 			->with('var a = \'hello\';
 
@@ -464,13 +479,13 @@ var b = \'world\';
 
 
 ');
-		$depsFile->expects($this->at(0))->method('putContent')->with($this->callback(
+		$depsFile->expects($this->once())->method('putContent')->with($this->callback(
 			function ($content) {
 				$deps = json_decode($content, true);
 				return array_key_exists(__DIR__ . '/data//1.js', $deps)
 					&& array_key_exists(__DIR__ . '/data//2.js', $deps);
 			}));
-		$gzFile->expects($this->at(0))->method('putContent')->with($this->callback(
+		$gzFile->expects($this->once())->method('putContent')->with($this->callback(
 			function ($content) {
 				return gzdecode($content) === 'var a = \'hello\';
 
@@ -550,9 +565,8 @@ var b = \'world\';
 		$this->cacheFactory->expects($this->once())
 			->method('createDistributed')
 			->willReturn($cache);
-		$cache->expects($this->once())
-			->method('clear')
-			->with('');
+		$cache->expects($this->never())
+			->method('clear');
 		$this->appData->expects($this->once())
 			->method('getDirectoryListing')
 			->willReturn([$folder]);

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -66,20 +66,21 @@ class VersionCheckTest extends \Test\TestCase {
 		];
 
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(2))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(time());
-		$this->config
-			->expects($this->at(2))
-			->method('getAppValue')
-			->with('core', 'lastupdateResult')
-			->willReturn(json_encode($expectedResult));
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'lastupdateResult']
+			)
+			->willReturnOnConsecutiveCalls(
+				time(),
+				json_encode($expectedResult)
+			);
 
 		$this->assertSame($expectedResult, $this->updater->check());
 	}
@@ -96,38 +97,37 @@ class VersionCheckTest extends \Test\TestCase {
 		];
 
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(4))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(0);
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'installedat'],
+				['core', 'installedat'],
+				['core', 'lastupdatedat'],
+			)
+			->willReturnOnConsecutiveCalls(
+				0,
+				'installedat',
+				'installedat',
+				'lastupdatedat'
+			);
 		$this->config
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
 			->willReturnArgument(1);
 		$this->config
-			->expects($this->at(3))
+			->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(5))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->willReturn('installedat');
-		$this->config
-			->expects($this->at(6))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('lastupdatedat');
-		$this->config
-			->expects($this->at(7))
-			->method('setAppValue')
-			->with('core', 'lastupdateResult', json_encode($expectedResult));
+			->withConsecutive(
+				['core', 'lastupdatedat', $this->isType('integer')],
+				['core', 'lastupdateResult', json_encode($expectedResult)]
+			);
 
 		$updateXml = '<?xml version="1.0"?>
 <owncloud>
@@ -149,38 +149,37 @@ class VersionCheckTest extends \Test\TestCase {
 
 	public function testCheckWithInvalidXml() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(4))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(0);
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'installedat'],
+				['core', 'installedat'],
+				['core', 'lastupdatedat'],
+			)
+			->willReturnOnConsecutiveCalls(
+				0,
+				'installedat',
+				'installedat',
+				'lastupdatedat'
+			);
 		$this->config
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
 			->willReturnArgument(1);
 		$this->config
-			->expects($this->at(3))
+			->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(5))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->willReturn('installedat');
-		$this->config
-			->expects($this->at(6))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('lastupdatedat');
-		$this->config
-			->expects($this->at(7))
-			->method('setAppValue')
-			->with('core', 'lastupdateResult', '[]');
+			->withConsecutive(
+				['core', 'lastupdatedat', $this->isType('integer')],
+				['core', 'lastupdateResult', '[]']
+			);
 
 		$updateXml = 'Invalid XML Response!';
 		$this->updater
@@ -204,34 +203,37 @@ class VersionCheckTest extends \Test\TestCase {
 		];
 
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(4))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(0);
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'installedat'],
+				['core', 'installedat'],
+				['core', 'lastupdatedat'],
+			)
+			->willReturnOnConsecutiveCalls(
+				0,
+				'installedat',
+				'installedat',
+				'lastupdatedat'
+			);
 		$this->config
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
 			->willReturnArgument(1);
 		$this->config
-			->expects($this->at(3))
+			->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(5))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->willReturn('installedat');
-		$this->config
-			->expects($this->at(6))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('lastupdatedat');
+			->withConsecutive(
+				['core', 'lastupdatedat', $this->isType('integer')],
+				['core', 'lastupdateResult', $this->isType('string')]
+			);
 
 		$updateXml = '<?xml version="1.0"?>
 <owncloud>
@@ -254,38 +256,37 @@ class VersionCheckTest extends \Test\TestCase {
 		$expectedResult = [];
 
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(4))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(0);
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'installedat'],
+				['core', 'installedat'],
+				['core', 'lastupdatedat'],
+			)
+			->willReturnOnConsecutiveCalls(
+				0,
+				'installedat',
+				'installedat',
+				'lastupdatedat'
+			);
 		$this->config
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
 			->willReturnArgument(1);
 		$this->config
-			->expects($this->at(3))
+			->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(5))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->willReturn('installedat');
-		$this->config
-			->expects($this->at(6))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('lastupdatedat');
-		$this->config
-			->expects($this->at(7))
-			->method('setAppValue')
-			->with('core', 'lastupdateResult', json_encode($expectedResult));
+			->withConsecutive(
+				['core', 'lastupdatedat', $this->isType('integer')],
+				['core', 'lastupdateResult', json_encode($expectedResult)]
+			);
 
 		$updateXml = '';
 		$this->updater
@@ -309,34 +310,37 @@ class VersionCheckTest extends \Test\TestCase {
 		];
 
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(true);
 		$this->config
-			->expects($this->at(1))
+			->expects($this->exactly(4))
 			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn(0);
+			->withConsecutive(
+				['core', 'lastupdatedat'],
+				['core', 'installedat'],
+				['core', 'installedat'],
+				['core', 'lastupdatedat'],
+			)
+			->willReturnOnConsecutiveCalls(
+				0,
+				'installedat',
+				'installedat',
+				'lastupdatedat'
+			);
 		$this->config
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getSystemValue')
 			->with('updater.server.url', 'https://updates.nextcloud.com/updater_server/')
 			->willReturnArgument(1);
 		$this->config
-			->expects($this->at(3))
+			->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'lastupdatedat', $this->isType('integer'));
-		$this->config
-			->expects($this->at(5))
-			->method('getAppValue')
-			->with('core', 'installedat')
-			->willReturn('installedat');
-		$this->config
-			->expects($this->at(6))
-			->method('getAppValue')
-			->with('core', 'lastupdatedat')
-			->willReturn('lastupdatedat');
+			->withConsecutive(
+				['core', 'lastupdatedat', $this->isType('integer')],
+				['core', 'lastupdateResult', $this->isType('string')]
+			);
 
 		// missing autoupdater element should still not fail
 		$updateXml = '<?xml version="1.0"?>
@@ -357,7 +361,7 @@ class VersionCheckTest extends \Test\TestCase {
 
 	public function testNoInternet() {
 		$this->config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(false);

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -693,24 +693,24 @@ class ManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$config
-			->expects($this->at(0))
+			->expects($this->once())
 			->method('getUsersForUserValueCaseInsensitive')
 			->with('settings', 'email', 'test@example.com')
 			->willReturn(['uid1', 'uid99', 'uid2']);
 
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);
-		$backend->expects($this->at(0))
+		$backend->expects($this->exactly(3))
 			->method('userExists')
-			->with($this->equalTo('uid1'))
-			->willReturn(true);
-		$backend->expects($this->at(1))
-			->method('userExists')
-			->with($this->equalTo('uid99'))
-			->willReturn(false);
-		$backend->expects($this->at(2))
-			->method('userExists')
-			->with($this->equalTo('uid2'))
-			->willReturn(true);
+			->withConsecutive(
+				[$this->equalTo('uid1')],
+				[$this->equalTo('uid99')],
+				[$this->equalTo('uid2')]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				false,
+				true
+			);
 
 		$manager = new \OC\User\Manager($config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);


### PR DESCRIPTION
Follow up of https://github.com/nextcloud/server/pull/32901

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>