### PR TITLE
fix default value for updatedirectory setting

### DIFF
--- a/lib/private/Repair/MoveUpdaterStepFile.php
+++ b/lib/private/Repair/MoveUpdaterStepFile.php
@@ -43,7 +43,7 @@ class MoveUpdaterStepFile implements IRepairStep {
 	}
 
 	public function run(IOutput $output) {
-		$updateDir = $this->config->getSystemValue('updatedirectory') ?? $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
+		$updateDir = $this->config->getSystemValue('updatedirectory', null) ?? $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
 		$instanceId = $this->config->getSystemValue('instanceid', null);
 
 		if (!is_string($instanceId) || empty($instanceId)) {


### PR DESCRIPTION
After a Nextcloud upgrade, a .step file is left in the update-$INSTANCEID directory, which is moved by the repair step, after the successful upgrade, to unblock future upgrades. The default value if `getSystemValue` if not specified differently, is an empty string. Thus, the repair step had a wrong location to move the file.

Fixes https://github.com/nextcloud/updater/issues/437