### PR TITLE
Fix svg images not supported by imaginary autorotate

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -92,20 +92,20 @@ class Imaginary extends ProviderV2 {
 
 		$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
 
-		$operations = [
-			[
-				'operation' => 'autorotate',
-			],
-			[
-				'operation' => ($crop ? 'smartcrop' : 'fit'),
-				'params' => [
-					'width' => $maxX,
-					'height' => $maxY,
-					'stripmeta' => 'true',
-					'type' => $mimeType,
-					'norotation' => 'true',
-					'quality' => $quality,
-				]
+		$operations = [];
+		if (!in_array($file->getMimeType(), ['image/svg+xml', 'image/svg'])) {
+			$operations[]['operation'] = 'autorotate';
+		}
+
+		$operations[] = [
+			'operation' => ($crop ? 'smartcrop' : 'fit'),
+			'params' => [
+				'width' => $maxX,
+				'height' => $maxY,
+				'stripmeta' => 'true',
+				'type' => $mimeType,
+				'norotation' => 'true',
+				'quality' => $quality,
 			]
 		];
 


### PR DESCRIPTION
## Summary

Pull request #31829 added the `autorotate` operation as first operation sent to imaginary. For svg images, this will fail with the following error messages:

- using the official *h2non/imaginary* docker image: `Error while processing the image: VIPS cannot save to "svg"`
- using imaginary docker image from the nextcloud aio package: `Error while processing the image: Unsupported image output type`

As soon as the `autorotate` operation is removed from the imaginary pipeline, the svg image is correctly resized (*fit*) and converted to an jpeg image.

This PR skips the `autorotate` operation if the mime type of the image is:
- `image/svg+xml`
   or
- `image/svg`

## Additional notes

The imaginary `pipeline` API operation has an [option `ignore_failure`](https://github.com/h2non/imaginary#operations-json-specification) for each operation. If this option is enabled for an operation, that operation should fail silently and the pipeline would continue with the next operation without failing.

Unfortunately that did not work for me.