### PR TITLE
Add new CS fixer cache file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ CVS/*
 RCS/*
 *.backup*
 .php_cs.cache
+.php-cs-fixer.cache
 
 # kdevelop
 .kdev


### PR DESCRIPTION
Every time you run `composer run cs:fix` locally this file is created. Annoyance.