### PR TITLE
Deprecate PHP7.4

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -330,7 +330,7 @@ class CheckSetupController extends Controller {
 	 * @return bool
 	 */
 	protected function isPhpOutdated(): bool {
-		return PHP_VERSION_ID < 70400;
+		return PHP_VERSION_ID < 80000;
 	}
 
 	/**

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -303,12 +303,6 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_INFO
 						})
 					}
-					if (data.phpSupported && data.phpSupported.version.substr(0, 3) === '7.3') {
-						messages.push({
-							msg: t('core', 'Nextcloud 23 is the last release supporting PHP 7.3. Nextcloud 24 requires at least PHP 7.4.'),
-							type: OC.SetupChecks.MESSAGE_TYPE_INFO
-						})
-					}
 					if(!data.forwardedForHeadersWorking) {
 						messages.push({
 							msg: t('core', 'The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud. Further information can be found in the {linkstart}documentation ↗{linkend}.')


### PR DESCRIPTION
Because it is running out of support: https://www.php.net/supported-versions.php

Ref https://github.com/nextcloud/server/issues/35025