### PR TITLE
remove listeners to OC_Filesystem::(write|rename) old style hooks

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -745,7 +745,6 @@ class OC {
 		}
 
 		self::registerCleanupHooks($systemConfig);
-		self::registerFilesystemHooks();
 		self::registerShareHooks($systemConfig);
 		self::registerEncryptionWrapperAndHooks();
 		self::registerAccountHooks();
@@ -915,15 +914,6 @@ class OC {
 
 	private static function registerFileReferenceEventListener() {
 		\OC\Collaboration\Reference\File\FileReferenceEventListener::register(Server::get(IEventDispatcher::class));
-	}
-
-	/**
-	 * register hooks for the filesystem
-	 */
-	public static function registerFilesystemHooks() {
-		// Check for blacklisted files
-		OC_Hook::connect('OC_Filesystem', 'write', Filesystem::class, 'isBlacklisted');
-		OC_Hook::connect('OC_Filesystem', 'rename', Filesystem::class, 'isBlacklisted');
 	}
 
 	/**

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -489,25 +489,6 @@ class Filesystem {
 	}
 
 	/**
-	 * checks if a file is blacklisted for storage in the filesystem
-	 * Listens to write and rename hooks
-	 *
-	 * @param array $data from hook
-	 */
-	public static function isBlacklisted($data) {
-		if (isset($data['path'])) {
-			$path = $data['path'];
-		} elseif (isset($data['newpath'])) {
-			$path = $data['newpath'];
-		}
-		if (isset($path)) {
-			if (self::isFileBlacklisted($path)) {
-				$data['run'] = false;
-			}
-		}
-	}
-
-	/**
 	 * @param string $filename
 	 * @return bool
 	 */


### PR DESCRIPTION
- the events are not emitted anymore
- OC_Filesystem::isBlacklisted() is not called from anywhere else

my checks: 

![Screenshot_20220926_210330](https://user-images.githubusercontent.com/2184312/192359950-06d4689e-9749-40ef-b3bf-e91c26986fd1.png)

![Screenshot_20220926_210944](https://user-images.githubusercontent.com/2184312/192360034-2e78eb29-af9c-4b70-b25d-9d88dc95baa1.png)

![Screenshot_20220926_211006](https://user-images.githubusercontent.com/2184312/192360104-484e8b5a-9cf7-4ccf-85ae-f33a6f95a466.png)

Since it's also internal methods and signals, there should be no emitters or listeners in other apps.