### PR TITLE
optimize background image migration job

### DIFF
--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -44,7 +44,7 @@ class MigrateBackgroundImages extends QueuedJob {
 	protected const STAGE_PREPARE = 'prepare';
 	protected const STAGE_EXECUTE = 'execute';
 	// will be saved in appdata/theming/global/
-	protected const STATE_FILE_NAME = '25_dashboard_to_theming_migration_users.txt';
+	protected const STATE_FILE_NAME = '25_dashboard_to_theming_migration_users.json';
 
 	private IAppDataFactory $appDataFactory;
 	private IJobList $jobList;

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
 namespace OCA\Theming\Jobs;
 
 use OCA\Theming\AppInfo\Application;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\QueuedJob;
@@ -45,7 +44,6 @@ class MigrateBackgroundImages extends QueuedJob {
 	protected const STAGE_EXECUTE = 'execute';
 
 	private IConfig $config;
-	private IAppManager $appManager;
 	private IAppDataFactory $appDataFactory;
 	private IJobList $jobList;
 	private IDBConnection $dbc;
@@ -54,13 +52,11 @@ class MigrateBackgroundImages extends QueuedJob {
 		ITimeFactory $time,
 		IAppDataFactory $appDataFactory,
 		IConfig $config,
-		IAppManager $appManager,
 		IJobList $jobList,
 		IDBConnection $dbc
 	) {
 		parent::__construct($time);
 		$this->config = $config;
-		$this->appManager = $appManager;
 		$this->appDataFactory = $appDataFactory;
 		$this->jobList = $jobList;
 		$this->dbc = $dbc;
@@ -115,11 +111,6 @@ class MigrateBackgroundImages extends QueuedJob {
 		$userIds = $notSoFastMode ? array_slice($allUserIds, 0, 5000) : $allUserIds;
 		foreach ($userIds as $userId) {
 			try {
-				// precondition
-				if (!$this->appManager->isEnabledForUser('dashboard', $userId)) {
-					continue;
-				}
-
 				// migration
 				$file = $dashboardData->getFolder($userId)->getFile('background.jpg');
 				$targetDir = $this->getUserFolder($userId);

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -71,7 +71,7 @@ class MigrateBackgroundImages extends QueuedJob {
 	protected function run($argument): void {
 		if (!isset($argument['stage'])) {
 			// not executed in 25.0.0?!
-			$argument['stage'] = 'prepare';
+			$argument['stage'] = self::STAGE_PREPARE;
 		}
 
 		switch ($argument['stage']) {

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -41,8 +41,8 @@ use Psr\Log\LoggerInterface;
 class MigrateBackgroundImages extends QueuedJob {
 	public const TIME_SENSITIVE = 0;
 
-	protected const STAGE_PREPARE = 'prepare';
-	protected const STAGE_EXECUTE = 'execute';
+	public const STAGE_PREPARE = 'prepare';
+	public const STAGE_EXECUTE = 'execute';
 	// will be saved in appdata/theming/global/
 	protected const STATE_FILE_NAME = '25_dashboard_to_theming_migration_users.json';
 

--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -195,10 +195,10 @@ class MigrateBackgroundImages extends QueuedJob {
 			try {
 				$file->delete();
 			} catch (NotPermittedException $e) {
-				$this->logger->info('Could not delete {name} due to permissions. It is safe to delete manually inside data -> appdata -> theming -> global.',
+				$this->logger->info('Could not delete {file} due to permissions. It is safe to delete manually inside data -> appdata -> theming -> global.',
 					[
 						'app' => 'theming',
-						'name' => $file->getName(),
+						'file' => $file->getName(),
 						'exception' => $e,
 					]
 				);

--- a/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
+++ b/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
@@ -43,6 +43,6 @@ class InitBackgroundImagesMigration implements \OCP\Migration\IRepairStep {
 	}
 
 	public function run(IOutput $output) {
-		$this->jobList->add(MigrateBackgroundImages::class, ['stage' => 'prepare']);
+		$this->jobList->add(MigrateBackgroundImages::class, ['stage' => MigrateBackgroundImages::STAGE_PREPARE]);
 	}
 }

--- a/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
+++ b/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
@@ -43,6 +43,6 @@ class InitBackgroundImagesMigration implements \OCP\Migration\IRepairStep {
 	}
 
 	public function run(IOutput $output) {
-		$this->jobList->add(MigrateBackgroundImages::class);
+		$this->jobList->add(MigrateBackgroundImages::class, ['stage' => 'prepare']);
 	}
 }


### PR DESCRIPTION
fixes #34602 

- separate in two stages: to prepare, and to actually migrate
- in step one, prepare a list of users to be migrated, and store it
  compressed as app config
  - gzcompress can be used, because we already require zlib
- upon the next calls (step two), slice off the first 5000 users
  and migrate them. Re-add job if necessary to repeat.
- downside is that an app config value will in the beginning use the
  RAM with any request, until it thins out. Examples: 2m UUIDs (75 MiB)
  result in ~40 MiB compressed data, while 0.2Mib for 10 000 UUIDs,
  0.4MiB for 20 000 and 4.1 MiB for 200 000. Acceptable.
-  remove dashboard check, as fallback did not consider it either 

* [ ] some testing 