### PR TITLE
Catch Exceptions when loading storage data of users

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -277,6 +277,8 @@ abstract class AUserData extends OCSController {
 					'exception' => $e,
 				]
 			);
+			/* In case the Exception left things in a bad state */
+			\OC_Util::tearDownFS();
 			return [];
 		}
 		return $data;

--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -268,6 +268,16 @@ abstract class AUserData extends OCSController {
 				self::USER_FIELD_QUOTA => $quota !== false ? $quota : 'none',
 				'used' => 0
 			];
+		} catch (\Exception $e) {
+			\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+				"Could not load storage info for {user}",
+				[
+					'app' => 'provisioning_api',
+					'user' => $userId,
+					'exception' => $e,
+				]
+			);
+			return [];
 		}
 		return $data;
 	}


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>

## Summary

This avoids having the whole userlist crashing because a user external
 storage fails to load. With this change only the problematic user
 storage/quota information will be empty.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
