### PR TITLE
[stable23] Wait for the new user form to be visible in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/UsersSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/UsersSettingsContext.php
@@ -293,8 +293,12 @@ class UsersSettingsContext implements Context, ActorAwareInterface {
 	 * @Then I see that the new user form is shown
 	 */
 	public function iSeeThatTheNewUserFormIsShown() {
-		Assert::assertTrue(
-			$this->actor->find(self::newUserForm(), 10)->isVisible());
+		if (!WaitFor::elementToBeEventuallyShown(
+				$this->actor,
+				self::newUserForm(),
+				$timeout = 10 * $this->actor->getFindTimeoutMultiplier())) {
+			Assert::fail("The new user form is not shown yet after $timeout seconds");
+		}
 	}
 
 	/**


### PR DESCRIPTION
Extracted from #33568

This should make the acceptance tests more robust and avoid failures like https://drone.nextcloud.com/nextcloud/server/21674/63/4

It only touches an acceptance test file, so it should not affect the RC (but fine to merge it after v23.0.9 too).

Before it was checked if the new user form was visible, but it was not waited for it. It seems that it can happen that the new user form is in the DOM, and therefore found, but not visible yet when the tests run, which caused them to (randomly) fail. Due to that now it is explicitly waited until it is visible, rather than assuming that it is visible as soon as it appears in the DOM.