### PR TITLE
Ignore invalid share types

### DIFF
--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -157,6 +157,8 @@ class Notifier implements INotifier {
 			if ($share->getStatus() !== IShare::STATUS_PENDING) {
 				throw new AlreadyProcessedException();
 			}
+		} else {
+			throw new \InvalidArgumentException('Invalid share type');
 		}
 
 		switch ($notification->getSubject()) {


### PR DESCRIPTION
Seems to happen sometimes, that a wrong share type ends up with a notification.
Then you end up with the following error on the GroupManager / Database backend
> Argument 1 passed to OC\\Group\\Database::getGroupDetails() must be of the type string, null given, called in /var/www/nextcloud/lib/private/Group/Manager.php on line 187 in file /var /www/nextcloud/lib/private/Group/Database.php line 468