### PR TITLE
Fix URLs on reference resolving

### DIFF
--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -61,7 +61,7 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 * @NoAdminRequired
 	 */
 	public function resolveOne(string $reference): DataResponse {
-		$resolvedReference = $this->referenceManager->resolveReference($reference);
+		$resolvedReference = $this->referenceManager->resolveReference(trim($reference));
 
 		$response = new DataResponse(['references' => [ $reference => $resolvedReference ]]);
 		$response->cacheFor(3600, false, true);


### PR DESCRIPTION
The vue-richtext app currently sends leading spaces if they are in the text.

---

Company log is being spamed by
```
Could not detect any host in  https://github.com/nextcloud
```
 at the moment. Note the double space before the url.

Already patched company instance

Additional proper fix at https://github.com/nextcloud/vue-richtext/pull/805
