### PR TITLE
restoring clearCachedConfig()

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -427,4 +427,13 @@ class AppConfig implements IAppConfig {
 
 		$this->configLoaded = true;
 	}
+
+
+	/**
+	 * Clear all the cached app config values
+	 * New cache will be generated next time a config value is retrieved
+	 */
+	public function clearCachedConfig(): void {
+		$this->configLoaded = false;
+	}
 }


### PR DESCRIPTION
restoring clearCachedConfig() that was removed in 25.0.0 with #32261

It can be useful in some use-case when config is edited by a parallel process