### PR TITLE
Do not auto merge package-lock.json, but treat as text file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 /dist/* binary
-/package-lock.json binary
+/package-lock.json merge=binary


### PR DESCRIPTION
If package-lock is specified to be a binary file, it becomes impossible to diff any changes. Since we only want to prevent git from merging changes in the lockfile, we can be more specific and tell it that binary handling is only required as merge strategy.

Based on the discussion at https://github.com/nextcloud/server/pull/30714#issuecomment-1318466355.