### PR TITLE
Check return value and improve error handling on certificate manager

### DIFF
--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -228,7 +228,7 @@ class CertificateManager implements ICertificateManager {
 	 */
 	public function getAbsoluteBundlePath(): string {
 		try {
-			if (!$this->bundlePath) {
+			if ($this->bundlePath === null) {
 				if (!$this->hasCertificates()) {
 					$this->bundlePath = \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 				}
@@ -237,13 +237,16 @@ class CertificateManager implements ICertificateManager {
 					$this->createCertificateBundle();
 				}
 
-				$this->bundlePath = $this->view->getLocalFile($this->getCertificateBundle()) ?: null;
-			}
-			if ($this->bundlePath === null) {
-				throw new \Exception('Failed to get absolute bundle path');
+				$certificateBundle = $this->getCertificateBundle();
+				$this->bundlePath = $this->view->getLocalFile($certificateBundle) ?: null;
+
+				if ($this->bundlePath === null) {
+					throw new \RuntimeException('Unable to get certificate bundle "' . $certificateBundle . '".');
+				}
 			}
 			return $this->bundlePath;
 		} catch (\Exception $e) {
+			$this->logger->error('Failed to get absolute bundle path. Fallback to default ca-bundle.crt', ['exception' => $e]);
 			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 		}
 	}

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -138,6 +138,10 @@ class CertificateManager implements ICertificateManager {
 		$tmpPath = $certPath . '.tmp' . $this->random->generate(10, ISecureRandom::CHAR_DIGITS);
 		$fhCerts = $this->view->fopen($tmpPath, 'w');
 
+		if (!is_resource($fhCerts)) {
+			throw new \RuntimeException('Unable to open file handler to create certificate bundle "' . $tmpPath . '".');
+		}
+
 		// Write user certificates
 		foreach ($certs as $cert) {
 			$file = $path . '/uploads/' . $cert->getName();


### PR DESCRIPTION
close #33487 

With S3 primary storage there was a problem with getting the CA bundle from the storage without having the CA bundle for the connection which causes that the `CertificateManager` was throwing an Error. (handled in https://github.com/nextcloud/server/commit/bffa67c48beced2147af196a5b63414c113aaad4)
This commit improves the handling in `CertificateManager` and log unexpected behaviors.

**this issue is releated to #31605 so it should also be backported to Nextcloud v22**