### PR TITLE
Added parameter to disallow calendar subscription via link

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3,6 +3,7 @@
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @copyright Copyright (c) 2018 Georg Ehrke
  * @copyright Copyright (c) 2020, leith abdulla (<online-nextcloud@eleith.com>)
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Chih-Hsuan Yen <yan12125@gmail.com>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -2424,6 +2425,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return mixed
 	 */
 	public function createSubscription($principalUri, $uri, array $properties) {
+		// Subscription via link must be enabled.
+		if ($this->config->getAppValue('calendar', 'allow_subscribe_link', 'yes') === 'no') {
+			throw new Forbidden('Calendar subscription via link is disabled.');
+		}
 		if (!isset($properties['{http://calendarserver.org/ns/}source'])) {
 			throw new Forbidden('The {http://calendarserver.org/ns/}source property is required when creating subscriptions');
 		}

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3,7 +3,6 @@
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @copyright Copyright (c) 2018 Georg Ehrke
  * @copyright Copyright (c) 2020, leith abdulla (<online-nextcloud@eleith.com>)
- * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Chih-Hsuan Yen <yan12125@gmail.com>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -2425,10 +2424,6 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return mixed
 	 */
 	public function createSubscription($principalUri, $uri, array $properties) {
-		// Subscription via link must be enabled.
-		if ($this->config->getAppValue('calendar', 'allow_subscribe_link', 'yes') === 'no') {
-			throw new Forbidden('Calendar subscription via link is disabled.');
-		}
 		if (!isset($properties['{http://calendarserver.org/ns/}source'])) {
 			throw new Forbidden('The {http://calendarserver.org/ns/}source property is required when creating subscriptions');
 		}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -178,7 +178,7 @@ class Server {
 
 			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\WebcalCaching\Plugin($request));
-			if (\OC::$server->getConfig()->getAppValue('calendar', 'allow_subscribe_link', 'yes') === 'yes') {
+			if (\OC::$server->getConfig()->getAppValue('dav', 'allow_calendar_link_subscriptions', 'yes') === 'yes') {
 				$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 			}
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
@@ -177,7 +178,9 @@ class Server {
 
 			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\WebcalCaching\Plugin($request));
-			$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
+			if (\OC::$server->getConfig()->getAppValue('calendar', 'allow_subscribe_link', 'yes') === 'yes') {
+				$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
+			}
 
 			$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest(), \OC::$server->getConfig()));


### PR DESCRIPTION
Added calendar application config parameter `allow_subscribe_link` to disallow calendar subscription via link (i.e. for internal Nextcloud setups). Use

```
occ config:app:set calendar allow_subscribe_link --value 'yes'
```

to allow (default if not set) and

```
occ config:app:set calendar allow_subscribe_link --value 'no'
```

to disallow calendar subscription via link.

Author-Change-Id: IB#1126265
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>