### PR TITLE
[stable24] Properly compare quota against both float/int values

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -227,7 +227,7 @@ class Quota extends Wrapper {
 
 	public function mkdir($path) {
 		$free = $this->free_space($path);
-		if ($this->shouldApplyQuota($path) && $free === 0.0) {
+		if ($this->shouldApplyQuota($path) && $free == 0) {
 			return false;
 		}
 
@@ -236,7 +236,7 @@ class Quota extends Wrapper {
 
 	public function touch($path, $mtime = null) {
 		$free = $this->free_space($path);
-		if ($free === 0.0) {
+		if ($free == 0) {
 			return false;
 		}
 


### PR DESCRIPTION
free_space may return an integer value instead of a float if the user has their quota set to 0.

Without this change users without quota were still able to touch empty files and create directories.

On master/stable25 this change was already introduced by https://github.com/nextcloud/server/pull/33600/files#diff-b89bc6bd7d5336d68032bb5a5c1f309df16f27173f9f58d9f338ec495d3f951bL230
