### PR TITLE
Appropriate length check in Notification.php

### DIFF
--- a/lib/private/Notification/Notification.php
+++ b/lib/private/Notification/Notification.php
@@ -197,12 +197,12 @@ class Notification implements INotification {
 	 * @since 8.2.0 - 9.0.0: Type of $id changed to string
 	 */
 	public function setObject(string $type, string $id): INotification {
-		if ($type === '' || isset($type[64])) {
+		if ($type === '' || mb_strlen($type) > 64) {
 			throw new \InvalidArgumentException('The given object type is invalid');
 		}
 		$this->objectType = $type;
 
-		if ($id === '' || isset($id[64])) {
+		if ($id === '' || mb_strlen($id) > 64) {
 			throw new \InvalidArgumentException('The given object id is invalid');
 		}
 		$this->objectId = $id;


### PR DESCRIPTION
There is an issue(bug) when using UTF-8 symbols in any method, which checks the length of string as `isset($id[64])` in Notification.php.

You can set only 32 UTF-8 symbols because they are 2 byte, and this "array" check seems inapropriate in this case, as it throws unexpected exceptions for strings with length less than 64 symbols (in UTF-8).

Close https://github.com/nextcloud/server/issues/35016