### PR TITLE
Fix size calculation on copying the skeleton files

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -255,7 +255,7 @@ class OC_Util {
 						closedir($dir);
 						return;
 					}
-					stream_copy_to_stream($sourceStream, $child->fopen('w'));
+					$child->putContent($sourceStream);
 				}
 			}
 		}


### PR DESCRIPTION
Use proper storage methods to copy the skeleton files as otherwise the size propagation for the newly added files (and the user quota usage) will be wrong after the first login with object storage.

For local storage this works fine as the files are getting scanned afterwards.
