### PR TITLE
Update FilesPlugin.php

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -352,7 +352,7 @@ class FilesPlugin extends ServerPlugin {
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {
 				return json_encode($this->previewManager->isAvailable($node->getFileInfo()));
 			});
-			$propFind->handle(self::SIZE_PROPERTYNAME, function () use ($node): ?int {
+			$propFind->handle(self::SIZE_PROPERTYNAME, function () use ($node): ?float {
 				return $node->getSize();
 			});
 			$propFind->handle(self::MOUNT_TYPE_PROPERTYNAME, function () use ($node) {


### PR DESCRIPTION
"External Storage Error. Directory not found"

With return value type "float" there is no error anymore.

https://help.nextcloud.com/t/cannot-access-files-after-upgrade-to-nextcloud-25/147823/4

Signed-off-by: CK1-CK <65177756+CK1-CK@users.noreply.github.com>