### PR TITLE
[stable25] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 /lib/public/Profiler               @CarlSchwan
 
 # Security team
-resources/config/ca-bundle.crt    @ChristophWurst @eneiluj @miaulalala @nickvergessen
+resources/config/ca-bundle.crt    @ChristophWurst @julien-nc @miaulalala @nickvergessen


### PR DESCRIPTION
Signed-off-by: Joas Schilling <213943+nickvergessen@users.noreply.github.com>