### PR TITLE
Only setup redis connection if needed

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -33,20 +33,28 @@ use OCP\IMemcacheTTL;
 
 class Redis extends Cache implements IMemcacheTTL {
 	/**
-	 * @var \Redis $cache
+	 * @var \Redis|\RedisCluster $cache
 	 */
 	private static $cache = null;
 
 	public function __construct($prefix = '', string $logFile = '') {
 		parent::__construct($prefix);
+	}
+
+	/**
+	 * @return \Redis|\RedisCluster|null
+	 * @throws \Exception
+	 */
+	public function getCache() {
 		if (is_null(self::$cache)) {
 			self::$cache = \OC::$server->getGetRedisFactory()->getInstance();
 		}
+		return self::$cache;
 	}
 
 	public function get($key) {
-		$result = self::$cache->get($this->getPrefix() . $key);
-		if ($result === false && !self::$cache->exists($this->getPrefix() . $key)) {
+		$result = $this->getCache()->get($this->getPrefix() . $key);
+		if ($result === false && !$this->getCache()->exists($this->getPrefix() . $key)) {
 			return null;
 		} else {
 			return json_decode($result, true);
@@ -55,18 +63,18 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	public function set($key, $value, $ttl = 0) {
 		if ($ttl > 0) {
-			return self::$cache->setex($this->getPrefix() . $key, $ttl, json_encode($value));
+			return $this->getCache()->setex($this->getPrefix() . $key, $ttl, json_encode($value));
 		} else {
-			return self::$cache->set($this->getPrefix() . $key, json_encode($value));
+			return $this->getCache()->set($this->getPrefix() . $key, json_encode($value));
 		}
 	}
 
 	public function hasKey($key) {
-		return (bool)self::$cache->exists($this->getPrefix() . $key);
+		return (bool)$this->getCache()->exists($this->getPrefix() . $key);
 	}
 
 	public function remove($key) {
-		if (self::$cache->del($this->getPrefix() . $key)) {
+		if ($this->getCache()->del($this->getPrefix() . $key)) {
 			return true;
 		} else {
 			return false;
@@ -75,8 +83,8 @@ class Redis extends Cache implements IMemcacheTTL {
 
 	public function clear($prefix = '') {
 		$prefix = $this->getPrefix() . $prefix . '*';
-		$keys = self::$cache->keys($prefix);
-		$deleted = self::$cache->del($keys);
+		$keys = $this->getCache()->keys($prefix);
+		$deleted = $this->getCache()->del($keys);
 
 		return (is_array($keys) && (count($keys) === $deleted));
 	}
@@ -100,7 +108,7 @@ class Redis extends Cache implements IMemcacheTTL {
 			$args['ex'] = $ttl;
 		}
 
-		return self::$cache->set($this->getPrefix() . $key, $value, $args);
+		return $this->getCache()->set($this->getPrefix() . $key, (string)$value, $args);
 	}
 
 	/**
@@ -111,7 +119,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	 * @return int | bool
 	 */
 	public function inc($key, $step = 1) {
-		return self::$cache->incrBy($this->getPrefix() . $key, $step);
+		return $this->getCache()->incrBy($this->getPrefix() . $key, $step);
 	}
 
 	/**
@@ -125,7 +133,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		if (!$this->hasKey($key)) {
 			return false;
 		}
-		return self::$cache->decrBy($this->getPrefix() . $key, $step);
+		return $this->getCache()->decrBy($this->getPrefix() . $key, $step);
 	}
 
 	/**
@@ -140,14 +148,14 @@ class Redis extends Cache implements IMemcacheTTL {
 		if (!is_int($new)) {
 			$new = json_encode($new);
 		}
-		self::$cache->watch($this->getPrefix() . $key);
+		$this->getCache()->watch($this->getPrefix() . $key);
 		if ($this->get($key) === $old) {
-			$result = self::$cache->multi()
+			$result = $this->getCache()->multi()
 				->set($this->getPrefix() . $key, $new)
 				->exec();
 			return $result !== false;
 		}
-		self::$cache->unwatch();
+		$this->getCache()->unwatch();
 		return false;
 	}
 
@@ -159,19 +167,19 @@ class Redis extends Cache implements IMemcacheTTL {
 	 * @return bool
 	 */
 	public function cad($key, $old) {
-		self::$cache->watch($this->getPrefix() . $key);
+		$this->getCache()->watch($this->getPrefix() . $key);
 		if ($this->get($key) === $old) {
-			$result = self::$cache->multi()
+			$result = $this->getCache()->multi()
 				->del($this->getPrefix() . $key)
 				->exec();
 			return $result !== false;
 		}
-		self::$cache->unwatch();
+		$this->getCache()->unwatch();
 		return false;
 	}
 
 	public function setTTL($key, $ttl) {
-		self::$cache->expire($this->getPrefix() . $key, $ttl);
+		$this->getCache()->expire($this->getPrefix() . $key, $ttl);
 	}
 
 	public static function isAvailable(): bool {


### PR DESCRIPTION
Defer redis connections until they are actually required. This can be especially useful if APCu is used on single instance setups and Redis is only used for locking.
