### PR TITLE
Update rich-workspace visibility

### DIFF
--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -81,10 +81,18 @@
 			if (action === 'upload') {
 				OC.hideMenus();
 			} else {
-				event.preventDefault();
-				this.$el.find('.menuitem.active').removeClass('active');
-				$target.addClass('active');
-				this._promptFileName($target);
+				var actionItem = _.filter(this._menuItems, function(item) {
+					return item.id === action
+				}).pop();
+				if (typeof actionItem.useInput === 'undefined' || actionItem.useInput === true) {
+					event.preventDefault();
+					this.$el.find('.menuitem.active').removeClass('active');
+					$target.addClass('active');
+					this._promptFileName($target);
+				} else {
+					actionItem.actionHandler();
+					OC.hideMenus();
+				}
 			}
 		},
 
@@ -198,8 +206,10 @@
 				templateName: actionSpec.templateName,
 				iconClass: actionSpec.iconClass,
 				fileType: actionSpec.fileType,
+				useInput: actionSpec.useInput,
 				actionHandler: actionSpec.actionHandler,
-				checkFilename: actionSpec.checkFilename
+				checkFilename: actionSpec.checkFilename,
+				shouldShow: actionSpec.shouldShow,
 			});
 		},
 
@@ -220,10 +230,11 @@
 		 * Renders the menu with the currently set items
 		 */
 		render: function() {
+			const menuItems = this._menuItems.filter(item => !item.shouldShow || (item.shouldShow instanceof Function && item.shouldShow() === true))
 			this.$el.html(this.template({
 				uploadMaxHumanFileSize: 'TODO',
 				uploadLabel: t('files', 'Upload file'),
-				items: this._menuItems
+				items: menuItems
 			}));
 
 			// Trigger upload action also with keyboard navigation on enter


### PR DESCRIPTION
With the new flow to create rich workspace Readme files described in https://github.com/nextcloud/text/issues/3209 we need a hook to be able to show or hide the entry in the new files menu depending on the current folder. For that reason this PR adds a callback that can be provided to show/hide when the menu is shown.

Required for https://github.com/nextcloud/text/pull/3291

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
