### PR TITLE
on installation save channel to config.php if not stable

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3371,6 +3371,9 @@
       <code>$content !== ''</code>
       <code>$type === 'pdo'</code>
     </RedundantCondition>
+    <UndefinedVariable occurrences="1">
+      <code>$vendor</code>
+    </UndefinedVariable>
   </file>
   <file src="lib/private/Setup/AbstractDatabase.php">
     <UndefinedThisPropertyFetch occurrences="4">

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -393,7 +393,12 @@ class Setup {
 			$config = \OC::$server->getConfig();
 			$config->setAppValue('core', 'installedat', microtime(true));
 			$config->setAppValue('core', 'lastupdatedat', microtime(true));
-			$config->setAppValue('core', 'vendor', $this->getVendor());
+
+			$vendorData = $this->getVendorData();
+			$config->setAppValue('core', 'vendor', $vendorData['vendor']);
+			if ($vendorData['channel'] !== 'stable') {
+				$config->setSystemValue('updater.release.channel', $vendorData['channel']);
+			}
 
 			$group = \OC::$server->getGroupManager()->createGroup('admin');
 			if ($group instanceof IGroup) {
@@ -582,17 +587,14 @@ class Setup {
 		file_put_contents($baseDir . '/index.html', '');
 	}
 
-	/**
-	 * Return vendor from which this version was published
-	 *
-	 * @return string Get the vendor
-	 *
-	 * Copy of \OC\Updater::getVendor()
-	 */
-	private function getVendor() {
+	private function getVendorData(): array {
 		// this should really be a JSON file
 		require \OC::$SERVERROOT . '/version.php';
-		/** @var string $vendor */
-		return (string)$vendor;
+		/** @var mixed $vendor */
+		/** @var mixed $OC_Channel */
+		return [
+			'vendor' => (string)$vendor,
+			'channel' => (string)$OC_Channel,
+		];
 	}
 }


### PR DESCRIPTION
- the default channel to the NC server is what is provided in /version.php unless it is overridden in config.php
- the default channel to the NC Updater however is 'stable'
- this resultant in inconsistent results and confusing admin experience
- therefore "stable" is considered default and other channels are being written to config.php now upon installation

This seems to be more straight forward than to maintaining the same strategy of determining a default on the Updater (and forgetting about it).

Fixes https://github.com/nextcloud/updater/issues/436