### PR TITLE
[stable25] Fix default theming variables

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -55,6 +55,7 @@
   --background-invert-if-bright: invert(100%);
   --background-image-invert-if-bright: no;
   --image-background: url('/core/img/app-background.jpg');
+  --image-background-default: url('/core/img/app-background.jpg');
   --color-background-plain: #0082c9;
   --primary-invert-if-bright: no;
   --color-primary: #00639a;
@@ -66,6 +67,7 @@
   --color-primary-light-hover: #dbe4e9;
   --color-primary-text-dark: #ededed;
   --color-primary-element: #00639a;
+  --color-primary-element-default-hover: #329bd3;
   --color-primary-element-text: #ffffff;
   --color-primary-element-hover: #3282ae;
   --color-primary-element-light: #e5eff4;

--- a/apps/theming/css/settings-admin.css
+++ b/apps/theming/css/settings-admin.css
@@ -98,7 +98,7 @@
   margin-bottom: 20px;
   cursor: pointer;
   background-color: var(--color-primary-default);
-  background-image: var(--image-background, var(--image-background-plain, url("../../../core/img/app-background.jpg"), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
+  background-image: var(--image-background-default, var(--image-background-plain, url("../../../core/img/app-background.jpg"), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
 }
 #theming #theming-preview #theming-preview-logo {
   cursor: pointer;

--- a/apps/theming/css/settings-admin.scss
+++ b/apps/theming/css/settings-admin.scss
@@ -112,7 +112,7 @@
         margin-bottom: 20px;
         cursor: pointer;
         background-color: var(--color-primary-default);
-        background-image: var(--image-background, var(--image-background-plain, url('../../../core/img/app-background.jpg'), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
+        background-image: var(--image-background-default, var(--image-background-plain, url('../../../core/img/app-background.jpg'), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
 
         #theming-preview-logo {
             cursor: pointer;

--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -40,6 +40,7 @@ trait CommonThemeTrait {
 	protected function generatePrimaryVariables(string $colorMainBackground, string $colorMainText): array {
 		$colorPrimaryLight = $this->util->mix($this->primaryColor, $colorMainBackground, -80);
 		$colorPrimaryElement = $this->util->elementColor($this->primaryColor);
+		$colorPrimaryElementDefault = $this->util->elementColor($this->defaultPrimaryColor);
 		$colorPrimaryElementLight = $this->util->mix($colorPrimaryElement, $colorMainBackground, -80);
 
 		// primary related colours
@@ -64,6 +65,7 @@ trait CommonThemeTrait {
 
 			// used for buttons, inputs...
 			'--color-primary-element' => $colorPrimaryElement,
+			'--color-primary-element-default-hover' => $this->util->mix($colorPrimaryElementDefault, $colorMainBackground, 60),
 			'--color-primary-element-text' => $this->util->invertTextColor($colorPrimaryElement) ? '#000000' : '#ffffff',
 			'--color-primary-element-hover' => $this->util->mix($colorPrimaryElement, $colorMainBackground, 60),
 			'--color-primary-element-light' => $colorPrimaryElementLight,
@@ -80,6 +82,7 @@ trait CommonThemeTrait {
 	 * Generate admin theming background-related variables
 	 */
 	protected function generateGlobalBackgroundVariables(): array {
+		$user = $this->userSession->getUser();
 		$backgroundDeleted = $this->config->getAppValue(Application::APP_ID, 'backgroundMime', '') === 'backgroundColor';
 		$hasCustomLogoHeader = $this->util->isLogoThemed();
 
@@ -87,9 +90,11 @@ trait CommonThemeTrait {
 
 		// If primary as background has been request or if we have a custom primary colour
 		// let's not define the background image
-		if ($backgroundDeleted && $this->themingDefaults->isUserThemingDisabled()) {
-			$variables['--image-background-plain'] = 'true';
+		if ($backgroundDeleted) {
 			$variables['--color-background-plain'] = $this->themingDefaults->getColorPrimary();
+			if ($this->themingDefaults->isUserThemingDisabled() || $user === null) {
+				$variables['--image-background-plain'] = 'true';
+			}
 		}
 
 		// Register image variables only if custom-defined
@@ -99,9 +104,11 @@ trait CommonThemeTrait {
 				if ($image === 'background') {
 					// If background deleted is set, ignoring variable
 					if ($backgroundDeleted) {
+						$variables['--image-background-default'] = 'no';
 						continue;
 					}
 					$variables['--image-background-size'] = 'cover';
+					$variables['--image-background-default'] = "url('" . $imageUrl . "')";
 				}
 				$variables["--image-$image"] = "url('" . $imageUrl . "')";
 			}

--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -104,6 +104,12 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 			.menutoggle {
 				opacity: 1 !important;
 			}
+			#app-navigation {
+				border-right: 1px solid var(--color-border);
+			}
+			div.crumb {
+				filter: brightness(150%);
+			}
 		";
 	}
 }

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -193,6 +193,7 @@ class DefaultTheme implements ITheme {
 
 			// Default last fallback values
 			'--image-background' => "url('" . $this->urlGenerator->imagePath('core', 'app-background.jpg') . "')",
+			'--image-background-default' => "url('" . $this->urlGenerator->imagePath('core', 'app-background.jpg') . "')",
 			'--color-background-plain' => $this->defaultPrimaryColor,
 		];
 

--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -104,6 +104,9 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 			.menutoggle {
 				opacity: 1 !important;
 			}
+			#app-navigation {
+				border-right: 1px solid var(--color-border);
+			}
 		";
 	}
 }

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -477,7 +477,7 @@ class ThemingDefaults extends \OC_Defaults {
 				$returnValue = $this->getSlogan();
 				break;
 			case 'color':
-				$returnValue = $this->getColorPrimary();
+				$returnValue = $this->getDefaultColorPrimary();
 				break;
 			case 'logo':
 			case 'logoheader':

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -623,16 +623,14 @@ class ThemingDefaultsTest extends TestCase {
 			->method('deleteAppValue')
 			->with('theming', 'color');
 		$this->config
-			->expects($this->exactly(3))
+			->expects($this->exactly(2))
 			->method('getAppValue')
 			->withConsecutive(
 				['theming', 'cachebuster', '0'],
 				['theming', 'color', null],
-				['theming', 'disable-user-theming', 'no'],
 			)->willReturnOnConsecutiveCalls(
 				'15',
 				$this->defaults->getColorPrimary(),
-				'no',
 			);
 		$this->config
 			->expects($this->once())

--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -23,8 +23,8 @@ body {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 	color: var(--color-text);
 	text-align: center;
-	background-color: var(--color-main-background-not-plain, var(--color-primary));
-	background-image: var(--image-background, var(--image-background-plain, url('../../../core/img/app-background.jpg'), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
+	background-color: var(--color-primary-default, var(--color-primary));
+	background-image: var(--image-background-plain, var(--image-background, url('../../../core/img/app-background.jpg'), linear-gradient(40deg, #0082c9 0%, #30b6ff 100%)));
     background-attachment: fixed;
 	min-height: 100%; /* fix sticky footer */
 	height: auto;


### PR DESCRIPTION
@Pytal fixed part of it in the vue migration: https://github.com/nextcloud/server/pull/34359

Here is a pick of the fixes only without vue

Fix https://github.com/nextcloud/server/issues/34968
Fix https://github.com/nextcloud/server/issues/35002
Fix reverting default admin colour using user primary instead of default Nextcloud colour
