### PR TITLE
Added parameter to disallow calendar subscription via link

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
@@ -177,7 +178,9 @@ class Server {
 
 			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\WebcalCaching\Plugin($request));
-			$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
+			if (\OC::$server->getConfig()->getAppValue('dav', 'allow_calendar_link_subscriptions', 'yes') === 'yes') {
+				$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
+			}
 
 			$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest(), \OC::$server->getConfig()));


### PR DESCRIPTION
Added calendar application config parameter `dav.allow_calendar_link_subscriptions` to disallow calendar subscription via link (i.e. for internal Nextcloud setups). Use

```
occ config:app:set dav allow_calendar_link_subscriptions --value 'yes'
```

to allow (default if not set) and

```
occ config:app:set dav allow_calendar_link_subscriptions --value 'no'
```

to disallow calendar subscription via link.

Author-Change-Id: IB#1126265
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>