### PR TITLE
Improve dependency injection error message

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -108,7 +108,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 						return $this->query($resolveName);
 					} catch (QueryException $e2) {
 						// don't lose the error we got while trying to query by type
-						throw new QueryException($e2->getMessage(), (int) $e2->getCode(), $e);
+						throw new QueryException($e->getMessage(), (int) $e->getCode(), $e);
 					}
 				}
 


### PR DESCRIPTION
Change from display the name of the parameter to the type of the parameter. This is that in most cases is usefull.