### PR TITLE
display displayname on federated shares

### DIFF
--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -102,8 +102,9 @@ class Notifier implements INotifier {
 				$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/share.svg')));
 
 				$params = $notification->getSubjectParameters();
+				$displayName = (count($params) > 3) ? $params[3] : '';
 				if ($params[0] !== $params[1] && $params[1] !== null) {
-					$remoteInitiator = $this->createRemoteUser($params[0]);
+					$remoteInitiator = $this->createRemoteUser($params[0], $displayName);
 					$remoteOwner = $this->createRemoteUser($params[1]);
 					$params[3] = $remoteInitiator['name'] . '@' . $remoteInitiator['server'];
 					$params[4] = $remoteOwner['name'] . '@' . $remoteOwner['server'];
@@ -121,7 +122,7 @@ class Notifier implements INotifier {
 						]
 					);
 				} else {
-					$remoteOwner = $this->createRemoteUser($params[0]);
+					$remoteOwner = $this->createRemoteUser($params[0], $displayName);
 					$params[3] = $remoteOwner['name'] . '@' . $remoteOwner['server'];
 
 					$notification->setRichSubject(
@@ -166,19 +167,21 @@ class Notifier implements INotifier {
 
 	/**
 	 * @param string $cloudId
+	 * @param string $displayName - overwrite display name
+	 *
 	 * @return array
 	 */
-	protected function createRemoteUser($cloudId, $displayName = null) {
+	protected function createRemoteUser(string $cloudId, string $displayName = '') {
 		try {
 			$resolvedId = $this->cloudIdManager->resolveCloudId($cloudId);
-			if ($displayName === null) {
+			if ($displayName === '') {
 				$displayName = $this->getDisplayName($resolvedId);
 			}
 			$user = $resolvedId->getUser();
 			$server = $resolvedId->getRemote();
 		} catch (HintException $e) {
 			$user = $cloudId;
-			$displayName = $cloudId;
+			$displayName = ($displayName !== '') ? $displayName : $cloudId;
 			$server = '';
 		}
 

--- a/apps/files_sharing/lib/Activity/Providers/Base.php
+++ b/apps/files_sharing/lib/Activity/Providers/Base.php
@@ -157,9 +157,11 @@ abstract class Base implements IProvider {
 
 	/**
 	 * @param string $uid
+	 * @param string $overwriteDisplayName - overwrite display name, only if user is not local
+	 *
 	 * @return array
 	 */
-	protected function getUser($uid) {
+	protected function getUser(string $uid, string $overwriteDisplayName = '') {
 		// First try local user
 		$displayName = $this->userManager->getDisplayName($uid);
 		if ($displayName !== null) {
@@ -176,7 +178,7 @@ abstract class Base implements IProvider {
 			return [
 				'type' => 'user',
 				'id' => $cloudId->getUser(),
-				'name' => $this->getDisplayNameFromAddressBook($cloudId->getDisplayId()),
+				'name' => (($overwriteDisplayName !== '') ? $overwriteDisplayName : $this->getDisplayNameFromAddressBook($cloudId->getDisplayId())),
 				'server' => $cloudId->getRemote(),
 			];
 		}
@@ -185,7 +187,7 @@ abstract class Base implements IProvider {
 		return [
 			'type' => 'user',
 			'id' => $uid,
-			'name' => $uid,
+			'name' => (($overwriteDisplayName !== '') ? $overwriteDisplayName : $uid),
 		];
 	}
 

--- a/apps/files_sharing/lib/Activity/Providers/RemoteShares.php
+++ b/apps/files_sharing/lib/Activity/Providers/RemoteShares.php
@@ -115,13 +115,14 @@ class RemoteShares extends Base {
 		switch ($subject) {
 			case self::SUBJECT_REMOTE_SHARE_RECEIVED:
 			case self::SUBJECT_REMOTE_SHARE_UNSHARED:
+				$displayName = (count($parameters) > 2) ? $parameters[2] : '';
 				return [
 					'file' => [
 						'type' => 'pending-federated-share',
 						'id' => $parameters[1],
 						'name' => $parameters[1],
 					],
-					'user' => $this->getUser($parameters[0]),
+					'user' => $this->getUser($parameters[0], $displayName)
 				];
 			case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
 			case self::SUBJECT_REMOTE_SHARE_DECLINED:

--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -209,11 +209,12 @@ class CloudIdManager implements ICloudIdManager {
 	 * @param string $url
 	 * @return string
 	 */
-	private function removeProtocolFromUrl($url) {
+	public function removeProtocolFromUrl(string $url): string {
 		if (str_starts_with($url, 'https://')) {
-			return substr($url, strlen('https://'));
-		} elseif (str_starts_with($url, 'http://')) {
-			return substr($url, strlen('http://'));
+			return substr($url, 8);
+		}
+		if (str_starts_with($url, 'http://')) {
+			return substr($url, 7);
 		}
 
 		return $url;

--- a/lib/public/Federation/ICloudIdManager.php
+++ b/lib/public/Federation/ICloudIdManager.php
@@ -62,4 +62,14 @@ interface ICloudIdManager {
 	 * @since 12.0.0
 	 */
 	public function isValidCloudId(string $cloudId): bool;
+
+	/**
+	 * remove scheme/protocol from an url
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 * @since 28.0.0
+	 */
+	public function removeProtocolFromUrl(string $url): string;
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -87,6 +87,7 @@
 			<errorLevel type="suppress">
 				<referencedClass name="OCA\GroupFolders\Mount\GroupFolderStorage"/>
 				<referencedClass name="OCA\TwoFactorNextcloudNotification\Controller\APIController"/>
+				<referencedClass name="OCA\GlobalSiteSelector\Service\SlaveService"/>
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedFunction>
@@ -130,6 +131,7 @@
 				<!-- Helper classes for sharing API integration from other apps -->
 				<referencedClass name="OCA\Deck\Sharing\ShareAPIHelper" />
 				<referencedClass name="OCA\Talk\Share\Helper\DeletedShareAPIController" />
+				<referencedClass name="OCA\GlobalSiteSelector\Service\SlaveService"/>
 			</errorLevel>
 		</UndefinedDocblockClass>
 	</issueHandlers>


### PR DESCRIPTION
retrieve data from lookup-server if available when displaying shares.
includes some caching

also needed:

- lus: https://github.com/nextcloud/lookup-server/pull/100
- gss: https://github.com/nextcloud/globalsiteselector/pull/83

<img width="418" alt="210675677-e2c390ea-9936-40cc-93d3-78e0bb0674d6" src="https://user-images.githubusercontent.com/1038617/216039662-a3fb9e3c-ba43-4d58-973b-584fcf337503.PNG">
<img width="358" alt="210675676-1be333c9-e8ba-4d7b-a13b-017369ffcfcc" src="https://user-images.githubusercontent.com/1038617/216039677-1dcf8880-4b1b-4059-bed3-b317de073c33.png">
<img width="631" alt="210675669-4bdc2059-c86a-488c-96a0-28be48695e2d" src="https://user-images.githubusercontent.com/1038617/216039691-bbf87a53-5cde-4138-8727-4c1f34f38bc0.PNG">
