### PR TITLE
Fix unnecessary highlighting of selected element

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -609,8 +609,8 @@ table td.selection {
 .select-all + label {
   padding: 16px;
 }
-.files-fileList tr td.selection > .selectCheckBox:focus + label,
-.select-all:focus + label {
+.files-fileList tr td.selection > .selectCheckBox:focus-visible + label,
+.select-all:focus-visible + label {
   background-color: var(--color-background-hover);
   border-radius: var(--border-radius-pill);
   outline: none !important;

--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -504,7 +504,7 @@ table td.selection {
 		padding: 16px;
 	}
 
-	&:focus + label {
+	&:focus-visible + label {
 		background-color: var(--color-background-hover);
 		border-radius: var(--border-radius-pill);
 		outline: none !important;

--- a/apps/files/css/merged.css
+++ b/apps/files/css/merged.css
@@ -609,8 +609,8 @@ table td.selection {
 .select-all + label {
   padding: 16px;
 }
-.files-fileList tr td.selection > .selectCheckBox:focus + label,
-.select-all:focus + label {
+.files-fileList tr td.selection > .selectCheckBox:focus-visible + label,
+.select-all:focus-visible + label {
   background-color: var(--color-background-hover);
   border-radius: var(--border-radius-pill);
   outline: none !important;


### PR DESCRIPTION
Use focus-visible to only show focus ring on keyboard navigation

Fix #34589