### PR TITLE
Make the LoginController strict

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017, Sandro Lutz <sandro.lutz@temparus.ch>
  * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
@@ -227,7 +230,7 @@ class LoginController extends Controller {
 			$user = null;
 		}
 
-		$passwordLink = $this->config->getSystemValue('lost_password_link', '');
+		$passwordLink = $this->config->getSystemValueString('lost_password_link', '');
 
 		$this->initialStateService->provideInitialState(
 			'core',

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @author Lukas Reschke <lukas@owncloud.com>
  *
@@ -337,11 +340,16 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->exactly(2))
+			->expects(self::once())
 			->method('getSystemValue')
 			->willReturnMap([
 				['login_form_autocomplete', true, true],
-				['lost_password_link', '', false],
+			]);
+		$this->config
+			->expects(self::once())
+			->method('getSystemValueString')
+			->willReturnMap([
+				['lost_password_link', '', ''],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user
@@ -386,11 +394,16 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->exactly(2))
+			->expects(self::once())
 			->method('getSystemValue')
 			->willReturnMap([
 				['login_form_autocomplete', true, true],
-				['lost_password_link', '', false],
+			]);
+		$this->config
+			->expects(self::once())
+			->method('getSystemValueString')
+			->willReturnMap([
+				['lost_password_link', '', ''],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())


### PR DESCRIPTION
Resolves: N/a

## Summary

Strict types are love. Strict types are life.

## TODO

- [x] Enable strict types
- [x] Fix type errors

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
