### PR TITLE
Hook into sabre event lifecycle for iMip Messages

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarImpl.php
+++ b/apps/dav/lib/CalDAV/CalendarImpl.php
@@ -229,7 +229,7 @@ class CalendarImpl implements ICreateFromString, IHandleImipMessage {
 		$iTipMessage->component = 'VEVENT';
 		$iTipMessage->sequence = isset($vEvent->{'SEQUENCE'}) ? (int)$vEvent->{'SEQUENCE'}->getValue() : 0;
 		$iTipMessage->message = $vObject;
-		$schedulingPlugin->scheduleLocalDelivery($iTipMessage);
+		$server->server->emit('schedule', [$iTipMessage]);
 	}
 
 	public function getInvitationResponseServer(): InvitationResponseServer {

--- a/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
@@ -168,9 +168,6 @@ EOF;
 		$schedulingPlugin = $this->createMock(Plugin::class);
 		$iTipMessage = $this->getITipMessage($message);
 		$iTipMessage->recipient = "mailto:lewis@stardew-tent-living.com";
-		$schedulingPlugin->expects(self::once())
-			->method('scheduleLocalDelivery')
-			->with($iTipMessage);
 
 		$server = $this->createMock(Server::class);
 		$server->expects($this->any())
@@ -180,6 +177,8 @@ EOF;
 				['acl', $aclPlugin],
 				['caldav-schedule', $schedulingPlugin]
 			]);
+		$server->expects(self::once())
+			->method('emit');
 
 		$invitationResponseServer = $this->createPartialMock(InvitationResponseServer::class, ['getServer', 'isExternalAttendee']);
 		$invitationResponseServer->server = $server;
@@ -224,6 +223,8 @@ EOF;
 				['acl', $aclPlugin],
 				['caldav-schedule', $schedulingPlugin]
 			]);
+		$server->expects(self::never())
+			->method('emit');
 
 		$invitationResponseServer = $this->createPartialMock(InvitationResponseServer::class, ['getServer']);
 		$invitationResponseServer->server = $server;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/4819

## Summary
Currently, repsonding to an iMip email doesn't trigger a corresponding email to the ORGANIZER as I didn't hook the iMip processing up to the sabre event lifecycle.

This PR hooks the iMIP processing up with the `schedule` event, which will trigger the local delivery and the iMIP email plugin.

This will work nicely with the impoved iMip emails in https://github.com/nextcloud/server/pull/35743

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
