### PR TITLE
Remove potential mismatching dav session data during login

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -371,6 +371,7 @@ class Session implements IUserSession, Emitter {
 
 		if ($regenerateSessionId) {
 			$this->session->regenerateId();
+			$this->session->remove(Auth::DAV_AUTHENTICATED);
 		}
 
 		$this->setUser($user);


### PR DESCRIPTION
This PR will make sure that whenever a session is being reused during login we properly clean up the dav session data which is only required to prioritise basic auth over the session login on WebDAV. (ref https://github.com/owncloud/core/issues/13245)

We can safely reset this if the session id is being regenerated during login.

The issue never occurred in the wild as far as I can see but was just a side effect of the cypress tests in viewer that reused the cookie jar that was used for userA webdav requests to run a login and e2e test for userB.

See https://github.com/nextcloud/server/pull/34934#issuecomment-1303678819 for more technical insights.