### PR TITLE
Only expose storage location to admins

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -104,6 +104,7 @@ abstract class AUserData extends OCSController {
 	 */
 	protected function getUserData(string $userId, bool $includeScopes = false): array {
 		$currentLoggedInUser = $this->userSession->getUser();
+		assert($currentLoggedInUser !== null, 'No user logged in');
 
 		$data = [];
 
@@ -113,8 +114,8 @@ abstract class AUserData extends OCSController {
 			throw new OCSNotFoundException('User does not exist');
 		}
 
-		// Should be at least Admin Or SubAdmin!
-		if ($this->groupManager->isAdmin($currentLoggedInUser->getUID())
+		$isAdmin = $this->groupManager->isAdmin($currentLoggedInUser->getUID());
+		if ($isAdmin
 			|| $this->groupManager->getSubAdmin()->isUserAccessible($currentLoggedInUser, $targetUserObject)) {
 			$data['enabled'] = $this->config->getUserValue($targetUserObject->getUID(), 'core', 'enabled', 'true') === 'true';
 		} else {
@@ -132,13 +133,15 @@ abstract class AUserData extends OCSController {
 			$gids[] = $group->getGID();
 		}
 
-		try {
-			# might be thrown by LDAP due to handling of users disappears
-			# from the external source (reasons unknown to us)
-			# cf. https://github.com/nextcloud/server/issues/12991
-			$data['storageLocation'] = $targetUserObject->getHome();
-		} catch (NoUserException $e) {
-			throw new OCSNotFoundException($e->getMessage(), $e);
+		if ($isAdmin) {
+			try {
+				# might be thrown by LDAP due to handling of users disappears
+				# from the external source (reasons unknown to us)
+				# cf. https://github.com/nextcloud/server/issues/12991
+				$data['storageLocation'] = $targetUserObject->getHome();
+			} catch (NoUserException $e) {
+				throw new OCSNotFoundException($e->getMessage(), $e);
+			}
 		}
 
 		// Find the data

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1165,9 +1165,8 @@ class UsersControllerTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('Demo User');
 		$targetUser
-			->expects($this->once())
-			->method('getHome')
-			->willReturn('/var/www/newtcloud/data/UID');
+			->expects($this->never())
+			->method('getHome');
 		$targetUser
 			->expects($this->once())
 			->method('getLastLogin')
@@ -1206,7 +1205,6 @@ class UsersControllerTest extends TestCase {
 		$expected = [
 			'id' => 'UID',
 			'enabled' => true,
-			'storageLocation' => '/var/www/newtcloud/data/UID',
 			'lastLogin' => 1521191471000,
 			'backend' => 'Database',
 			'subadmin' => [],
@@ -1349,9 +1347,8 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('UID');
 		$targetUser
-			->expects($this->once())
-			->method('getHome')
-			->willReturn('/var/www/newtcloud/data/UID');
+			->expects($this->never())
+			->method('getHome');
 		$targetUser
 			->expects($this->once())
 			->method('getLastLogin')
@@ -1385,7 +1382,6 @@ class UsersControllerTest extends TestCase {
 
 		$expected = [
 			'id' => 'UID',
-			'storageLocation' => '/var/www/newtcloud/data/UID',
 			'lastLogin' => 1521191471000,
 			'backend' => 'Database',
 			'subadmin' => [],


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) => unsure
