### PR TITLE
Fix sidebar not automatically hidden in Files app

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -321,7 +321,7 @@
 					dir: e.dir ? e.dir : '/'
 				};
 				this._changeUrl(params.view, params.dir);
-				OC.Apps.hideAppSidebar($('.detailsView'));
+				OCA.Files.Sidebar.close();
 				this.navigation.getActiveContainer().trigger(new $.Event('urlChanged', params));
 				window._nc_event_bus.emit('files:navigation:changed')
 			}
@@ -352,7 +352,7 @@
 		_onChangeViewerMode: function(e) {
 			var state = !!e.viewerModeEnabled;
 			if (e.viewerModeEnabled) {
-				OC.Apps.hideAppSidebar($('.detailsView'));
+				OCA.Files.Sidebar.close();
 			}
 			$('#app-navigation').toggleClass('hidden', state);
 			$('.app-files').toggleClass('viewer-mode no-sidebar', state);

--- a/apps/files/js/gotoplugin.js
+++ b/apps/files/js/gotoplugin.js
@@ -45,7 +45,7 @@
 				type: OCA.Files.FileActions.TYPE_DROPDOWN,
 				actionHandler: function (fileName, context) {
 					var fileModel = context.fileInfoModel;
-					OC.Apps.hideAppSidebar($('.detailsView'));
+					OCA.Files.Sidebar.close();
 					OCA.Files.App.setActiveView('files', { silent: true });
 					OCA.Files.App.fileList.changeDirectory(fileModel.get('path'), true, true).then(function() {
 						OCA.Files.App.fileList.scrollTo(fileModel.get('name'));


### PR DESCRIPTION
Fixes #33848

This might be happening since #15719 (but I have not verified it)

Although the Files app [creates the legacy sidebar](https://github.com/nextcloud/server/blob/cfbbace45060c70d80cc01c79595c983747c63c4/apps/files/js/filelist.js#L305) (details view) it is then [replaced with the newer Vue app sidebar](https://github.com/nextcloud/server/blob/14e57bf70a612c16eccdd733b3562d46053419c5/apps/files/src/sidebar.js#L60). Due to this `.detailsView` no longer finds an element and therefore nothing was hidden when `hideAppSidebar($('.detailsView'))` was called (for example, when changing to another section).

However, `OC.Apps.hideAppSidebar()` does not properly work either with the Vue sidebar used in the Files app ([once hidden the sidebar is not shown again](https://github.com/nextcloud/server/blob/14e57bf70a612c16eccdd733b3562d46053419c5/core/src/OC/apps.js#L53)). For simplicity, and to avoid any possible side effect in other apps from changing `OC.Apps.hideAppSidebar`, now `OC.Files.Sidebar.close()` is used instead.

## How to test

- Open the Files app
- Show the sidebar for any file
- Change to a different section (_Recent_, _Favorites_...)

### Result with this pull request

The sidebar is hidden

### Result without this pull request

The sidebar is not hidden
