### PR TITLE
Read encrypted session data again on reopen

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -163,7 +163,11 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	}
 
 	public function reopen(): bool {
-		return $this->session->reopen();
+		$reopened = $this->session->reopen();
+		if ($reopened) {
+			$this->initializeSession();
+		}
+		return $reopened;
 	}
 
 	/**

--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -143,7 +143,6 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 		$reopened = $this->reopen();
 		$this->isModified = true;
 		unset($this->sessionValues[$key]);
-		$this->session->remove(self::encryptedSessionName);
 		if ($reopened) {
 			$this->close();
 		}


### PR DESCRIPTION
This should avoid working with outdated session data after reopening the PHP session