### PR TITLE
Reduce number of queries to read shares in a folder

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -915,13 +915,12 @@ class ShareAPIController extends OCSController {
 			throw new OCSBadRequestException($this->l->t('Not a directory'));
 		}
 
-		$nodes = $folder->getDirectoryListing();
-
 		/** @var \OCP\Share\IShare[] $shares */
-		$shares = array_reduce($nodes, function ($carry, $node) {
-			$carry = array_merge($carry, $this->getAllShares($node, true));
-			return $carry;
-		}, []);
+		$shares = [];
+		$sharesInFolder = $this->shareManager->getSharesInFolder($this->currentUser, $folder, true);
+		foreach ($sharesInFolder as $key => &$value) {
+			$shares = array_merge($shares, $value);
+		}
 
 		// filter out duplicate shares
 		$known = [];

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -918,7 +918,7 @@ class ShareAPIController extends OCSController {
 		/** @var \OCP\Share\IShare[] $shares */
 		$shares = [];
 		$sharesInFolder = $this->shareManager->getSharesInFolder($this->currentUser, $folder, true);
-		foreach ($sharesInFolder as $key => &$value) {
+		foreach ($sharesInFolder as $key => $value) {
 			$shares = array_merge($shares, $value);
 		}
 
@@ -1996,49 +1996,6 @@ class ShareAPIController extends OCSController {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Get all the shares for the current user
-	 *
-	 * @param Node|null $path
-	 * @param boolean $reshares
-	 * @return IShare[]
-	 */
-	private function getAllShares(?Node $path = null, bool $reshares = false) {
-		// Get all shares
-		$userShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_USER, $path, $reshares, -1, 0);
-		$groupShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_GROUP, $path, $reshares, -1, 0);
-		$linkShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_LINK, $path, $reshares, -1, 0);
-
-		// EMAIL SHARES
-		$mailShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_EMAIL, $path, $reshares, -1, 0);
-
-		// CIRCLE SHARES
-		$circleShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_CIRCLE, $path, $reshares, -1, 0);
-
-		// TALK SHARES
-		$roomShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_ROOM, $path, $reshares, -1, 0);
-
-		// DECK SHARES
-		$deckShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_DECK, $path, $reshares, -1, 0);
-
-		// SCIENCEMESH SHARES
-		$sciencemeshShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_SCIENCEMESH, $path, $reshares, -1, 0);
-
-		// FEDERATION
-		if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
-			$federatedShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_REMOTE, $path, $reshares, -1, 0);
-		} else {
-			$federatedShares = [];
-		}
-		if ($this->shareManager->outgoingServer2ServerGroupSharesAllowed()) {
-			$federatedGroupShares = $this->shareManager->getSharesBy($this->currentUser, IShare::TYPE_REMOTE_GROUP, $path, $reshares, -1, 0);
-		} else {
-			$federatedGroupShares = [];
-		}
-
-		return array_merge($userShares, $groupShares, $linkShares, $mailShares, $circleShares, $roomShares, $deckShares, $sciencemeshShares, $federatedShares, $federatedGroupShares);
 	}
 
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1459,9 +1459,9 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturn($extraShareTypes[ISHARE::TYPE_REMOTE_GROUP] ?? false);
 
 		$sharesWithoutTypes = [];
-		foreach ($shares as $file => &$fileShares) {
+		foreach ($shares as $file => $fileShares) {
 			$sharesWithoutTypes[$file] = [];
-			foreach ($fileShares as $shareType => &$shareTypeShares) {
+			foreach ($fileShares as $shareType => $shareTypeShares) {
 				if ($shareType === ISHARE::TYPE_REMOTE or $shareType === ISHARE::TYPE_REMOTE_GROUP) {
 					if ($extraShareTypes[$shareType] ?? false) {
 						$sharesWithoutTypes[$file] = array_merge($sharesWithoutTypes[$file], $shareTypeShares);

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1458,6 +1458,22 @@ class ShareAPIControllerTest extends TestCase {
 			->method('outgoingServer2ServerGroupSharesAllowed')
 			->willReturn($extraShareTypes[ISHARE::TYPE_REMOTE_GROUP] ?? false);
 
+		$sharesWithoutTypes = [];
+		foreach ($shares as $file => &$fileShares) {
+			$sharesWithoutTypes[$file] = [];
+			foreach ($fileShares as $shareType => &$shareTypeShares) {
+				if ($shareType === ISHARE::TYPE_REMOTE or $shareType === ISHARE::TYPE_REMOTE_GROUP) {
+					if ($extraShareTypes[$shareType] ?? false) {
+						$sharesWithoutTypes[$file] = array_merge($sharesWithoutTypes[$file], $shareTypeShares);
+					}
+				} else {
+					$sharesWithoutTypes[$file] = array_merge($sharesWithoutTypes[$file], $shareTypeShares);
+				}
+			}
+		}
+		$this->shareManager
+			->method('getSharesInFolder')->willReturn($sharesWithoutTypes);
+
 		$this->groupManager
 			->method('isInGroup')
 			->willReturnCallback(

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -674,13 +674,6 @@ class DefaultShareProvider implements IShareProvider {
 		 */
 		if ($reshares === false) {
 			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
-		} else {
-			$qb->andWhere(
-				$qb->expr()->orX(
-					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
-					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
-				)
-			);
 		}
 
 		// todo? maybe get these from the oc_mounts table

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -674,13 +674,6 @@ class DefaultShareProvider implements IShareProvider {
 		 */
 		if ($reshares === false) {
 			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
-		// } else {
-		// 	$qb->andWhere(
-		// 		$qb->expr()->orX(
-		// 			$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
-		// 			$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
-		// 		)
-		// 	);
 		}
 
 		// todo? maybe get these from the oc_mounts table

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -674,13 +674,13 @@ class DefaultShareProvider implements IShareProvider {
 		 */
 		if ($reshares === false) {
 			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
-		} else {
-			$qb->andWhere(
-				$qb->expr()->orX(
-					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
-					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
-				)
-			);
+		// } else {
+		// 	$qb->andWhere(
+		// 		$qb->expr()->orX(
+		// 			$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+		// 			$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+		// 		)
+		// 	);
 		}
 
 		// todo? maybe get these from the oc_mounts table

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -674,6 +674,13 @@ class DefaultShareProvider implements IShareProvider {
 		 */
 		if ($reshares === false) {
 			$qb->andWhere($qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)));
+		} else {
+			$qb->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+				)
+			);
 		}
 
 		// todo? maybe get these from the oc_mounts table


### PR DESCRIPTION
While working on https://github.com/nextcloud/android/issues/10783 I have found that the API call to retrieve shares for files in a folder (_/ocs/v2.php/apps/files_sharing/api/v1/shares?path=xyz&reshares=true&subfiles=true_) executes 6 database queries for each file.

I have modified implementation of the **ShareAPIController::getSharesInDir** to use **OC\Share20\Manager::getSharesInDir** rather than retrieving shares separately for each file in the folder.

This significantly reduces the number of database queries and improves performance. In my tests (331 files in a folder) I got the following results (most of the time is now spent in the initialization code):

_ | Execution time [ms] | # of DB queries
--- | ---: | ---:
Before | 980 | 2021
After | 280 | 40

After implementing this change, I have noticed some changes in data returned from the API.

- Permissions for room shares returned from **RoomShareProvider::getSharesInFolder** are incorrect. I have submitted [a separate PR in nextcloud/spreed](https://github.com/nextcloud/spreed/pull/8305) to fix the issue.
- ~Original code handling this API call also returned information about incoming group shares. I do not know if this was an intended behaviour or an error in the original implementation.~ **Update** - after removing the uid check for re-shares mode in https://github.com/nextcloud/server/pull/34918/commits/d0c52e56864e466f7a07cd4499d4d4831f7ba286, the new code returns the same information in this case as the original one.
