### PR TITLE
Use the official phpDocumentor release

### DIFF
--- a/build/phpDocumentor.sh
+++ b/build/phpDocumentor.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-# Use a cached version of phpDocumentor for now since there is no release yet
-# and the github actions artifacts might disappear
-# This phar is downloaded from https://github.com/phpDocumentor/phpDocumentor/actions/runs/221599704
-
-wget https://bitgrid.net/~jus/phpDocumentor.phar
+wget https://phpdoc.org/phpDocumentor.phar
 
 mkdir -p api/
 


### PR DESCRIPTION
The previous cached version download URL was broken and only a non-functional version was downloaded leading and so the API reference was not updated since NC24.
See https://app.netlify.com/sites/nextcloud-server/deploys/635bbcc012344b0008f4eaf1 for reference (`phpDocumentor.phar` downloaded and executed but only outputs *Works for me* as the downloaded file is broken / website is down).

This will then also fix https://github.com/nextcloud/documentation/issues/9262