### PR TITLE
Allow to set a custom timeout for ldap connections

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -120,6 +120,7 @@ class Configuration {
 		'ldapDefaultPPolicyDN' => null,
 		'ldapExtStorageHomeAttribute' => null,
 		'ldapMatchingRuleInChainState' => self::LDAP_SERVER_FEATURE_UNKNOWN,
+		'ldapConnectionTimeout' => 15,
 	];
 
 	public function __construct(string $configPrefix, bool $autoRead = true) {
@@ -463,6 +464,7 @@ class Configuration {
 			'ldap_user_avatar_rule' => 'default',
 			'ldap_ext_storage_home_attribute' => '',
 			'ldap_matching_rule_in_chain_state' => self::LDAP_SERVER_FEATURE_UNKNOWN,
+			'ldap_connection_timeout' => 15,
 		];
 	}
 
@@ -526,6 +528,7 @@ class Configuration {
 			'ldap_ext_storage_home_attribute' => 'ldapExtStorageHomeAttribute',
 			'ldap_matching_rule_in_chain_state' => 'ldapMatchingRuleInChainState',
 			'ldapIgnoreNamingRules' => 'ldapIgnoreNamingRules',	// sysconfig
+			'ldap_connection_timeout' => 'ldapConnectionTimeout',
 		];
 		return $array;
 	}

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -649,6 +649,10 @@ class Connection extends LDAPUtility {
 			throw new ServerNotAvailableException('Could not disable LDAP referrals.');
 		}
 
+		if (!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_NETWORK_TIMEOUT, $this->configuration->ldapConnectionTimeout)) {
+			throw new ServerNotAvailableException('Could not set network timeout');
+		}
+
 		if ($this->configuration->ldapTLS) {
 			if (!$this->ldap->startTls($this->ldapConnectionRes)) {
 				throw new ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');


### PR DESCRIPTION
Not tested, only blind copying and pasting. Could @blizzz or @come-nc test this new setting ? I could test with a single LDAP server, but I guess we should try with a primary and a backup server.