### PR TITLE
handle errors from hash_final

### DIFF
--- a/lib/private/Files/Stream/HashWrapper.php
+++ b/lib/private/Files/Stream/HashWrapper.php
@@ -69,8 +69,13 @@ class HashWrapper extends Wrapper {
 		if (is_callable($this->callback)) {
 			// if the stream is closed as a result of the end-of-request GC, the hash context might be cleaned up before this stream
 			if ($this->hash instanceof \HashContext) {
-				$hash = hash_final($this->hash);
-				call_user_func($this->callback, $hash);
+				try {
+					$hash = @hash_final($this->hash);
+					if ($hash) {
+						call_user_func($this->callback, $hash);
+					}
+				} catch (\Throwable $e) {
+				}
 			}
 			// prevent further calls by potential PHP 7 GC ghosts
 			$this->callback = null;


### PR DESCRIPTION
Follow up from https://github.com/nextcloud/server/pull/33774

Turns out the `HashContext` can get into a state where it still detects as being an instance of the class but can't be used with `hash_` functions.