### PR TITLE
Add brute force protection on all methods wrapped by PublicShareMiddleware

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -304,7 +304,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				new OC\AppFramework\Middleware\PublicShare\PublicShareMiddleware(
 					$c->get(IRequest::class),
 					$c->get(ISession::class),
-					$c->get(\OCP\IConfig::class)
+					$c->get(\OCP\IConfig::class),
+					$c->get(OC\Security\Bruteforce\Throttler::class)
 				)
 			);
 			$dispatcher->registerMiddleware(

--- a/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
+++ b/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
@@ -24,6 +24,7 @@
 namespace OC\AppFramework\Middleware\PublicShare;
 
 use OC\AppFramework\Middleware\PublicShare\Exceptions\NeedAuthenticationException;
+use OC\Security\Bruteforce\Throttler;
 use OCP\AppFramework\AuthPublicShareController;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Middleware;
@@ -34,6 +35,7 @@ use OCP\IRequest;
 use OCP\ISession;
 
 class PublicShareMiddleware extends Middleware {
+
 	/** @var IRequest */
 	private $request;
 
@@ -43,16 +45,25 @@ class PublicShareMiddleware extends Middleware {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(IRequest $request, ISession $session, IConfig $config) {
+	/** @var Throttler */
+	private $throttler;
+
+	public function __construct(IRequest $request, ISession $session, IConfig $config, Throttler $throttler) {
 		$this->request = $request;
 		$this->session = $session;
 		$this->config = $config;
+		$this->throttler = $throttler;
 	}
 
 	public function beforeController($controller, $methodName) {
 		if (!($controller instanceof PublicShareController)) {
 			return;
 		}
+
+		$controllerClassPath = explode('\\', get_class($controller));
+		$controllerShortClass = end($controllerClassPath);
+		$bruteforceProtectionAction = $controllerShortClass . '::' . $methodName;
+		$this->throttler->sleepDelayOrThrowOnMax($this->request->getRemoteAddress(), $bruteforceProtectionAction);
 
 		if (!$this->isLinkSharingEnabled()) {
 			throw new NotFoundException('Link sharing is disabled');
@@ -68,6 +79,8 @@ class PublicShareMiddleware extends Middleware {
 		$controller->setToken($token);
 
 		if (!$controller->isValidToken()) {
+			$this->throttle($bruteforceProtectionAction, $token);
+
 			$controller->shareNotFound();
 			throw new NotFoundException();
 		}
@@ -88,6 +101,7 @@ class PublicShareMiddleware extends Middleware {
 			throw new NeedAuthenticationException();
 		}
 
+		$this->throttle($bruteforceProtectionAction, $token);
 		throw new NotFoundException();
 	}
 
@@ -127,5 +141,11 @@ class PublicShareMiddleware extends Middleware {
 		}
 
 		return true;
+	}
+
+	private function throttle($bruteforceProtectionAction, $token): void {
+		$ip = $this->request->getRemoteAddress();
+		$this->throttler->sleepDelay($ip, $bruteforceProtectionAction);
+		$this->throttler->registerAttempt($bruteforceProtectionAction, $ip, ['token' => $token]);
 	}
 }

--- a/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
@@ -25,6 +25,7 @@ namespace Test\AppFramework\Middleware\PublicShare;
 
 use OC\AppFramework\Middleware\PublicShare\Exceptions\NeedAuthenticationException;
 use OC\AppFramework\Middleware\PublicShare\PublicShareMiddleware;
+use OC\Security\Bruteforce\Throttler;
 use OCP\AppFramework\AuthPublicShareController;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\NotFoundResponse;
@@ -44,6 +45,8 @@ class PublicShareMiddlewareTest extends \Test\TestCase {
 	private $session;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $throttler;
 
 	/** @var PublicShareMiddleware */
 	private $middleware;
@@ -55,11 +58,13 @@ class PublicShareMiddlewareTest extends \Test\TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->throttler = $this->createMock(Throttler::class);
 
 		$this->middleware = new PublicShareMiddleware(
 			$this->request,
 			$this->session,
-			$this->config
+			$this->config,
+			$this->throttler
 		);
 	}
 


### PR DESCRIPTION
This adds a rate limit on all methods wrapped by PublicShareMiddleware if an invalid token is provided.

As the token check does not happen in the controller methods but in the middleware, we can't use the `@AnonRateThrottle` annotation on those methods.

Remaining questions:
* Does it make sense to use the brute force protection mechanism instead? If so, same issue, we can't use the annotation in the controller.
* Do the limit (10) and period (120) values make sense?
* Does it make sense to call registerAnonRequest only if the token check fails like it's done here?
    * It could be called in other cases
    * Where should it be called to apply the limit when the token is correct but the password is wrong?