### PR TITLE
Add typed DB entities based on PHP reflection

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -34,6 +34,7 @@ return array(
     'OCP\\AppFramework\\Db\\MultipleObjectsReturnedException' => $baseDir . '/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php',
     'OCP\\AppFramework\\Db\\QBMapper' => $baseDir . '/lib/public/AppFramework/Db/QBMapper.php',
     'OCP\\AppFramework\\Db\\TTransactional' => $baseDir . '/lib/public/AppFramework/Db/TTransactional.php',
+    'OCP\\AppFramework\\Db\\TypedEntity' => $baseDir . '/lib/public/AppFramework/Db/TypedEntity.php',
     'OCP\\AppFramework\\Http' => $baseDir . '/lib/public/AppFramework/Http.php',
     'OCP\\AppFramework\\Http\\ContentSecurityPolicy' => $baseDir . '/lib/public/AppFramework/Http/ContentSecurityPolicy.php',
     'OCP\\AppFramework\\Http\\DataDisplayResponse' => $baseDir . '/lib/public/AppFramework/Http/DataDisplayResponse.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -67,6 +67,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\AppFramework\\Db\\MultipleObjectsReturnedException' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/MultipleObjectsReturnedException.php',
         'OCP\\AppFramework\\Db\\QBMapper' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/QBMapper.php',
         'OCP\\AppFramework\\Db\\TTransactional' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/TTransactional.php',
+        'OCP\\AppFramework\\Db\\TypedEntity' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/TypedEntity.php',
         'OCP\\AppFramework\\Http' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http.php',
         'OCP\\AppFramework\\Http\\ContentSecurityPolicy' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/ContentSecurityPolicy.php',
         'OCP\\AppFramework\\Http\\DataDisplayResponse' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/DataDisplayResponse.php',

--- a/lib/public/AppFramework/Db/TypedEntity.php
+++ b/lib/public/AppFramework/Db/TypedEntity.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2022 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\AppFramework\Db;
+
+use ReflectionClass;
+
+class TypedEntity extends Entity {
+
+	public function __construct() {
+		$reflectedSelf = new ReflectionClass($this);
+		$fieldTypes = $this->getFieldTypes();
+		foreach ($reflectedSelf->getProperties() as $property) {
+			if (isset($fieldTypes[$property->getName()])) {
+				// Don't override
+				continue;
+			}
+			$propertyType = $property->getType();
+			if ($propertyType === null) {
+				// Can't derive
+				continue;
+			}
+
+			if (!$propertyType->isBuiltin()) {
+				// Complex type is not supported
+				continue;
+			}
+
+			$this->addType($property->getName(), $propertyType->getName());
+		}
+	}
+
+}


### PR DESCRIPTION
Resolves: n/a

## Summary

Right now columns of a type other than string need to be refined using `Entity::addType`, typically from the Entity constructor. We can derive this information from typed properties in PHP7.4+ and the help of reflection.

Combined with *constructor property promostion* in PHP8.0+ entities can be as simple as

```php
class Foo extends TypedEntity {
    public function __construct(
        protected int $id, 
        protected string $bar, 
        protected float $x,
        protected float $y,
    ) {}
}
```

While having PHPs full type support and automatic database type conversion.

The reason why I haven't added this feature into the existing `Entity` is that it has to be done in the constructor and Entity has none. https://en.wikipedia.org/wiki/Fragile_base_class

## TODO

- [ ] Add `TypedEntity`
- [ ] Tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
