### PR TITLE
Fix unsuccessful token login logged as error

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -868,7 +868,7 @@ class Session implements IUserSession, Emitter {
 		$tokens = $this->config->getUserKeys($uid, 'login_token');
 		// test cookies token against stored tokens
 		if (!in_array($currentToken, $tokens, true)) {
-			$this->logger->error('Tried to log in {uid} but could not verify token', [
+			$this->logger->info('Tried to log in {uid} but could not verify token', [
 				'app' => 'core',
 				'uid' => $uid,
 			]);


### PR DESCRIPTION
The condition of a non-existent login token can happen for concurrent requests. Admins can not do anything about this. So this is to be expected to happen occasionally. This event is only bad if none of the requests is able to re-acquire a session. Luckily this happens rarely.

If a login loop persists an admin can still lower the log level to find this info. But a default error log level will no longer write those infos about the failed cookie login of one request.

This is a refinement of the logging added with https://github.com/nextcloud/server/pull/33772.

Ref https://github.com/nextcloud/server/issues/33919