### PR TITLE
Get rid of deprecated at matcher in dav application tests

### DIFF
--- a/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
@@ -87,15 +87,15 @@ class CleanupInvitationTokenJobTest extends TestCase {
 			->with()
 			->willReturn($queryBuilder);
 
-		$queryBuilder->expects($this->at(0))
+		$queryBuilder->expects($this->once())
 			->method('delete')
 			->with('calendar_invitations')
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(3))
+		$queryBuilder->expects($this->once())
 			->method('where')
 			->with($function)
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(4))
+		$queryBuilder->expects($this->once())
 			->method('execute')
 			->with()
 			->willReturn($stmt);

--- a/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
@@ -36,7 +36,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class EventReminderJobTest extends TestCase {
-
 	/** @var ITimeFactory|MockObject */
 	private $time;
 
@@ -80,17 +79,16 @@ class EventReminderJobTest extends TestCase {
 	 * @param bool $expectCall
 	 */
 	public function testRun(bool $sendEventReminders, bool $sendEventRemindersMode, bool $expectCall): void {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly($sendEventReminders ? 2 : 1))
 			->method('getAppValue')
-			->with('dav', 'sendEventReminders', 'yes')
-			->willReturn($sendEventReminders ? 'yes' : 'no');
-
-		if ($sendEventReminders) {
-			$this->config->expects($this->at(1))
-				->method('getAppValue')
-				->with('dav', 'sendEventRemindersMode', 'backgroundjob')
-				->willReturn($sendEventRemindersMode ? 'backgroundjob' : 'cron');
-		}
+			->withConsecutive(
+				['dav', 'sendEventReminders', 'yes'],
+				['dav', 'sendEventRemindersMode', 'backgroundjob'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$sendEventReminders ? 'yes' : 'no',
+				$sendEventRemindersMode ? 'backgroundjob' : 'cron'
+			);
 
 		if ($expectCall) {
 			$this->reminderService->expects($this->once())

--- a/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
@@ -32,13 +32,11 @@ use OCA\DAV\BackgroundJob\GenerateBirthdayCalendarBackgroundJob;
 use OCA\DAV\BackgroundJob\RegisterRegenerateBirthdayCalendars;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
-use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use Test\TestCase;
 
 class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
-
 	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $time;
 
@@ -81,24 +79,22 @@ class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
 				$closure($user3);
 			});
 
-		$this->jobList->expects($this->at(0))
+		$this->jobList->expects($this->exactly(3))
 			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, [
-				'userId' => 'uid1',
-				'purgeBeforeGenerating' => true
-			]);
-		$this->jobList->expects($this->at(1))
-			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, [
-				'userId' => 'uid2',
-				'purgeBeforeGenerating' => true
-			]);
-		$this->jobList->expects($this->at(2))
-			->method('add')
-			->with(GenerateBirthdayCalendarBackgroundJob::class, [
-				'userId' => 'uid3',
-				'purgeBeforeGenerating' => true
-			]);
+			->withConsecutive(
+				[GenerateBirthdayCalendarBackgroundJob::class, [
+					'userId' => 'uid1',
+					'purgeBeforeGenerating' => true
+				]],
+				[GenerateBirthdayCalendarBackgroundJob::class, [
+					'userId' => 'uid2',
+					'purgeBeforeGenerating' => true
+				]],
+				[GenerateBirthdayCalendarBackgroundJob::class, [
+					'userId' => 'uid3',
+					'purgeBeforeGenerating' => true
+				]],
+			);
 
 		$this->backgroundJob->run([]);
 	}

--- a/apps/dav/tests/unit/CalDAV/CachedSubscriptionTest.php
+++ b/apps/dav/tests/unit/CalDAV/CachedSubscriptionTest.php
@@ -141,7 +141,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$calendar->propPatch($propPatch);
 	}
 
-	
+
 	public function testGetChild() {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 		$this->expectExceptionMessage('Calendar object not found');
@@ -154,17 +154,19 @@ class CachedSubscriptionTest extends \Test\TestCase {
 			'uri' => 'cal',
 		];
 
-		$backend->expects($this->at(0))
+		$backend->expects($this->exactly(2))
 			->method('getCalendarObject')
-			->with(666, 'foo1', 1)
-			->willReturn([
-				'id' => 99,
-				'uri' => 'foo1'
-			]);
-		$backend->expects($this->at(1))
-			->method('getCalendarObject')
-			->with(666, 'foo2', 1)
-			->willReturn(null);
+			->withConsecutive(
+				[666, 'foo1', 1],
+				[666, 'foo2', 1],
+			)
+			->willReturnOnConsecutiveCalls(
+				[
+					'id' => 99,
+					'uri' => 'foo1'
+				],
+				null
+			);
 
 		$calendar = new CachedSubscription($backend, $calendarInfo);
 
@@ -183,7 +185,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 			'uri' => 'cal',
 		];
 
-		$backend->expects($this->at(0))
+		$backend->expects($this->once())
 			->method('getCalendarObjects')
 			->with(666, 1)
 			->willReturn([
@@ -214,7 +216,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 			'uri' => 'cal',
 		];
 
-		$backend->expects($this->at(0))
+		$backend->expects($this->once())
 			->method('getMultipleCalendarObjects')
 			->with(666, ['foo1', 'foo2'], 1)
 			->willReturn([
@@ -236,7 +238,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$this->assertInstanceOf(CachedSubscriptionObject::class, $res[1]);
 	}
 
-	
+
 	public function testCreateFile() {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('Creating objects in cached subscription is not allowed');
@@ -262,17 +264,19 @@ class CachedSubscriptionTest extends \Test\TestCase {
 			'uri' => 'cal',
 		];
 
-		$backend->expects($this->at(0))
+		$backend->expects($this->exactly(2))
 			->method('getCalendarObject')
-			->with(666, 'foo1', 1)
-			->willReturn([
-				'id' => 99,
-				'uri' => 'foo1'
-			]);
-		$backend->expects($this->at(1))
-			->method('getCalendarObject')
-			->with(666, 'foo2', 1)
-			->willReturn(null);
+			->withConsecutive(
+				[666, 'foo1', 1],
+				[666, 'foo2', 1],
+			)
+			->willReturnOnConsecutiveCalls(
+				[
+					'id' => 99,
+					'uri' => 'foo1'
+				],
+				null
+			);
 
 		$calendar = new CachedSubscription($backend, $calendarInfo);
 

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
@@ -32,11 +32,8 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV\Reminder\NotificationProvider;
 
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\EmailProvider;
-use OCP\IConfig;
 use OCP\IL10N;
-use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\L10N\IFactory as L10NFactory;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
@@ -112,61 +109,46 @@ class EmailProviderTest extends AbstractNotificationProviderTest {
 		$message21 = $this->getMessageMock('uid2@example.com', $template2);
 		$message22 = $this->getMessageMock('uid3@example.com', $template2);
 
-		$this->mailer->expects($this->at(0))
+		$this->mailer->expects($this->exactly(2))
 			->method('createEMailTemplate')
 			->with('dav.calendarReminder')
-			->willReturn($template1);
+			->willReturnOnConsecutiveCalls(
+				$template1,
+				$template2
+			);
 
-		$this->mailer->expects($this->at(1))
+		$this->mailer->expects($this->exactly(4))
 			->method('validateMailAddress')
-			->with('uid1@example.com')
-			->willReturn(true);
+			->withConsecutive(
+				['uid1@example.com'],
+				['uid2@example.com'],
+				['uid3@example.com'],
+				['invalid'],
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				true,
+				true,
+				false,
+			);
 
-		$this->mailer->expects($this->at(2))
+		$this->mailer->expects($this->exactly(3))
 			->method('createMessage')
 			->with()
-			->willReturn($message11);
-		$this->mailer->expects($this->at(3))
+			->willReturnOnConsecutiveCalls(
+				$message11,
+				$message21,
+				$message22
+			);
+
+		$this->mailer->expects($this->exactly(3))
 			->method('send')
-			->with($message11)
+			->withConsecutive(
+				[$message11],
+				[$message21],
+				[$message22],
+			)
 			->willReturn([]);
-
-		$this->mailer->expects($this->at(4))
-			->method('createEMailTemplate')
-			->with('dav.calendarReminder')
-			->willReturn($template2);
-
-		$this->mailer->expects($this->at(5))
-			->method('validateMailAddress')
-			->with('uid2@example.com')
-			->willReturn(true);
-
-		$this->mailer->expects($this->at(6))
-			->method('createMessage')
-			->with()
-			->willReturn($message21);
-		$this->mailer->expects($this->at(7))
-			->method('send')
-			->with($message21)
-			->willReturn([]);
-		$this->mailer->expects($this->at(8))
-			->method('validateMailAddress')
-			->with('uid3@example.com')
-			->willReturn(true);
-
-		$this->mailer->expects($this->at(9))
-			->method('createMessage')
-			->with()
-			->willReturn($message22);
-		$this->mailer->expects($this->at(10))
-			->method('send')
-			->with($message22)
-			->willReturn([]);
-
-		$this->mailer->expects($this->at(11))
-			->method('validateMailAddress')
-			->with('invalid')
-			->willReturn(false);
 
 		$this->setupURLGeneratorMock(2);
 
@@ -351,42 +333,27 @@ class EmailProviderTest extends AbstractNotificationProviderTest {
 	private function getTemplateMock():IEMailTemplate {
 		$template = $this->createMock(IEMailTemplate::class);
 
-		$template->expects($this->at(0))
+		$template->expects($this->once())
 			->method('addHeader')
 			->with()
 			->willReturn($template);
 
-		$template->expects($this->at(1))
+		$template->expects($this->once())
 			->method('setSubject')
 			->with()
 			->willReturn($template);
 
-		$template->expects($this->at(2))
+		$template->expects($this->once())
 			->method('addHeading')
 			->with()
 			->willReturn($template);
 
-		$template->expects($this->at(3))
+		$template->expects($this->exactly(4))
 			->method('addBodyListItem')
 			->with()
 			->willReturn($template);
 
-		$template->expects($this->at(4))
-			->method('addBodyListItem')
-			->with()
-			->willReturn($template);
-
-		$template->expects($this->at(5))
-			->method('addBodyListItem')
-			->with()
-			->willReturn($template);
-
-		$template->expects($this->at(6))
-			->method('addBodyListItem')
-			->with()
-			->willReturn($template);
-
-		$template->expects($this->at(7))
+		$template->expects($this->once())
 			->method('addFooter')
 			->with()
 			->willReturn($template);
@@ -404,24 +371,27 @@ class EmailProviderTest extends AbstractNotificationProviderTest {
 		$message = $this->createMock(IMessage::class);
 		$i = 0;
 
-		$message->expects($this->at($i++))
+		$message->expects($this->once())
 			->method('setFrom')
 			->with([\OCP\Util::getDefaultEmailAddress('reminders-noreply')])
 			->willReturn($message);
 
 		if ($replyTo) {
-			$message->expects($this->at($i++))
+			$message->expects($this->once())
 				->method('setReplyTo')
 				->with($replyTo)
 				->willReturn($message);
+		} else {
+			$message->expects($this->never())
+				->method('setReplyTo');
 		}
 
-		$message->expects($this->at($i++))
+		$message->expects($this->once())
 			->method('setTo')
 			->with([$toMail])
 			->willReturn($message);
 
-		$message->expects($this->at($i++))
+		$message->expects($this->once())
 			->method('useTemplate')
 			->with($templateMock)
 			->willReturn($message);
@@ -500,56 +470,25 @@ class EmailProviderTest extends AbstractNotificationProviderTest {
 		return $vcalendar;
 	}
 
-	private function setupURLGeneratorMock(int $times = 1):void {
-		for ($i = 0; $i < $times; $i++) {
-			$this->urlGenerator
-				->expects($this->at(8 * $i))
-				->method('imagePath')
-				->with('core', 'actions/info.png')
-				->willReturn('imagePath1');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 1))
-				->method('getAbsoluteURL')
-				->with('imagePath1')
-				->willReturn('AbsURL1');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 2))
-				->method('imagePath')
-				->with('core', 'places/calendar.png')
-				->willReturn('imagePath2');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 3))
-				->method('getAbsoluteURL')
-				->with('imagePath2')
-				->willReturn('AbsURL2');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 4))
-				->method('imagePath')
-				->with('core', 'actions/address.png')
-				->willReturn('imagePath3');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 5))
-				->method('getAbsoluteURL')
-				->with('imagePath3')
-				->willReturn('AbsURL3');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 6))
-				->method('imagePath')
-				->with('core', 'actions/more.png')
-				->willReturn('imagePath4');
-
-			$this->urlGenerator
-				->expects($this->at(8 * $i + 7))
-				->method('getAbsoluteURL')
-				->with('imagePath4')
-				->willReturn('AbsURL4');
-		}
+	private function setupURLGeneratorMock(int $times = 1): void {
+		$this->urlGenerator
+			->expects($this->exactly($times * 4))
+			->method('imagePath')
+			->willReturnMap([
+				['core', 'actions/info.png', 'imagePath1'],
+				['core', 'places/calendar.png', 'imagePath2'],
+				['core', 'actions/address.png', 'imagePath3'],
+				['core', 'actions/more.png', 'imagePath4'],
+			]);
+		$this->urlGenerator
+			->expects($this->exactly($times * 4))
+			->method('getAbsoluteURL')
+			->willReturnMap([
+				['imagePath1', 'AbsURL1'],
+				['imagePath2', 'AbsURL2'],
+				['imagePath3', 'AbsURL3'],
+				['imagePath4', 'AbsURL4'],
+			]);
 	}
 
 	private function getUsers(): array {

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -32,16 +32,11 @@ namespace OCA\DAV\Tests\unit\CalDAV\Reminder\NotificationProvider;
 
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\PushProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\IConfig;
-use OCP\IL10N;
-use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\L10N\IFactory as L10NFactory;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 
 class PushProviderTest extends AbstractNotificationProviderTest {
-
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $manager;
 
@@ -121,28 +116,22 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 		$notification2 = $this->createNotificationMock('uid2', $dateTime);
 		$notification3 = $this->createNotificationMock('uid3', $dateTime);
 
-		$this->manager->expects($this->at(0))
+		$this->manager->expects($this->exactly(3))
 			->method('createNotification')
 			->with()
-			->willReturn($notification1);
-		$this->manager->expects($this->at(2))
-			->method('createNotification')
-			->with()
-			->willReturn($notification2);
-		$this->manager->expects($this->at(4))
-			->method('createNotification')
-			->with()
-			->willReturn($notification3);
+			->willReturnOnConsecutiveCalls(
+				$notification1,
+				$notification2,
+				$notification3
+			);
 
-		$this->manager->expects($this->at(1))
+		$this->manager->expects($this->exactly(3))
 			->method('notify')
-			->with($notification1);
-		$this->manager->expects($this->at(3))
-			->method('notify')
-			->with($notification2);
-		$this->manager->expects($this->at(5))
-			->method('notify')
-			->with($notification3);
+			->withConsecutive(
+				[$notification1],
+				[$notification2],
+				[$notification3],
+			);
 
 		$this->provider->send($this->vcalendar->VEVENT, $this->calendarDisplayName, [], $users);
 	}

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -353,7 +353,7 @@ EOD;
 	}
 
 	public function testProcessReminders():void {
-		$this->backend->expects($this->at(0))
+		$this->backend->expects($this->once())
 			->method('getRemindersToProcess')
 			->with()
 			->willReturn([
@@ -449,60 +449,34 @@ EOD;
 				]
 			]);
 
-		$this->notificationProviderManager->expects($this->at(0))
+		$this->notificationProviderManager->expects($this->exactly(5))
 			->method('hasProvider')
-			->with('EMAIL')
-			->willReturn(true);
+			->willReturnMap([
+				['EMAIL', true],
+				['DISPLAY', true],
+			]);
 
 		$provider1 = $this->createMock(INotificationProvider::class);
-		$this->notificationProviderManager->expects($this->at(1))
-			->method('getProvider')
-			->with('EMAIL')
-			->willReturn($provider1);
-
-		$this->notificationProviderManager->expects($this->at(2))
-			->method('hasProvider')
-			->with('EMAIL')
-			->willReturn(true);
-
 		$provider2 = $this->createMock(INotificationProvider::class);
-		$this->notificationProviderManager->expects($this->at(3))
-			->method('getProvider')
-			->with('EMAIL')
-			->willReturn($provider2);
-
-		$this->notificationProviderManager->expects($this->at(4))
-			->method('hasProvider')
-			->with('DISPLAY')
-			->willReturn(true);
-
 		$provider3 = $this->createMock(INotificationProvider::class);
-		$this->notificationProviderManager->expects($this->at(5))
-			->method('getProvider')
-			->with('DISPLAY')
-			->willReturn($provider3);
-
-		$this->notificationProviderManager->expects($this->at(6))
-			->method('hasProvider')
-			->with('EMAIL')
-			->willReturn(true);
-
 		$provider4 = $this->createMock(INotificationProvider::class);
-		$this->notificationProviderManager->expects($this->at(7))
-			->method('getProvider')
-			->with('EMAIL')
-			->willReturn($provider4);
-
-		$this->notificationProviderManager->expects($this->at(8))
-			->method('hasProvider')
-			->with('EMAIL')
-			->willReturn(true);
-
 		$provider5 = $this->createMock(INotificationProvider::class);
-		$this->notificationProviderManager->expects($this->at(9))
+		$this->notificationProviderManager->expects($this->exactly(5))
 			->method('getProvider')
-			->with('EMAIL')
-			->willReturn($provider5);
+			->withConsecutive(
+				['EMAIL'],
+				['EMAIL'],
+				['DISPLAY'],
+				['EMAIL'],
+				['EMAIL'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$provider1,
+				$provider2,
+				$provider3,
+				$provider4,
+				$provider5,
+			);
 
 		$user = $this->createMock(IUser::class);
 		$this->userManager->expects($this->exactly(5))
@@ -551,45 +525,19 @@ EOD;
 				return true;
 			}, 'Displayname 123', $user));
 
-		$this->backend->expects($this->at(1))
+		$this->backend->expects($this->exactly(5))
 			->method('removeReminder')
-			->with(1);
-		$this->backend->expects($this->at(2))
-			->method('removeReminder')
-			->with(2);
-		$this->backend->expects($this->at(3))
-			->method('removeReminder')
-			->with(3);
-		$this->backend->expects($this->at(4))
-			->method('removeReminder')
-			->with(4);
-		$this->backend->expects($this->at(5))
+			->withConsecutive([1], [2], [3], [4], [5]);
+		$this->backend->expects($this->exactly(6))
 			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848700, false)
-			->willReturn(99);
-
-		$this->backend->expects($this->at(6))
-			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848820, true)
-			->willReturn(99);
-		$this->backend->expects($this->at(7))
-			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848940, true)
-			->willReturn(99);
-		$this->backend->expects($this->at(8))
-			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467849060, true)
-			->willReturn(99);
-		$this->backend->expects($this->at(9))
-			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467849180, true)
-			->willReturn(99);
-		$this->backend->expects($this->at(10))
-			->method('removeReminder')
-			->with(5);
-		$this->backend->expects($this->at(11))
-			->method('insertReminder')
-			->with(1337, 42, 'wej2z68l9h', true, 1468454400, false, 'fbdb2726bc0f7dfacac1d881c1453e20', '8996992118817f9f311ac5cc56d1cc97', 'EMAIL', true, 1467763200, false)
+			->withConsecutive(
+				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848700, false],
+				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848820, true],
+				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467848940, true],
+				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467849060, true],
+				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', 'ecacbf07d413c3c78d1ac7ad8c469602', 'EMAIL', true, 1467849180, true],
+				[1337, 42, 'wej2z68l9h', true, 1468454400, false, 'fbdb2726bc0f7dfacac1d881c1453e20', '8996992118817f9f311ac5cc56d1cc97', 'EMAIL', true, 1467763200, false],
+			)
 			->willReturn(99);
 
 		$this->timeFactory->method('getDateTime')

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
@@ -35,7 +35,6 @@ use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 abstract class AbstractPrincipalBackendTest extends TestCase {
-
 	/** @var \OCA\DAV\CalDAV\ResourceBooking\ResourcePrincipalBackend|\OCA\DAV\CalDAV\ResourceBooking\RoomPrincipalBackend */
 	protected $principalBackend;
 
@@ -228,43 +227,43 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 	}
 
 	public function testSetGroupMemberSet() {
-		$this->proxyMapper->expects($this->at(0))
+		$this->proxyMapper->expects($this->once())
 			->method('getProxiesOf')
 			->with($this->principalPrefix . '/backend1-res1')
 			->willReturn([]);
 
-		$this->proxyMapper->expects($this->at(1))
+		$this->proxyMapper->expects($this->exactly(2))
 			->method('insert')
-			->with($this->callback(function ($proxy) {
-				/** @var Proxy $proxy */
-				if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
-					return false;
-				}
-				if ($proxy->getProxyId() !== $this->principalPrefix . '/backend1-res2') {
-					return false;
-				}
-				if ($proxy->getPermissions() !== 3) {
-					return false;
-				}
+			->withConsecutive(
+				[$this->callback(function ($proxy) {
+					/** @var Proxy $proxy */
+					if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
+						return false;
+					}
+					if ($proxy->getProxyId() !== $this->principalPrefix . '/backend1-res2') {
+						return false;
+					}
+					if ($proxy->getPermissions() !== 3) {
+						return false;
+					}
 
-				return true;
-			}));
-		$this->proxyMapper->expects($this->at(2))
-			->method('insert')
-			->with($this->callback(function ($proxy) {
-				/** @var Proxy $proxy */
-				if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
-					return false;
-				}
-				if ($proxy->getProxyId() !== $this->principalPrefix . '/backend2-res3') {
-					return false;
-				}
-				if ($proxy->getPermissions() !== 3) {
-					return false;
-				}
+					return true;
+				})],
+				[$this->callback(function ($proxy) {
+					/** @var Proxy $proxy */
+					if ($proxy->getOwnerId() !== $this->principalPrefix . '/backend1-res1') {
+						return false;
+					}
+					if ($proxy->getProxyId() !== $this->principalPrefix . '/backend2-res3') {
+						return false;
+					}
+					if ($proxy->getPermissions() !== 3) {
+						return false;
+					}
 
-				return true;
-			}));
+					return true;
+				})],
+			);
 
 		$this->principalBackend->setGroupMemberSet($this->principalPrefix . '/backend1-res1/calendar-proxy-write', [$this->principalPrefix . '/backend1-res2', $this->principalPrefix . '/backend2-res3']);
 	}

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -37,7 +37,6 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Mail\IAttachment;
@@ -52,8 +51,7 @@ use Sabre\VObject\ITip\Message;
 use Test\TestCase;
 
 class IMipPluginTest extends TestCase {
-
-		/** @var IMessage|MockObject */
+	/** @var IMessage|MockObject */
 	private $mailMessage;
 
 	/** @var IMailer|MockObject */
@@ -135,10 +133,11 @@ class IMipPluginTest extends TestCase {
 
 	public function testDelivery() {
 		$this->config
-	  ->expects($this->at(1))
+			->expects($this->any())
 			->method('getAppValue')
-			->with('dav', 'invitation_link_recipients', 'yes')
-			->willReturn('yes');
+			->willReturnMap([
+				['dav', 'invitation_link_recipients', 'yes', 'yes'],
+			]);
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
@@ -149,10 +148,11 @@ class IMipPluginTest extends TestCase {
 
 	public function testFailedDelivery() {
 		$this->config
-	  ->expects($this->at(1))
+			->expects($this->any())
 			->method('getAppValue')
-			->with('dav', 'invitation_link_recipients', 'yes')
-			->willReturn('yes');
+			->willReturnMap([
+				['dav', 'invitation_link_recipients', 'yes', 'yes'],
+			]);
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
@@ -174,10 +174,11 @@ class IMipPluginTest extends TestCase {
 
 	public function testDeliveryWithNoCommonName() {
 		$this->config
-	  ->expects($this->at(1))
+			->expects($this->any())
 			->method('getAppValue')
-			->with('dav', 'invitation_link_recipients', 'yes')
-			->willReturn('yes');
+			->willReturnMap([
+				['dav', 'invitation_link_recipients', 'yes', 'yes'],
+			]);
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage();
@@ -198,8 +199,8 @@ class IMipPluginTest extends TestCase {
 	 */
 	public function testNoMessageSendForPastEvents(array $veventParams, bool $expectsMail) {
 		$this->config
-	  ->method('getAppValue')
-	  ->willReturn('yes');
+			->method('getAppValue')
+			->willReturn('yes');
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage($veventParams);
@@ -234,15 +235,16 @@ class IMipPluginTest extends TestCase {
 	 * @dataProvider dataIncludeResponseButtons
 	 */
 	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons) {
-		$message = $this->_testMessage([],$recipient);
+		$message = $this->_testMessage([], $recipient);
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$this->_expectSend($recipient, true, $has_buttons);
 		$this->config
-	  ->expects($this->at(1))
+			->expects($this->any())
 			->method('getAppValue')
-			->with('dav', 'invitation_link_recipients', 'yes')
-			->willReturn($config_setting);
+			->willReturnMap([
+				['dav', 'invitation_link_recipients', 'yes', $config_setting],
+			]);
 
 		$this->plugin->schedule($message);
 		$this->assertEquals('1.1', $message->getScheduleStatus());
@@ -268,7 +270,7 @@ class IMipPluginTest extends TestCase {
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
 		$message = $this->_testMessage(['SUMMARY' => '']);
-		$this->_expectSend('frodo@hobb.it', true, true,'Invitation: Untitled event');
+		$this->_expectSend('frodo@hobb.it', true, true, 'Invitation: Untitled event');
 		$this->emailTemplate->expects($this->once())
 			->method('addHeading')
 			->with('Invitation');
@@ -296,7 +298,6 @@ class IMipPluginTest extends TestCase {
 
 
 	private function _expectSend(string $recipient = 'frodo@hobb.it', bool $expectSend = true, bool $expectButtons = true, string $subject = 'Invitation: Fellowship meeting') {
-
 		// if the event is in the past, we skip out
 		if (!$expectSend) {
 			$this->mailer
@@ -322,14 +323,14 @@ class IMipPluginTest extends TestCase {
 			->method('send');
 
 		if ($expectButtons) {
-			$this->queryBuilder->expects($this->at(0))
+			$this->queryBuilder->expects($this->once())
 				->method('insert')
 				->with('calendar_invitations')
 				->willReturn($this->queryBuilder);
-			$this->queryBuilder->expects($this->at(8))
+			$this->queryBuilder->expects($this->once())
 				->method('values')
 				->willReturn($this->queryBuilder);
-			$this->queryBuilder->expects($this->at(9))
+			$this->queryBuilder->expects($this->once())
 				->method('execute');
 		} else {
 			$this->queryBuilder->expects($this->never())

--- a/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
@@ -61,7 +61,7 @@ class SearchPluginTest extends TestCase {
 
 		$plugin = new SearchPlugin();
 
-		$server->expects($this->at(0))
+		$server->expects($this->once())
 			->method('on')
 			->with('report', [$plugin, 'report']);
 		$server->xml = new Service();
@@ -84,15 +84,15 @@ class SearchPluginTest extends TestCase {
 		$report = $this->createMock(CalendarSearchReport::class);
 		$report->filters = [];
 		$calendarHome = $this->createMock(CalendarHome::class);
-		$this->server->expects($this->at(0))
+		$this->server->expects($this->once())
 			->method('getRequestUri')
 			->with()
 			->willReturn('/re/quest/u/r/i');
-		$this->server->tree->expects($this->at(0))
+		$this->server->tree->expects($this->once())
 			->method('getNodeForPath')
 			->with('/re/quest/u/r/i')
 			->willReturn($calendarHome);
-		$this->server->expects($this->at(1))
+		$this->server->expects($this->once())
 			->method('getHTTPDepth')
 			->with(2)
 			->willReturn(2);
@@ -101,7 +101,7 @@ class SearchPluginTest extends TestCase {
 			->willReturn([
 				'return' => null
 			]);
-		$calendarHome->expects($this->at(0))
+		$calendarHome->expects($this->once())
 			->method('calendarSearch')
 			->willReturn([]);
 

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
@@ -29,12 +29,12 @@ use OCP\IRequest;
 class PluginTest extends \Test\TestCase {
 	public function testDisabled() {
 		$request = $this->createMock(IRequest::class);
-		$request->expects($this->at(0))
+		$request->expects($this->once())
 			->method('isUserAgent')
 			->with(Plugin::ENABLE_FOR_CLIENTS)
 			->willReturn(false);
 
-		$request->expects($this->at(1))
+		$request->expects($this->once())
 			->method('getHeader')
 			->with('X-NC-CalDAV-Webcal-Caching')
 			->willReturn('');
@@ -46,12 +46,12 @@ class PluginTest extends \Test\TestCase {
 
 	public function testEnabled() {
 		$request = $this->createMock(IRequest::class);
-		$request->expects($this->at(0))
+		$request->expects($this->once())
 			->method('isUserAgent')
 			->with(Plugin::ENABLE_FOR_CLIENTS)
 			->willReturn(false);
 
-		$request->expects($this->at(1))
+		$request->expects($this->once())
 			->method('getHeader')
 			->with('X-NC-CalDAV-Webcal-Caching')
 			->willReturn('On');

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -40,7 +40,6 @@ use Sabre\VObject\Property\Text;
 use Test\TestCase;
 
 class AddressBookImplTest extends TestCase {
-
 	/** @var AddressBookImpl  */
 	private $addressBookImpl;
 
@@ -94,7 +93,6 @@ class AddressBookImplTest extends TestCase {
 	}
 
 	public function testSearch() {
-
 		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
@@ -226,7 +224,7 @@ class AddressBookImplTest extends TestCase {
 		$uri = 'bla.vcf';
 		$properties = ['URI' => $uri, 'UID' => $uid, 'FN' => 'John Doe', 'ADR' => [['type' => 'HOME', 'value' => ';;street;city;;;country']]];
 		$vCard = new vCard;
-		$textProperty = $vCard->createProperty('KEY','value');
+		$textProperty = $vCard->createProperty('KEY', 'value');
 
 		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
@@ -322,8 +320,12 @@ class AddressBookImplTest extends TestCase {
 			->setMethods(['getUid'])
 			->getMock();
 
-		$addressBookImpl->expects($this->at(0))->method('getUid')->willReturn('uid0');
-		$addressBookImpl->expects($this->at(1))->method('getUid')->willReturn('uid1');
+		$addressBookImpl->expects($this->exactly(2))
+			->method('getUid')
+			->willReturnOnConsecutiveCalls(
+				'uid0',
+				'uid1',
+			);
 
 		// simulate that 'uid0' already exists, so the second uid will be returned
 		$this->backend->expects($this->exactly(2))->method('getContact')

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -34,12 +34,10 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use Sabre\VObject\Component\VCalendar;
-use Sabre\VObject\Property\ICalendar\Duration;
 use Sabre\VObject\Reader;
 use Test\TestCase;
 
 class BirthdayServiceTest extends TestCase {
-
 	/** @var BirthdayService */
 	private $service;
 	/** @var CalDavBackend | \PHPUnit\Framework\MockObject\MockObject */
@@ -71,7 +69,7 @@ class BirthdayServiceTest extends TestCase {
 				return vsprintf($string, $args);
 			});
 
-		$this->service = new BirthdayService($this->calDav,$this->cardDav,
+		$this->service = new BirthdayService($this->calDav, $this->cardDav,
 			$this->groupPrincipalBackend, $this->config,
 			$this->dbConnection, $this->l10n);
 	}
@@ -172,9 +170,13 @@ class BirthdayServiceTest extends TestCase {
 			->willReturn([
 				'id' => 1234
 			]);
-		$this->calDav->expects($this->at(1))->method('deleteCalendarObject')->with(1234, 'default-gump.vcf.ics');
-		$this->calDav->expects($this->at(2))->method('deleteCalendarObject')->with(1234, 'default-gump.vcf-death.ics');
-		$this->calDav->expects($this->at(3))->method('deleteCalendarObject')->with(1234, 'default-gump.vcf-anniversary.ics');
+		$this->calDav->expects($this->exactly(3))
+			->method('deleteCalendarObject')
+			->withConsecutive(
+				[1234, 'default-gump.vcf.ics'],
+				[1234, 'default-gump.vcf-death.ics'],
+				[1234, 'default-gump.vcf-anniversary.ics'],
+			);
 		$this->cardDav->expects($this->once())->method('getShares')->willReturn([]);
 
 		$this->service->onCardDeleted(666, 'gump.vcf');
@@ -279,7 +281,7 @@ class BirthdayServiceTest extends TestCase {
 				[1234, 'default-gump.vcf.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"],
 				[1234, 'default-gump.vcf-death.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"],
 				[1234, 'default-gump.vcf-anniversary.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"]
-				);
+			);
 		}
 		if ($expectedOp === 'update') {
 			$vCal = new VCalendar();
@@ -292,7 +294,7 @@ class BirthdayServiceTest extends TestCase {
 				[1234, 'default-gump.vcf.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"],
 				[1234, 'default-gump.vcf-death.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"],
 				[1234, 'default-gump.vcf-anniversary.ics', "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nCALSCALE:GREGORIAN\r\nPRODID:-//Nextcloud testing//mocked object//\r\nEND:VCALENDAR\r\n"]
-				);
+			);
 		}
 
 		$service->onCardChanged(666, 'gump.vcf', '');
@@ -360,27 +362,23 @@ class BirthdayServiceTest extends TestCase {
 	}
 
 	public function testResetForUser() {
-		$this->calDav->expects($this->at(0))
+		$this->calDav->expects($this->once())
 			->method('getCalendarByUri')
 			->with('principals/users/user123', 'contact_birthdays')
 			->willReturn(['id' => 42]);
 
-		$this->calDav->expects($this->at(1))
+		$this->calDav->expects($this->once())
 			->method('getCalendarObjects')
 			->with(42, 0)
 			->willReturn([['uri' => '1.ics'], ['uri' => '2.ics'], ['uri' => '3.ics']]);
 
-		$this->calDav->expects($this->at(2))
+		$this->calDav->expects($this->exactly(3))
 			->method('deleteCalendarObject')
-			->with(42, '1.ics', 0);
-
-		$this->calDav->expects($this->at(3))
-			->method('deleteCalendarObject')
-			->with(42, '2.ics', 0);
-
-		$this->calDav->expects($this->at(4))
-			->method('deleteCalendarObject')
-			->with(42, '3.ics', 0);
+			->withConsecutive(
+				[42, '1.ics', 0],
+				[42, '2.ics', 0],
+				[42, '3.ics', 0],
+			);
 
 		$this->service->resetForUser('user123');
 	}

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -64,7 +64,6 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit\CardDAV
  */
 class CardDavBackendTest extends TestCase {
-
 	/** @var CardDavBackend */
 	private $backend;
 
@@ -183,7 +182,6 @@ class CardDavBackendTest extends TestCase {
 	}
 
 	public function testAddressBookOperations() {
-
 		// create a new address book
 		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Example', []);
 
@@ -243,7 +241,6 @@ class CardDavBackendTest extends TestCase {
 	}
 
 	public function testCardOperations() {
-
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)
 				->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
@@ -257,8 +254,12 @@ class CardDavBackendTest extends TestCase {
 
 		$uri = $this->getUniqueID('card');
 		// updateProperties is expected twice, once for createCard and once for updateCard
-		$backend->expects($this->at(0))->method('updateProperties')->with($bookId, $uri, $this->vcardTest0);
-		$backend->expects($this->at(1))->method('updateProperties')->with($bookId, $uri, $this->vcardTest1);
+		$backend->expects($this->exactly(2))
+			->method('updateProperties')
+			->withConsecutive(
+				[$bookId, $uri, $this->vcardTest0],
+				[$bookId, $uri, $this->vcardTest1],
+			);
 
 		// Expect event
 		$this->dispatcher
@@ -666,14 +667,14 @@ class CardDavBackendTest extends TestCase {
 		for ($i = 0; $i < 3; $i++) {
 			$query->insert($this->dbCardsTable)
 					->values(
-							[
-								'addressbookid' => $query->createNamedParameter(0),
-								'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), IQueryBuilder::PARAM_LOB),
-								'uri' => $query->createNamedParameter('uri' . $i),
-								'lastmodified' => $query->createNamedParameter(time()),
-								'etag' => $query->createNamedParameter('etag' . $i),
-								'size' => $query->createNamedParameter(120),
-							]
+						[
+							'addressbookid' => $query->createNamedParameter(0),
+							'carddata' => $query->createNamedParameter($vCards[$i]->serialize(), IQueryBuilder::PARAM_LOB),
+							'uri' => $query->createNamedParameter('uri' . $i),
+							'lastmodified' => $query->createNamedParameter(time()),
+							'etag' => $query->createNamedParameter('etag' . $i),
+							'size' => $query->createNamedParameter(120),
+						]
 					);
 			$query->execute();
 			$vCardIds[] = $query->getLastInsertId();
@@ -770,14 +771,14 @@ class CardDavBackendTest extends TestCase {
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsTable)
 				->values(
-						[
-							'addressbookid' => $query->createNamedParameter(1),
-							'carddata' => $query->createNamedParameter('carddata', IQueryBuilder::PARAM_LOB),
-							'uri' => $query->createNamedParameter('uri'),
-							'lastmodified' => $query->createNamedParameter(5489543),
-							'etag' => $query->createNamedParameter('etag'),
-							'size' => $query->createNamedParameter(120),
-						]
+					[
+						'addressbookid' => $query->createNamedParameter(1),
+						'carddata' => $query->createNamedParameter('carddata', IQueryBuilder::PARAM_LOB),
+						'uri' => $query->createNamedParameter('uri'),
+						'lastmodified' => $query->createNamedParameter(5489543),
+						'etag' => $query->createNamedParameter('etag'),
+						'size' => $query->createNamedParameter(120),
+					]
 				);
 		$query->execute();
 
@@ -798,14 +799,14 @@ class CardDavBackendTest extends TestCase {
 		for ($i = 0; $i < 2; $i++) {
 			$query->insert($this->dbCardsTable)
 					->values(
-							[
-								'addressbookid' => $query->createNamedParameter($i),
-								'carddata' => $query->createNamedParameter('carddata' . $i, IQueryBuilder::PARAM_LOB),
-								'uri' => $query->createNamedParameter('uri' . $i),
-								'lastmodified' => $query->createNamedParameter(5489543),
-								'etag' => $query->createNamedParameter('etag' . $i),
-								'size' => $query->createNamedParameter(120),
-							]
+						[
+							'addressbookid' => $query->createNamedParameter($i),
+							'carddata' => $query->createNamedParameter('carddata' . $i, IQueryBuilder::PARAM_LOB),
+							'uri' => $query->createNamedParameter('uri' . $i),
+							'lastmodified' => $query->createNamedParameter(5489543),
+							'etag' => $query->createNamedParameter('etag' . $i),
+							'size' => $query->createNamedParameter(120),
+						]
 					);
 			$query->execute();
 		}

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -39,7 +39,6 @@ use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
 class ImageExportPluginTest extends TestCase {
-
 	/** @var ResponseInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $response;
 	/** @var RequestInterface|\PHPUnit\Framework\MockObject\MockObject */
@@ -150,16 +149,6 @@ class ImageExportPluginTest extends TestCase {
 				$this->fail();
 			});
 
-		$this->response->expects($this->at(0))
-			->method('setHeader')
-			->with('Cache-Control', 'private, max-age=3600, must-revalidate');
-		$this->response->expects($this->at(1))
-			->method('setHeader')
-			->with('Etag', '"myEtag"');
-		$this->response->expects($this->at(2))
-			->method('setHeader')
-			->with('Pragma', 'public');
-
 		$size = $size === null ? -1 : $size;
 
 		if ($photo) {
@@ -173,12 +162,15 @@ class ImageExportPluginTest extends TestCase {
 				->with(1, 'card', $size, $card)
 				->willReturn($file);
 
-			$this->response->expects($this->at(3))
+			$this->response->expects($this->exactly(5))
 				->method('setHeader')
-				->with('Content-Type', 'image/jpeg');
-			$this->response->expects($this->at(4))
-				->method('setHeader')
-				->with('Content-Disposition', 'attachment; filename=card.jpg');
+				->withConsecutive(
+					['Cache-Control', 'private, max-age=3600, must-revalidate'],
+					['Etag', '"myEtag"'],
+					['Pragma', 'public'],
+					['Content-Type', 'image/jpeg'],
+					['Content-Disposition', 'attachment; filename=card.jpg'],
+				);
 
 			$this->response->expects($this->once())
 				->method('setStatus')
@@ -187,6 +179,13 @@ class ImageExportPluginTest extends TestCase {
 				->method('setBody')
 				->with('imgdata');
 		} else {
+			$this->response->expects($this->exactly(3))
+				->method('setHeader')
+				->withConsecutive(
+					['Cache-Control', 'private, max-age=3600, must-revalidate'],
+					['Etag', '"myEtag"'],
+					['Pragma', 'public'],
+				);
 			$this->cache->method('get')
 				->with(1, 'card', $size, $card)
 				->willThrowException(new NotFoundException());

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -75,8 +75,12 @@ class SyncServiceTest extends TestCase {
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->exactly(1))->method('createAddressBook');
-		$backend->expects($this->at(0))->method('getAddressBooksByUri')->willReturn(null);
-		$backend->expects($this->at(1))->method('getAddressBooksByUri')->willReturn([]);
+		$backend->expects($this->exactly(2))
+			->method('getAddressBooksByUri')
+			->willReturnOnConsecutiveCalls(
+				null,
+				[],
+			);
 
 		/** @var IUserManager $userManager */
 		$userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -220,7 +220,7 @@ class AuthTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
-	
+
 	public function testValidateUserPassWithPasswordLoginForbidden() {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden::class);
 
@@ -329,7 +329,7 @@ class AuthTest extends TestCase {
 		$this->auth->check($request, $response);
 	}
 
-	
+
 	public function testAuthenticateAlreadyLoggedInWithoutTwoFactorChallengePassed() {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('2FA challenge not passed.');
@@ -383,7 +383,7 @@ class AuthTest extends TestCase {
 		$this->auth->check($request, $response);
 	}
 
-	
+
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndIncorrectlyDavAuthenticated() {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('CSRF check not passed.');
@@ -564,7 +564,7 @@ class AuthTest extends TestCase {
 		$this->assertEquals([false, 'No \'Authorization: Basic\' header found. Either the client didn\'t send one, or the server is misconfigured'], $response);
 	}
 
-	
+
 	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjax() {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('Cannot authenticate over ajax calls');
@@ -639,15 +639,16 @@ class AuthTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getHeader')
-			->with('X-Requested-With')
-			->willReturn(null);
-		$server->httpRequest
-			->expects($this->at(1))
-			->method('getHeader')
-			->with('Authorization')
-			->willReturn('basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+			->withConsecutive(
+				['X-Requested-With'],
+				['Authorization'],
+			)
+			->willReturnOnConsecutiveCalls(
+				null,
+				'basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+			);
 		$server->httpResponse = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -678,15 +679,16 @@ class AuthTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$server->httpRequest
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('getHeader')
-			->with('X-Requested-With')
-			->willReturn(null);
-		$server->httpRequest
-			->expects($this->at(1))
-			->method('getHeader')
-			->with('Authorization')
-			->willReturn('basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+			->withConsecutive(
+				['X-Requested-With'],
+				['Authorization'],
+			)
+			->willReturnOnConsecutiveCalls(
+				null,
+				'basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+			);
 		$server->httpResponse = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -66,13 +66,12 @@ class BearerAuthTest extends TestCase {
 
 	public function testValidateBearerToken() {
 		$this->userSession
-			->expects($this->at(0))
+			->expects($this->exactly(2))
 			->method('isLoggedIn')
-			->willReturn(false);
-		$this->userSession
-			->expects($this->at(2))
-			->method('isLoggedIn')
-			->willReturn(true);
+			->willReturnOnConsecutiveCalls(
+				false,
+				true,
+			);
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
@@ -56,21 +56,14 @@ class FakeLockerPluginTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$server
-			->expects($this->at(0))
+			->expects($this->exactly(4))
 			->method('on')
-			->with('method:LOCK', [$this->fakeLockerPlugin, 'fakeLockProvider'], 1);
-		$server
-			->expects($this->at(1))
-			->method('on')
-			->with('method:UNLOCK', [$this->fakeLockerPlugin, 'fakeUnlockProvider'], 1);
-		$server
-			->expects($this->at(2))
-			->method('on')
-			->with('propFind', [$this->fakeLockerPlugin, 'propFind']);
-		$server
-			->expects($this->at(3))
-			->method('on')
-			->with('validateTokens', [$this->fakeLockerPlugin, 'validateTokens']);
+			->withConsecutive(
+				['method:LOCK', [$this->fakeLockerPlugin, 'fakeLockProvider'], 1],
+				['method:UNLOCK', [$this->fakeLockerPlugin, 'fakeUnlockProvider'], 1],
+				['propFind', [$this->fakeLockerPlugin, 'propFind']],
+				['validateTokens', [$this->fakeLockerPlugin, 'validateTokens']],
+			);
 
 		$this->fakeLockerPlugin->initialize($server);
 	}
@@ -98,12 +91,12 @@ class FakeLockerPluginTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propFind->expects($this->at(0))
+		$propFind->expects($this->exactly(2))
 			->method('handle')
-			->with('{DAV:}supportedlock');
-		$propFind->expects($this->at(1))
-			->method('handle')
-			->with('{DAV:}lockdiscovery');
+			->withConsecutive(
+				['{DAV:}supportedlock'],
+				['{DAV:}lockdiscovery'],
+			);
 
 		$this->fakeLockerPlugin->propFind($propFind, $node);
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -217,14 +217,16 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->at(0))
+		$this->tagMapper->expects($this->exactly(2))
 			->method('getObjectIdsForTags')
-			->with('123', 'files')
-			->willReturn(['111', '222']);
-		$this->tagMapper->expects($this->at(1))
-			->method('getObjectIdsForTags')
-			->with('456', 'files')
-			->willReturn(['111', '222', '333']);
+			->withConsecutive(
+				['123', 'files'],
+				['456', 'files'],
+			)
+			->willReturnOnConsecutiveCalls(
+				['111', '222'],
+				['111', '222', '333'],
+			);
 
 		$reportTargetNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
@@ -260,14 +262,16 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userFolder->expects($this->at(0))
+		$this->userFolder->expects($this->exactly(2))
 			->method('getById')
-			->with('111')
-			->willReturn([$filesNode1]);
-		$this->userFolder->expects($this->at(1))
-			->method('getById')
-			->with('222')
-			->willReturn([$filesNode2]);
+			->withConsecutive(
+				['111'],
+				['222'],
+			)
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1],
+				[$filesNode2],
+			);
 
 		$this->server->expects($this->any())
 			->method('getRequestUri')
@@ -300,14 +304,16 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('getPath')
 			->willReturn('/');
 
-		$this->userFolder->expects($this->at(0))
+		$this->userFolder->expects($this->exactly(2))
 			->method('getById')
-			->with('111')
-			->willReturn([$filesNode1]);
-		$this->userFolder->expects($this->at(1))
-			->method('getById')
-			->with('222')
-			->willReturn([$filesNode2]);
+			->withConsecutive(
+				['111'],
+				['222'],
+			)
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1],
+				[$filesNode2],
+			);
 
 		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
@@ -346,19 +352,21 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->userFolder->expects($this->at(0))
+		$this->userFolder->expects($this->once())
 			->method('get')
 			->with('/sub1/sub2')
 			->willReturn($subNode);
 
-		$subNode->expects($this->at(0))
+		$subNode->expects($this->exactly(2))
 			->method('getById')
-			->with('111')
-			->willReturn([$filesNode1]);
-		$subNode->expects($this->at(1))
-			->method('getById')
-			->with('222')
-			->willReturn([$filesNode2]);
+			->withConsecutive(
+				['111'],
+				['222'],
+			)
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1],
+				[$filesNode2],
+			);
 
 		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
@@ -588,14 +596,16 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->tagManager->expects($this->never())
 			->method('getTagsByIds');
 
-		$this->tagMapper->expects($this->at(0))
+		$this->tagMapper->expects($this->exactly(2))
 			->method('getObjectIdsForTags')
-			->with('123')
-			->willReturn(['111', '222']);
-		$this->tagMapper->expects($this->at(1))
-			->method('getObjectIdsForTags')
-			->with('456')
-			->willReturn(['222', '333']);
+			->withConsecutive(
+				['123'],
+				['456'],
+			)
+			->willReturnOnConsecutiveCalls(
+				['111', '222'],
+				['222', '333'],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
@@ -676,14 +686,16 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with(['123', '456'])
 			->willReturn([$tag1, $tag2]);
 
-		$this->tagMapper->expects($this->at(0))
+		$this->tagMapper->expects($this->exactly(2))
 			->method('getObjectIdsForTags')
-			->with('123')
-			->willReturn(['111', '222']);
-		$this->tagMapper->expects($this->at(1))
-			->method('getObjectIdsForTags')
-			->with('456')
-			->willReturn(['222', '333']);
+			->withConsecutive(
+				['123'],
+				['456'],
+			)
+			->willReturnOnConsecutiveCalls(
+				['111', '222'],
+				['222', '333'],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -304,21 +304,21 @@ class TagsPluginTest extends \Test\TestCase {
 			->with('/dummypath')
 			->willReturn($node);
 
-		$this->tagger->expects($this->at(0))
+		$this->tagger->expects($this->once())
 			->method('getTagsForObjects')
 			->with($this->equalTo([123]))
 			->willReturn([123 => ['tagkeep', 'tagremove', self::TAG_FAVORITE]]);
 
 		// then tag as tag1 and tag2
-		$this->tagger->expects($this->at(1))
+		$this->tagger->expects($this->exactly(2))
 			->method('tagAs')
-			->with(123, 'tag1');
-		$this->tagger->expects($this->at(2))
-			->method('tagAs')
-			->with(123, 'tag2');
+			->withConsecutive(
+				[123, 'tag1'],
+				[123, 'tag2'],
+			);
 
 		// it will untag tag3
-		$this->tagger->expects($this->at(3))
+		$this->tagger->expects($this->once())
 			->method('unTag')
 			->with(123, 'tagremove');
 
@@ -355,22 +355,22 @@ class TagsPluginTest extends \Test\TestCase {
 			->with('/dummypath')
 			->willReturn($node);
 
-		$this->tagger->expects($this->at(0))
+		$this->tagger->expects($this->once())
 			->method('getTagsForObjects')
 			->with($this->equalTo([123]))
 			->willReturn([]);
 
 		// then tag as tag1 and tag2
-		$this->tagger->expects($this->at(1))
+		$this->tagger->expects($this->exactly(2))
 			->method('tagAs')
-			->with(123, 'tag1');
-		$this->tagger->expects($this->at(2))
-			->method('tagAs')
-			->with(123, 'tag2');
+			->withConsecutive(
+				[123, 'tag1'],
+				[123, 'tag2'],
+			);
 
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch([
-			self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2', 'tagkeep'])
+			self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2'])
 		]);
 
 		$this->plugin->handleUpdateProperties(

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -477,19 +477,19 @@ EOF;
 			->with()
 			->willReturn($queryBuilder);
 
-		$queryBuilder->expects($this->at(0))
+		$queryBuilder->expects($this->once())
 			->method('select')
 			->with('*')
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(1))
+		$queryBuilder->expects($this->once())
 			->method('from')
 			->with('calendar_invitations')
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(4))
+		$queryBuilder->expects($this->once())
 			->method('where')
 			->with($function)
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(5))
+		$queryBuilder->expects($this->once())
 			->method('execute')
 			->with()
 			->willReturn($stmt);

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -39,7 +39,6 @@ use Test\TestCase;
  * @group DB
  */
 class CustomPropertiesBackendTest extends TestCase {
-
 	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
 	private $tree;
 
@@ -129,7 +128,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		);
 
 		$propFind = $this->createMock(PropFind::class);
-		$propFind->expects($this->at(0))
+		$propFind->expects($this->once())
 			->method('get404Properties')
 			->with()
 			->willReturn([

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -329,7 +329,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 					->method('getUser')
 					->willReturn($user);
 
-				$this->groupManager->expects($this->at(0))
+				$this->groupManager->expects($this->once())
 					->method('getUserGroupIds')
 					->with($user)
 					->willReturn(['group1', 'group2', 'group5']);

--- a/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
+++ b/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
@@ -36,7 +36,6 @@ use OCP\Migration\IOutput;
 use Test\TestCase;
 
 class RefreshWebcalJobRegistrarTest extends TestCase {
-
 	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
 	private $db;
 
@@ -69,77 +68,68 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 			->method('getQueryBuilder')
 			->willReturn($queryBuilder);
 
-		$queryBuilder->expects($this->at(0))
+		$queryBuilder->expects($this->once())
 			->method('select')
 			->with(['principaluri', 'uri'])
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(1))
+		$queryBuilder->expects($this->once())
 			->method('from')
 			->with('calendarsubscriptions')
 			->willReturn($queryBuilder);
-		$queryBuilder->expects($this->at(2))
+		$queryBuilder->expects($this->once())
 			->method('execute')
 			->willReturn($statement);
 
-		$statement->expects($this->at(0))
+		$statement->expects($this->exactly(4))
 			->method('fetch')
 			->with(\PDO::FETCH_ASSOC)
-			->willReturn([
-				'principaluri' => 'foo1',
-				'uri' => 'bar1',
-			]);
-		$statement->expects($this->at(1))
-			->method('fetch')
-			->with(\PDO::FETCH_ASSOC)
-			->willReturn([
-				'principaluri' => 'foo2',
-				'uri' => 'bar2',
-			]);
-		$statement->expects($this->at(2))
-			->method('fetch')
-			->with(\PDO::FETCH_ASSOC)
-			->willReturn([
-				'principaluri' => 'foo3',
-				'uri' => 'bar3',
-			]);
-		$statement->expects($this->at(0))
-			->method('fetch')
-			->with(\PDO::FETCH_ASSOC)
-			->willReturn(null);
+			->willReturnOnConsecutiveCalls(
+				[
+					'principaluri' => 'foo1',
+					'uri' => 'bar1',
+				],
+				[
+					'principaluri' => 'foo2',
+					'uri' => 'bar2',
+				],
+				[
+					'principaluri' => 'foo3',
+					'uri' => 'bar3',
+				],
+				null
+			);
 
-		$this->jobList->expects($this->at(0))
+		$this->jobList->expects($this->exactly(3))
 			->method('has')
-			->with(RefreshWebcalJob::class, [
-				'principaluri' => 'foo1',
-				'uri' => 'bar1',
-			])
-			->willReturn(false);
-		$this->jobList->expects($this->at(1))
+			->withConsecutive(
+				[RefreshWebcalJob::class, [
+					'principaluri' => 'foo1',
+					'uri' => 'bar1',
+				]],
+				[RefreshWebcalJob::class, [
+					'principaluri' => 'foo2',
+					'uri' => 'bar2',
+				]],
+				[RefreshWebcalJob::class, [
+					'principaluri' => 'foo3',
+					'uri' => 'bar3',
+				]])
+			->willReturnOnConsecutiveCalls(
+				false,
+				true,
+				false,
+			);
+		$this->jobList->expects($this->exactly(2))
 			->method('add')
-			->with(RefreshWebcalJob::class, [
-				'principaluri' => 'foo1',
-				'uri' => 'bar1',
-			]);
-		$this->jobList->expects($this->at(2))
-			->method('has')
-			->with(RefreshWebcalJob::class, [
-				'principaluri' => 'foo2',
-				'uri' => 'bar2',
-			])
-			->willReturn(true);
-		$this->jobList->expects($this->at(3))
-			->method('has')
-			->with(RefreshWebcalJob::class, [
-				'principaluri' => 'foo3',
-				'uri' => 'bar3',
-			])
-			->willReturn(false);
-		$this->jobList->expects($this->at(4))
-			->method('add')
-			->with(RefreshWebcalJob::class, [
-				'principaluri' => 'foo3',
-				'uri' => 'bar3',
-			]);
+			->withConsecutive(
+				[RefreshWebcalJob::class, [
+					'principaluri' => 'foo1',
+					'uri' => 'bar1',
+				]],
+				[RefreshWebcalJob::class, [
+					'principaluri' => 'foo3',
+					'uri' => 'bar3',
+				]]);
 
 		$output->expects($this->once())
 			->method('info')

--- a/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
+++ b/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
@@ -111,7 +111,7 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 		$qb->method('execute')
 			->willReturn($result);
 
-		$result->expects($this->at(0))
+		$result->expects($this->once())
 			->method('fetchOne')
 			->willReturn(count($subscriptions));
 

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
@@ -30,7 +30,6 @@ use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 class AppleProvisioningNodeTest extends TestCase {
-
 	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
 
@@ -69,7 +68,7 @@ class AppleProvisioningNodeTest extends TestCase {
 	}
 
 	public function testGetProperties() {
-		$this->timeFactory->expects($this->at(0))
+		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
 			->willReturn(new \DateTime('2000-01-01'));
 

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -36,7 +36,6 @@ use OCP\IUserSession;
 use Test\TestCase;
 
 class AppleProvisioningPluginTest extends TestCase {
-
 	/** @var \Sabre\DAV\Server|\PHPUnit\Framework\MockObject\MockObject */
 	protected $server;
 
@@ -96,7 +95,7 @@ class AppleProvisioningPluginTest extends TestCase {
 			function () {
 			});
 
-		$server->expects($this->at(0))
+		$server->expects($this->once())
 			->method('on')
 			->with('method:GET', [$plugin, 'httpGet'], 90);
 
@@ -104,36 +103,36 @@ class AppleProvisioningPluginTest extends TestCase {
 	}
 
 	public function testHttpGetOnHttp() {
-		$this->sabreRequest->expects($this->at(0))
+		$this->sabreRequest->expects($this->once())
 			->method('getPath')
 			->with()
 			->willReturn('provisioning/apple-provisioning.mobileconfig');
 
 		$user = $this->createMock(IUser::class);
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
 
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getServerProtocol')
 			->wilLReturn('http');
 
-		$this->themingDefaults->expects($this->at(0))
+		$this->themingDefaults->expects($this->once())
 			->method('getName')
 			->willReturn('InstanceName');
 
-		$this->l10n->expects($this->at(0))
+		$this->l10n->expects($this->once())
 			->method('t')
 			->with('Your %s needs to be configured to use HTTPS in order to use CalDAV and CardDAV with iOS/macOS.', ['InstanceName'])
 			->willReturn('LocalizedErrorMessage');
 
-		$this->sabreResponse->expects($this->at(0))
+		$this->sabreResponse->expects($this->once())
 			->method('setStatus')
 			->with(200);
-		$this->sabreResponse->expects($this->at(1))
+		$this->sabreResponse->expects($this->once())
 			->method('setHeader')
 			->with('Content-Type', 'text/plain; charset=utf-8');
-		$this->sabreResponse->expects($this->at(2))
+		$this->sabreResponse->expects($this->once())
 			->method('setBody')
 			->with('LocalizedErrorMessage');
 
@@ -143,21 +142,21 @@ class AppleProvisioningPluginTest extends TestCase {
 	}
 
 	public function testHttpGetOnHttps() {
-		$this->sabreRequest->expects($this->at(0))
+		$this->sabreRequest->expects($this->once())
 			->method('getPath')
 			->with()
 			->willReturn('provisioning/apple-provisioning.mobileconfig');
 
 		$user = $this->createMock(IUser::class);
-		$user->expects($this->at(0))
+		$user->expects($this->once())
 			->method('getUID')
 			->willReturn('userName');
 
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
 
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getServerProtocol')
 			->wilLReturn('https');
 
@@ -165,30 +164,31 @@ class AppleProvisioningPluginTest extends TestCase {
 			->method('getBaseUrl')
 			->willReturn('https://nextcloud.tld/nextcloud');
 
-		$this->themingDefaults->expects($this->at(0))
+		$this->themingDefaults->expects($this->once())
 			->method('getName')
 			->willReturn('InstanceName');
 
-		$this->l10n->expects($this->at(0))
+		$this->l10n->expects($this->exactly(2))
 			->method('t')
-			->with('Configures a CalDAV account')
-			->willReturn('LocalizedConfiguresCalDAV');
+			->withConsecutive(
+				['Configures a CalDAV account'],
+				['Configures a CardDAV account'],
+			)
+			->willReturnOnConsecutiveCalls(
+				'LocalizedConfiguresCalDAV',
+				'LocalizedConfiguresCardDAV',
+			);
 
-		$this->l10n->expects($this->at(1))
-			->method('t')
-			->with('Configures a CardDAV account')
-			->willReturn('LocalizedConfiguresCardDAV');
-
-		$this->sabreResponse->expects($this->at(0))
+		$this->sabreResponse->expects($this->once())
 			->method('setStatus')
 			->with(200);
-		$this->sabreResponse->expects($this->at(1))
+		$this->sabreResponse->expects($this->exactly(2))
 			->method('setHeader')
-			->with('Content-Disposition', 'attachment; filename="userName-apple-provisioning.mobileconfig"');
-		$this->sabreResponse->expects($this->at(2))
-			->method('setHeader')
-			->with('Content-Type', 'application/xml; charset=utf-8');
-		$this->sabreResponse->expects($this->at(3))
+			->withConsecutive(
+				['Content-Disposition', 'attachment; filename="userName-apple-provisioning.mobileconfig"'],
+				['Content-Type', 'application/xml; charset=utf-8'],
+			);
+		$this->sabreResponse->expects($this->once())
 			->method('setBody')
 			->with(<<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -262,7 +262,7 @@ class AppleProvisioningPluginTest extends TestCase {
 </plist>
 
 EOF
-);
+			);
 
 		$returnValue = $this->plugin->httpGet($this->sabreRequest, $this->sabreResponse);
 

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -39,7 +39,6 @@ use Sabre\VObject\Reader;
 use Test\TestCase;
 
 class EventsSearchProviderTest extends TestCase {
-
 	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $appManager;
 
@@ -420,15 +419,15 @@ class EventsSearchProviderTest extends TestCase {
 	}
 
 	public function testGetDeepLinkToCalendarApp(): void {
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects($this->once())
 			->method('linkTo')
 			->with('', 'remote.php')
 			->willReturn('link-to-remote.php');
-		$this->urlGenerator->expects($this->at(1))
+		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with('calendar.view.index')
 			->willReturn('link-to-route-calendar/');
-		$this->urlGenerator->expects($this->at(2))
+		$this->urlGenerator->expects($this->once())
 			->method('getAbsoluteURL')
 			->with('link-to-route-calendar/edit/bGluay10by1yZW1vdGUucGhwL2Rhdi9jYWxlbmRhcnMvam9obi5kb2UvZm9vL2Jhci5pY3M=')
 			->willReturn('absolute-url-to-route');

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -35,8 +35,6 @@ use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
 class ChunkingPluginTest extends TestCase {
-
-
 	/**
 	 * @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject
 	 */
@@ -97,14 +95,16 @@ class ChunkingPluginTest extends TestCase {
 		$sourceNode = $this->createMock(FutureFile::class);
 		$targetNode = $this->createMock(Directory::class);
 
-		$this->tree->expects($this->at(0))
+		$this->tree->expects($this->exactly(2))
 			->method('getNodeForPath')
-			->with('source')
-			->willReturn($sourceNode);
-		$this->tree->expects($this->at(1))
-			->method('getNodeForPath')
-			->with('target')
-			->willReturn($targetNode);
+			->withConsecutive(
+				['source'],
+				['target'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$sourceNode,
+				$targetNode,
+			);
 		$this->response->expects($this->never())
 			->method('setStatus');
 
@@ -117,14 +117,16 @@ class ChunkingPluginTest extends TestCase {
 			->method('getSize')
 			->willReturn(4);
 
-		$this->tree->expects($this->at(0))
+		$this->tree->expects($this->exactly(2))
 			->method('getNodeForPath')
-			->with('source')
-			->willReturn($sourceNode);
-		$this->tree->expects($this->at(1))
-			->method('getNodeForPath')
-			->with('target')
-			->willThrowException(new NotFound());
+			->withConsecutive(
+				['source'],
+				['target'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$sourceNode,
+				$this->throwException(new NotFound()),
+			);
 		$this->tree->expects($this->any())
 			->method('nodeExists')
 			->with('target')
@@ -149,14 +151,17 @@ class ChunkingPluginTest extends TestCase {
 			->method('getSize')
 			->willReturn(4);
 
-		$this->tree->expects($this->at(0))
+
+		$this->tree->expects($this->exactly(2))
 			->method('getNodeForPath')
-			->with('source')
-			->willReturn($sourceNode);
-		$this->tree->expects($this->at(1))
-			->method('getNodeForPath')
-			->with('target')
-			->willThrowException(new NotFound());
+			->withConsecutive(
+				['source'],
+				['target'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$sourceNode,
+				$this->throwException(new NotFound()),
+			);
 		$this->tree->expects($this->any())
 			->method('nodeExists')
 			->with('target')
@@ -189,14 +194,17 @@ class ChunkingPluginTest extends TestCase {
 			->method('getSize')
 			->willReturn(3);
 
-		$this->tree->expects($this->at(0))
+
+		$this->tree->expects($this->exactly(2))
 			->method('getNodeForPath')
-			->with('source')
-			->willReturn($sourceNode);
-		$this->tree->expects($this->at(1))
-			->method('getNodeForPath')
-			->with('target')
-			->willThrowException(new NotFound());
+			->withConsecutive(
+				['source'],
+				['target'],
+			)
+			->willReturnOnConsecutiveCalls(
+				$sourceNode,
+				$this->throwException(new NotFound()),
+			);
 		$this->request->expects($this->once())
 			->method('getHeader')
 			->with('OC-Total-Length')


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

~100 less warnings.