### PR TITLE
Update cache when file size === 0

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1191,13 +1191,13 @@ class View {
 					throw $e;
 				}
 
-				if ($result && in_array('delete', $hooks)) {
+				if ($result !== false && in_array('delete', $hooks)) {
 					$this->removeUpdate($storage, $internalPath);
 				}
-				if ($result && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
+				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
 					$this->writeUpdate($storage, $internalPath);
 				}
-				if ($result && in_array('touch', $hooks)) {
+				if ($result !== false && in_array('touch', $hooks)) {
 					$this->writeUpdate($storage, $internalPath, $extraParam);
 				}
 


### PR DESCRIPTION
The conditions were false when `$result === 0`.
`$results` here contains the number of written bits.
The correct way of checking for operation success is to check if `$result === false`

## Question

- Not sure what `$result` is supposed to contain for other operation, but it is probably safe to assume that none were returning 0 for saying error

## How to test

1. Create a new plain text file toto.txt
2. Add a dummy content and wait for it to be saved
3. Clear the content and wait for it to be savec
4. Refresh view and constat that file size and mtime is not up to date.
