### PR TITLE
Use proper error pages instead of always redirecting

### DIFF
--- a/core/Controller/ErrorController.php
+++ b/core/Controller/ErrorController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
+
+class ErrorController extends \OCP\AppFramework\Controller {
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 */
+	public function error403(): TemplateResponse {
+		$response = new TemplateResponse(
+			'core',
+			'403',
+			[],
+			'error'
+		);
+		$response->setStatus(Http::STATUS_FORBIDDEN);
+		return $response;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 */
+	public function error404(): TemplateResponse {
+		$response = new TemplateResponse(
+			'core',
+			'404',
+			[],
+			'error'
+		);
+		$response->setStatus(Http::STATUS_NOT_FOUND);
+		return $response;
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -97,6 +97,9 @@ $application->registerRoutes($this, [
 		['name' => 'WebAuthn#startAuthentication', 'url' => 'login/webauthn/start', 'verb' => 'POST'],
 		['name' => 'WebAuthn#finishAuthentication', 'url' => 'login/webauthn/finish', 'verb' => 'POST'],
 
+		['name' => 'Error#error404', 'url' => 'error/404'],
+		['name' => 'Error#error403', 'url' => 'error/403'],
+
 		// Well known requests https://tools.ietf.org/html/rfc5785
 		['name' => 'WellKnown#handle', 'url' => '.well-known/{service}'],
 

--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -17,8 +17,8 @@ if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 <?php else: ?>
 	<div class="body-login-container update">
 		<div class="icon-big icon-search"></div>
-		<h2><?php p($l->t('File not found')); ?></h2>
-		<p class="infogroup"><?php p($l->t('The document could not be found on the server. Maybe the share was deleted or has expired?')); ?></p>
+		<h2><?php p($l->t('Page not found')); ?></h2>
+		<p class="infogroup"><?php p($l->t('The page could not be found on the server.')); ?></p>
 		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
 			<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 		</a></p>

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -976,6 +976,7 @@ return array(
     'OC\\Core\\Controller\\CollaborationResourcesController' => $baseDir . '/core/Controller/CollaborationResourcesController.php',
     'OC\\Core\\Controller\\ContactsMenuController' => $baseDir . '/core/Controller/ContactsMenuController.php',
     'OC\\Core\\Controller\\CssController' => $baseDir . '/core/Controller/CssController.php',
+    'OC\\Core\\Controller\\ErrorController' => $baseDir . '/core/Controller/ErrorController.php',
     'OC\\Core\\Controller\\GuestAvatarController' => $baseDir . '/core/Controller/GuestAvatarController.php',
     'OC\\Core\\Controller\\HoverCardController' => $baseDir . '/core/Controller/HoverCardController.php',
     'OC\\Core\\Controller\\JsController' => $baseDir . '/core/Controller/JsController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1009,6 +1009,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Controller\\CollaborationResourcesController' => __DIR__ . '/../../..' . '/core/Controller/CollaborationResourcesController.php',
         'OC\\Core\\Controller\\ContactsMenuController' => __DIR__ . '/../../..' . '/core/Controller/ContactsMenuController.php',
         'OC\\Core\\Controller\\CssController' => __DIR__ . '/../../..' . '/core/Controller/CssController.php',
+        'OC\\Core\\Controller\\ErrorController' => __DIR__ . '/../../..' . '/core/Controller/ErrorController.php',
         'OC\\Core\\Controller\\GuestAvatarController' => __DIR__ . '/../../..' . '/core/Controller/GuestAvatarController.php',
         'OC\\Core\\Controller\\HoverCardController' => __DIR__ . '/../../..' . '/core/Controller/HoverCardController.php',
         'OC\\Core\\Controller\\JsController' => __DIR__ . '/../../..' . '/core/Controller/JsController.php',

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -509,10 +509,10 @@ class Setup {
 		$htaccessContent = explode($content, $htaccessContent, 2)[0];
 
 		//custom 403 error page
-		$content .= "\nErrorDocument 403 " . $webRoot . '/';
+		$content .= "\nErrorDocument 403 " . $webRoot . '/index.php/error/403';
 
 		//custom 404 error page
-		$content .= "\nErrorDocument 404 " . $webRoot . '/';
+		$content .= "\nErrorDocument 404 " . $webRoot . '/index.php/error/404';
 
 		// Add rewrite rules if the RewriteBase is configured
 		$rewriteBase = $config->getValue('htaccess.RewriteBase', '');


### PR DESCRIPTION
Implements a generic 404 error page instead of always redirecting to the login page or dashboard as discussed in https://github.com/nextcloud/server/issues/33048

Can be tested by browsing to an invalid url like `/index.php/apps/nonexisting`

![Screenshot 2022-10-18 at 20 30 14](https://user-images.githubusercontent.com/3404133/196514652-4db1e4fa-f5bb-41d7-b23f-7514b74f0bd8.png)

Added the `pending documentation` label as we need to adjust the nginx config in the docs accordingly to what was done in the htaccess.