### PR TITLE
Extend ViewOnly DAV plugin to versions endpoint

### DIFF
--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -23,6 +23,7 @@ namespace OCA\DAV\DAV;
 
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File as DavFile;
+use OCA\Files_Versions\Sabre\VersionFile;
 use OCP\Files\NotFoundException;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Server;
@@ -70,11 +71,14 @@ class ViewOnlyPlugin extends ServerPlugin {
 		try {
 			assert($this->server !== null);
 			$davNode = $this->server->tree->getNodeForPath($path);
-			if (!($davNode instanceof DavFile)) {
+			if ($davNode instanceof DavFile) {
+				// Restrict view-only to nodes which are shared
+				$node = $davNode->getNode();
+			} else if ($davNode instanceof VersionFile) {
+				$node = $davNode->getVersion()->getSourceFile();
+			} else {
 				return true;
 			}
-			// Restrict view-only to nodes which are shared
-			$node = $davNode->getNode();
 
 			$storage = $node->getStorage();
 


### PR DESCRIPTION
## Summary

Applies the ViewOnly DAV plugin also to the versions DAV endpoint

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
