### PR TITLE
[Performance] Test valid path only if file info has to be retrieved

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -99,10 +99,10 @@ class Node implements \OCP\Files\Node {
 	 * @throws NotFoundException
 	 */
 	public function getFileInfo() {
-		if (!Filesystem::isValidPath($this->path)) {
-			throw new InvalidPathException();
-		}
 		if (!$this->fileInfo) {
+			if (!Filesystem::isValidPath($this->path)) {
+				throw new InvalidPathException();
+			}
 			$fileInfo = $this->view->getFileInfo($this->path);
 			if ($fileInfo instanceof FileInfo) {
 				$this->fileInfo = $fileInfo;


### PR DESCRIPTION
Filesystem::isValidPath seems to be useless here, since we already have our file info anyway.

After applying #34910 it still gives me the following improvement, when running preview generator on a folder with 1473 images, all already generated.
- Before:
```
 Performance counter stats for './occ preview:generate-all -vv --path=/users/files/photos/2008 - 09 - Viet Nam/' (5 runs):

         13 124,93 msec task-clock                       #    0,653 CPUs utilized            ( +-  1,17% )
             5 826      context-switches                 #  451,999 /sec                     ( +-  1,01% )
               719      cpu-migrations                   #   55,782 /sec                     ( +-  6,37% )
            20 846      page-faults                      #    1,617 K/sec                    ( +-  0,01% )
    24 144 069 088      cycles                           #    1,873 GHz                      ( +-  1,17% )  (50,38%)
     5 539 208 540      instructions                     #    0,23  insn per cycle           ( +-  0,17% )  (74,88%)
     1 124 152 538      branches                         #   87,215 M/sec                    ( +-  0,16% )  (74,30%)
       164 879 701      branch-misses                    #   14,65% of all branches          ( +-  0,31% )  (75,34%)

            20,084 +- 0,267 seconds time elapsed  ( +-  1,33% )
```
- After:
```
 Performance counter stats for './occ preview:generate-all -vv --path=/users/files/photos/2008 - 09 - Viet Nam/' (5 runs):

         10 918,60 msec task-clock                       #    0,615 CPUs utilized            ( +-  1,20% )
             5 702      context-switches                 #  531,419 /sec                     ( +-  1,06% )
               802      cpu-migrations                   #   74,745 /sec                     ( +-  8,95% )
            20 827      page-faults                      #    1,941 K/sec                    ( +-  0,01% )
    20 074 183 445      cycles                           #    1,871 GHz                      ( +-  1,19% )  (49,12%)
     4 660 549 008      instructions                     #    0,24  insn per cycle           ( +-  0,17% )  (74,39%)
       928 891 708      branches                         #   86,571 M/sec                    ( +-  0,13% )  (75,05%)
       137 892 289      branch-misses                    #   14,85% of all branches          ( +-  0,40% )  (75,87%)

            17,768 +- 0,242 seconds time elapsed  ( +-  1,36% )
```

It's a small use case, but 10% improvement seems valuable to me :)