### PR TITLE
Smaller performance optimizations

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -594,6 +594,7 @@ class OC {
 
 		// Add default composer PSR-4 autoloader
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
+		self::$composerAutoloader->setApcuPrefix('composer_autoload');
 
 		try {
 			self::initPaths();

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -79,6 +79,7 @@ use Psr\Log\LoggerInterface;
  * @deprecated 20.0.0
  */
 class DIContainer extends SimpleContainer implements IAppContainer {
+	private string $appName;
 
 	/**
 	 * @var array
@@ -94,8 +95,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @param array $urlParams
 	 * @param ServerContainer|null $server
 	 */
-	public function __construct($appName, $urlParams = [], ServerContainer $server = null) {
+	public function __construct(string $appName, array $urlParams = [], ServerContainer $server = null) {
 		parent::__construct();
+		$this->appName = $appName;
 		$this['appName'] = $appName;
 		$this['urlParams'] = $urlParams;
 
@@ -437,6 +439,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	}
 
 	public function query(string $name, bool $autoload = true) {
+		if ($name === 'AppName' || $name === 'appName') {
+			return $this->appName;
+		}
 		try {
 			return $this->queryNoFallback($name);
 		} catch (QueryException $firstException) {
@@ -461,11 +466,11 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		if ($this->offsetExists($name)) {
 			return parent::query($name);
-		} elseif ($this['AppName'] === 'settings' && strpos($name, 'OC\\Settings\\') === 0) {
+		} elseif ($this->appName === 'settings' && strpos($name, 'OC\\Settings\\') === 0) {
 			return parent::query($name);
-		} elseif ($this['AppName'] === 'core' && strpos($name, 'OC\\Core\\') === 0) {
+		} elseif ($this->appName === 'core' && strpos($name, 'OC\\Core\\') === 0) {
 			return parent::query($name);
-		} elseif (strpos($name, \OC\AppFramework\App::buildAppNamespace($this['AppName']) . '\\') === 0) {
+		} elseif (strpos($name, \OC\AppFramework\App::buildAppNamespace($this->appName) . '\\') === 0) {
 			return parent::query($name);
 		}
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -442,6 +442,12 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		if ($name === 'AppName' || $name === 'appName') {
 			return $this->appName;
 		}
+
+		$isServerClass = str_starts_with($name, 'OCP\\') || str_starts_with($name, 'OC\\');
+		if ($isServerClass && !$this->has($name)) {
+			return $this->getServer()->query($name, $autoload);
+		}
+
 		try {
 			return $this->queryNoFallback($name);
 		} catch (QueryException $firstException) {

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -472,11 +472,11 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		if ($this->offsetExists($name)) {
 			return parent::query($name);
-		} elseif ($this->appName === 'settings' && strpos($name, 'OC\\Settings\\') === 0) {
+		} elseif ($this->appName === 'settings' && str_starts_with($name, 'OC\\Settings\\')) {
 			return parent::query($name);
-		} elseif ($this->appName === 'core' && strpos($name, 'OC\\Core\\') === 0) {
+		} elseif ($this->appName === 'core' && str_starts_with($name, 'OC\\Core\\')) {
 			return parent::query($name);
-		} elseif (strpos($name, \OC\AppFramework\App::buildAppNamespace($this->appName) . '\\') === 0) {
+		} elseif (str_starts_with($name, \OC\AppFramework\App::buildAppNamespace($this->appName) . '\\')) {
 			return parent::query($name);
 		}
 

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -40,6 +40,8 @@ declare(strict_types=1);
 
 namespace OC\L10N;
 
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUser;
@@ -94,7 +96,9 @@ class Factory implements IFactory {
 	protected $request;
 
 	/** @var IUserSession */
-	protected $userSession;
+	protected IUserSession $userSession;
+
+	private ICache $cache;
 
 	/** @var string */
 	protected $serverRoot;
@@ -109,11 +113,13 @@ class Factory implements IFactory {
 		IConfig $config,
 		IRequest $request,
 		IUserSession $userSession,
+		ICacheFactory $cacheFactory,
 		$serverRoot
 	) {
 		$this->config = $config;
 		$this->request = $request;
 		$this->userSession = $userSession;
+		$this->cache = $cacheFactory->createLocal('L10NFactory');
 		$this->serverRoot = $serverRoot;
 	}
 
@@ -338,6 +344,10 @@ class Factory implements IFactory {
 			$key = 'null';
 		}
 
+		if ($availableLanguages = $this->cache->get($key)) {
+			$this->availableLanguages[$key] = $availableLanguages;
+		}
+
 		// also works with null as key
 		if (!empty($this->availableLanguages[$key])) {
 			return $this->availableLanguages[$key];
@@ -374,6 +384,7 @@ class Factory implements IFactory {
 		}
 
 		$this->availableLanguages[$key] = $available;
+		$this->cache->set($key, $available, 60);
 		return $available;
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -688,6 +688,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(\OCP\IConfig::class),
 				$c->getRequest(),
 				$c->get(IUserSession::class),
+				$c->get(ICacheFactory::class),
 				\OC::$SERVERROOT
 			);
 		});

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -139,10 +139,13 @@ class ServerContainer extends SimpleContainer {
 	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
 
-		try {
-			return parent::query($name, false);
-		} catch (QueryException $e) {
-			// Continue with general autoloading then
+		if (strpos($name, 'OCA\\') !== 0) {
+			// Skip server container query for app namespace classes
+			try {
+				return parent::query($name, false);
+			} catch (QueryException $e) {
+				// Continue with general autoloading then
+			}
 		}
 
 		// In case the service starts with OCA\ we try to find the service in

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -139,7 +139,7 @@ class ServerContainer extends SimpleContainer {
 	public function query(string $name, bool $autoload = true) {
 		$name = $this->sanitizeName($name);
 
-		if (strpos($name, 'OCA\\') !== 0) {
+		if (str_starts_with($name, 'OCA\\')) {
 			// Skip server container query for app namespace classes
 			try {
 				return parent::query($name, false);

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -34,14 +34,8 @@ namespace OC\Template;
 use Psr\Log\LoggerInterface;
 
 class CSSResourceLocator extends ResourceLocator {
-
-	/**
-	 * @param string $theme
-	 * @param array $core_map
-	 * @param array $party_map
-	 */
-	public function __construct(LoggerInterface $logger, $theme, $core_map, $party_map) {
-		parent::__construct($logger, $theme, $core_map, $party_map);
+	public function __construct(LoggerInterface $logger) {
+		parent::__construct($logger);
 	}
 
 	/**

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -44,8 +44,7 @@ class CSSResourceLocator extends ResourceLocator {
 	public function doFind($style) {
 		$app = substr($style, 0, strpos($style, '/'));
 		if (strpos($style, '3rdparty') === 0
-			&& $this->appendIfExist($this->thirdpartyroot, $style.'.css')
-			|| $this->appendIfExist($this->serverroot, $style.'.css')
+			&& $this->appendIfExist($this->serverroot, $style.'.css')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$style.'.css')
 		) {
 			return;

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -34,8 +34,8 @@ class JSResourceLocator extends ResourceLocator {
 	/** @var JSCombiner */
 	protected $jsCombiner;
 
-	public function __construct(LoggerInterface $logger, $theme, array $core_map, array $party_map, JSCombiner $JSCombiner) {
-		parent::__construct($logger, $theme, $core_map, $party_map);
+	public function __construct(LoggerInterface $logger, JSCombiner $JSCombiner) {
+		parent::__construct($logger);
 
 		$this->jsCombiner = $JSCombiner;
 	}

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -45,10 +45,6 @@ class JSResourceLocator extends ResourceLocator {
 	 */
 	public function doFind($script) {
 		$theme_dir = 'themes/'.$this->theme.'/';
-		if (strpos($script, '3rdparty') === 0
-			&& $this->appendIfExist($this->thirdpartyroot, $script.'.js')) {
-			return;
-		}
 
 		// Extracting the appId and the script file name
 		$app = substr($script, 0, strpos($script, '/'));

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -43,18 +43,15 @@ abstract class ResourceLocator {
 
 	protected LoggerInterface $logger;
 
-	/**
-	 * @param string $theme
-	 * @param array $core_map
-	 * @param array $party_map
-	 */
-	public function __construct(LoggerInterface $logger, $theme, $core_map, $party_map) {
+	public function __construct(LoggerInterface $logger) {
 		$this->logger = $logger;
-		$this->theme = $theme;
-		$this->mapping = $core_map + $party_map;
-		$this->serverroot = key($core_map);
-		$this->thirdpartyroot = key($party_map);
+		$this->mapping = [
+			\OC::$SERVERROOT => \OC::$WEBROOT
+		];
+		$this->serverroot = \OC::$SERVERROOT;
+		$this->thirdpartyroot = \OC::$SERVERROOT;
 		$this->webroot = $this->mapping[$this->serverroot];
+		$this->theme = \OC_Util::getTheme();
 	}
 
 	/**

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -36,7 +36,6 @@ abstract class ResourceLocator {
 
 	protected $mapping;
 	protected $serverroot;
-	protected $thirdpartyroot;
 	protected $webroot;
 
 	protected $resources = [];
@@ -49,8 +48,7 @@ abstract class ResourceLocator {
 			\OC::$SERVERROOT => \OC::$WEBROOT
 		];
 		$this->serverroot = \OC::$SERVERROOT;
-		$this->thirdpartyroot = \OC::$SERVERROOT;
-		$this->webroot = $this->mapping[$this->serverroot];
+		$this->webroot = \OC::$WEBROOT;
 		$this->theme = \OC_Util::getTheme();
 	}
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -44,8 +44,9 @@ namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Search\SearchQuery;
-use OC\Template\JSCombiner;
+use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;
+use OC\Template\JSResourceLocator;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -54,10 +55,15 @@ use OCP\INavigationManager;
 use OCP\IUserSession;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
-use Psr\Log\LoggerInterface;
 
 class TemplateLayout extends \OC_Template {
 	private static $versionHash = '';
+
+	/** @var CSSResourceLocator|null */
+	public static $cssLocator = null;
+
+	/** @var JSResourceLocator|null */
+	public static $jsLocator = null;
 
 	/** @var IConfig */
 	private $config;
@@ -332,17 +338,11 @@ class TemplateLayout extends \OC_Template {
 	 * @return array
 	 */
 	public static function findStylesheetFiles($styles, $compileScss = true) {
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
-
-		$locator = new \OC\Template\CSSResourceLocator(
-			\OC::$server->get(LoggerInterface::class),
-			$theme,
-			[ \OC::$SERVERROOT => \OC::$WEBROOT ],
-			[ \OC::$SERVERROOT => \OC::$WEBROOT ],
-		);
-		$locator->find($styles);
-		return $locator->getResources();
+		if (!self::$cssLocator) {
+			self::$cssLocator = \OCP\Server::get(CSSResourceLocator::class);
+		}
+		self::$cssLocator->find($styles);
+		return self::$cssLocator->getResources();
 	}
 
 	/**
@@ -366,18 +366,11 @@ class TemplateLayout extends \OC_Template {
 	 * @return array
 	 */
 	public static function findJavascriptFiles($scripts) {
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
-
-		$locator = new \OC\Template\JSResourceLocator(
-			\OC::$server->get(LoggerInterface::class),
-			$theme,
-			[ \OC::$SERVERROOT => \OC::$WEBROOT ],
-			[ \OC::$SERVERROOT => \OC::$WEBROOT ],
-			\OC::$server->query(JSCombiner::class)
-			);
-		$locator->find($scripts);
-		return $locator->getResources();
+		if (!self::$jsLocator) {
+			self::$jsLocator = \OCP\Server::get(JSResourceLocator::class);
+		}
+		self::$jsLocator->find($scripts);
+		return self::$jsLocator->getResources();
 	}
 
 	/**

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -13,6 +13,7 @@ namespace Test\L10N;
 
 use OC\L10N\Factory;
 use OC\L10N\LanguageNotFoundException;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUser;
@@ -32,6 +33,9 @@ class FactoryTest extends TestCase {
 	/** @var IUserSession|MockObject */
 	protected $userSession;
 
+	/** @var ICacheFactory|MockObject */
+	protected $cacheFactory;
+
 	/** @var string */
 	protected $serverRoot;
 
@@ -41,6 +45,7 @@ class FactoryTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 
 		$this->serverRoot = \OC::$SERVERROOT;
 	}
@@ -64,13 +69,14 @@ class FactoryTest extends TestCase {
 					$this->config,
 					$this->request,
 					$this->userSession,
+					$this->cacheFactory,
 					$this->serverRoot,
 				])
 				->setMethods($methods)
 				->getMock();
 		}
 
-		return new Factory($this->config, $this->request, $this->userSession, $this->serverRoot);
+		return new Factory($this->config, $this->request, $this->userSession, $this->cacheFactory, $this->serverRoot);
 	}
 
 	public function dataFindAvailableLanguages(): array {

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -11,6 +11,7 @@ namespace Test\L10N;
 use DateTime;
 use OC\L10N\Factory;
 use OC\L10N\L10N;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -32,7 +33,8 @@ class L10nTest extends TestCase {
 		$request = $this->createMock(IRequest::class);
 		/** @var IUserSession $userSession */
 		$userSession = $this->createMock(IUserSession::class);
-		return new Factory($config, $request, $userSession, \OC::$SERVERROOT);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		return new Factory($config, $request, $userSession, $cacheFactory, \OC::$SERVERROOT);
 	}
 
 	public function testSimpleTranslationWithTrailingColon(): void {

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -63,9 +63,6 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		);
 		return new JSResourceLocator(
 			$this->logger,
-			'theme',
-			['core' => 'map'],
-			['3rd' => 'party'],
 			$jsCombiner
 		);
 	}


### PR DESCRIPTION
This is a collection of smaller performance improvements in different areas that I've found when looking at some profiles in regards to class loading, dependency injection and server initialization. The commit messages contain more details about the individual changes.

- Avoid container dance for appName
- Skip querying the app container for server namespace
- Take some shortcut when setting up the application class
- Use single resource locator instance
- Set apcu prefix for composer
- Cache available languages locally

https://blackfire.io/profiles/compare/b5552647-5f7f-4848-93c7-862084400a89/graph for comparison

While the changes itself are rather small optimizations in total they contribute quite a bit to the overall CPU time, especially since some of the calls depend on the number of enabled apps.

![Screenshot 2022-11-17 at 12 07 42](https://user-images.githubusercontent.com/3404133/202430686-c5d2d692-583c-4cdd-b39d-ca194b18b38e.png)
