### PR TITLE
filter index.php from cloudId

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -556,6 +556,9 @@ class User implements IUser {
 	public function getCloudId() {
 		$uid = $this->getUID();
 		$server = $this->urlGenerator->getAbsoluteURL('/');
+		if (substr($server, -10) === '/index.php') {
+			$server = substr($server, 0, -10);
+		}
 		$server = rtrim($this->removeProtocolFromUrl($server), '/');
 		return $uid . '@' . $server;
 	}


### PR DESCRIPTION
if generated from CLI, the cloudId is based on `overwrite.cli.url` which might contains `/index.php`.

This is a quick fix that will filters the result and returns cloudId with no trailing `/index.php`