### PR TITLE
fix: Make sure to reopen session before cleaning

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -152,6 +152,7 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * Reset and recreate the session
 	 */
 	public function clear() {
+		$reopened = $this->reopen();
 		$requesttoken = $this->get('requesttoken');
 		$this->sessionValues = [];
 		if ($requesttoken !== null) {
@@ -159,6 +160,9 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 		}
 		$this->isModified = true;
 		$this->session->clear();
+		if ($reopened) {
+			$this->close();
+		}
 	}
 
 	public function reopen(): bool {


### PR DESCRIPTION
## Summary

Otherwise restoring the requesttoken would reopen and read the existing
session data and restore it instead of clearing.

This is only an issue if the session clean method is called without having a
session already open (e.g. with the `@UseSession` controller annotation. This
is the reason why the regular logout works but user_saml not.

There is a hot fix available for user_saml in https://github.com/nextcloud/user_saml/pull/677 so this could be addressed without another server release.

Signed-off-by: Julius Härtl <jus@bitgrid.net>


* Resolves: #35708


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
