### PR TITLE
Avoid allocating too much memory for the buffer on s3 uploads

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -152,7 +152,7 @@ trait S3ObjectTrait {
 		// ($psrStream->isSeekable() && $psrStream->getSize() !== null) evaluates to true for a On-Seekable stream
 		// so the optimisation does not apply
 		$buffer = new Psr7\Stream(fopen("php://memory", 'rwb+'));
-		Utils::copyToStream($psrStream, $buffer, $this->uploadPartSize);
+		Utils::copyToStream($psrStream, $buffer, $this->putSizeLimit);
 		$buffer->seek(0);
 		if ($buffer->getSize() < $this->putSizeLimit) {
 			// buffer is fully seekable, so use it directly for the small upload


### PR DESCRIPTION
Otherwise we try to allocate ~500MB in memory which does fail on larger file uploads with our default memory limit. We only need the put file limit configured anyways.

Steps to reproduce on 24+:
1. use s3 primary storage
2. upload a 500mb file through the web ui or clients

Before that change the MOVE request ended in an Allowed Memory Size Exhausted error.