### PR TITLE
fix reading newly written encrypted files before their cache entry is written

### DIFF
--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -22,6 +22,7 @@
 
 namespace OCA\Encryption\Command;
 
+use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\ServerNotAvailableException;
 use OCA\Encryption\Util;
@@ -165,6 +166,13 @@ class FixEncryptedVersion extends Command {
 	 */
 	private function verifyFileContent(string $path, OutputInterface $output, bool $ignoreCorrectEncVersionCall = true): bool {
 		try {
+			// since we're manually poking around the encrypted state we need to ensure that this isn't cached in the encryption wrapper
+			$mount = $this->view->getMount($path);
+			$storage = $mount->getStorage();
+			if ($storage && $storage->instanceOfStorage(Encryption::class)) {
+				$storage->clearIsEncryptedCache();
+			}
+
 			/**
 			 * In encryption, the files are read in a block size of 8192 bytes
 			 * Read block size of 8192 and a bit more (808 bytes)

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1095,4 +1095,8 @@ class Encryption extends Wrapper {
 
 		return $count;
 	}
+
+	public function clearIsEncryptedCache(): void {
+		$this->encryptedPaths->clear();
+	}
 }


### PR DESCRIPTION
Keep track of which files we know are encrypted so we know to decrypt them even if they are not in the cache.

This fixes an interaction with `files_accesscontrol` where it tried to check the mimetype before the item was added to cache, resulting in it always detecting the mimetype as `application/octet-stream` (note that in a later step the mimetype was detected properly)

To test:

- Apply https://github.com/nextcloud/server/pull/34579 to fix another accesscontrol+encryption issue
- Enable server-side encryption and files_accesscontrol
- Setup an access control rule blocking files with the mimetype `application/octet-stream`
- Attempt to upload any file