### PR TITLE
Add restrictions when downloading to resolve with opengraph link provider

### DIFF
--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -105,6 +105,22 @@ class LinkReferenceProvider implements IReferenceProvider {
 
 		$client = $this->clientService->newClient();
 		try {
+			$headResponse = $client->head($reference->getId(), [ 'timeout' => 10 ]);
+		} catch (\Exception $e) {
+			$this->logger->debug('Failed to perform HEAD request to get target metadata', ['exception' => $e]);
+			return;
+		}
+		$linkContentLength = $headResponse->getHeader('Content-Length');
+		if (is_numeric($linkContentLength) && (int) $linkContentLength > 5 * 1024 * 1024) {
+			$this->logger->debug('Skip resolving links pointing to content length > 5 MB');
+			return;
+		}
+		$linkContentType = $headResponse->getHeader('Content-Type');
+		if ($linkContentType !== 'text/html') {
+			$this->logger->debug('Skip resolving links pointing to content type that is not "text/html"');
+			return;
+		}
+		try {
 			$response = $client->get($reference->getId(), [ 'timeout' => 10 ]);
 		} catch (\Exception $e) {
 			$this->logger->debug('Failed to fetch link for obtaining open graph data', ['exception' => $e]);


### PR DESCRIPTION
This makes a HEAD request before the GET one and skips links if either:
* content-type is not `text/html`
* or content-length is more than 5 MB

Another approach would be to use the [stream Guzzle option](https://docs.guzzlephp.org/en/stable/request-options.html#stream) when performing the GET request to avoid the extra HEAD request and either: 

1. stop reading the body after a size limit
I don't know if it makes sense since we probably can't properly parse a partial html content.

2. directly check the size and type from the headers and skip bad links even before reading the body.
I don't know if the headers are retrieved before downloading/streaming the body.

What do you think?