### PR TITLE
Use TimedJob from OCP instead of OC

### DIFF
--- a/apps/admin_audit/lib/BackgroundJobs/Rotate.php
+++ b/apps/admin_audit/lib/BackgroundJobs/Rotate.php
@@ -27,7 +27,8 @@ declare(strict_types=1);
  */
 namespace OCA\AdminAudit\BackgroundJobs;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\Log\RotationTrait;
 
@@ -37,13 +38,16 @@ class Rotate extends TimedJob {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(IConfig  $config) {
+	public function __construct(ITimeFactory $time,
+								IConfig  $config) {
+		parent::__construct($time);
+
 		$this->config = $config;
 
 		$this->setInterval(60 * 60 * 3);
 	}
 
-	protected function run($argument) {
+	protected function run($argument): void {
 		$default = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/audit.log';
 		$this->filePath = $this->config->getAppValue('admin_audit', 'logfile', $default);
 

--- a/apps/files/lib/BackgroundJob/CleanupDirectEditingTokens.php
+++ b/apps/files/lib/BackgroundJob/CleanupDirectEditingTokens.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Julius Härtl <jus@bitgrid.net>
  *
@@ -23,18 +26,18 @@
  */
 namespace OCA\Files\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\DirectEditing\IManager;
 
 class CleanupDirectEditingTokens extends TimedJob {
 	private const INTERVAL_MINUTES = 15 * 60;
 
-	/**
-	 * @var IManager
-	 */
-	private $manager;
+	private IManager $manager;
 
-	public function __construct(IManager $manager) {
+	public function __construct(ITimeFactory $time,
+								IManager $manager) {
+		parent::__construct($time);
 		$this->interval = self::INTERVAL_MINUTES;
 		$this->manager = $manager;
 	}

--- a/apps/files/lib/BackgroundJob/CleanupFileLocks.php
+++ b/apps/files/lib/BackgroundJob/CleanupFileLocks.php
@@ -23,14 +23,14 @@
  */
 namespace OCA\Files\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OC\Lock\DBLockingProvider;
 
 /**
  * Clean up all file locks that are expired for the DB file locking provider
  */
 class CleanupFileLocks extends TimedJob {
-
 	/**
 	 * Default interval in minutes
 	 *
@@ -41,7 +41,9 @@ class CleanupFileLocks extends TimedJob {
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct() {
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
+
 		$this->interval = $this->defaultIntervalMin * 60;
 	}
 

--- a/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
+++ b/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
@@ -24,7 +24,8 @@
  */
 namespace OCA\Files\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
@@ -49,7 +50,8 @@ class DeleteOrphanedItems extends TimedJob {
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct() {
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
 		$this->interval = $this->defaultIntervalMin * 60;
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->logger = \OC::$server->getLogger();

--- a/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
+++ b/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
@@ -24,6 +24,7 @@
 namespace OCA\Files\Tests\BackgroundJob;
 
 use OCA\Files\BackgroundJob\DeleteOrphanedItems;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
@@ -34,13 +35,15 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  * @package Test\BackgroundJob
  */
 class DeleteOrphanedItemsJobTest extends \Test\TestCase {
-
 	/** @var \OCP\IDBConnection */
 	protected $connection;
+
+	protected ITimeFactory $timeFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 	}
 
 	protected function cleanMapping($table) {
@@ -95,7 +98,7 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 		$mapping = $this->getMappings('systemtag_object_mapping');
 		$this->assertCount(2, $mapping);
 
-		$job = new DeleteOrphanedItems();
+		$job = new DeleteOrphanedItems($this->timeFactory);
 		$this->invokePrivate($job, 'cleanSystemTags');
 
 		$mapping = $this->getMappings('systemtag_object_mapping');
@@ -144,7 +147,7 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 		$mapping = $this->getMappings('vcategory_to_object');
 		$this->assertCount(2, $mapping);
 
-		$job = new DeleteOrphanedItems();
+		$job = new DeleteOrphanedItems($this->timeFactory);
 		$this->invokePrivate($job, 'cleanUserTags');
 
 		$mapping = $this->getMappings('vcategory_to_object');
@@ -195,7 +198,7 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 		$mapping = $this->getMappings('comments');
 		$this->assertCount(2, $mapping);
 
-		$job = new DeleteOrphanedItems();
+		$job = new DeleteOrphanedItems($this->timeFactory);
 		$this->invokePrivate($job, 'cleanComments');
 
 		$mapping = $this->getMappings('comments');
@@ -244,7 +247,7 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 		$mapping = $this->getMappings('comments_read_markers');
 		$this->assertCount(2, $mapping);
 
-		$job = new DeleteOrphanedItems();
+		$job = new DeleteOrphanedItems($this->timeFactory);
 		$this->invokePrivate($job, 'cleanCommentMarkers');
 
 		$mapping = $this->getMappings('comments_read_markers');

--- a/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
@@ -26,7 +26,8 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Sharing\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\IDBConnection;
 use OCP\OCS\IDiscoveryService;
 
@@ -36,8 +37,10 @@ class FederatedSharesDiscoverJob extends TimedJob {
 	/** @var IDiscoveryService */
 	private $discoveryService;
 
-	public function __construct(IDBConnection $connection,
+	public function __construct(ITimeFactory $time,
+								IDBConnection $connection,
 								IDiscoveryService $discoveryService) {
+		parent::__construct($time);
 		$this->connection = $connection;
 		$this->discoveryService = $discoveryService;
 

--- a/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
+++ b/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
@@ -24,13 +24,13 @@
  */
 namespace OCA\Files_Sharing;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 
 /**
  * Delete all share entries that have no matching entries in the file cache table.
  */
 class DeleteOrphanedSharesJob extends TimedJob {
-
 	/**
 	 * Default interval in minutes
 	 *
@@ -41,7 +41,9 @@ class DeleteOrphanedSharesJob extends TimedJob {
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct() {
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
+
 		$this->interval = $this->defaultIntervalMin * 60;
 	}
 

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -27,6 +27,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\DeleteOrphanedSharesJob;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Share\IShare;
 
 /**
@@ -37,7 +38,6 @@ use OCP\Share\IShare;
  * @package OCA\Files_Sharing\Tests
  */
 class DeleteOrphanedSharesJobTest extends \Test\TestCase {
-
 	/**
 	 * @var bool
 	 */
@@ -94,7 +94,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
-		$this->job = new DeleteOrphanedSharesJob();
+		$this->job = new DeleteOrphanedSharesJob(\OCP\Server::get(ITimeFactory::class));
 	}
 
 	protected function tearDown(): void {

--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -26,10 +26,11 @@ declare(strict_types=1);
  */
 namespace OCA\UpdateNotification\Notification;
 
-use OC\BackgroundJob\TimedJob;
 use OC\Installer;
 use OC\Updater\VersionCheck;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -60,12 +61,14 @@ class BackgroundJob extends TimedJob {
 	/** @var string[] */
 	protected $users;
 
-	public function __construct(IConfig $config,
+	public function __construct(ITimeFactory $timeFactory,
+								IConfig $config,
 								IManager $notificationManager,
 								IGroupManager $groupManager,
 								IAppManager $appManager,
 								IClientService $client,
 								Installer $installer) {
+		parent::__construct($timeFactory);
 		// Run once a day
 		$this->setInterval(60 * 60 * 24);
 

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -31,6 +31,7 @@ use OC\Installer;
 use OC\Updater\VersionCheck;
 use OCA\UpdateNotification\Notification\BackgroundJob;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -38,22 +39,24 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class BackgroundJobTest extends TestCase {
-
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	protected $config;
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IManager|MockObject */
 	protected $notificationManager;
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IGroupManager|MockObject */
 	protected $groupManager;
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IAppManager|MockObject */
 	protected $appManager;
-	/** @var IClientService|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IClientService|MockObject */
 	protected $client;
-	/** @var Installer|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Installer|MockObject */
 	protected $installer;
+	/** @var ITimeFactory|MockObject */
+	protected $timeFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -64,15 +67,17 @@ class BackgroundJobTest extends TestCase {
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->client = $this->createMock(IClientService::class);
 		$this->installer = $this->createMock(Installer::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 	}
 
 	/**
 	 * @param array $methods
-	 * @return BackgroundJob|\PHPUnit\Framework\MockObject\MockObject
+	 * @return BackgroundJob|MockObject
 	 */
 	protected function getJob(array $methods = []) {
 		if (empty($methods)) {
 			return new BackgroundJob(
+				$this->timeFactory,
 				$this->config,
 				$this->notificationManager,
 				$this->groupManager,
@@ -84,6 +89,7 @@ class BackgroundJobTest extends TestCase {
 		{
 			return $this->getMockBuilder(BackgroundJob::class)
 				->setConstructorArgs([
+					$this->timeFactory,
 					$this->config,
 					$this->notificationManager,
 					$this->groupManager,
@@ -429,7 +435,7 @@ class BackgroundJobTest extends TestCase {
 
 	/**
 	 * @param string[] $userIds
-	 * @return IUser[]|\PHPUnit\Framework\MockObject\MockObject[]
+	 * @return IUser[]|MockObject[]
 	 */
 	protected function getUsers(array $userIds): array {
 		$users = [];
@@ -445,7 +451,7 @@ class BackgroundJobTest extends TestCase {
 
 	/**
 	 * @param string $gid
-	 * @return \OCP\IGroup|\PHPUnit\Framework\MockObject\MockObject
+	 * @return \OCP\IGroup|MockObject
 	 */
 	protected function getGroup(string $gid) {
 		$group = $this->createMock(IGroup::class);

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -25,7 +25,8 @@
  */
 namespace OCA\User_LDAP\Jobs;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
@@ -64,7 +65,12 @@ class CleanUp extends TimedJob {
 	/** @var DeletedUsersIndex */
 	protected $dui;
 
-	public function __construct(User_Proxy $userBackend, DeletedUsersIndex $dui) {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		User_Proxy $userBackend,
+		DeletedUsersIndex $dui
+	) {
+		parent::__construct($timeFactory);
 		$minutes = \OC::$server->getConfig()->getSystemValue(
 			'ldapUserCleanupInterval', (string)$this->defaultIntervalMin);
 		$this->setInterval((int)$minutes * 60);

--- a/apps/user_ldap/tests/Jobs/CleanUpTest.php
+++ b/apps/user_ldap/tests/Jobs/CleanUpTest.php
@@ -29,6 +29,7 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\Jobs\CleanUp;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_Proxy;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use Test\TestCase;
@@ -42,7 +43,7 @@ class CleanUpTest extends TestCase {
 
 	public function setUp(): void {
 		$this->createMocks();
-		$this->bgJob = new CleanUp($this->mocks['userBackend'], $this->mocks['deletedUsersIndex']);
+		$this->bgJob = new CleanUp($this->mocks['timeFactory'], $this->mocks['userBackend'], $this->mocks['deletedUsersIndex']);
 		$this->bgJob->setArguments($this->mocks);
 	}
 
@@ -53,6 +54,7 @@ class CleanUpTest extends TestCase {
 		$this->mocks['ocConfig'] = $this->createMock(IConfig::class);
 		$this->mocks['db'] = $this->createMock(IDBConnection::class);
 		$this->mocks['helper'] = $this->createMock(Helper::class);
+		$this->mocks['timeFactory'] = $this->createMock(ITimeFactory::class);
 	}
 
 	/**

--- a/apps/workflowengine/lib/BackgroundJobs/Rotate.php
+++ b/apps/workflowengine/lib/BackgroundJobs/Rotate.php
@@ -23,14 +23,16 @@
  */
 namespace OCA\WorkflowEngine\BackgroundJobs;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCA\WorkflowEngine\AppInfo\Application;
 use OCP\Log\RotationTrait;
 
 class Rotate extends TimedJob {
 	use RotationTrait;
 
-	public function __construct() {
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
 		$this->setInterval(60 * 60 * 3);
 	}
 

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -25,8 +25,9 @@ declare(strict_types=1);
  */
 namespace OC\Preview;
 
-use OC\BackgroundJob\TimedJob;
 use OC\Preview\Storage\Root;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\NotFoundException;
@@ -34,7 +35,6 @@ use OCP\Files\NotPermittedException;
 use OCP\IDBConnection;
 
 class BackgroundCleanupJob extends TimedJob {
-
 	/** @var IDBConnection */
 	private $connection;
 
@@ -47,10 +47,12 @@ class BackgroundCleanupJob extends TimedJob {
 	/** @var IMimeTypeLoader */
 	private $mimeTypeLoader;
 
-	public function __construct(IDBConnection $connection,
+	public function __construct(ITimeFactory $timeFactory,
+								IDBConnection $connection,
 								Root $previewFolder,
 								IMimeTypeLoader $mimeTypeLoader,
 								bool $isCLI) {
+		parent::__construct($timeFactory);
 		// Run at most once an hour
 		$this->setInterval(3600);
 

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -25,6 +25,7 @@ namespace Test\Preview;
 use OC\Preview\BackgroundCleanupJob;
 use OC\Preview\Storage\Root;
 use OC\PreviewManager;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
@@ -62,6 +63,8 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 	/** @var IMimeTypeLoader */
 	private $mimeTypeLoader;
 
+	private ITimeFactory $timeFactory;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -83,6 +86,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$this->previewManager = \OC::$server->getPreviewManager();
 		$this->rootFolder = \OC::$server->getRootFolder();
 		$this->mimeTypeLoader = \OC::$server->getMimeTypeLoader();
+		$this->timeFactory = \OCP\Server::get(ITimeFactory::class);
 	}
 
 	protected function tearDown(): void {
@@ -142,7 +146,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$root = $this->getRoot();
 
 		$this->assertSame(11, $this->countPreviews($root, $fileIds));
-		$job = new BackgroundCleanupJob($this->connection, $root, $this->mimeTypeLoader, true);
+		$job = new BackgroundCleanupJob($this->timeFactory, $this->connection, $root, $this->mimeTypeLoader, true);
 		$job->run([]);
 
 		foreach ($files as $file) {
@@ -166,7 +170,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$root = $this->getRoot();
 
 		$this->assertSame(11, $this->countPreviews($root, $fileIds));
-		$job = new BackgroundCleanupJob($this->connection, $root, $this->mimeTypeLoader, false);
+		$job = new BackgroundCleanupJob($this->timeFactory, $this->connection, $root, $this->mimeTypeLoader, false);
 		$job->run([]);
 
 		foreach ($files as $file) {
@@ -196,7 +200,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$appdata = \OC::$server->getAppDataDir('preview');
 		$this->assertSame(2, count($appdata->getDirectoryListing()));
 
-		$job = new BackgroundCleanupJob($this->connection, $this->getRoot(), $this->mimeTypeLoader, true);
+		$job = new BackgroundCleanupJob($this->timeFactory, $this->connection, $this->getRoot(), $this->mimeTypeLoader, true);
 		$job->run([]);
 
 		$appdata = \OC::$server->getAppDataDir('preview');


### PR DESCRIPTION
While searching for source of https://github.com/nextcloud/server/issues/35543 I took the opportunity to move all TimedJob subclasses to using OCP.
Does not fix the bug.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>