### PR TITLE
Fix errors in calendar tests saying function handleIMipMessage does n…

### DIFF
--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -28,12 +28,19 @@ use OC\Calendar\Manager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Calendar\ICalendar;
 use OCP\Calendar\ICreateFromString;
+use OCP\Calendar\IHandleImipMessage;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\Document;
 use Sabre\VObject\Reader;
 use Test\TestCase;
+
+/*
+ * This allows us to create Mock object supporting both interfaces
+ */
+interface ICreateFromStringAndHandleImipMessage extends ICreateFromString, IHandleImipMessage {
+}
 
 class ManagerTest extends TestCase {
 
@@ -334,7 +341,7 @@ class ManagerTest extends TestCase {
 				'getCalendarsForPrincipal'
 			])
 			->getMock();
-		$calendar = $this->createMock(ICreateFromString::class);
+		$calendar = $this->createMock(ICreateFromStringAndHandleImipMessage::class);
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
 		$recipient = 'linus@stardew-tent-living.com';
@@ -371,7 +378,7 @@ class ManagerTest extends TestCase {
 				'getCalendarsForPrincipal'
 			])
 			->getMock();
-		$calendar = $this->createMock(ICreateFromString::class);
+		$calendar = $this->createMock(ICreateFromStringAndHandleImipMessage::class);
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
 		$recipient = 'linus@stardew-tent-living.com';
@@ -495,7 +502,7 @@ class ManagerTest extends TestCase {
 		$sender = 'clint@stardew-blacksmiths.com';
 		$recipient = 'pierre@general-store.com';
 		$replyTo = 'linus@stardew-tent-living.com';
-		$calendar = $this->createMock(ICreateFromString::class);
+		$calendar = $this->createMock(ICreateFromStringAndHandleImipMessage::class);
 		$calendarData = $this->getVCalendarCancel();
 
 		$this->time->expects(self::once())
@@ -532,7 +539,7 @@ class ManagerTest extends TestCase {
 		$sender = 'linus@stardew-tent-living.com';
 		$recipient = 'pierre@general-store.com';
 		$replyTo = null;
-		$calendar = $this->createMock(ICreateFromString::class);
+		$calendar = $this->createMock(ICreateFromStringAndHandleImipMessage::class);
 		$calendarData = $this->getVCalendarCancel();
 
 		$this->time->expects(self::once())


### PR DESCRIPTION
…ot exists on ICreateFromString

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

Fixes the following:
```
1) Test\Calendar\ManagerTest::testHandleImipReplyEventNotFound
PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException: Trying to configure method "handleIMipMessage" which cannot be configured because it does not exist, has not been specified, is final, or is static

/home/mcmic/dev/nextcloud/server/tests/lib/Calendar/ManagerTest.php:356

2) Test\Calendar\ManagerTest::testHandleImipReply
PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException: Trying to configure method "handleIMipMessage" which cannot be configured because it does not exist, has not been specified, is final, or is static

/home/mcmic/dev/nextcloud/server/tests/lib/Calendar/ManagerTest.php:391

3) Test\Calendar\ManagerTest::testHandleImipCancelOrganiserInReplyTo
PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException: Trying to configure method "handleIMipMessage" which cannot be configured because it does not exist, has not been specified, is final, or is static

/home/mcmic/dev/nextcloud/server/tests/lib/Calendar/ManagerTest.php:513

4) Test\Calendar\ManagerTest::testHandleImipCancel
TypeError: PHPUnit\Framework\TestCase::createMock(): Argument #1 ($originalClassName) must be of type string, array given, called in /home/mcmic/dev/nextcloud/server/tests/lib/Calendar/ManagerTest.php on line 536
```
