### PR TITLE
Fix edit locally action to not appear for folders

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -220,6 +220,9 @@
 			if (this.actions.all) {
 				actions = $.extend(actions, this.actions.all);
 			}
+			if (mime !== 'httpd/unix-directory' && this.actions.files) {
+				actions = $.extend(actions, this.actions.files);
+			}
 			if (type) {//type is 'dir' or 'file'
 				if (this.actions[type]) {
 					actions = $.extend(actions, this.actions[type]);
@@ -311,6 +314,8 @@
 				name = this.defaults[mimePart];
 			} else if (type && this.defaults[type]) {
 				name = this.defaults[type];
+			} else if (mime !== 'httpd/unix-directory' && this.defaults.files) {
+				name = this.defaults.files;
 			} else {
 				name = this.defaults.all;
 			}
@@ -719,7 +724,7 @@
 							return t('files', 'Edit locally');
 						}
 					},
-					mime: 'all',
+					mime: 'files',
 					order: -23,
 					icon: function(filename, context) {
 						var locked = context.$file.data('locked');

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -140,6 +140,33 @@ describe('OCA.Files.FileActions tests', function() {
 			expect($tr.find('.action.action-match').length).toEqual(1);
 			expect($tr.find('.action.action-nomatch').length).toEqual(0);
 		});
+		it('only renders file specific actions for files', function() {
+			var folderData = {
+				id: 19,
+				type: 'folder',
+				name: 'testfolder',
+				mimetype: 'httpd/unix-directory',
+				size: '1234',
+				etag: 'a01234c',
+				mtime: '123456',
+				permissions: OC.PERMISSION_READ | OC.PERMISSION_UPDATE
+			};
+
+			var $folder = fileList.add(folderData);
+
+			fileActions.registerAction({
+				name: 'filesonly',
+				displayName: 'MatchDisplay',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				mime: 'files',
+				permissions: OC.PERMISSION_READ
+			});
+
+			fileActions.display($tr.find('td.filename'), true, fileList);
+			fileActions.display($folder.find('td.filename'), true, fileList);
+			expect($tr.find('.action.action-filesonly').length).toEqual(1);
+			expect($folder.find('.action.action-filesonly').length).toEqual(0);
+		});
 		it('only renders actions relevant to the permissions', function() {
 			fileActions.registerAction({
 				name: 'Match',


### PR DESCRIPTION
Extends FileActions to also allow the meta "files" mime type.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
