### PR TITLE
Checkout current branch in cypress tests in CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   APP_NAME: viewer
-  BRANCH: ${{ github.base_ref }}
+  BRANCH: ${{ github.ref }}
   TESTING: true
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
+          cache: "npm"
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}

--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -83,6 +83,9 @@ export const startNextcloud = async function(branch: string = 'master'): Promise
 			HostConfig: {
 				Binds: [],
 			},
+			Env: [
+				`BRANCH=${branch}`,
+			]
 		})
 		await container.start()
 


### PR DESCRIPTION
+ Set the `BRANCH` environment variable to the current branch and not the ref one.
+ Correctly forward `BRANCH` environment variable to the docker container