### PR TITLE
Use a PHP implementation of openssl_seal that allows to use modern ciphers

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -6,13 +6,14 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
  * @author Joas Schilling <coding@schilljs.com>
+ * @author Kevin Niehage <kevin@niehage.name>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Stefan Weiberg <sweiberg@suse.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Kevin Niehage <kevin@niehage.name>
  *
  * @license AGPL-3.0
  *
@@ -761,8 +762,9 @@ class Crypt {
 	/**
 	 * Uses phpseclib RC4 implementation
 	 */
-	protected function rc4Decrypt(string $data, string $secret): string {
+	private function rc4Decrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
+		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->decrypt($data);
@@ -771,21 +773,21 @@ class Crypt {
 	/**
 	 * Uses phpseclib RC4 implementation
 	 */
-	protected function rc4Encrypt(string $data, string $secret): string {
+	private function rc4Encrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
+		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->encrypt($data);
 	}
 
 	/**
-	 * wraps openssl_open() for cases where RC4 is not supported by OpenSSL v3
-	 * and replaces it with a custom implementation where necessary
+	 * Custom implementation of openssl_open()
 	 *
 	 * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $private_key
 	 * @throws DecryptionFailedException
 	 */
-	public function opensslOpen(string $data, string &$output, string $encrypted_key, $private_key, string $cipher_algo): bool {
+	private function opensslOpen(string $data, string &$output, string $encrypted_key, $private_key, string $cipher_algo): bool {
 		$result = false;
 
 		// check if RC4 is used
@@ -809,7 +811,7 @@ class Crypt {
 	 *
 	 * @throws EncryptionFailedException
 	 */
-	public function opensslSeal(string $data, string &$sealed_data, array &$encrypted_keys, array $public_key, string $cipher_algo): int|false {
+	private function opensslSeal(string $data, string &$sealed_data, array &$encrypted_keys, array $public_key, string $cipher_algo): int|false {
 		$result = false;
 
 		// check if RC4 is used


### PR DESCRIPTION
Follow-up on https://github.com/nextcloud/server/pull/35916

## Summary

PHP `openssl_seal` do not support any cipher.
We currently use rc4 which is not available with modern openssl version and default configuration.
Using our own implementation for openssl_seal allows:

- As a first step to still be able to read rc4 on modern system, to be able to read encrypted data from previous versions without turning on legacy ciphers
- To move to a more modern cipher instead of rc4 for new data, ideally one with an auth tag like AES-256-GCM
- Things should be made so it’s easy to switch again in the future to something more modern when needed. Encryption ciphers will always keep evolving.

## TODO

- [x] Strong type
- [x] Replace rc4 custom implementation by call to seclib
- [x] Remove fallback to php openssl_seal, always use the same implementation
- [ ] Add support for newer cipher (may be done in followup PR)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
