### PR TITLE
Fix missing maintenance mode header for OCS request

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -35,6 +35,7 @@ if (\OCP\Util::needUpgrade()
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	http_response_code(503);
+	header('X-Nextcloud-Maintenance-Mode: 1');
 	$response = new \OC\OCS\Result(null, 503, 'Service unavailable');
 	OC_API::respond($response, OC_API::requestedFormat());
 	exit;


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/33173.