### PR TITLE
docs: document types flag for search options

### DIFF
--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -40,13 +40,15 @@ class ContactsManager implements IManager {
 	 * @param string $pattern which should match within the $searchProperties
 	 * @param array $searchProperties defines the properties within the query pattern should match
 	 * @param array $options = array() to define the search behavior
+	 * 	- 'types' boolean (since 15.0.0) If set to true, fields that come with a TYPE property will be an array
+	 *    example: ['id' => 5, 'FN' => 'Thomas Tanghus', 'EMAIL' => ['type => 'HOME', 'value' => 'g@h.i']]
 	 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
 	 * 	- 'limit' - Set a numeric limit for the search results
 	 * 	- 'offset' - Set the offset for the limited search results
 	 * 	- 'enumeration' - (since 23.0.0) Whether user enumeration on system address book is allowed
 	 * 	- 'fullmatch' - (since 23.0.0) Whether matching on full detail in system address book is allowed
 	 * 	- 'strict_search' - (since 23.0.0) Whether the search pattern is full string or partial search
-	 * @psalm-param array{escape_like_param?: bool, limit?: int, offset?: int, enumeration?: bool, fullmatch?: bool, strict_search?: bool} $options
+	 * @psalm-param array{types?: bool, escape_like_param?: bool, limit?: int, offset?: int, enumeration?: bool, fullmatch?: bool, strict_search?: bool} $options
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 */
 	public function search($pattern, $searchProperties = [], $options = []) {

--- a/lib/public/Contacts/IManager.php
+++ b/lib/public/Contacts/IManager.php
@@ -90,13 +90,15 @@ interface IManager {
 	 * @param string $pattern which should match within the $searchProperties
 	 * @param array $searchProperties defines the properties within the query pattern should match
 	 * @param array $options = array() to define the search behavior
+	 *  - 'types' boolean (since 15.0.0) If set to true, fields that come with a TYPE property will be an array
+	 *    example: ['id' => 5, 'FN' => 'Thomas Tanghus', 'EMAIL' => ['type => 'HOME', 'value' => 'g@h.i']]
 	 * 	- 'escape_like_param' - If set to false wildcards _ and % are not escaped
 	 * 	- 'limit' - Set a numeric limit for the search results
 	 * 	- 'offset' - Set the offset for the limited search results
 	 * 	- 'enumeration' - (since 23.0.0) Whether user enumeration on system address book is allowed
 	 * 	- 'fullmatch' - (since 23.0.0) Whether matching on full detail in system addresss book is allowed
 	 * 	- 'strict_search' - (since 23.0.0) Whether the search pattern is full string or partial search
-	 * @psalm-param array{escape_like_param?: bool, limit?: int, offset?: int, enumeration?: bool, fullmatch?: bool, strict_search?: bool} $options
+	 * @psalm-param array{types?: bool, escape_like_param?: bool, limit?: int, offset?: int, enumeration?: bool, fullmatch?: bool, strict_search?: bool} $options
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 * @since 6.0.0
 	 */


### PR DESCRIPTION
## Summary

Psalm warning for Mail:

`ERROR: InvalidArgument - lib/Service/ContactsIntegration.php:183:59 - Argument 3 of OCP\Contacts\IManager::search expects array{enumeration?: bool, escape_like_param?: bool, fullmatch?: bool, limit?: int, offset?: int, strict_search?: bool}, but array{limit: 1, types: true} with additional array shape fields (types) was provided (see https://psalm.dev/004)`

`$result = $this->contactsManager->search($uid, ['UID'], ['types' => true, 'limit' => 1]);`


https://github.com/nextcloud/server/blob/2e0d26286442c33b5f8de2cfd9b2cfa317b96252/lib/public/IAddressBook.php#L61-L80

The documentation for IAdressBook is up-to-date. 
OCP\Contacts\IManager misses the `types` search options flag. 



## TODO

- [x] Make Psalm happy

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
