### PR TITLE
[stable23] Do not empty config.php file if reading failed for any reason

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -239,6 +239,10 @@ class Config {
 	 * @throws \Exception If no file lock can be acquired
 	 */
 	private function writeData() {
+		if (!is_file(\OC::$configDir.'/CAN_INSTALL') && !isset($this->cache['version'])) {
+			throw new HintException(sprintf('Configuration was not read or initialized correctly, not overwriting %s', $this->configFilePath));
+		}
+
 		// Create a php file ...
 		$content = "<?php\n";
 		$content .= '$CONFIG = ';


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/34021 and https://github.com/nextcloud/server/pull/33921

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>
Signed-off-by: szaimen <szaimen@e.mail.de>