### PR TITLE
fix link to documentation of php function

### DIFF
--- a/lib/public/Files/Storage.php
+++ b/lib/public/Files/Storage.php
@@ -293,7 +293,7 @@ interface Storage extends IStorage {
 	public function hash($type, $path, $raw = false);
 
 	/**
-	 * see https://www.php.net/manual/en/function.free_space.php
+	 * see https://www.php.net/manual/en/function.disk-free-space.php
 	 *
 	 * @param string $path
 	 * @return int|bool


### PR DESCRIPTION
Signed-off-by: bbx-github <53237674+bbx-github@users.noreply.github.com>


* Resolves: #35953 <!-- related github issue -->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) ~~has been updated or~~ is not required
- [ ] ~~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~~
