### PR TITLE
Fix missing cast of double controller parameters

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -194,7 +194,7 @@ class Dispatcher {
 		$arguments = [];
 
 		// valid types that will be casted
-		$types = ['int', 'integer', 'bool', 'boolean', 'float'];
+		$types = ['int', 'integer', 'bool', 'boolean', 'float', 'double'];
 
 		foreach ($this->reflector->getParameters() as $param => $default) {
 

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -51,11 +51,12 @@ class TestController extends Controller {
 	/**
 	 * @param int $int
 	 * @param bool $bool
+	 * @param double $foo
 	 * @param int $test
-	 * @param int $test2
+	 * @param integer $test2
 	 * @return array
 	 */
-	public function exec($int, $bool, $test = 4, $test2 = 1) {
+	public function exec($int, $bool, $foo, $test = 4, $test2 = 1) {
 		$this->registerResponder('text', function ($in) {
 			return new JSONResponse(['text' => $in]);
 		});
@@ -315,7 +316,8 @@ class DispatcherTest extends \Test\TestCase {
 			[
 				'post' => [
 					'int' => '3',
-					'bool' => 'false'
+					'bool' => 'false',
+					'double' => 1.2,
 				],
 				'method' => 'POST'
 			],
@@ -346,6 +348,7 @@ class DispatcherTest extends \Test\TestCase {
 				'post' => [
 					'int' => '3',
 					'bool' => 'false',
+					'double' => 1.2,
 					'test2' => 7
 				],
 				'method' => 'POST',
@@ -377,7 +380,8 @@ class DispatcherTest extends \Test\TestCase {
 			[
 				'post' => [
 					'int' => '3',
-					'bool' => 'false'
+					'bool' => 'false',
+					'double' => 1.2,
 				],
 				'urlParams' => [
 					'format' => 'text'
@@ -410,7 +414,8 @@ class DispatcherTest extends \Test\TestCase {
 			[
 				'post' => [
 					'int' => '3',
-					'bool' => 'false'
+					'bool' => 'false',
+					'double' => 1.2,
 				],
 				'urlParams' => [
 					'format' => 'json'
@@ -443,7 +448,8 @@ class DispatcherTest extends \Test\TestCase {
 			[
 				'post' => [
 					'int' => '3',
-					'bool' => 'false'
+					'bool' => 'false',
+					'double' => 1.2,
 				],
 				'server' => [
 					'HTTP_ACCEPT' => 'application/text, test',
@@ -477,7 +483,8 @@ class DispatcherTest extends \Test\TestCase {
 			[
 				'post' => [
 					'int' => '3',
-					'bool' => 'false'
+					'bool' => 'false',
+					'double' => 1.2,
 				],
 				'get' => [
 					'format' => 'text'


### PR DESCRIPTION
Resolves: N/a

## Summary

``settype`` allows 'double' as alias of 'float': https://www.php.net/manual/en/function.settype.php

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
