### PR TITLE
fix(CI): Check for the image-optimization binaries we want to use

### DIFF
--- a/build/image-optimization.sh
+++ b/build/image-optimization.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+set -e
+
+OPTIPNG=$(which optipng)
+if ! [ -x "$OPTIPNG" ]; then
+	echo "optipng executable not found, please install" >&2
+	exit 1
+fi
+JPEGOPTIM=$(which jpegoptim)
+if ! [ -x "$JPEGOPTIM" ]; then
+	echo "jpegoptim executable not found, please install" >&2
+	exit 2
+fi
+SCOUR=$(which scour)
+if ! [ -x "$SCOUR" ]; then
+	echo "scour executable not found, please install" >&2
+	exit 3
+fi
+
+set +e
+
 CHECK_DIR='../'
 if [[ -d "$1" ]]; then
 	CHECK_DIR=$1
@@ -20,7 +40,7 @@ function recursive_optimize_images() {
 	do
 		[[ -e "$png" ]] || break
 
-		optipng -o6 -strip all "$png"
+		$OPTIPNG -o6 -strip all "$png"
 	done
 
 	# Optimize all JPGs
@@ -28,7 +48,7 @@ function recursive_optimize_images() {
 	do
 		[[ -e "$jpg" ]] || break
 
-		jpegoptim --strip-all "$jpg"
+		$JPEGOPTIM --strip-all "$jpg"
 	done
 
 	# Optimize all SVGs
@@ -37,7 +57,7 @@ function recursive_optimize_images() {
 		[[ -e "$svg" ]] || break
 
 		mv $svg $svg.opttmp
-		scour --create-groups \
+		$SCOUR --create-groups \
 			--enable-id-stripping \
 			--enable-comment-stripping \
 			--shorten-ids \


### PR DESCRIPTION
### Before

Run
```
cd build
bash image-optimization.sh
```
And notice all SVG icons have been deleted....

### After

❌  Note about scour missing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
