### PR TITLE
Do not check quota for non Node

### DIFF
--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -148,14 +148,14 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	public function beforeCopy(string $sourcePath, string $destinationPath): bool {
 		$sourceNode = $this->server->tree->getNodeForPath($sourcePath);
 		if (!$sourceNode instanceof Node) {
-			return false;
+			return true;
 		}
 
 		// get target node for proper path conversion
 		if ($this->server->tree->nodeExists($destinationPath)) {
 			$destinationNode = $this->server->tree->getNodeForPath($destinationPath);
 			if (!$destinationNode instanceof Node) {
-				return false;
+				return true;
 			}
 			$path = $destinationNode->getPath();
 		} else {
@@ -165,7 +165,7 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 			$parentNode = $this->server->tree->getNodeForPath($parent);
 			if (!$parentNode instanceof Node) {
-				return false;
+				return true;
 			}
 			$path = $parentNode->getPath();
 		}


### PR DESCRIPTION
After https://github.com/nextcloud/server/pull/35009, the copy of elements that are not `Node` will fail.

This PR considers that non `Node` objects are not subject to quota limitation, and therefore should not be blocked.

It would be ok to limit the change to the `parentNode` only.