### PR TITLE
[stable25] ci: update minio image for s3 primary storage tests

### DIFF
--- a/.github/workflows/s3-primary.yml
+++ b/.github/workflows/s3-primary.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
-        image: bitnami/minio:2021.10.6
+        image: bitnami/minio:2021.12.29
         ports:
           - "9000:9000"
 
@@ -50,8 +50,6 @@ jobs:
 
       - name: Wait for S3
         run: |
-          sleep 10
-          curl -f -m 1 --retry-connrefused --retry 10 --retry-delay 10 http://localhost:9000/minio/health/ready
           sleep 10
           curl -f -m 1 --retry-connrefused --retry 10 --retry-delay 10 http://localhost:9000/minio/health/ready
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/35653


* Resolves: /

## Summary

>  Unable to initialize console server: Specified port is already in use

Is fixed by bitnami/minio:2021.10.13-debian-10-r0.

## TODO

- [x] Check CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
