### PR TITLE
Fix calendar emails to be outlook compatible

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -285,14 +285,12 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$message->useTemplate($template);
 
-		$vCalendar = $this->imipService->generateVCalendar($iTipMessage, $vEvent);
-
-		$attachment = $this->mailer->createAttachment(
-			$vCalendar->serialize(),
+		$itip_msg = $iTipMessage->message->serialize();
+		$message->attachInline(
+				$itip_msg,
 			'event.ics',
-			'text/calendar; method=' . $iTipMessage->method
+				'text/calendar; method=' . $iTipMessage->method,
 		);
-		$message->attach($attachment);
 
 		try {
 			$failed = $this->mailer->send($message);

--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -76,6 +76,22 @@ class Message implements IMessage {
 	}
 
 	/**
+	 * Can be used to "attach content inline" as message parts with specific MIME type and encoding.
+	 * {@inheritDoc}
+	 * @since 26.0.0
+	 */
+	public function attachInline(string $body, string $name, string $contentType = null): IMessage {
+		# To be sure this works with iCalendar messages, we encode with 8bit instead of
+		# quoted-printable encoding. We save the current encoder, replace the current
+		# encoder with an 8bit encoder and after we've finished, we reset the encoder
+		# to the previous one. Originally intended to be added after the message body,
+		# as it is curently unknown if all mail clients handle this properly if added
+		# before.
+		$this->symfonyEmail->embed($body, $name, $contentType);
+		return $this;
+	}
+
+	/**
 	 * Converts the [['displayName' => 'email'], ['displayName2' => 'email2']] arrays to valid Adresses
 	 *
 	 * @param array $addresses Array of mail addresses

--- a/lib/public/Mail/IMessage.php
+++ b/lib/public/Mail/IMessage.php
@@ -40,6 +40,18 @@ interface IMessage {
 	public function attach(IAttachment $attachment): IMessage;
 
 	/**
+	 * Can be used to "attach content inline" as message parts with specific MIME type and encoding.
+	 *
+	 * @param string $body body of the MIME part
+	 * @param string $name the file name
+	 * @param string|null $contentType MIME Content-Type (e.g. text/plain or text/calendar)
+	 *
+	 * @return IMessage
+	 * @since 26.0.0
+	 */
+	public function attachInline(string $body, string $name, string $contentType = null): IMessage;
+
+	/**
 	 * Set the from address of this message.
 	 *
 	 * If no "From" address is used \OC\Mail\Mailer will use mail_from_address and mail_domain from config.php


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/12885

## Summary

Resubmit and formatted version of https://github.com/nextcloud/server/pull/34324

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
