### PR TITLE
Adjust branding of errorlog log messages

### DIFF
--- a/lib/private/Log/Errorlog.php
+++ b/lib/private/Log/Errorlog.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  *  The MIT License (MIT)
  *
@@ -32,7 +35,7 @@ class Errorlog implements IWriter {
 	/** @var string */
 	protected $tag;
 
-	public function __construct(string $tag = 'owncloud') {
+	public function __construct(string $tag = 'nextcloud') {
 		$this->tag = $tag;
 	}
 


### PR DESCRIPTION
Resolves: N/a

## Summary

Welcome to 2022.

Let's not backport this because admins might use the tag to filter their logs. I will update the admin docs to mention this.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
