### PR TITLE
Fix alternative logins custom css class

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -722,7 +722,7 @@ class OC_App {
 				self::$altLogin[] = [
 					'name' => $provider->getLabel(),
 					'href' => $provider->getLink(),
-					'style' => $provider->getClass(),
+					'class' => $provider->getClass(),
 				];
 			} catch (Throwable $e) {
 				\OC::$server->getLogger()->logException($e, [


### PR DESCRIPTION
In NC 25 login page was changed, and alternative login css class get from `class` prop but not `style`.  It is correct change in my opinion, so just add backend fix.

Signed-off-by: zorn-v <zorn7@yandex.ru>