### PR TITLE
Propagate attributes when resharing

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -537,6 +537,7 @@ class ShareAPIController extends OCSController {
 			$share = $this->setShareAttributes($share, $attributes);
 		}
 
+		$share->setSharedBy($this->currentUser);
 		$this->checkInheritedAttributes($share);
 
 		if ($shareType === IShare::TYPE_USER) {
@@ -691,7 +692,6 @@ class ShareAPIController extends OCSController {
 		}
 
 		$share->setShareType($shareType);
-		$share->setSharedBy($this->currentUser);
 
 		if ($note !== '') {
 			$share->setNote($note);
@@ -1894,10 +1894,13 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function checkInheritedAttributes(IShare $share): void {
+		if (!$share->getSharedBy()) {
+			return; // Probably in a test
+		}
 		$userFolder = $this->rootFolder->getUserFolder($share->getSharedBy());
 		$nodes = $userFolder->getById($share->getNodeId());
 		if (empty($nodes)) {
-			throw new NotFoundException('Node for share not found, fileid: ' . $share->getNodeId());
+			return;
 		}
 		$node = $nodes[0];
 		if ($node->getStorage()->instanceOfStorage(SharedStorage::class)) {

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -533,6 +533,10 @@ class ShareAPIController extends OCSController {
 			$permissions &= ~($permissions & ~$node->getPermissions());
 		}
 
+		if ($attributes !== null) {
+			$share = $this->setShareAttributes($share, $attributes);
+		}
+
 		$this->checkInheritedAttributes($share);
 
 		if ($shareType === IShare::TYPE_USER) {
@@ -691,10 +695,6 @@ class ShareAPIController extends OCSController {
 
 		if ($note !== '') {
 			$share->setNote($note);
-		}
-
-		if ($attributes !== null) {
-			$share = $this->setShareAttributes($share, $attributes);
 		}
 
 		try {
@@ -1112,24 +1112,10 @@ class ShareAPIController extends OCSController {
 			$share->setNote($note);
 		}
 
-		$userFolder = $this->rootFolder->getUserFolder($this->currentUser);
-
-		// get the node with the point of view of the current user
-		$nodes = $userFolder->getById($share->getNode()->getId());
-		if (count($nodes) > 0) {
-			$node = $nodes[0];
-			$storage = $node->getStorage();
-			if ($storage && $storage->instanceOfStorage(SharedStorage::class)) {
-				/** @var \OCA\Files_Sharing\SharedStorage $storage */
-				$inheritedAttributes = $storage->getShare()->getAttributes();
-				if ($inheritedAttributes !== null && $inheritedAttributes->getAttribute('permissions', 'download') === false) {
-					if ($hideDownload === 'false') {
-						throw new OCSBadRequestException($this->l->t('Cannot increase permissions'));
-					}
-					$share->setHideDownload(true);
-				}
-			}
+		if ($attributes !== null) {
+			$share = $this->setShareAttributes($share, $attributes);
 		}
+		$this->checkInheritedAttributes($share);
 
 		/**
 		 * expirationdate, password and publicUpload only make sense for link shares
@@ -1261,10 +1247,6 @@ class ShareAPIController extends OCSController {
 				}
 				$share->setExpirationDate($expireDate);
 			}
-		}
-
-		if ($attributes !== null) {
-			$share = $this->setShareAttributes($share, $attributes);
 		}
 
 		try {
@@ -1912,8 +1894,14 @@ class ShareAPIController extends OCSController {
 	}
 
 	private function checkInheritedAttributes(IShare $share): void {
-		if ($share->getNode()->getStorage()->instanceOfStorage(SharedStorage::class)) {
-			$storage = $share->getNode()->getStorage();
+		$userFolder = $this->rootFolder->getUserFolder($share->getSharedBy());
+		$nodes = $userFolder->getById($share->getNodeId());
+		if (empty($nodes)) {
+			throw new NotFoundException('Node for share not found, fileid: ' . $share->getNodeId());
+		}
+		$node = $nodes[0];
+		if ($node->getStorage()->instanceOfStorage(SharedStorage::class)) {
+			$storage = $node->getStorage();
 			if ($storage instanceof Wrapper) {
 				$storage = $storage->getInstanceOfStorage(SharedStorage::class);
 				if ($storage === null) {
@@ -1926,6 +1914,11 @@ class ShareAPIController extends OCSController {
 			$inheritedAttributes = $storage->getShare()->getAttributes();
 			if ($inheritedAttributes !== null && $inheritedAttributes->getAttribute('permissions', 'download') === false) {
 				$share->setHideDownload(true);
+				$attributes = $share->getAttributes();
+				if ($attributes) {
+					$attributes->setAttribute('permissions', 'download', false);
+					$share->setAttributes($attributes);
+				}
 			}
 		}
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1667,7 +1667,7 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
@@ -1695,7 +1695,7 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
@@ -1741,7 +1741,7 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
@@ -1791,7 +1791,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('createShare')->willReturnArgument(0);
 		$this->shareManager->method('allowGroupSharing')->willReturn(true);
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
@@ -2244,7 +2244,7 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
@@ -2310,7 +2310,7 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		[$userFolder, $path] = $this->getNonSharedUserFile();
 		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
@@ -2549,11 +2549,21 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
+
+		$path = $this->getMockBuilder(Folder::class)->getMock();
+		$storage = $this->createMock(Storage::class);
+		$storage->method('instanceOfStorage')
+			->willReturnMap([
+				['OCA\Files_Sharing\External\Storage', true],
+				['OCA\Files_Sharing\SharedStorage', false],
+			]);
+		$userFolder->method('getStorage')->willReturn($storage);
+		$path->method('getStorage')->willReturn($storage);
 
 		$path->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
 		$userFolder->expects($this->once())
@@ -2561,7 +2571,7 @@ class ShareAPIControllerTest extends TestCase {
 			->with('valid-path')
 			->willReturn($path);
 		$userFolder->method('getById')
-			->willReturn([$path]);
+			->willReturn([]);
 
 		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1667,20 +1667,12 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('valid-path')
@@ -1703,20 +1695,12 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('valid-path')
@@ -1757,20 +1741,12 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -1815,20 +1791,12 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('createShare')->willReturnArgument(0);
 		$this->shareManager->method('allowGroupSharing')->willReturn(true);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -1876,20 +1844,12 @@ class ShareAPIControllerTest extends TestCase {
 				['shareWith', null, 'validGroup'],
 			]);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(Folder::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('valid-path')
@@ -1932,20 +1892,12 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(Folder::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('valid-path')
@@ -2292,20 +2244,12 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -2366,20 +2310,12 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -2422,20 +2358,12 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFile();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -2508,20 +2436,12 @@ class ShareAPIControllerTest extends TestCase {
 		$share = $this->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$path->method('getPath')->willReturn('valid-path');
 		$userFolder->expects($this->once())
 				->method('get')
@@ -2551,22 +2471,15 @@ class ShareAPIControllerTest extends TestCase {
 		$ocs = $this->mockFormatShare();
 
 		$share = $this->newShare();
+		$share->setSharedBy('currentUser');
 		$this->shareManager->method('newShare')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFile();
+		$this->rootFolder->expects($this->exactly(2))
 				->method('getUserFolder')
 				->with('currentUser')
 				->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(File::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$userFolder->expects($this->once())
 				->method('get')
 				->with('valid-path')
@@ -2636,27 +2549,19 @@ class ShareAPIControllerTest extends TestCase {
 			])->setMethods(['formatShare'])
 			->getMock();
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$this->rootFolder->expects($this->once())
+		[$userFolder, $path] = $this->getNonSharedUserFolder();
+		$this->rootFolder->expects($this->exactly(2))
 			->method('getUserFolder')
 			->with('currentUser')
 			->willReturn($userFolder);
 
-		$path = $this->getMockBuilder(Folder::class)->getMock();
-		$storage = $this->createMock(Storage::class);
-		$storage->method('instanceOfStorage')
-			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', true],
-				['OCA\Files_Sharing\SharedStorage', false],
-			]);
-		$path->method('getStorage')->willReturn($storage);
 		$path->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('valid-path')
 			->willReturn($path);
 		$userFolder->method('getById')
-			->willReturn([]);
+			->willReturn([$path]);
 
 		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
 
@@ -2676,7 +2581,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->expectException(\OCP\AppFramework\OCS\OCSNotFoundException::class);
 		$this->expectExceptionMessage('Wrong share ID, share does not exist');
 
-		$node = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$share = $this->newShare();
 		$share->setNode($node);
 
@@ -2686,7 +2591,6 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->shareManager->method('getShareById')->with('ocinternal:42')->willReturn($share);
 
-		$userFolder = $this->getMockBuilder('OCP\Files\Folder')->getMock();
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -2743,7 +2647,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareClear() {
 		$ocs = $this->mockFormatShare();
 
-		$node = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$node->method('getId')
 			->willReturn(42);
 		$share = $this->newShare();
@@ -2780,7 +2684,6 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('getSharedWith')
 			->willReturn([]);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -2805,7 +2708,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareSet() {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -2835,7 +2738,6 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('getSharedWith')
 			->willReturn([]);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -2863,7 +2765,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareEnablePublicUpload($permissions, $publicUpload, $expireDate, $password) {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -2886,7 +2788,6 @@ class ShareAPIControllerTest extends TestCase {
 			})
 		)->willReturnArgument(0);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -2925,7 +2826,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareSetCRUDPermissions($permissions) {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -2945,7 +2846,6 @@ class ShareAPIControllerTest extends TestCase {
 			->method('updateShare')
 			->willReturnArgument(0);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3007,15 +2907,14 @@ class ShareAPIControllerTest extends TestCase {
 		$this->expectExceptionMessage('Invalid date. Format must be YYYY-MM-DD');
 
 		$ocs = $this->mockFormatShare();
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$folder]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3055,15 +2954,14 @@ class ShareAPIControllerTest extends TestCase {
 		$this->expectExceptionMessage('Public upload disabled by the administrator');
 
 		$ocs = $this->mockFormatShare();
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$folder]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
 		$folder->method('getId')->willReturn(42);
 
 		$share = \OC::$server->getShareManager()->newShare();
@@ -3088,10 +2986,10 @@ class ShareAPIControllerTest extends TestCase {
 		$file = $this->getMockBuilder(File::class)->getMock();
 		$file->method('getId')
 			->willReturn(42);
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$folder]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3114,12 +3012,11 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$node = $this->getMockBuilder(File::class)->getMock();
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$node->method('getId')->willReturn(42);
-		$userFolder = $this->createMock(Folder::class);
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$node]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3167,14 +3064,13 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$node]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
-		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -3226,14 +3122,13 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$node]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
-		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -3267,14 +3162,13 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$userFolder->method('getById')
 			->with(42)
-			->willReturn([]);
+			->willReturn([$node]);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
-		$node = $this->getMockBuilder(File::class)->getMock();
 		$node->method('getId')->willReturn(42);
 		$share = $this->newShare();
 		$share->setPermissions(\OCP\Constants::PERMISSION_ALL)
@@ -3322,7 +3216,7 @@ class ShareAPIControllerTest extends TestCase {
 		$date = new \DateTime('2000-01-01');
 		$date->setTime(0,0,0);
 
-		$node = $this->getMockBuilder(File::class)->getMock();
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$node->method('getId')
 			->willReturn(42);
 
@@ -3359,7 +3253,6 @@ class ShareAPIControllerTest extends TestCase {
 			})
 		)->willReturnArgument(0);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3390,7 +3283,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateLinkShareExpireDateDoesNotChangeOther() {
 		$ocs = $this->mockFormatShare();
 
-		$node = $this->getMockBuilder(File::class)->getMock();
+		[$userFolder, $node] = $this->getNonSharedUserFolder();
 		$node->method('getId')
 			->willReturn(42);
 
@@ -3428,7 +3321,6 @@ class ShareAPIControllerTest extends TestCase {
 			})
 		)->willReturnArgument(0);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3455,7 +3347,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3490,7 +3382,6 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager->method('getSharedWith')
 			->willReturn([]);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3517,7 +3408,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3551,7 +3442,6 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3578,7 +3468,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$date = new \DateTime('2000-01-01');
 
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3610,7 +3500,6 @@ class ShareAPIControllerTest extends TestCase {
 			})
 		)->willReturnArgument(0);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3637,7 +3526,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateOtherPermissions() {
 		$ocs = $this->mockFormatShare();
 
-		$file = $this->getMockBuilder(File::class)->getMock();
+		[$userFolder, $file] = $this->getNonSharedUserFolder();
 		$file->method('getId')
 			->willReturn(42);
 
@@ -3658,7 +3547,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$this->shareManager->method('getSharedWith')->willReturn([]);
 
-		$userFolder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3683,7 +3572,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateShareCannotIncreasePermissions() {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3725,7 +3614,6 @@ class ShareAPIControllerTest extends TestCase {
 				['currentUser', IShare::TYPE_ROOM, $share->getNode(), -1, 0, []]
 			]);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -3756,7 +3644,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function testUpdateShareCanIncreasePermissionsIfOwner() {
 		$ocs = $this->mockFormatShare();
 
-		$folder = $this->createMock(Folder::class);
+		[$userFolder, $folder] = $this->getNonSharedUserFolder();
 		$folder->method('getId')
 			->willReturn(42);
 
@@ -3796,7 +3684,6 @@ class ShareAPIControllerTest extends TestCase {
 			->with($share)
 			->willReturn($share);
 
-		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
@@ -4915,5 +4802,33 @@ class ShareAPIControllerTest extends TestCase {
 
 		$result = $this->invokePrivate($this->ocs, 'formatShare', [$share]);
 		$this->assertEquals($expects, $result);
+	}
+
+	private function getNonSharedUserFolder(): array {
+		$node = $this->getMockBuilder(Folder::class)->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$storage = $this->createMock(Storage::class);
+		$storage->method('instanceOfStorage')
+			->willReturnMap([
+				['OCA\Files_Sharing\External\Storage', false],
+				['OCA\Files_Sharing\SharedStorage', false],
+			]);
+		$userFolder->method('getStorage')->willReturn($storage);
+		$node->method('getStorage')->willReturn($storage);
+		return [$userFolder, $node];
+	}
+
+	private function getNonSharedUserFile(): array {
+		$node = $this->getMockBuilder(File::class)->getMock();
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$storage = $this->createMock(Storage::class);
+		$storage->method('instanceOfStorage')
+			->willReturnMap([
+				['OCA\Files_Sharing\External\Storage', false],
+				['OCA\Files_Sharing\SharedStorage', false],
+			]);
+		$userFolder->method('getStorage')->willReturn($storage);
+		$node->method('getStorage')->willReturn($storage);
+		return [$userFolder, $node];
 	}
 }


### PR DESCRIPTION
When updating a share, load the node from the initiator instead of the owner similar to how this is done when creating the share.