### PR TITLE
Allow setting default location for weather widget

### DIFF
--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -287,9 +287,9 @@ class WeatherStatusService {
 	 * @return WeatherStatusLocationWithMode which contains coordinates, formatted address and current weather status mode
 	 */
 	public function getLocation(): array {
-		$lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', '');
-		$lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', '');
-		$address = $this->config->getUserValue($this->userId, Application::APP_ID, 'address', '');
+        $lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', $this->config->getAppValue(Application::APP_ID, 'lat', ''));
+        $lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', $this->config->getAppValue(Application::APP_ID, 'lat', ''));
+        $address = $this->config->getUserValue($this->userId, Application::APP_ID, 'address', $this->config->getAppValue(Application::APP_ID, 'address', ''));
 		$mode = $this->config->getUserValue($this->userId, Application::APP_ID, 'mode', self::MODE_MANUAL_LOCATION);
 		return [
 			'lat' => $lat,
@@ -305,9 +305,9 @@ class WeatherStatusService {
 	 * @return WeatherStatusForecast[]|array{error: string}|WeatherStatusSuccess which contains success state and filtered forecast data
 	 */
 	public function getForecast(): array {
-		$lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', '');
-		$lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', '');
-		$alt = $this->config->getUserValue($this->userId, Application::APP_ID, 'altitude', '');
+        $lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', $this->config->getAppValue(Application::APP_ID, 'lat', ''));
+        $lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', $this->config->getAppValue(Application::APP_ID, 'lon', ''));
+        $alt = $this->config->getUserValue($this->userId, Application::APP_ID, 'altitude', $this->config->getAppValue(Application::APP_ID, 'altitude', ''));
 		if (!is_numeric($alt)) {
 			$alt = 0;
 		}

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -288,7 +288,7 @@ class WeatherStatusService {
 	 */
 	public function getLocation(): array {
         $lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', $this->config->getAppValue(Application::APP_ID, 'lat', ''));
-        $lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', $this->config->getAppValue(Application::APP_ID, 'lat', ''));
+        $lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', $this->config->getAppValue(Application::APP_ID, 'lon', ''));
         $address = $this->config->getUserValue($this->userId, Application::APP_ID, 'address', $this->config->getAppValue(Application::APP_ID, 'address', ''));
 		$mode = $this->config->getUserValue($this->userId, Application::APP_ID, 'mode', self::MODE_MANUAL_LOCATION);
 		return [


### PR DESCRIPTION
In cases where all of the users are from the same geographical area, it would be extremely useful to be able to set a default location for the dashboard weather widget. With these changes, this option becomes available, as default values can be set with occ config:app:set weather_status [lat,lon,altitude,address] --value 'value'

These changes also implement the path 2 described in feature request https://github.com/nextcloud/server/issues/27908 denied in 2021

Signed-off-by: Tuomas Nurmi <tuomas.nurmi@opinsys.fi>