### PR TITLE
fix: play single audio shares with the viewer

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -153,7 +153,7 @@ OCA.Sharing.PublicApp = {
 		});
 
 		if (OCA.Viewer && OCA.Viewer.mimetypes.includes(mimetype)
-			&& (mimetype.startsWith('image/') || mimetype.startsWith('video/'))) {
+			&& (mimetype.startsWith('image/') || mimetype.startsWith('video/') || mimetype.startsWith('audio'))) {
 			OCA.Viewer.setRootElement('#imgframe')
 			OCA.Viewer.open({ path: '/' })
 		} else if (mimetype.substr(0, mimetype.indexOf('/')) === 'text' && window.btoa) {


### PR DESCRIPTION
Use the viewer to play audio files.

Close https://github.com/nextcloud/server/issues/34027

- [ ] wait for https://github.com/nextcloud/server/pull/34028 and do a rebase
- [ ] still lacks styling.