### PR TITLE
Do not output a warning when a file is not found

### DIFF
--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -23,8 +23,6 @@ namespace OCA\DAV\DAV;
 
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File as DavFile;
-use OCA\DAV\Meta\MetaFile;
-use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Server;
@@ -36,7 +34,6 @@ use Sabre\DAV\Exception\NotFound;
  * Sabre plugin for restricting file share receiver download:
  */
 class ViewOnlyPlugin extends ServerPlugin {
-
 	private ?Server $server = null;
 	private LoggerInterface $logger;
 
@@ -99,9 +96,7 @@ class ViewOnlyPlugin extends ServerPlugin {
 				throw new Forbidden('Access to this resource has been denied because it is in view-only mode.');
 			}
 		} catch (NotFound $e) {
-			$this->logger->warning($e->getMessage(), [
-				'exception' => $e,
-			]);
+			// File not found
 		}
 
 		return true;


### PR DESCRIPTION
This would spam log with warnings from Desktop client doing HEAD on
 non-existing path to test them.

Fix https://github.com/nextcloud/server/issues/33896

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>