### PR TITLE
Interlace all output JPEG

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -290,6 +290,8 @@ class OC_Image implements \OCP\IImage {
 				$retVal = imagegif($this->resource, $filePath);
 				break;
 			case IMAGETYPE_JPEG:
+				/** @psalm-suppress InvalidScalarArgument */
+				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
 				$retVal = imagejpeg($this->resource, $filePath, $this->getJpegQuality());
 				break;
 			case IMAGETYPE_PNG:
@@ -379,6 +381,8 @@ class OC_Image implements \OCP\IImage {
 				$res = imagepng($this->resource);
 				break;
 			case "image/jpeg":
+				/** @psalm-suppress InvalidScalarArgument */
+				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
 				$quality = $this->getJpegQuality();
 				if ($quality !== null) {
 					$res = imagejpeg($this->resource, null, $quality);

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -149,6 +149,8 @@ class ImageTest extends \Test\TestCase {
 		$img = new \OC_Image(null, null, $config);
 		$img->loadFromFile(OC::$SERVERROOT.'/tests/data/testimage.jpg');
 		$raw = imagecreatefromstring(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.jpg'));
+		/** @psalm-suppress InvalidScalarArgument */
+		imageinterlace($raw, (PHP_VERSION_ID >= 80000 ? true : 1));
 		ob_start();
 		imagejpeg($raw);
 		$expected = ob_get_clean();


### PR DESCRIPTION
Progressive images are both smaller and faster to load.

Before and after on simulated fast 3G:

![ezgif-1-8ea4d887bf](https://user-images.githubusercontent.com/10709794/196811952-72b9986c-8b5b-416c-bbcb-6fbb0fd56901.gif)

Signed-off-by: Varun Patil <radialapps@gmail.com>