### PR TITLE
Fix "email changed" activity email check

### DIFF
--- a/apps/settings/lib/Hooks.php
+++ b/apps/settings/lib/Hooks.php
@@ -178,12 +178,17 @@ class Hooks {
 		if ($actor instanceof IUser) {
 			$subject = Provider::EMAIL_CHANGED_SELF;
 			if ($actor->getUID() !== $user->getUID()) {
+				// set via the OCS API
+				if ($this->config->getAppValue('settings', 'disable_activity.email_address_changed_by_admin', 'no') === 'yes') {
+					return;
+				}
 				$subject = Provider::EMAIL_CHANGED;
 			}
 			$text = $l->t('Your email address on %s was changed.', [$instanceUrl]);
 			$event->setAuthor($actor->getUID())
 				->setSubject($subject);
 		} else {
+			// set with occ
 			if ($this->config->getAppValue('settings', 'disable_activity.email_address_changed_by_admin', 'no') === 'yes') {
 				return;
 			}


### PR DESCRIPTION
Check `disable_activity.email_address_changed_by_admin` when email is changed by admin via the OCS API and not just only when set via OCC.

This setting value was never checked if there was an actor (meaning it was done by the API) but if the actor is different than the target user, we can safely assume it is an admin and apply the settings which prevent notifications for this event.

If you want to test that, here are the 2 methods to change a user email address as an admin:
OCC:
``` bash
occ user:setting USER_ID settings email 'NEW_EMAIL'
```
OCS API:
``` bash
curl -H "ocs-apirequest: true" \
    -u ADMIN_USER_ID:ADMIN_PASSWORD \
    -X PUT \
    -d 'key=email&value=URL_ENCODED_NEW_EMAIL' \
    https://my.nc.org/ocs/v1.php/cloud/users/USER_ID
```

How to toggle the setting:
```
# DISABLE the notification
occ config:app:set settings disable_activity.email_address_changed_by_admin --value yes
# ENABLE it
occ config:app:set settings disable_activity.email_address_changed_by_admin --value no
```

With this PR, there is no more email notification when changing the email via the OCS request when the user making the request is different than the target user.

This could be backported to 24 and 23.