### PR TITLE
Run integration tests on 3rdparty bump

### DIFF
--- a/tests/drone-run-integration-tests.sh
+++ b/tests/drone-run-integration-tests.sh
@@ -20,4 +20,6 @@ echo "========================="
 
 [[ $(git diff --name-only origin/$DRONE_TARGET_BRANCH...$DRONE_COMMIT_SHA | grep -c "^build/integration/") -gt 0 ]] && echo "Integration test files are modified" && exit 0
 
+[[ $(git diff --name-only origin/$DRONE_TARGET_BRANCH...$DRONE_COMMIT_SHA | grep -c "3rdparty") -gt 0 ]] && echo "3rdparty is modified" && exit 0
+
 exit 1


### PR DESCRIPTION
Similarly to https://github.com/nextcloud/server/blob/master/tests/drone-run-php-tests.sh#L25 we should run integration tests on 3rdparty changes.
Noticed in https://github.com/nextcloud/server/pull/35084