### PR TITLE
fix(files): Make sure that static routes on /apps/files still work

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -58,18 +58,6 @@ $application->registerRoutes(
 				'verb' => 'GET',
 			],
 			[
-				'name' => 'view#index',
-				'url' => '/{view}',
-				'verb' => 'GET',
-				'postfix' => 'view',
-			],
-			[
-				'name' => 'view#index',
-				'url' => '/{view}/{fileid}',
-				'verb' => 'GET',
-				'postfix' => 'fileid',
-			],
-			[
 				'name' => 'View#showFile',
 				'url' => '/f/{fileid}',
 				'verb' => 'GET',
@@ -146,6 +134,18 @@ $application->registerRoutes(
 				'name' => 'DirectEditingView#edit',
 				'url' => '/directEditing/{token}',
 				'verb' => 'GET'
+			],
+			[
+				'name' => 'view#index',
+				'url' => '/{view}',
+				'verb' => 'GET',
+				'postfix' => 'view',
+			],
+			[
+				'name' => 'view#index',
+				'url' => '/{view}/{fileid}',
+				'verb' => 'GET',
+				'postfix' => 'fileid',
 			],
 		],
 		'ocs' => [


### PR DESCRIPTION
## Summary

With the merge of https://github.com/nextcloud/server/pull/35772 already existing routes under /app/files like `/apps/files/directEditing` stopped working as seen in the text app cypress tests. The reason is that the placeholder route matching takes precendence. THerefore I moved the placeholder route for the new views to the end which fixes the issue and makes the existing routes work again.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
