### PR TITLE
Allow additional Sabre plugins in publicwebdav.php

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -111,6 +111,9 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, funct
 
 $server->addPlugin($linkCheckPlugin);
 $server->addPlugin($filesDropPlugin);
+// allow setup of additional plugins
+$event = new \OCP\SabrePluginEvent($server);
+\OC::$server->getEventDispatcher()->dispatch('OCA\DAV\Connector\Sabre::addPublicPlugin', $event);
 
 // And off we go!
 $server->exec();

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -30,6 +30,8 @@
  *
  */
 
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\SabrePublicPluginEvent;
 use Psr\Log\LoggerInterface;
 
 // load needed apps
@@ -112,8 +114,10 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, funct
 $server->addPlugin($linkCheckPlugin);
 $server->addPlugin($filesDropPlugin);
 // allow setup of additional plugins
-$event = new \OCP\SabrePluginEvent($server);
-\OC::$server->getEventDispatcher()->dispatch('OCA\DAV\Connector\Sabre::addPublicPlugin', $event);
+$event = new SabrePublicPluginEvent($server);
+/** @var IEventDispatcher $eventDispatcher */
+$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
+$eventDispatcher->dispatchTyped($event);
 
 // And off we go!
 $server->exec();

--- a/lib/public/SabrePublicPluginEvent.php
+++ b/lib/public/SabrePublicPluginEvent.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright Julien Veyssier <eneiluj@posteo.net> 2022
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP;
+
+class SabrePublicPluginEvent extends SabrePluginEvent {
+}


### PR DESCRIPTION
It could be useful to have additional Sabre plugins in `publicwebdav.php`. I just added something similar to https://github.com/nextcloud/server/blob/master/apps/dav/appinfo/v1/webdav.php#L80-L82

Concrete use case: in the context of https://github.com/nextcloud/integration_openproject , we want to allow upload to a public share from a browser (from an OpenProject page actually). For that, we need a Sabre plugin to allow the origin website via the CORS headers.

Any strong reason why the `OCA\DAV\Connector\Sabre::addPlugin` event is not dispatched in `publicwebdav.php`?