### PR TITLE
lock closed issues after 14 days

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,20 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with: 
+          issue-inactive-days: '14'
+          process-only: 'issues'


### PR DESCRIPTION
Motivation: The idea is to decrease the notification spam on already closed issues that sometimes happens if people think they have the same issue even though the issue is already closed. People should rather create a new bug report in that case with up-to-date information.

The issue-inactive-days property is set to 14 so that issues only get locked if they were inactive for a timespan bigger than 14 days after closing it, which means that if someone comments in an interval of 13 days, the issue will never get locked.

Note that maintainers still can always comment.