### PR TITLE
rtrim cloudId url earlier

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -555,11 +555,11 @@ class User implements IUser {
 	 */
 	public function getCloudId() {
 		$uid = $this->getUID();
-		$server = $this->urlGenerator->getAbsoluteURL('/');
+		$server = rtrim($this->urlGenerator->getAbsoluteURL('/'), '/');
 		if (substr($server, -10) === '/index.php') {
 			$server = substr($server, 0, -10);
 		}
-		$server = rtrim($this->removeProtocolFromUrl($server), '/');
+		$server = $this->removeProtocolFromUrl($server);
 		return $uid . '@' . $server;
 	}
 


### PR DESCRIPTION
rtrim the url earlier, to compare a better formatted string. This will avoid address ending with `/index.php/`