### PR TITLE
Fix hasBigIntConversionPendingColumns missing files_trash

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -769,6 +769,7 @@ Raw output
 			'federated_reshares' => ['share_id'],
 			'filecache' => ['fileid', 'storage', 'parent', 'mimetype', 'mimepart', 'mtime', 'storage_mtime'],
 			'filecache_extended' => ['fileid'],
+			'files_trash' => ['auto_id'],
 			'file_locks' => ['id'],
 			'file_metadata' => ['id'],
 			'jobs' => ['id'],


### PR DESCRIPTION
The two tables seem to have gone out of sync, causing the web interface to miss `files_trash.auto_id` not being a bigint.