### PR TITLE
Add a command to update the 3rdparty submodule to the same branch as …

### DIFF
--- a/.github/workflows/command-pull-3rdparty.yml
+++ b/.github/workflows/command-pull-3rdparty.yml
@@ -1,0 +1,50 @@
+name: Update 3rdparty command
+
+on:
+  issue_comment:
+    types: created
+
+permissions:
+  contents: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: none
+
+    # On pull requests and if the comment starts with `/update-3rdparty`
+    if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/update-3rdparty')
+
+    steps:
+      - name: Add reaction on start
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: "+1"
+
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+
+      - name: Pull 3rdparty
+        run: git submodule foreach 'if [ "$sm_path" == "3rdparty" ]; then git pull origin ${{ github.event.pull_request.base.ref }}; fi'
+
+      - name: Commit and push changes
+        run: |
+          git add 3rdparty
+          git commit -m "Update submodule 3rdparty to latest ${{ github.event.pull_request.base.ref }}"
+          git push
+
+      - name: Add reaction on failure
+        uses: peter-evans/create-or-update-comment@v2
+        if: failure()
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: "-1"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ After that, please also include the autoloader file changes in your commits.
 - [🌊 WAVE](https://wave.webaim.org/extension/) for accessibility testing
 - [🚨 Lighthouse](https://developers.google.com/web/tools/lighthouse/) for testing performance, accessibility, and more
 
+#### Helpful bots at github :robot:
+
+- Comment on a pull request with `/update-3rdparty` to update the 3rd party submodule. It will update to the last commit of the 3rd party branch named like the PR target.
 
 ## Contribution guidelines 📜
 


### PR DESCRIPTION
…the PR target

Instead of doing this by hand and sometimes pull stable25 in master or the other way around, I would be able to just comment «/update-3rdparty» once the PR on 3rdparty is merged.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>