### PR TITLE
Do not throw errors when invalid setTo email is provided

### DIFF
--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -78,14 +78,18 @@ class Message implements IMessage {
 		$convertedAddresses = [];
 
 		foreach ($addresses as $email => $readableName) {
-			if (!is_numeric($email)) {
-				[$name, $domain] = explode('@', $email, 2);
-				$domain = idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
-				$convertedAddresses[$name.'@'.$domain] = $readableName;
+			$parsableEmail = is_numeric($email) ? $readableName : $email;
+			if (strpos($parsableEmail, '@') === false) {
+				$convertedAddresses[$parsableEmail] = $readableName;
+				continue;
+			}
+
+			[$name, $domain] = explode('@', $parsableEmail, 2);
+			$domain = idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+			if (is_numeric($email)) {
+				$convertedAddresses[] = $name . '@' . $domain;
 			} else {
-				[$name, $domain] = explode('@', $readableName, 2);
-				$domain = idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
-				$convertedAddresses[$email] = $name.'@'.$domain;
+				$convertedAddresses[$name . '@' . $domain] = $readableName;
 			}
 		}
 

--- a/tests/lib/Mail/MessageTest.php
+++ b/tests/lib/Mail/MessageTest.php
@@ -102,12 +102,23 @@ class MessageTest extends TestCase {
 		$this->assertSame('lukas@owncloud.com', $this->message->getReplyTo());
 	}
 
-	public function testSetTo() {
+	/** @dataProvider dataSetTo */
+	public function testSetTo(array $to, array $expected) {
 		$this->swiftMessage
 			->expects($this->once())
 			->method('setTo')
-			->with(['lukas@owncloud.com']);
-		$this->message->setTo(['lukas@owncloud.com']);
+			->with($expected);
+		$this->message->setTo($to);
+	}
+
+	public function dataSetTo(): array {
+		return [
+			[['robot@example.com'], ['robot@example.com']],
+			[['robot'], ['robot' => 'robot']],
+			[['robot' => 'robot display name'], ['robot' => 'robot display name']],
+			[['example@🤖.com'], ['example@xn--yp9h.com']],
+			[['example@🤖.com' => 'A robot'], ['example@xn--yp9h.com' => 'A robot']],
+		];
 	}
 
 	/**


### PR DESCRIPTION
Throwing errors during the setTo (or other) calls is unexpected so we should still handle invalid addresses being passed.

The send() method is expected to throw in those cases anyways according to:

https://github.com/nextcloud/server/blob/9b8ca9ad1f3df5d32df241d8848c8dc92c9a1fc2/lib/private/Mail/Mailer.php#L168
