### PR TITLE
Do not store generated mysql password if it was not used

### DIFF
--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -183,6 +183,9 @@ class MySQL extends AbstractDatabase {
 						$i++;
 					}
 				}
+			} else {
+				// Reuse existing password if a database config is already present
+				$this->dbPassword = $rootPassword;
 			}
 		} catch (\Exception $ex) {
 			$this->logger->info('Can not create a new MySQL user, will continue with the provided user.', [


### PR DESCRIPTION
Make sure that we do not store and use the generated password if it wasn't used for user creation  in cases where there is a dbpass already preconfigured 

https://github.com/nextcloud/server/blob/bugfix/noid/db-password-install/lib/private/Setup/MySQL.php#L158-L159