### PR TITLE
Default Jpeg quality to 80

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -415,7 +415,7 @@ class OC_Image implements \OCP\IImage {
 	 * @return int|null
 	 */
 	protected function getJpegQuality() {
-		$quality = $this->config->getAppValue('preview', 'jpeg_quality', 80);
+		$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
 		if ($quality !== null) {
 			$quality = min(100, max(10, (int) $quality));
 		}

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -415,7 +415,7 @@ class OC_Image implements \OCP\IImage {
 	 * @return int|null
 	 */
 	protected function getJpegQuality() {
-		$quality = $this->config->getAppValue('preview', 'jpeg_quality', 90);
+		$quality = $this->config->getAppValue('preview', 'jpeg_quality', 80);
 		if ($quality !== null) {
 			$quality = min(100, max(10, (int) $quality));
 		}

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -140,7 +140,7 @@ class ImageTest extends \Test\TestCase {
 		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getAppValue')
-			->with('preview', 'jpeg_quality', 80)
+			->with('preview', 'jpeg_quality', '80')
 			->willReturn(null);
 		$config->expects($this->once())
 			->method('getSystemValueInt')

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -140,7 +140,7 @@ class ImageTest extends \Test\TestCase {
 		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getAppValue')
-			->with('preview', 'jpeg_quality', 90)
+			->with('preview', 'jpeg_quality', 80)
 			->willReturn(null);
 		$config->expects($this->once())
 			->method('getSystemValueInt')


### PR DESCRIPTION
See https://sirv.com/help/articles/jpeg-quality-comparison/
Almost 50% of file size (compared to 90) and no visual differences.

In very big instances, this is a big deal.

Signed-off-by: Git'Fellow <12234510+solracsf@users.noreply.github.com>