### PR TITLE
Create the users from database backend in a transaction

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -45,6 +45,7 @@ declare(strict_types=1);
  */
 namespace OC\User;
 
+use OCP\AppFramework\Db\TTransactional;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
@@ -85,6 +86,8 @@ class Database extends ABackend implements
 	/** @var string */
 	private $table;
 
+	use TTransactional;
+
 	/**
 	 * \OC\User\Database constructor.
 	 *
@@ -122,20 +125,24 @@ class Database extends ABackend implements
 		if (!$this->userExists($uid)) {
 			$this->eventDispatcher->dispatchTyped(new ValidatePasswordPolicyEvent($password));
 
-			$qb = $this->dbConn->getQueryBuilder();
-			$qb->insert($this->table)
-				->values([
-					'uid' => $qb->createNamedParameter($uid),
-					'password' => $qb->createNamedParameter(\OC::$server->getHasher()->hash($password)),
-					'uid_lower' => $qb->createNamedParameter(mb_strtolower($uid)),
-				]);
+			return $this->atomic(function () use ($uid, $password) {
+				$qb = $this->dbConn->getQueryBuilder();
+				$qb->insert($this->table)
+					->values([
+						'uid' => $qb->createNamedParameter($uid),
+						'password' => $qb->createNamedParameter(\OC::$server->getHasher()->hash($password)),
+						'uid_lower' => $qb->createNamedParameter(mb_strtolower($uid)),
+					]);
 
-			$result = $qb->execute();
+				$result = $qb->executeStatement();
 
-			// Clear cache
-			unset($this->cache[$uid]);
+				// Clear cache
+				unset($this->cache[$uid]);
+				// Repopulate the cache
+				$this->loadUser($uid);
 
-			return $result ? true : false;
+				return (bool) $result;
+			}, $this->dbConn);
 		}
 
 		return false;


### PR DESCRIPTION
## Summary

In `OC\User\Manager::createUserFromBackend` the newly created user is read again using `getUserObject($uid, $backend)` but that can cause causal read issues (wrote in DB primary, not yet in secondary).

In `OC\User\Database` user backend the user cache is unset after the insert, so it can't be used by `getRealUID()` (which is called by `getUserObject()`).

To avoid that we make sure the user cache is repopulated in a transaction. This doesn't change the total number of queries made.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
