### PR TITLE
Listen to cache event for managing metadata

### DIFF
--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -37,7 +37,7 @@ use OCP\DB\Exception;
 use OCP\DB\Exception as DBException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Cache\CacheEntryRemovedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Node;
@@ -299,6 +299,6 @@ class FilesMetadataManager implements IFilesMetadataManager {
 	 */
 	public static function loadListeners(IEventDispatcher $eventDispatcher): void {
 		$eventDispatcher->addServiceListener(NodeWrittenEvent::class, MetadataUpdate::class);
-		$eventDispatcher->addServiceListener(NodeDeletedEvent::class, MetadataDelete::class);
+		$eventDispatcher->addServiceListener(CacheEntryRemovedEvent::class, MetadataDelete::class);
 	}
 }

--- a/lib/private/FilesMetadata/Listener/MetadataDelete.php
+++ b/lib/private/FilesMetadata/Listener/MetadataDelete.php
@@ -28,14 +28,14 @@ namespace OC\FilesMetadata\Listener;
 use Exception;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Cache\CacheEntryRemovedEvent;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use Psr\Log\LoggerInterface;
 
 /**
  * Handle file deletion event and remove stored metadata related to the deleted file
  *
- * @template-implements IEventListener<NodeDeletedEvent>
+ * @template-implements IEventListener<CacheEntryRemovedEvent>
  */
 class MetadataDelete implements IEventListener {
 	public function __construct(
@@ -44,16 +44,13 @@ class MetadataDelete implements IEventListener {
 	) {
 	}
 
-	/**
-	 * @param Event $event
-	 */
 	public function handle(Event $event): void {
-		if (!($event instanceof NodeDeletedEvent)) {
+		if (!($event instanceof CacheEntryRemovedEvent)) {
 			return;
 		}
 
 		try {
-			$nodeId = (int)$event->getNode()->getId();
+			$nodeId = $event->getFileId();
 			if ($nodeId > 0) {
 				$this->filesMetadataManager->deleteMetadata($nodeId);
 			}


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/34424
Need https://github.com/nextcloud/server/pull/34773

 `NodeDeletedEvent` is called when a file is put to the trash, and we want to remove metadata when the file is really deleted, so we now listen to `CacheEntryRemovedEvent`.
- Also, a bit of refactoring to adapt code to this change.
