### PR TITLE
Fix github action "performance-8.0" when PR is from a fork.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -51,8 +51,9 @@ jobs:
 
       - name: Apply PR
         run: |
-          git fetch origin ${{ github.event.pull_request.head.ref }}
-          git checkout ${{ github.event.pull_request.head.ref }}
+          git remote add pr ${{ github.event.pull_request.head.repo.clone_url }}
+          git fetch pr ${{ github.event.pull_request.head.ref }}
+          git checkout -b pr/${{ github.event.pull_request.head.ref }}
           git submodule update
 
           ./occ upgrade


### PR DESCRIPTION
I noticed in another PR of mine that the `performance-8.0` test was failing, where it was passing for many other PRs. On inspection, there were others PRs where this failed, and all of them were where the PR came from a fork rather than a branch in this repo.

This is because there is an assumption in the workflow that the PR is from the same origin as the base it is being merged into. This is fixed so that instead of doing a `git fetch origin`, it now fetches from the `clone_url` of the PR head.

Subsequent to fetching commits from that repository, it then clones based on sha1 instead of branch name. This is because we didn't name the remote when performing a fetch, so can't use the syntax `remote-name/ref` (e.g. "myusername/fix-issue-12").

We could equally go and add a remote before fetching, then fetch from that remote (e.g `git add remote head ...` && `git fetch head`) which would then let us `git merge head/${{ ref }}` - it doesn't really matter which way we do it.