### PR TITLE
Fix Calendar tests mocking a non-existant method.

### DIFF
--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -251,7 +251,7 @@ class ManagerTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('warning');
 		$this->time->expects(self::never())
-			->method('getTimestamp');
+			->method('getTime');
 
 		$result = $this->manager->handleIMipReply($principalUri, $sender, $recipient, $calendarData->serialize());
 		$this->assertFalse($result);
@@ -266,7 +266,7 @@ class ManagerTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('warning');
 		$this->time->expects(self::never())
-			->method('getTimestamp');
+			->method('getTime');
 
 		$result = $this->manager->handleIMipReply($principalUri, $sender, $recipient, $calendarData->serialize());
 		$this->assertFalse($result);
@@ -280,7 +280,7 @@ class ManagerTest extends TestCase {
 		$calendarData->VEVENT->DTSTART = new \DateTime('2013-04-07'); // set to in the past
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(time());
 
 		$this->logger->expects(self::once())
@@ -308,7 +308,7 @@ class ManagerTest extends TestCase {
 		$calendarData = $this->getVCalendarReply();
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
@@ -339,7 +339,7 @@ class ManagerTest extends TestCase {
 		$calendarData = $this->getVCalendarReply();
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
@@ -375,7 +375,7 @@ class ManagerTest extends TestCase {
 		$calendarData = $this->getVCalendarReply();
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
@@ -402,7 +402,7 @@ class ManagerTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('warning');
 		$this->time->expects(self::never())
-			->method('getTimestamp');
+			->method('getTime');
 
 		$result = $this->manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
 		$this->assertFalse($result);
@@ -419,7 +419,7 @@ class ManagerTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('warning');
 		$this->time->expects(self::never())
-			->method('getTimestamp');
+			->method('getTime');
 
 		$result = $this->manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
 		$this->assertFalse($result);
@@ -434,7 +434,7 @@ class ManagerTest extends TestCase {
 		$calendarData->VEVENT->DTSTART = new \DateTime('2013-04-07'); // set to in the past
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(time());
 		$this->logger->expects(self::once())
 			->method('warning');
@@ -462,7 +462,7 @@ class ManagerTest extends TestCase {
 		$calendarData = $this->getVCalendarCancel();
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
@@ -496,7 +496,7 @@ class ManagerTest extends TestCase {
 		$calendarData->VEVENT->METHOD = 'CANCEL';
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
@@ -533,7 +533,7 @@ class ManagerTest extends TestCase {
 		$calendarData->VEVENT->METHOD = 'CANCEL';
 
 		$this->time->expects(self::once())
-			->method('getTimestamp')
+			->method('getTime')
 			->willReturn(202208219);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -310,7 +310,7 @@ class ManagerTest extends TestCase {
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->willReturn([]);
@@ -342,7 +342,7 @@ class ManagerTest extends TestCase {
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->willReturn([$calendar]);
@@ -379,7 +379,7 @@ class ManagerTest extends TestCase {
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->willReturn([$calendar]);
@@ -400,7 +400,7 @@ class ManagerTest extends TestCase {
 		$recipient = 'pierre@general-store.com';
 		$replyTo = null;
 		$calendarData = $this->getVCalendarCancel();
-		$calendarData->VEVENT->METHOD = 'REQUEST';
+		$calendarData->METHOD = 'REQUEST';
 
 		$this->logger->expects(self::once())
 			->method('warning');
@@ -417,7 +417,6 @@ class ManagerTest extends TestCase {
 		$recipient = 'leah@general-store.com';
 		$replyTo = null;
 		$calendarData = $this->getVCalendarCancel();
-		$calendarData->VEVENT->METHOD = 'CANCEL';
 
 		$this->logger->expects(self::once())
 			->method('warning');
@@ -467,7 +466,7 @@ class ManagerTest extends TestCase {
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->with($principalUri)
@@ -475,8 +474,8 @@ class ManagerTest extends TestCase {
 		$this->logger->expects(self::once())
 			->method('warning');
 
-		$result = $this->manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
-		$this->assertTrue($result);
+		$result = $manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
+		$this->assertFalse($result);
 	}
 
 	public function testHandleImipCancelOrganiserInReplyTo(): void {
@@ -498,11 +497,10 @@ class ManagerTest extends TestCase {
 		$replyTo = 'linus@stardew-tent-living.com';
 		$calendar = $this->createMock(ICreateFromString::class);
 		$calendarData = $this->getVCalendarCancel();
-		$calendarData->VEVENT->METHOD = 'CANCEL';
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->with($principalUri)
@@ -513,8 +511,8 @@ class ManagerTest extends TestCase {
 		$calendar->expects(self::once())
 			->method('handleIMipMessage')
 			->with('testname.ics', $calendarData->serialize());
-		$result = $this->manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
-		$this->assertFalse($result);
+		$result = $manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
+		$this->assertTrue($result);
 	}
 
 	public function testHandleImipCancel(): void {
@@ -536,11 +534,10 @@ class ManagerTest extends TestCase {
 		$replyTo = null;
 		$calendar = $this->createMock(ICreateFromString::class);
 		$calendarData = $this->getVCalendarCancel();
-		$calendarData->VEVENT->METHOD = 'CANCEL';
 
 		$this->time->expects(self::once())
 			->method('getTime')
-			->willReturn(202208219);
+			->willReturn(1628374233);
 		$manager->expects(self::once())
 			->method('getCalendarsForPrincipal')
 			->with($principalUri)
@@ -551,8 +548,8 @@ class ManagerTest extends TestCase {
 		$calendar->expects(self::once())
 			->method('handleIMipMessage')
 			->with('testname.ics', $calendarData->serialize());
-		$result = $this->manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
-		$this->assertFalse($result);
+		$result = $manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
+		$this->assertTrue($result);
 	}
 
 	private function getVCalendarReply(): Document {

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -301,7 +301,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
 		$recipient = 'linus@stardew-tent-living.com';
@@ -331,7 +332,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$calendar = $this->createMock(ICreateFromString::class);
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
@@ -367,7 +369,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$calendar = $this->createMock(ICreateFromString::class);
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
@@ -454,7 +457,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$principalUri = 'principals/user/pierre';
 		$sender = 'linus@stardew-tent-living.com';
 		$recipient = 'pierre@general-store.com';
@@ -486,7 +490,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$principalUri = 'principals/user/pierre';
 		$sender = 'clint@stardew-blacksmiths.com';
 		$recipient = 'pierre@general-store.com';
@@ -523,7 +528,8 @@ class ManagerTest extends TestCase {
 			])
 			->setMethods([
 				'getCalendarsForPrincipal'
-			]);
+			])
+			->getMock();
 		$principalUri = 'principals/user/pierre';
 		$sender = 'linus@stardew-tent-living.com';
 		$recipient = 'pierre@general-store.com';


### PR DESCRIPTION
There is no ITimeFactory::getTimestamp method, only getTime

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>