### PR TITLE
generate user themed icons

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -86,16 +86,17 @@ class IconController extends Controller {
 	 * @throws \Exception
 	 */
 	public function getThemedIcon(string $app, string $image): Response {
+		$color = $this->themingDefaults->getColorPrimary();
 		try {
-			$iconFile = $this->imageManager->getCachedImage('icon-' . $app . '-' . str_replace('/', '_',$image));
+			$iconFileName = $this->imageManager->getCachedImage('icon-' . $app . '-' . $color . str_replace('/', '_', $image));
 		} catch (NotFoundException $exception) {
 			$icon = $this->iconBuilder->colorSvg($app, $image);
 			if ($icon === false || $icon === '') {
 				return new NotFoundResponse();
 			}
-			$iconFile = $this->imageManager->setCachedImage('icon-' . $app . '-' . str_replace('/', '_',$image), $icon);
+			$iconFileName = $this->imageManager->setCachedImage('icon-' . $app . '-' . $color . str_replace('/', '_', $image),  $icon);
 		}
-		$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/svg+xml']);
+		$response = new FileDisplayResponse($iconFileName, Http::STATUS_OK, ['Content-Type' => 'image/svg+xml']);
 		$response->cacheFor(86400, false, true);
 		return $response;
 	}

--- a/apps/theming/lib/Service/JSDataService.php
+++ b/apps/theming/lib/Service/JSDataService.php
@@ -59,7 +59,7 @@ class JSDataService implements \JsonSerializable {
 			'imprintUrl' => $this->themingDefaults->getImprintUrl(),
 			'privacyUrl' => $this->themingDefaults->getPrivacyUrl(),
 			'inverted' => $this->util->invertTextColor($this->themingDefaults->getColorPrimary()),
-			'cacheBuster' => $this->appConfig->getAppValue(Application::APP_ID, 'cachebuster', '0'),
+			'cacheBuster' => $this->util->getCacheBuster(),
 			'enabledThemes' => $this->themesService->getEnabledThemes(),
 		];
 	}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -420,7 +420,7 @@ class ThemingDefaults extends \OC_Defaults {
 		}
 
 		if ($route) {
-			return $route . '?v=' . $cacheBusterValue;
+			return $route . '?v=' . $this->util->getCacheBuster();
 		}
 
 		return false;

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -34,6 +34,7 @@ use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
+use OCP\IUserSession;
 use Mexitek\PHPColors\Color;
 
 class Util {
@@ -265,5 +266,21 @@ class Util {
 	public function isLogoThemed() {
 		return $this->imageManager->hasImage('logo')
 			|| $this->imageManager->hasImage('logoheader');
+	}
+
+	public function getCacheBuster(): string {
+		$userSession = \OC::$server->get(IUserSession::class);
+		$userId = '';
+		$user = $userSession->getUser();
+		if (!is_null($user)) {
+			$userId = $user->getUID();
+		}
+		$userCacheBuster = '';
+		if ($userId) {
+			$userCacheBusterValue = (int)$this->config->getUserValue($userId, 'theming', 'userCacheBuster', '0');
+			$userCacheBuster = $userId . '_' . $userCacheBusterValue;
+		}
+		$systemCacheBuster = $this->config->getAppValue('theming', 'cachebuster', '0');
+		return substr(sha1($userCacheBuster . $systemCacheBuster), 0, 8);
 	}
 }

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -868,7 +868,7 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	/** @dataProvider dataReplaceImagePath */
-	public function testReplaceImagePath($app, $image, $result = 'themingRoute?v=0') {
+	public function testReplaceImagePath($app, $image, $result = 'themingRoute?v=1234abcd') {
 		$this->cache->expects($this->any())
 			->method('get')
 			->with('shouldReplaceIcons')
@@ -882,6 +882,12 @@ class ThemingDefaultsTest extends TestCase {
 			->expects($this->any())
 			->method('linkToRoute')
 			->willReturn('themingRoute');
+		if ($result) {
+			$this->util
+				->expects($this->once())
+				->method('getCacheBuster')
+				->willReturn('1234abcd');
+		}
 		$this->assertEquals($result, $this->template->replaceImagePath($app, $image));
 	}
 }


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/34654

Signed-off-by: Simon L <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
--name nextcloud-easy-test \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.24.128 \
-e SERVER_BRANCH=enh/34654/try-go-generate-user-themed-icons \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>