### PR TITLE
Fix dynamic property warning in files_version tests

### DIFF
--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -949,12 +949,6 @@ class VersioningTest extends \Test\TestCase {
 			\OC::$server->getUserManager()->registerBackend($backend);
 		}
 
-		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
-		$isInitialized = $storage->getProperty('initialized');
-		$isInitialized->setAccessible(true);
-		$isInitialized->setValue($storage, false);
-		$isInitialized->setAccessible(false);
-
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		\OC\Files\Filesystem::tearDown();


### PR DESCRIPTION
The code had no effect as $storage is not an instance of SharedStorage,
 the call to setValue failed with a warning.

Same thing as https://github.com/nextcloud/server/pull/33430

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>