### PR TITLE
fix(PHP8.2): Declare Symfony Application property in console application

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -49,6 +49,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class Application {
 	/** @var IConfig */
 	private $config;
+	private SymfonyApplication $application;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 	/** @var IRequest */


### PR DESCRIPTION
* Resolves: ``"Creation of dynamic property OC\\Console\\Application::$application is deprecated at nextcloud/lib/private/Console/Application.php#68``

## Summary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
