### PR TITLE
always use the default fs owner when storing versions

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -46,6 +46,7 @@ use OC\Files\Search\SearchQuery;
 use OC_User;
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCA\Files_Sharing\SharedMount;
 use OCA\Files_Versions\AppInfo\Application;
 use OCA\Files_Versions\Command\Expire;
 use OCA\Files_Versions\Events\CreateVersionEvent;
@@ -188,33 +189,45 @@ class Storage {
 			return false;
 		}
 
-		[$uid, $filename] = self::getUidAndFilename($filename);
+		// since hook paths are always relative to the "default filesystem view"
+		// we always use the owner from there to get the full node
+		$uid = Filesystem::getView()->getOwner('');
 
-		$files_view = new View('/'.$uid .'/files');
+		/** @var IRootFolder $rootFolder */
+		$rootFolder = \OC::$server->get(IRootFolder::class);
+		$userFolder = $rootFolder->getUserFolder($uid);
 
 		$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
-		$fileInfo = $files_view->getFileInfo($filename);
-		$id = $fileInfo->getId();
-		$nodes = \OC::$server->get(IRootFolder::class)->getUserFolder($uid)->getById($id);
-		foreach ($nodes as $node) {
-			$event = new CreateVersionEvent($node);
-			$eventDispatcher->dispatch('OCA\Files_Versions::createVersion', $event);
-			if ($event->shouldCreateVersion() === false) {
-				return false;
+		try {
+			$file = $userFolder->get($filename);
+		} catch (NotFoundException $e) {
+			return false;
+		}
+
+		$mount = $file->getMountPoint();
+		if ($mount instanceof SharedMount) {
+			$ownerFolder = $rootFolder->getUserFolder($mount->getShare()->getShareOwner());
+			$ownerNodes = $ownerFolder->getById($file->getId());
+			if (count($ownerNodes)) {
+				$file = current($ownerNodes);
 			}
 		}
 
 		// no use making versions for empty files
-		if ($fileInfo->getSize() === 0) {
+		if ($file->getSize() === 0) {
+			return false;
+		}
+
+		$event = new CreateVersionEvent($file);
+		$eventDispatcher->dispatch('OCA\Files_Versions::createVersion', $event);
+		if ($event->shouldCreateVersion() === false) {
 			return false;
 		}
 
 		/** @var IVersionManager $versionManager */
 		$versionManager = \OC::$server->get(IVersionManager::class);
-		$userManager = \OC::$server->get(IUserManager::class);
-		$user = $userManager->get($uid);
 
-		$versionManager->createVersion($user, $fileInfo);
+		$versionManager->createVersion($file->getOwner(), $file);
 	}
 
 


### PR DESCRIPTION
Alternative to https://github.com/nextcloud/server/pull/33305

since hook paths are always relative to the "default filesystem view" we should use that uid for filesystem stuff instead of trying to get the owner for the file.