### PR TITLE
Run s3 primary tests sequential

### DIFF
--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       # do not stop on another job's failure
       fail-fast: false
+      max-parallel: 1
       matrix:
         php-versions: ['8.0']
         key: ['objectstore', 'objectstore_multibucket']
@@ -50,8 +51,6 @@ jobs:
 
       - name: Wait for S3
         run: |
-          sleep 10
-          curl -f -m 1 --retry-connrefused --retry 10 --retry-delay 10 http://localhost:9000/minio/health/ready
           sleep 10
           curl -f -m 1 --retry-connrefused --retry 10 --retry-delay 10 http://localhost:9000/minio/health/ready
 


### PR DESCRIPTION
* Resolves: /

## Summary

The test matrix (https://github.com/nextcloud/server/blob/master/.github/workflows/s3-primary.yml) defines two jobs. Both require and define a minio service to run the tests. 

Because the jobs run within the same docker network and the same github runner, only one minio instance can use port 9000. 

**First approach**

Using a random port for minio to avoid conflicts.

![image](https://user-images.githubusercontent.com/3902676/203636777-7ede12fd-c06d-4e72-8360-fc6f7a63b0a4.png)

Random ports are not a solution because there is a chance that the same random port is assigned. Sounds unlikely but happend here for multiple test runs. 

| Before | After |
| --- | --- |
| ![Screenshot from 2022-11-25 15-30-23](https://user-images.githubusercontent.com/3902676/204011415-309124ef-6dc6-4801-94d0-d169b67ecf6e.png) | ![Screenshot from 2022-11-25 15-30-37](https://user-images.githubusercontent.com/3902676/204011470-6d1bb6b4-0807-4542-8ec9-78a4ff7b1604.png) |

**Second approach**

Use `jobs.<job_id>.container` works, but makes it impossible to fetch the dockers logs for the minio container. 

**Third approach**

Set `max-parallel` to 1 to execute the jobs sequential.

## TODO

- [x] Check CI run

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
