### PR TITLE
Add a capability for the reference API and expose the regex to clients

### DIFF
--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -24,6 +24,7 @@ namespace OC\OCS;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 
 /**
  * Class Capabilities
@@ -52,7 +53,9 @@ class CoreCapabilities implements ICapability {
 			'core' => [
 				'pollinterval' => $this->config->getSystemValue('pollinterval', 60),
 				'webdav-root' => $this->config->getSystemValue('webdav-root', 'remote.php/webdav'),
-			]
+				'reference-api' => true,
+				'reference-regex' => IURLGenerator::URL_REGEX_NO_MODIFIERS,
+			],
 		];
 	}
 }

--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -43,7 +43,16 @@ interface IURLGenerator {
 	 *
 	 * @since 25.0.0
 	 */
-	public const URL_REGEX = '/(\s|\n|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|\n|$)/mi';
+	public const URL_REGEX = '/' . self::URL_REGEX_NO_MODIFIERS . '/mi';
+
+	/**
+	 * Regex for matching http(s) urls (without modifiers for client compatibility)
+	 *
+	 * This is a copy of the frontend regex in core/src/OCP/comments.js, make sure to adjust both when changing
+	 *
+	 * @since 25.0.0
+	 */
+	public const URL_REGEX_NO_MODIFIERS = '(\s|\n|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|\n|$)';
 
 	/**
 	 * Returns the URL for a route


### PR DESCRIPTION
Fix #34278 

```json
{
  "ocs": {
    "meta": {
      "status": "ok",
      "statuscode": 200,
      "message": "OK"
    },
    "data": {
      "version": {
        "major": 26,
        "minor": 0,
        "micro": 0,
        "string": "26.0.0 dev",
        "edition": "",
        "extendedSupport": false
      },
      "capabilities": {
        "core": {
          "pollinterval": 60,
          "webdav-root": "remote.php/webdav",
          "reference-api": true,
          "reference-regex": "(\\s|\\n|^)(https?:\\/\\/)((?:[-A-Z0-9+_]+\\.)+[-A-Z]+(?:\\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\\s|\\n|$)"
        },
…
```