### PR TITLE
Invalidate share mount cache when renaming

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -137,8 +137,6 @@ class SharedMount extends MountPoint implements MoveableMount {
 			$this->updateFileTarget($newMountPoint, $share);
 		}
 
-		$this->cache->set($cacheKey, $newMountPoint, 60 * 60);
-
 		return $newMountPoint;
 	}
 
@@ -158,6 +156,9 @@ class SharedMount extends MountPoint implements MoveableMount {
 		}
 
 		$this->eventDispatcher->dispatchTyped(new InvalidateMountCacheEvent($this->user));
+
+		$cacheKey = $this->user->getUID() . '/' . $share->getId();
+		$this->cache->set($cacheKey, $newPath, 60 * 60);
 	}
 
 


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

## Notes

It is still unclear why it worked before, which means this fix might be the wrong approach.