### PR TITLE
Remove Bootstrap version reference from tooltip.scss

### DIFF
--- a/core/css/server.css
+++ b/core/css/server.css
@@ -4512,7 +4512,7 @@ kbd {
  * @copyright Copyright (c) 2016, Erik Pellikka <erik@pellikka.org>
  * @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
  *
- * Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Bootstrap (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/core/css/tooltip.css
+++ b/core/css/tooltip.css
@@ -6,7 +6,7 @@
  * @copyright Copyright (c) 2016, Erik Pellikka <erik@pellikka.org>
  * @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
  *
- * Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Bootstrap (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */

--- a/core/css/tooltip.scss
+++ b/core/css/tooltip.scss
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2016, Erik Pellikka <erik@pellikka.org>
  * @copyright Copyright (c) 2015, Vincent Petry <pvince81@owncloud.com>
  *
- * Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Bootstrap (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */


### PR DESCRIPTION
We've had some reports that Nextcloud is using an outdated/deprecated Bootstrap version v3.3.5. 

I believe this to be caused by the string "Bootstrap v3.3.5"  removed in this PR, which after bundling ends up in `core-common.js`, and trips up some security scanners.

It may also be worth investigating why the comments are not getting stripped when bundling the JS.

cc @nickvergessen 
