### PR TITLE
Added parameter to disallow changing additional e-mail addresses

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
@@ -606,7 +607,11 @@ class UsersController extends AUserData {
 			$permittedFields[] = IAccountManager::PROPERTY_EMAIL;
 		}
 
-		$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+		// Editing additional e-mail addresses if enabled.
+		if ($this->config->getSystemValue('allow_to_change_additional_emails', true) !== false) {
+			$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+		}
+
 		$permittedFields[] = IAccountManager::PROPERTY_PHONE;
 		$permittedFields[] = IAccountManager::PROPERTY_ADDRESS;
 		$permittedFields[] = IAccountManager::PROPERTY_WEBSITE;
@@ -649,14 +654,20 @@ class UsersController extends AUserData {
 
 		$permittedFields = [];
 		if ($targetUser->getUID() === $currentLoggedInUser->getUID()) {
-			// Editing self (display, email)
-			$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
-			$permittedFields[] = IAccountManager::COLLECTION_EMAIL . self::SCOPE_SUFFIX;
+			// Editing additional e-mail addresses if enabled.
+			if ($this->config->getSystemValue('allow_to_change_additional_emails', true) !== false) {
+				$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+				$permittedFields[] = IAccountManager::COLLECTION_EMAIL . self::SCOPE_SUFFIX;
+			}
 		} else {
 			// Check if admin / subadmin
 			if ($isAdminOrSubadmin) {
 				// They have permissions over the user
-				$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+
+				// Editing additional e-mail addresses if enabled.
+				if ($this->config->getSystemValue('allow_to_change_additional_emails', true) !== false) {
+					$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+				}
 			} else {
 				// No rights
 				throw new OCSException('', OCSController::RESPOND_NOT_FOUND);
@@ -750,7 +761,10 @@ class UsersController extends AUserData {
 			$permittedFields[] = IAccountManager::PROPERTY_DISPLAYNAME . self::SCOPE_SUFFIX;
 			$permittedFields[] = IAccountManager::PROPERTY_EMAIL . self::SCOPE_SUFFIX;
 
-			$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+			// Editing additional e-mail addresses if enabled.
+			if ($this->config->getSystemValue('allow_to_change_additional_emails', true) !== false) {
+				$permittedFields[] = IAccountManager::COLLECTION_EMAIL;
+			}
 
 			$permittedFields[] = self::USER_FIELD_PASSWORD;
 			$permittedFields[] = self::USER_FIELD_NOTIFICATION_EMAIL;

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -171,6 +172,7 @@ class PersonalInfo implements ISettings {
 
 		$accountParameters = [
 			'displayNameChangeSupported' => $user->canChangeDisplayName(),
+			'additionalEmailsChangeSupported' => $user->canChangeAdditionalEmails(),
 			'lookupServerUploadEnabled' => $lookupServerUploadEnabled,
 		];
 

--- a/apps/settings/src/components/PersonalInfo/EmailSection/EmailSection.vue
+++ b/apps/settings/src/components/PersonalInfo/EmailSection/EmailSection.vue
@@ -1,5 +1,6 @@
 <!--
 	- @copyright 2021, Christopher Ng <chrng8@gmail.com>
+	- @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
 	-
 	- @author Christopher Ng <chrng8@gmail.com>
 	-
@@ -25,7 +26,7 @@
 		<HeaderBar :input-id="inputId"
 			:readable="primaryEmail.readable"
 			:handle-scope-change="savePrimaryEmailScope"
-			:is-editable="true"
+			:is-editable="additionalEmailsChangeSupported"
 			:is-multi-value-supported="true"
 			:is-valid-section="isValidSection"
 			:scope.sync="primaryEmail.scope"
@@ -74,7 +75,7 @@ import { validateEmail } from '../../../utils/validate.js'
 import logger from '../../../logger.js'
 
 const { emailMap: { additionalEmails, primaryEmail, notificationEmail } } = loadState('settings', 'personalInfoParameters', {})
-const { displayNameChangeSupported } = loadState('settings', 'accountParameters', {})
+const { displayNameChangeSupported, additionalEmailsChangeSupported } = loadState('settings', 'accountParameters', {})
 
 export default {
 	name: 'EmailSection',
@@ -89,6 +90,7 @@ export default {
 			accountProperty: ACCOUNT_PROPERTY_READABLE_ENUM.EMAIL,
 			additionalEmails: additionalEmails.map(properties => ({ ...properties, key: this.generateUniqueKey() })),
 			displayNameChangeSupported,
+			additionalEmailsChangeSupported,
 			primaryEmail: { ...primaryEmail, readable: NAME_READABLE_ENUM[primaryEmail.name] },
 			savePrimaryEmailScope,
 			notificationEmail,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -239,6 +239,12 @@ $CONFIG = [
 'allow_user_to_change_display_name' => true,
 
 /**
+ * ``true`` allows to change additional user e-mail addresses and ``false``
+ * disallows it.
+ */
+'allow_to_change_additional_emails' => true,
+
+/**
  * Lifetime of the remember login cookie. This should be larger than the
  * session_lifetime. If it is set to 0 remember me is disabled.
  *

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -96,6 +97,10 @@ class LazyUser implements IUser {
 
 	public function canChangeDisplayName() {
 		return $this->getUser()->canChangeDisplayName();
+	}
+
+	public function canChangeAdditionalEmails() {
+		return $this->getUser()->canChangeAdditionalEmails();
 	}
 
 	public function isEnabled() {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bart Visscher <bartv@thisnet.nl>
@@ -418,6 +419,18 @@ class User implements IUser {
 			return false;
 		}
 		return $this->backend->implementsActions(Backend::SET_DISPLAYNAME);
+	}
+
+	/**
+	 * check if additional e-mail addresses changing and displaying is enabled
+	 *
+	 * @return bool
+	 */
+	public function canChangeAdditionalEmails() {
+		if ($this->config->getSystemValue('allow_to_change_additional_emails') === false) {
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author John Molakvoæ <skjnldsv@protonmail.com>
@@ -140,6 +141,14 @@ interface IUser {
 	 * @since 8.0.0
 	 */
 	public function canChangeDisplayName();
+
+	/**
+	 * check if additional e-mail addresses changing and displaying is enabled
+	 *
+	 * @return bool
+	 * @since 25.0.0
+	 */
+	public function canChangeAdditionalEmails();
 
 	/**
 	 * check if the user is enabled


### PR DESCRIPTION
Added config parameter `allow_to_change_additional_emails` to disallow
changing additional e-mail addresses (i.e. when LDAP DB should be
the only source of user e-mail addresses). Use

```
config:system:set allow_to_change_additional_emails --value='false' --type=boolean
```

to disallow and

```
config:system:set allow_to_change_additional_emails --value='true' --type=boolean
```

to allow changing additional user e-mail addresses.

Related: https://github.com/nextcloud/server/issues/26866
Author-Change-Id: IB#1124888