### PR TITLE
Link reference provider: Improve content-type check

### DIFF
--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -116,7 +116,9 @@ class LinkReferenceProvider implements IReferenceProvider {
 			return;
 		}
 		$linkContentType = $headResponse->getHeader('Content-Type');
-		if ($linkContentType !== 'text/html') {
+		$expectedContentType = 'text/html';
+		// check the header begins with the expected content type
+		if (substr($linkContentType, 0, strlen($expectedContentType)) !== $expectedContentType) {
 			$this->logger->debug('Skip resolving links pointing to content type that is not "text/html"');
 			return;
 		}


### PR DESCRIPTION
closes #36042 
The content-type sometimes contains the charset:

```
content-type: text/html; charset=utf-8
```

So the link provider check was too strict. We now check it begins with `text/html`.

