### PR TITLE
computerFileSize(): allow comma as decimal-point

### DIFF
--- a/core/src/OC/util.js
+++ b/core/src/OC/util.js
@@ -83,7 +83,7 @@ export default {
 			return null
 		}
 
-		const s = string.toLowerCase().trim()
+		const s = string.toLowerCase().replaceAll(',', '.').trim()
 		let bytes = null
 
 		const bytesArray = {


### PR DESCRIPTION
This should fix the issue  #18468 (Cannot set user quota with uneven values using locales that use a comma as decimal separator)

Signed-off-by: Ruben Barkow-Kuder <rubo77@users.noreply.github.com>