### PR TITLE
cURL time out

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -272,7 +272,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$client = $this->httpClient->newClient();
 		try {
 			$result = $client->get($url, [
-				'timeout' => 10,
+				'timeout' => 60,
 				'connect_timeout' => 10,
 			])->getBody();
 			$data = json_decode($result);

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -74,7 +74,7 @@ class Client implements IClient {
 
 		$defaults = [
 			RequestOptions::VERIFY => $this->getCertBundle(),
-			RequestOptions::TIMEOUT => 30,
+			RequestOptions::TIMEOUT => 120,
 		];
 
 		$options['nextcloud']['allow_local_address'] = $this->isLocalAddressAllowed($options);


### PR DESCRIPTION
* Resolves: --

## Summary
Fixed cURL regarding: 
https://help.nextcloud.com/t/curl-error-28-operation-timed-out-after-30000-milliseconds-with-0-bytes-received-federated-nextcloud/113088

## TODO
--

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
