### PR TITLE
Convert file_metadata.id from int(11) to bigint(20)

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -770,6 +770,7 @@ Raw output
 			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
 			'filecache_extended' => ['fileid'],
 			'file_locks' => ['id'],
+			'file_metadata' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],
 			'mounts' => ['id', 'storage_id', 'root_id', 'mount_id'],

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -67,6 +67,7 @@ class ConvertFilecacheBigInt extends Command {
 			'filecache_extended' => ['fileid'],
 			'files_trash' => ['auto_id'],
 			'file_locks' => ['id'],
+			'file_metadata' => ['id'],
 			'jobs' => ['id'],
 			'mimetypes' => ['id'],
 			'mounts' => ['id', 'storage_id', 'root_id', 'mount_id'],

--- a/core/Migrations/Version24000Date20220404230027.php
+++ b/core/Migrations/Version24000Date20220404230027.php
@@ -45,7 +45,7 @@ class Version24000Date20220404230027 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('file_metadata')) {
 			$table = $schema->createTable('file_metadata');
-			$table->addColumn('id', Types::INTEGER, [
+			$table->addColumn('id', Types::BIGINT, [
 				'notnull' => true,
 			]);
 			$table->addColumn('group_name', Types::STRING, [


### PR DESCRIPTION
file_metadata.id runs out of range for very large instances.