### PR TITLE
fix s3 directory copy

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -608,9 +608,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			}
 
 			foreach ($this->getDirectoryContent($source) as $item) {
-				$source = $source . '/' . $item['name'];
-				$target = $target . '/' . $item['name'];
-				$this->copy($source, $target, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER);
+				$childSource = $source . '/' . $item['name'];
+				$childTarget = $target . '/' . $item['name'];
+				$this->copy($childSource, $childTarget, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER);
 			}
 		}
 


### PR DESCRIPTION
Fix overwriting the `$source` and `$target` variables which was introduced with https://github.com/nextcloud/server/pull/34624