### PR TITLE
Modify user_ldap checkPassword to not fetch records from ldap each time because of extremely high CPU usage!

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -76,11 +76,12 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * @return string|false
 	 * @throws \Exception
 	 */
-	public function loginName2UserName($loginName) {
+	public function loginName2UserName($loginName, bool $forceLdapRefetch = false) {
 		$cacheKey = 'loginName2UserName-' . $loginName;
 		$username = $this->access->connection->getFromCache($cacheKey);
 
-		if ($username !== null) {
+		$ignoreCache = ($username === false && $forceLdapRefetch);
+		if ($username !== null && !$ignoreCache) {
 			return $username;
 		}
 
@@ -95,6 +96,9 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 			}
 			$username = $user->getUsername();
 			$this->access->connection->writeToCache($cacheKey, $username);
+			if ($forceLdapRefetch) {
+				$user->processAttributes($ldapRecord);
+			}
 			return $username;
 		} catch (NotOnLDAP $e) {
 			$this->access->connection->writeToCache($cacheKey, false);
@@ -138,16 +142,11 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * @return false|string
 	 */
 	public function checkPassword($uid, $password) {
-		try {
-			$ldapRecord = $this->getLDAPUserByLoginName($uid);
-		} catch (NotOnLDAP $e) {
-			$this->logger->debug(
-				$e->getMessage(),
-				['app' => 'user_ldap', 'exception' => $e]
-			);
+		$username = $this->loginName2UserName($uid, true);
+		if ($username === false) {
 			return false;
 		}
-		$dn = $ldapRecord['dn'][0];
+		$dn = $this->access->username2dn($username);
 		$user = $this->access->userManager->get($dn);
 
 		if (!$user instanceof User) {
@@ -165,7 +164,6 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 			}
 
 			$this->access->cacheUserExists($user->getUsername());
-			$user->processAttributes($ldapRecord);
 			$user->markLogin();
 
 			return $user->getUsername();

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -149,6 +149,10 @@ class User_LDAPTest extends TestCase {
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->willReturn($retVal);
 		$this->access->expects($this->any())
+			   ->method('username2dn')
+			   ->with($this->equalTo('gunslinger'))
+			   ->willReturn('dnOfRoland,dc=test');
+		$this->access->expects($this->any())
 			   ->method('stringResemblesDN')
 			   ->with($this->equalTo('dnOfRoland,dc=test'))
 			   ->willReturn(true);


### PR DESCRIPTION
## Summary
- Currently on each `checkPassword` call, [the function `getLDAPUserByLoginName` is called](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/User_LDAP.php#L180)
- This calls `fetchListOfUsers` which is defined [here](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/Access.php#L858)
- So on each authentication request:
  - there is first an admin bind to LDAP(if not already existing)
  - a search request to LDAP
  - a bunch of SQL UPDATEs from calling [`batchApplyUserAttributes`](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/Access.php#L892)
  - [a user BIND to LDAP](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/User_LDAP.php#L201) to check if credentials are valid
 

- DAV mobile clients(for example [DAVx5](https://github.com/bitfireAT/davx5-ose)) don't support token auth or oauth yet. This means that they pass the username and password on every single sync request
- We have an NC instance serving around 100 DAV sync requests every second
- For every sync request the LDAP logs look like(admin bind + search for user):
```
conn=1687813954 fd=21 ACCEPT from IP=*** (IP=***)
conn=1687813954 op=0 BIND dn="***" method=128
conn=1687813954 op=0 BIND dn="***" mech=SIMPLE bind_ssf=0 ssf=0
conn=1687813954 op=0 RESULT tag=97 err=0 qtime=0.000014 etime=0.000156 text=
conn=1687813954 op=1 SRCH base="***" scope=2 deref=0 filter="***"
conn=1687813954 op=1 SRCH attr=entryuuid nsuniqueid objectguid guid ipauniqueid dn uid samaccountname memberof 
conn=1687813954 op=1 SEARCH RESULT tag=101 err=0 qtime=0.000027 etime=0.000332 nentries=1 text=
```
- followed by BIND(to check user credentials)
```
conn=1687813956 fd=51 ACCEPT from IP=*** (IP=***)
conn=1687813956 op=0 BIND dn="***" method=128
conn=1687813956 op=0 BIND dn="***" mech=SIMPLE bind_ssf=0 ssf=0
conn=1687813956 op=0 RESULT tag=97 err=0 qtime=0.000012 etime=0.004391 text=
```
- CPU Usage by openldap is extremely high! CPU usage by database is similarly extremely high but lower compared to LDAP


### Proposed solution here

- Get username and dn from cache if existing
  - Use the [loginName2UserName](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/User_LDAP.php#L117) function that will fetch the ldap record and update attributes if it is not in cache
- Check credentials with BIND but don't process attributes again 
  - [`$user->processAttributes`](https://github.com/nextcloud/server/blob/5c4b4bde1b2da872c3e03846954214a8aa8c598e/apps/user_ldap/lib/User_LDAP.php#L206) here seems redundant as it is already done during the `getLDAPUserByLoginName` function call
- Will save ~0.5ms per auth request if user already cached
  - Doesn't sound like too big a deal but with 100 auth requests per second, this can definitely help the load issue
- Will also avoid  ~12 SQL UPDATE operations on each authentication request
  - ~6 if user is not cached yet 
  - `UNBIND` happens in the destructor of the `Connection` class so pretty sure it is done only after all these SQL commands are completed, which means the LDAP bind stays open till then


Please do let me know if there are any pitfalls to this and if the ldap record fetching and processing on every single authentication request happens for an unavoidable reason I am not aware of..

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
