### PR TITLE
fix multiline-format-error in file-conflict modal

### DIFF
--- a/apps/files/css/merged.css
+++ b/apps/files/css/merged.css
@@ -1541,7 +1541,7 @@ table.dragshadow td.size {
 .oc-dialog .fileexists .original,
 .oc-dialog .fileexists .replacement {
   float: left;
-  width: 225px;
+  width: 50%;
 }
 
 .oc-dialog .fileexists .conflicts {

--- a/apps/files/css/upload.css
+++ b/apps/files/css/upload.css
@@ -187,7 +187,7 @@
 .oc-dialog .fileexists .original,
 .oc-dialog .fileexists .replacement {
   float: left;
-  width: 225px;
+  width: 50%;
 }
 
 .oc-dialog .fileexists .conflicts {

--- a/apps/files/css/upload.scss
+++ b/apps/files/css/upload.scss
@@ -156,7 +156,7 @@
 .oc-dialog .fileexists .original,
 .oc-dialog .fileexists .replacement {
 	float: left;
-	width: 225px;
+	width: 50%;
 }
 .oc-dialog .fileexists .conflicts {
 	overflow-y: auto;


### PR DESCRIPTION
when multiple files have conflicts, a scrollbar is shown in the file-conflict modal. due to the scrollbar the width of original/existing is to large, so that instead of being next to each other they flow into the next line. this change fixes this
see screenshots below

## Before:
![Screenshot 2022-11-26 164849](https://user-images.githubusercontent.com/4939546/204074360-31b68984-7a69-4dfd-9575-7968254cf93e.jpg)

## After:
![Screenshot 2022-11-26 164802](https://user-images.githubusercontent.com/4939546/204074359-bfb079cd-5f1f-4935-be0b-2ca4f8715220.jpg)

Signed-off-by: Zyc <Zyclotrop-j@users.noreply.github.com>


* Resolves: # I haven't opened a github issue / haven't searched for an open one (happy to do so, let me know)

## Summary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ N/A ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [Y] Screenshots before/after for front-end changes
- [ N/A ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ N/A ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
