### PR TITLE
Avoid a crash when a PHP extension has no version

### DIFF
--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -50,7 +50,7 @@ class PlatformRepository {
 			$ext = new \ReflectionExtension($name);
 			try {
 				$prettyVersion = $ext->getVersion();
-				$prettyVersion = $this->normalizeVersion($prettyVersion);
+				$prettyVersion = $this->normalizeVersion($prettyVersion ?? '0');
 			} catch (\UnexpectedValueException $e) {
 				$prettyVersion = '0';
 				$prettyVersion = $this->normalizeVersion($prettyVersion);
@@ -111,6 +111,9 @@ class PlatformRepository {
 					continue 2;
 			}
 
+			if ($prettyVersion === null) {
+				continue;
+			}
 			try {
 				$prettyVersion = $this->normalizeVersion($prettyVersion);
 			} catch (\UnexpectedValueException $e) {

--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -50,6 +50,10 @@ class PlatformRepository {
 			$ext = new \ReflectionExtension($name);
 			try {
 				$prettyVersion = $ext->getVersion();
+				/** @psalm-suppress TypeDoesNotContainNull
+				 * @psalm-suppress RedundantCondition
+				 * TODO Remove these annotations once psalm fixes the method signature ( https://github.com/vimeo/psalm/pull/8655 )
+				 */
 				$prettyVersion = $this->normalizeVersion($prettyVersion ?? '0');
 			} catch (\UnexpectedValueException $e) {
 				$prettyVersion = '0';


### PR DESCRIPTION
The signature known to our psalm is somehow wrong here, getVersion can actually return null according to php documentation and issues opened by users.
Should fix #34716 

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>