### PR TITLE
Fix case sensitivity of email when saving settings

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -491,7 +491,7 @@ class UsersController extends Controller {
 
 		$oldEmailAddress = $userAccount->getUser()->getSystemEMailAddress();
 		$oldEmailAddress = strtolower((string)$oldEmailAddress);
-		if ($oldEmailAddress !== $userAccount->getProperty(IAccountManager::PROPERTY_EMAIL)->getValue()) {
+		if ($oldEmailAddress !== strtolower($userAccount->getProperty(IAccountManager::PROPERTY_EMAIL)->getValue())) {
 			// this is the only permission a backend provides and is also used
 			// for the permission of setting a email address
 			if (!$userAccount->getUser()->canChangeDisplayName()) {

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -649,7 +649,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$user->method('getSystemEMailAddress')->willReturn($oldEmailAddress);
 		$user->method('canChangeDisplayName')->willReturn(true);
 
-		if ($data[IAccountManager::PROPERTY_EMAIL]['value'] === $oldEmailAddress ||
+		if (strtolower($data[IAccountManager::PROPERTY_EMAIL]['value']) === strtolower($oldEmailAddress) ||
 			($oldEmailAddress === null && $data[IAccountManager::PROPERTY_EMAIL]['value'] === '')) {
 			$user->expects($this->never())->method('setSystemEMailAddress');
 		} else {
@@ -743,6 +743,14 @@ class UsersControllerTest extends \Test\TestCase {
 					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'john doe'],
 				],
 				'john@example.com',
+				null
+			],
+			[
+				[
+					IAccountManager::PROPERTY_EMAIL => ['value' => 'john@example.com'],
+					IAccountManager::PROPERTY_DISPLAYNAME => ['value' => 'john doe'],
+				],
+				'JOHN@example.com',
 				null
 			],
 


### PR DESCRIPTION
Otherwise we detect a email change all the time and since email are immutable in ldap this prevent updating other fields.

Related: https://github.com/nextcloud/server/pull/33813

Signed-off-by: Carl Schwan <carl@carlschwan.eu>