### PR TITLE
Move iMIP to its own interface

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Georg Ehrke <oc.list@georgehrke.com>
+ * @author Anna Larch <anna.larch@gmx.net>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -33,6 +34,7 @@ use OCP\Calendar\ICalendar;
 use OCP\Calendar\ICalendarProvider;
 use OCP\Calendar\ICalendarQuery;
 use OCP\Calendar\ICreateFromString;
+use OCP\Calendar\IHandleImipMessage;
 use OCP\Calendar\IManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -280,7 +282,7 @@ class Manager implements IManager {
 		// Drawback: attendees that have been deleted will still be able to update their partstat
 		foreach ($calendars as $calendar) {
 			// We should not search in writable calendars
-			if ($calendar instanceof ICreateFromString) {
+			if ($calendar instanceof IHandleImipMessage) {
 				$o = $calendar->search($sender, ['ATTENDEE'], ['uid' => $vEvent->{'UID'}->getValue()]);
 				if (!empty($o)) {
 					$found = $calendar;
@@ -358,7 +360,7 @@ class Manager implements IManager {
 		// Drawback: attendees that have been deleted will still be able to update their partstat
 		foreach ($calendars as $calendar) {
 			// We should not search in writable calendars
-			if ($calendar instanceof ICreateFromString) {
+			if ($calendar instanceof IHandleImipMessage) {
 				$o = $calendar->search($recipient, ['ATTENDEE'], ['uid' => $vEvent->{'UID'}->getValue()]);
 				if (!empty($o)) {
 					$found = $calendar;

--- a/lib/public/Calendar/IHandleImipMessage.php
+++ b/lib/public/Calendar/IHandleImipMessage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright 2021 Anna Larch <anna.larch@gmx.net>
+ * @copyright 2022 Anna Larch <anna.larch@gmx.net>
  *
  * @author Anna Larch <anna.larch@gmx.net>
  *
@@ -28,16 +28,21 @@ use OCP\Calendar\Exceptions\CalendarException;
 
 /**
  * Extends the current ICalendar interface
- * to add a public write method
+ * to add a public write method to handle
+ * iMIP data
  *
- * @since 23.0.0
+ * @link https://www.rfc-editor.org/rfc/rfc6047
+ *
+ * @since 26.0.0
  */
-interface ICreateFromString extends ICalendar {
+interface IHandleImipMessage extends ICalendar {
 
 	/**
-	 * @since 23.0.0
+	 * Handle an iMIP VEvent for validation and processing
 	 *
-	 * @throws CalendarException
+	 * @since 26.0.0
+	 *
+	 * @throws CalendarException  on validation failure or calendar write error
 	 */
-	public function createFromString(string $name, string $calendarData): void;
+	public function handleIMipMessage(string $name, string $calendarData): void;
 }


### PR DESCRIPTION
and clean up the code a bit.

The old implementation forced every writable calendar to support iMIP.

Added:
- author

Removed:
- unused imports

Changed:
- moved iMIP handling to new interface
- pointed code to new implementation

Documentation: https://github.com/nextcloud/documentation/pull/9269
