### PR TITLE
Fix log_type errorlog: should behave like other log handlers

### DIFF
--- a/lib/private/Log/Errorlog.php
+++ b/lib/private/Log/Errorlog.php
@@ -27,22 +27,15 @@ namespace OC\Log;
 
 use OCP\Log\IWriter;
 
-class Errorlog implements IWriter {
-
-	/** @var string */
-	protected $tag;
-
-	public function __construct(string $tag = 'owncloud') {
-		$this->tag = $tag;
-	}
-
+class Errorlog extends LogDetails implements IWriter {
 	/**
 	 * write a message in the log
 	 * @param string $app
-	 * @param string $message
+	 * @param string|array $message
 	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level) {
-		error_log('[' . $this->tag . ']['.$app.']['.$level.'] '.$message);
+		$entry = $this->logDetailsAsJSON($app, $message, $level);
+		error_log($entry);
 	}
 }

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -49,7 +49,7 @@ class LogFactory implements ILogFactory {
 	public function get(string $type):IWriter {
 		switch (strtolower($type)) {
 			case 'errorlog':
-				return new Errorlog();
+				return $this->c->resolve(Errorlog::class);
 			case 'syslog':
 				return $this->c->resolve(Syslog::class);
 			case 'systemd':
@@ -73,7 +73,7 @@ class LogFactory implements ILogFactory {
 	protected function createNewLogger(string $type, string $tag, string $path): IWriter {
 		switch (strtolower($type)) {
 			case 'errorlog':
-				return new Errorlog($tag);
+				return new Errorlog($this->systemConfig);
 			case 'syslog':
 				return new Syslog($this->systemConfig, $tag);
 			case 'systemd':


### PR DESCRIPTION
Configuration with `'log_type' => 'errorlog'` are affected by #33313. This is due to the fact that the `ErrorLog` handler currently doesn't correctly implement the `write()` method. According to other implementations, the `$message` parameter can be either a string or an array.

Other implementations use `logDetailsAsJSON` to convert a structured log message into a `string`. `ErrorLog` should do the same.

Note: This PR also removes the `$tag` instance variable. A log tag is important for writers like `syslog` and `systemd` where log messages of multiple subsystems are merged into a common journal. This is clearly not the case for the `errlog` writer.