### PR TITLE
Ext storage configs default value support + enable SSL by default

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1054,6 +1054,14 @@ MountConfigListView.prototype = _.extend({
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 
+		if (placeholder.defaultValue) {
+			if (placeholder.type === MountConfigListView.ParameterTypes.BOOLEAN) {
+				newElement.find('input').prop('checked', placeholder.defaultValue);
+			} else {
+				newElement.val(placeholder.defaultValue);
+			}
+		}
+
 		if (placeholder.tooltip) {
 			newElement.attr('title', placeholder.tooltip);
 		}

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -48,7 +48,8 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('region', $l->t('Region')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))

--- a/apps/files_external/lib/Lib/Backend/DAV.php
+++ b/apps/files_external/lib/Lib/Backend/DAV.php
@@ -43,7 +43,8 @@ class DAV extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure https://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -43,7 +43,8 @@ class FTP extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure ftps://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/Backend/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Backend/OwnCloud.php
@@ -41,7 +41,8 @@ class OwnCloud extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure https://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/DefinitionParameter.php
+++ b/apps/files_external/lib/Lib/DefinitionParameter.php
@@ -43,40 +43,45 @@ class DefinitionParameter implements \JsonSerializable {
 	public const FLAG_USER_PROVIDED = 2;
 
 	/** @var string name of parameter */
-	private $name;
+	private string $name;
 
 	/** @var string human-readable parameter text */
-	private $text;
+	private string $text;
 
 	/** @var string human-readable parameter tooltip */
-	private $tooltip = '';
+	private string $tooltip = '';
 
 	/** @var int value type, see self::VALUE_* constants */
-	private $type = self::VALUE_TEXT;
+	private int $type = self::VALUE_TEXT;
 
 	/** @var int flags, see self::FLAG_* constants */
-	private $flags = self::FLAG_NONE;
+	private int $flags = self::FLAG_NONE;
+
+	/** @var mixed */
+	private $defaultValue;
 
 	/**
-	 * @param string $name
-	 * @param string $text
+	 * @param string $name parameter name
+	 * @param string $text parameter description
+	 * @param mixed $defaultValue default value
 	 */
-	public function __construct($name, $text) {
+	public function __construct(string $name, string $text, $defaultValue = null) {
 		$this->name = $name;
 		$this->text = $text;
+		$this->defaultValue = $defaultValue;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->name;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getText() {
+	public function getText(): string {
 		return $this->text;
 	}
 
@@ -85,7 +90,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 *
 	 * @return int
 	 */
-	public function getType() {
+	public function getType(): int {
 		return $this->type;
 	}
 
@@ -95,15 +100,31 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @param int $type
 	 * @return self
 	 */
-	public function setType($type) {
+	public function setType(int $type) {
 		$this->type = $type;
+		return $this;
+	}
+
+	/**
+	 * @return mixed default value
+	 */
+	public function getDefaultValue() {
+		return $this->defaultValue;
+	}
+
+	/**
+	 * @param mixed $defaultValue default value
+	 * @return self
+	 */
+	public function setDefaultValue($defaultValue) {
+		$this->defaultValue = $defaultValue;
 		return $this;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getTypeName() {
+	public function getTypeName(): string {
 		switch ($this->type) {
 			case self::VALUE_BOOLEAN:
 				return 'boolean';
@@ -119,7 +140,7 @@ class DefinitionParameter implements \JsonSerializable {
 	/**
 	 * @return int
 	 */
-	public function getFlags() {
+	public function getFlags(): int {
 		return $this->flags;
 	}
 
@@ -127,7 +148,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @param int $flags
 	 * @return self
 	 */
-	public function setFlags($flags) {
+	public function setFlags(int $flags) {
 		$this->flags = $flags;
 		return $this;
 	}
@@ -136,7 +157,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @param int $flag
 	 * @return self
 	 */
-	public function setFlag($flag) {
+	public function setFlag(int $flag) {
 		$this->flags |= $flag;
 		return $this;
 	}
@@ -145,7 +166,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @param int $flag
 	 * @return bool
 	 */
-	public function isFlagSet($flag) {
+	public function isFlagSet(int $flag): bool {
 		return (bool)($this->flags & $flag);
 	}
 
@@ -169,15 +190,20 @@ class DefinitionParameter implements \JsonSerializable {
 	 * Serialize into JSON for client-side JS
 	 */
 	public function jsonSerialize(): array {
-		return [
+		$result = [
 			'value' => $this->getText(),
 			'flags' => $this->getFlags(),
 			'type' => $this->getType(),
 			'tooltip' => $this->getTooltip(),
 		];
+		$defaultValue = $this->getDefaultValue();
+		if ($defaultValue) {
+			$result['defaultValue'] = $defaultValue;
+		}
+		return $result;
 	}
 
-	public function isOptional() {
+	public function isOptional(): bool {
 		return $this->isFlagSet(self::FLAG_OPTIONAL) || $this->isFlagSet(self::FLAG_USER_PROVIDED);
 	}
 
@@ -188,7 +214,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @param mixed $value Value to check
 	 * @return bool success
 	 */
-	public function validateValue(&$value) {
+	public function validateValue(&$value): bool {
 		switch ($this->getType()) {
 			case self::VALUE_BOOLEAN:
 				if (!is_bool($value)) {

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -47,6 +47,7 @@ class DefinitionParameterTest extends \Test\TestCase {
 
 		$param->setType(Param::VALUE_PASSWORD);
 		$param->setFlag(Param::FLAG_OPTIONAL);
+		$param->setDefaultValue(null);
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => Param::FLAG_OPTIONAL,

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -36,11 +36,13 @@ class DefinitionParameterTest extends \Test\TestCase {
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_BOOLEAN);
+		$param->setDefaultValue(true);
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => 0,
 			'type' => Param::VALUE_BOOLEAN,
 			'tooltip' => '',
+			'defaultValue' => true,
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_PASSWORD);


### PR DESCRIPTION
## Summary

- Extend the external storage configuration parameters definition to allow to specify a default value
- Enable SSL by default in external storage configurations (at creation time)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required => seems there is no doc at all about writing ext storages, so skipping for now
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) => not needed?
