### PR TITLE
fix(session): Always setup the session if a session cookie is passed

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -411,7 +411,7 @@ class OC {
 	public static function initSession(): void {
 		$request = Server::get(IRequest::class);
 		$isDavRequest = strpos($request->getRequestUri(), '/remote.php/dav') === 0 || strpos($request->getRequestUri(), '/remote.php/webdav') === 0;
-		if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest) {
+		if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest && !isset($_COOKIE['nc_session_id'])) {
 			setcookie('cookie_test', 'test', time() + 3600);
 			// Do not initialize the session if a request is authenticated directly
 			// unless there is a session cookie already sent along


### PR DESCRIPTION
Follow-up fix for #28311 as the merge has shown failures in E2E tests of text.

The issue is that the test pass both a session cookie as well as basic auth which then leads to the session not being opened. If a session cookie is present however we should always proceed with the previous behaviour to setup the session.
