### PR TITLE
Fix duplicate event email notifications

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -42,10 +43,12 @@ interface INotificationProvider {
 	 *
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
+	 * @param string[] $principalEmailAddresses All email addresses associated to the principal owning the calendar object
 	 * @param IUser[] $users
 	 * @return void
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName,
+						 array  $principalEmailAddresses,
 						 array $users = []): void;
 }

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -82,11 +83,13 @@ abstract class AbstractProvider implements INotificationProvider {
 	 *
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
+	 * @param string[] $principalEmailAddresses
 	 * @param IUser[] $users
 	 * @return void
 	 */
 	abstract public function send(VEvent $vevent,
 						   string $calendarDisplayName,
+						   array $principalEmailAddresses,
 						   array $users = []): void;
 
 	/**

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -71,16 +71,28 @@ class EmailProvider extends AbstractProvider {
 	 *
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
+	 * @param string[] $principalEmailAddresses
 	 * @param array $users
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
 						 string $calendarDisplayName,
+	                     array $principalEmailAddresses,
 						 array $users = []):void {
 		$fallbackLanguage = $this->getFallbackLanguage();
 
+		$organizerEmailAddress = null;
+		if (isset($vevent->ORGANIZER)) {
+			$organizerEmailAddress = $this->getEMailAddressOfAttendee($vevent->ORGANIZER);
+		}
+
 		$emailAddressesOfSharees = $this->getEMailAddressesOfAllUsersWithWriteAccessToCalendar($users);
-		$emailAddressesOfAttendees = $this->getAllEMailAddressesFromEvent($vevent);
+		$emailAddressesOfAttendees = [];
+		if (count($principalEmailAddresses) === 0
+			|| ($organizerEmailAddress && in_array($organizerEmailAddress, $principalEmailAddresses, true))
+		) {
+			$emailAddressesOfAttendees = $this->getAllEMailAddressesFromEvent($vevent);
+		}
 
 		// Quote from php.net:
 		// If the input arrays have the same string keys, then the later value for that key will overwrite the previous one.

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Citharel <nextcloud@tcit.fr>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -73,11 +74,13 @@ class PushProvider extends AbstractProvider {
 	 *
 	 * @param VEvent $vevent
 	 * @param string $calendarDisplayName
+	 * @param string[] $principalEmailAddresses
 	 * @param IUser[] $users
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
-						 string $calendarDisplayName = null,
+						 string $calendarDisplayName,
+						 array $principalEmailAddresses,
 						 array $users = []):void {
 		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'no') !== 'yes') {
 			return;

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -607,4 +607,44 @@ class Principal implements BackendInterface {
 
 		return [];
 	}
+
+	/**
+	 * Get all email addresses associated to a principal.
+	 *
+	 * @param array $principal Data from getPrincipal*()
+	 * @return string[] All email addresses without the mailto: prefix
+	 */
+	public function getEmailAddressesOfPrincipal(array $principal): array {
+		$emailAddresses = [];
+
+		if (($primaryAddress = $principal['{http://sabredav.org/ns}email-address'])) {
+			$emailAddresses[] = $primaryAddress;
+		}
+
+		if (isset($principal['{DAV:}alternate-URI-set'])) {
+			foreach ($principal['{DAV:}alternate-URI-set'] as $address) {
+				if (str_starts_with($address, 'mailto:')) {
+					$emailAddresses[] = substr($address, 7);
+				}
+			}
+		}
+
+		if (isset($principal['{urn:ietf:params:xml:ns:caldav}calendar-user-address-set'])) {
+			foreach ($principal['{urn:ietf:params:xml:ns:caldav}calendar-user-address-set'] as $address) {
+				if (str_starts_with($address, 'mailto:')) {
+					$emailAddresses[] = substr($address, 7);
+				}
+			}
+		}
+
+		if (isset($principal['{http://calendarserver.org/ns/}email-address-set'])) {
+			foreach ($principal['{http://calendarserver.org/ns/}email-address-set'] as $address) {
+				if (str_starts_with($address, 'mailto:')) {
+					$emailAddresses[] = substr($address, 7);
+				}
+			}
+		}
+
+		return array_values(array_unique($emailAddresses));
+	}
 }

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Citharel <nextcloud@tcit.fr>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -90,7 +91,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 
 		$users = [$user1, $user2, $user3];
 
-		$this->provider->send($this->vcalendar->VEVENT, $this->calendarDisplayName, $users);
+		$this->provider->send($this->vcalendar->VEVENT, $this->calendarDisplayName, [], $users);
 	}
 
 	public function testSend(): void {
@@ -143,7 +144,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 			->method('notify')
 			->with($notification3);
 
-		$this->provider->send($this->vcalendar->VEVENT, $this->calendarDisplayName, $users);
+		$this->provider->send($this->vcalendar->VEVENT, $this->calendarDisplayName, [], $users);
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @author Georg Ehrke <oc.list@georgehrke.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Citharel <nextcloud@tcit.fr>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -33,6 +34,7 @@ use OCA\DAV\CalDAV\Reminder\Backend;
 use OCA\DAV\CalDAV\Reminder\INotificationProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProviderManager;
 use OCA\DAV\CalDAV\Reminder\ReminderService;
+use OCA\DAV\Connector\Sabre\Principal;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -202,6 +204,7 @@ EOD;
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->principalConnector = $this->createMock(Principal::class);
 
 		$this->caldavBackend->method('getShares')->willReturn([]);
 
@@ -214,6 +217,7 @@ EOD;
 			$this->timeFactory,
 			$this->config,
 			$this->logger,
+			$this->principalConnector,
 		);
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -11,6 +11,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0
  *
@@ -973,5 +974,35 @@ class PrincipalTest extends TestCase {
 			['mailto:user2@foo.bar', 'user2@foo.bar', 'principals/users/user2'],
 			['mailto:user3@foo.bar', 'user3@foo.bar', 'principals/users/user3'],
 		];
+	}
+
+	public function testGetEmailAddressesOfPrincipal(): void {
+		$principal = [
+			'{http://sabredav.org/ns}email-address' => 'bar@company.org',
+			'{DAV:}alternate-URI-set' => [
+				'/some/url',
+				'mailto:foo@bar.com',
+				'mailto:duplicate@example.com',
+			],
+			'{urn:ietf:params:xml:ns:caldav}calendar-user-address-set' => [
+				'mailto:bernard@example.com',
+				'mailto:bernard.desruisseaux@example.com',
+			],
+			'{http://calendarserver.org/ns/}email-address-set' => [
+				'mailto:duplicate@example.com',
+				'mailto:user@some.org',
+			],
+		];
+
+		$expected = [
+			'bar@company.org',
+			'foo@bar.com',
+			'duplicate@example.com',
+			'bernard@example.com',
+			'bernard.desruisseaux@example.com',
+			'user@some.org',
+		];
+		$actual = $this->connector->getEmailAddressesOfPrincipal($principal);
+		$this->assertEquals($expected, $actual);
 	}
 }


### PR DESCRIPTION
Fix #21370

### This PR incorporates 2 fixes:
1. VALARMs shouldn't be propagated to attendees via iTIP (not mandatory but recommended by RFC).
2. Multiple email notifications are dispatched because there is no differentiation between when the owning user is the organizer of an event and when the owning user is an attendee.
3. ~The email of the organizer was never extracted properly because the usage of `strcasecmp($organizer->getValue(), 'mailto:') !== 0` was wrong. This lead to the `Reply-To` header not being set.~ -> **Moved to a separate PR because it's not related.**

## How to test

### Preparations

1. Have at least 2 users.
4. Configure your instance to be able to send emails.
5. Enable instant event reminder sending: `occ config:app:set dav sendEventRemindersMode --value occ`
6. Apply the following patch to make testing easier (by ignoring actual trigger date and time):
```diff
diff --git a/apps/dav/lib/CalDAV/Reminder/Backend.php b/apps/dav/lib/CalDAV/Reminder/Backend.php
index b0476e9594c..74a980d3f91 100644
--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -66,7 +66,6 @@ class Backend {
 		$query = $this->db->getQueryBuilder();
 		$query->select(['cr.*', 'co.calendardata', 'c.displayname', 'c.principaluri'])
 			->from('calendar_reminders', 'cr')
-			->where($query->expr()->lte('cr.notification_date', $query->createNamedParameter($this->timeFactory->getTime())))
 			->join('cr', 'calendarobjects', 'co', $query->expr()->eq('cr.object_id', 'co.id'))
 			->join('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'));
 		$stmt = $query->execute();
```

### Routine

1. Create a new event with at least one email reminder (trigger date and time don't matter).
2. Add the other user as an attendee.
3. Save the event.
4. Trigger reminder sending: `occ dav:send-event-reminders`
7. Observe that each users receives a **single** reminder email -> **Duplicate emails fixed** :heavy_check_mark: 
8. Login with the other user (which is an attendee).
9. Observe that there are no reminders on the incoming event -> **ALARMS shouldn't be propagated (recommended by the RFC)** :heavy_check_mark: 
10. Add a *"private"* email reminder to my local copy.
11. Save the event and trigger reminder sending again.
12. Observe that **only** I (the attendee) receive an email -> **Only the email reminders of organizers should be sent to all attendees** :heavy_check_mark: 