### PR TITLE
Implement occ maintenance:mode --check-if-disabled

### DIFF
--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -55,6 +55,12 @@ class Mode extends Command {
 				null,
 				InputOption::VALUE_NONE,
 				'disable maintenance mode'
+			)
+			->addOption(
+				'check-if-disabled',
+				null,
+				InputOption::VALUE_NONE,
+				'return 0 if maintenance mode is disabled, otherwise return 1'
 			);
 	}
 
@@ -73,6 +79,12 @@ class Mode extends Command {
 				$output->writeln('Maintenance mode disabled');
 			} else {
 				$output->writeln('Maintenance mode already disabled');
+			}
+		} elseif ($input->getOption('check-if-disabled')) {
+			if ($maintenanceMode === false) {
+				return 0;
+			} else {
+				return 1;
 			}
 		} else {
 			if ($maintenanceMode) {


### PR DESCRIPTION
Signed-off-by: Lee Garrett <lgarrett@rocketjump.eu>


* Resolves: #35704

## Summary
Add a parameter that can be used in scripts. Returns 0 when there is no maintenance mode, and 1 if there is.

## TODO

- [ ] Test coverage?

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
