### PR TITLE
Fix array to string conversion in errorlog writer

### DIFF
--- a/lib/private/Log/Errorlog.php
+++ b/lib/private/Log/Errorlog.php
@@ -28,24 +28,27 @@ declare(strict_types=1);
 
 namespace OC\Log;
 
+use OC\SystemConfig;
 use OCP\Log\IWriter;
 
-class Errorlog implements IWriter {
+class Errorlog extends LogDetails implements IWriter {
 
 	/** @var string */
 	protected $tag;
 
-	public function __construct(string $tag = 'nextcloud') {
+	public function __construct(SystemConfig $config, string $tag = 'nextcloud') {
+		parent::__construct($config);
 		$this->tag = $tag;
 	}
 
 	/**
-	 * write a message in the log
+	 * Write a message in the log
+	 *
 	 * @param string $app
-	 * @param string $message
+	 * @param string|array $message
 	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level) {
-		error_log('[' . $this->tag . ']['.$app.']['.$level.'] '.$message);
+		error_log('[' . $this->tag . ']['.$app.']['.$level.'] '.$this->logDetailsAsJSON($app, $message, $level));
 	}
 }

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -49,7 +49,7 @@ class LogFactory implements ILogFactory {
 	public function get(string $type):IWriter {
 		switch (strtolower($type)) {
 			case 'errorlog':
-				return new Errorlog();
+				return new Errorlog($this->systemConfig);
 			case 'syslog':
 				return $this->c->resolve(Syslog::class);
 			case 'systemd':
@@ -73,7 +73,7 @@ class LogFactory implements ILogFactory {
 	protected function createNewLogger(string $type, string $tag, string $path): IWriter {
 		switch (strtolower($type)) {
 			case 'errorlog':
-				return new Errorlog($tag);
+				return new Errorlog($this->systemConfig, $tag);
 			case 'syslog':
 				return new Syslog($this->systemConfig, $tag);
 			case 'systemd':

--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -53,7 +53,7 @@ class Syslog extends LogDetails implements IWriter {
 	/**
 	 * write a message in the log
 	 * @param string $app
-	 * @param string $message
+	 * @param string|array $message
 	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level) {

--- a/lib/private/Log/Systemdlog.php
+++ b/lib/private/Log/Systemdlog.php
@@ -72,7 +72,7 @@ class Systemdlog extends LogDetails implements IWriter {
 	/**
 	 * Write a message to the log.
 	 * @param string $app
-	 * @param string $message
+	 * @param string|array $message
 	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level) {

--- a/lib/public/Log/IWriter.php
+++ b/lib/public/Log/IWriter.php
@@ -30,6 +30,10 @@ namespace OCP\Log;
 interface IWriter {
 	/**
 	 * @since 14.0.0
+	 *
+	 * @param string $app
+	 * @param string|array $message
+	 * @param int $level
 	 */
 	public function write(string $app, $message, int $level);
 }


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/server/issues/35589

## Summary

https://github.com/nextcloud/server/pull/8946 changed log messages from `string` to `string|array` but not for the interface and all possible implementations. All loggers still worked except the errorlog one.

## TODO

- [x] Fix the bug
- [x] Test the bug https://github.com/nextcloud/server/pull/35614#issuecomment-1339886424

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
