### PR TITLE
Add Talk converstation delete API

### DIFF
--- a/lib/private/Talk/Broker.php
+++ b/lib/private/Talk/Broker.php
@@ -106,4 +106,12 @@ class Broker implements IBroker {
 			$options ?? ConversationOptions::default()
 		);
 	}
+
+	public function deleteConversation(string $id): void {
+		if (!$this->hasBackend()) {
+			throw new NoBackendException("The Talk broker has no registered backend");
+		}
+
+		$this->backend->deleteConversation($id);
+	}
 }

--- a/lib/public/Talk/IBroker.php
+++ b/lib/public/Talk/IBroker.php
@@ -71,4 +71,15 @@ interface IBroker {
 	public function createConversation(string $name,
 									   array $moderators,
 									   IConversationOptions $options = null): IConversation;
+
+	/**
+	 * Delete a conversation by id
+	 *
+	 * @param string $id conversation id
+	 *
+	 * @return void
+	 * @throws NoBackendException when Talk is not available
+	 * @since 26.0.0
+	 */
+	public function deleteConversation(string $id): void;
 }

--- a/lib/public/Talk/IConversation.php
+++ b/lib/public/Talk/IConversation.php
@@ -31,6 +31,14 @@ namespace OCP\Talk;
 interface IConversation {
 
 	/**
+	 * Get the unique token that identifies this conversation
+	 *
+	 * @return string
+	 * @since 26.0.0
+	 */
+	public function getId(): string;
+
+	/**
 	 * Get the absolute URL to this conversation
 	 *
 	 * @return string

--- a/lib/public/Talk/ITalkBackend.php
+++ b/lib/public/Talk/ITalkBackend.php
@@ -49,4 +49,14 @@ interface ITalkBackend {
 	public function createConversation(string $name,
 									   array $moderators,
 									   IConversationOptions $options): IConversation;
+
+	/**
+	 * Delete a conversation by id
+	 *
+	 * @param string $id conversation id
+	 *
+	 * @return void
+	 * @since 26.0.0
+	 */
+	public function deleteConversation(string $id): void;
 }


### PR DESCRIPTION
## Use case

For https://github.com/nextcloud/calendar/issues/3480 we want to create Talk rooms for every booked appointment. We have to create the Talk URL before we can write the event data or send the booking confirmation email. That means the processing order can't be changed and if the booking itself fails we have a "dangling" conversation that doesn't belong to any booked appointment.

Therefore I would like to be able to delete a conversation as part of the error handling.

## Backwards compatibility

Generally speaking this type of change is not backwards compatible as we require implementers of the broker interface to now implement a second method. In the specific case we know the only implementation is in Talk ~~and I'm opening a companion PR shortly.~~. PR can be found at https://github.com/nextcloud/spreed/pull/8262.

This means the change is not breaking any instances practically.

## Documentation

https://github.com/nextcloud/documentation/pull/9268