### PR TITLE
Add accessibility entry in user menu

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -135,7 +135,11 @@ trait CommonSettingsTrait {
 
 	private function getIndexResponse(string $type, string $section): TemplateResponse {
 		if ($type === 'personal') {
-			$this->navigationManager->setActiveEntry('settings');
+			if ($section === 'theming') {
+				$this->navigationManager->setActiveEntry('accessibility_settings');
+			} else {
+				$this->navigationManager->setActiveEntry('settings');
+			}
 		} elseif ($type === 'admin') {
 			$this->navigationManager->setActiveEntry('admin_settings');
 		}

--- a/apps/theming/img/accessibility-dark.svg
+++ b/apps/theming/img/accessibility-dark.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="21"
+   viewBox="0 0 21 21"
+   width="21"
+   fill="#000000"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="accessibility-dark.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="30.958333"
+     inkscape:cx="2.551817"
+     inkscape:cy="9.9811575"
+     inkscape:window-width="1920"
+     inkscape:window-height="1039"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M -3,-2 H 21 V 22 H -3 Z"
+     fill="none"
+     id="path2" />
+  <path
+     d="m 19,4.5 c -2.61,0.7 -5.67,1 -8.5,1 C 7.67,5.5 4.61,5.2 2,4.5 l -0.5,2 c 1.86,0.5 4,0.83 6,1 v 13 h 2 v -6 h 2 v 6 h 2 v -13 c 2,-0.17 4.14,-0.5 6,-1 z m -8.5,0 c 1.1,0 2,-0.9 2,-2 0,-1.1 -0.9,-2 -2,-2 -1.1,0 -2,0.9 -2,2 0,1.1 0.9,2 2,2 z"
+     id="path4" />
+</svg>

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -201,12 +201,23 @@ class NavigationManager implements INavigationManager {
 		}
 
 		if ($this->userSession->isLoggedIn()) {
+			// Accessibility settings
+			if ($this->appManager->isEnabledForUser('theming', $this->userSession->getUser())) {
+				$this->add([
+					'type' => 'settings',
+					'id' => 'accessibility_settings',
+					'order' => 2,
+					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index', ['section' => 'theming']),
+					'name' => $l->t('Appearance and accessibility'),
+					'icon' => $this->urlGenerator->imagePath('theming', 'accessibility-dark.svg'),
+				]);
+			}
 			if ($this->isAdmin()) {
 				// App management
 				$this->add([
 					'type' => 'settings',
 					'id' => 'core_apps',
-					'order' => 4,
+					'order' => 5,
 					'href' => $this->urlGenerator->linkToRoute('settings.AppSettings.viewApps'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'apps.svg'),
 					'name' => $l->t('Apps'),
@@ -216,7 +227,7 @@ class NavigationManager implements INavigationManager {
 				$this->add([
 					'type' => 'settings',
 					'id' => 'settings',
-					'order' => 2,
+					'order' => 3,
 					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
 					'name' => $l->t('Personal settings'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'personal.svg'),
@@ -226,7 +237,7 @@ class NavigationManager implements INavigationManager {
 				$this->add([
 					'type' => 'settings',
 					'id' => 'admin_settings',
-					'order' => 3,
+					'order' => 4,
 					'href' => $this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'overview']),
 					'name' => $l->t('Administration settings'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
@@ -236,7 +247,7 @@ class NavigationManager implements INavigationManager {
 				$this->add([
 					'type' => 'settings',
 					'id' => 'settings',
-					'order' => 2,
+					'order' => 3,
 					'href' => $this->urlGenerator->linkToRoute('settings.PersonalSettings.index'),
 					'name' => $l->t('Settings'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
@@ -261,7 +272,7 @@ class NavigationManager implements INavigationManager {
 				$this->add([
 					'type' => 'settings',
 					'id' => 'core_users',
-					'order' => 5,
+					'order' => 6,
 					'href' => $this->urlGenerator->linkToRoute('settings.Users.usersList'),
 					'name' => $l->t('Users'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'users.svg'),

--- a/tests/acceptance/features/header.feature
+++ b/tests/acceptance/features/header.feature
@@ -5,8 +5,9 @@ Feature: header
     Given I am logged in as the admin
     When I open the Settings menu
     Then I see that the Settings menu is shown
-    And I see that the Settings menu has only 8 items
+    And I see that the Settings menu has only 9 items
     And I see that the "Set status" item in the Settings menu is shown
+    And I see that the "Appearance and accessibility" item in the Settings menu is shown
     And I see that the "Personal settings" item in the Settings menu is shown
     And I see that the "Administration settings" item in the Settings menu is shown
     And I see that the "Apps" item in the Settings menu is shown
@@ -18,8 +19,9 @@ Feature: header
     Given I am logged in
     When I open the Settings menu
     Then I see that the Settings menu is shown
-    And I see that the Settings menu has only 5 items
+    And I see that the Settings menu has only 6 items
     And I see that the "Set status" item in the Settings menu is shown
+    And I see that the "Appearance and accessibility" item in the Settings menu is shown
     And I see that the "Settings" item in the Settings menu is shown
     And I see that the "Help" item in the Settings menu is shown
     And I see that the "Log out" item in the Settings menu is shown

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -215,7 +215,19 @@ class NavigationManagerTest extends TestCase {
 			return vsprintf($text, $parameters);
 		});
 
+		$this->appManager->expects($this->any())
+		   ->method('isEnabledForUser')
+		   ->with('theming')
+		   ->willReturn(true);
 		$this->appManager->expects($this->once())->method('getAppInfo')->with('test')->willReturn($navigation);
+		/*
+		$this->appManager->expects($this->any())
+				   ->method('getAppInfo')
+				   ->will($this->returnValueMap([
+					   ['test', null, null, $navigation],
+					   ['theming', null, null, null],
+					]));
+		 */
 		$this->l10nFac->expects($this->any())->method('get')->willReturn($l);
 		$this->urlGenerator->expects($this->any())->method('imagePath')->willReturnCallback(function ($appName, $file) {
 			return "/apps/$appName/img/$file";
@@ -230,7 +242,7 @@ class NavigationManagerTest extends TestCase {
 		$user->expects($this->any())->method('getUID')->willReturn('user001');
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
 		$this->userSession->expects($this->any())->method('isLoggedIn')->willReturn(true);
-		$this->appManager->expects($this->once())
+		$this->appManager->expects($this->any())
 			 ->method('getEnabledAppsForUser')
 			 ->with($user)
 			 ->willReturn(['test']);
@@ -248,7 +260,7 @@ class NavigationManagerTest extends TestCase {
 		$apps = [
 			'core_apps' => [
 				'id' => 'core_apps',
-				'order' => 4,
+				'order' => 5,
 				'href' => '/apps/test/',
 				'icon' => '/apps/settings/img/apps.svg',
 				'name' => 'Apps',
@@ -259,9 +271,20 @@ class NavigationManagerTest extends TestCase {
 			]
 		];
 		$defaults = [
+			'accessibility_settings' => [
+				'type' => 'settings',
+				'id' => 'accessibility_settings',
+				'order' => 2,
+				'href' => '/apps/test/',
+				'name' => 'Appearance and accessibility',
+				'icon' => '/apps/theming/img/accessibility-dark.svg',
+				'active' => false,
+				'classes' => '',
+				'unread' => 0,
+			],
 			'settings' => [
 				'id' => 'settings',
-				'order' => 2,
+				'order' => 3,
 				'href' => '/apps/test/',
 				'icon' => '/apps/settings/img/admin.svg',
 				'name' => 'Settings',
@@ -283,9 +306,10 @@ class NavigationManagerTest extends TestCase {
 			]
 		];
 		$adminSettings = [
+			'accessibility_settings' => $defaults['accessibility_settings'],
 			'settings' => [
 				'id' => 'settings',
-				'order' => 2,
+				'order' => 3,
 				'href' => '/apps/test/',
 				'icon' => '/apps/settings/img/personal.svg',
 				'name' => 'Personal settings',
@@ -296,7 +320,7 @@ class NavigationManagerTest extends TestCase {
 			],
 			'admin_settings' => [
 				'id' => 'admin_settings',
-				'order' => 3,
+				'order' => 4,
 				'href' => '/apps/test/',
 				'icon' => '/apps/settings/img/admin.svg',
 				'name' => 'Administration settings',
@@ -310,6 +334,7 @@ class NavigationManagerTest extends TestCase {
 		return [
 			'minimalistic' => [
 				array_merge(
+					['accessibility_settings' => $defaults['accessibility_settings']],
 					['settings' => $defaults['settings']],
 					['test' => [
 						'id' => 'test',
@@ -332,6 +357,7 @@ class NavigationManagerTest extends TestCase {
 			],
 			'minimalistic-settings' => [
 				array_merge(
+					['accessibility_settings' => $defaults['accessibility_settings']],
 					['settings' => $defaults['settings']],
 					['test' => [
 						'id' => 'test',


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/33736

<img width="153" alt="image" src="https://user-images.githubusercontent.com/277525/190116235-2c0f9af3-ac4e-45cc-b061-3ddf3c5670af.png">

Note: if the theming app is disabled the entry will remove itself.
