### PR TITLE
[stable25] docs: trusted_proxies support IPv6 ranges

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -669,16 +669,16 @@ $CONFIG = [
  * and a maximum time for trash bin retention.
  *
  * Minimum time is the number of days a file will be kept, after which it
- * _may be_ deleted. A file may be deleted after the minimum number of days 
- * is expired if space is needed. The file will not be deleted if space is 
- * not needed. 
+ * _may be_ deleted. A file may be deleted after the minimum number of days
+ * is expired if space is needed. The file will not be deleted if space is
+ * not needed.
  *
  * Whether "space is needed" depends on whether a user quota is defined or not:
  *
- *  * If no user quota is defined, the available space on the Nextcloud data 
+ *  * If no user quota is defined, the available space on the Nextcloud data
  *    partition sets the limit for the trashbin
  *    (issues: see https://github.com/nextcloud/server/issues/28451).
- *  * If a user quota is defined, 50% of the user's remaining quota space sets 
+ *  * If a user quota is defined, 50% of the user's remaining quota space sets
  *    the limit for the trashbin.
  *
  * Maximum time is the number of days at which it is _guaranteed
@@ -2005,9 +2005,7 @@ $CONFIG = [
  * - IPv4 addresses, e.g. `192.168.2.123`
  * - IPv4 ranges in CIDR notation, e.g. `192.168.2.0/24`
  * - IPv6 addresses, e.g. `fd9e:21a7:a92c:2323::1`
- *
- * _(CIDR notation for IPv6 is currently work in progress and thus not
- * available as of yet)_
+ * - IPv6 ranges in CIDR notation, e.g. `2001:db8:85a3:8d3:1319:8a20::/95`
  *
  * When an incoming request's `REMOTE_ADDR` matches any of the IP addresses
  * specified here, it is assumed to be a proxy instead of a client. Thus, the


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/35956


* Resolves: /

## Summary

Support for IPv6 ranges was added by https://github.com/nextcloud/server/pull/32615

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
