### PR TITLE
Avoid using the word 'password' in the APP_TOKEN_CREATED activity

### DIFF
--- a/apps/settings/lib/Activity/Provider.php
+++ b/apps/settings/lib/Activity/Provider.php
@@ -112,9 +112,9 @@ class Provider implements IProvider {
 			$subject = $this->l->t('Your email address was changed by an administrator');
 		} elseif ($event->getSubject() === self::APP_TOKEN_CREATED) {
 			if ($event->getAffectedUser() === $event->getAuthor()) {
-				$subject = $this->l->t('You created app password "{token}"');
+				$subject = $this->l->t('You created an app password for a session named "{token}"');
 			} else {
-				$subject = $this->l->t('An administrator created app password "{token}"');
+				$subject = $this->l->t('An administrator created an app password for a session named "{token}"');
 			}
 		} elseif ($event->getSubject() === self::APP_TOKEN_DELETED) {
 			$subject = $this->l->t('You deleted app password "{token}"');


### PR DESCRIPTION
The activity message `You created app password "{token}"` can make some users freak out because they might think they produced something insecure to access their account.

What do you think?