### PR TITLE
add a way to open the admin settings overview directly

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -134,7 +134,12 @@ trait CommonSettingsTrait {
 	}
 
 	private function getIndexResponse($type, $section) {
-		$this->navigationManager->setActiveEntry('settings');
+		if ($type === 'personal') {
+			$this->navigationManager->setActiveEntry('settings');
+		} elseif ($type === 'admin') {
+			$this->navigationManager->setActiveEntry('admin_settings');
+		}
+
 		$templateParams = [];
 		$templateParams = array_merge($templateParams, $this->getNavigationParameters($type, $section));
 		$templateParams = array_merge($templateParams, $this->getSettings($section));

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -211,17 +211,37 @@ class NavigationManager implements INavigationManager {
 					'icon' => $this->urlGenerator->imagePath('settings', 'apps.svg'),
 					'name' => $l->t('Apps'),
 				]);
-			}
 
-			// Personal and (if applicable) admin settings
-			$this->add([
-				'type' => 'settings',
-				'id' => 'settings',
-				'order' => 2,
-				'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
-				'name' => $l->t('Settings'),
-				'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
-			]);
+				// Personal settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'settings',
+					'order' => 2,
+					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
+					'name' => $l->t('Personal settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+
+				// Admin settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'admin_settings',
+					'order' => 3,
+					'href' => $this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'overview']),
+					'name' => $l->t('Admin settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+			} else {
+				// Personal settings
+				$this->add([
+					'type' => 'settings',
+					'id' => 'settings',
+					'order' => 2,
+					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
+					'name' => $l->t('Settings'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+				]);
+			}
 
 			$logoutUrl = \OC_User::getLogoutUrl($this->urlGenerator);
 			if ($logoutUrl !== '') {

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -219,7 +219,7 @@ class NavigationManager implements INavigationManager {
 					'order' => 2,
 					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
 					'name' => $l->t('Personal settings'),
-					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
+					'icon' => $this->urlGenerator->imagePath('settings', 'personal.svg'),
 				]);
 
 				// Admin settings

--- a/tests/acceptance/features/access-levels.feature
+++ b/tests/acceptance/features/access-levels.feature
@@ -18,6 +18,6 @@ Feature: access-levels
 
   Scenario: admin users can see admin-level items on the Settings page
     Given I am logged in as the admin
-    When I visit the settings page
+    When I visit the admin settings page
     Then I see that the "Personal" settings panel is shown
     And I see that the "Administration" settings panel is shown

--- a/tests/acceptance/features/app-files-sharing-link.feature
+++ b/tests/acceptance/features/app-files-sharing-link.feature
@@ -178,7 +178,7 @@ Feature: app-files-sharing-link
     And I see that the file list contains a file named "farewell.txt"
     And I share "farewell.txt" with "user0"
     And I see that the file is shared with "user0"
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled
@@ -209,7 +209,7 @@ Feature: app-files-sharing-link
     And I share the link for "farewell.txt"
     And I write down the shared link
     And I act as John
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled
@@ -239,7 +239,7 @@ Feature: app-files-sharing-link
     And I share the link for "farewell.txt"
     And I write down the shared link
     And I act as John
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled

--- a/tests/acceptance/features/app-files-sharing.feature
+++ b/tests/acceptance/features/app-files-sharing.feature
@@ -252,7 +252,7 @@ Feature: app-files-sharing
     And I see that the file list contains a file named "Shared folder"
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
-    When I visit the settings page
+    When I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled
@@ -273,7 +273,7 @@ Feature: app-files-sharing
     And I see that the file list contains a file named "Shared folder"
     And I share "Shared folder" with "user0"
     And I see that the file is shared with "user0"
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled
@@ -303,7 +303,7 @@ Feature: app-files-sharing
     And I open the Files app
     And I share "Shared folder" with "user1"
     And I act as John
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled
@@ -336,7 +336,7 @@ Feature: app-files-sharing
     And I open the Files app
     And I share "Shared folder" with "user1"
     And I act as John
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I disable resharing
     And I see that resharing is disabled

--- a/tests/acceptance/features/app-files-tags.feature
+++ b/tests/acceptance/features/app-files-tags.feature
@@ -21,7 +21,7 @@ Feature: app-files-tags
 
   Scenario: create tags using the Administration settings
     Given I am logged in as the admin
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Basic settings" section of the "Administration" group
     # The "create" button does nothing before JavaScript was initialized, and
     # the only way to detect that is waiting for the button to select tags to be
@@ -32,7 +32,7 @@ Feature: app-files-tags
 
 #  Scenario: add tags using the dropdown in the details view
 #    Given I am logged in as the admin
-#    And I visit the settings page
+#    And I visit the admin settings page
 #    And I open the "Basic settings" section of the "Administration" group
 #    # The "create" button does nothing before JavaScript was initialized, and
 #    # the only way to detect that is waiting for the button to select tags to be
@@ -60,7 +60,7 @@ Feature: app-files-tags
 #
 #  Scenario: remove tags using the dropdown in the details view
 #    Given I am logged in as the admin
-#    And I visit the settings page
+#    And I visit the admin settings page
 #    And I open the "Basic settings" section of the "Administration" group
 #    # The "create" button does nothing before JavaScript was initialized, and
 #    # the only way to detect that is waiting for the button to select tags to be

--- a/tests/acceptance/features/app-theming.feature
+++ b/tests/acceptance/features/app-theming.feature
@@ -3,7 +3,7 @@ Feature: app-theming
 
   Scenario: changing the color updates the header color
     Given I am logged in as the admin
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Theming" section
     And I see that the color selector in the Theming app has loaded
     # The "eventually" part is not really needed here, as the colour is not
@@ -16,7 +16,7 @@ Feature: app-theming
 
   Scenario: resetting the color updates the header color
     Given I am logged in as the admin
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Theming" section
     And I see that the color selector in the Theming app has loaded
     And I set the "Color" parameter in the Theming app to "#C9C9C9"

--- a/tests/acceptance/features/bootstrap/SettingsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/SettingsMenuContext.php
@@ -144,6 +144,14 @@ class SettingsMenuContext implements Context, ActorAwareInterface {
 	}
 
 	/**
+	 * @When I visit the admin settings page
+	 */
+	public function iVisitTheAdminSettingsPage() {
+		$this->iOpenTheSettingsMenu();
+		$this->actor->find(self::menuItemFor('Admin settings'), 2)->click();
+	}
+
+	/**
 	 * @When I log out
 	 */
 	public function iLogOut() {

--- a/tests/acceptance/features/header.feature
+++ b/tests/acceptance/features/header.feature
@@ -5,9 +5,10 @@ Feature: header
     Given I am logged in as the admin
     When I open the Settings menu
     Then I see that the Settings menu is shown
-    And I see that the Settings menu has only 7 items
+    And I see that the Settings menu has only 8 items
     And I see that the "Set status" item in the Settings menu is shown
-    And I see that the "Settings" item in the Settings menu is shown
+    And I see that the "Personal settings" item in the Settings menu is shown
+    And I see that the "Admin settings" item in the Settings menu is shown
     And I see that the "Apps" item in the Settings menu is shown
     And I see that the "Users" item in the Settings menu is shown
     And I see that the "Help" item in the Settings menu is shown
@@ -32,7 +33,7 @@ Feature: header
 
   Scenario: users from other groups are not seen in the contacts menu when autocompletion is restricted within the same group
     Given I am logged in as the admin
-    And I visit the settings page
+    And I visit the admin settings page
     And I open the "Sharing" section of the "Administration" group
     And I enable restricting username autocompletion to groups
     And I see that username autocompletion is restricted to groups

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -282,6 +282,30 @@ class NavigationManagerTest extends TestCase {
 				'unread' => 0
 			]
 		];
+		$adminSettings = [
+			'settings' => [
+				'id' => 'settings',
+				'order' => 2,
+				'href' => '/apps/test/',
+				'icon' => '/apps/settings/img/admin.svg',
+				'name' => 'Personal settings',
+				'active' => false,
+				'type' => 'settings',
+				'classes' => '',
+				'unread' => 0
+			],
+			'admin_settings' => [
+				'id' => 'admin_settings',
+				'order' => 3,
+				'href' => '/apps/test/',
+				'icon' => '/apps/settings/img/admin.svg',
+				'name' => 'Admin settings',
+				'active' => false,
+				'type' => 'settings',
+				'classes' => '',
+				'unread' => 0
+			]
+		];
 
 		return [
 			'minimalistic' => [
@@ -330,7 +354,7 @@ class NavigationManagerTest extends TestCase {
 			],
 			'admin' => [
 				array_merge(
-					['settings' => $defaults['settings']],
+					$adminSettings,
 					$apps,
 					['test' => [
 						'id' => 'test',
@@ -354,7 +378,7 @@ class NavigationManagerTest extends TestCase {
 			],
 			'no name' => [
 				array_merge(
-					['settings' => $defaults['settings']],
+					$adminSettings,
 					$apps,
 					['logout' => $defaults['logout']]
 				),

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -287,7 +287,7 @@ class NavigationManagerTest extends TestCase {
 				'id' => 'settings',
 				'order' => 2,
 				'href' => '/apps/test/',
-				'icon' => '/apps/settings/img/admin.svg',
+				'icon' => '/apps/settings/img/personal.svg',
 				'name' => 'Personal settings',
 				'active' => false,
 				'type' => 'settings',


### PR DESCRIPTION
This is best reviewed like this: https://github.com/nextcloud/server/pull/33756/files?diff=unified&w=1

### Motivation

I think this is a good idea and the community seems to agree: https://redd.it/x11gue

Also Jan said that it is fine by him :)


### Screenshot
<details>
<summary>click here</summary>

![image](https://user-images.githubusercontent.com/42591237/157017678-bb36e328-8a62-4965-b56d-455b196ce947.png)

</details>

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e SERVER_BRANCH=enh/noid/admin-settings-directly \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.130 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>