### PR TITLE
Don't use quota cache through user management

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -245,7 +245,7 @@ abstract class AUserData extends OCSController {
 		try {
 			\OC_Util::tearDownFS();
 			\OC_Util::setupFS($userId);
-			$storage = OC_Helper::getStorageInfo('/');
+			$storage = OC_Helper::getStorageInfo('/', null, true, false);
 			$data = [
 				'free' => $storage['free'],
 				'used' => $storage['used'],

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -457,10 +457,12 @@ class OC_Helper {
 	 *
 	 * @param string $path
 	 * @param \OCP\Files\FileInfo $rootInfo (optional)
+	 * @param bool $includeMountPoints whether to include mount points in the size calculation
+	 * @param bool $useCache whether to use the cached quota values
 	 * @return array
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	public static function getStorageInfo($path, $rootInfo = null, $includeMountPoints = true) {
+	public static function getStorageInfo($path, $rootInfo = null, $includeMountPoints = true, $useCache = true) {
 		/** @var ICacheFactory $cacheFactory */
 		$cacheFactory = \OC::$server->get(ICacheFactory::class);
 		$memcache = $cacheFactory->createLocal('storage_info');
@@ -470,9 +472,11 @@ class OC_Helper {
 
 		$fullPath = Filesystem::getView()->getAbsolutePath($path);
 		$cacheKey = $fullPath. '::' . ($includeMountPoints ? 'include' : 'exclude');
-		$cached = $memcache->get($cacheKey);
-		if ($cached) {
-			return $cached;
+		if ($useCache) {
+			$cached = $memcache->get($cacheKey);
+			if ($cached) {
+				return $cached;
+			}
 		}
 
 		if (!$rootInfo) {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/34961

Note: this addresses the "delayed quota" topic from that issue, not the 32-bit one which is separate.

When querying the free space through user management APIs, don't use the cached quota value. The latter is only there to accelerate PROPFINDs.
