### PR TITLE
feat: add event for failed logins

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -83,6 +83,7 @@ return array(
     'OCP\\App\\AppPathNotFoundException' => $baseDir . '/lib/public/App/AppPathNotFoundException.php',
     'OCP\\App\\IAppManager' => $baseDir . '/lib/public/App/IAppManager.php',
     'OCP\\App\\ManagerEvent' => $baseDir . '/lib/public/App/ManagerEvent.php',
+    'OCP\\Authentication\\Events\\AnyLoginFailedEvent' => $baseDir . '/lib/public/Authentication/Events/AnyLoginFailedEvent.php',
     'OCP\\Authentication\\Events\\LoginFailedEvent' => $baseDir . '/lib/public/Authentication/Events/LoginFailedEvent.php',
     'OCP\\Authentication\\Exceptions\\CredentialsUnavailableException' => $baseDir . '/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php',
     'OCP\\Authentication\\Exceptions\\PasswordUnavailableException' => $baseDir . '/lib/public/Authentication/Exceptions/PasswordUnavailableException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -116,6 +116,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\App\\AppPathNotFoundException' => __DIR__ . '/../../..' . '/lib/public/App/AppPathNotFoundException.php',
         'OCP\\App\\IAppManager' => __DIR__ . '/../../..' . '/lib/public/App/IAppManager.php',
         'OCP\\App\\ManagerEvent' => __DIR__ . '/../../..' . '/lib/public/App/ManagerEvent.php',
+        'OCP\\Authentication\\Events\\AnyLoginFailedEvent' => __DIR__ . '/../../..' . '/lib/public/Authentication/Events/AnyLoginFailedEvent.php',
         'OCP\\Authentication\\Events\\LoginFailedEvent' => __DIR__ . '/../../..' . '/lib/public/Authentication/Events/LoginFailedEvent.php',
         'OCP\\Authentication\\Exceptions\\CredentialsUnavailableException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php',
         'OCP\\Authentication\\Exceptions\\PasswordUnavailableException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/PasswordUnavailableException.php',

--- a/lib/private/Authentication/Listeners/LoginFailedListener.php
+++ b/lib/private/Authentication/Listeners/LoginFailedListener.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OC\Authentication\Listeners;
 
 use OC\Authentication\Events\LoginFailed;
+use OCP\Authentication\Events\AnyLoginFailedEvent;
 use OCP\Authentication\Events\LoginFailedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -54,6 +55,8 @@ class LoginFailedListener implements IEventListener {
 		if (!($event instanceof LoginFailed)) {
 			return;
 		}
+
+		$this->dispatcher->dispatchTyped(new AnyLoginFailedEvent($event->getLoginName(), $event->getPassword()));
 
 		$uid = $event->getLoginName();
 		Util::emitHook(

--- a/lib/private/Authentication/Login/LoggedInCheckCommand.php
+++ b/lib/private/Authentication/Login/LoggedInCheckCommand.php
@@ -48,11 +48,12 @@ class LoggedInCheckCommand extends ALoginCommand {
 	public function process(LoginData $loginData): LoginResult {
 		if ($loginData->getUser() === false) {
 			$loginName = $loginData->getUsername();
+			$password = $loginData->getPassword();
 			$ip = $loginData->getRequest()->getRemoteAddress();
 
 			$this->logger->warning("Login failed: $loginName (Remote IP: $ip)");
 
-			$this->dispatcher->dispatchTyped(new LoginFailed($loginName));
+			$this->dispatcher->dispatchTyped(new LoginFailed($loginName, $password));
 
 			return LoginResult::failure($loginData, LoginController::LOGIN_MSG_INVALIDPASSWORD);
 		}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -458,7 +458,7 @@ class Session implements IUserSession, Emitter {
 
 				$throttler->registerAttempt('login', $request->getRemoteAddress(), ['user' => $user]);
 
-				$this->dispatcher->dispatchTyped(new OC\Authentication\Events\LoginFailed($user));
+				$this->dispatcher->dispatchTyped(new OC\Authentication\Events\LoginFailed($user, $password));
 
 				if ($currentDelay === 0) {
 					$throttler->sleepDelay($request->getRemoteAddress(), 'login');

--- a/lib/public/Authentication/Events/AnyLoginFailedEvent.php
+++ b/lib/public/Authentication/Events/AnyLoginFailedEvent.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2020, Roeland Jago Douma <roeland@famdouma.nl>
+ * @copyright Copyright (c) 2022, Roeland Jago Douma <roeland@famdouma.nl>
  *
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -23,14 +23,22 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OC\Authentication\Events;
+namespace OCP\Authentication\Events;
 
 use OCP\EventDispatcher\Event;
 
-class LoginFailed extends Event {
+/**
+ * Emitted when the authentication fails
+ *
+ * @since 26.0.0
+ */
+class AnyLoginFailedEvent extends Event {
 	private string $loginName;
 	private ?string $password;
 
+	/**
+	 * @since 26.0.0
+	 */
 	public function __construct(string $loginName, ?string $password) {
 		parent::__construct();
 
@@ -38,10 +46,16 @@ class LoginFailed extends Event {
 		$this->password = $password;
 	}
 
-	public function getLoginName(): string {
+	/**
+	 * @since 26.0.0
+	 */
+	public function geLoginName(): string {
 		return $this->loginName;
 	}
 
+	/**
+	 * @since 26.0.0
+	 */
 	public function getPassword(): ?string {
 		return $this->password;
 	}


### PR DESCRIPTION
Apps might also like to know about failed logins.
This adds that event.
The private interface changes are backwards compatible so all should be fine.
