### PR TITLE
Add endpoint to fetch a cachable reference data

### DIFF
--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -57,6 +57,16 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 		]);
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
+	public function resolveOne(string $reference): DataResponse {
+		$resolvedReference = $this->referenceManager->resolveReference($reference);
+
+		$response = new DataResponse(['references' => [ $reference => $resolvedReference ]]);
+		$response->cacheFor(3600, false, true);
+		return $response;
+	}
 
 	/**
 	 * @NoAdminRequired

--- a/core/routes.php
+++ b/core/routes.php
@@ -123,6 +123,7 @@ $application->registerRoutes($this, [
 		['root' => '/collaboration', 'name' => 'CollaborationResources#getCollectionsByResource', 'url' => '/resources/{resourceType}/{resourceId}', 'verb' => 'GET'],
 		['root' => '/collaboration', 'name' => 'CollaborationResources#createCollectionOnResource', 'url' => '/resources/{baseResourceType}/{baseResourceId}', 'verb' => 'POST'],
 
+		['root' => '/references', 'name' => 'ReferenceApi#resolveOne', 'url' => '/resolve', 'verb' => 'GET'],
 		['root' => '/references', 'name' => 'ReferenceApi#extract', 'url' => '/extract', 'verb' => 'POST'],
 		['root' => '/references', 'name' => 'ReferenceApi#resolve', 'url' => '/resolve', 'verb' => 'POST'],
 


### PR DESCRIPTION
Required for https://github.com/nextcloud/vue-richtext/pull/793 to make sure requests for link previews can properly be cached by browsers