### PR TITLE
Fix scrolling while dragging in file list view

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -449,7 +449,6 @@ var dragOptions={
 	revert: 'invalid',
 	revertDuration: 300,
 	opacity: 0.7,
-	appendTo: 'body',
 	cursorAt: { left: 24, top: 18 },
 	helper: createDragShadow,
 	cursor: 'move',
@@ -482,23 +481,26 @@ var dragOptions={
 		$('.crumbmenu').removeClass('canDropChildren');
 	},
 	drag: function(event, ui) {
-		var scrollingArea = FileList.$container;
-		var currentScrollTop = $(scrollingArea).scrollTop();
-		var scrollArea = Math.min(Math.floor($(window).innerHeight() / 2), 100);
+		/** @type {JQuery<HTMLDivElement>} */
+		const scrollingArea = FileList.$container;
 
-		var bottom = $(window).innerHeight() - scrollArea;
-		var top = $(window).scrollTop() + scrollArea;
-		if (event.pageY < top) {
-			$(scrollingArea).animate({
-				scrollTop: currentScrollTop - 10
-			}, 400);
+		// Get the top and bottom scroll trigger y positions
+		const containerHeight = scrollingArea.innerHeight() ?? 0
+		const scrollTriggerArea = Math.min(Math.floor(containerHeight / 2), 100);
+		const bottomTriggerY = containerHeight - scrollTriggerArea;
+		const topTriggerY = scrollTriggerArea;
 
-		} else if (event.pageY > bottom) {
-			$(scrollingArea).animate({
-				scrollTop: currentScrollTop + 10
-			}, 400);
+		// Get the cursor position relative to the container
+		const containerOffset = scrollingArea.offset() ?? {left: 0, top: 0}
+		const cursorPositionY = event.pageY - containerOffset.top
+
+		const currentScrollTop = scrollingArea.scrollTop() ?? 0
+
+		if (cursorPositionY < topTriggerY) {
+			scrollingArea.scrollTop(currentScrollTop - 10)
+		} else if (cursorPositionY > bottomTriggerY) {
+			scrollingArea.scrollTop(currentScrollTop + 10)
 		}
-
 	}
 };
 // sane browsers support using the distance option


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/33816

## Summary

During the migration from `window` as the scrolling container to `#app-content` we forgot to update the remaining of the drag handle function.

This PR fix the scrolling.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
