### PR TITLE
feat(CI): Enforce colored output for behat on drone CI

### DIFF
--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -60,7 +60,7 @@ if [ "$INSTALLED" == "true" ]; then
 
 fi
 
-vendor/bin/behat --strict -f junit -f pretty $TAGS $SCENARIO_TO_RUN
+vendor/bin/behat --strict --colors -f junit -f pretty $TAGS $SCENARIO_TO_RUN
 RESULT=$?
 
 kill $PHPPID


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>


* Resolves: # <!-- related github issue -->

## Summary

Drone supports colored output, but the way we invoke behat it assumes it does not. But specifying the `--colors` option allows this.
Heavily improves debugging failed tests. Utilizing this in talk since last week: https://drone.nextcloud.com/nextcloud/spreed/11213/5/4

## Screenshots

![Bildschirmfoto vom 2023-01-12 21-51-15](https://user-images.githubusercontent.com/213943/212178680-223930be-bba3-4b2f-9dd6-ca31db533d6c.png)
![Bildschirmfoto vom 2023-01-12 21-50-56](https://user-images.githubusercontent.com/213943/212178675-485d8f92-8132-4818-9183-7e6abff77764.png)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
