### PR TITLE
[BUGFIX] Prevents the selection of encrypted files at the bottom of the list(before scrolling)

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1421,14 +1421,14 @@
 					hidden = false;
 				}
 				tr = this._renderRow(fileData, {updateSummary: false, silent: true, hidden: hidden});
-				if (tr.attr('data-e2eencrypted') === 'true') {
-    					tr.toggleClass('selected', false);
-    					tr.find('td.selection > .selectCheckBox:visible').prop('checked', false);
-				}
 				this.$fileList.append(tr);
 				if (isAllSelected || this._selectedFiles[fileData.id]) {
 					tr.addClass('selected');
 					tr.find('.selectCheckBox').prop('checked', true);
+				}
+				if (tr.attr('data-e2eencrypted') === 'true') {
+    					tr.toggleClass('selected', false);
+    					tr.find('td.selection > .selectCheckBox:visible').prop('checked', false);
 				}
 				if (animate) {
 					tr.addClass('appear transparent');


### PR DESCRIPTION

https://github.com/nextcloud/server/pull/35299 
this PR is get merged but now we found one bug.
bug description -  encrypted files which are not in viewport are getting selected when we click on **select all** options, whereas they should not be get selected.