### PR TITLE
Filelist:-Deselecting all files checkboxes within cells of encrypted …

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -91,6 +91,11 @@
 				color: var(--color-text-maxcontrast);
 			}
 		}
+		
+		// Deactivates the possiblility to checkmark or click on the encrypted folder
+		tr[data-e2eencrypted="true"] {
+			pointer-events: none;
+		}
 	}
 }
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1271,7 +1271,6 @@
 		_onScroll: function(e) {
 			if (this.$container.scrollTop() + this.$container.height() > this.$el.height() - 300) {
 				this._nextPage(true);
-				this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);	
 			}
 		},
 
@@ -1422,6 +1421,7 @@
 					hidden = false;
 				}
 				tr = this._renderRow(fileData, {updateSummary: false, silent: true, hidden: hidden});
+				this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);	
 				this.$fileList.append(tr);
 				if (isAllSelected || this._selectedFiles[fileData.id]) {
 					tr.addClass('selected');

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -976,6 +976,7 @@
 			// Select only visible checkboxes to filter out unmatched file in search
 			this.$fileList.find('td.selection > .selectCheckBox:visible').prop('checked', checked)
 				.closest('tr').toggleClass('selected', checked);
+			//For prevents the selection of encrypted folders when clicking on the "Select all" checkbox
 			this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);
 
 			if (checked) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -976,7 +976,7 @@
 			// Select only visible checkboxes to filter out unmatched file in search
 			this.$fileList.find('td.selection > .selectCheckBox:visible').prop('checked', checked)
 				.closest('tr').toggleClass('selected', checked);
-			//For prevents the selection of encrypted folders when clicking on the "Select all" checkbox
+			// For prevents the selection of encrypted folders when clicking on the "Select all" checkbox
 			this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);
 
 			if (checked) {
@@ -1271,6 +1271,7 @@
 		_onScroll: function(e) {
 			if (this.$container.scrollTop() + this.$container.height() > this.$el.height() - 300) {
 				this._nextPage(true);
+				this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);	
 			}
 		},
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -976,6 +976,7 @@
 			// Select only visible checkboxes to filter out unmatched file in search
 			this.$fileList.find('td.selection > .selectCheckBox:visible').prop('checked', checked)
 				.closest('tr').toggleClass('selected', checked);
+			this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);
 
 			if (checked) {
 				for (var i = 0; i < this.files.length; i++) {
@@ -984,7 +985,7 @@
 					var fileData = this.files[i];
 					var fileRow = this.$fileList.find('tr[data-id=' + fileData.id + ']');
 					// do not select already selected ones
-					if (!fileRow.hasClass('hidden') && _.isUndefined(this._selectedFiles[fileData.id])) {
+					if (!fileRow.hasClass('hidden') && _.isUndefined(this._selectedFiles[fileData.id]) && (!fileData.isEncrypted)) {
 						this._selectedFiles[fileData.id] = fileData;
 						this._selectionSummary.add(fileData);
 					}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1421,7 +1421,10 @@
 					hidden = false;
 				}
 				tr = this._renderRow(fileData, {updateSummary: false, silent: true, hidden: hidden});
-				this.$fileList.find('tr[data-e2eencrypted="true"]').find('td.selection > .selectCheckBox:visible').prop('checked', false).closest('tr').toggleClass('selected', false);	
+				if (tr.attr('data-e2eencrypted') === 'true') {
+    					tr.toggleClass('selected', false);
+    					tr.find('td.selection > .selectCheckBox:visible').prop('checked', false);
+				}
 				this.$fileList.append(tr);
 				if (isAllSelected || this._selectedFiles[fileData.id]) {
 					tr.addClass('selected');


### PR DESCRIPTION
…folder

Signed-off-by: Kavita Sonawane <kavita.sonawane@t-systems.com>

**Problem statement:** In the File List view the encrypted folder should not get selected when we use **select all** option. If the encrypted folder gets selected the options in **actions** gets compromised. 
To resolve this issue we applied below solution:
After selecting all files in file list we will disable the clickable area for the checkbox within a cells of an encrypted folder.