### PR TITLE
includeTags -> include_tags

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -370,7 +370,7 @@ class ShareAPIController extends OCSController {
 	 * @return DataResponse
 	 * @throws OCSNotFoundException
 	 */
-	public function getShare(string $id, bool $includeTags = false): DataResponse {
+	public function getShare(string $id, bool $include_tags = false): DataResponse {
 		try {
 			$share = $this->getShareById($id);
 		} catch (ShareNotFound $e) {
@@ -381,7 +381,7 @@ class ShareAPIController extends OCSController {
 			if ($this->canAccessShare($share)) {
 				$share = $this->formatShare($share);
 
-				if ($includeTags) {
+				if ($include_tags) {
 					$share = Helper::populateTags([$share], 'file_source', \OC::$server->getTagManager());
 				} else {
 					$share = [$share];


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/34133

I realized that the other api /shares uses "include_tags", so we should use the same parameter.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>