### PR TITLE
Disable automatic Dependabot rebases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
     - "feature: dependencies"
   reviewers:
     - "nextcloud/server-dependabot"
+  # Disable automatic rebasing because without a build CI will likely fail anyway
+  rebase-strategy: "disabled"
 
 # Testing master npm
 - package-ecosystem: npm


### PR DESCRIPTION
Right now an npm Dependabot bump fails most likely due to the missing build.

Moreover, merging one bump causes a conflict on others. Dependabot will try to rebase unless manual modifications have been made, but the updated branch still won't pass CI. Therefore I propose to disable this automatism.