### PR TITLE
Replace getSystemValue in encryption app

### DIFF
--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -95,7 +95,7 @@ class FixEncryptedVersion extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+		$skipSignatureCheck = $this->config->getSystemValueBool('encryption_skip_signature_check', false);
 		$this->supportLegacy = $this->config->getSystemValueBool('encryption.legacy_format_support', false);
 
 		if ($skipSignatureCheck) {

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -275,7 +275,7 @@ class Crypt {
 		}
 
 		// Get cipher either from config.php or the default cipher defined in this class
-		$cipher = $this->config->getSystemValue('cipher', self::DEFAULT_CIPHER);
+		$cipher = $this->config->getSystemValueString('cipher', self::DEFAULT_CIPHER);
 		if (!isset(self::SUPPORTED_CIPHERS_AND_KEY_SIZE[$cipher])) {
 			$this->logger->warning(
 				sprintf(
@@ -524,7 +524,7 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function checkSignature($data, $passPhrase, $expectedSignature) {
-		$enforceSignature = !$this->config->getSystemValue('encryption_skip_signature_check', false);
+		$enforceSignature = !$this->config->getSystemValueBool('encryption_skip_signature_check', false);
 
 		$signature = $this->createSignature($data, $passPhrase);
 		$isCorrectHash = hash_equals($expectedSignature, $signature);
@@ -605,7 +605,7 @@ class Crypt {
 	 * @throws GenericEncryptionException
 	 */
 	private function hasSignature($catFile, $cipher) {
-		$skipSignatureCheck = $this->config->getSystemValue('encryption_skip_signature_check', false);
+		$skipSignatureCheck = $this->config->getSystemValueBool('encryption_skip_signature_check', false);
 
 		$meta = substr($catFile, -93);
 		$signaturePosition = strpos($meta, '00sig00');

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -111,7 +111,7 @@ class CryptTest extends TestCase {
 	 */
 	public function testGenerateHeader($keyFormat, $expected) {
 		$this->config->expects($this->once())
-			->method('getSystemValue')
+			->method('getSystemValueString')
 			->with($this->equalTo('cipher'), $this->equalTo('AES-256-CTR'))
 			->willReturn('AES-128-CFB');
 
@@ -147,7 +147,7 @@ class CryptTest extends TestCase {
 
 	public function testGetCipherWithInvalidCipher() {
 		$this->config->expects($this->once())
-				->method('getSystemValue')
+				->method('getSystemValueString')
 				->with($this->equalTo('cipher'), $this->equalTo('AES-256-CTR'))
 				->willReturn('Not-Existing-Cipher');
 		$this->logger
@@ -165,7 +165,7 @@ class CryptTest extends TestCase {
 	 */
 	public function testGetCipher($configValue, $expected) {
 		$this->config->expects($this->once())
-			->method('getSystemValue')
+			->method('getSystemValueString')
 			->with($this->equalTo('cipher'), $this->equalTo('AES-256-CTR'))
 			->willReturn($configValue);
 
@@ -208,7 +208,7 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestSplitMetaData
 	 */
 	public function testSplitMetaData($data, $expected) {
-		$this->config->method('getSystemValue')
+		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
 			->willReturn(true);
 		$result = self::invokePrivate($this->crypt, 'splitMetaData', [$data, 'AES-256-CFB']);
@@ -235,7 +235,7 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestHasSignature
 	 */
 	public function testHasSignature($data, $expected) {
-		$this->config->method('getSystemValue')
+		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
 			->willReturn(true);
 		$this->assertSame($expected,


### PR DESCRIPTION
## Summary
Getting rid off some more `getSystemValue()`, see #https://github.com/nextcloud/server/pull/35581 for context.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
