### PR TITLE
fix(authentication): Only verify each hash once

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -448,9 +448,11 @@ class PublicKeyTokenProvider implements IProvider {
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
 		$passwordHash = $this->hashPassword($password);
+		$verifiedHashes = [];
 		foreach ($tokens as $t) {
-			$publicKey = $t->getPublicKey();
-			if ($t->getPasswordHash() === null || $this->hasher->verify(sha1($password) . $password, $t->getPasswordHash())) {
+			if ($t->getPasswordHash() === null || isset($verifiedHashes[$t->getPasswordHash()]) || $this->hasher->verify(sha1($password) . $password, $t->getPasswordHash())) {
+				$verifiedHashes[$t->getPasswordHash() ?: ''] = true;
+				$publicKey = $t->getPublicKey();
 				$t->setPassword($this->encryptPassword($password, $publicKey));
 				$t->setPasswordHash($passwordHash);
 				$t->setPasswordInvalid(false);

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -447,13 +447,17 @@ class PublicKeyTokenProvider implements IProvider {
 
 		// Update the password for all tokens
 		$tokens = $this->mapper->getTokenByUser($uid);
-		$passwordHash = $this->hashPassword($password);
+		$newPasswordHash = null;
 		$verifiedHashes = [];
 		foreach ($tokens as $t) {
 			if ($t->getPasswordHash() === null || !isset($verifiedHashes[$t->getPasswordHash()]) || !$this->hasher->verify(sha1($password) . $password, $t->getPasswordHash())) {
+				if ($newPasswordHash === null) {
+					$newPasswordHash = $this->hashPassword($password);
+				}
+
 				$publicKey = $t->getPublicKey();
 				$t->setPassword($this->encryptPassword($password, $publicKey));
-				$t->setPasswordHash($passwordHash);
+				$t->setPasswordHash($newPasswordHash);
 				$t->setPasswordInvalid(false);
 				$this->updateToken($t);
 			} else {

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -450,13 +450,14 @@ class PublicKeyTokenProvider implements IProvider {
 		$passwordHash = $this->hashPassword($password);
 		$verifiedHashes = [];
 		foreach ($tokens as $t) {
-			if ($t->getPasswordHash() === null || isset($verifiedHashes[$t->getPasswordHash()]) || $this->hasher->verify(sha1($password) . $password, $t->getPasswordHash())) {
-				$verifiedHashes[$t->getPasswordHash() ?: ''] = true;
+			if ($t->getPasswordHash() === null || !isset($verifiedHashes[$t->getPasswordHash()]) || !$this->hasher->verify(sha1($password) . $password, $t->getPasswordHash())) {
 				$publicKey = $t->getPublicKey();
 				$t->setPassword($this->encryptPassword($password, $publicKey));
 				$t->setPasswordHash($passwordHash);
 				$t->setPasswordInvalid(false);
 				$this->updateToken($t);
+			} else {
+				$verifiedHashes[$t->getPasswordHash() ?: ''] = true;
 			}
 		}
 	}


### PR DESCRIPTION
Fix #36046 

Regression from #33898 

While the given patch heavily improves the situation, it still performs kind of a DDoS attach on the database, as all entries get updated on each authentication, which also is on basic auth.

I might be wrong, but I think `$this->hasher->verify` is meant to be `!$this->hasher->verify`, so we update the password of all tokens that do **NOT** decrypt to the current password?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
