### PR TITLE
ci: update minio image for s3 primary storage tests

### DIFF
--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       # do not stop on another job's failure
       fail-fast: false
-      max-parallel: 1
       matrix:
         php-versions: ['8.0']
         key: ['objectstore', 'objectstore_multibucket']
@@ -25,7 +24,7 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
-        image: bitnami/minio:2021.10.6
+        image: bitnami/minio:2021.12.29
         ports:
           - "9000:9000"
 


### PR DESCRIPTION
* Resolves: /

## Summary

Follow up for https://github.com/nextcloud/server/pull/35376

> Unable to initialize console server: Specified port is already in use

Is fixed by bitnami/minio:2021.10.13-debian-10-r0.

A more recent image (2022.12.7) fails with `SignatureDoesNotMatch` exceptions. 

## TODO

- [ ] Check CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
