### PR TITLE
Create a checksum of the config file in memory

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -260,11 +260,11 @@ class Config {
 			throw new HintException(sprintf('Configuration was not read or initialized correctly, not overwriting %s', $this->configFilePath));
 		}
 
-		/* This creates a checksum of the config file in memory.
-		 * The config file opcache code is only invalidated if the
-		 * config file data has been changed therefore all the other
-		 * code that depend on the the config file opcode will not
-		 * be recompiled. */
+		// This creates a checksum of the config file in memory.
+		// The config file opcache code is only invalidated if the
+		// config file data has been changed therefore all the other
+		// code that depend on the the config file opcode will not
+		// be recompiled.
 		$data = var_export($this->cache, true);
 		$currentChecksum = crc32($data);
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -322,8 +322,12 @@ class Config {
 
 	private function getLastChecksum(): int {
 		if ($this->lastChecksum == null) {
-			$data = file_get_contents($this->configFilePath);
-			$this->lastChecksum = crc32($data);
+			if (file_exists($this->configFilePath)) {
+				$data = file_get_contents($this->configFilePath);
+				$this->lastChecksum = crc32($data);
+			} else {
+				$this->lastChecksum = 0;
+			}
 		}
 		return $this->lastChecksum;
 	}


### PR DESCRIPTION
This fixes a massive performance bug when opcache is enabled.

Signed-off-by: Mateus de Lima Oliveira <mateus@ativarsoft.com>