### PR TITLE
Add support for s3 storage classes

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -47,6 +47,8 @@ class AmazonS3 extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('region', $l->t('Region')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('storageClass', $l->t('Storage Class')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -583,7 +583,8 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				$this->getConnection()->copyObject([
 					'Bucket' => $this->bucket,
 					'Key' => $this->cleanKey($target),
-					'CopySource' => S3Client::encodeKey($this->bucket . '/' . $source)
+					'CopySource' => S3Client::encodeKey($this->bucket . '/' . $source),
+					'StorageClass' => $this->storageClass,
 				]);
 				$this->testTimeout();
 			} catch (S3Exception $e) {

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -62,6 +62,9 @@ trait S3ConnectionTrait {
 	/** @var string */
 	protected $proxy;
 
+	/** @var string */
+	protected $storageClass;
+
 	/** @var int */
 	protected $uploadPartSize;
 
@@ -81,6 +84,7 @@ trait S3ConnectionTrait {
 		$this->bucket = $params['bucket'];
 		$this->proxy = $params['proxy'] ?? false;
 		$this->timeout = $params['timeout'] ?? 15;
+		$this->storageClass = !empty($params['storageClass']) ? $params['storageClass'] : 'STANDARD';
 		$this->uploadPartSize = $params['uploadPartSize'] ?? 524288000;
 		$this->putSizeLimit = $params['putSizeLimit'] ?? 104857600;
 		$params['region'] = empty($params['region']) ? 'eu-west-1' : $params['region'];

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -105,6 +105,7 @@ trait S3ObjectTrait {
 			'Body' => $stream,
 			'ACL' => 'private',
 			'ContentType' => $mimetype,
+			'StorageClass' => $this->storageClass,
 		]);
 	}
 
@@ -123,7 +124,8 @@ trait S3ObjectTrait {
 			'key' => $urn,
 			'part_size' => $this->uploadPartSize,
 			'params' => [
-				'ContentType' => $mimetype
+				'ContentType' => $mimetype,
+				'StorageClass' => $this->storageClass,
 			],
 		]);
 


### PR DESCRIPTION
* Resolves: #14031

## Summary

This add support for s3 storage class in both primary objectstore and *External Storage* (*files_external*) application.

## TODO

- [ ] Traductions for `files_external` app manually done for english (not sure that should be done manually) but not for other languages                                                                          
- [ ] Unit tests? (not sure how to test it)                                                                                                                                                                            
- [ ] Documentation                                                                                                                                                                                               
  - [ ] https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_files/primary_storage.rst#simple-storage-service-s3                                                                     
  - [ ] https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_files/external_storage/amazons3.rst

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)                                                                      
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits                                                                                           
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included                                                                                                                                              
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
