### PR TITLE
Prune core-common js and lazy load modules

### DIFF
--- a/apps/comments/src/components/Comment.vue
+++ b/apps/comments/src/components/Comment.vue
@@ -105,12 +105,12 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton'
-import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable'
 import RichEditorMixin from '@nextcloud/vue/dist/Mixins/richEditor'
 import ArrowRight from 'vue-material-design-icons/ArrowRight'
 
 import Moment from './Moment'
 import CommentMixin from '../mixins/CommentMixin'
+const NcRichContenteditable = () => import('@nextcloud/vue/dist/Components/NcRichContenteditable')
 
 export default {
 	name: 'Comment',

--- a/apps/comments/src/services/CommentsInstance.js
+++ b/apps/comments/src/services/CommentsInstance.js
@@ -25,6 +25,9 @@ import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 import CommentsApp from '../views/Comments'
 import Vue from 'vue'
 
+import { getRequestToken } from '@nextcloud/auth'
+__webpack_nonce__ = btoa(getRequestToken())
+
 const logger = getLoggerBuilder()
 	.setApp('comments')
 	.detectUser()

--- a/apps/dav/src/settings-personal-availability.js
+++ b/apps/dav/src/settings-personal-availability.js
@@ -1,9 +1,14 @@
 import Vue from 'vue'
 import { translate } from '@nextcloud/l10n'
-import Availability from './views/Availability'
+import { getRequestToken } from '@nextcloud/auth'
+
+__webpack_nonce__ = btoa(getRequestToken())
 
 Vue.prototype.$t = translate
 
-const View = Vue.extend(Availability);
+import('./views/Availability').then((module) => {
+	const Availability = module.default
+	const View = Vue.extend(Availability);
 
-(new View({})).$mount('#settings-personal-availability')
+	(new View({})).$mount('#settings-personal-availability')
+})

--- a/apps/dav/src/settings.js
+++ b/apps/dav/src/settings.js
@@ -1,7 +1,10 @@
 import Vue from 'vue'
+import { getRequestToken } from '@nextcloud/auth'
 import { loadState } from '@nextcloud/initial-state'
 import { translate } from '@nextcloud/l10n'
 import CalDavSettings from './views/CalDavSettings'
+
+__webpack_nonce__ = btoa(getRequestToken())
 
 Vue.prototype.$t = translate
 

--- a/apps/dav/src/views/Availability.vue
+++ b/apps/dav/src/views/Availability.vue
@@ -56,7 +56,7 @@ import jstz from 'jstimezonedetect'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch'
 import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection'
-import NcTimezonePicker from '@nextcloud/vue/dist/Components/NcTimezonePicker'
+const NcTimezonePicker = () => import('@nextcloud/vue/dist/Components/NcTimezonePicker')
 
 export default {
 	name: 'Availability',

--- a/apps/federatedfilesharing/src/components/AdminSettings.vue
+++ b/apps/federatedfilesharing/src/components/AdminSettings.vue
@@ -71,8 +71,8 @@ import { loadState } from '@nextcloud/initial-state'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 export default {
 	name: 'AdminSettings',

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -145,11 +145,11 @@ import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox'
-import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
-import NcActionTextEditable from '@nextcloud/vue/dist/Components/NcActionTextEditable'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
 
 import SharesMixin from '../mixins/SharesMixin.js'
+const NcActionInput = () => import('@nextcloud/vue/dist/Components/NcActionInput')
+const NcActionTextEditable = () => import('@nextcloud/vue/dist/Components/NcActionTextEditable')
 
 export default {
 	name: 'SharingEntry',

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -305,7 +305,6 @@ import Vue from 'vue'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox'
-import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink'
 import NcActionText from '@nextcloud/vue/dist/Components/NcActionText'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator'
@@ -319,6 +318,7 @@ import SharePermissionsEditor from './SharePermissionsEditor.vue'
 import GeneratePassword from '../utils/GeneratePassword.js'
 import Share from '../models/Share.js'
 import SharesMixin from '../mixins/SharesMixin.js'
+const NcActionInput = () => import('@nextcloud/vue/dist/Components/NcActionInput')
 
 export default {
 	name: 'SharingEntryLink',

--- a/apps/files_sharing/src/files_sharing_tab.js
+++ b/apps/files_sharing/src/files_sharing_tab.js
@@ -24,12 +24,15 @@
 import Vue from 'vue'
 import VueClipboard from 'vue-clipboard2'
 import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import { getRequestToken } from '@nextcloud/auth'
 
 import SharingTab from './views/SharingTab'
 import ShareSearch from './services/ShareSearch'
 import ExternalLinkActions from './services/ExternalLinkActions'
 import ExternalShareActions from './services/ExternalShareActions'
 import TabSections from './services/TabSections'
+
+__webpack_nonce__ = btoa(getRequestToken())
 
 // Init Sharing Tab Service
 if (!window.OCA.Sharing) {

--- a/apps/files_sharing/src/views/CollaborationView.vue
+++ b/apps/files_sharing/src/views/CollaborationView.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-import { CollectionList } from 'nextcloud-vue-collections'
+const CollectionList = () => import('nextcloud-vue-collections')
 
 export default {
 	name: 'CollaborationView',

--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -86,7 +86,6 @@
 </template>
 
 <script>
-import { CollectionList } from 'nextcloud-vue-collections'
 import { generateOcsUrl } from '@nextcloud/router'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar'
 import axios from '@nextcloud/axios'
@@ -103,6 +102,7 @@ import SharingInput from '../components/SharingInput'
 import SharingInherited from './SharingInherited'
 import SharingLinkList from './SharingLinkList'
 import SharingList from './SharingList'
+const CollectionList = () => import('nextcloud-vue-collections')
 
 export default {
 	name: 'SharingTab',

--- a/apps/settings/src/components/AdminTwoFactor.vue
+++ b/apps/settings/src/components/AdminTwoFactor.vue
@@ -71,7 +71,10 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadi
 import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection'
 import { loadState } from '@nextcloud/initial-state'
 
-import _ from 'lodash'
+import sortedUniq from 'lodash/sortedUniq'
+import uniq from 'lodash/uniq'
+import debounce from 'lodash/debounce'
+
 import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 
 export default {
@@ -123,19 +126,19 @@ export default {
 	mounted() {
 		// Groups are loaded dynamically, but the assigned ones *should*
 		// be valid groups, so let's add them as initial state
-		this.groups = _.sortedUniq(_.uniq(this.enforcedGroups.concat(this.excludedGroups)))
+		this.groups = sortedUniq(uniq(this.enforcedGroups.concat(this.excludedGroups)))
 
 		// Populate the groups with a first set so the dropdown is not empty
 		// when opening the page the first time
 		this.searchGroup('')
 	},
 	methods: {
-		searchGroup: _.debounce(function(query) {
+		searchGroup: debounce(function(query) {
 			this.loadingGroups = true
 			axios.get(generateOcsUrl('cloud/groups?offset=0&search={query}&limit=20', { query }))
 				.then(res => res.data.ocs)
 				.then(ocs => ocs.data.groups)
-				.then(groups => { this.groups = _.sortedUniq(_.uniq(this.groups.concat(groups))) })
+				.then(groups => { this.groups = sortedUniq(uniq(this.groups.concat(groups))) })
 				.catch(err => console.error('could not search groups', err))
 				.then(() => { this.loadingGroups = false })
 		}, 500),

--- a/apps/settings/src/components/AuthToken.vue
+++ b/apps/settings/src/components/AuthToken.vue
@@ -85,11 +85,9 @@
 </template>
 
 <script>
-import {
-	NcActions,
-	NcActionButton,
-	NcActionCheckbox,
-} from '@nextcloud/vue'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox'
 
 // When using capture groups the following parts are extracted the first is used as the version number, the second as the OS
 const userAgentMap = {

--- a/apps/settings/src/components/AuthTokenSection.vue
+++ b/apps/settings/src/components/AuthTokenSection.vue
@@ -36,12 +36,12 @@
 
 <script>
 import axios from '@nextcloud/axios'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import { generateUrl } from '@nextcloud/router'
 
 import AuthTokenList from './AuthTokenList'
 import AuthTokenSetupDialogue from './AuthTokenSetupDialogue'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const confirm = () => {
 	return new Promise(resolve => {

--- a/apps/settings/src/components/AuthTokenSetupDialogue.vue
+++ b/apps/settings/src/components/AuthTokenSetupDialogue.vue
@@ -80,11 +80,11 @@
 </template>
 
 <script>
-import QR from '@chenfengyuan/vue-qrcode'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import { getRootUrl } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton'
+const QR = () => import('@chenfengyuan/vue-qrcode')
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 export default {
 	name: 'AuthTokenSetupDialogue',

--- a/apps/settings/src/components/BasicSettings/BackgroundJob.vue
+++ b/apps/settings/src/components/BasicSettings/BackgroundJob.vue
@@ -92,8 +92,8 @@ import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import moment from '@nextcloud/moment'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const lastCron = loadState('settings', 'lastCron')
 const cronMaxAge = loadState('settings', 'cronMaxAge', '')

--- a/apps/settings/src/components/Encryption.vue
+++ b/apps/settings/src/components/Encryption.vue
@@ -84,9 +84,9 @@ import { loadState } from '@nextcloud/initial-state'
 import { getLoggerBuilder } from '@nextcloud/logger'
 
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import { showError } from '@nextcloud/dialogs'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const logger = getLoggerBuilder()
 	.setApp('settings')

--- a/apps/settings/src/components/GroupListItem.vue
+++ b/apps/settings/src/components/GroupListItem.vue
@@ -53,10 +53,10 @@
 </template>
 
 <script>
-import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble'
 import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem'
+const NcActionInput = () => import('@nextcloud/vue/dist/Components/NcActionInput')
 
 export default {
 	name: 'GroupListItem',

--- a/apps/settings/src/components/PersonalInfo/AvatarSection.vue
+++ b/apps/settings/src/components/PersonalInfo/AvatarSection.vue
@@ -101,7 +101,6 @@ import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton'
-import VueCropper from 'vue-cropperjs'
 // eslint-disable-next-line node/no-extraneous-import
 import 'cropperjs/dist/cropper.css'
 
@@ -111,6 +110,7 @@ import Delete from 'vue-material-design-icons/Delete'
 
 import HeaderBar from './shared/HeaderBar.vue'
 import { NAME_READABLE_ENUM } from '../../constants/AccountPropertyConstants.js'
+const VueCropper = () => import('vue-cropperjs')
 
 const { avatar } = loadState('settings', 'personalInfoParameters', {})
 const { avatarChangeSupported } = loadState('settings', 'accountParameters', {})

--- a/apps/settings/src/components/PersonalInfo/EmailSection/Email.vue
+++ b/apps/settings/src/components/PersonalInfo/EmailSection/Email.vue
@@ -86,7 +86,8 @@
 </template>
 
 <script>
-import { NcActions, NcActionButton } from '@nextcloud/vue'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 import AlertOctagon from 'vue-material-design-icons/AlertOctagon.vue'
 import Check from 'vue-material-design-icons/Check'

--- a/apps/settings/src/components/UserList/UserRow.vue
+++ b/apps/settings/src/components/UserList/UserRow.vue
@@ -239,12 +239,10 @@
 import ClickOutside from 'vue-click-outside'
 import Vue from 'vue'
 import VTooltip from 'v-tooltip'
-import {
-	NcPopoverMenu,
-	NcMultiselect,
-	NcActions,
-	NcActionButton,
-} from '@nextcloud/vue'
+import NcPopoverMenu from '@nextcloud/vue/dist/Components/NcPopoverMenu'
+import NcMultiselect from '@nextcloud/vue/dist/Components/NcMultiselect'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import UserRowSimple from './UserRowSimple'
 import UserRowMixin from '../../mixins/UserRowMixin'
 

--- a/apps/settings/src/components/WebAuthn/AddDevice.vue
+++ b/apps/settings/src/components/WebAuthn/AddDevice.vue
@@ -61,7 +61,6 @@
 </template>
 
 <script>
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 
 import logger from '../../logger'
@@ -69,6 +68,7 @@ import {
 	startRegistration,
 	finishRegistration,
 } from '../../service/WebAuthnRegistrationSerice'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const logAndPass = (text) => (data) => {
 	logger.debug(text)

--- a/apps/settings/src/components/WebAuthn/Section.vue
+++ b/apps/settings/src/components/WebAuthn/Section.vue
@@ -48,7 +48,6 @@
 </template>
 
 <script>
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import sortBy from 'lodash/fp/sortBy'
 
@@ -56,6 +55,7 @@ import AddDevice from './AddDevice'
 import Device from './Device'
 import logger from '../../logger'
 import { removeRegistration } from '../../service/WebAuthnRegistrationSerice'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const sortByName = sortBy('name')
 

--- a/apps/settings/src/service/PersonalInfo/EmailService.js
+++ b/apps/settings/src/service/PersonalInfo/EmailService.js
@@ -23,10 +23,10 @@
 import axios from '@nextcloud/axios'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 
 import { ACCOUNT_PROPERTY_ENUM, SCOPE_SUFFIX } from '../../constants/AccountPropertyConstants'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 /**
  * Save the primary email of the user

--- a/apps/settings/src/service/PersonalInfo/PersonalInfoService.js
+++ b/apps/settings/src/service/PersonalInfo/PersonalInfoService.js
@@ -23,10 +23,10 @@
 import axios from '@nextcloud/axios'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 
 import { SCOPE_SUFFIX } from '../../constants/AccountPropertyConstants'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 /**
  * Save the primary account property value for the user

--- a/apps/settings/src/service/ProfileService.js
+++ b/apps/settings/src/service/ProfileService.js
@@ -23,8 +23,8 @@
 import axios from '@nextcloud/axios'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 /**
  * Save the visibility of the profile parameter

--- a/apps/settings/src/store/api.js
+++ b/apps/settings/src/store/api.js
@@ -25,8 +25,8 @@
  */
 
 import axios from '@nextcloud/axios'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 const sanitize = function(url) {
 	return url.replace(/\/$/, '') // Remove last url slash

--- a/apps/sharebymail/src/components/AdminSettings.vue
+++ b/apps/sharebymail/src/components/AdminSettings.vue
@@ -44,8 +44,8 @@ import { loadState } from '@nextcloud/initial-state'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 export default {
 	name: 'AdminSettings',

--- a/apps/theming/src/admin-settings.js
+++ b/apps/theming/src/admin-settings.js
@@ -24,6 +24,9 @@ import Vue from 'vue'
 import App from './AdminTheming.vue'
 import { refreshStyles } from './helpers/refreshStyles.js'
 
+import { getRequestToken } from '@nextcloud/auth'
+__webpack_nonce__ = btoa(getRequestToken())
+
 Vue.prototype.OC = OC
 Vue.prototype.t = t
 

--- a/apps/theming/src/components/BackgroundSettings.vue
+++ b/apps/theming/src/components/BackgroundSettings.vue
@@ -84,8 +84,8 @@ import { loadState } from '@nextcloud/initial-state'
 import { prefixWithBaseUrl } from '../helpers/prefixWithBaseUrl.js'
 import axios from '@nextcloud/axios'
 import debounce from 'debounce'
-import NcColorPicker from '@nextcloud/vue/dist/Components/NcColorPicker'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip'
+const NcColorPicker = () => import('@nextcloud/vue/dist/Components/NcColorPicker')
 
 const shippedBackgroundList = loadState('theming', 'shippedBackgrounds')
 

--- a/apps/theming/src/personal-settings.js
+++ b/apps/theming/src/personal-settings.js
@@ -24,6 +24,9 @@ import Vue from 'vue'
 import App from './UserThemes.vue'
 import { refreshStyles } from './helpers/refreshStyles.js'
 
+import { getRequestToken } from '@nextcloud/auth'
+__webpack_nonce__ = btoa(getRequestToken())
+
 Vue.prototype.OC = OC
 Vue.prototype.t = t
 

--- a/apps/twofactor_backupcodes/src/views/PersonalSettings.vue
+++ b/apps/twofactor_backupcodes/src/views/PersonalSettings.vue
@@ -44,9 +44,9 @@
 </template>
 
 <script>
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import { print } from '../service/PrintService'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 export default {
 	name: 'PersonalSettings',

--- a/apps/user_status/src/components/CustomMessageInput.vue
+++ b/apps/user_status/src/components/CustomMessageInput.vue
@@ -44,7 +44,7 @@
 
 <script>
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
+const NcEmojiPicker = () => import('@nextcloud/vue/dist/Components/NcEmojiPicker.js')
 
 export default {
 	name: 'CustomMessageInput',

--- a/apps/user_status/src/views/Dashboard.vue
+++ b/apps/user_status/src/views/Dashboard.vue
@@ -48,11 +48,12 @@
 </template>
 
 <script>
-import { DashboardWidget, DashboardWidgetItem } from '@nextcloud/vue-dashboard'
 import { loadState } from '@nextcloud/initial-state'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent'
 import moment from '@nextcloud/moment'
+const DashboardWidget = () => import('@nextcloud/vue-dashboard')
+const DashboardWidgetItem = () => import('@nextcloud/vue-dashboard')
 
 export default {
 	name: 'Dashboard',

--- a/apps/weather_status/src/App.vue
+++ b/apps/weather_status/src/App.vue
@@ -77,11 +77,11 @@ import moment from '@nextcloud/moment'
 import { getLocale } from '@nextcloud/l10n'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
-import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator'
 import NcActionText from '@nextcloud/vue/dist/Components/NcActionText'
 import * as network from './services/weatherStatusService'
+const NcActionInput = () => import('@nextcloud/vue/dist/Components/NcActionInput')
 
 const MODE_BROWSER_LOCATION = 1
 const MODE_MANUAL_LOCATION = 2

--- a/apps/workflowengine/src/components/Checks/FileSystemTag.vue
+++ b/apps/workflowengine/src/components/Checks/FileSystemTag.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import MultiselectTags from '@nextcloud/vue/dist/Components/NcMultiselectTags.js'
+const MultiselectTags = () => import('@nextcloud/vue/dist/Components/NcMultiselectTags.js')
 
 export default {
 	name: 'FileSystemTag',

--- a/apps/workflowengine/src/components/Checks/request.js
+++ b/apps/workflowengine/src/components/Checks/request.js
@@ -20,10 +20,10 @@
  *
  */
 
-import RequestUserAgent from './RequestUserAgent'
-import RequestTime from './RequestTime'
-import RequestURL from './RequestURL'
-import RequestUserGroup from './RequestUserGroup'
+const RequestUserAgent = () => import('./RequestUserAgent')
+const RequestTime = () => import('./RequestTime')
+const RequestURL = () => import('./RequestURL')
+const RequestUserGroup = () => import('./RequestUserGroup')
 
 const RequestChecks = [
 	{

--- a/apps/workflowengine/src/store.js
+++ b/apps/workflowengine/src/store.js
@@ -28,9 +28,9 @@ import Vue from 'vue'
 import Vuex, { Store } from 'vuex'
 import axios from '@nextcloud/axios'
 import { getApiUrl } from './helpers/api'
-import { confirmPassword } from '@nextcloud/password-confirmation'
 import '@nextcloud/password-confirmation/dist/style.css'
 import { loadState } from '@nextcloud/initial-state'
+const confirmPassword = async () => await (await import('@nextcloud/password-confirmation')).confirmPassword()
 
 Vue.use(Vuex)
 

--- a/apps/workflowengine/src/workflowengine.js
+++ b/apps/workflowengine/src/workflowengine.js
@@ -27,6 +27,9 @@ import store from './store'
 import Settings from './components/Workflow'
 import ShippedChecks from './components/Checks'
 
+import { getRequestToken } from '@nextcloud/auth'
+__webpack_nonce__ = btoa(getRequestToken())
+
 /**
  * A plugin for displaying a custom value field for checks
  *

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -131,7 +131,7 @@ module.exports = {
 					// necessary to keep this name to properly inject it
 					// see OC_Template.php
 					name: 'core-common',
-					chunks: 'all',
+					chunks: 'initial',
 				},
 			},
 		},


### PR DESCRIPTION
Enables lazy loading of libraries in the JS bundle. This improves perceivable UI loading time ~~by almost 2x~~ (I realised my dev/test setup isn't ideal for testing this) in my test environment (to load the Files app) and reduces the transferred data from ~5MB to ~3MB. These results are shown beside the screenshots.

The most painful things loaded in `core-common.js` (now separate):
1. Nextcloud vue components. These are huge and not always required.
2. The password confirmation dialog. This one is the biggest.
3. Emoji and moment JSON

Caveat:
1. The total size of everything is slightly larger, but this is fine, since not everything is loaded (much less, actually)
2. Slightly increased complexity. I doubt it's significant.

**Production bundle before optimization:**
![before](https://user-images.githubusercontent.com/10709794/204048612-2e6480a9-a51c-4ce2-a6b8-4301cc46f548.png)

**After pruning**:
![after](https://user-images.githubusercontent.com/10709794/204048646-9aff2588-e913-4f4d-b43e-9acf9554f67e.png)

