### PR TITLE
Don't count range download in download limit

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -373,14 +373,14 @@ class ShareController extends AuthPublicShareController {
 		$userFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
 		$originalSharePath = $userFolder->getRelativePath($share->getNode()->getPath());
 
-		$isVideo = false;
+		$isVideoAudio = false;
 
 		// Single file share
 		if ($share->getNode() instanceof \OCP\Files\File) {
 			$node = $share->getNode();
 			// Single file download
 			$this->singleFileDownloaded($share, $node);
-			$isVideo = str_starts_with($node->getMimeType(), 'video/');
+			$isVideoAutio = str_starts_with($node->getMimeType(), 'video/') || str_starts_with($node->getMimeType(), 'audio/');
 		}
 		// Directory share
 		else {
@@ -404,7 +404,7 @@ class ShareController extends AuthPublicShareController {
 				$node = $share->getNode();
 				// Single file download
 				$this->singleFileDownloaded($share, $node);
-				$isVideo = str_starts_with($node->getMimeType(), 'video/');
+				$isVideoAutio = str_starts_with($node->getMimeType(), 'video/') || str_starts_with($node->getMimeType(), 'audio/');
 			} else {
 				try {
 					if (!empty($files_list)) {
@@ -437,8 +437,8 @@ class ShareController extends AuthPublicShareController {
 
 		$this->emitAccessShareHook($share);
 
-		// Ensure download limit is counted unless we are streaming a video
-		if (!isset($_SERVER['HTTP_RANGE']) || !$isVideo) {
+		// Ensure download limit is counted unless we are streaming a video or audio file
+		if (!isset($_SERVER['HTTP_RANGE']) || !$isVideoAudio) {
 			$this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD);
 		}
 

--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -431,7 +431,9 @@ class ShareController extends AuthPublicShareController {
 		}
 
 		$this->emitAccessShareHook($share);
-		$this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD);
+		if (!isset($_SERVER['HTTP_RANGE'])) {
+			$this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD);
+		}
 
 		$server_params = [ 'head' => $this->request->getMethod() === 'HEAD' ];
 


### PR DESCRIPTION
I tried to still count the first or the last range but this is not really reliable since we send two range `0-` at the beginning (one for the preview and one for the video) and the last range `xxxxxxxxx-` is also called multiple times