### PR TITLE
Add typings to config

### DIFF
--- a/apps/encryption/lib/Recovery.php
+++ b/apps/encryption/lib/Recovery.php
@@ -169,7 +169,7 @@ class Recovery {
 	 * @return bool
 	 */
 	public function isRecoveryKeyEnabled() {
-		$enabled = $this->config->getAppValue('encryption', 'recoveryAdminEnabled', 0);
+		$enabled = $this->config->getAppValue('encryption', 'recoveryAdminEnabled', '0');
 
 		return ($enabled === '1');
 	}

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -315,10 +315,10 @@ class ViewController extends Controller {
 		$params['allowShareWithLink'] = $this->shareManager->shareApiAllowLinks() ? 'yes' : 'no';
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
-		$params['showgridview'] = $this->config->getUserValue($user, 'files', 'show_grid', false);
-		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', false);
+		$params['showgridview'] = $this->config->getUserValue($user, 'files', 'show_grid', 'false');
+		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', 'false');
 		$params['showHiddenFiles'] = $showHidden ? 1 : 0;
-		$cropImagePreviews = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'crop_image_previews', true);
+		$cropImagePreviews = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'crop_image_previews', 'true');
 		$params['cropImagePreviews'] = $cropImagePreviews ? 1 : 0;
 		$params['fileNotFound'] = $fileNotFound ? 1 : 0;
 		$params['appNavigation'] = $nav;

--- a/apps/files/list.php
+++ b/apps/files/list.php
@@ -34,7 +34,7 @@ $userSession = Server::get(IUserSession::class);
 $shareManager = Server::get(IManager::class);
 $publicUploadEnabled = $shareManager->shareApiLinkAllowPublicUpload() ? 'yes' : 'no';
 
-$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
+$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', 'false');
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'list', '');

--- a/apps/files/recentlist.php
+++ b/apps/files/recentlist.php
@@ -27,7 +27,7 @@
 $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
-$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
+$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', 'false');
 
 $tmpl = new OCP\Template('files', 'recentlist', '');
 

--- a/apps/files/simplelist.php
+++ b/apps/files/simplelist.php
@@ -25,7 +25,7 @@
 $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
-$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
+$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', 'false');
 
 // renders the controls and table headers template
 $tmpl = new OCP\Template('files', 'simplelist', '');

--- a/apps/files_sharing/list.php
+++ b/apps/files_sharing/list.php
@@ -30,7 +30,7 @@ use OCP\Server;
 $config = Server::get(IConfig::class);
 $userSession = Server::get(IUserSession::class);
 
-$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
+$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', 'false');
 
 $tmpl = new OCP\Template('files_sharing', 'list', '');
 

--- a/apps/files_trashbin/list.php
+++ b/apps/files_trashbin/list.php
@@ -28,7 +28,7 @@
 $config = \OC::$server->getConfig();
 $userSession = \OC::$server->getUserSession();
 
-$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', false);
+$showgridview = $config->getUserValue($userSession->getUser()->getUID(), 'files', 'show_grid', 'false');
 
 $tmpl = new OCP\Template('files_trashbin', 'index', '');
 

--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -180,7 +180,7 @@ class RetryJob extends Job {
 				$user->getUID(),
 				'lookup_server_connector',
 				'update_retries',
-				$this->retries + 1
+				(string)($this->retries + 1)
 			);
 		}
 	}

--- a/apps/theming/lib/Migration/MigrateUserConfig.php
+++ b/apps/theming/lib/Migration/MigrateUserConfig.php
@@ -91,20 +91,18 @@ class MigrateUserConfig implements IRepairStep {
 		$this->userManager->callForSeenUsers(function (IUser $user) use ($output) {
 			$config = [];
 
-			$font = $this->config->getUserValue($user->getUID(), 'accessibility', 'font', false);
-			$highcontrast = $this->config->getUserValue($user->getUID(), 'accessibility', 'highcontrast', false);
-			$theme = $this->config->getUserValue($user->getUID(), 'accessibility', 'theme', false);
+			$font = $this->config->getUserValue($user->getUID(), 'accessibility', 'font', '');
+			$highcontrast = $this->config->getUserValue($user->getUID(), 'accessibility', 'highcontrast', '');
+			$theme = $this->config->getUserValue($user->getUID(), 'accessibility', 'theme', '');
 
-			if ($highcontrast || $theme) {
-				if ($theme === 'dark' && $highcontrast === 'highcontrast') {
-					$config[] = $this->darkHighContrastTheme->getId();
-				} else if ($theme === 'dark') {
-					$config[] = $this->darkTheme->getId();
-				} else if ($highcontrast === 'highcontrast') {
-					$config[] = $this->highContrastTheme->getId();
-				}
+			if ($theme === 'dark' && $highcontrast === 'highcontrast') {
+				$config[] = $this->darkHighContrastTheme->getId();
+			} else if ($theme === 'dark') {
+				$config[] = $this->darkTheme->getId();
+			} else if ($highcontrast === 'highcontrast') {
+				$config[] = $this->highContrastTheme->getId();
 			}
-			
+
 			if ($font === 'fontdyslexic') {
 				$config[] = $this->dyslexiaFont->getId();
 			}

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -268,7 +268,7 @@ class ThemingDefaults extends \OC_Defaults {
 		// explanation: if an SVG is requested and the app config value for logoMime is set then the logo is there.
 		// otherwise we need to check it and maybe also generate a PNG from the SVG (that's done in getImage() which
 		// needs to be called then)
-		if ($useSvg === true && $logo !== false) {
+		if ($useSvg === true && $logo !== null) {
 			$logoExists = true;
 		} else {
 			try {

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -85,7 +85,7 @@ class AdminController extends Controller {
 	 */
 	public function setChannel(string $channel): DataResponse {
 		Util::setChannel($channel);
-		$this->config->setAppValue('core', 'lastupdatedat', 0);
+		$this->config->setAppValue('core', 'lastupdatedat', '0');
 		return new DataResponse(['status' => 'success', 'data' => ['message' => $this->l10n->t('Channel updated')]]);
 	}
 
@@ -99,7 +99,7 @@ class AdminController extends Controller {
 
 		// Create a new job and store the creation date
 		$this->jobList->add(ResetTokenBackgroundJob::class);
-		$this->config->setAppValue('core', 'updater.secret.created', $this->timeFactory->getTime());
+		$this->config->setAppValue('core', 'updater.secret.created', (string) $this->timeFactory->getTime());
 
 		// Create a new token
 		$newToken = $this->secureRandom->generate(64);

--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -105,14 +105,14 @@ class BackgroundJob extends TimedJob {
 
 		$status = $updater->check();
 		if ($status === false) {
-			$errors = 1 + (int) $this->config->getAppValue('updatenotification', 'update_check_errors', 0);
-			$this->config->setAppValue('updatenotification', 'update_check_errors', $errors);
+			$errors = 1 + (int) $this->config->getAppValue('updatenotification', 'update_check_errors', '0');
+			$this->config->setAppValue('updatenotification', 'update_check_errors', (string) $errors);
 
 			if (\in_array($errors, $this->connectionNotifications, true)) {
 				$this->sendErrorNotifications($errors);
 			}
 		} elseif (\is_array($status)) {
-			$this->config->setAppValue('updatenotification', 'update_check_errors', 0);
+			$this->config->setAppValue('updatenotification', 'update_check_errors', '0');
 			$this->clearErrorNotifications();
 
 			if (isset($status['version'])) {
@@ -186,7 +186,7 @@ class BackgroundJob extends TimedJob {
 			return;
 		}
 
-		if ($lastNotification !== false) {
+		if ($lastNotification !== null) {
 			// Delete old updates
 			$this->deleteOutdatedNotifications($app, $lastNotification);
 		}

--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -116,7 +116,7 @@ class Notifier implements INotifier {
 
 		$l = $this->l10NFactory->get('updatenotification', $languageCode);
 		if ($notification->getSubject() === 'connection_error') {
-			$errors = (int) $this->config->getAppValue('updatenotification', 'update_check_errors', 0);
+			$errors = (int) $this->config->getAppValue('updatenotification', 'update_check_errors', '0');
 			if ($errors === 0) {
 				$this->notificationManager->markProcessed($notification);
 				throw new \InvalidArgumentException('Update checked worked again');

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -190,7 +190,7 @@ class Manager {
 	 */
 	public function isDeletedUser($id) {
 		$isDeleted = $this->ocConfig->getUserValue(
-			$id, 'user_ldap', 'isDeleted', 0);
+			$id, 'user_ldap', 'isDeleted', '0');
 		return (int)$isDeleted === 1;
 	}
 

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -599,9 +599,9 @@ class User {
 	 * @throws \OC\ServerNotAvailableException
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function getExtStorageHome():string {
+	public function getExtStorageHome(): string {
 		$value = $this->config->getUserValue($this->getUsername(), 'user_ldap', 'extStorageHome', '');
-		if ($value !== '') {
+		if ($value !== '' && $value !== null) {
 			return $value;
 		}
 
@@ -619,7 +619,7 @@ class User {
 	 * @throws \OCP\PreConditionNotMetException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function updateExtStorageHome(string $valueFromLDAP = null):string {
+	public function updateExtStorageHome(?string $valueFromLDAP = null): string {
 		if ($valueFromLDAP === null) {
 			$extHomeValues = $this->access->readAttribute($this->getDN(), $this->connection->ldapExtStorageHomeAttribute);
 		} else {

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -394,7 +394,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 			}
 		}
 
-		$marked = (int)$this->ocConfig->getUserValue($uid, 'user_ldap', 'isDeleted', 0);
+		$marked = (int)$this->ocConfig->getUserValue($uid, 'user_ldap', 'isDeleted', '0');
 		if ($marked === 0) {
 			try {
 				$user = $this->access->userManager->get($uid);

--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -333,7 +333,7 @@ class WeatherStatusService {
 		$lat = $this->config->getUserValue($this->userId, Application::APP_ID, 'lat', '');
 		$lon = $this->config->getUserValue($this->userId, Application::APP_ID, 'lon', '');
 		$address = $this->config->getUserValue($this->userId, Application::APP_ID, 'address', '');
-		$mode = $this->config->getUserValue($this->userId, Application::APP_ID, 'mode', self::MODE_MANUAL_LOCATION);
+		$mode = $this->config->getUserValue($this->userId, Application::APP_ID, 'mode', (string) self::MODE_MANUAL_LOCATION);
 		return [
 			'lat' => $lat,
 			'lon' => $lon,

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -77,7 +77,7 @@ class WhatsNewController extends OCSController {
 		if ($user === null) {
 			throw new \RuntimeException("Acting user cannot be resolved");
 		}
-		$lastRead = $this->config->getUserValue($user->getUID(), 'core', 'whatsNewLastRead', 0);
+		$lastRead = $this->config->getUserValue($user->getUID(), 'core', 'whatsNewLastRead', '0');
 		$currentVersion = $this->whatsNewService->normalizeVersion($this->config->getSystemValue('version'));
 
 		if (version_compare($lastRead, $currentVersion, '>=')) {

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -85,185 +88,118 @@ class AllConfig implements IConfig {
 	 * otherwise a SQLite database is created in the wrong directory
 	 * because the database connection was created with an uninitialized config
 	 */
-	private function fixDIInit() {
+	private function fixDIInit(): void {
 		if ($this->connection === null) {
 			$this->connection = \OC::$server->get(IDBConnection::class);
 		}
 	}
 
 	/**
-	 * Sets and deletes system wide values
-	 *
-	 * @param array $configs Associative array with `key => value` pairs
-	 *                       If value is null, the config key will be deleted
+	 * @inheritdoc
 	 */
-	public function setSystemValues(array $configs) {
+	public function setSystemValues(array $configs): void {
 		$this->systemConfig->setValues($configs);
 	}
 
 	/**
-	 * Sets a new system wide value
-	 *
-	 * @param string $key the key of the value, under which will be saved
-	 * @param mixed $value the value that should be stored
+	 * @inheritdoc
 	 */
-	public function setSystemValue($key, $value) {
+	public function setSystemValue(string $key, $value): void {
 		$this->systemConfig->setValue($key, $value);
 	}
 
 	/**
-	 * Looks up a system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @inheritdoc
 	 */
 	public function getSystemValue($key, $default = '') {
 		return $this->systemConfig->getValue($key, $default);
 	}
 
 	/**
-	 * Looks up a boolean system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param bool $default the default value to be returned if the value isn't set
-	 *
-	 * @return bool
-	 *
-	 * @since 16.0.0
+	 * @inheritdoc
 	 */
 	public function getSystemValueBool(string $key, bool $default = false): bool {
 		return (bool) $this->getSystemValue($key, $default);
 	}
 
 	/**
-	 * Looks up an integer system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param int $default the default value to be returned if the value isn't set
-	 *
-	 * @return int
-	 *
-	 * @since 16.0.0
+	 * @inheritdoc
 	 */
 	public function getSystemValueInt(string $key, int $default = 0): int {
 		return (int) $this->getSystemValue($key, $default);
 	}
 
 	/**
-	 * Looks up a string system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param string $default the default value to be returned if the value isn't set
-	 *
-	 * @return string
-	 *
-	 * @since 16.0.0
+	 * @inheritdoc
 	 */
 	public function getSystemValueString(string $key, string $default = ''): string {
 		return (string) $this->getSystemValue($key, $default);
 	}
 
 	/**
-	 * Looks up a system wide defined value and filters out sensitive data
-	 *
-	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @inheritdoc
 	 */
-	public function getFilteredSystemValue($key, $default = '') {
+	public function getFilteredSystemValue(string $key, string $default = ''): string {
 		return $this->systemConfig->getFilteredValue($key, $default);
 	}
 
 	/**
-	 * Delete a system wide defined value
-	 *
-	 * @param string $key the key of the value, under which it was saved
+	 * @inheritdoc
 	 */
-	public function deleteSystemValue($key) {
+	public function deleteSystemValue(string $key): void {
 		$this->systemConfig->deleteValue($key);
 	}
 
 	/**
-	 * Get all keys stored for an app
-	 *
-	 * @param string $appName the appName that we stored the value under
-	 * @return string[] the keys stored for the app
+	 * @inheritdoc
 	 */
-	public function getAppKeys($appName) {
+	public function getAppKeys(string $appName): array {
 		return \OC::$server->get(AppConfig::class)->getKeys($appName);
 	}
 
 	/**
-	 * Writes a new app wide value
-	 *
-	 * @param string $appName the appName that we want to store the value under
-	 * @param string $key the key of the value, under which will be saved
-	 * @param string|float|int $value the value that should be stored
+	 * @inheritdoc
 	 */
-	public function setAppValue($appName, $key, $value) {
+	public function setAppValue(string $appName, string $key, string $value): void {
 		\OC::$server->get(AppConfig::class)->setValue($appName, $key, $value);
 	}
 
 	/**
-	 * Looks up an app wide defined value
-	 *
-	 * @param string $appName the appName that we stored the value under
-	 * @param string $key the key of the value, under which it was saved
-	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the saved value
+	 * @inheritdoc
 	 */
-	public function getAppValue($appName, $key, $default = '') {
+	public function getAppValue(string $appName, string $key, $default = '') {
 		return \OC::$server->get(AppConfig::class)->getValue($appName, $key, $default);
 	}
 
 	/**
-	 * Delete an app wide defined value
-	 *
-	 * @param string $appName the appName that we stored the value under
-	 * @param string $key the key of the value, under which it was saved
+	 * @inheritdoc
 	 */
-	public function deleteAppValue($appName, $key) {
+	public function deleteAppValue(string $appName, string $key): void {
 		\OC::$server->get(AppConfig::class)->deleteKey($appName, $key);
 	}
 
 	/**
-	 * Removes all keys in appconfig belonging to the app
-	 *
-	 * @param string $appName the appName the configs are stored under
+	 * @inheritdoc
 	 */
-	public function deleteAppValues($appName) {
+	public function deleteAppValues(string $appName): void {
 		\OC::$server->get(AppConfig::class)->deleteApp($appName);
 	}
 
-
 	/**
-	 * Set a user defined value
-	 *
-	 * @param string $userId the userId of the user that we want to store the value under
-	 * @param string $appName the appName that we want to store the value under
-	 * @param string $key the key under which the value is being stored
-	 * @param string|float|int $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
-	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
-	 * @throws \UnexpectedValueException when trying to store an unexpected value
+	 * @inheritdoc
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null) {
-		if (!is_int($value) && !is_float($value) && !is_string($value)) {
-			throw new \UnexpectedValueException('Only integers, floats and strings are allowed as value');
-		}
-
+	public function setUserValue(string $userId, string $appName, string $key, string $value, ?string $preCondition = null): void {
 		// TODO - FIXME
 		$this->fixDIInit();
 
 		if ($appName === 'settings' && $key === 'email') {
-			$value = strtolower((string) $value);
+			$value = strtolower($value);
 		}
 
 		$prevValue = $this->getUserValue($userId, $appName, $key, null);
 
 		if ($prevValue !== null) {
-			if ($prevValue === (string)$value) {
+			if ($prevValue === $value) {
 				return;
 			} elseif ($preCondition !== null && $prevValue !== (string)$preCondition) {
 				throw new PreConditionNotMetException();
@@ -306,15 +242,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Getting a user defined value
-	 *
-	 * @param ?string $userId the userId of the user that we want to store the value under
-	 * @param string $appName the appName that we stored the value under
-	 * @param string $key the key under which the value is being stored
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return string
+	 * @inheritdoc
 	 */
-	public function getUserValue($userId, $appName, $key, $default = '') {
+	public function getUserValue(?string $userId, string $appName, string $key, ?string $default = ''): ?string {
 		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName][$key])) {
 			return $data[$appName][$key];
@@ -324,13 +254,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Get the keys of all stored by an app for the user
-	 *
-	 * @param string $userId the userId of the user that we want to store the value under
-	 * @param string $appName the appName that we stored the value under
-	 * @return string[]
+	 * @inheritdoc
 	 */
-	public function getUserKeys($userId, $appName) {
+	public function getUserKeys(?string $userId, string $appName): array {
 		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName])) {
 			return array_keys($data[$appName]);
@@ -340,13 +266,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Delete a user value
-	 *
-	 * @param string $userId the userId of the user that we want to store the value under
-	 * @param string $appName the appName that we stored the value under
-	 * @param string $key the key under which the value is being stored
+	 * @inheritdoc
 	 */
-	public function deleteUserValue($userId, $appName, $key) {
+	public function deleteUserValue(string $userId, string $appName, string $key): void {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -363,11 +285,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Delete all user values
-	 *
-	 * @param string $userId the userId of the user that we want to remove all values from
+	 * @inheritdoc
 	 */
-	public function deleteAllUserValues($userId) {
+	public function deleteAllUserValues(string $userId): void {
 		// TODO - FIXME
 		$this->fixDIInit();
 		$qb = $this->connection->getQueryBuilder();
@@ -379,11 +299,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Delete all user related values of one app
-	 *
-	 * @param string $appName the appName of the app that we want to remove all values from
+	 * @inheritdoc
 	 */
-	public function deleteAppFromAllUsers($appName) {
+	public function deleteAppFromAllUsers(string $appName): void {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -398,14 +316,7 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Returns all user configs sorted by app of one user
-	 *
-	 * @param ?string $userId the user ID to get the app configs from
-	 * @psalm-return array<string, array<string, string>>
-	 * @return array[] - 2 dimensional array with the following structure:
-	 *     [ $appId =>
-	 *         [ $key => $value ]
-	 *     ]
+	 * @inheritdoc
 	 */
 	public function getAllUserValues(?string $userId): array {
 		if (isset($this->userCache[$userId])) {
@@ -438,18 +349,13 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Fetches a mapped list of userId -> value, for a specified app and key and a list of user IDs.
-	 *
-	 * @param string $appName app to get the value for
-	 * @param string $key the key to get the value for
-	 * @param array $userIds the user IDs to fetch the values for
-	 * @return array Mapped values: userId => value
+	 * @inheritdoc
 	 */
-	public function getUserValueForUsers($appName, $key, $userIds) {
+	public function getUserValueForUsers(string $appName, string $key, array $userIds): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 
-		if (empty($userIds) || !is_array($userIds)) {
+		if (empty($userIds)) {
 			return [];
 		}
 
@@ -478,14 +384,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Determines the users that have the given value set for a specific app-key-pair
-	 *
-	 * @param string $appName the app to get the user for
-	 * @param string $key the key to get the user for
-	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @inheritdoc
 	 */
-	public function getUsersForUserValue($appName, $key, $value) {
+	public function getUsersForUserValue(string $appName, string $key, string $value): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -509,14 +410,9 @@ class AllConfig implements IConfig {
 	}
 
 	/**
-	 * Determines the users that have the given value set for a specific app-key-pair
-	 *
-	 * @param string $appName the app to get the user for
-	 * @param string $key the key to get the user for
-	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @inheritdoc
 	 */
-	public function getUsersForUserValueCaseInsensitive($appName, $key, $value) {
+	public function getUsersForUserValueCaseInsensitive(string $appName, string $key, string $value): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017, Joas Schilling <coding@schilljs.com>
  * @copyright Copyright (c) 2016, ownCloud, Inc.
@@ -44,7 +47,7 @@ use OCP\IConfig;
 class AppConfig implements IAppConfig {
 
 	/** @var array[] */
-	protected $sensitiveValues = [
+	protected const SENSITIVE_VALUES = [
 		'circles' => [
 			'/^key_pairs$/',
 			'/^local_gskey$/',
@@ -158,7 +161,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $app
 	 * @return array
 	 */
-	private function getAppValues($app) {
+	private function getAppValues(string $app): array {
 		$this->loadConfigValues();
 
 		if (isset($this->cache[$app])) {
@@ -169,14 +172,9 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * Get all apps using the config
-	 *
-	 * @return array an array of app ids
-	 *
-	 * This function returns a list of all apps that have at least one
-	 * entry in the appconfig table.
+	 * @inheritdoc
 	 */
-	public function getApps() {
+	public function getApps(): array {
 		$this->loadConfigValues();
 
 		return $this->getSortedKeys($this->cache);
@@ -191,7 +189,7 @@ class AppConfig implements IAppConfig {
 	 * This function gets all keys of an app. Please note that the values are
 	 * not returned.
 	 */
-	public function getKeys($app) {
+	public function getKeys(string $app): array {
 		$this->loadConfigValues();
 
 		if (isset($this->cache[$app])) {
@@ -201,7 +199,7 @@ class AppConfig implements IAppConfig {
 		return [];
 	}
 
-	public function getSortedKeys($data) {
+	public function getSortedKeys(array $data): array {
 		$keys = array_keys($data);
 		sort($keys);
 		return $keys;
@@ -218,7 +216,7 @@ class AppConfig implements IAppConfig {
 	 * This function gets a value from the appconfig table. If the key does
 	 * not exist the default value will be returned
 	 */
-	public function getValue($app, $key, $default = null) {
+	public function getValue(string $app, string $key, ?string $default = null): ?string {
 		$this->loadConfigValues();
 
 		if ($this->hasKey($app, $key)) {
@@ -229,13 +227,9 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * check if a key is set in the appconfig
-	 *
-	 * @param string $app
-	 * @param string $key
-	 * @return bool
+	 * @inheritdoc
 	 */
-	public function hasKey($app, $key) {
+	public function hasKey(string $app, string $key): bool {
 		$this->loadConfigValues();
 
 		return isset($this->cache[$app][$key]);
@@ -249,7 +243,7 @@ class AppConfig implements IAppConfig {
 	 * @param string|float|int $value value
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
-	public function setValue($app, $key, $value) {
+	public function setValue(string $app, string $key, $value): bool {
 		if (!$this->hasKey($app, $key)) {
 			$inserted = (bool) $this->conn->insertIfNotExist('*PREFIX*appconfig', [
 				'appid' => $app,
@@ -317,7 +311,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $key key
 	 * @return boolean
 	 */
-	public function deleteKey($app, $key) {
+	public function deleteKey(string $app, string $key): bool {
 		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
@@ -340,7 +334,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * Removes all keys in appconfig belonging to the app.
 	 */
-	public function deleteApp($app) {
+	public function deleteApp(string $app): bool {
 		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
@@ -354,11 +348,7 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * get multiple values, either the app or key can be used as wildcard by setting it to false
-	 *
-	 * @param string|false $app
-	 * @param string|false $key
-	 * @return array|false
+	 * @inheritdoc
 	 */
 	public function getValues($app, $key) {
 		if (($app !== false) === ($key !== false)) {
@@ -379,16 +369,13 @@ class AppConfig implements IAppConfig {
 	}
 
 	/**
-	 * get all values of the app or and filters out sensitive data
-	 *
-	 * @param string $app
-	 * @return array
+	 * @inheritdoc
 	 */
-	public function getFilteredValues($app) {
+	public function getFilteredValues(string $app): array {
 		$values = $this->getValues($app, false);
 
-		if (isset($this->sensitiveValues[$app])) {
-			foreach ($this->sensitiveValues[$app] as $sensitiveKeyExp) {
+		if (isset(self::SENSITIVE_VALUES[$app])) {
+			foreach (self::SENSITIVE_VALUES[$app] as $sensitiveKeyExp) {
 				$sensitiveKeys = preg_grep($sensitiveKeyExp, array_keys($values));
 				foreach ($sensitiveKeys as $sensitiveKey) {
 					$values[$sensitiveKey] = IConfig::SENSITIVE_VALUE;
@@ -402,7 +389,7 @@ class AppConfig implements IAppConfig {
 	/**
 	 * Load all the app config values
 	 */
-	protected function loadConfigValues() {
+	protected function loadConfigValues(): void {
 		if ($this->configLoaded) {
 			return;
 		}

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -66,7 +66,7 @@ class AppConfig implements IAppConfig {
 		$this->config->setUserValue($userId, $this->appName, $key, $value, $preCondition);
 	}
 
-	public function getUserValue(string $userId, string $key, string $default = ''): string {
+	public function getUserValue(string $userId, string $key, string $default = ''): ?string {
 		return $this->config->getUserValue($userId, $this->appName, $key, $default);
 	}
 

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -279,7 +279,7 @@ class Manager {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
 			$tokenId = $token->getId();
-			$this->config->deleteUserValue($user->getUID(), 'login_token_2fa', $tokenId);
+			$this->config->deleteUserValue($user->getUID(), 'login_token_2fa', (string)$tokenId);
 
 			$dispatchEvent = new GenericEvent($user, ['provider' => $provider->getDisplayName()]);
 			$this->legacyDispatcher->dispatch(IProvider::EVENT_SUCCESS, $dispatchEvent);
@@ -395,7 +395,7 @@ class Manager {
 
 		$id = $this->session->getId();
 		$token = $this->tokenProvider->getToken($id);
-		$this->config->setUserValue($user->getUID(), 'login_token_2fa', (string) $token->getId(), $this->timeFactory->getTime());
+		$this->config->setUserValue($user->getUID(), 'login_token_2fa', (string) $token->getId(), (string) $this->timeFactory->getTime());
 	}
 
 	public function clearTwoFactorPending(string $userId) {

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -94,7 +94,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	/**
 	 * Formats a message according to the given styles.
 	 *
-	 * @param string $message The message to style
+	 * @param ?string $message The message to style
 	 * @return string The styled message, prepended with a timestamp using the
 	 * log timezone and dateformat, e.g. "2015-06-23T17:24:37+02:00"
 	 */

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -287,7 +287,7 @@ class JSConfigHelper {
 		if ($this->currentUser !== null) {
 			$array['oc_userconfig'] = json_encode([
 				'avatar' => [
-					'version' => (int)$this->config->getUserValue($uid, 'avatar', 'version', 0),
+					'version' => (int)$this->config->getUserValue($uid, 'avatar', 'version', '0'),
 					'generated' => $this->config->getUserValue($uid, 'avatar', 'generated', 'true') === 'true',
 				]
 			]);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -154,7 +154,7 @@ class TemplateLayout extends \OC_Template {
 				$this->assign('userStatus', false);
 			} else {
 				$this->assign('userAvatarSet', true);
-				$this->assign('userAvatarVersion', $this->config->getUserValue(\OC_User::getUser(), 'avatar', 'version', 0));
+				$this->assign('userAvatarVersion', $this->config->getUserValue(\OC_User::getUser(), 'avatar', 'version', '0'));
 			}
 		} elseif ($renderAs === TemplateResponse::RENDER_AS_ERROR) {
 			parent::__construct('core', 'layout.guest', '', false);

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -238,7 +238,7 @@ class User implements IUser {
 	 */
 	public function getLastLogin() {
 		if ($this->lastLogin === null) {
-			$this->lastLogin = (int) $this->config->getUserValue($this->uid, 'login', 'lastLogin', 0);
+			$this->lastLogin = (int) $this->config->getUserValue($this->uid, 'login', 'lastLogin', '0');
 		}
 		return (int) $this->lastLogin;
 	}

--- a/lib/public/AppFramework/Services/IAppConfig.php
+++ b/lib/public/AppFramework/Services/IAppConfig.php
@@ -94,11 +94,11 @@ interface IAppConfig {
 	 *
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return string
+	 * @param string $default the default value to be returned if the value isn't set
+	 * @return ?string
 	 * @since 20.0.0
 	 */
-	public function getUserValue(string $userId, string $key, string $default = ''): string;
+	public function getUserValue(string $userId, string $key, string $default = ''): ?string;
 
 	/**
 	 * Delete a user value

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -39,7 +42,7 @@ interface IAppConfig {
 	 * @return bool
 	 * @since 7.0.0
 	 */
-	public function hasKey($app, $key);
+	public function hasKey(string $app, string $key): bool;
 
 	/**
 	 * get multiply values, either the app or key can be used as wildcard by setting it to false
@@ -58,7 +61,7 @@ interface IAppConfig {
 	 * @return array
 	 * @since 12.0.0
 	 */
-	public function getFilteredValues($app);
+	public function getFilteredValues(string $app): array;
 
 	/**
 	 * Get all apps using the config
@@ -68,5 +71,5 @@ interface IAppConfig {
 	 * entry in the appconfig table.
 	 * @since 7.0.0
 	 */
-	public function getApps();
+	public function getApps(): array;
 }

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -50,7 +53,7 @@ interface IConfig {
 	 * @throws HintException if config file is read-only
 	 * @since 8.0.0
 	 */
-	public function setSystemValues(array $configs);
+	public function setSystemValues(array $configs): void;
 
 	/**
 	 * Sets a new system wide value
@@ -60,17 +63,18 @@ interface IConfig {
 	 * @throws HintException if config file is read-only
 	 * @since 8.0.0
 	 */
-	public function setSystemValue($key, $value);
+	public function setSystemValue(string $key, $value): void;
 
 	/**
-	 * Looks up a system wide defined value
+	 * Looks up a system wide defined value.
+	 * Prefer getSystemValueBool, getSystemValueInt or getSystemValueString if applicable.
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param mixed $default the default value to be returned if the value isn't set
 	 * @return mixed the value or $default
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getSystemValue($key, $default = '');
+	public function getSystemValue(string $key, $default = '');
 
 	/**
 	 * Looks up a boolean system wide defined value
@@ -106,11 +110,11 @@ interface IConfig {
 	 * Looks up a system wide defined value and filters out sensitive data
 	 *
 	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @param string $default the default value to be returned if the value isn't set
+	 * @return string the value or $default
 	 * @since 8.2.0
 	 */
-	public function getFilteredSystemValue($key, $default = '');
+	public function getFilteredSystemValue(string $key, string $default = ''): string;
 
 	/**
 	 * Delete a system wide defined value
@@ -118,7 +122,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteSystemValue($key);
+	public function deleteSystemValue(string $key): void;
 
 	/**
 	 * Get all keys stored for an app
@@ -127,29 +131,29 @@ interface IConfig {
 	 * @return string[] the keys stored for the app
 	 * @since 8.0.0
 	 */
-	public function getAppKeys($appName);
+	public function getAppKeys(string $appName): array;
 
 	/**
 	 * Writes a new app wide value
 	 *
 	 * @param string $appName the appName that we want to store the value under
-	 * @param string|float|int $key the key of the value, under which will be saved
+	 * @param string $key the key of the value, under which will be saved
 	 * @param string $value the value that should be stored
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function setAppValue($appName, $key, $value);
+	public function setAppValue(string $appName, string $key, string $value): void;
 
 	/**
 	 * Looks up an app wide defined value
 	 *
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
-	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the saved value
+	 * @param mixed $default the default value to be returned if the value isn't set
+	 * @return mixed the saved value
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getAppValue($appName, $key, $default = '');
+	public function getAppValue(string $appName, string $key, $default = '');
 
 	/**
 	 * Delete an app wide defined value
@@ -158,7 +162,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteAppValue($appName, $key);
+	public function deleteAppValue(string $appName, string $key): void;
 
 	/**
 	 * Removes all keys in appconfig belonging to the app
@@ -166,7 +170,7 @@ interface IConfig {
 	 * @param string $appName the appName the configs are stored under
 	 * @since 8.0.0
 	 */
-	public function deleteAppValues($appName);
+	public function deleteAppValues(string $appName): void;
 
 
 	/**
@@ -181,7 +185,7 @@ interface IConfig {
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
+	public function setUserValue(string $userId, string $appName, string $key, string $value, ?string $preCondition = null): void;
 
 	/**
 	 * Shortcut for getting a user defined value
@@ -189,11 +193,11 @@ interface IConfig {
 	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return string
+	 * @param ?string $default the default value to be returned if the value isn't set
+	 * @return ?string
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getUserValue($userId, $appName, $key, $default = '');
+	public function getUserValue(?string $userId, string $appName, string $key, ?string $default = ''): ?string;
 
 	/**
 	 * Fetches a mapped list of userId -> value, for a specified app and key and a list of user IDs.
@@ -204,22 +208,22 @@ interface IConfig {
 	 * @return array Mapped values: userId => value
 	 * @since 8.0.0
 	 */
-	public function getUserValueForUsers($appName, $key, $userIds);
+	public function getUserValueForUsers(string $appName, string $key, array $userIds): array;
 
 	/**
 	 * Get the keys of all stored by an app for the user
 	 *
-	 * @param string $userId the userId of the user that we want to store the value under
+	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @return string[]
 	 * @since 8.0.0
 	 */
-	public function getUserKeys($userId, $appName);
+	public function getUserKeys(?string $userId, string $appName): array;
 
 	/**
 	 * Get all user configs sorted by app of one user
 	 *
-	 * @param string $userId the userId of the user that we want to get all values from
+	 * @param ?string $userId the userId of the user that we want to get all values from
 	 * @psalm-return array<string, array<string, string>>
 	 * @return array[] - 2 dimensional array with the following structure:
 	 *     [ $appId =>
@@ -227,7 +231,7 @@ interface IConfig {
 	 *     ]
 	 * @since 24.0.0
 	 */
-	public function getAllUserValues(string $userId): array;
+	public function getAllUserValues(?string $userId): array;
 
 	/**
 	 * Delete a user value
@@ -237,7 +241,7 @@ interface IConfig {
 	 * @param string $key the key under which the value is being stored
 	 * @since 8.0.0
 	 */
-	public function deleteUserValue($userId, $appName, $key);
+	public function deleteUserValue(string $userId, string $appName, string $key): void;
 
 	/**
 	 * Delete all user values
@@ -245,7 +249,7 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAllUserValues($userId);
+	public function deleteAllUserValues(string $userId): void;
 
 	/**
 	 * Delete all user related values of one app
@@ -253,7 +257,7 @@ interface IConfig {
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAppFromAllUsers($appName);
+	public function deleteAppFromAllUsers(string $appName): void;
 
 	/**
 	 * Determines the users that have the given value set for a specific app-key-pair
@@ -264,5 +268,5 @@ interface IConfig {
 	 * @return array of user IDs
 	 * @since 8.0.0
 	 */
-	public function getUsersForUserValue($appName, $key, $value);
+	public function getUsersForUserValue(string $appName, string $key, string $value): array;
 }


### PR DESCRIPTION
## Summary
Add some typing interfaces to config classes.

## TODO (not in this PR)

- [ ] get rid of the mixed `''` vs `null` usage in default vaules.
- [ ] replace `getSystemValue` with type save alternatives
- [ ] maybe also implement type safe `getUserValue` and `getAppValue`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
