### PR TITLE
Reduce number of database queries during WebDAV propfind request

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -365,7 +365,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		$share = $storage->getShare();
 		$note = $share->getNote();
-		if ($share->getShareOwner() !== $user && !empty($note)) {
+		if ($share->getShareOwner() !== $user) {
 			return $note;
 		}
 		return '';

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -355,23 +355,19 @@ abstract class Node implements \Sabre\DAV\INode {
 			return '';
 		}
 
-		$types = [
-			IShare::TYPE_USER,
-			IShare::TYPE_GROUP,
-			IShare::TYPE_CIRCLE,
-			IShare::TYPE_ROOM
-		];
-
-		foreach ($types as $shareType) {
-			$shares = $this->shareManager->getSharedWith($user, $shareType, $this, -1);
-			foreach ($shares as $share) {
-				$note = $share->getNote();
-				if ($share->getShareOwner() !== $user && !empty($note)) {
-					return $note;
-				}
-			}
+		// Retrieve note from the share object already loaded into
+		// memory, to avoid additional database queries.
+		$storage = $this->getNode()->getStorage();
+		if (!$storage->instanceOfStorage(\OCA\Files_Sharing\SharedStorage::class)) {
+			return '';
 		}
+		/** @var \OCA\Files_Sharing\SharedStorage $storage */
 
+		$share = $storage->getShare();
+		$note = $share->getNote();
+		if ($share->getShareOwner() !== $user && !empty($note)) {
+			return $note;
+		}
 		return '';
 	}
 

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -229,6 +229,13 @@ class MountProvider implements IMountProvider {
 				->setShareType($shares[0]->getShareType())
 				->setTarget($shares[0]->getTarget());
 
+			// Gather notes from all the shares.
+			// Since these are readly available here, storing them
+			// enables the DAV FilesPlugin to avoid executing many
+			// DB queries to retrieve the same information.
+			$allNotes = implode("\n", array_map(function ($sh) { return $sh->getNote(); }, $shares));
+			$superShare->setNote($allNotes);
+
 			// use most permissive permissions
 			// this covers the case where there are multiple shares for the same
 			// file e.g. from different groups and different permissions


### PR DESCRIPTION
While working on https://github.com/nextcloud/android/issues/10783 I have found the following.

- When reading complete data for a folder the Android client requests the **nc:note** attribute in the WebDAV propfind request.
- Current implementation of retrieval of this attribute executes four separate database queries for each file in the folder.

With help of @PVince81 I have been able to refactor the code to avoid issuing additional database queries, since required data is already loaded into memory.

Performance is improved significantly - almost four times faster in my tests (331 files in a folder)

_ | Execution time [ms] | # of DB queries
--- | ---: | ---:
Before | 1300 | 1699
After | 350 | 372

Proposed changes introduce a slight change in behaviour when a file has been shared more than once with the same user - e.g. with a direct share and a group share.

- Previously in this case only note from the first share found was returned.
- Now notes from all shares are concatenated (with a new-line) and returned.

With the new implementation the notes are presented like this in the Android client:

<img src="https://user-images.githubusercontent.com/8277636/194663716-d55fab0b-c347-45b3-bd62-dbe7ae83ec69.png" width="300">

I have not been able to find the share notes in the UI of the web client.