### PR TITLE
enable locking for upload chunks

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1957,7 +1957,7 @@ class View {
 			} catch (LockedException $e) {
 				// rethrow with the a human-readable path
 				throw new LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
+					$this->getRelativePath($absolutePath),
 					$e,
 					$e->getExistingLock()
 				);
@@ -2000,7 +2000,7 @@ class View {
 				try {
 					// rethrow with the a human-readable path
 					throw new LockedException(
-						$this->getPathRelativeToFiles($absolutePath),
+						$this->getRelativePath($absolutePath),
 						$e,
 						$e->getExistingLock()
 					);
@@ -2115,7 +2115,7 @@ class View {
 		$pathSegments = explode('/', $path);
 		if (isset($pathSegments[2])) {
 			// E.g.: /username/files/path-to-file
-			return ($pathSegments[2] === 'files') && (count($pathSegments) > 3);
+			return ($pathSegments[2] === 'files' || $pathSegments[2] === 'uploads') && (count($pathSegments) > 3);
 		}
 
 		return strpos($path, '/appdata_') !== 0;


### PR DESCRIPTION
To test:

- Add a `sleep(20);` at line 165 before the `$node->put` to simulate a slow upload processing
- Start a chunked uploaded with the browser's devtools open
- Use the devtools to resend a chunk upload requests while it's still active.