### PR TITLE
Don't run cron.php for 14min but only 4

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -136,10 +136,10 @@ try {
 		// Work
 		$jobList = \OC::$server->getJobList();
 
-		// We only ask for jobs for 14 minutes, because after 5 minutes the next
-		// system cron task should spawn and we want to have at most three
-		// cron jobs running in parallel.
-		$endTime = time() + 14 * 60;
+		// We only ask for jobs for 4 minutes, because after 5 minutes the next
+		// system cron task should spawn and we want to have at most one
+		// cron jobs.
+		$endTime = time() + 4 * 60;
 
 		$executedJobs = [];
 		while ($job = $jobList->getNext($onlyTimeSensitive)) {


### PR DESCRIPTION
Apparently cron.php runs for 14min but is called every 5 minutes.
Is there a reason for the discrepancy?

Original issue: https://github.com/nextcloud/recognize/issues/335