### PR TITLE
Use a Generator for job list to fix background-job:list command

### DIFF
--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -67,7 +67,7 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$jobs = $this->jobList->getJobs($input->getOption('class'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
+		$jobs = $this->jobList->getJobsIterator($input->getOption('class'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
 		$this->writeTableInOutputFormat($input, $output, $this->formatJobs($jobs));
 		return 0;
 	}

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -72,15 +72,16 @@ class ListCommand extends Base {
 		return 0;
 	}
 
-	protected function formatJobs(array $jobs): array {
-		return array_map(
-			fn ($job) => [
+	protected function formatJobs(iterable $jobs): array {
+		$jobsInfo = [];
+		foreach ($jobs as $job) {
+			$jobsInfo[] = [
 				'id' => $job->getId(),
 				'class' => get_class($job),
 				'last_run' => date(DATE_ATOM, $job->getLastRun()),
 				'argument' => json_encode($job->getArgument()),
-			],
-			$jobs
-		);
+			];
+		}
+		return $jobsInfo;
 	}
 }

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -158,17 +158,6 @@ class JobList implements IJobList {
 	}
 
 	/**
-	 * get all jobs in the list
-	 *
-	 * @return iterable<IJob>
-	 * @deprecated 9.0.0 - This method is dangerous since it can cause load and
-	 * memory problems when creating too many instances. Use getJobs instead.
-	 */
-	public function getAll(): iterable {
-		return $this->getJobs(null, null, 0);
-	}
-
-	/**
 	 * @param IJob|class-string<IJob>|null $job
 	 * @return iterable<IJob> Avoid to store these objects as they may share a Singleton instance. You should instead use these IJobs instances while looping on the iterable.
 	 */

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -160,19 +160,19 @@ class JobList implements IJobList {
 	/**
 	 * get all jobs in the list
 	 *
-	 * @return IJob[]
+	 * @return iterable<IJob>
 	 * @deprecated 9.0.0 - This method is dangerous since it can cause load and
 	 * memory problems when creating too many instances. Use getJobs instead.
 	 */
-	public function getAll(): array {
+	public function getAll(): iterable {
 		return $this->getJobs(null, null, 0);
 	}
 
 	/**
 	 * @param IJob|class-string<IJob>|null $job
-	 * @return IJob[]
+	 * @return iterable<IJob> Avoid to store these objects as they may share a Singleton instance. You should instead use these IJobs instances while looping on the iterable.
 	 */
-	public function getJobs($job, ?int $limit, int $offset): array {
+	public function getJobs($job, ?int $limit, int $offset): iterable {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
@@ -190,20 +190,18 @@ class JobList implements IJobList {
 
 		$result = $query->executeQuery();
 
-		$jobs = [];
 		while ($row = $result->fetch()) {
 			$job = $this->buildJob($row);
 			if ($job) {
-				$jobs[] = $job;
+				yield $job;
 			}
 		}
 		$result->closeCursor();
-
-		return $jobs;
 	}
 
 	/**
-	 * get the next job in the list
+	 * Get the next job in the list
+	 * @return ?IJob the next job to run. Beware that this object may be a singleton and may be modified by the next call to buildJob.
 	 */
 	public function getNext(bool $onlyTimeSensitive = false): ?IJob {
 		$query = $this->connection->getQueryBuilder();
@@ -261,6 +259,9 @@ class JobList implements IJobList {
 		}
 	}
 
+	/**
+	 * @return ?IJob The job matching the id. Beware that this object may be a singleton and may be modified by the next call to buildJob.
+	 */
 	public function getById(int $id): ?IJob {
 		$row = $this->getDetailsById($id);
 
@@ -291,6 +292,7 @@ class JobList implements IJobList {
 	 * get the job object from a row in the db
 	 *
 	 * @param array{class:class-string<IJob>, id:mixed, last_run:mixed, argument:string} $row
+	 * @return ?IJob the next job to run. Beware that this object may be a singleton and may be modified by the next call to buildJob.
 	 */
 	private function buildJob(array $row): ?IJob {
 		try {

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -157,11 +157,20 @@ class JobList implements IJobList {
 		return (bool) $row;
 	}
 
+	public function getJobs($job, ?int $limit, int $offset): array {
+		$iterable = $this->getJobsIterator($job, $limit, $offset);
+		if (is_array($iterable)) {
+			return $iterable;
+		} else {
+			return iterator_to_array($iterable);
+		}
+	}
+
 	/**
 	 * @param IJob|class-string<IJob>|null $job
 	 * @return iterable<IJob> Avoid to store these objects as they may share a Singleton instance. You should instead use these IJobs instances while looping on the iterable.
 	 */
-	public function getJobs($job, ?int $limit, int $offset): iterable {
+	public function getJobsIterator($job, ?int $limit, int $offset): iterable {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -76,16 +76,6 @@ interface IJobList {
 	public function has($job, $argument): bool;
 
 	/**
-	 * get all jobs in the list
-	 *
-	 * @return iterable<IJob>
-	 * @since 7.0.0
-	 * @deprecated 9.0.0 - This method is dangerous since it can cause load and
-	 * memory problems when creating too many instances. Use getJobs instead.
-	 */
-	public function getAll(): iterable;
-
-	/**
 	 * Get jobs matching the search
 	 *
 	 * @param IJob|class-string<IJob>|null $job

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -78,21 +78,21 @@ interface IJobList {
 	/**
 	 * get all jobs in the list
 	 *
-	 * @return IJob[]
+	 * @return iterable<IJob>
 	 * @since 7.0.0
 	 * @deprecated 9.0.0 - This method is dangerous since it can cause load and
 	 * memory problems when creating too many instances. Use getJobs instead.
 	 */
-	public function getAll(): array;
+	public function getAll(): iterable;
 
 	/**
 	 * Get jobs matching the search
 	 *
 	 * @param IJob|class-string<IJob>|null $job
-	 * @return IJob[]
+	 * @return iterable<IJob>
 	 * @since 25.0.0
 	 */
-	public function getJobs($job, ?int $limit, int $offset): array;
+	public function getJobs($job, ?int $limit, int $offset): iterable;
 
 	/**
 	 * get the next job in the list

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -79,10 +79,20 @@ interface IJobList {
 	 * Get jobs matching the search
 	 *
 	 * @param IJob|class-string<IJob>|null $job
-	 * @return iterable<IJob>
+	 * @return array<IJob>
 	 * @since 25.0.0
+	 * @deprecated 26.0.0 Use getJobsIterator instead to avoid duplicated job objects
 	 */
-	public function getJobs($job, ?int $limit, int $offset): iterable;
+	public function getJobs($job, ?int $limit, int $offset): array;
+
+	/**
+	 * Get jobs matching the search
+	 *
+	 * @param IJob|class-string<IJob>|null $job
+	 * @return iterable<IJob>
+	 * @since 26.0.0
+	 */
+	public function getJobsIterator($job, ?int $limit, int $offset): iterable;
 
 	/**
 	 * get the next job in the list

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -72,7 +72,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 		return $this->jobs;
 	}
 
-	public function getJobs($job, ?int $limit, int $offset): array {
+	public function getJobsIterator($job, ?int $limit, int $offset): array {
 		if ($job instanceof IJob) {
 			$jobClass = get_class($job);
 		} else {

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -54,7 +54,7 @@ class JobListTest extends TestCase {
 	}
 
 	protected function getAllSorted() {
-		$iterator = $this->instance->getJobs(null, null, 0);
+		$iterator = $this->instance->getJobsIterator(null, null, 0);
 		$jobs = [];
 
 		foreach ($iterator as $job) {

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -54,7 +54,12 @@ class JobListTest extends TestCase {
 	}
 
 	protected function getAllSorted() {
-		$jobs = $this->instance->getAll();
+		$iterator = $this->instance->getJobs(null, null, 0);
+		$jobs = [];
+
+		foreach ($iterator as $job) {
+			$jobs[] = clone $job;
+		}
 
 		usort($jobs, function (IJob $job1, IJob $job2) {
 			return $job1->getId() - $job2->getId();


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

* Resolves: #35993 

## Summary

Job instances are singleton, so it is not possible to group them together in an array without getting corrupted data with several times the same id.
So instead I use a generator which is also better for memory consumption.

This breaks API for getJobs introduced in 25 by making it return a Generator instead of an array. Code calling can type that as iterable and only use foreach on it to be compatible with both 25 and 26.
This also breaks getAll as it calls getJobs, I would favor removing getAll because it is both broken and deprecated.

## TODO

- [x] Decide what to do with getAll
- [x] Fix tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
