### PR TITLE
Add test for received share in share_folder

### DIFF
--- a/build/integration/features/bootstrap/SharingContext.php
+++ b/build/integration/features/bootstrap/SharingContext.php
@@ -46,5 +46,7 @@ class SharingContext implements Context, SnippetAcceptingContext {
 		$this->deleteServerConfig('core', 'shareapi_default_expire_date');
 		$this->deleteServerConfig('core', 'shareapi_expire_after_n_days');
 		$this->deleteServerConfig('core', 'link_defaultExpDays');
+
+		$this->runOcc(['config:system:delete', 'share_folder']);
 	}
 }

--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -514,6 +514,20 @@ Feature: sharing
     Then as "user1" the file "/shared/shared_file.txt" exists
     And as "user0" the file "/shared/shared_file.txt" exists
 
+  Scenario: receiving shares into a configured share_folder
+    Given As an "admin"
+    And invoking occ with "config:system:set share_folder --value received_shares"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared_folder"
+    And User "user0" moved file "/textfile0.txt" to "/shared_file.txt"
+    When folder "/shared_folder" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
+    Then as "user1" the file "/received_shares/shared_folder" exists
+    When file "/shared_file.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
+    Then as "user1" the file "/received_shares/shared_file.txt" exists
+
   Scenario: Owner of subshares is adjusted after moving into received share
     Given As an "admin"
     And user "user0" exists


### PR DESCRIPTION
Add integration test for receiving a share in a configured "share_folder".

I noticed that we didn't have any such tests so I added one.

This was mostly in the hope to reproduce this regression: https://github.com/nextcloud/server/issues/34976
But it didn't.

Let's still merge the test for the future.