### PR TITLE
DashBoard : Allow up to 5 widgets side by side

### DIFF
--- a/apps/dashboard/src/DashboardApp.vue
+++ b/apps/dashboard/src/DashboardApp.vue
@@ -441,7 +441,7 @@ export default {
 .panels {
 	width: auto;
 	margin: auto;
-	max-width: 1500px;
+	max-width: 1800px;
 	display: flex;
 	justify-content: center;
 	flex-direction: row;


### PR DESCRIPTION
Like many people, I have a resolution of 1920x1080 (and more and more people have even higher resolutions) ... and I think more widgets should be allowed side by side. This is in my opinion a good compromise.

Note : This change does not change anything for people with lower resolutions.

Before, on my 1920x1080 screen : 
![2022-09-22_15-18](https://user-images.githubusercontent.com/33763786/191758863-17bab5cd-8e06-41d4-81ea-af963853f17e.png)

After, on my 1920x1080 screen : 
![2022-09-22_15-17](https://user-images.githubusercontent.com/33763786/191758895-494c92a9-40bc-4336-bb37-15f4a95fd2e8.png)

Signed-off-by: Jérôme Herbinet <j.herbinet@protonmail.ch>

Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

