### PR TITLE
Add seperator in high contrast mode

### DIFF
--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -101,6 +101,12 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 			.menutoggle {
 				opacity: 1 !important;
 			}
+			#app-navigation {
+				border-right: 1px solid var(--color-border);
+			}
+			div.crumb {
+				filter: brightness(150%);
+			}
 		";
 	}
 }

--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -101,6 +101,9 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 			.menutoggle {
 				opacity: 1 !important;
 			}
+			#app-navigation {
+				border-right: 1px solid var(--color-border);
+			}
 		";
 	}
 }


### PR DESCRIPTION
Between navigation and content and between entry in breadcrump

![image](https://user-images.githubusercontent.com/23653902/195204328-1648a8d1-344f-4e32-8ae0-66f9c6d5bd58.png)
