### PR TITLE
Added parameter to disallow app auth token creating

### DIFF
--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Daniel Kesselberg <mail@danielkesselberg.de>
@@ -46,6 +47,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
@@ -56,6 +58,9 @@ class AuthSettingsController extends Controller {
 
 	/** @var IProvider */
 	private $tokenProvider;
+
+	/** @var IConfig */
+	private $config;
 
 	/** @var ISession */
 	private $session;
@@ -93,6 +98,7 @@ class AuthSettingsController extends Controller {
 	public function __construct(string $appName,
 								IRequest $request,
 								IProvider $tokenProvider,
+								IConfig $config,
 								ISession $session,
 								ISecureRandom $random,
 								?string $userId,
@@ -103,6 +109,7 @@ class AuthSettingsController extends Controller {
 		parent::__construct($appName, $request);
 		$this->tokenProvider = $tokenProvider;
 		$this->uid = $userId;
+		$this->config = $config;
 		$this->userSession = $userSession;
 		$this->session = $session;
 		$this->random = $random;
@@ -120,6 +127,12 @@ class AuthSettingsController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function create($name) {
+
+		// Don't create app auth token if disallowed in configuration.
+		if (($this->config->getSystemValue('allow_create_app_auth_tokens', true) === false)) {
+			return $this->getServiceNotAvailableResponse();
+		}
+
 		if ($this->checkAppToken()) {
 			return $this->getServiceNotAvailableResponse();
 		}

--- a/apps/settings/lib/Settings/Personal/Security/Authtokens.php
+++ b/apps/settings/lib/Settings/Personal/Security/Authtokens.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -26,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Settings\Settings\Personal\Security;
 
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
 use OCP\IUserSession;
 use function array_map;
 use OC\Authentication\Exceptions\InvalidTokenException;
@@ -42,6 +44,9 @@ class Authtokens implements ISettings {
 	/** @var IAuthTokenProvider */
 	private $tokenProvider;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var ISession */
 	private $session;
 
@@ -55,11 +60,13 @@ class Authtokens implements ISettings {
 	private $userSession;
 
 	public function __construct(IAuthTokenProvider $tokenProvider,
+								IConfig $config,
 								ISession $session,
 								IUserSession $userSession,
 								IInitialState $initialState,
 								?string $UserId) {
 		$this->tokenProvider = $tokenProvider;
+		$this->config = $config;
 		$this->session = $session;
 		$this->initialState = $initialState;
 		$this->uid = $UserId;
@@ -74,7 +81,7 @@ class Authtokens implements ISettings {
 
 		$this->initialState->provideInitialState(
 			'can_create_app_token',
-			$this->userSession->getImpersonatingUserID() === null
+			($this->userSession->getImpersonatingUserID() === null) && ($this->config->getSystemValue('allow_create_app_auth_tokens', true) !== false)
 		);
 
 		return new TemplateResponse('settings', 'settings/personal/security/authtokens');

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Daniel Kesselberg <mail@danielkesselberg.de>
@@ -42,6 +43,7 @@ use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
@@ -58,6 +60,8 @@ class AuthSettingsControllerTest extends TestCase {
 	private $request;
 	/** @var IProvider|MockObject */
 	private $tokenProvider;
+	/** @var IConfig */
+	private $config;
 	/** @var ISession|MockObject */
 	private $session;
 	/**@var IUserSession|MockObject */
@@ -75,6 +79,7 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$this->request = $this->createMock(IRequest::class);
 		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
@@ -87,6 +92,7 @@ class AuthSettingsControllerTest extends TestCase {
 			'core',
 			$this->request,
 			$this->tokenProvider,
+			$this->config,
 			$this->session,
 			$this->secureRandom,
 			$this->uid,

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -40,6 +41,9 @@ class AuthtokensTest extends TestCase {
 	/** @var IAuthTokenProvider|MockObject */
 	private $authTokenProvider;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var ISession|MockObject */
 	private $session;
 
@@ -59,6 +63,7 @@ class AuthtokensTest extends TestCase {
 		parent::setUp();
 
 		$this->authTokenProvider = $this->createMock(IAuthTokenProvider::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->initialState = $this->createMock(IInitialState::class);
@@ -66,6 +71,7 @@ class AuthtokensTest extends TestCase {
 
 		$this->section = new Authtokens(
 			$this->authTokenProvider,
+			$this->config,
 			$this->session,
 			$this->userSession,
 			$this->initialState,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -306,6 +306,13 @@ $CONFIG = [
 'token_auth_activity_update' => 60,
 
 /**
+ * Allow (when true) or disallow (when false) application authentication token creating.
+ *
+ * Defaults to ``true``
+ */
+'allow_create_app_auth_tokens' => true,
+
+/**
  * Whether the bruteforce protection shipped with Nextcloud should be enabled or not.
  *
  * Disabling this is discouraged for security reasons.


### PR DESCRIPTION
Added config parameter `allow_create_app_auth_tokens` to disallow creating
application authentication tokens (i.e. when Nextcloud setup does not allow
this kind of authentication for security purposes). Use

```
config:system:set allow_create_app_auth_tokens --value='true' --type=boolean
```

to allow (default if not set) and

```
config:system:set allow_create_app_auth_tokens --value='false' --type=boolean
```

to disallow creating application authentication tokens.

Related: https://github.com/nextcloud/server/issues/3228
Author-Change-Id: IB#1124945
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>