### PR TITLE
Automatically build sass and sass:icons after build

### DIFF
--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -86,12 +86,6 @@ jobs:
           npm ci
           npm run build --if-present
 
-      - name: Build css
-        run: npm run --if-present sass
-
-      - name: Build icons css
-        run: npm run --if-present sass:icons
-
       - name: Commit and push default
         if: ${{ needs.init.outputs.arg1 != 'fixup' && needs.init.outputs.arg1 != 'amend' }}
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -45,12 +45,6 @@ jobs:
           npm ci
           npm run build --if-present
 
-      - name: Build css
-        run: npm run sass
-
-      - name: Build icons css
-        run: npm run sass:icons
-
       - name: Check webpack build changes
         run: |
           bash -c "[[ ! \"`git status --porcelain `\" ]] || (echo 'Please recompile and commit the assets, see the section \"Show changes on failure\" for details' && exit 1)"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
+    "postbuild": "npm run sass && npm run sass:icons",
     "dev": "NODE_ENV=development webpack --progress --config webpack.dev.js",
     "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js",
     "lint": "eslint 'apps/*/src/**/*.{vue,js}' 'core/src/**/*.{vue,js}'",


### PR DESCRIPTION
Since it's mandatory, make it automatic
After each `npm run build` the following will be executed:
- ` npm run sass`
- ` npm run sass:icons`