### PR TITLE
LDAP variables can be integers

### DIFF
--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -332,7 +332,7 @@ class Configuration {
 		} else {
 			$finalValue = [];
 			foreach ($value as $key => $val) {
-				if (is_string($val) || is_numeric($int)) {
+				if (is_string($val) || is_numeric($val)) {
 					$val = trim($val);
 					if ($val !== '') {
 						//accidental line breaks are not wanted and can cause

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -332,7 +332,7 @@ class Configuration {
 		} else {
 			$finalValue = [];
 			foreach ($value as $key => $val) {
-				if (is_string($val)) {
+				if (is_string($val) || is_numeric($int)) {
 					$val = trim($val);
 					if ($val !== '') {
 						//accidental line breaks are not wanted and can cause

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -703,7 +703,8 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 					if ($userMatch !== false) {
 						// match found so this user is in this group
 						$groupName = $this->access->dn2groupname($dynamicGroup['dn'][0]);
-						if (is_string($groupName)) {
+						// in case it is just an integer (is_string(int) returns false
+						if (is_string($groupName) || is_numeric($groupName)) {
 							// be sure to never return false if the dn could not be
 							// resolved to a name, for whatever reason.
 							$groups[] = $groupName;
@@ -730,7 +731,8 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			$groupDNs = $this->_getGroupDNsFromMemberOf($userDN);
 			foreach ($groupDNs as $dn) {
 				$groupName = $this->access->dn2groupname($dn);
-				if (is_string($groupName)) {
+                                // in case it is just an integer (is_string(int) returns false
+				if (is_string($groupName) || is_numeric($groupName)) {
 					// be sure to never return false if the dn could not be
 					// resolved to a name, for whatever reason.
 					$groups[] = $groupName;
@@ -1138,7 +1140,8 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 	protected function filterValidGroups(array $listOfGroups): array {
 		$validGroupDNs = [];
 		foreach ($listOfGroups as $key => $item) {
-			$dn = is_string($item) ? $item : $item['dn'][0];
+                        // in case it is just an integer (is_string(int) returns false
+			$dn = !is_array($item) ? $item : $item['dn'][0];
 			if (is_array($item) && !isset($item[$this->access->connection->ldapGroupDisplayName][0])) {
 				continue;
 			}
@@ -1191,7 +1194,8 @@ class Group_LDAP extends BackendUtility implements GroupInterface, IGroupLDAP, I
 			if ($dn = $this->groupPluginManager->createGroup($gid)) {
 				//updates group mapping
 				$uuid = $this->access->getUUID($dn, false);
-				if (is_string($uuid)) {
+                                // in case it is just an integer, not sure if this UUID could ever be an int though
+				if (is_string($uuid) || is_numeric($uuid)) {
 					$this->access->mapAndAnnounceIfApplicable(
 						$this->access->getGroupMapper(),
 						$dn,

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -192,8 +192,7 @@ abstract class AbstractMapping {
 	 */
 	protected function getDNHash(string $fdn): string {
 		$hash = hash('sha256', $fdn, false);
-		// very rare but a hash could just be numbers? is_string(int) would return false
-		if (is_string($hash) || is_numeric($hash)) {
+		if (is_string($hash)) {
 			return $hash;
 		} else {
 			throw new \RuntimeException('hash function did not return a string');

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -192,7 +192,8 @@ abstract class AbstractMapping {
 	 */
 	protected function getDNHash(string $fdn): string {
 		$hash = hash('sha256', $fdn, false);
-		if (is_string($hash)) {
+		// very rare but a hash could just be numbers? is_string(int) would return false
+		if (is_string($hash) || is_numeric($hash)) {
 			return $hash;
 		} else {
 			throw new \RuntimeException('hash function did not return a string');

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -304,7 +304,8 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function userExistsOnLDAP($user, bool $ignoreCache = false): bool {
-		if (is_string($user)) {
+                // in case it is just an integer (is_string(int) returns false
+		if (is_string($user) || is_numeric($user)) {
 			$user = $this->access->userManager->get($user);
 		}
 		if (is_null($user)) {
@@ -645,7 +646,8 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 				if (is_string($dn)) {
 					// the NC user creation work flow requires a know user id up front
 					$uuid = $this->access->getUUID($dn, true);
-					if (is_string($uuid)) {
+					// not sure if UUID could ever be just a number
+					if (is_string($uuid) || is_numeric($uuid)) {
 						$this->access->mapAndAnnounceIfApplicable(
 							$this->access->getUserMapper(),
 							$dn,


### PR DESCRIPTION
Signed-off-by: Alexie Papanicolaou <alpapan@gmail.com>

* Resolves:  #35642 

Some LDAP variables (such as cn / uids, group names) can be only integers. The is_string(int) returns false.
This commit adds an || is_numeric or !is_array() check for these use cases.
added // comments above most changes. I was not sure what UUID was and whether it could ever be just a number.

## TODO

Please review.

- [ ] Backports should be needed

## Checklist


- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
