### PR TITLE
docs: add design contribution guidelines

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,24 @@
+# Nextcloud Design contribution guidelines
+
+## 👋 Welcome
+
+At Nextcloud we want to make sure to have everything in place to enable designers to contribute – making our apps universally accessible and easy to use.
+
+## 🚢 How to contribute design
+
+We have a dedicated page with more in-detail guidelines on our website: 
+https://nextcloud.com/design/
+
+**TL;DR**
+
+1. Check out open [issues](https://github.com/nextcloud/server/issues) here on GitHub (we label them with `design`)
+2. Make sure create publicly accessible assets 
+3. Add your contributions to an issue and we promise we will review your contribution carefully and foster discussions
+
+[This issue](https://github.com/nextcloud/desktop/issues/877) has examples of other apps, some simple mockups, and specifications about the design. In the discussions in the comments there are updates to the design as well.
+
+[This pull request](https://github.com/nextcloud/desktop/pull/1565) by a developer has the implementation of that issue, the changes they made, and more design discussions and adjustments.
+
+**We encourage you to:**
+
+- Get in touch with the team by joining our [public Talk channel](https://cloud.nextcloud.com/call/gqff69i8)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/server/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/server/?branch=master)
 [![codecov](https://codecov.io/gh/nextcloud/server/branch/master/graph/badge.svg)](https://codecov.io/gh/nextcloud/server)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/209/badge)](https://bestpractices.coreinfrastructure.org/projects/209)
+[![Design](https://contribute.design/api/shield/nextcloud/server)](https://contribute.design/nextcloud/server)
 
 **A safe home for all your data.**
 


### PR DESCRIPTION
## Summary

You are offering some wonderful design contribution guidelines on your website – which is super rare these days. But we think you might be missing some visibility across Designers. 
 
We're on a mission to enable OSS and Design collaboration via our portal at https://contribute.design 

Since there is currently a huge interest by Designers to contribute to OSS we thought you'd love to participate in this initiative and get Nextcloud listed. :) 

Now for designers it would of course be ideal if they'd find similar guidelines in each repository. 

Ideally we would extend these docs a little bit more in deep (e.g. links to existing resources they can clone, color guides, tokens, etc etc etc) – but I thought this might be a good first start.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
