### PR TITLE
Dynamically adjustment for footer height

### DIFF
--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -21,6 +21,8 @@
  */
 
 window.addEventListener('DOMContentLoaded', function () {
+	//change footer size given legal links
+	console.log(document)
 
 	$('#body-public').find('.header-right .menutoggle').click(function() {
 		$(this).next('.popovermenu').toggleClass('open');

--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -21,8 +21,8 @@
  */
 
 window.addEventListener('DOMContentLoaded', function () {
-	//change footer size given legal links
-	console.log(document)
+    //dynamically changes footer size if there's presence of links
+    if(document.querySelectorAll("a.legal").length > 0) console.log(1)
 
 	$('#body-public').find('.header-right .menutoggle').click(function() {
 		$(this).next('.popovermenu').toggleClass('open');

--- a/core/js/public/publicpage.js
+++ b/core/js/public/publicpage.js
@@ -21,8 +21,9 @@
  */
 
 window.addEventListener('DOMContentLoaded', function () {
-    //dynamically changes footer size if there's presence of links
-    if(document.querySelectorAll("a.legal").length > 0) console.log(1)
+	
+    //dynamically changes footer size depending on presence of links
+    if(document.querySelectorAll("a.legal").length > 0) document.getElementById("body-public").querySelector('footer').style = 'height: 95px'
 
 	$('#body-public').find('.header-right .menutoggle').click(function() {
 		$(this).next('.popovermenu').toggleClass('open');


### PR DESCRIPTION
Footer height is dynamically adjusted to 95px if one of the legal links is set; originally 65px. (first-time contributor)
Fix #34305