### PR TITLE
Replace custom tooltips with native ones in files

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -64,7 +64,6 @@
 			// Toggle for grid view
 			this.$showGridView = $('input#showgridview');
 			this.$showGridView.on('change', _.bind(this._onGridviewChange, this));
-			$('#view-toggle').tooltip({placement: 'bottom', trigger: 'hover'});
 
 			if ($('#fileNotFound').val() === "1") {
 				OC.Notification.show(t('files', 'File could not be found'), {type: 'error'});
@@ -146,10 +145,6 @@
 			this._setupEvents();
 			// trigger URL change event handlers
 			this._onPopState(urlParams);
-
-			$('#quota.has-tooltip').tooltip({
-				placement: 'top'
-			});
 
 			this._debouncedPersistShowHiddenFilesState = _.debounce(this._persistShowHiddenFilesState, 1200);
 			this._debouncedPersistCropImagePreviewsState = _.debounce(this._persistCropImagePreviewsState, 1200);
@@ -428,10 +423,9 @@
 			this.$showGridView.next('#view-toggle')
 				.removeClass('icon-toggle-filelist icon-toggle-pictures')
 				.addClass(isGridView ? 'icon-toggle-filelist' : 'icon-toggle-pictures')
-			this.$showGridView.next('#view-toggle').attr(
-				'data-original-title',
-				isGridView ? t('files', 'Show list view') : t('files', 'Show grid view'),
-			)
+			this.$showGridView.next('#view-toggle')
+				.attr('title', isGridView ? t('files', 'Show list view') : t('files', 'Show grid view'))
+			this.$showGridView.attr('aria-label', isGridView ? t('files', 'Show list view') : t('files', 'Show grid view'))
 
 			if (this.currentFileList) {
 				this.currentFileList.setGridView(isGridView);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1102,8 +1102,6 @@ OC.Uploader.prototype = _.extend({
 				 */
 				start: function(e) {
 					self.log('start', e, null);
-					//hide the tooltip otherwise it covers the progress bar
-					$('#upload').tooltip('hide');
 					self._uploading = true;
 				},
 				fail: function(e, data) {

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -470,7 +470,7 @@
 					);
 				}
 			);
-			$actionEl.tooltip({placement:'top'});
+
 			return $actionEl;
 		},
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1856,9 +1856,7 @@
 				"title": formatted,
 				"data-timestamp": mtime,
 				"style": 'color:rgb('+modifiedColor+','+modifiedColor+','+modifiedColor+')'
-			}).text(text)
-			  .tooltip({placement: 'top'})
-			);
+			}).text(text));
 			tr.find('.filesize').text(simpleSize);
 			tr.append(td);
 			return tr;
@@ -2893,7 +2891,6 @@
 			};
 
 			function restore() {
-				input.tooltip('hide');
 				tr.data('renaming',false);
 				form.remove();
 				td.children('a.name').children(':not(.thumbnail-wrapper)').show();
@@ -2914,7 +2911,6 @@
 
 				try {
 					var newName = input.val().trim();
-					input.tooltip('hide');
 					form.remove();
 
 					if (newName !== oldName) {
@@ -2974,9 +2970,6 @@
 					}
 				} catch (error) {
 					input.attr('title', error);
-					input.tooltip({placement: 'right', trigger: 'manual'});
-					input.tooltip('_fixTitle');
-					input.tooltip('show');
 					input.addClass('error');
 				}
 				return false;
@@ -2985,13 +2978,9 @@
 				// verify filename on typing
 				try {
 					checkInput();
-					input.tooltip('hide');
 					input.removeClass('error');
 				} catch (error) {
 					input.attr('title', error);
-					input.tooltip({placement: 'right', trigger: 'manual'});
-					input.tooltip('_fixTitle');
-					input.tooltip('show');
 					input.addClass('error');
 				}
 				if (event.keyCode === 27) {
@@ -3852,7 +3841,6 @@
 			}));
 
 			$actionsContainer.prepend($newButton);
-			$newButton.tooltip({'placement': 'bottom'});
 			$newButton.attr('aria-expanded', 'false');
 			$newButton.click(_.bind(this._onClickNewButton, this));
 			this._newButton = $newButton;
@@ -3863,7 +3851,6 @@
 			if (!$target.hasClass('.button')) {
 				$target = $target.closest('.button');
 			}
-			this._newButton.tooltip('hide');
 			$target.attr('aria-expanded', 'true');
 			event.preventDefault();
 			if ($target.hasClass('disabled')) {

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -72,7 +72,7 @@
 			}
 			if (response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
 				$('#free_space').val(response.data.freeSpace);
-				$('#upload.button').attr('data-original-title', response.data.maxHumanFilesize);
+				$('#upload.button').attr('title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
 				$('#usedSpacePercent').data('mount-type', response.data.mountType);
 				$('#usedSpacePercent').data('mount-point', response.data.mountPoint);
@@ -85,7 +85,7 @@
 				return;
 			}
 			if (response[0].uploadMaxFilesize !== undefined) {
-				$('#upload.button').attr('data-original-title', response[0].maxHumanFilesize);
+				$('#upload.button').attr('title', response[0].maxHumanFilesize);
 				$('#usedSpacePercent').val(response[0].usedSpacePercent);
 				Files.displayStorageWarnings();
 			}
@@ -104,7 +104,7 @@
 				var humanUsed = OC.Util.humanFileSize(response.data.used, true);
 				var humanTotal = OC.Util.humanFileSize(response.data.total, true);
 				if (response.data.quota > 0) {
-					$('#quota').attr('data-original-title', t('files', '{used}%', {used: Math.round(response.data.usedSpacePercent)}));
+					$('#quota').attr('title', t('files', '{used}%', {used: Math.round(response.data.usedSpacePercent)}));
 					$('#quota progress').val(response.data.usedSpacePercent);
 					$('#quotatext').html(t('files', '{used} of {quota} used', {used: humanUsed, quota: humanTotal}));
 				} else {
@@ -345,8 +345,6 @@
 				this.focus();
 				this.setSelectionRange(0, this.value.length);
 			});
-
-			$('#upload').tooltip({placement:'right'});
 
 			//FIXME scroll to and highlight preselected file
 			/*

--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -69,17 +69,7 @@
 		_setupClipboard: function() {
 			var clipboard = new Clipboard('.permalink');
 			clipboard.on('success', function(e) {
-				var $el = $(e.trigger);
-				$el.tooltip('hide')
-					.attr('data-original-title', t('core', 'Copied!'))
-					.tooltip('_fixTitle')
-					.tooltip({placement: 'bottom', trigger: 'manual'})
-					.tooltip('show');
-				_.delay(function() {
-					$el.tooltip('hide');
-					$el.attr('data-original-title', t('files', 'Copy direct link (only works for users who have access to this file/folder)'))
-						.tooltip('_fixTitle');
-				}, 3000);
+				OC.Notification.show(t('files', 'Direct link was copied (only works for users who have access to this file/folder)'), {type: 'success'});
 			});
 			clipboard.on('error', function(e) {
 				var $row = this.$('.permalink-field');
@@ -192,7 +182,6 @@
 					}
 					$iconDiv.css('background-image', 'url("' + iconUrl + '")');
 				}
-				this.$el.find('[title]').tooltip({placement: 'bottom'});
 			} else {
 				this.$el.empty();
 			}

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -137,9 +137,6 @@
 					}
 				} catch (error) {
 					$input.attr('title', error);
-					$input.tooltip({placement: 'right', trigger: 'manual', container: self.$el});
-					$input.tooltip('_fixTitle');
-					$input.tooltip('show');
 					$input.addClass('error');
 				}
 				return false;
@@ -148,7 +145,6 @@
 			// verify filename on typing
 			$input.keyup(function() {
 				if (checkInput()) {
-					$input.tooltip('hide');
 					$input.removeClass('error');
 				}
 			});

--- a/apps/files/js/operationprogressbar.js
+++ b/apps/files/js/operationprogressbar.js
@@ -63,9 +63,8 @@
 			$('#uploadprogressbar .ui-progressbar-value>em').addClass('inner');
 			$('#uploadprogressbar>em').replaceWith(labelHtml);
 			$('#uploadprogressbar>em').addClass('outer');
-			$('#uploadprogressbar').tooltip({placement: 'bottom', container: '#uploadprogresswrapper'});
 			if (title) {
-				$('#uploadprogressbar').attr('data-original-title', title);
+				$('#uploadprogressbar').attr('title', title);
 				$('#uploadprogresswrapper .tooltip-inner').text(title);
 			}
 			if(textDesktop || textMobile) {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -65,7 +65,6 @@ OCA.Sharing.PublicApp = {
 			// Toggle for grid view
 			this.$showGridView = $('input#showgridview');
 			this.$showGridView.on('change', _.bind(this._onGridviewChange, this));
-			$('#view-toggle').tooltip({placement: 'bottom', trigger: 'hover'});
 
 			var filesClient = new OC.Files.Client({
 				host: OC.getHost(),
@@ -380,7 +379,7 @@ OCA.Sharing.PublicApp = {
 			.removeClass('icon-toggle-filelist icon-toggle-pictures')
 			.addClass(isGridView ? 'icon-toggle-filelist' : 'icon-toggle-pictures')
 		this.$showGridView.next('#view-toggle').attr(
-			'data-original-title',
+			'title',
 			isGridView ? t('files', 'Show list view') : t('files', 'Show grid view'),
 		)
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/35770

## Summary

to be written

## TODO

- [x] Replace custom tooltips with native ones in files
- [x] check if implementation in the apps/files/js/mainfileinfodetailview.js is right.
- [x] check if implementation in the apps/files/js/newfilemenu.js is right.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
