### PR TITLE
docs: trusted_proxies support IPv6 ranges

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2027,9 +2027,7 @@ $CONFIG = [
  * - IPv4 addresses, e.g. `192.168.2.123`
  * - IPv4 ranges in CIDR notation, e.g. `192.168.2.0/24`
  * - IPv6 addresses, e.g. `fd9e:21a7:a92c:2323::1`
- *
- * _(CIDR notation for IPv6 is currently work in progress and thus not
- * available yet)_
+ * - IPv6 ranges in CIDR notation, e.g. `2001:db8:85a3:8d3:1319:8a20::/95`
  *
  * When an incoming request's `REMOTE_ADDR` matches any of the IP addresses
  * specified here, it is assumed to be a proxy instead of a client. Thus, the
@@ -2288,9 +2286,9 @@ $CONFIG = [
  *
  * For instance, if the phone property should default to the private scope
  * instead of the local one:
- * 
+ *
  * ::
- * 
+ *
  * 	[
  * 	  \OCP\Accounts\IAccountManager::PROPERTY_PHONE => \OCP\Accounts\IAccountManager::SCOPE_PRIVATE
  * 	]


### PR DESCRIPTION
* Resolves: /

## Summary

Support for IPv6 ranges was added by https://github.com/nextcloud/server/pull/32615

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
