### PR TITLE
Makes untrusted domain error on info

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -802,7 +802,7 @@ class OC {
 			if (!$isScssRequest) {
 				http_response_code(400);
 
-				\OC::$server->getLogger()->warning(
+				\OC::$server->getLogger()->info(
 					'Trusted domain error. "{remoteAddress}" tried to access using "{host}" as host.',
 					[
 						'app' => 'core',


### PR DESCRIPTION
Signed-off-by: Andy Xheli <axheli@axtsolutions.com>

Since https://github.com/nextcloud/server/commit/e6d9ef2e38daffcab808eaa41b18ab16c6253b97 was applied logs get filled up with Trusted domain error. "X.X.X.X tried to access using "X.X.X.X" as host alot of users missed important errors do to https://github.com/nextcloud/server/commit/e6d9ef2e38daffcab808eaa41b18ab16c6253b97   please see https://github.com/nextcloud/server/issues/32599

This should fix. 
https://github.com/nextcloud/server/issues/32599#event-7281164903

