### PR TITLE
Skip general login with email for non-valid addresses and LDAP

### DIFF
--- a/tests/lib/Authentication/Login/EmailLoginCommandTest.php
+++ b/tests/lib/Authentication/Login/EmailLoginCommandTest.php
@@ -55,7 +55,7 @@ class EmailLoginCommandTest extends ALoginCommandTest {
 
 	public function testProcessNotAnEmailLogin() {
 		$data = $this->getFailedLoginData();
-		$this->userManager->expects($this->once())
+		$this->userManager->expects($this->never())
 			->method('getByEmail')
 			->with($this->username)
 			->willReturn([]);
@@ -67,9 +67,10 @@ class EmailLoginCommandTest extends ALoginCommandTest {
 
 	public function testProcessDuplicateEmailLogin() {
 		$data = $this->getFailedLoginData();
+		$data->setUsername('user@example.com');
 		$this->userManager->expects($this->once())
 			->method('getByEmail')
-			->with($this->username)
+			->with('user@example.com')
 			->willReturn([
 				$this->createMock(IUser::class),
 				$this->createMock(IUser::class),


### PR DESCRIPTION
This is a workaround until https://github.com/nextcloud/server/issues/5221 gets implemented, so that at least we stick to configured LDAP settings if the email is not part of the login filter
