### PR TITLE
fix: Disable AWS SDK attempt to find shared config

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -130,6 +130,7 @@ trait S3ConnectionTrait {
 			'use_path_style_endpoint' => isset($this->params['use_path_style']) ? $this->params['use_path_style'] : false,
 			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
 			'csm' => false,
+			'use_aws_shared_config_files' => false,
 			'use_arn_region' => false,
 			'http' => ['verify' => $this->getCertificateBundlePath()],
 		];


### PR DESCRIPTION
Hey all,

Thanks for maintaining this project!

It seems that AWS SDK shall attempt to detect `~/.aws/config` when initialized when using S3-like Object Storage as observed [here](https://github.com/aws/aws-sdk-php/issues/2303) and [here](https://github.com/aws/aws-sdk-php/issues/1931).

This behaviour is undesired - especially when using S3-compatible endpoints - as the documentation already required users to explicity declare the endpoint [when using Object Storage as Primary Storage](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/primary_storage.html) and [when using as External Storage](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/external_storage_configuration_gui.html). In a shared hosting environment the default path `~/.aws/config` may not be readable, [flooding log tail with error messages](https://community.keyhelp.de/viewtopic.php?t=10395).

This PR shall disable AWS SDK from seeking for the shared config file thus fixing the log flooding issue.

Other fixes are possible - e.g., exposing this as a config argument - but the marginal benefit seems to be limited: we can further discuss alternative approaches in this PR.

Thanks,