### PR TITLE
More flexible date validation

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1555,7 +1555,7 @@ class ShareAPIController extends OCSController {
 	 */
 	private function parseDate(string $expireDate): \DateTime {
 		try {
-			$date = new \DateTime($expireDate);
+			$date = new \DateTime(trim($expireDate, "\""));
 		} catch (\Exception $e) {
 			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
 		}


### PR DESCRIPTION
Fix #34542

The new native file picket add a `"` before and after the string, so trim that. 

Signed-off-by: Carl Schwan <carl@carlschwan.eu>