### PR TITLE
Remove reference to Redis sentinel from configuration docs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1405,10 +1405,7 @@ $CONFIG = [
 ],
 
 /**
- * Connection details for a Redis Cluster
- *
- * Only for use with Redis Clustering, for Sentinel-based setups use the single
- * server configuration above, and perform HA on the hostname.
+ * Connection details for a Redis Cluster.
  *
  * Redis Cluster support requires the php module phpredis in version 3.0.0 or
  * higher.


### PR DESCRIPTION
Removes reference to Redis Sentinel configuration, which implies that Sentinel is supported,  ([Relevant documentation page](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#memory-caching-backend-configuration))


As far as I can tell do not currently support configurations for [Redis Sentinel](https://github.com/phpredis/phpredis/blob/develop/sentinel.md#readme) in the `RedisFactory`
