### PR TITLE
Revert "fix external storages access"

### DIFF
--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -28,6 +28,7 @@ namespace OC\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\CurlHandler;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
@@ -62,7 +63,8 @@ class ClientService implements IClientService {
 	 * @return Client
 	 */
 	public function newClient(): IClient {
-		$stack = HandlerStack::create();
+		$handler = new CurlHandler();
+		$stack = HandlerStack::create($handler);
 		$stack->push($this->dnsPinMiddleware->addDnsPinning());
 
 		$client = new GuzzleClient(['handler' => $stack]);

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -10,6 +10,7 @@ namespace Test\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\CurlHandler;
 use OC\Http\Client\Client;
 use OC\Http\Client\ClientService;
 use OC\Http\Client\DnsPinMiddleware;
@@ -41,7 +42,8 @@ class ClientServiceTest extends \Test\TestCase {
 			$localAddressChecker
 		);
 
-		$stack = HandlerStack::create();
+		$handler = new CurlHandler();
+		$stack = HandlerStack::create($handler);
 		$stack->push($dnsPinMiddleware->addDnsPinning());
 		$guzzleClient = new GuzzleClient(['handler' => $stack]);
 


### PR DESCRIPTION
Reverts nextcloud/server#33087 as it seems to break a CI test in master. Was not discovered before since the branch was not up-to-date.

