### PR TITLE
Fix parameter type for EntityCollection::setReadMarker in comments app

### DIFF
--- a/apps/dav/lib/Comments/EntityCollection.php
+++ b/apps/dav/lib/Comments/EntityCollection.php
@@ -162,12 +162,9 @@ class EntityCollection extends RootCollection implements IProperties {
 
 	/**
 	 * Sets the read marker to the specified date for the logged in user
-	 *
-	 * @param \DateTime $value
-	 * @return bool
 	 */
-	public function setReadMarker($value) {
-		$dateTime = new \DateTime($value);
+	public function setReadMarker(?string $value): bool {
+		$dateTime = new \DateTime($value ?? 'now');
 		$user = $this->userSession->getUser();
 		$this->commentsManager->setReadMark($this->name, $this->id, $dateTime, $user);
 		return true;


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

Fix https://github.com/nextcloud/server/issues/35773