### PR TITLE
Explicitly inherit stricly typed database schema closure of migrations

### DIFF
--- a/lib/public/Migration/IMigrationStep.php
+++ b/lib/public/Migration/IMigrationStep.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
  */
 namespace OCP\Migration;
 
+use Closure;
 use OCP\DB\ISchemaWrapper;
 
 /**
@@ -34,7 +35,7 @@ use OCP\DB\ISchemaWrapper;
  */
 interface IMigrationStep {
 	/**
-	 * Human readable name of the migration step
+	 * Human-readable name of the migration step
 	 *
 	 * @return string
 	 * @since 14.0.0
@@ -42,7 +43,7 @@ interface IMigrationStep {
 	public function name(): string;
 
 	/**
-	 * Human readable description of the migration steps
+	 * Human-readable description of the migration step
 	 *
 	 * @return string
 	 * @since 14.0.0
@@ -51,29 +52,29 @@ interface IMigrationStep {
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @since 13.0.0
 	 */
-	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options);
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options);
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 * @since 13.0.0
 	 */
-	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options);
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options);
 
 	/**
 	 * @param IOutput $output
-	 * @param \Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 * @since 13.0.0
 	 */
-	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options);
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options);
 }

--- a/lib/public/Migration/SimpleMigrationStep.php
+++ b/lib/public/Migration/SimpleMigrationStep.php
@@ -28,12 +28,15 @@ declare(strict_types=1);
  */
 namespace OCP\Migration;
 
+use Closure;
+use OCP\DB\ISchemaWrapper;
+
 /**
  * @since 13.0.0
  */
 abstract class SimpleMigrationStep implements IMigrationStep {
 	/**
-	 * Human readable name of the migration step
+	 * Human-readable name of the migration step
 	 *
 	 * @return string
 	 * @since 14.0.0
@@ -43,7 +46,7 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	}
 
 	/**
-	 * Human readable description of the migration step
+	 * Human-readable description of the migration step
 	 *
 	 * @return string
 	 * @since 14.0.0
@@ -53,16 +56,21 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
+	 * @param array $options
 	 * @since 13.0.0
 	 */
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
 	 * @since 13.0.0
 	 */
 	public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options) {
@@ -70,8 +78,10 @@ abstract class SimpleMigrationStep implements IMigrationStep {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 *
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
+	 * @param array $options
 	 * @since 13.0.0
 	 */
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {


### PR DESCRIPTION
Resolves: N/a

## Summary

It seems Psalm sees the Closure type widened by `SimpleMigrationStep` because it doesn't read inheritdoc. If we copy-paste the types they inherit down to the classes that extend `SimpleMigrationStep`.

https://github.com/vimeo/psalm/issues/8846

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
