### PR TITLE
Add option to return an exit-code when occ status signals an update is needed

### DIFF
--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -29,6 +29,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\Util;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends Base {
@@ -47,17 +48,33 @@ class Status extends Base {
 
 		$this
 			->setDescription('show some status information')
-		;
+			->addOption(
+				'exit-code',
+				'e',
+				InputOption::VALUE_NONE,
+				'exit with 0 if running in normal mode, 1 when in maintenance mode, 2 when `./occ upgrade` is needed. Does not write any output to STDOUT.'
+			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$maintenanceMode = $this->config->getSystemValueBool('maintenance', false);
+		$needUpgrade = Util::needUpgrade();
+		if ($input->getOption('exit-code')) {
+			if ($maintenanceMode === true) {
+				return 1;
+			} elseif ($needUpgrade == true) {
+				return 2;
+			} else {
+				return 0;
+			}
+		}
 		$values = [
 			'installed' => $this->config->getSystemValueBool('installed', false),
 			'version' => implode('.', Util::getVersion()),
 			'versionstring' => OC_Util::getVersionString(),
 			'edition' => '',
-			'maintenance' => $this->config->getSystemValueBool('maintenance', false),
-			'needsDbUpgrade' => Util::needUpgrade(),
+			'maintenance' => $maintenanceMode,
+			'needsDbUpgrade' => $needUpgrade,
 			'productname' => $this->themingDefaults->getProductName(),
 			'extendedSupport' => Util::hasExtendedSupport()
 		];

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -59,15 +59,6 @@ class Status extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maintenanceMode = $this->config->getSystemValueBool('maintenance', false);
 		$needUpgrade = Util::needUpgrade();
-		if ($input->getOption('exit-code')) {
-			if ($maintenanceMode === true) {
-				return 1;
-			} elseif ($needUpgrade == true) {
-				return 2;
-			} else {
-				return 0;
-			}
-		}
 		$values = [
 			'installed' => $this->config->getSystemValueBool('installed', false),
 			'version' => implode('.', Util::getVersion()),
@@ -80,6 +71,14 @@ class Status extends Base {
 		];
 
 		$this->writeArrayInOutputFormat($input, $output, $values);
+		if ($input->getOption('exit-code')) {
+			if ($maintenanceMode === true) {
+				return 1;
+			}
+			if ($needUpgrade === true) {
+				return 2;
+			}
+		}
 		return 0;
 	}
 }

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -70,7 +70,10 @@ class Status extends Base {
 			'extendedSupport' => Util::hasExtendedSupport()
 		];
 
-		$this->writeArrayInOutputFormat($input, $output, $values);
+		if ($input->getOption('verbose') || !$input->getOption('exit-code')) {
+			$this->writeArrayInOutputFormat($input, $output, $values);
+		}
+
 		if ($input->getOption('exit-code')) {
 			if ($maintenanceMode === true) {
 				return 1;

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -181,7 +181,8 @@ class Application {
 		InputInterface $input, ConsoleOutputInterface $output
 	) {
 		if ($input->getArgument('command') !== '_completion'
-			&& $input->getArgument('command') !== 'maintenance:mode') {
+			&& $input->getArgument('command') !== 'maintenance:mode'
+			&& $input->getArgument('command') !== 'status') {
 			$errOutput = $output->getErrorOutput();
 			$errOutput->writeln(
 				'<comment>Nextcloud is in maintenance mode, hence the database isn\'t accessible.' . PHP_EOL .


### PR DESCRIPTION
Signed-off-by: Lee Garrett <lgarrett@rocketjump.eu>

* Resolves: #35704

## Summary
This is an improved version of my earlier PR  #35830. This is now a parameter to `status`, so it allows for adding more return codes later, which can then for example be consumed in systemd units, or monitoring checks.

It adds a parameter that can be used in scripts. `./occ status -e` returns 0 when operating normally, and 1 if there is maintenance mode, 2 if `./occ upgrade` is required.

## TODO

- [ ] Test coverage?

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
