### PR TITLE
Format of Databasehost for Sockets

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -108,7 +108,7 @@ $CONFIG = [
  * Your host server name, for example ``localhost``, ``hostname``,
  * ``hostname.example.com``, or the IP address. To specify a port use
  * ``hostname:####``; to specify a Unix socket use
- * ``/path/to/directory/containing/socket`` e.g. ``/run/postgresql/``.
+ * ``localhost:/path/to/directory/containing/socket`` e.g. ``localhost:/run/postgresql/``.
  */
 'dbhost' => '',
 

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -249,6 +249,11 @@ class ConnectionFactory {
 			'host' => $host,
 		];
 
+		// Host variable may only be an unix socket.
+		if ((strpos($host, '/') !== false) and (strpos($host, ':') === false)) {
+			$host = 'localhost:'.$host;
+		}
+
 		$matches = [];
 		if (preg_match('/^(.*):([^\]:]+)$/', $host, $matches)) {
 			// Host variable carries a port or socket.

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -47,6 +47,8 @@ abstract class AbstractDatabase {
 	/** @var string */
 	protected $dbName;
 	/** @var string */
+	protected $unix_socket;
+	/** @var string */
 	protected $dbHost;
 	/** @var string */
 	protected $dbPort;
@@ -114,10 +116,16 @@ abstract class AbstractDatabase {
 			'user' => $this->dbUser,
 			'password' => $this->dbPassword,
 			'tablePrefix' => $this->tablePrefix,
-			'dbname' => $this->dbName
+			'dbname' => $this->dbName,
+			'unix_socket' => $this->unix_socket
 		];
 
 		// adding port support through installer
+		// Host variable may only be an unix socket.
+		if ((strpos($this->dbHost, '/') !== false) and (strpos($this->dbHost, ':') === false)) {
+			$this->unix_socket = $this->dbHost;
+			$this->dbHost = 'localhost:'.$this->dbHost;
+		}
 		if (!empty($this->dbPort)) {
 			if (ctype_digit($this->dbPort)) {
 				$connectionParams['port'] = $this->dbPort;
@@ -133,10 +141,6 @@ abstract class AbstractDatabase {
 				$connectionParams['unix_socket'] = $portOrSocket;
 			}
 			$connectionParams['host'] = $host;
-		} elseif (strpos($this->dbHost, '/') >= 0) {
-			// Host variable may only be an unix socket.
-			$connectionParams['unix_socket'] = $this->dbHost;
-			$connectionParams['host'] = 'localhost';
 		}
 
 		$connectionParams = array_merge($connectionParams, $configOverwrite);

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -133,6 +133,10 @@ abstract class AbstractDatabase {
 				$connectionParams['unix_socket'] = $portOrSocket;
 			}
 			$connectionParams['host'] = $host;
+		} elseif (strpos($this->dbHost, '/') >= 0) {
+			// Host variable may only be an unix socket.
+			$connectionParams['unix_socket'] = $this->dbHost;
+			$connectionParams['host'] = 'localhost';
 		}
 
 		$connectionParams = array_merge($connectionParams, $configOverwrite);


### PR DESCRIPTION
* Resolves: #35378

## Summary
First, the Documentation was wrong for the dbhost in config.php when using sockets and second, made the installer accept the filename without adding "localhost:" in front, which is uncommon so not intuitive and not documented.

## TODO

nothing.

## Checklist

X Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
X [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [?] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [-] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [?] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
