### PR TITLE
Fix theming migration repair step by passing correct type for argument

### DIFF
--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -68,10 +68,9 @@ class MigrateBackgroundImages extends QueuedJob {
 		$this->logger = $logger;
 	}
 
-	protected function run($argument): void {
-		if (!isset($argument['stage'])) {
-			// not executed in 25.0.0?!
-			$argument['stage'] = self::STAGE_PREPARE;
+	protected function run(mixed $argument): void {
+		if (!is_array($argument) || !isset($argument['stage'])) {
+			throw new \Exception('Job '.self::class.' called with wrong argument');
 		}
 
 		switch ($argument['stage']) {
@@ -99,10 +98,10 @@ class MigrateBackgroundImages extends QueuedJob {
 			$userIds = $result->fetchAll(\PDO::FETCH_COLUMN);
 			$this->storeUserIdsToProcess($userIds);
 		} catch (\Throwable $t) {
-			$this->jobList->add(self::class, self::STAGE_PREPARE);
+			$this->jobList->add(self::class, ['stage' => self::STAGE_PREPARE]);
 			throw $t;
 		}
-		$this->jobList->add(self::class, self::STAGE_EXECUTE);
+		$this->jobList->add(self::class, ['stage' => self::STAGE_EXECUTE]);
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

* Resolves: #35921 

## Summary

The migration step to migrate background image in 25 had a type error.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
