### PR TITLE
Update the unencrypted file size when closing streams

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -528,6 +528,7 @@ class Encryption extends Wrapper {
 	 */
 	protected function writeHeader() {
 		$header = $this->util->createHeader($this->newHeader, $this->encryptionModule);
+		$this->fileUpdated = true;
 		return parent::stream_write($header);
 	}
 

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -465,7 +465,7 @@ class Encryption extends Wrapper {
 			$cacheEntry = $cache->get($this->internalPath);
 			if ($cacheEntry) {
 				$version = $cacheEntry['encryptedVersion'] + 1;
-				$cache->update($cacheEntry->getId(), ['encrypted' => $version, 'encryptedVersion' => $version]);
+				$cache->update($cacheEntry->getId(), ['encrypted' => $version, 'encryptedVersion' => $version, 'unencrypted_size' => $this->unencryptedSize]);
 			}
 		}
 

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -12,6 +12,7 @@ use OCP\IConfig;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EncryptionTest extends \Test\TestCase {
+	public const DEFAULT_WRAPPER = '\OC\Files\Stream\Encryption';
 
 	/** @var  \OCP\Encryption\IEncryptionModule | \PHPUnit\Framework\MockObject\MockObject  */
 	private $encryptionModule;
@@ -22,7 +23,7 @@ class EncryptionTest extends \Test\TestCase {
 	 * @param integer $unencryptedSize
 	 * @return resource
 	 */
-	protected function getStream($fileName, $mode, $unencryptedSize, $wrapper = '\OC\Files\Stream\Encryption') {
+	protected function getStream($fileName, $mode, $unencryptedSize, $wrapper = self::DEFAULT_WRAPPER, $unencryptedSizeOnClose = 0) {
 		clearstatcache();
 		$size = filesize($fileName);
 		$source = fopen($fileName, $mode);
@@ -64,9 +65,10 @@ class EncryptionTest extends \Test\TestCase {
 		$entry = new CacheEntry([
 			'fileid' => 5,
 			'encryptedVersion' => 2,
+			'unencrypted_size' => $unencryptedSizeOnClose,
 		]);
 		$cache->expects($this->any())->method('get')->willReturn($entry);
-		$cache->expects($this->any())->method('update')->with(5, ['encrypted' => 3, 'encryptedVersion' => 3]);
+		$cache->expects($this->any())->method('update')->with(5, ['encrypted' => 3, 'encryptedVersion' => 3, 'unencrypted_size' => $unencryptedSizeOnClose]);
 
 
 		return $wrapper::wrap($source, $internalPath,
@@ -188,7 +190,7 @@ class EncryptionTest extends \Test\TestCase {
 
 	public function testWriteRead() {
 		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
+		$stream = $this->getStream($fileName, 'w+', 0, self::DEFAULT_WRAPPER, 6);
 		$this->assertEquals(6, fwrite($stream, 'foobar'));
 		fclose($stream);
 
@@ -196,7 +198,7 @@ class EncryptionTest extends \Test\TestCase {
 		$this->assertEquals('foobar', fread($stream, 100));
 		fclose($stream);
 
-		$stream = $this->getStream($fileName, 'r+', 6);
+		$stream = $this->getStream($fileName, 'r+', 6, self::DEFAULT_WRAPPER, 6);
 		$this->assertEquals(3, fwrite($stream, 'bar'));
 		fclose($stream);
 
@@ -209,7 +211,7 @@ class EncryptionTest extends \Test\TestCase {
 
 	public function testRewind() {
 		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
+		$stream = $this->getStream($fileName, 'w+', 0, self::DEFAULT_WRAPPER, 6);
 		$this->assertEquals(6, fwrite($stream, 'foobar'));
 		$this->assertEquals(true, rewind($stream));
 		$this->assertEquals('foobar', fread($stream, 100));
@@ -227,7 +229,7 @@ class EncryptionTest extends \Test\TestCase {
 	public function testSeek() {
 		$fileName = tempnam("/tmp", "FOO");
 
-		$stream = $this->getStream($fileName, 'w+', 0);
+		$stream = $this->getStream($fileName, 'w+', 0, self::DEFAULT_WRAPPER, 9);
 		$this->assertEquals(6, fwrite($stream, 'foobar'));
 		$this->assertEquals(0, fseek($stream, 3));
 		$this->assertEquals(6, fwrite($stream, 'foobar'));
@@ -261,7 +263,7 @@ class EncryptionTest extends \Test\TestCase {
 		$expectedData = file_get_contents(\OC::$SERVERROOT . '/tests/data/' . $testFile);
 		// write it
 		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0);
+		$stream = $this->getStream($fileName, 'w+', 0, self::DEFAULT_WRAPPER, strlen($expectedData));
 		// while writing the file from the beginning to the end we should never try
 		// to read parts of the file. This should only happen for write operations
 		// in the middle of a file
@@ -302,7 +304,7 @@ class EncryptionTest extends \Test\TestCase {
 		$expectedData = file_get_contents(\OC::$SERVERROOT . '/tests/data/' . $testFile);
 		// write it
 		$fileName = tempnam("/tmp", "FOO");
-		$stream = $this->getStream($fileName, 'w+', 0, '\Test\Files\Stream\DummyEncryptionWrapper');
+		$stream = $this->getStream($fileName, 'w+', 0, '\Test\Files\Stream\DummyEncryptionWrapper', strlen($expectedData));
 		// while writing the file from the beginning to the end we should never try
 		// to read parts of the file. This should only happen for write operations
 		// in the middle of a file
@@ -311,7 +313,7 @@ class EncryptionTest extends \Test\TestCase {
 		fclose($stream);
 
 		// read it all
-		$stream = $this->getStream($fileName, 'r', strlen($expectedData), '\Test\Files\Stream\DummyEncryptionWrapper');
+		$stream = $this->getStream($fileName, 'r', strlen($expectedData), '\Test\Files\Stream\DummyEncryptionWrapper', strlen($expectedData));
 		$data = stream_get_contents($stream);
 		fclose($stream);
 


### PR DESCRIPTION
## Summary

* Fixes https://github.com/nextcloud/richdocuments/issues/2102

This PR fixes two issues related to primary object storage and master key encryption, both related to apps using the PHP Nodes api for file access. 

[77edd36](https://github.com/nextcloud/server/pull/35649/commits/77edd36583b7a12ba550d31c18df1138edb1a846) makes sure that the proper unencrypted size is written into the filecache when writing to a file through the putContent method. This for example is done by Collabora to save a file. Without updating the unencrypted size any follow up download would cause a BadSignature error.

[f6d6898](https://github.com/nextcloud/server/pull/35649/commits/f6d68987b2e8cd302add1b2aa42728ec92af98d6) Addresses a similar issue when a newFile was created with empty content. In this case the encryption stream writes just the header to the file but never updates the isEncrypted flag on it, so when creating a new empty file in the text app the encrypted content is returned to the user instead of the decrypted one.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
