### PR TITLE
Fix autotest creating PostgreSQL database before install

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -307,7 +307,7 @@ function execute_tests {
 	if [ "$DB" == "pgsql" ] ; then
 		if [ ! -z "$USEDOCKER" ] ; then
 			echo "Fire up the postgres docker"
-			DOCKER_CONTAINER_ID=$(docker run -e POSTGRES_USER="$DATABASEUSER" -e POSTGRES_PASSWORD=owncloud -d postgres)
+			DOCKER_CONTAINER_ID=$(docker run -e POSTGRES_DB="$DATABASENAME" -e POSTGRES_USER="$DATABASEUSER" -e POSTGRES_PASSWORD=owncloud -d postgres)
 			DATABASEHOST=$(docker inspect --format="{{.NetworkSettings.IPAddress}}" "$DOCKER_CONTAINER_ID")
 
 			echo "Waiting for Postgres initialisation ..."


### PR DESCRIPTION
Problem:
```
Failed to connect to the database: An exception occurred in the driver: SQLSTATE[08006] [7] FATAL:  database "oc_autotest" does not exist
```
Broked test:
https://drone.nextcloud.com/nextcloud/server/24833/16/5
Identified in the PR: #34645

MySQL and other databases create the database before run the tests, only PostgreSQL not. I fixed following the documentation of official PostgreSQL Docker image:

https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_db