### PR TITLE
Update static code analysis workflow

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -26,14 +26,13 @@ jobs:
         run: composer i
 
       - name: Psalm
-        run: composer run psalm -- --monochrome --no-progress --output-format=github --update-baseline || ( git diff -- . ':!lib/composer' && exit 1 )
+        run: composer run psalm -- --monochrome --no-progress --output-format=github --update-baseline || { git diff -- . ':!lib/composer'; exit 1; }
 
       - name: Check diff
         run: git diff -- . ':!lib/composer'
 
       - name: Show potential changes in Psalm baseline
-        run: |
-          bash -c "[[ ! \"`git status --porcelain build/psalm-baseline.xml`\" ]] || ( echo 'Uncommited changes in Psalm baseline' && git status && git diff build/psalm-baseline.xml)"
+        run: test -z "$(git status --porcelain build/psalm-baseline.xml)" || { echo 'Uncommited changes in Psalm baseline'; git status; git diff build/psalm-baseline.xml; }
 
   static-code-analysis-ocp:
     runs-on: ubuntu-latest
@@ -57,11 +56,10 @@ jobs:
         run: composer i
 
       - name: Psalm
-        run: composer run psalm -- -c psalm-ocp.xml --monochrome --no-progress --output-format=github --update-baseline || ( git diff -- . ':!lib/composer' && exit 1 )
+        run: composer run psalm -- -c psalm-ocp.xml --monochrome --no-progress --output-format=github --update-baseline || { git diff -- . ':!lib/composer'; exit 1; }
 
       - name: Check diff
         run: git diff -- . ':!lib/composer'
 
       - name: Show potential changes in Psalm baseline
-        run: |
-          bash -c "[[ ! \"`git status --porcelain build/psalm-baseline-ocp.xml`\" ]] || ( echo 'Uncommited changes in Psalm baseline' && git status && git diff build/psalm-baseline.xml)"
+        run: test -z "$(git status --porcelain build/psalm-baseline-ocp.xml)" || { echo 'Uncommited changes in Psalm baseline'; git status; git diff build/psalm-baseline-ocp.xml; }


### PR DESCRIPTION
## Summary
- Fix for incorrect diff at end of static-code-analysis-ocp job
- Remove bashism
- Prefer command group over subshell
- Do not use "&&" condition if the following command shall run in any case
- Single-line last step and eliminate the need for a wrapping bash call

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
