### PR TITLE
Correctly handle Redis::keys returning false

### DIFF
--- a/build/stubs/redis.php
+++ b/build/stubs/redis.php
@@ -2177,7 +2177,7 @@ class Redis
      *
      * @param string $pattern pattern, using '*' as a wildcard
      *
-     * @return array string[] The keys that match a certain pattern.
+     * @return string[]|false The keys that match a certain pattern.
      *
      * @link    https://redis.io/commands/keys
      * @example

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -78,7 +78,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		$keys = self::$cache->keys($prefix);
 		$deleted = self::$cache->del($keys);
 
-		return count($keys) === $deleted;
+		return (is_array($keys) && (count($keys) === $deleted));
 	}
 
 	/**


### PR DESCRIPTION
It seems a lot of \Redis method can actually return false, so not sure if this is the only case.

Fix https://github.com/nextcloud/server/issues/34155

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>