### PR TITLE
Fix reference preview when no server-side cache configured

### DIFF
--- a/core/Controller/ReferenceController.php
+++ b/core/Controller/ReferenceController.php
@@ -48,18 +48,21 @@ class ReferenceController extends Controller {
 	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @param string $referenceId the reference cache key
+	 * @return Response
 	 */
 	public function preview(string $referenceId): Response {
 		$reference = $this->referenceManager->getReferenceByCacheKey($referenceId);
-		if ($reference === null) {
-			return new DataResponse('', Http::STATUS_NOT_FOUND);
-		}
 
 		try {
 			$appData = $this->appDataFactory->get('core');
 			$folder = $appData->getFolder('opengraph');
 			$file = $folder->getFile($referenceId);
-			$response = new DataDownloadResponse($file->getContent(), $referenceId, $reference->getImageContentType());
+			$response = new DataDownloadResponse(
+				$file->getContent(),
+				$referenceId,
+				$reference === null ? $file->getMimeType() : $reference->getImageContentType()
+			);
 		} catch (NotFoundException|NotPermittedException $e) {
 			$response = new DataResponse('', Http::STATUS_NOT_FOUND);
 		}


### PR DESCRIPTION
Short version: We can't rely on cached values to get the link preview image file type.

Long version:
Currently, when getting a reference image preview with `/core/references/preview/REF_CACHE_KEY` we use the info we have to build the DataResponse:
* the image file itself that was fetched by `LinkReferenceProvider::fetchReference()` and stored in appData
* the image content type stored in the cached reference

Problem is if no server side cache is configured we don't cache the reference so basically the preview endpoint does not work :grin:.

That leaves us with 2 potential solutions:
* fetching the reference again just to get the image mime type (pretty heavy, it means we do it twice each time the reference is displayed...)
* use the appData image file mimetype (that what's done in this PR) but this returns `application/octet-stream` most likely because our `File::getMimeType()` is based on file name extension and there is none for those files. Browsers are fine with that though...

