### PR TITLE
Add isDeleted to OCP\Calendar\ICalendar

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarImpl.php
+++ b/apps/dav/lib/CalDAV/CalendarImpl.php
@@ -131,6 +131,13 @@ class CalendarImpl implements ICreateFromString {
 	}
 
 	/**
+	 * @since 26.0.0
+	 */
+	public function isDeleted(): bool {
+		return $this->calendar->isDeleted();
+	}
+
+	/**
 	 * Create a new calendar event for this calendar
 	 * by way of an ICS string
 	 *

--- a/lib/public/Calendar/ICalendar.php
+++ b/lib/public/Calendar/ICalendar.php
@@ -75,4 +75,10 @@ interface ICalendar {
 	 * @since 13.0.0
 	 */
 	public function getPermissions(): int;
+
+	/**
+	 * Whether the calendar is deleted
+	 * @since 26.0.0
+	 */
+	public function isDeleted(): bool;
 }


### PR DESCRIPTION
The DAV calendar provider can return instances of deleted calendars, which can be acceptable, but let's provide a way for users of the public API to know that they might not want to use them. 

- [ ] https://github.com/nextcloud/documentation/issues/9248