### PR TITLE
perf(autoloader): Drop legacy class autoloader

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -298,8 +298,6 @@ class OC_App {
 			require_once $path . '/composer/autoload.php';
 		} else {
 			\OC::$composerAutoloader->addPsr4($appNamespace . '\\', $path . '/lib/', true);
-			// Register on legacy autoloader
-			\OC::$loader->addValidRoot($path);
 		}
 
 		// Register Test namespace only when testing


### PR DESCRIPTION
* Resolves: n/a

## Summary

The documentation says apps should use PSR-4 to get their classes loaded. The legacy PSR-0 is still in place and has a negative impact on performance.

1) PSR-4 autoloading was introduced in https://github.com/owncloud/core/pull/24386
2) App autoloader support was added in https://github.com/nextcloud/server/pull/6853
3) Our documentation says app should use PSR-4 https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/classloader.html. PSR-0 (legacy) is not even mentioned.

PSR-0 was deprecated in 2014: https://www.php-fig.org/psr/psr-0/. Our docs also list it as deprecated: https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/psr.html#psr-0-autoloading

This is a hard breaking change for the apps that have not yet been upgraded to PSR-4. Therefore I would suggest to warn about this in the 26 upgrade docs and drop the loader only with Nextcloud 27 or later. @AndyScherzinger @PVince81 your call.

## Benchmarks

``time for i in `seq 1 100`; do php occ; done``

### Before

real    0m53,323s
user    0m46,178s
sys     0m6,851s

### After

real    0m49,161s
user    0m42,581s
sys     0m6,555s

^ that is 7.8% speedup for a generic Nextcloud process

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  * https://github.com/nextcloud/documentation/pull/10231
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
