### PR TITLE
Log if cookie login failed with token mismatch or session unavailability

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -865,6 +865,10 @@ class Session implements IUserSession, Emitter {
 		$tokens = $this->config->getUserKeys($uid, 'login_token');
 		// test cookies token against stored tokens
 		if (!in_array($currentToken, $tokens, true)) {
+			$this->logger->error('Tried to log in {uid} but could not verify token', [
+				'app' => 'core',
+				'uid' => $uid,
+			]);
 			return false;
 		}
 		// replace successfully used token with a new one
@@ -876,6 +880,10 @@ class Session implements IUserSession, Emitter {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		} catch (SessionNotAvailableException $ex) {
+			$this->logger->warning('Could not renew session token for {uid} because the session is unavailable', [
+				'app' => 'core',
+				'uid' => $uid,
+			]);
 			return false;
 		} catch (InvalidTokenException $ex) {
 			$this->logger->warning('Renewing session token failed', ['app' => 'core']);


### PR DESCRIPTION
Extracted the less scary bits of https://github.com/nextcloud/server/pull/33769 into a safe PR.

This allows us to verify that the assumed scenario actually happens in production.