### PR TITLE
Add a const for the max user password length

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -389,7 +389,7 @@ class UsersController extends AUserData {
 		}
 
 		$generatePasswordResetToken = false;
-		if (strlen($password) > 469) {
+		if (strlen($password) > IUserManager::MAX_PASSWORD_LENGTH) {
 			throw new OCSException('Invalid password value', 101);
 		}
 		if ($password === '') {
@@ -889,7 +889,7 @@ class UsersController extends AUserData {
 				break;
 			case self::USER_FIELD_PASSWORD:
 				try {
-					if (strlen($value) > 469) {
+					if (strlen($value) > IUserManager::MAX_PASSWORD_LENGTH) {
 						throw new OCSException('Invalid password value', 102);
 					}
 					if (!$targetUser->canChangePassword()) {

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -95,7 +95,7 @@ class ChangePasswordController extends Controller {
 		}
 
 		try {
-			if ($newpassword === null || strlen($newpassword) > 469 || $user->setPassword($newpassword) === false) {
+			if ($newpassword === null || strlen($newpassword) > IUserManager::MAX_PASSWORD_LENGTH || $user->setPassword($newpassword) === false) {
 				return new JSONResponse([
 					'status' => 'error',
 					'data' => [
@@ -146,7 +146,7 @@ class ChangePasswordController extends Controller {
 			]);
 		}
 
-		if (strlen($password) > 469) {
+		if (strlen($password) > IUserManager::MAX_PASSWORD_LENGTH) {
 			return new JSONResponse([
 				'status' => 'error',
 				'data' => [

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -240,7 +240,7 @@ class LostController extends Controller {
 			$this->eventDispatcher->dispatchTyped(new BeforePasswordResetEvent($user, $password));
 			\OC_Hook::emit('\OC\Core\LostPassword\Controller\LostController', 'pre_passwordReset', ['uid' => $userId, 'password' => $password]);
 
-			if (strlen($password) > 469) {
+			if (strlen($password) > IUserManager::MAX_PASSWORD_LENGTH) {
 				throw new HintException('Password too long', $this->l10n->t('Password is too long. Maximum allowed length is 469 characters.'));
 			}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use Psr\Log\LoggerInterface;
 
@@ -397,7 +398,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$dbToken->setPrivateKey($this->encrypt($privateKey, $token));
 
 		if (!is_null($password) && $this->config->getSystemValueBool('auth.storeCryptedPassword', true)) {
-			if (strlen($password) > 469) {
+			if (strlen($password) > IUserManager::MAX_PASSWORD_LENGTH) {
 				throw new \RuntimeException('Trying to save a password with more than 469 characters is not supported. If you want to use big passwords, disable the auth.storeCryptedPassword option in config.php');
 			}
 			$dbToken->setPassword($this->encryptPassword($password, $publicKey));

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -46,6 +46,12 @@ namespace OCP;
  * @since 8.0.0
  */
 interface IUserManager {
+
+	/**
+	 * @since 26.0.0
+	 */
+	public const MAX_PASSWORD_LENGTH = 469;
+
 	/**
 	 * register a user backend
 	 *


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/35965#discussion_r1060717533

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
