### PR TITLE
WebDAV - use file/folder name for dav:displayname

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -71,6 +71,7 @@ class FilesPlugin extends ServerPlugin {
 	public const GETETAG_PROPERTYNAME = '{DAV:}getetag';
 	public const LASTMODIFIED_PROPERTYNAME = '{DAV:}lastmodified';
 	public const CREATIONDATE_PROPERTYNAME = '{DAV:}creationdate';
+	public const DISPLAYNAME_PROPERTYNAME = '{DAV:}displayname';
 	public const OWNER_ID_PROPERTYNAME = '{http://owncloud.org/ns}owner-id';
 	public const OWNER_DISPLAY_NAME_PROPERTYNAME = '{http://owncloud.org/ns}owner-display-name';
 	public const CHECKSUMS_PROPERTYNAME = '{http://owncloud.org/ns}checksums';
@@ -379,6 +380,15 @@ class FilesPlugin extends ServerPlugin {
 			$propFind->handle(self::CREATION_TIME_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getCreationTime();
 			});
+			/**
+			 * Return file/folder name as displayname. The primary reason to
+			 * implement it this way is to avoid costly fallback to 
+			 * CustomPropertiesBackend (esp. visible when querying all files
+			 * in a folder).
+			 */
+			$propFind->handle(self::DISPLAYNAME_PROPERTYNAME, function () use ($node) {
+				return $node->getName();
+			});
 		}
 
 		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
@@ -553,6 +563,13 @@ class FilesPlugin extends ServerPlugin {
 			}
 			$node->setCreationTime((int) $time);
 			return true;
+		});
+		/**
+		 * Disable modification of the displayname property for files and
+		 * folders via PROPPATCH. See PROPFIND for more information.
+		 */
+		$propPatch->handle(self::DISPLAYNAME_PROPERTYNAME, function ($displayName) {
+			return 403;
 		});
 	}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/17778

Follow-up to #34471 - also found during investigation of https://github.com/nextcloud/android/issues/10783.

I have found that:

- The Android client requests **dav:displayname** property when reading folder contents.
- The **FilesPlugin** does not handle this property.
- Handling falls back to **CustomPropertiesBackend** and executes a database query for each file in the folder.

This is an attempt to improve performance by handling the **dav:displayname** property in the **FilesPlugin** and avoiding the fallback.

Performance results - 331 files in a folder, assuming #34471 is in place, timings are not very consistent:
_ | Execution time [ms] | # of DB queries
--- | ---: | ---:
Before | 365 | 372
After | 270 | 41

Additional notes:

- This **changes responses** of WebDAV PROPFIND calls for files/folders. The **dav:displayname** used to be returned in **404 Not Found** section of the multistatus response, now the file/folder name is returned in **200 OK** section. I am not sure if this can break some clients. On the other hand there has been a [request to return displayname](https://github.com/nextcloud/server/issues/17778) in some cases. After reading [RFC4918](https://www.rfc-editor.org/rfc/rfc4918.html), I am not 100% sure that the new behaviour is fully compliant, but seems to be close. :wink:
- As discussed with @PVince81, trying to PROPPATCH this property will mow raise an error (403). Seems to be more or less in line with the RFC.
- When sharing a folder with a public link, the folder name is already visible in the UI to the anonymous user, so it seems that with this change we do not disclose more information that previously.
- The documentation should be updated to reflect the change.
