### PR TITLE
Fetch the reference preview image if not found in cache

### DIFF
--- a/core/routes.php
+++ b/core/routes.php
@@ -81,7 +81,7 @@ $application->registerRoutes($this, [
 		['name' => 'Preview#getPreviewByFileId', 'url' => '/core/preview', 'verb' => 'GET'],
 		['name' => 'Preview#getPreview', 'url' => '/core/preview.png', 'verb' => 'GET'],
 		['name' => 'RecommendedApps#index', 'url' => '/core/apps/recommended', 'verb' => 'GET'],
-		['name' => 'Reference#preview', 'url' => '/core/references/preview/{referenceId}', 'verb' => 'GET'],
+		['name' => 'Reference#preview', 'url' => '/core/references/preview', 'verb' => 'GET'],
 		['name' => 'Css#getCss', 'url' => '/css/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'Js#getJs', 'url' => '/js/{appName}/{fileName}', 'verb' => 'GET'],
 		['name' => 'contactsMenu#index', 'url' => '/contactsmenu/contacts', 'verb' => 'POST'],

--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -145,7 +145,11 @@ class LinkReferenceProvider implements IReferenceProvider {
 					$bodyStream = new LimitStream($stream, self::MAX_PREVIEW_SIZE, 0);
 					$reference->setImageContentType($contentType);
 					$folder->newFile(md5($reference->getId()), $bodyStream->getContents());
-					$reference->setImageUrl($this->urlGenerator->linkToRouteAbsolute('core.Reference.preview', ['referenceId' => md5($reference->getId())]));
+					$reference->setImageUrl(
+						$this->urlGenerator->linkToRouteAbsolute('core.Reference.preview', [])
+							.'?imageUrl=' . rawurlencode($object->images[0]->url)
+							.'&referenceString=' . rawurlencode($reference->getUrl())
+					);
 				}
 			} catch (\Throwable $e) {
 				$this->logger->error('Failed to fetch and store the open graph image for ' . $reference->getId(), ['exception' => $e]);


### PR DESCRIPTION
It could not work with no server-side cache configured as the link provider was saving the preview in the cache and the reference manager was completely relying on the cache.

The reference manager does not fetch the image if needed and tells the browser to cache it for an hour.