### PR TITLE
change zu zugreifen to zuzugreifen in mail notification

### DIFF
--- a/apps/sharebymail/l10n/de.js
+++ b/apps/sharebymail/l10n/de.js
@@ -37,7 +37,7 @@ OC.L10N.register(
     "%1$s shared »%2$s« with you.\nYou should have already received a separate mail with a link to access it.\n" : "%1$s hat  »%2$s« mit dir geteilt.\nDu solltest bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.\n",
     "%1$s shared »%2$s« with you. You should have already received a separate mail with a link to access it." : "%1$s hat »%2$s« mit dir geteilt. Du solltest bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben. ",
     "Password to access »%1$s« shared to you by %2$s" : "Das Passwort zum Zugriff auf %1$s wurde durch %2$s mit dir geteilt.",
-    "Password to access »%s«" : "Passwort um auf »%s« zu zugreifen",
+    "Password to access »%s«" : "Passwort um auf »%s« zuzugreifen",
     "It is protected with the following password:" : "Dies ist mit dem folgendem Passwort geschützt:",
     "This password will expire at %s" : "Dieses Passwort wird um %s ablaufen.",
     "%1$s shared »%2$s« with you and wants to add:" : "%1$s hat »%2$s« mit dir geteilt und möchte folgendes hinzufügen:",

--- a/apps/sharebymail/l10n/de.json
+++ b/apps/sharebymail/l10n/de.json
@@ -35,7 +35,7 @@
     "%1$s shared »%2$s« with you.\nYou should have already received a separate mail with a link to access it.\n" : "%1$s hat  »%2$s« mit dir geteilt.\nDu solltest bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.\n",
     "%1$s shared »%2$s« with you. You should have already received a separate mail with a link to access it." : "%1$s hat »%2$s« mit dir geteilt. Du solltest bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben. ",
     "Password to access »%1$s« shared to you by %2$s" : "Das Passwort zum Zugriff auf %1$s wurde durch %2$s mit dir geteilt.",
-    "Password to access »%s«" : "Passwort um auf »%s« zu zugreifen",
+    "Password to access »%s«" : "Passwort um auf »%s« zuzugreifen",
     "It is protected with the following password:" : "Dies ist mit dem folgendem Passwort geschützt:",
     "This password will expire at %s" : "Dieses Passwort wird um %s ablaufen.",
     "%1$s shared »%2$s« with you and wants to add:" : "%1$s hat »%2$s« mit dir geteilt und möchte folgendes hinzufügen:",

--- a/apps/sharebymail/l10n/de_DE.js
+++ b/apps/sharebymail/l10n/de_DE.js
@@ -37,7 +37,7 @@ OC.L10N.register(
     "%1$s shared »%2$s« with you.\nYou should have already received a separate mail with a link to access it.\n" : "%1$s hat »%2$s« mit Ihnen geteilt.\nSie sollten bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.\n",
     "%1$s shared »%2$s« with you. You should have already received a separate mail with a link to access it." : "%1$s hat »%2$s« mit Ihnen geteilt. Sie sollten bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.",
     "Password to access »%1$s« shared to you by %2$s" : "Das Passwort zum Zugriff auf %1$s wurde durch %2$s mit Ihnen geteilt.",
-    "Password to access »%s«" : "Passwort um auf »%s« zu zugreifen",
+    "Password to access »%s«" : "Passwort um auf »%s« zuzugreifen",
     "It is protected with the following password:" : "Dies ist mit dem folgendem Passwort geschützt:",
     "This password will expire at %s" : "Dieses Passwort wird um %s ablaufen.",
     "%1$s shared »%2$s« with you and wants to add:" : "%1$s hat » %2$s« mit Ihnen geteilt und möchte folgendes hinzufügen:",

--- a/apps/sharebymail/l10n/de_DE.json
+++ b/apps/sharebymail/l10n/de_DE.json
@@ -35,7 +35,7 @@
     "%1$s shared »%2$s« with you.\nYou should have already received a separate mail with a link to access it.\n" : "%1$s hat »%2$s« mit Ihnen geteilt.\nSie sollten bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.\n",
     "%1$s shared »%2$s« with you. You should have already received a separate mail with a link to access it." : "%1$s hat »%2$s« mit Ihnen geteilt. Sie sollten bereits eine weitere E-Mail mit einem Link für den Zugriff erhalten haben.",
     "Password to access »%1$s« shared to you by %2$s" : "Das Passwort zum Zugriff auf %1$s wurde durch %2$s mit Ihnen geteilt.",
-    "Password to access »%s«" : "Passwort um auf »%s« zu zugreifen",
+    "Password to access »%s«" : "Passwort um auf »%s« zuzugreifen",
     "It is protected with the following password:" : "Dies ist mit dem folgendem Passwort geschützt:",
     "This password will expire at %s" : "Dieses Passwort wird um %s ablaufen.",
     "%1$s shared »%2$s« with you and wants to add:" : "%1$s hat » %2$s« mit Ihnen geteilt und möchte folgendes hinzufügen:",


### PR DESCRIPTION
* Resolves: #35422

## Summary
Fix a translation mistake of "zu zugreifen" to "zuzugreifen"

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
