### PR TITLE
Use type safe method to get secret and instanceid

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -373,7 +373,7 @@ class Crypt {
 	 */
 	protected function generatePasswordHash($password, $cipher, $uid = '') {
 		$instanceId = $this->config->getSystemValue('instanceid');
-		$instanceSecret = $this->config->getSystemValue('secret');
+		$instanceSecret = $this->config->getSystemValueString('secret');
 		$salt = hash('sha256', $uid . $instanceId . $instanceSecret, true);
 		$keySize = $this->getKeySize($cipher);
 

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -372,7 +372,7 @@ class Crypt {
 	 * @return string
 	 */
 	protected function generatePasswordHash($password, $cipher, $uid = '') {
-		$instanceId = $this->config->getSystemValue('instanceid');
+		$instanceId = $this->config->getSystemValueString('instanceid');
 		$instanceSecret = $this->config->getSystemValueString('secret');
 		$salt = hash('sha256', $uid . $instanceId . $instanceSecret, true);
 		$keySize = $this->getKeySize($cipher);

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -742,8 +742,8 @@ class KeyManager {
 	 * @throws \Exception
 	 */
 	public function getMasterKeyPassword() {
-		$password = $this->config->getSystemValue('secret');
-		if (empty($password)) {
+		$password = $this->config->getSystemValueString('secret');
+		if ($password === '') {
 			throw new \Exception('Can not get secret from Nextcloud instance');
 		}
 

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -404,7 +404,7 @@ class KeyManagerTest extends TestCase {
 
 		if ($isMasterKeyEnabled) {
 			$expectedUid = 'masterKeyId';
-			$this->configMock->expects($this->any())->method('getSystemValue')->with('secret')
+			$this->configMock->expects($this->any())->method('getSystemValueString')->with('secret')
 				->willReturn('password');
 		} elseif (!$uid) {
 			$expectedUid = 'systemKeyId';
@@ -560,7 +560,7 @@ class KeyManagerTest extends TestCase {
 	}
 
 	public function testGetMasterKeyPassword() {
-		$this->configMock->expects($this->once())->method('getSystemValue')->with('secret')
+		$this->configMock->expects($this->once())->method('getSystemValueString')->with('secret')
 			->willReturn('password');
 
 		$this->assertSame('password',
@@ -572,7 +572,7 @@ class KeyManagerTest extends TestCase {
 	public function testGetMasterKeyPasswordException() {
 		$this->expectException(\Exception::class);
 
-		$this->configMock->expects($this->once())->method('getSystemValue')->with('secret')
+		$this->configMock->expects($this->once())->method('getSystemValueString')->with('secret')
 			->willReturn('');
 
 		$this->invokePrivate($this->instance, 'getMasterKeyPassword', []);

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -267,9 +267,9 @@ class ScanAppData extends Base {
 	 * @throws NotFoundException
 	 */
 	private function getAppDataFolder() {
-		$instanceId = $this->config->getSystemValue('instanceid', null);
+		$instanceId = $this->config->getSystemValueString('instanceid');
 
-		if ($instanceId === null) {
+		if ($instanceId === '') {
 			throw new NotFoundException();
 		}
 

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -56,9 +59,9 @@ class RSA extends AuthMechanism {
 		;
 	}
 
-	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null): void {
 		$auth = new RSACrypt();
-		$auth->setPassword($this->config->getSystemValue('secret', ''));
+		$auth->setPassword($this->config->getSystemValueString('secret'));
 		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
 			// Add fallback routine for a time where secret was not enforced to be exists
 			$auth->setPassword('');
@@ -78,7 +81,7 @@ class RSA extends AuthMechanism {
 	public function createKey($keyLength) {
 		$rsa = new RSACrypt();
 		$rsa->setPublicKeyFormat(RSACrypt::PUBLIC_FORMAT_OPENSSH);
-		$rsa->setPassword($this->config->getSystemValue('secret', ''));
+		$rsa->setPassword($this->config->getSystemValueString('secret'));
 
 		if ($keyLength !== 1024 && $keyLength !== 2048 && $keyLength !== 4096) {
 			$keyLength = 1024;

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2018, Roeland Jago Douma <roeland@famdouma.nl>
  *
@@ -54,9 +57,9 @@ class RSAPrivateKey extends AuthMechanism {
 			]);
 	}
 
-	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null): void {
 		$auth = new RSACrypt();
-		$auth->setPassword($this->config->getSystemValue('secret', ''));
+		$auth->setPassword($this->config->getSystemValueString('secret'));
 		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
 			// Add fallback routine for a time where secret was not enforced to be exists
 			$auth->setPassword('');

--- a/apps/settings/lib/Mailer/NewUserMailHelper.php
+++ b/apps/settings/lib/Mailer/NewUserMailHelper.php
@@ -108,8 +108,8 @@ class NewUserMailHelper {
 				ISecureRandom::CHAR_ALPHANUMERIC
 			);
 			$tokenValue = $this->timeFactory->getTime() . ':' . $token;
-			$mailAddress = (null !== $user->getEMailAddress()) ? $user->getEMailAddress() : '';
-			$encryptedValue = $this->crypto->encrypt($tokenValue, $mailAddress . $this->config->getSystemValue('secret'));
+			$mailAddress = $user->getEMailAddress() ?? '';
+			$encryptedValue = $this->crypto->encrypt($tokenValue, $mailAddress . $this->config->getSystemValueString('secret'));
 			$this->config->setUserValue($user->getUID(), 'core', 'lostpassword', $encryptedValue);
 			$link = $this->urlGenerator->linkToRouteAbsolute('core.lost.resetform', ['userId' => $user->getUID(), 'token' => $token]);
 		} else {

--- a/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
+++ b/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
@@ -46,9 +46,9 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 	 */
 	public function run($arguments) {
 		$updateDir = $this->config->getSystemValue('updatedirectory', null) ?? $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
-		$instanceId = $this->config->getSystemValue('instanceid', null);
+		$instanceId = $this->config->getSystemValueString('instanceid');
 
-		if (!is_string($instanceId) || empty($instanceId)) {
+		if ($instanceId === '') {
 			return;
 		}
 

--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -217,7 +217,7 @@ class LoginFlowV2Service {
 	}
 
 	private function hashToken(string $token): string {
-		$secret = $this->config->getSystemValue('secret');
+		$secret = $this->config->getSystemValueString('secret');
 		return hash('sha512', $token . $secret);
 	}
 

--- a/lib/private/Repair/NC25/AddMissingSecretJob.php
+++ b/lib/private/Repair/NC25/AddMissingSecretJob.php
@@ -51,7 +51,7 @@ class AddMissingSecretJob implements IRepairStep {
 			}
 		}
 
-		$secret = $this->config->getSystemValueString('secret', '');
+		$secret = $this->config->getSystemValueString('secret');
 		if ($secret === '') {
 			try {
 				$this->config->setSystemValue('secret', $this->random->generate(48));

--- a/lib/private/Repair/NC25/AddMissingSecretJob.php
+++ b/lib/private/Repair/NC25/AddMissingSecretJob.php
@@ -42,7 +42,7 @@ class AddMissingSecretJob implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		$passwordSalt = $this->config->getSystemValueString('passwordsalt', '');
+		$passwordSalt = $this->config->getSystemValueString('passwordsalt');
 		if ($passwordSalt === '') {
 			try {
 				$this->config->setSystemValue('passwordsalt', $this->random->generate(30));

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -122,7 +122,7 @@ class Crypto implements ICrypto {
 	 * @throws Exception If the decryption failed
 	 */
 	public function decrypt(string $authenticatedCiphertext, string $password = ''): string {
-		$secret = $this->config->getSystemValue('secret');
+		$secret = $this->config->getSystemValueString('secret');
 		try {
 			if ($password === '') {
 				return $this->decryptWithoutSecret($authenticatedCiphertext, $secret);

--- a/lib/private/Security/IdentityProof/Manager.php
+++ b/lib/private/Security/IdentityProof/Manager.php
@@ -153,8 +153,8 @@ class Manager {
 	 * @throws \RuntimeException
 	 */
 	public function getSystemKey(): Key {
-		$instanceId = $this->config->getSystemValue('instanceid', null);
-		if ($instanceId === null) {
+		$instanceId = $this->config->getSystemValueString('instanceid');
+		if ($instanceId === '') {
 			throw new \RuntimeException('no instance id!');
 		}
 		return $this->retrieveKey('system-' . $instanceId);

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -201,9 +201,9 @@ class OC_Util {
 			}
 		}
 
-		$instanceId = \OC::$server->getConfig()->getSystemValue('instanceid', '');
+		$instanceId = \OC::$server->getConfig()->getSystemValueString('instanceid');
 
-		if ($instanceId === null) {
+		if ($instanceId === '') {
 			throw new \RuntimeException('no instance id!');
 		}
 		$appdata = 'appdata_' . $instanceId;

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -77,7 +77,7 @@ interface IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param bool $default the default value to be returned if the value isn't set
-	 * @return bool the value or $default
+	 * @return bool the value or $default, must not be null
 	 * @since 16.0.0
 	 */
 	public function getSystemValueBool(string $key, bool $default = false): bool;
@@ -87,7 +87,7 @@ interface IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param int $default the default value to be returned if the value isn't set
-	 * @return int the value or $default
+	 * @return int the value or $default, must not be null
 	 * @since 16.0.0
 	 */
 	public function getSystemValueInt(string $key, int $default = 0): int;
@@ -97,7 +97,7 @@ interface IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the value or $default
+	 * @return string the value or $default, must not be null
 	 * @since 16.0.0
 	 */
 	public function getSystemValueString(string $key, string $default = ''): string;

--- a/tests/lib/Security/IdentityProof/ManagerTest.php
+++ b/tests/lib/Security/IdentityProof/ManagerTest.php
@@ -210,7 +210,7 @@ class ManagerTest extends TestCase {
 		/** @var Key|\PHPUnit\Framework\MockObject\MockObject $key */
 		$key = $this->createMock(Key::class);
 
-		$this->config->expects($this->once())->method('getSystemValue')
+		$this->config->expects($this->once())->method('getSystemValueString')
 			->with('instanceid', null)->willReturn('instanceId');
 
 		$manager->expects($this->once())->method('retrieveKey')->with('system-instanceId')
@@ -229,7 +229,7 @@ class ManagerTest extends TestCase {
 		/** @var Key|\PHPUnit\Framework\MockObject\MockObject $key */
 		$key = $this->createMock(Key::class);
 
-		$this->config->expects($this->once())->method('getSystemValue')
+		$this->config->expects($this->once())->method('getSystemValueString')
 			->with('instanceid', null)->willReturn(null);
 
 		$manager->getSystemKey();


### PR DESCRIPTION
## Summary
Getting rid off some more `getSystemValue()`, see #https://github.com/nextcloud/server/pull/35581 for context.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
