### PR TITLE
normalize userid in user:setting

### DIFF
--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -113,9 +113,14 @@ class Setting extends Base {
 	}
 
 	protected function checkInput(InputInterface $input) {
-		$uid = $input->getArgument('uid');
-		if (!$input->getOption('ignore-missing-user') && !$this->userManager->userExists($uid)) {
-			throw new \InvalidArgumentException('The user "' . $uid . '" does not exist.');
+		if (!$input->getOption('ignore-missing-user')) {
+			$uid = $input->getArgument('uid');
+			$user = $this->userManager->get($uid);
+			if (!$user) {
+				throw new \InvalidArgumentException('The user "' . $uid . '" does not exist.');
+			}
+			// normalize uid
+			$input->setArgument('uid', $user->getUID());
 		}
 
 		if ($input->getArgument('key') === '' && $input->hasParameterOption('--default-value')) {


### PR DESCRIPTION
Currently using the `occ user:setting` with userid using the wrong casing can lead to unexpected behavior, as trying to set a value will appear to work, but the preference entry with the wrongly cased userid will never be used.

Normalizing the uid parameter avoid accidental errors by the admin