### PR TITLE
[stable23] Ext storage configs default value support + enable SSL by default

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1021,6 +1021,14 @@ MountConfigListView.prototype = _.extend({
 			newElement = $('<input type="text" class="'+classes.join(' ')+'" data-parameter="'+parameter+'" placeholder="'+ trimmedPlaceholder+'" />');
 		}
 
+		if (placeholder.defaultValue) {
+			if (placeholder.type === MountConfigListView.ParameterTypes.BOOLEAN) {
+				newElement.find('input').prop('checked', placeholder.defaultValue);
+			} else {
+				newElement.val(placeholder.defaultValue);
+			}
+		}
+
 		if (placeholder.tooltip) {
 			newElement.attr('title', placeholder.tooltip);
 		}

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -47,7 +47,8 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('region', $l->t('Region')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('use_ssl', $l->t('Enable SSL')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 				(new DefinitionParameter('use_path_style', $l->t('Enable Path Style')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))

--- a/apps/files_external/lib/Lib/Backend/DAV.php
+++ b/apps/files_external/lib/Lib/Backend/DAV.php
@@ -43,7 +43,8 @@ class DAV extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure https://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -43,7 +43,8 @@ class FTP extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure ftps://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/Backend/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Backend/OwnCloud.php
@@ -41,7 +41,8 @@ class OwnCloud extends Backend {
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure https://')))
-					->setType(DefinitionParameter::VALUE_BOOLEAN),
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 			->setLegacyAuthMechanism($legacyAuth)

--- a/apps/files_external/lib/Lib/DefinitionParameter.php
+++ b/apps/files_external/lib/Lib/DefinitionParameter.php
@@ -57,13 +57,18 @@ class DefinitionParameter implements \JsonSerializable {
 	/** @var int flags, see self::FLAG_* constants */
 	private $flags = self::FLAG_NONE;
 
+	/** @var mixed */
+	private $defaultValue;
+
 	/**
-	 * @param string $name
-	 * @param string $text
+	 * @param string $name parameter name
+	 * @param string $text parameter description
+	 * @param mixed $defaultValue default value
 	 */
-	public function __construct($name, $text) {
+	public function __construct($name, $text, $defaultValue = null) {
 		$this->name = $name;
 		$this->text = $text;
+		$this->defaultValue = $defaultValue;
 	}
 
 	/**
@@ -97,6 +102,22 @@ class DefinitionParameter implements \JsonSerializable {
 	 */
 	public function setType($type) {
 		$this->type = $type;
+		return $this;
+	}
+
+	/**
+	 * @return mixed default value
+	 */
+	public function getDefaultValue() {
+		return $this->defaultValue;
+	}
+
+	/**
+	 * @param mixed $defaultValue default value
+	 * @return self
+	 */
+	public function setDefaultValue($defaultValue) {
+		$this->defaultValue = $defaultValue;
 		return $this;
 	}
 
@@ -171,12 +192,17 @@ class DefinitionParameter implements \JsonSerializable {
 	 * @return string
 	 */
 	public function jsonSerialize() {
-		return [
+		$result = [
 			'value' => $this->getText(),
 			'flags' => $this->getFlags(),
 			'type' => $this->getType(),
 			'tooltip' => $this->getTooltip(),
 		];
+		$defaultValue = $this->getDefaultValue();
+		if ($defaultValue) {
+			$result['defaultValue'] = $defaultValue;
+		}
+		return $result;
 	}
 
 	public function isOptional() {

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -47,6 +47,7 @@ class DefinitionParameterTest extends \Test\TestCase {
 
 		$param->setType(Param::VALUE_PASSWORD);
 		$param->setFlag(Param::FLAG_OPTIONAL);
+		$param->setDefaultValue(null);
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => Param::FLAG_OPTIONAL,

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -36,11 +36,13 @@ class DefinitionParameterTest extends \Test\TestCase {
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_BOOLEAN);
+		$param->setDefaultValue(true);
 		$this->assertEquals([
 			'value' => 'bar',
 			'flags' => 0,
 			'type' => Param::VALUE_BOOLEAN,
 			'tooltip' => '',
+			'defaultValue' => true,
 		], $param->jsonSerialize());
 
 		$param->setType(Param::VALUE_PASSWORD);


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/36089 to stable23

- [x] conflicts resolved
- [x] :warning: needs testing, please help! especially that there were conflicts.

stable23 only runs on php < 8.1 and I don't have this available, please help testing as follows:
1. enable ext storage
2. select "FTP"
3. see that "secure" is ticked by default
4. that's it
