### PR TITLE
[stable24] downgrade ubuntu in order to fix CI

### DIFF
--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   s3-primary-tests-minio:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       # do not stop on another job's failure


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/35580

The oci.yml already has ubuntu-20.04 set so this change is not needed here.