### PR TITLE
merge last_activity and last_check updates

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -299,10 +299,12 @@ class PublicKeyTokenProvider implements IProvider {
 		$activityInterval = $this->config->getSystemValueInt('token_auth_activity_update', 60);
 		$activityInterval = min(max($activityInterval, 0), 300);
 
+		$updatedFields = $token->getUpdatedFields();
+		unset($updatedFields['lastActivity']);
+
 		/** @var PublicKeyToken $token */
 		$now = $this->time->getTime();
-		if ($token->getLastActivity() < ($now - $activityInterval)) {
-			$token->setLastActivity($now);
+		if ($token->getLastActivity() < ($now - $activityInterval) || count($updatedFields)) {
 			$this->mapper->updateActivity($token, $now);
 			$this->cacheToken($token);
 		}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -757,7 +757,6 @@ class Session implements IUserSession, Emitter {
 		if ($dbToken instanceof PublicKeyToken) {
 			$dbToken->setLastActivity($now);
 		}
-		$this->tokenProvider->updateToken($dbToken);
 		return true;
 	}
 

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -146,22 +146,15 @@ abstract class QBMapper {
 	}
 
 	/**
-	 * Updates an entry in the db from an entity
+	 * Create an update query that saves all updated fields
 	 *
-	 * @param Entity $entity the entity that should be created
-	 * @psalm-param T $entity the entity that should be created
-	 * @return Entity the saved entity with the set id
-	 * @psalm-return T the saved entity with the set id
-	 * @throws Exception
-	 * @throws \InvalidArgumentException if entity has no id
-	 * @since 14.0.0
+	 * @param Entity $entity the entity that should be updated
+	 * @psalm-param T $entity the entity that should be updated
+	 * @return IQueryBuilder
+	 * @since 25.0.0
 	 */
-	public function update(Entity $entity): Entity {
-		// if entity wasn't changed it makes no sense to run a db query
+	protected function createUpdateQuery(Entity $entity): IQueryBuilder {
 		$properties = $entity->getUpdatedFields();
-		if (\count($properties) === 0) {
-			return $entity;
-		}
 
 		// entity needs an id
 		$id = $entity->getId();
@@ -193,6 +186,29 @@ abstract class QBMapper {
 		$qb->where(
 			$qb->expr()->eq('id', $qb->createNamedParameter($id, $idType))
 		);
+
+		return $qb;
+	}
+
+	/**
+	 * Updates an entry in the db from an entity
+	 *
+	 * @param Entity $entity the entity that should be created
+	 * @psalm-param T $entity the entity that should be created
+	 * @return Entity the saved entity with the set id
+	 * @psalm-return T the saved entity with the set id
+	 * @throws Exception
+	 * @throws \InvalidArgumentException if entity has no id
+	 * @since 14.0.0
+	 */
+	public function update(Entity $entity): Entity {
+		// if entity wasn't changed it makes no sense to run a db query
+		$properties = $entity->getUpdatedFields();
+		if (\count($properties) === 0) {
+			return $entity;
+		}
+
+		$qb = $this->createUpdateQuery($entity);
 		$qb->executeStatement();
 
 		return $entity;

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -191,8 +191,6 @@ class PublicKeyTokenProviderTest extends TestCase {
 			]);
 
 		$this->tokenProvider->updateTokenActivity($tk);
-
-		$this->assertEquals($this->time, $tk->getLastActivity());
 	}
 
 	public function testUpdateTokenDebounce() {
@@ -204,6 +202,22 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$tk->setLastActivity($this->time - 30);
 
 		$this->mapper->expects($this->never())
+			->method('updateActivity')
+			->with($tk, $this->time);
+
+		$this->tokenProvider->updateTokenActivity($tk);
+	}
+
+	public function testUpdateTokenDebounceWithUpdatedFields() {
+		$tk = new PublicKeyToken();
+		$this->config->method('getSystemValueInt')
+			->willReturnCallback(function ($value, $default) {
+				return $default;
+			});
+		$tk->setLastActivity($this->time - 30);
+		$tk->setLastCheck($this->time - 30);
+
+		$this->mapper->expects($this->once())
 			->method('updateActivity')
 			->with($tk, $this->time);
 


### PR DESCRIPTION
`updateActivity` has been updated to also write any other changed field.

the debounce for updating last_activity is changed so it always updates if another field of the token has been updated, this ensures that last_check if updated even if last_activity is still in the debounce period.

This is pretty much a 2nd version of https://github.com/nextcloud/server/pull/1037, which was reverted(https://github.com/nextcloud/server/pull/29682) after the `last_activity` updating changed by https://github.com/nextcloud/server/pull/29357