### PR TITLE
Improve exception serializing

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -59,21 +59,11 @@ use function strtr;
  * MonoLog is an example implementing this interface.
  */
 class Log implements ILogger, IDataLogger {
-
-	/** @var IWriter */
-	private $logger;
-
-	/** @var SystemConfig */
-	private $config;
-
-	/** @var boolean|null cache the result of the log condition check for the request */
-	private $logConditionSatisfied = null;
-
-	/** @var Normalizer */
-	private $normalizer;
-
-	/** @var IRegistry */
-	private $crashReporters;
+	private IWriter $logger;
+	private ?SystemConfig $config;
+	private ?bool $logConditionSatisfied = null;
+	private ?Normalizer $normalizer;
+	private ?IRegistry $crashReporters;
 
 	/**
 	 * @param IWriter $logger The logger that should be used
@@ -81,7 +71,7 @@ class Log implements ILogger, IDataLogger {
 	 * @param Normalizer|null $normalizer
 	 * @param IRegistry|null $registry
 	 */
-	public function __construct(IWriter $logger, SystemConfig $config = null, $normalizer = null, IRegistry $registry = null) {
+	public function __construct(IWriter $logger, SystemConfig $config = null, Normalizer $normalizer = null, IRegistry $registry = null) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {
 			$config = \OC::$server->getSystemConfig();

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -312,6 +312,11 @@ class Log implements ILogger, IDataLogger {
 		$app = $context['app'] ?? 'no app in context';
 		$level = $context['level'] ?? ILogger::ERROR;
 
+		$minLevel = $this->getLogLevel($context);
+		if ($level < $minLevel && ($this->crashReporters === null || !$this->crashReporters->hasReporters())) {
+			return;
+		}
+
 		// if an error is raised before the autoloader is properly setup, we can't serialize exceptions
 		try {
 			$serializer = $this->getSerializer();
@@ -325,7 +330,6 @@ class Log implements ILogger, IDataLogger {
 		$data = array_merge($serializer->serializeException($exception), $data);
 		$data = $this->interpolateMessage($data, $context['message'] ?? '--', 'CustomMessage');
 
-		$minLevel = $this->getLogLevel($context);
 
 		array_walk($context, [$this->normalizer, 'format']);
 

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -223,13 +223,13 @@ class ExceptionSerializer {
 	}
 
 	private function encodeTrace($trace) {
-		$filteredTrace = $this->filterTrace($trace);
-		return array_map(function (array $line) {
+		$trace = array_map(function (array $line) {
 			if (isset($line['args'])) {
 				$line['args'] = array_map([$this, 'encodeArg'], $line['args']);
 			}
 			return $line;
-		}, $filteredTrace);
+		}, $trace);
+		return $this->filterTrace($trace);
 	}
 
 	private function encodeArg($arg, $nestingLevel = 5) {

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -147,4 +147,8 @@ class Registry implements IRegistry {
 			}
 		}
 	}
+
+	public function hasReporters(): bool {
+		return !empty($this->lazyReporters) || !empty($this->reporters);
+	}
 }

--- a/lib/public/Support/CrashReport/IRegistry.php
+++ b/lib/public/Support/CrashReport/IRegistry.php
@@ -81,4 +81,13 @@ interface IRegistry {
 	 * @since 17.0.0
 	 */
 	public function delegateMessage(string $message, array $context = []): void;
+
+	/**
+	 * Check if any reporter has been registered to delegate to
+	 *
+	 * @return bool
+	 * @deprecated use internally only
+	 * @since 26.0.0
+	 */
+	public function hasReporters(): bool;
 }


### PR DESCRIPTION
## Summary

Small improvement to not start serializing an exception during logging if the log level would skip it anyways. Noticed when seeing errors due to `Nesting level too deep - recursive dependency? at /var/www/html/lib/private/Log/ExceptionSerializer.php#215` while there was no actual error logged when commenting out the argument cleanup

The second commit avoids such cases by handling the arguments first (which limits to a recursion depth of 5) before iterating over them for filtering for sensitive parameters.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
