### PR TITLE
escape path prefix when doing cache jail search

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -317,7 +317,7 @@ class CacheJail extends CacheWrapper {
 					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR,
 						[
 							new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'path', $this->getGetUnjailedRoot()),
-							new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', $this->getGetUnjailedRoot() . '/%'),
+							new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', SearchComparison::escapeLikeParameter($this->getGetUnjailedRoot()) . '/%'),
 						],
 					)
 				]

--- a/lib/private/Files/Search/QueryOptimizer/PathPrefixOptimizer.php
+++ b/lib/private/Files/Search/QueryOptimizer/PathPrefixOptimizer.php
@@ -23,15 +23,12 @@ declare(strict_types=1);
 
 namespace OC\Files\Search\QueryOptimizer;
 
+use OC\Files\Search\SearchComparison;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
 
 class PathPrefixOptimizer extends QueryOptimizerStep {
-	public function escapeLikeParameter(string $param): string {
-		return addcslashes($param, '\\_%');
-	}
-
 	public function processOperator(ISearchOperator &$operator) {
 		// normally the `path = "$prefix"` search query part of the prefix filter would be generated as an `path_hash = md5($prefix)` sql query
 		// since the `path_hash` sql column usually provides much faster querying that selecting on the `path` sql column
@@ -43,11 +40,11 @@ class PathPrefixOptimizer extends QueryOptimizerStep {
 			$b = $operator->getArguments()[1];
 			if ($a instanceof ISearchComparison && $b instanceof ISearchComparison && $a->getField() === 'path' && $b->getField() === 'path') {
 				if ($a->getType() === ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE && $b->getType() === ISearchComparison::COMPARE_EQUAL
-					&& $a->getValue() === $this->escapeLikeParameter($b->getValue()) . '/%') {
+					&& $a->getValue() === SearchComparison::escapeLikeParameter($b->getValue()) . '/%') {
 					$b->setQueryHint(ISearchComparison::HINT_PATH_EQ_HASH, false);
 				}
 				if ($b->getType() === ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE && $a->getType() === ISearchComparison::COMPARE_EQUAL
-					&& $b->getValue() === $this->escapeLikeParameter($a->getValue()) . '/%') {
+					&& $b->getValue() === SearchComparison::escapeLikeParameter($a->getValue()) . '/%') {
 					$a->setQueryHint(ISearchComparison::HINT_PATH_EQ_HASH, false);
 				}
 			}

--- a/lib/private/Files/Search/SearchComparison.php
+++ b/lib/private/Files/Search/SearchComparison.php
@@ -74,4 +74,8 @@ class SearchComparison implements ISearchComparison {
 	public function setQueryHint(string $name, $value): void {
 		$this->hints[$name] = $value;
 	}
+
+	public static function escapeLikeParameter(string $param): string {
+		return addcslashes($param, '\\_%');
+	}
 }


### PR DESCRIPTION
Currently the `CacheJail` doesn't escape the path of the jail when creating the search query for the files inside the jail. This doesn't break things since at most it will make the sql query return a few more results which will be filtered out in later steps.

It does however interfere with the optimization step that is required for mysql to be able to use the "path prefix" index on the search query. Which does properly like-escape the paths.

This causes the "path prefix" index to not be used when a cache jail with an "_" in the path is part of the search. (This also includes any groupfolders since those always have "__groupfolders" in the search path)