### PR TITLE
Remove comment and guests option from Invitations UI

### DIFF
--- a/apps/dav/templates/schedule-response-options.php
+++ b/apps/dav/templates/schedule-response-options.php
@@ -25,10 +25,6 @@
 				</label>
 			</div>
 		</fieldset>
-		<fieldset id="more_options">
-			<input type="number" min="0" name="guests" placeholder="<?php p($l->t('Number of guests')); ?>" />
-			<input type="text" name="comment" placeholder="<?php p($l->t('Comment')); ?>" />
-		</fieldset>
 		<fieldset>
 			<input type="submit" value="<?php p($l->t('Save'));?>">
 		</fieldset>

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -379,18 +379,10 @@ EOF;
 	 * @dataProvider attendeeProvider
 	 */
 	public function testProcessMoreOptionsResult(bool $isExternalAttendee): void {
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getParam')
 			->with('partStat')
 			->willReturn('TENTATIVE');
-		$this->request->expects($this->at(1))
-			->method('getParam')
-			->with('guests')
-			->willReturn('7');
-		$this->request->expects($this->at(2))
-			->method('getParam')
-			->with('comment')
-			->willReturn('Foo bar Bli blub');
 
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -409,14 +401,12 @@ VERSION:2.0
 PRODID:-//Nextcloud/Nextcloud CalDAV Server//EN
 METHOD:REPLY
 BEGIN:VEVENT
-ATTENDEE;PARTSTAT=TENTATIVE;X-RESPONSE-COMMENT=Foo bar Bli blub;X-NUM-GUEST
- S=7:mailto:attendee@foo.bar
+ATTENDEE;PARTSTAT=TENTATIVE:mailto:attendee@foo.bar
 ORGANIZER:mailto:organizer@foo.bar
 UID:this-is-the-events-uid
 SEQUENCE:0
 REQUEST-STATUS:2.0;Success
 DTSTAMP:19700101T002217Z
-COMMENT:Foo bar Bli blub
 END:VEVENT
 END:VCALENDAR
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/23927

## Summary

Sabre doesn't support comments and guests. As such, these values are never passed on to the backend and are never stored anywhere. For the moment, the only solution is to remove the option completely.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [ ] https://github.com/nextcloud/server/pull/35761
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
