### PR TITLE
Inject services into controller methods

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -71,7 +71,6 @@ class LoginController extends Controller {
 	private IURLGenerator $urlGenerator;
 	private Defaults $defaults;
 	private Throttler $throttler;
-	private Chain $loginChain;
 	private IInitialStateService $initialStateService;
 	private WebAuthnManager $webAuthnManager;
 	private IManager $manager;
@@ -86,7 +85,6 @@ class LoginController extends Controller {
 								IURLGenerator $urlGenerator,
 								Defaults $defaults,
 								Throttler $throttler,
-								Chain $loginChain,
 								IInitialStateService $initialStateService,
 								WebAuthnManager $webAuthnManager,
 								IManager $manager,
@@ -99,7 +97,6 @@ class LoginController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->defaults = $defaults;
 		$this->throttler = $throttler;
-		$this->loginChain = $loginChain;
 		$this->initialStateService = $initialStateService;
 		$this->webAuthnManager = $webAuthnManager;
 		$this->manager = $manager;
@@ -290,15 +287,10 @@ class LoginController extends Controller {
 	 * @NoCSRFRequired
 	 * @BruteForceProtection(action=login)
 	 *
-	 * @param string $user
-	 * @param string $password
-	 * @param string $redirect_url
-	 * @param string $timezone
-	 * @param string $timezone_offset
-	 *
 	 * @return RedirectResponse
 	 */
-	public function tryLogin(string $user,
+	public function tryLogin(Chain $loginChain,
+							 string $user,
 							 string $password,
 							 string $redirect_url = null,
 							 string $timezone = '',
@@ -330,7 +322,7 @@ class LoginController extends Controller {
 			$timezone,
 			$timezone_offset
 		);
-		$result = $this->loginChain->process($data);
+		$result = $loginChain->process($data);
 		if (!$result->isSuccess()) {
 			return $this->createLoginFailedResponse(
 				$data->getUsername(),

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -191,7 +191,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c->get(IConfig::class),
 				$c->get(IDBConnection::class),
 				$c->get(LoggerInterface::class),
-				$c->get(EventLogger::class)
+				$c->get(EventLogger::class),
+				$c,
 			);
 		});
 

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\Diagnostics\IEventLogger;
 use OCP\IConfig;
 use OCP\IRequest;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -73,6 +74,8 @@ class Dispatcher {
 	/** @var IEventLogger */
 	private $eventLogger;
 
+	private ContainerInterface $appContainer;
+
 	/**
 	 * @param Http $protocol the http protocol with contains all status headers
 	 * @param MiddlewareDispatcher $middlewareDispatcher the dispatcher which
@@ -92,7 +95,8 @@ class Dispatcher {
 								IConfig $config,
 								ConnectionAdapter $connection,
 								LoggerInterface $logger,
-								IEventLogger $eventLogger) {
+								IEventLogger $eventLogger,
+								ContainerInterface $appContainer) {
 		$this->protocol = $protocol;
 		$this->middlewareDispatcher = $middlewareDispatcher;
 		$this->reflector = $reflector;
@@ -101,6 +105,7 @@ class Dispatcher {
 		$this->connection = $connection;
 		$this->logger = $logger;
 		$this->eventLogger = $eventLogger;
+		$this->appContainer = $appContainer;
 	}
 
 
@@ -216,6 +221,8 @@ class Dispatcher {
 				$value = false;
 			} elseif ($value !== null && \in_array($type, $types, true)) {
 				settype($value, $type);
+			} elseif ($value === null && $type !== null && $this->appContainer->has($type)) {
+				$value = $this->appContainer->get($type);
 			}
 
 			$arguments[] = $value;

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -36,6 +36,7 @@ use OCP\Diagnostics\IEventLogger;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use OCP\IRequestId;
 
@@ -104,10 +105,10 @@ class DispatcherTest extends \Test\TestCase {
 	private $config;
 	/** @var LoggerInterface|MockObject  */
 	private $logger;
-	/**
-	 * @var IEventLogger|MockObject
-	 */
+	/** @var IEventLogger|MockObject */
 	private $eventLogger;
+	/** @var ContainerInterface|MockObject */
+	private $container;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -116,6 +117,7 @@ class DispatcherTest extends \Test\TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->eventLogger = $this->createMock(IEventLogger::class);
+		$this->container = $this->createMock(ContainerInterface::class);
 		$app = $this->getMockBuilder(
 			'OC\AppFramework\DependencyInjection\DIContainer')
 			->disableOriginalConstructor()
@@ -154,7 +156,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container,
 		);
 
 		$this->response = $this->createMock(Response::class);
@@ -330,7 +333,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -362,7 +366,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -397,7 +402,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -431,7 +437,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -466,7 +473,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 
@@ -503,7 +511,8 @@ class DispatcherTest extends \Test\TestCase {
 			$this->config,
 			\OC::$server->getDatabaseConnection(),
 			$this->logger,
-			$this->eventLogger
+			$this->eventLogger,
+			$this->container
 		);
 		$controller = new TestController('app', $this->request);
 


### PR DESCRIPTION
Resolves: N/a

## Summary

Usually Nextcloud DI goes through constructor injection. This has the implication that each instance of a class builds the full DI tree. That is the injected services, their services, etc. Occasionally there is a service that is only needed for one controller method. Then the DI tree is build regardless if used or not.

If services are injected into the method, we only build the DI tree if that method gets executed.

This is also how Laravel allows injection for controllers: https://laravel.com/docs/9.x/controllers#dependency-injection-and-controllers as well as Symfony: https://symfony.com/doc/current/controller.html#fetching-services

As a demo I've migrated the LoginController. The *login chain* is only used in one of the three controller methods. Yet if you load the login page, the chain and its dependencies need to be build.
With this patch the chain is only built and injected for the POST request of the login.

Services that are used in all controller methods, like the ISession in the Login controller, would not benefit from an injection into the method. Those can stay as constructor injection. 

## TODO

- [x] Make the change
- [x] Demo the change

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [x] https://github.com/nextcloud/documentation/pull/9560
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
