### PR TITLE
Fix missing background on upgrade

### DIFF
--- a/apps/theming/appinfo/info.xml
+++ b/apps/theming/appinfo/info.xml
@@ -31,6 +31,9 @@
 		<pre-migration>
 			<step>OCA\Theming\Migration\MigrateUserConfig</step>
 		</pre-migration>
+		<post-migration>
+			<step>OCA\Theming\Migration\InitBackgroundImagesMigration</step>
+		</post-migration>
 	</repair-steps>
 
 	<commands>

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Theming\Jobs;
+
+use OCA\Theming\AppInfo\Application;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IConfig;
+
+class MigrateBackgroundImages extends QueuedJob {
+	public const TIME_SENSITIVE = 0;
+
+	private IConfig $config;
+	private IAppManager $appManager;
+	private IAppDataFactory $appDataFactory;
+	private IJobList $jobList;
+
+	public function __construct(ITimeFactory $time, IAppDataFactory $appDataFactory, IConfig $config, IAppManager $appManager, IJobList $jobList) {
+		parent::__construct($time);
+		$this->config = $config;
+		$this->appManager = $appManager;
+		$this->appDataFactory = $appDataFactory;
+		$this->jobList = $jobList;
+	}
+
+	protected function run($argument): void {
+		if (!$this->appManager->isEnabledForUser('dashboard')) {
+			return;
+		}
+
+		$themingData = $this->appDataFactory->get(Application::APP_ID);
+		$dashboardData = $this->appDataFactory->get('dashboard');
+
+		$userIds = $this->config->getUsersForUserValue('theming', 'background', 'custom');
+
+		$notSoFastMode = \count($userIds) > 5000;
+		$reTrigger = false;
+		$processed = 0;
+
+		foreach ($userIds as $userId) {
+			try {
+				// precondition
+				if ($notSoFastMode) {
+					if ($this->config->getUserValue($userId, 'theming', 'background-migrated', '0') === '1') {
+						// already migrated
+						continue;
+					}
+					$reTrigger = true;
+				}
+
+				// migration
+				$file = $dashboardData->getFolder($userId)->getFile('background.jpg');
+				try {
+					$targetDir = $themingData->getFolder($userId);
+				} catch (NotFoundException $e) {
+					$targetDir = $themingData->newFolder($userId);
+				}
+				if (!$targetDir->fileExists('background.jpg')) {
+					$targetDir->newFile('background.jpg', $file->getContent());
+				}
+				$file->delete();
+			} catch (NotFoundException|NotPermittedException $e) {
+			}
+			// capture state
+			if ($notSoFastMode) {
+				$this->config->setUserValue($userId, 'theming', 'background-migrated', '1');
+				$processed++;
+			}
+			if ($processed > 4999) {
+				break;
+			}
+		}
+
+		if ($reTrigger) {
+			$this->jobList->add(self::class);
+		}
+	}
+}

--- a/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
+++ b/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Theming\Migration;
+
+use OCA\Theming\Jobs\MigrateBackgroundImages;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+
+class InitBackgroundImagesMigration implements \OCP\Migration\IRepairStep {
+
+	private IJobList $jobList;
+
+	public function __construct(IJobList $jobList) {
+		$this->jobList = $jobList;
+	}
+
+	public function getName() {
+		return 'Initialize migration of background images from dashboard to theming app';
+	}
+
+	public function run(IOutput $output) {
+		$this->jobList->add(MigrateBackgroundImages::class);
+	}
+}

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -38,9 +38,7 @@ use OCP\Migration\SimpleMigrationStep;
  *
  */
 class Version25000Date20221007010957 extends SimpleMigrationStep {
-
-	/** @var IDBConnection */
-	protected $connection;
+	protected IDBConnection $connection;
 
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -52,13 +52,19 @@ class Version25000Date20221007010957 extends SimpleMigrationStep {
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		$qb = $this->connection->getQueryBuilder();
 
+		$orExpr = $qb->expr()->orX(
+			$qb->expr()->eq('configkey', $qb->createNamedParameter('background')),
+			$qb->expr()->eq('configkey', $qb->createNamedParameter('backgroundVersion')),
+		);
+
+		$qb->delete('preferences')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter('theming')))
+			->andWhere($orExpr);
+
 		$qb->update('preferences')
 			->set('appid', $qb->createNamedParameter('theming'))
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter('dashboard')))
-			->andWhere($qb->expr()->orX(
-				$qb->expr()->eq('configkey', $qb->createNamedParameter('background')),
-				$qb->expr()->eq('configkey', $qb->createNamedParameter('backgroundVersion'))
-			));
+			->andWhere($orExpr);
 
 		$qb->executeStatement();
 	}

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2022 Christopher Ng <chrng8@gmail.com>
+ *
+ * @author Christopher Ng <chrng8@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * User background settings handling was moved from the
+ * dashboard app to the theming app so we migrate the
+ * respective preference values here
+ *
+ */
+class Version25000Date20221007010957 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb->update('preferences')
+			->set('appid', 'theming')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter('dashboard')))
+			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('background')))
+			->orWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('backgroundVersion')));
+
+		$qb->executeStatement();
+	}
+}

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -51,23 +51,22 @@ class Version25000Date20221007010957 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		$cleanUpQuery = $this->connection->getQueryBuilder();
-
-		$orExpr = $cleanUpQuery->expr()->orX(
-			$cleanUpQuery->expr()->eq('configkey', $cleanUpQuery->createNamedParameter('background')),
-			$cleanUpQuery->expr()->eq('configkey', $cleanUpQuery->createNamedParameter('backgroundVersion')),
-		);
-
 		$cleanUpQuery->delete('preferences')
 			->where($cleanUpQuery->expr()->eq('appid', $cleanUpQuery->createNamedParameter('theming')))
-			->andWhere($orExpr);
+			->andWhere($cleanUpQuery->expr()->orX(
+				$cleanUpQuery->expr()->eq('configkey', $cleanUpQuery->createNamedParameter('background')),
+				$cleanUpQuery->expr()->eq('configkey', $cleanUpQuery->createNamedParameter('backgroundVersion')),
+			));
 		$cleanUpQuery->executeStatement();
 
 		$updateQuery = $this->connection->getQueryBuilder();
 		$updateQuery->update('preferences')
 			->set('appid', $updateQuery->createNamedParameter('theming'))
 			->where($updateQuery->expr()->eq('appid', $updateQuery->createNamedParameter('dashboard')))
-			->andWhere($orExpr);
-
+			->andWhere($updateQuery->expr()->orX(
+				$updateQuery->expr()->eq('configkey', $updateQuery->createNamedParameter('background')),
+				$updateQuery->expr()->eq('configkey', $updateQuery->createNamedParameter('backgroundVersion')),
+			));
 		$updateQuery->executeStatement();
 	}
 }

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -55,10 +55,12 @@ class Version25000Date20221007010957 extends SimpleMigrationStep {
 		$qb = $this->connection->getQueryBuilder();
 
 		$qb->update('preferences')
-			->set('appid', 'theming')
+			->set('appid', $qb->createNamedParameter('theming'))
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter('dashboard')))
-			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('background')))
-			->orWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('backgroundVersion')));
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('configkey', $qb->createNamedParameter('background')),
+				$qb->expr()->eq('configkey', $qb->createNamedParameter('backgroundVersion'))
+			));
 
 		$qb->executeStatement();
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1062,6 +1062,7 @@ return array(
     'OC\\Core\\Migrations\\Version24000Date20220425072957' => $baseDir . '/core/Migrations/Version24000Date20220425072957.php',
     'OC\\Core\\Migrations\\Version25000Date20220515204012' => $baseDir . '/core/Migrations/Version25000Date20220515204012.php',
     'OC\\Core\\Migrations\\Version25000Date20220602190540' => $baseDir . '/core/Migrations/Version25000Date20220602190540.php',
+    'OC\\Core\\Migrations\\Version25000Date20221007010957' => $baseDir . '/core/Migrations/Version25000Date20221007010957.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1095,6 +1095,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version24000Date20220425072957' => __DIR__ . '/../../..' . '/core/Migrations/Version24000Date20220425072957.php',
         'OC\\Core\\Migrations\\Version25000Date20220515204012' => __DIR__ . '/../../..' . '/core/Migrations/Version25000Date20220515204012.php',
         'OC\\Core\\Migrations\\Version25000Date20220602190540' => __DIR__ . '/../../..' . '/core/Migrations/Version25000Date20220602190540.php',
+        'OC\\Core\\Migrations\\Version25000Date20221007010957' => __DIR__ . '/../../..' . '/core/Migrations/Version25000Date20221007010957.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
 
-$OC_Version = [26, 0, 0, 0];
+$OC_Version = [26, 0, 0, 1];
 
 // The human readable string
 $OC_VersionString = '26.0.0 dev';


### PR DESCRIPTION
Fix ~~https://github.com/nextcloud/server/issues/34458~~ https://github.com/nextcloud/server/issues/34216

Background settings previously were set in the `oc_preferences` table with the appid `"dashboard"`, after https://github.com/nextcloud/server/pull/33733 the settings were queried for with the appid `"theming"`

This migration aims to fix the background loss on upgrade by updating the appid to `"theming"`