### PR TITLE
Update docblock for cacheFor

### DIFF
--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -105,8 +105,10 @@ class Response {
 
 	/**
 	 * Caches the response
-	 * @param int $cacheSeconds the amount of seconds that should be cached
-	 * if 0 then caching will be disabled
+	 *
+	 * @param int $cacheSeconds amount of seconds the response is fresh, 0 to disable cache.
+	 * @param bool $public
+	 * @param bool $immutable
 	 * @return $this
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -107,8 +107,8 @@ class Response {
 	 * Caches the response
 	 *
 	 * @param int $cacheSeconds amount of seconds the response is fresh, 0 to disable cache.
-	 * @param bool $public
-	 * @param bool $immutable
+	 * @param bool $public whether the page should be cached by public proxy. Usually should be false, unless this is a static resources.
+	 * @param bool $immutable whether browser should treat the resource as immutable and not ask the server for each page load if the resource changed.
 	 * @return $this
 	 * @since 6.0.0 - return value was added in 7.0.0
 	 */


### PR DESCRIPTION
```
ERROR: TooManyArguments - lib/Controller/AvatarsController.php:85:14 - Too many arguments for method OCP\AppFramework\Http\Response::cachefor - saw 3 (see https://psalm.dev/026)
                $response->cacheFor(7 * 24 * 60 * 60, false, true);
```

Psalm _sometimes_ complains about the outdated docblock. 