### PR TITLE
Put storage cache initalization in a transaction

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -29,8 +29,12 @@
  */
 namespace OC\Files\Cache;
 
+use OC\DB\Exceptions\DbalException;
+use OCP\AppFramework\Db\TTransactional;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Storage\IStorage;
+use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -50,6 +54,8 @@ class Storage {
 	private $storageId;
 	private $numericId;
 
+	use TTransactional;
+
 	/**
 	 * @return StorageGlobal
 	 */
@@ -65,7 +71,7 @@ class Storage {
 	 * @param bool $isAvailable
 	 * @throws \RuntimeException
 	 */
-	public function __construct($storage, $isAvailable = true) {
+	public function __construct($storage, bool $isAvailable = true) {
 		if ($storage instanceof IStorage) {
 			$this->storageId = $storage->getId();
 		} else {
@@ -73,21 +79,31 @@ class Storage {
 		}
 		$this->storageId = self::adjustStorageId($this->storageId);
 
-		if ($row = self::getStorageById($this->storageId)) {
-			$this->numericId = (int)$row['numeric_id'];
-		} else {
-			$connection = \OC::$server->getDatabaseConnection();
-			$available = $isAvailable ? 1 : 0;
-			if ($connection->insertIfNotExist('*PREFIX*storages', ['id' => $this->storageId, 'available' => $available])) {
-				$this->numericId = $connection->lastInsertId('*PREFIX*storages');
+		$dbConnection = \OC::$server->get(IDBConnection::class);
+
+		$this->numericId = $this->atomic(function () use ($isAvailable, $dbConnection) {
+			if ($row = self::getStorageById($this->storageId)) {
+				return (int)$row['numeric_id'];
 			} else {
-				if ($row = self::getStorageById($this->storageId)) {
-					$this->numericId = (int)$row['numeric_id'];
-				} else {
-					throw new \RuntimeException('Storage could neither be inserted nor be selected from the database: ' . $this->storageId);
+				$qb = $dbConnection->getQueryBuilder();
+				try {
+					$qb->insert('storages')
+						->values(['id' => $qb->createNamedParameter($this->storageId), 'available' => $qb->createNamedParameter($isAvailable ? 1 : 0)])
+						->executeStatement();
+					return $qb->getLastInsertId();
+				} catch (DbalException $e) {
+					if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+						// If a storage already exists with this ID, return it
+						if ($row = self::getStorageById($this->storageId)) {
+							return (int)$row['numeric_id'];
+						} else {
+							throw new \RuntimeException('Storage could neither be inserted nor be selected from the database: ' . $this->storageId);
+						}
+					}
+					throw $e;
 				}
 			}
-		}
+		}, $dbConnection);
 	}
 
 	/**


### PR DESCRIPTION
Fixes

```{
   "Exception":"RuntimeException",
   "Message":"Storage could neither be inserted nor be selected from the database: object::user:test",
   "Code":0,
   "Trace":[
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Cache/Cache.php",
         "line":122,
         "function":"__construct",
         "class":"OC\\\\Files\\\\Cache\\\\Storage",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Storage/Common.php",
         "line":344,
         "function":"__construct",
         "class":"OC\\\\Files\\\\Cache\\\\Cache",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Storage/Wrapper/Wrapper.php",
         "line":395,
         "function":"getCache",
         "class":"OC\\\\Files\\\\Storage\\\\Common",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Storage/Wrapper/Wrapper.php",
         "line":395,
         "function":"getCache",
         "class":"OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Storage/Wrapper/Wrapper.php",
         "line":395,
         "function":"getCache",
         "class":"OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/apps/terms_of_service/lib/Filesystem/StorageWrapper.php",
         "line":99,
         "function":"getCache",
         "class":"OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Mount/MountPoint.php",
         "line":295,
         "function":"getCache",
         "class":"OCA\\\\TermsOfService\\\\Filesystem\\\\StorageWrapper",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/SetupManager.php",
         "line":256,
         "function":"getStorageRootId",
         "class":"OC\\\\Files\\\\Mount\\\\MountPoint",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/SetupManager.php",
         "line":311,
         "function":"oneTimeUserSetup",
         "class":"OC\\\\Files\\\\SetupManager",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/SetupManager.php",
         "line":226,
         "function":"setupForUserWith",
         "class":"OC\\\\Files\\\\SetupManager",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/legacy/OC_Util.php",
         "line":111,
         "function":"setupForUser",
         "class":"OC\\\\Files\\\\SetupManager",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/apps/provisioning_api/lib/Controller/AUserData.php",
         "line":247,
         "function":"setupFS",
         "class":"OC_Util",
         "type":"::"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/apps/provisioning_api/lib/Controller/AUserData.php",
         "line":149,
         "function":"fillStorageInfo",
         "class":"OCA\\\\Provisioning_API\\\\Controller\\\\AUserData",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/apps/provisioning_api/lib/Controller/UsersController.php",
         "line":528,
         "function":"getUserData",
         "class":"OCA\\\\Provisioning_API\\\\Controller\\\\AUserData",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/AppFramework/Http/Dispatcher.php",
         "line":225,
         "function":"getUser",
         "class":"OCA\\\\Provisioning_API\\\\Controller\\\\UsersController",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/AppFramework/Http/Dispatcher.php",
         "line":133,
         "function":"executeController",
         "class":"OC\\\\AppFramework\\\\Http\\\\Dispatcher",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/AppFramework/App.php",
         "line":172,
         "function":"dispatch",
         "class":"OC\\\\AppFramework\\\\Http\\\\Dispatcher",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/lib/private/Route/Router.php",
         "line":298,
         "function":"main",
         "class":"OC\\\\AppFramework\\\\App",
         "type":"::"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/ocs/v1.php",
         "line":63,
         "function":"match",
         "class":"OC\\\\Route\\\\Router",
         "type":"->"
      },
      {
         "file":"/var/www/nc/nextcloud-25.0.1/ocs/v2.php",
         "line":23,
         "args":[
            "/var/www/nc/nextcloud-25.0.1/ocs/v1.php"
         ],
         "function":"require_once"
      }
   ],
   "File":"/var/www/nc/nextcloud-25.0.1/lib/private/Files/Cache/Storage.php",
   "Line":87
}
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
