### PR TITLE
Make sure the instance is in maintenance mode before reseting opcache…

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -973,10 +973,10 @@ class OC {
 			self::checkMaintenanceMode($systemConfig);
 
 			if (\OCP\Util::needUpgrade()) {
-				if (function_exists('opcache_reset')) {
-					opcache_reset();
-				}
 				if (!((bool) $systemConfig->getValue('maintenance', false))) {
+					if (function_exists('opcache_reset')) {
+						opcache_reset();
+					}
 					self::printUpgradePage($systemConfig);
 					exit();
 				}


### PR DESCRIPTION
opcache_reset was being called when there is an update available but the user has not upgraded yet so the instance gets awfully slow if it can be upgraded somehow. This patch ensures that the instance is in maintenance mode. It means that the administrator of the instance is expecting and wants an upgrade.