### PR TITLE
twofactor_totp should be enabled by default

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -83,6 +83,7 @@
     "systemtags",
     "text",
     "theming",
+    "twofactor_totp",
     "updatenotification",
     "user_status",
     "viewer",


### PR DESCRIPTION
Reason: after initial install would the admin otherwise need to first enable the app before being able to use it which is an unnecessary step imho.

Signed-off-by: Simon L <szaimen@e.mail.de>