### PR TITLE
ExifProvider.php: handle unhandled exception

### DIFF
--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -70,7 +70,7 @@ class ExifProvider implements IMetadataProvider {
 		if (!$data) {
 			try {
 				$sizeResult = getimagesizefromstring($file->getContent());
-			} catch (\Exception $ex) {
+			} catch (\Throwable $ex) {
 				$this->logger->warning("Couldn't get image for ".$file->getId(), ['exception' => $ex]);
 				$sizeResult = false;
 			}

--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -68,7 +68,12 @@ class ExifProvider implements IMetadataProvider {
 		$size->setMetadata([]);
 
 		if (!$data) {
-			$sizeResult = getimagesizefromstring($file->getContent());
+			try {
+				$sizeResult = getimagesizefromstring($file->getContent());
+			} catch (\Exception $ex) {
+				$this->logger->warning("Couldn't get image for ".$file->getId(), ['exception' => $ex]);
+				$sizeResult = false;
+			}
 			if ($sizeResult !== false) {
 				$size->setMetadata([
 					'width' => $sizeResult[0],


### PR DESCRIPTION
Signed-off-by: luxifr <luxifer@luxifer.fyi>


* Resolves: #35931 <!-- related github issue -->

## Summary
Handle unhandled exception to keep files:scan run from crashing when it encounters a file with invalid exif data.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [N/A] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
