### PR TITLE
[Performance] List preview directory only once

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -561,7 +561,7 @@ class Generator {
 	 */
 	private function getCachedPreview($files, $width, $height, $crop, $mimeType, $prefix) {
 		$path = $this->generatePath($width, $height, $crop, $mimeType, $prefix);
-		foreach($files as $file) {
+		foreach ($files as $file) {
 			if ($file->getName() === $path) {
 				return $file;
 			}

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -169,6 +169,8 @@ class Generator {
 		[$maxWidth, $maxHeight] = $this->getPreviewSize($maxPreview, $previewVersion);
 
 		$preview = null;
+		// List every existing preview first instead of trying to find them one by one
+		$previewFiles = $previewFolder->getDirectoryListing();
 
 		foreach ($specifications as $specification) {
 			$width = $specification['width'] ?? -1;
@@ -195,7 +197,7 @@ class Generator {
 			// Try to get a cached preview. Else generate (and store) one
 			try {
 				try {
-					$preview = $this->getCachedPreview($previewFolder, $width, $height, $crop, $maxPreview->getMimeType(), $previewVersion);
+					$preview = $this->getCachedPreview($previewFiles, $width, $height, $crop, $maxPreview->getMimeType(), $previewVersion);
 				} catch (NotFoundException $e) {
 					if (!$this->previewManager->isMimeSupported($mimeType)) {
 						throw new NotFoundException();
@@ -206,6 +208,8 @@ class Generator {
 					}
 
 					$preview = $this->generatePreview($previewFolder, $maxPreviewImage, $width, $height, $crop, $maxWidth, $maxHeight, $previewVersion);
+					// New file, augment our array
+					$previewFiles[] = $preview;
 				}
 			} catch (\InvalidArgumentException $e) {
 				throw new NotFoundException("", 0, $e);
@@ -545,7 +549,7 @@ class Generator {
 	}
 
 	/**
-	 * @param ISimpleFolder $previewFolder
+	 * @param array $files Array of FileInfo, as the result of getDirectoryListing()
 	 * @param int $width
 	 * @param int $height
 	 * @param bool $crop
@@ -555,10 +559,14 @@ class Generator {
 	 *
 	 * @throws NotFoundException
 	 */
-	private function getCachedPreview(ISimpleFolder $previewFolder, $width, $height, $crop, $mimeType, $prefix) {
+	private function getCachedPreview($files, $width, $height, $crop, $mimeType, $prefix) {
 		$path = $this->generatePath($width, $height, $crop, $mimeType, $prefix);
-
-		return $previewFolder->getFile($path);
+		foreach($files as $file) {
+			if ($file->getName() === $path) {
+				return $file;
+			}
+		}
+		throw new NotFoundException();
 	}
 
 	/**

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -206,9 +206,6 @@ class Generator {
 					if ($maxPreviewImage === null) {
 						$maxPreviewImage = $this->helper->getImage($maxPreview);
 					}
-					if ($maxPreviewImage === null) {
-						throw new NotFoundException();
-					}
 
 					$preview = $this->generatePreview($previewFolder, $maxPreviewImage, $width, $height, $crop, $maxWidth, $maxHeight, $previewVersion);
 					// New file, augment our array

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -206,6 +206,9 @@ class Generator {
 					if ($maxPreviewImage === null) {
 						$maxPreviewImage = $this->helper->getImage($maxPreview);
 					}
+					if ($maxPreviewImage === null) {
+						throw new NotFoundException();
+					}
 
 					$preview = $this->generatePreview($previewFolder, $maxPreviewImage, $width, $height, $crop, $maxWidth, $maxHeight, $previewVersion);
 					// New file, augment our array

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -552,7 +552,7 @@ class Generator {
 	}
 
 	/**
-	 * @param array $files Array of FileInfo, as the result of getDirectoryListing()
+	 * @param ISimpleFile[] $files Array of FileInfo, as the result of getDirectoryListing()
 	 * @param int $width
 	 * @param int $height
 	 * @param bool $crop

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -106,15 +106,12 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview->method('getMimeType')
 			->willReturn('image/png');
 
-		$previewFolder->method('getDirectoryListing')
-			->willReturn([$maxPreview]);
-
 		$previewFile = $this->createMock(ISimpleFile::class);
 		$previewFile->method('getSize')->willReturn(1000);
+		$previewFile->method('getName')->willReturn('256-256.png');
 
-		$previewFolder->method('getFile')
-			->with($this->equalTo('256-256.png'))
-			->willReturn($previewFile);
+		$previewFolder->method('getDirectoryListing')
+			->willReturn([$maxPreview, $previewFile]);
 
 		$this->legacyEventDispatcher->expects($this->once())
 			->method('dispatch')
@@ -340,14 +337,12 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview->method('getMimeType')
 			->willReturn('image/png');
 
-		$previewFolder->method('getDirectoryListing')
-			->willReturn([$maxPreview]);
-
 		$preview = $this->createMock(ISimpleFile::class);
 		$preview->method('getSize')->willReturn(1000);
-		$previewFolder->method('getFile')
-			->with($this->equalTo('1024-512-crop.png'))
-			->willReturn($preview);
+		$preview->method('getName')->willReturn('1024-512-crop.png');
+
+		$previewFolder->method('getDirectoryListing')
+			->willReturn([$maxPreview, $preview]);
 
 		$this->previewManager->expects($this->never())
 			->method('isMimeSupported');


### PR DESCRIPTION
getCachedPreview used to call `getFile`, and this calls `getDirectoryListing` (or underlying function that list directory) to find the file. This was done for every preview spec. Now, this is done only once at the beginning of the loop, and the array is just iterated when needed to find the correct entry.

I have a slow machine, and the result of `preview:generate-all` from [Preview Generator](https://github.com/nextcloud/previewgenerator/) on an image directory containing 1474 images went from 159 seconds to 33 seconds **when all preview images already exist**. When preview must be generated, this is barely efficient, since image operation are much more expensive.

But this is really needed for running re-generation checks.