### PR TITLE
Reference url can always fallback to the link itself

### DIFF
--- a/lib/public/Collaboration/Reference/IReference.php
+++ b/lib/public/Collaboration/Reference/IReference.php
@@ -98,7 +98,7 @@ interface IReference extends JsonSerializable {
 	/**
 	 * @since 25.0.0
 	 */
-	public function getUrl(): ?string;
+	public function getUrl(): string;
 
 	/**
 	 * Set the reference specific rich object representation

--- a/lib/public/Collaboration/Reference/Reference.php
+++ b/lib/public/Collaboration/Reference/Reference.php
@@ -149,8 +149,8 @@ class Reference implements IReference {
 	 * @inheritdoc
 	 * @since 25.0.0
 	 */
-	public function getUrl(): ?string {
-		return $this->url;
+	public function getUrl(): string {
+		return $this->url ?? $this->reference;
 	}
 
 	/**


### PR DESCRIPTION
As we don't try to resolve links without protocols anymore, it now makes sense to have the link itself as a reference url fallback.