### PR TITLE
fix: also apply top margin to audio in firefox

### DIFF
--- a/apps/files_sharing/css/public.css
+++ b/apps/files_sharing/css/public.css
@@ -62,7 +62,7 @@
   margin-right: auto;
 }
 
-#imgframe:has(audio) {
+#imgframe #viewer[data-handler=audios] {
   margin-top: 400px;
 }
 

--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -45,7 +45,7 @@ $download-button-section-height: 200px;
 	margin-right: auto;
 }
 
-#imgframe:has(audio) {
+#imgframe #viewer[data-handler=audios] {
 	// for speed settings
     margin-top: 400px;
 }

--- a/apps/files_sharing/css/publicView.css
+++ b/apps/files_sharing/css/publicView.css
@@ -62,7 +62,7 @@
   margin-right: auto;
 }
 
-#imgframe:has(audio) {
+#imgframe #viewer[data-handler=audios] {
   margin-top: 400px;
 }
 


### PR DESCRIPTION
Based on https://github.com/nextcloud/viewer/pull/1371 .

If we are displaying an audio file in a single page share provide enough margin to display the speed settings.

Follow up to #34055 .