### PR TITLE
preview: respect quality in Imaginary

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -90,6 +90,8 @@ class Imaginary extends ProviderV2 {
 				$mimeType = 'jpeg';
 		}
 
+		$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
+
 		$operations = [
 			[
 				'operation' => 'autorotate',
@@ -102,6 +104,7 @@ class Imaginary extends ProviderV2 {
 					'stripmeta' => 'true',
 					'type' => $mimeType,
 					'norotation' => 'true',
+					'quality' => $quality,
 				]
 			]
 		];


### PR DESCRIPTION
Currently uses the default of 80.

Btw, Imaginary is both slower and produces bigger images compared to Imagick for me. At least for HEIF. I was a bit surprised.

Signed-off-by: Varun Patil <varunpatil@ucla.edu>