### PR TITLE
Add edit locally file action

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -711,6 +711,30 @@
 			});
 
 			this.registerAction({
+				name: 'EditLocally',
+				displayName: function(context) {
+					var locked = context.$file.data('locked');
+					if (!locked) {
+						return t('files', 'Edit locally');
+					}
+				},
+				mime: 'all',
+				order: -23,
+				iconClass: function(filename, context) {
+					var locked = context.$file.data('locked');
+					if (!locked) {
+						return 'icon-rename';
+					}
+				},
+				permissions: OC.PERMISSION_UPDATE,
+				actionHandler: function (filename, context) {
+					var dir = context.dir || context.fileList.getCurrentDirectory();
+					var path = dir === '/' ? dir + filename : dir + '/' + filename;
+					context.fileList.openLocalClient(path);
+				},
+			});
+
+			this.registerAction({
 				name: 'Open',
 				mime: 'dir',
 				permissions: OC.PERMISSION_READ,

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2807,6 +2807,15 @@
 			});
 		},
 
+		openLocalClient: function(path) {
+			var scheme = 'nc://';
+			var command = 'open';
+			var uid = OC.getCurrentUser().uid;
+			var url = scheme + command + '/' + uid + '@' + window.location.host + (window.location.port ? `:${window.location.port}` : '') + OC.encodePath(path);
+
+			window.location.href = url;
+		},
+
 		/**
 		 * Updates the given row with the given file info
 		 *


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/33275

![image](https://user-images.githubusercontent.com/24800714/191350242-859e7876-9eda-47fc-8a07-fc8e71040a7f.png)

Based on https://github.com/nextcloud/desktop/blob/v3.6.0/doc/architecture.rst#local-file-editing

@jancborchardt @nimishavijay currently using the same icon as "Rename", any new icon suggestions?

@tobiasKaminsky @allexzander this was tested on the https://github.com/nextcloud/desktop/releases/tag/v3.6.0 client, let me know if any changes are needed