### PR TITLE
[Performance] Reuse preview directory listing

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -208,6 +208,9 @@ class Generator {
 					if ($maxPreviewImage === null) {
 						$maxPreviewImage = $this->helper->getImage($maxPreview);
 					}
+					if ($maxPreviewImage === null) {
+						throw new NotFoundException();
+					}
 
 					$preview = $this->generatePreview($previewFolder, $maxPreviewImage, $width, $height, $crop, $maxWidth, $maxHeight, $previewVersion);
 					// New file, augment our array

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -208,9 +208,6 @@ class Generator {
 					if ($maxPreviewImage === null) {
 						$maxPreviewImage = $this->helper->getImage($maxPreview);
 					}
-					if ($maxPreviewImage === null) {
-						throw new NotFoundException();
-					}
 
 					$preview = $this->generatePreview($previewFolder, $maxPreviewImage, $width, $height, $crop, $maxWidth, $maxHeight, $previewVersion);
 					// New file, augment our array

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -656,7 +656,7 @@ class Generator {
 	}
 
 	/**
-	 * @param array $files Array of FileInfo, as the result of getDirectoryListing()
+	 * @param ISimpleFile[] $files Array of FileInfo, as the result of getDirectoryListing()
 	 * @param int $width
 	 * @param int $height
 	 * @param bool $crop

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -236,7 +236,7 @@ class Generator {
 	/**
 	 * Generate a small image straight away without generating a max preview first
 	 * Preview generated is 256x256
-	 * 
+	 *
 	 * @param ISimpleFile[] $previewFiles
 	 *
 	 * @throws NotFoundException
@@ -247,7 +247,7 @@ class Generator {
 
 		try {
 			return $this->getCachedPreview($previewFiles, $width, $height, $crop, $mimeType, $prefix);
-		} catch (NotFoundException) {
+		} catch (NotFoundException $e) {
 			return $this->generateProviderPreview($previewFolder, $file, $width, $height, $crop, false, $mimeType, $prefix);
 		}
 	}

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -665,7 +665,7 @@ class Generator {
 	 */
 	private function getCachedPreview($files, $width, $height, $crop, $mimeType, $prefix) {
 		$path = $this->generatePath($width, $height, $crop, $mimeType, $prefix);
-		foreach($files as $file) {
+		foreach ($files as $file) {
 			if ($file->getName() === $path) {
 				return $file;
 			}

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -105,15 +105,12 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview->method('getMimeType')
 			->willReturn('image/png');
 
-		$previewFolder->method('getDirectoryListing')
-			->willReturn([$maxPreview]);
-
 		$previewFile = $this->createMock(ISimpleFile::class);
 		$previewFile->method('getSize')->willReturn(1000);
+		$previewFile->method('getName')->willReturn('256-256.png');
 
-		$previewFolder->method('getFile')
-			->with($this->equalTo('256-256.png'))
-			->willReturn($previewFile);
+		$previewFolder->method('getDirectoryListing')
+			->willReturn([$maxPreview, $previewFile]);
 
 		$this->legacyEventDispatcher->expects($this->once())
 			->method('dispatch')
@@ -344,14 +341,12 @@ class GeneratorTest extends \Test\TestCase {
 		$maxPreview->method('getMimeType')
 			->willReturn('image/png');
 
-		$previewFolder->method('getDirectoryListing')
-			->willReturn([$maxPreview]);
-
 		$preview = $this->createMock(ISimpleFile::class);
 		$preview->method('getSize')->willReturn(1000);
-		$previewFolder->method('getFile')
-			->with($this->equalTo('1024-512-crop.png'))
-			->willReturn($preview);
+		$preview->method('getName')->willReturn('1024-512-crop.png');
+
+		$previewFolder->method('getDirectoryListing')
+			->willReturn([$maxPreview, $preview]);
 
 		$this->previewManager->expects($this->never())
 			->method('isMimeSupported');


### PR DESCRIPTION
Superseed #34910

Use directory listing in both functions to gain 25% speed on run where every preview already exist.

I went from "./occ preview:generate-all" from 159 seconds down to 17 seconds on a directory full of images with already generated previews.