### PR TITLE
Update AppMenu.vue

### DIFF
--- a/core/src/components/AppMenu.vue
+++ b/core/src/components/AppMenu.vue
@@ -167,7 +167,6 @@ $header-icon-size: 20px;
 			}
 
 			.app-menu-entry--label {
-				transition: 
 				font-weight: bold;
 			}
 		}

--- a/core/src/components/AppMenu.vue
+++ b/core/src/components/AppMenu.vue
@@ -167,6 +167,7 @@ $header-icon-size: 20px;
 			}
 
 			.app-menu-entry--label {
+				transition: 
 				font-weight: bold;
 			}
 		}
@@ -232,6 +233,10 @@ $header-icon-size: 20px;
 		.app-menu-entry--label {
 			opacity: 1;
 			bottom: 0;
+			border-radius: 18px;
+			width: auto;
+			padding: 0 5px;
+			backdrop-filter:blur(30px)
 		}
 
 		&::before, .app-menu-entry::before {


### PR DESCRIPTION
Add a blurred background on header nav labels, when hovered or focused, to fix visibility issue with long labels.

Before:
<img width="402" alt="Capture d’écran 2022-10-28 à 20 43 25" src="https://user-images.githubusercontent.com/49282232/198711932-b66ffef9-ea54-4e67-b7fb-a1058f887a84.png">

After:
<img width="403" alt="Capture d’écran 2022-10-28 à 20 57 14" src="https://user-images.githubusercontent.com/49282232/198711963-fe957307-5c74-4962-8746-355f8226f88c.png">


Signed-off-by: Louis Vedel <49282232+relisiuol@users.noreply.github.com>