### PR TITLE
Clean up and deprecate app container parameter aliases

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -96,7 +96,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 */
 	public function __construct($appName, $urlParams = [], ServerContainer $server = null) {
 		parent::__construct();
-		$this['AppName'] = $appName;
+		$this['appName'] = $appName;
 		$this['urlParams'] = $urlParams;
 
 		$this->registerAlias('Request', IRequest::class);
@@ -109,9 +109,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->server->registerAppContainer($appName, $this);
 
 		// aliases
-		$this->registerAlias('appName', 'AppName');
-		$this->registerAlias('webRoot', 'WebRoot');
-		$this->registerAlias('userId', 'UserId');
+		/** @deprecated inject $appName */
+		$this->registerAlias('AppName', 'appName');
+		/** @deprecated inject $webRoot*/
+		$this->registerAlias('WebRoot', 'webRoot');
+		/** @deprecated inject $userId */
+		$this->registerAlias('UserId', 'userId');
 
 		/**
 		 * Core services
@@ -158,11 +161,11 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerAlias(IAppContainer::class, ContainerInterface::class);
 
 		// commonly used attributes
-		$this->registerService('UserId', function (ContainerInterface $c) {
+		$this->registerService('userId', function (ContainerInterface $c) {
 			return $c->get(IUserSession::class)->getSession()->get('user_id');
 		});
 
-		$this->registerService('WebRoot', function (ContainerInterface $c) {
+		$this->registerService('webRoot', function (ContainerInterface $c) {
 			return $c->get(IServerContainer::class)->getWebRoot();
 		});
 


### PR DESCRIPTION
An app can have app name, web root and user ID injected. Those parameters are registered in pascal case with a camel case alias. Our coding styles suggest camel case, so it always felt weird that we inject `$UserId` in so many places and then assign it to a `private $userId` (lowering the first letter). Now I found out that we actually even have aliases for the lower case variant and they just make more sense.

So with this change I'm flipping the service registration. The lower case ones (camel case) are the intended ones, upper (pascal case) are the aliases. In the same step I'm deprecating the aliases so we can remove them one day. This is a micro optimization because it's one registration less on every app container.

Documentation: https://github.com/nextcloud/documentation/pull/9285