### PR TITLE
Addresses #35642: LDAP variables can be integers

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -120,7 +120,6 @@ class Configuration {
 		'ldapDefaultPPolicyDN' => null,
 		'ldapExtStorageHomeAttribute' => null,
 		'ldapMatchingRuleInChainState' => self::LDAP_SERVER_FEATURE_UNKNOWN,
-		'ldapConnectionTimeout' => 15,
 	];
 
 	public function __construct(string $configPrefix, bool $autoRead = true) {
@@ -332,7 +331,8 @@ class Configuration {
 		} else {
 			$finalValue = [];
 			foreach ($value as $key => $val) {
-				if (is_string($val)) {
+				// $val can be just numbers
+				if (is_string($val) || is_numeric($val)) {
 					$val = trim($val);
 					if ($val !== '') {
 						//accidental line breaks are not wanted and can cause
@@ -464,7 +464,6 @@ class Configuration {
 			'ldap_user_avatar_rule' => 'default',
 			'ldap_ext_storage_home_attribute' => '',
 			'ldap_matching_rule_in_chain_state' => self::LDAP_SERVER_FEATURE_UNKNOWN,
-			'ldap_connection_timeout' => 15,
 		];
 	}
 
@@ -528,7 +527,6 @@ class Configuration {
 			'ldap_ext_storage_home_attribute' => 'ldapExtStorageHomeAttribute',
 			'ldap_matching_rule_in_chain_state' => 'ldapMatchingRuleInChainState',
 			'ldapIgnoreNamingRules' => 'ldapIgnoreNamingRules',	// sysconfig
-			'ldap_connection_timeout' => 'ldapConnectionTimeout',
 		];
 		return $array;
 	}
@@ -561,12 +559,5 @@ class Configuration {
 			\OC::$server->getLogger()->warning('Invalid config value to ldapUserAvatarRule; falling back to default.');
 		}
 		return $defaultAttributes;
-	}
-
-	/**
-	 * Returns TRUE if the ldapHost variable starts with 'ldapi://'
-	 */
-	public function usesLdapi(): bool {
-		return (substr($this->config['ldapHost'], 0, strlen('ldapi://')) === 'ldapi://');
 	}
 }

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -24,8 +24,6 @@
  * @author Victor Dubiniuk <dubiniuk@owncloud.com>
  * @author Vinicius Cubas Brand <vinicius@eita.org.br>
  * @author Xuanwo <xuanwo@yunify.com>
- * @author Carl Schwan <carl@carlschwan.eu>
- * @author Côme Chilliet <come.chilliet@nextcloud.com>
  *
  * @license AGPL-3.0
  *
@@ -44,30 +42,34 @@
  */
 namespace OCA\User_LDAP;
 
+use Closure;
 use Exception;
+use OC;
 use OCP\Cache\CappedMemoryCache;
-use OCP\GroupInterface;
-use OCP\Group\Backend\IDeleteGroupBackend;
-use OCP\Group\Backend\IGetDisplayNameBackend;
 use OC\ServerNotAvailableException;
+use OCP\Group\Backend\IGetDisplayNameBackend;
+use OCP\Group\Backend\IDeleteGroupBackend;
+use OCP\GroupInterface;
 use Psr\Log\LoggerInterface;
 
 class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, IDeleteGroupBackend {
-	protected bool $enabled = false;
+	protected $enabled = false;
 
 	/** @var CappedMemoryCache<string[]> $cachedGroupMembers array of users with gid as key */
 	protected CappedMemoryCache $cachedGroupMembers;
-	/** @var CappedMemoryCache<array[]> $cachedGroupsByMember array of groups with uid as key */
+	/** @var CappedMemoryCache<string[]> $cachedGroupsByMember array of groups with uid as key */
 	protected CappedMemoryCache $cachedGroupsByMember;
 	/** @var CappedMemoryCache<string[]> $cachedNestedGroups array of groups with gid (DN) as key */
 	protected CappedMemoryCache $cachedNestedGroups;
-	protected GroupPluginManager $groupPluginManager;
-	protected LoggerInterface $logger;
+	/** @var GroupPluginManager */
+	protected $groupPluginManager;
+	/** @var LoggerInterface */
+	protected $logger;
 
 	/**
 	 * @var string $ldapGroupMemberAssocAttr contains the LDAP setting (in lower case) with the same name
 	 */
-	protected string $ldapGroupMemberAssocAttr;
+	protected $ldapGroupMemberAssocAttr;
 
 	public function __construct(Access $access, GroupPluginManager $groupPluginManager) {
 		parent::__construct($access);
@@ -81,19 +83,20 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 		$this->cachedGroupsByMember = new CappedMemoryCache();
 		$this->cachedNestedGroups = new CappedMemoryCache();
 		$this->groupPluginManager = $groupPluginManager;
-		$this->logger = \OCP\Server::get(LoggerInterface::class);
+		$this->logger = OC::$server->get(LoggerInterface::class);
 		$this->ldapGroupMemberAssocAttr = strtolower((string)$gAssoc);
 	}
 
 	/**
-	 * Check if user is in group
+	 * is user in group?
 	 *
 	 * @param string $uid uid of the user
 	 * @param string $gid gid of the group
+	 * @return bool
 	 * @throws Exception
 	 * @throws ServerNotAvailableException
 	 */
-	public function inGroup($uid, $gid): bool {
+	public function inGroup($uid, $gid) {
 		if (!$this->enabled) {
 			return false;
 		}
@@ -237,17 +240,24 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * Get group members from dn.
-	 * @psalm-param array<string, bool> $seen List of DN that have already been processed.
 	 * @throws ServerNotAvailableException
 	 */
-	private function _groupMembers(string $dnGroup, array $seen = [], bool &$recursive = false): array {
-		if (isset($seen[$dnGroup])) {
-			$recursive = true;
+	private function _groupMembers(string $dnGroup, ?array &$seen = null): array {
+		if ($seen === null) {
+			$seen = [];
+			// the root entry has to be marked as processed to avoid infinite loops,
+			// but not included in the results laters on
+			$excludeFromResult = $dnGroup;
+		}
+		// cache only base groups, otherwise groups get additional unwarranted members
+		$shouldCacheResult = count($seen) === 0;
+
+		static $rawMemberReads = []; // runtime cache for intermediate ldap read results
+		$allMembers = [];
+
+		if (array_key_exists($dnGroup, $seen)) {
 			return [];
 		}
-		$seen[$dnGroup] = true;
-
 		// used extensively in cron job, caching makes sense for nested groups
 		$cacheKey = '_groupMembers' . $dnGroup;
 		$groupMembers = $this->access->connection->getFromCache($cacheKey);
@@ -261,7 +271,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			&& $this->access->connection->ldapMatchingRuleInChainState !== Configuration::LDAP_SERVER_FEATURE_UNAVAILABLE
 		) {
 			$attemptedLdapMatchingRuleInChain = true;
-			// Use matching rule 1.2.840.113556.1.4.1941 if available (LDAP_MATCHING_RULE_IN_CHAIN)
+			// compatibility hack with servers supporting :1.2.840.113556.1.4.1941:, and others)
 			$filter = $this->access->combineFilterWithAnd([
 				$this->access->connection->ldapUserFilter,
 				$this->access->connection->ldapUserDisplayName . '=*',
@@ -276,50 +286,40 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 				return $carry;
 			}, []);
 			if ($this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_AVAILABLE) {
-				$this->access->connection->writeToCache($cacheKey, $result);
 				return $result;
 			} elseif (!empty($memberRecords)) {
 				$this->access->connection->ldapMatchingRuleInChainState = Configuration::LDAP_SERVER_FEATURE_AVAILABLE;
 				$this->access->connection->saveConfiguration();
-				$this->access->connection->writeToCache($cacheKey, $result);
 				return $result;
 			}
 			// when feature availability is unknown, and the result is empty, continue and test with original approach
 		}
 
-		$allMembers = [];
-		$members = $this->access->readAttribute($dnGroup, $this->access->connection->ldapGroupMemberAssocAttr);
+		$seen[$dnGroup] = 1;
+		$members = $rawMemberReads[$dnGroup] ?? null;
+		if ($members === null) {
+			$members = $this->access->readAttribute($dnGroup, $this->access->connection->ldapGroupMemberAssocAttr);
+			$rawMemberReads[$dnGroup] = $members;
+		}
 		if (is_array($members)) {
-			if ((int)$this->access->connection->ldapNestedGroups === 1) {
-				while ($recordDn = array_shift($members)) {
-					$nestedMembers = $this->_groupMembers($recordDn, $seen, $recursive);
-					if (!empty($nestedMembers)) {
-						// Group, queue its members for processing
-						$members = array_merge($members, $nestedMembers);
-					} else {
-						// User (or empty group, or previously seen group), add it to the member list
-						$allMembers[] = $recordDn;
-					}
-				}
-			} else {
-				$allMembers = $members;
-			}
+			$fetcher = function ($memberDN) use (&$seen) {
+				return $this->_groupMembers($memberDN, $seen);
+			};
+			$allMembers = $this->walkNestedGroups($dnGroup, $fetcher, $members, $seen);
 		}
 
 		$allMembers += $this->getDynamicGroupMembers($dnGroup);
-
-		$allMembers = array_unique($allMembers);
-
-		// A group cannot be a member of itself
-		$index = array_search($dnGroup, $allMembers, true);
-		if ($index !== false) {
-			unset($allMembers[$index]);
+		if (isset($excludeFromResult)) {
+			$index = array_search($excludeFromResult, $allMembers, true);
+			if ($index !== false) {
+				unset($allMembers[$index]);
+			}
 		}
 
-		if (!$recursive) {
+		if ($shouldCacheResult) {
 			$this->access->connection->writeToCache($cacheKey, $allMembers);
+			unset($rawMemberReads[$dnGroup]);
 		}
-
 		if (isset($attemptedLdapMatchingRuleInChain)
 			&& $this->access->connection->ldapMatchingRuleInChainState === Configuration::LDAP_SERVER_FEATURE_UNKNOWN
 			&& !empty($allMembers)
@@ -327,47 +327,75 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$this->access->connection->ldapMatchingRuleInChainState = Configuration::LDAP_SERVER_FEATURE_UNAVAILABLE;
 			$this->access->connection->saveConfiguration();
 		}
-
 		return $allMembers;
 	}
 
 	/**
-	 * @return string[]
 	 * @throws ServerNotAvailableException
 	 */
-	private function _getGroupDNsFromMemberOf(string $dn, array &$seen = []): array {
-		if (isset($seen[$dn])) {
+	private function _getGroupDNsFromMemberOf(string $dn): array {
+		$groups = $this->access->readAttribute($dn, 'memberOf');
+		if (!is_array($groups)) {
 			return [];
 		}
-		$seen[$dn] = true;
 
-		if (isset($this->cachedNestedGroups[$dn])) {
-			return $this->cachedNestedGroups[$dn];
+		$fetcher = function ($groupDN) {
+			if (isset($this->cachedNestedGroups[$groupDN])) {
+				$nestedGroups = $this->cachedNestedGroups[$groupDN];
+			} else {
+				$nestedGroups = $this->access->readAttribute($groupDN, 'memberOf');
+				if (!is_array($nestedGroups)) {
+					$nestedGroups = [];
+				}
+				$this->cachedNestedGroups[$groupDN] = $nestedGroups;
+			}
+			return $nestedGroups;
+		};
+
+		$groups = $this->walkNestedGroups($dn, $fetcher, $groups);
+		return $this->filterValidGroups($groups);
+	}
+
+	private function walkNestedGroups(string $dn, Closure $fetcher, array $list, array &$seen = []): array {
+		$nesting = (int)$this->access->connection->ldapNestedGroups;
+		// depending on the input, we either have a list of DNs or a list of LDAP records
+		// also, the output expects either DNs or records. Testing the first element should suffice.
+		$recordMode = is_array($list) && isset($list[0]) && is_array($list[0]) && isset($list[0]['dn'][0]);
+
+		if ($nesting !== 1) {
+			if ($recordMode) {
+				// the keys are numeric, but should hold the DN
+				return array_reduce($list, function ($transformed, $record) use ($dn) {
+					if ($record['dn'][0] != $dn) {
+						$transformed[$record['dn'][0]] = $record;
+					}
+					return $transformed;
+				}, []);
+			}
+			return $list;
 		}
 
-		$allGroups = [];
-		$groups = $this->access->readAttribute($dn, 'memberOf');
-		if (is_array($groups)) {
-			if ((int)$this->access->connection->ldapNestedGroups === 1) {
-				while ($recordDn = array_shift($groups)) {
-					$nestedParents = $this->_getGroupDNsFromMemberOf($recordDn, $seen);
-					$groups = array_merge($groups, $nestedParents);
-					$allGroups[] = $recordDn;
-				}
-			} else {
-				$allGroups = $groups;
+		while ($record = array_shift($list)) {
+			$recordDN = $record['dn'][0] ?? $record;
+			if ($recordDN === $dn || array_key_exists($recordDN, $seen)) {
+				// Prevent loops
+				continue;
+			}
+			$fetched = $fetcher($record);
+			$list = array_merge($list, $fetched);
+			if (!isset($seen[$recordDN]) || is_bool($seen[$recordDN]) && is_array($record)) {
+				$seen[$recordDN] = $record;
 			}
 		}
 
-		// We do not perform array_unique here at it is done in getUserGroups later
-		$this->cachedNestedGroups[$dn] = $allGroups;
-		return $this->filterValidGroups($allGroups);
+		// on record mode, filter out intermediate state
+		return $recordMode ? array_filter($seen, 'is_array') : array_keys($seen);
 	}
 
 	/**
-	 * Translates a gidNumber into the Nextcloud internal name.
+	 * translates a gidNumber into an ownCloud internal name
 	 *
-	 * @return string|false The nextcloud internal name.
+	 * @return string|bool
 	 * @throws Exception
 	 * @throws ServerNotAvailableException
 	 */
@@ -388,7 +416,6 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|null|false The name of the group
 	 * @throws ServerNotAvailableException
 	 * @throws Exception
 	 */
@@ -411,7 +438,9 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|bool The entry's gidNumber
+	 * returns the entry's gidNumber
+	 *
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	private function getEntryGidNumber(string $dn, string $attribute) {
@@ -423,7 +452,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|bool The group's gidNumber
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	public function getGroupGidNumber(string $dn) {
@@ -431,7 +460,9 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|bool The user's gidNumber
+	 * returns the user's gidNumber
+	 *
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	public function getUserGidNumber(string $dn) {
@@ -466,7 +497,8 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return array A list of users that have the given group as gid number
+	 * returns a list of users that have the given group as gid number
+	 *
 	 * @throws ServerNotAvailableException
 	 */
 	public function getUsersInGidNumber(
@@ -493,7 +525,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 
 	/**
 	 * @throws ServerNotAvailableException
-	 * @return false|string
+	 * @return bool
 	 */
 	public function getUserGroupByGid(string $dn) {
 		$groupID = $this->getUserGidNumber($dn);
@@ -508,9 +540,9 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * Translates a primary group ID into an Nextcloud internal name
+	 * translates a primary group ID into an Nextcloud internal name
 	 *
-	 * @return string|false
+	 * @return string|bool
 	 * @throws Exception
 	 * @throws ServerNotAvailableException
 	 */
@@ -535,7 +567,9 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|false The entry's group Id
+	 * returns the entry's primary group ID
+	 *
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	private function getEntryGroupID(string $dn, string $attribute) {
@@ -547,7 +581,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|false The entry's primary group Id
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	public function getGroupPrimaryGroupID(string $dn) {
@@ -555,7 +589,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|false
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	public function getUserPrimaryGroupIDs(string $dn) {
@@ -635,7 +669,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return string|false
+	 * @return string|bool
 	 * @throws ServerNotAvailableException
 	 */
 	public function getUserPrimaryGroup(string $dn) {
@@ -657,7 +691,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	 * This function includes groups based on dynamic group membership.
 	 *
 	 * @param string $uid Name of the user
-	 * @return string[] Group names
+	 * @return array with group names
 	 * @throws Exception
 	 * @throws ServerNotAvailableException
 	 */
@@ -687,7 +721,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$groupsToMatch = $this->access->fetchListOfGroups(
 				$this->access->connection->ldapGroupFilter, ['dn', $dynamicGroupMemberURL]);
 			foreach ($groupsToMatch as $dynamicGroup) {
-				if (!isset($dynamicGroup[$dynamicGroupMemberURL][0])) {
+				if (!array_key_exists($dynamicGroupMemberURL, $dynamicGroup)) {
 					continue;
 				}
 				$pos = strpos($dynamicGroup[$dynamicGroupMemberURL][0], '(');
@@ -703,7 +737,9 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 					if ($userMatch !== false) {
 						// match found so this user is in this group
 						$groupName = $this->access->dn2groupname($dynamicGroup['dn'][0]);
-						if (is_string($groupName)) {
+						// groups and users can be just a string of numbers
+						//  is_string(int) returns false so add is_numeric
+						if (is_string($groupName) || is_numeric($groupName)) {
 							// be sure to never return false if the dn could not be
 							// resolved to a name, for whatever reason.
 							$groups[] = $groupName;
@@ -728,48 +764,64 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			&& $this->ldapGroupMemberAssocAttr !== 'memberuid'
 			&& $this->ldapGroupMemberAssocAttr !== 'zimbramailforwardingaddress') {
 			$groupDNs = $this->_getGroupDNsFromMemberOf($userDN);
-			foreach ($groupDNs as $dn) {
-				$groupName = $this->access->dn2groupname($dn);
-				if (is_string($groupName)) {
-					// be sure to never return false if the dn could not be
-					// resolved to a name, for whatever reason.
-					$groups[] = $groupName;
+			if (is_array($groupDNs)) {
+				foreach ($groupDNs as $dn) {
+					$groupName = $this->access->dn2groupname($dn);
+					if (is_string($groupName) || is_numeric($groupName)) {
+						// be sure to never return false if the dn could not be
+						// resolved to a name, for whatever reason.
+						$groups[] = $groupName;
+					}
 				}
 			}
-		} else {
-			// uniqueMember takes DN, memberuid the uid, so we need to distinguish
-			switch ($this->ldapGroupMemberAssocAttr) {
-				case 'uniquemember':
-				case 'member':
-					$uid = $userDN;
-					break;
 
-				case 'memberuid':
-				case 'zimbramailforwardingaddress':
-					$result = $this->access->readAttribute($userDN, 'uid');
-					if ($result === false) {
-						$this->logger->debug('No uid attribute found for DN {dn} on {host}',
-							[
-								'app' => 'user_ldap',
-								'dn' => $userDN,
-								'host' => $this->access->connection->ldapHost,
-							]
-						);
-						$uid = false;
-					} else {
-						$uid = $result[0];
-					}
-					break;
-
-				default:
-					// just in case
-					$uid = $userDN;
-					break;
+			if ($primaryGroup !== false) {
+				$groups[] = $primaryGroup;
 			}
+			if ($gidGroupName !== false) {
+				$groups[] = $gidGroupName;
+			}
+			$this->access->connection->writeToCache($cacheKey, $groups);
+			return $groups;
+		}
 
-			if ($uid !== false) {
+		//uniqueMember takes DN, memberuid the uid, so we need to distinguish
+		switch ($this->ldapGroupMemberAssocAttr) {
+			case 'uniquemember':
+			case 'member':
+				$uid = $userDN;
+				break;
+
+			case 'memberuid':
+			case 'zimbramailforwardingaddress':
+				$result = $this->access->readAttribute($userDN, 'uid');
+				if ($result === false) {
+					$this->logger->debug('No uid attribute found for DN {dn} on {host}',
+						[
+							'app' => 'user_ldap',
+							'dn' => $userDN,
+							'host' => $this->access->connection->ldapHost,
+						]
+					);
+					$uid = false;
+				} else {
+					$uid = $result[0];
+				}
+				break;
+
+			default:
+				// just in case
+				$uid = $userDN;
+				break;
+		}
+
+		if ($uid !== false) {
+			if (isset($this->cachedGroupsByMember[$uid])) {
+				$groups = array_merge($groups, $this->cachedGroupsByMember[$uid]);
+			} else {
 				$groupsByMember = array_values($this->getGroupsByMember($uid));
 				$groupsByMember = $this->access->nextcloudGroupNames($groupsByMember);
+				$this->cachedGroupsByMember[$uid] = $groupsByMember;
 				$groups = array_merge($groups, $groupsByMember);
 			}
 		}
@@ -788,19 +840,18 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @return array[]
 	 * @throws ServerNotAvailableException
 	 */
-	private function getGroupsByMember(string $dn, array &$seen = []): array {
-		if (isset($seen[$dn])) {
+	private function getGroupsByMember(string $dn, array &$seen = null): array {
+		if ($seen === null) {
+			$seen = [];
+		}
+		if (array_key_exists($dn, $seen)) {
+			// avoid loops
 			return [];
 		}
+		$allGroups = [];
 		$seen[$dn] = true;
-
-		if (isset($this->cachedGroupsByMember[$dn])) {
-			return $this->cachedGroupsByMember[$dn];
-		}
-
 		$filter = $this->access->connection->ldapGroupMemberAssocAttr . '=' . $dn;
 
 		if ($this->ldapGroupMemberAssocAttr === 'zimbramailforwardingaddress') {
@@ -813,24 +864,22 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$filter = $this->access->combineFilterWithAnd([$filter, $this->access->connection->ldapGroupFilter]);
 		}
 
-		$allGroups = [];
 		$groups = $this->access->fetchListOfGroups($filter,
 			[strtolower($this->access->connection->ldapGroupMemberAssocAttr), $this->access->connection->ldapGroupDisplayName, 'dn']);
-
-		if ($nesting === 1) {
-			while ($record = array_shift($groups)) {
-				// Note: this has no effect when ldapGroupMemberAssocAttr is uid based
-				$nestedParents = $this->getGroupsByMember($record['dn'][0], $seen);
-				$groups = array_merge($groups, $nestedParents);
-				$allGroups[] = $record;
+		$fetcher = function ($dn) use (&$seen) {
+			if (is_array($dn) && isset($dn['dn'][0])) {
+				$dn = $dn['dn'][0];
 			}
-		} else {
-			$allGroups = $groups;
+			return $this->getGroupsByMember($dn, $seen);
+		};
+
+		if (empty($dn)) {
+			$dn = "";
 		}
 
+		$allGroups = $this->walkNestedGroups($dn, $fetcher, $groups, $seen);
 		$visibleGroups = $this->filterValidGroups($allGroups);
-		$this->cachedGroupsByMember[$dn] = $visibleGroups;
-		return $visibleGroups;
+		return array_intersect_key($allGroups, $visibleGroups);
 	}
 
 	/**
@@ -872,7 +921,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 
 		$groupDN = $this->access->groupname2dn($gid);
 		if (!$groupDN) {
-			// group couldn't be found, return empty result-set
+			// group couldn't be found, return empty resultset
 			$this->access->connection->writeToCache($cacheKey, []);
 			return [];
 		}
@@ -1129,21 +1178,16 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	}
 
 	/**
-	 * @template T
-	 * @param array<array-key, T> $listOfGroups
-	 * @return array<array-key, T>
 	 * @throws ServerNotAvailableException
 	 * @throws Exception
 	 */
 	protected function filterValidGroups(array $listOfGroups): array {
 		$validGroupDNs = [];
 		foreach ($listOfGroups as $key => $item) {
-			$dn = is_string($item) ? $item : $item['dn'][0];
-			if (is_array($item) && !isset($item[$this->access->connection->ldapGroupDisplayName][0])) {
-				continue;
-			}
-			$name = $item[$this->access->connection->ldapGroupDisplayName][0] ?? null;
-			$gid = $this->access->dn2groupname($dn, $name);
+			// usernames can just be a string of numbers,
+			// is_string(int) returns false so use !is_array
+			$dn = !is_array($item) ? $item : $item['dn'][0];
+			$gid = $this->access->dn2groupname($dn);
 			if (!$gid) {
 				continue;
 			}
@@ -1191,7 +1235,7 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			if ($dn = $this->groupPluginManager->createGroup($gid)) {
 				//updates group mapping
 				$uuid = $this->access->getUUID($dn, false);
-				if (is_string($uuid)) {
+				if (is_string($uuid) || is_numeric($uuid)) {
 					$this->access->mapAndAnnounceIfApplicable(
 						$this->access->getGroupMapper(),
 						$dn,
@@ -1324,11 +1368,10 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 
 		if (($displayName !== false) && (count($displayName) > 0)) {
 			$displayName = $displayName[0];
-		} else {
-			$displayName = '';
+			$this->access->connection->writeToCache($cacheKey, $displayName);
+			return $displayName;
 		}
 
-		$this->access->connection->writeToCache($cacheKey, $displayName);
-		return $displayName;
+		return '';
 	}
 }

--- a/apps/user_ldap/lib/ILDAPWrapper.php
+++ b/apps/user_ldap/lib/ILDAPWrapper.php
@@ -30,6 +30,7 @@
 namespace OCA\User_LDAP;
 
 interface ILDAPWrapper {
+
 	//LDAP functions in use
 
 	/**
@@ -47,9 +48,19 @@ interface ILDAPWrapper {
 	 * connect to an LDAP server
 	 * @param string $host The host to connect to
 	 * @param string $port The port to connect to
-	 * @return resource|\LDAP\Connection|false a link resource on success, otherwise false
+	 * @return mixed a link resource on success, otherwise false
 	 */
 	public function connect($host, $port);
+
+	/**
+	 * Send LDAP pagination control
+	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param int $pageSize number of results per page
+	 * @param bool $isCritical Indicates whether the pagination is critical of not.
+	 * @param string $cookie structure sent by LDAP server
+	 * @return bool true on success, false otherwise
+	 */
+	public function controlPagedResult($link, $pageSize, $isCritical);
 
 	/**
 	 * Retrieve the LDAP pagination cookie
@@ -105,7 +116,7 @@ interface ILDAPWrapper {
 	 * Get attributes from a search result entry
 	 * @param resource|\LDAP\Connection $link LDAP link resource
 	 * @param resource|\LDAP\ResultEntry $result LDAP result resource
-	 * @return array|false containing the results, false on error
+	 * @return array containing the results, false on error
 	 * */
 	public function getAttributes($link, $result);
 
@@ -113,7 +124,7 @@ interface ILDAPWrapper {
 	 * Get the DN of a result entry
 	 * @param resource|\LDAP\Connection $link LDAP link resource
 	 * @param resource|\LDAP\ResultEntry $result LDAP result resource
-	 * @return string|false containing the DN, false on error
+	 * @return string containing the DN, false on error
 	 */
 	public function getDN($link, $result);
 
@@ -121,7 +132,7 @@ interface ILDAPWrapper {
 	 * Get all result entries
 	 * @param resource|\LDAP\Connection $link LDAP link resource
 	 * @param resource|\LDAP\Result $result LDAP result resource
-	 * @return array|false containing the results, false on error
+	 * @return array containing the results, false on error
 	 */
 	public function getEntries($link, $result);
 
@@ -153,7 +164,7 @@ interface ILDAPWrapper {
 	 * @param int $limit optional, limits the result entries
 	 * @return resource|\LDAP\Result|false an LDAP search result resource, false on error
 	 */
-	public function search($link, string $baseDN, string $filter, array $attr, int $attrsOnly = 0, int $limit = 0, int $pageSize = 0, string $cookie = '');
+	public function search($link, $baseDN, $filter, $attr, $attrsOnly = 0, $limit = 0);
 
 	/**
 	 * Replace the value of a userPassword by $password
@@ -163,13 +174,6 @@ interface ILDAPWrapper {
 	 * @return bool true on success, false otherwise
 	 */
 	public function modReplace($link, $userDN, $password);
-
-	/**
-	 * Performs a PASSWD extended operation.
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @return bool|string The generated password if new_password is empty or omitted. Otherwise true on success and false on failure.
-	 */
-	public function exopPasswd($link, string $userDN, string $oldPassword, string $password);
 
 	/**
 	 * Sets the value of the specified option to be $value

--- a/apps/user_ldap/lib/LDAPUtility.php
+++ b/apps/user_ldap/lib/LDAPUtility.php
@@ -25,7 +25,7 @@
 namespace OCA\User_LDAP;
 
 abstract class LDAPUtility {
-	protected ILDAPWrapper $ldap;
+	protected $ldap;
 
 	/**
 	 * constructor, make sure the subclasses call this one!

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -27,9 +27,9 @@
 namespace OCA\User_LDAP\Mapping;
 
 use Doctrine\DBAL\Exception;
+use OC\DB\QueryBuilder\QueryBuilder;
 use OCP\DB\IPreparedStatement;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 
 /**
  * Class AbstractMapping
@@ -192,7 +192,8 @@ abstract class AbstractMapping {
 	 */
 	protected function getDNHash(string $fdn): string {
 		$hash = hash('sha256', $fdn, false);
-		if (is_string($hash)) {
+		// rare case of hash being an integer only? then is_string(int) returns false
+		if (is_string($hash) || is_numeric($hash)) {
 			return $hash;
 		} else {
 			throw new \RuntimeException('hash function did not return a string');
@@ -219,12 +220,12 @@ abstract class AbstractMapping {
 		$qb = $this->dbc->getQueryBuilder();
 		$qb->select('owncloud_name', 'ldap_dn_hash', 'ldap_dn')
 			->from($this->getTableName(false))
-			->where($qb->expr()->in('ldap_dn_hash', $qb->createNamedParameter($hashList, IQueryBuilder::PARAM_STR_ARRAY)));
+			->where($qb->expr()->in('ldap_dn_hash', $qb->createNamedParameter($hashList, QueryBuilder::PARAM_STR_ARRAY)));
 		return $qb;
 	}
 
 	protected function collectResultsFromListOfIdsQuery(IQueryBuilder $qb, array &$results): void {
-		$stmt = $qb->executeQuery();
+		$stmt = $qb->execute();
 		while ($entry = $stmt->fetch(\Doctrine\DBAL\FetchMode::ASSOCIATIVE)) {
 			$results[$entry['ldap_dn']] = $entry['owncloud_name'];
 			$this->cache[$entry['ldap_dn']] = $entry['owncloud_name'];
@@ -239,7 +240,7 @@ abstract class AbstractMapping {
 	public function getListOfIdsByDn(array $fdns): array {
 		$totalDBParamLimit = 65000;
 		$sliceSize = 1000;
-		$maxSlices = $this->dbc->getDatabasePlatform() instanceof SqlitePlatform ? 9 : $totalDBParamLimit / $sliceSize;
+		$maxSlices = $totalDBParamLimit / $sliceSize;
 		$results = [];
 
 		$slice = 1;
@@ -261,7 +262,7 @@ abstract class AbstractMapping {
 			}
 
 			if (!empty($fdnsSlice)) {
-				$qb->orWhere($qb->expr()->in('ldap_dn_hash', $qb->createNamedParameter($fdnsSlice, IQueryBuilder::PARAM_STR_ARRAY)));
+				$qb->orWhere($qb->expr()->in('ldap_dn_hash', $qb->createNamedParameter($fdnsSlice, QueryBuilder::PARAM_STR_ARRAY)));
 			}
 
 			if ($slice % $maxSlices === 0) {

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -304,7 +304,8 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function userExistsOnLDAP($user, bool $ignoreCache = false): bool {
-		if (is_string($user)) {
+		// user can be just integers and is_string(int) returns false
+		if (is_string($user) || is_numeric($user)) {
 			$user = $this->access->userManager->get($user);
 		}
 		if (is_null($user)) {
@@ -645,7 +646,8 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 				if (is_string($dn)) {
 					// the NC user creation work flow requires a know user id up front
 					$uuid = $this->access->getUUID($dn, true);
-					if (is_string($uuid)) {
+					// can uuid ever be just integers?
+					if (is_string($uuid) || is_numeric($uuid)) {
 						$this->access->mapAndAnnounceIfApplicable(
 							$this->access->getUserMapper(),
 							$dn,


### PR DESCRIPTION
* Resolves:  #35642 

## Summary

Some LDAP variables (such as cn / uids, group names) can be only integers. The is_string(int) returns false.
This commit adds an || is_numeric or !is_array() check for these use cases.
added // comments above most changes. I was not sure what UUID was and whether it could ever be just a number.

## TODO

Please review.

Backports should be needed

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
