### PR TITLE
Continue registering and loading other dashboard widgets when one fai…

### DIFF
--- a/lib/private/Dashboard/Manager.php
+++ b/lib/private/Dashboard/Manager.php
@@ -82,9 +82,10 @@ class Manager implements IManager {
 				 * we can not inject it. Thus the static call.
 				 */
 				\OC::$server->get(LoggerInterface::class)->critical(
-					'Could not load lazy dashboard widget: ' . $e->getMessage(),
-					['excepiton' => $e]
+					'Could not load lazy dashboard widget: ' . $service['class'],
+					['exception' => $e]
 				);
+				continue;
 			}
 			/**
 			 * Try to register the loaded reporter. Theoretically it could be of a wrong
@@ -98,9 +99,10 @@ class Manager implements IManager {
 				 * we can not inject it. Thus the static call.
 				 */
 				\OC::$server->get(LoggerInterface::class)->critical(
-					'Could not register lazy dashboard widget: ' . $e->getMessage(),
+					'Could not register lazy dashboard widget: ' . $service['class'],
 					['exception' => $e]
 				);
+				continue;
 			}
 
 			try {
@@ -119,9 +121,10 @@ class Manager implements IManager {
 				}
 			} catch (Throwable $e) {
 				\OC::$server->get(LoggerInterface::class)->critical(
-					'Error during dashboard widget loading: ' . $e->getMessage(),
+					'Error during dashboard widget loading: ' . $service['class'],
 					['exception' => $e]
 				);
+				continue;
 			}
 		}
 		$this->lazyWidgets = [];


### PR DESCRIPTION
…led creation

---

### Background

In talk we noticed that the dashboard widget is shown and renders (still not functional) when the user is not allowed to use Talk:
* https://github.com/nextcloud/spreed/issues/8232

As a shortcut I sent a pull request to break loading the widget class:
* https://github.com/nextcloud/spreed/pull/8233

But turns out that this breaks all widgets of apps that are registered after Talk:

> ![image](https://user-images.githubusercontent.com/213943/198198052-c13575b9-d70b-43ce-9b4b-b066e30c62e5.png)

So fixing that with the missing continue for backports.
The correct way going forward will be an IConditionalWidget interface that allows an app to return a boolean to check if it should be registered:
* https://github.com/nextcloud/server/pull/34832