### PR TITLE
Fix : Should make appear missing collaborative tag icon

### DIFF
--- a/dist/icons.css
+++ b/dist/icons.css
@@ -1048,6 +1048,14 @@ body .icon-starred-white,
 body .icon-starred.icon-white {
   background-image: var(--icon-starred-white);
 }
+body .icon-systemtags,
+body .icon-systemtags-dark {
+  background-image: var(--icon-tag-dark);
+}
+body .icon-systemtags-white,
+body .icon-systemtags.icon-white {
+  background-image: var(--icon-tag-white);
+}
 body .icon-tablet,
 body .icon-tablet-dark {
   background-image: var(--icon-tablet-dark);


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

This added lines should make appear missing shared tag icon (CSS file was incomplete).

Expected result : 
![2022-09-27_14-45](https://user-images.githubusercontent.com/33763786/192530595-1efb0560-c345-4b82-825d-645d9b773d0f.png)
