### PR TITLE
Show Nextcloud Hub 3 in overview page when applicable

### DIFF
--- a/apps/settings/templates/settings/admin/overview.php
+++ b/apps/settings/templates/settings/admin/overview.php
@@ -67,5 +67,9 @@
 <div id="version" class="section">
 	<!-- should be the last part, so Updater can follow if enabled (it has no heading therefore). -->
 	<h2><?php p($l->t('Version'));?></h2>
+	<?php if ($theme->getTitle() === 'Nextcloud'): ?>
+	<p><strong><a href="<?php print_unescaped($theme->getBaseUrl()); ?>" rel="noreferrer noopener" target="_blank">Nextcloud Hub 3</a> (<?php p(OC_Util::getHumanVersion()) ?>)</strong></p>
+	<?php else: ?>
 	<p><strong><a href="<?php print_unescaped($theme->getBaseUrl()); ?>" rel="noreferrer noopener" target="_blank"><?php p($theme->getTitle()); ?></a> <?php p(OC_Util::getHumanVersion()) ?></strong></p>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
Similar pattern we used before: https://github.com/nextcloud/server/blob/v23.0.4/apps/settings/templates/settings/admin/overview.php#L70

Please note that it's not possible to hard-code this title in \OC_Defaults because the title itself needs special formatting of the version, otherwise it doesn't look good as `Nextcloud Hub 3 25.0.0 beta6` => `Nextcloud Hub (25.0.0 beta 6)`

<img width="353" alt="image" src="https://user-images.githubusercontent.com/277525/190082914-fb332036-f156-4353-a9c2-85dcc87cb64e.png">
