### PR TITLE
handle cases where the hash context gets cleaned up before the hash wrapper

### DIFF
--- a/lib/private/Files/Stream/HashWrapper.php
+++ b/lib/private/Files/Stream/HashWrapper.php
@@ -67,7 +67,11 @@ class HashWrapper extends Wrapper {
 
 	public function stream_close() {
 		if (is_callable($this->callback)) {
-			call_user_func($this->callback, hash_final($this->hash));
+			// if the stream is closed as a result of the end-of-request GC, the hash context might be cleaned up before this stream
+			if ($this->hash instanceof \HashContext) {
+				$hash = hash_final($this->hash);
+				call_user_func($this->callback, $hash);
+			}
 			// prevent further calls by potential PHP 7 GC ghosts
 			$this->callback = null;
 		}


### PR DESCRIPTION
While we do try to close the stream before the end-of-request cleanup, in cases where this isn't done for any reason we shouldn't error