### PR TITLE
Add cloud id resolver interface

### DIFF
--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -27,7 +27,7 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
-use OC\Federation\CloudId;
+use OCP\Federation\CloudId;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;

--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -34,8 +34,10 @@ use OCA\DAV\Events\CardUpdatedEvent;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\CloudId;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
+use OCP\Federation\ICloudIdResolver;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IURLGenerator;
@@ -52,6 +54,8 @@ class CloudIdManager implements ICloudIdManager {
 	private ICache $memCache;
 	/** @var array[] */
 	private array $cache = [];
+	/** @var ICloudIdResolver[] */
+	private array $cloudIdResolvers = [];
 
 	public function __construct(
 		IManager $contactsManager,
@@ -100,6 +104,12 @@ class CloudIdManager implements ICloudIdManager {
 	 */
 	public function resolveCloudId(string $cloudId): ICloudId {
 		// TODO magic here to get the url and user instead of just splitting on @
+		
+		foreach ($this->cloudIdResolvers as $resolver) {
+			if ($resolver->isValidCloudId($cloudId)) {
+				return $resolver->resolveCloudId($cloudId);
+			}
+		}
 
 		if (!$this->isValidCloudId($cloudId)) {
 			throw new \InvalidArgumentException('Invalid cloud id');
@@ -246,6 +256,28 @@ class CloudIdManager implements ICloudIdManager {
 	 * @return bool
 	 */
 	public function isValidCloudId(string $cloudId): bool {
+		foreach ($this->cloudIdResolvers as $resolver) {
+			if ($resolver->isValidCloudId($cloudId)) {
+				return true;
+			}
+		}
+
 		return strpos($cloudId, '@') !== false;
+	}
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 */
+	public function registerCloudIdResolver(ICloudIdResolver $resolver) {
+		array_unshift($this->cloudIdResolvers, $resolver);
+	}
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 */
+	public function unregisterCloudIdResolver(ICloudIdResolver $resolver) {
+		if (($key = array_search($resolver, $this->cloudIdResolvers)) !== false) {
+			array_splice($this->cloudIdResolvers, $key, 1);
+		}
 	}
 }

--- a/lib/public/Federation/CloudId.php
+++ b/lib/public/Federation/CloudId.php
@@ -25,9 +25,7 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-namespace OC\Federation;
-
-use OCP\Federation\ICloudId;
+namespace OCP\Federation;
 
 class CloudId implements ICloudId {
 	/** @var string */

--- a/lib/public/Federation/ICloudIdResolver.php
+++ b/lib/public/Federation/ICloudIdResolver.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * @author Joas Schilling <coding@schilljs.com>
  * @author Robin Appelman <robin@icewind.nl>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Sandro Mesterheide <sandro.mesterheide@extern.publicplan.de>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -30,28 +31,17 @@ namespace OCP\Federation;
 /**
  * Interface for resolving federated cloud ids
  *
- * @since 12.0.0
+ * @since 26.0.0
  */
-interface ICloudIdManager {
+interface ICloudIdResolver {
 	/**
 	 * @param string $cloudId
 	 * @return ICloudId
 	 * @throws \InvalidArgumentException
 	 *
-	 * @since 12.0.0
+	 * @since 26.0.0
 	 */
 	public function resolveCloudId(string $cloudId): ICloudId;
-
-	/**
-	 * Get the cloud id for a remote user
-	 *
-	 * @param string $user
-	 * @param string|null $remote (optional since 23.0.0 for local users)
-	 * @return ICloudId
-	 *
-	 * @since 12.0.0
-	 */
-	public function getCloudId(string $user, ?string $remote): ICloudId;
 
 	/**
 	 * Check if the input is a correctly formatted cloud id
@@ -59,21 +49,7 @@ interface ICloudIdManager {
 	 * @param string $cloudId
 	 * @return bool
 	 *
-	 * @since 12.0.0
+	 * @since 26.0.0
 	 */
 	public function isValidCloudId(string $cloudId): bool;
-
-	/**
-	 * @param ICloudIdResolver $resolver
-	 *
-	 * @since 26.0.0
-	 */
-	public function registerCloudIdResolver(ICloudIdResolver $resolver);
-
-	/**
-	 * @param ICloudIdResolver $resolver
-	 *
-	 * @since 26.0.0
-	 */
-	public function unregisterCloudIdResolver(ICloudIdResolver $resolver);
 }

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -24,7 +24,7 @@
 namespace Test\Collaboration\Collaborators;
 
 use OC\Collaboration\Collaborators\LookupPlugin;
-use OC\Federation\CloudId;
+use OCP\Federation\CloudId;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 use OCP\Federation\ICloudId;

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -21,7 +21,7 @@
 
 namespace Test\Federation;
 
-use OC\Federation\CloudId;
+use OCP\Federation\CloudId;
 use Test\TestCase;
 
 class CloudIdTest extends TestCase {


### PR DESCRIPTION
## Summary

This is a companion/sub PR of #34132. An application requires group ids that contain slashes and colons. Full reasoning given:

> Cloud Ids consist of username and remote parts. Usernames can also be group names. Federated groups are required to have "prefixes" to distinguish them from regular groups. Here group ids (gids) are written as Uniform Resource Names (URNs) that have colons and slashes as part of the uri scheme. We need to allow these characters as part of group names. Keep in mind that groups in Nextcloud can already contain these characters anyway.

## Changes

* Instead of validating all possible cloud ids there is now a mechanism to register cloud id resolver

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required