### PR TITLE
preview: fix HEIC orientation

### DIFF
--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -115,6 +115,9 @@ class HEIC extends ProviderV2 {
 		// Layer 0 contains either the bitmap or a flat representation of all vector layers
 		$bp->readImage($tmpPath . '[0]');
 
+		// Fix orientation from EXIF
+		$bp->autoOrient();
+
 		$bp->setImageFormat('jpg');
 
 		$bp = $this->resize($bp, $maxX, $maxY);


### PR DESCRIPTION
iOS camera images previews are not correctly oriented with HEIC for portrait. This fixes the orientation. A sample image is attached (zip cause GitHub forbids HEIC).

Request: please backport to 25.

[IMG_5820.zip](https://github.com/nextcloud/server/files/10190488/IMG_5820.zip)
