### PR TITLE
delay updating setup providers untill we register the mounts

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -40,6 +40,7 @@ use OC_Util;
 use OCP\Constants;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IHomeMountProvider;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IUserMountCache;
@@ -414,9 +415,9 @@ class SetupManager {
 
 		$mounts = [];
 		if (!in_array($cachedMount->getMountProvider(), $setupProviders)) {
-			$setupProviders[] = $cachedMount->getMountProvider();
 			$currentProviders[] = $cachedMount->getMountProvider();
 			if ($cachedMount->getMountProvider()) {
+				$setupProviders[] = $cachedMount->getMountProvider();
 				$mounts = $this->mountProviderCollection->getUserMountsForProviderClasses($user, [$cachedMount->getMountProvider()]);
 			} else {
 				$this->logger->debug("mount at " . $cachedMount->getMountPoint() . " has no provider set, performing full setup");
@@ -427,16 +428,21 @@ class SetupManager {
 
 		if ($includeChildren) {
 			$subCachedMounts = $this->userMountCache->getMountsInPath($user, $path);
-			foreach ($subCachedMounts as $cachedMount) {
-				if (!in_array($cachedMount->getMountProvider(), $setupProviders)) {
-					$setupProviders[] = $cachedMount->getMountProvider();
-					$currentProviders[] = $cachedMount->getMountProvider();
-					if ($cachedMount->getMountProvider()) {
+
+			$needsFullSetup = array_reduce($subCachedMounts, function (bool $needsFullSetup, ICachedMountInfo $cachedMountInfo) {
+				return $needsFullSetup || $cachedMountInfo->getMountProvider() === '';
+			}, false);
+
+			if ($needsFullSetup) {
+				$this->logger->debug("mount has no provider set, performing full setup");
+				$this->setupForUser($user);
+				return;
+			} else {
+				foreach ($subCachedMounts as $cachedMount) {
+					if (!in_array($cachedMount->getMountProvider(), $setupProviders)) {
+						$currentProviders[] = $cachedMount->getMountProvider();
+						$setupProviders[] = $cachedMount->getMountProvider();
 						$mounts = array_merge($mounts, $this->mountProviderCollection->getUserMountsForProviderClasses($user, [$cachedMount->getMountProvider()]));
-					} else {
-						$this->logger->debug("mount at " . $cachedMount->getMountPoint() . " has no provider set, performing full setup");
-						$this->setupForUser($user);
-						return;
 					}
 				}
 			}


### PR DESCRIPTION
otherwise the fallback to a full setup for a missing cached mount provider will lead to a race condition

Signed-off-by: Robin Appelman <robin@icewind.nl>

Fix https://github.com/nextcloud/server/issues/34752#