### PR TITLE
[stable24] use the updated mariadb10.6 container in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -374,7 +374,7 @@ services:
 - name: cache
   image: ghcr.io/nextcloud/continuous-integration-redis:latest
 - name: mariadb
-  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.6continuous-integration-mariadb-10.6:10.6
+  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.6:latest
   environment:
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: oc_autotest


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/33631

Signed-off-by: Simon L <szaimen@e.mail.de>