### PR TITLE
fix(caldav): Fix reminder timezone drift for all-day events

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -658,7 +658,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
-	 * @return array{id: int, uri: string, '{http://calendarserver.org/ns/}getctag': string, '{http://sabredav.org/ns}sync-token': int, '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set': SupportedCalendarComponentSet, '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp': ScheduleCalendarTransp }|null
+	 * @return array{id: int, uri: string, '{http://calendarserver.org/ns/}getctag': string, '{http://sabredav.org/ns}sync-token': int, '{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set': SupportedCalendarComponentSet, '{urn:ietf:params:xml:ns:caldav}schedule-calendar-transp': ScheduleCalendarTransp, '{urn:ietf:params:xml:ns:caldav}calendar-timezone': ?string }|null
 	 */
 	public function getCalendarById(int $calendarId): ?array {
 		$fields = array_column($this->propertyMap, 0);

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\Tests\unit\CalDAV\Reminder;
 
+use DateTime;
+use DateTimeZone;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Reminder\Backend;
 use OCA\DAV\CalDAV\Reminder\INotificationProvider;
@@ -194,6 +196,87 @@ END:VEVENT
 END:VCALENDAR
 EOD;
 
+	private const CALENDAR_DATA_ONE_TIME = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 4.3.0-alpha.0//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20230203T154600Z
+DTSTAMP:20230203T154602Z
+LAST-MODIFIED:20230203T154602Z
+SEQUENCE:2
+UID:f6a565b6-f9a8-4d1e-9d01-c8dcbe716b7e
+DTSTART;TZID=Europe/Vienna:20230204T090000
+DTEND;TZID=Europe/Vienna:20230204T120000
+STATUS:CONFIRMED
+SUMMARY:TEST
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT1H
+END:VALARM
+END:VEVENT
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOD;
+
+	private const CALENDAR_DATA_ALL_DAY = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//IDN nextcloud.com//Calendar app 4.3.0-alpha.0//EN
+CALSCALE:GREGORIAN
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20230203T113430Z
+DTSTAMP:20230203T113432Z
+LAST-MODIFIED:20230203T113432Z
+SEQUENCE:2
+UID:a163a056-ba26-44a2-8080-955f19611a8f
+DTSTART;VALUE=DATE:20230204
+DTEND;VALUE=DATE:20230205
+STATUS:CONFIRMED
+SUMMARY:TEST
+BEGIN:VALARM
+ACTION:EMAIL
+TRIGGER;RELATED=START:-PT1H
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+	private const PAGO_PAGO_VTIMEZONE_ICS = <<<ICS
+BEGIN:VCALENDAR
+BEGIN:VTIMEZONE
+TZID:Pacific/Pago_Pago
+BEGIN:STANDARD
+TZOFFSETFROM:-1100
+TZOFFSETTO:-1100
+TZNAME:SST
+DTSTART:19700101T000000
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+ICS;
+
+
+	/** @var null|string */
+	private $oldTimezone;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -254,7 +337,7 @@ EOD;
 		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
 			->with()
-			->willReturn(\DateTime::createFromFormat(\DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
 
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
@@ -281,7 +364,7 @@ EOD;
 		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
 			->with()
-			->willReturn(\DateTime::createFromFormat(\DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
 
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
@@ -304,8 +387,7 @@ EOD;
 
 		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
-			->with()
-			->willReturn(\DateTime::createFromFormat(\DateTime::ATOM, '2016-06-29T00:00:00+00:00'));
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-29T00:00:00+00:00'));
 
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
@@ -324,6 +406,60 @@ EOD;
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
 
+	public function testOnCalendarObjectCreateAllDayWithoutTimezone(): void {
+		$objectData = [
+			'calendardata' => self::CALENDAR_DATA_ALL_DAY,
+			'id' => '42',
+			'calendarid' => '1337',
+			'component' => 'vevent',
+		];
+		$this->timeFactory->expects($this->once())
+			->method('getDateTime')
+			->with()
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2023-02-03T13:28:00+00:00'));
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarById')
+			->with(1337)
+			->willReturn([
+				'{urn:ietf:params:xml:ns:caldav}calendar-timezone' => null,
+			]);
+
+		// One hour before midnight relative to the server's time
+		$expectedReminderTimstamp = (new DateTime('2023-02-03T23:00:00'))->getTimestamp();
+		$this->backend->expects(self::once())
+			->method('insertReminder')
+			->with(1337, 42, self::anything(), false, 1675468800, false, self::anything(), self::anything(), 'EMAIL', true, $expectedReminderTimstamp, false);
+
+		$this->reminderService->onCalendarObjectCreate($objectData);
+	}
+
+	public function testOnCalendarObjectCreateAllDayWithTimezone(): void {
+		$objectData = [
+			'calendardata' => self::CALENDAR_DATA_ALL_DAY,
+			'id' => '42',
+			'calendarid' => '1337',
+			'component' => 'vevent',
+		];
+		$this->timeFactory->expects($this->once())
+			->method('getDateTime')
+			->with()
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2023-02-03T13:28:00+00:00'));
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarById')
+			->with(1337)
+			->willReturn([
+				'{urn:ietf:params:xml:ns:caldav}calendar-timezone' => self::PAGO_PAGO_VTIMEZONE_ICS,
+			]);
+
+		// One hour before midnight relative to the timezone
+		$expectedReminderTimstamp = (new DateTime('2023-02-03T23:00:00', new DateTimeZone('Pacific/Pago_Pago')))->getTimestamp();
+		$this->backend->expects(self::once())
+			->method('insertReminder')
+			->with(1337, 42, 'a163a056-ba26-44a2-8080-955f19611a8f', false, self::anything(), false, self::anything(), self::anything(), 'EMAIL', true, $expectedReminderTimstamp, false);
+
+		$this->reminderService->onCalendarObjectCreate($objectData);
+	}
+
 	public function testOnCalendarObjectCreateRecurringEntryWithRepeat():void {
 		$objectData = [
 			'calendardata' => self::CALENDAR_DATA_RECURRING_REPEAT,
@@ -331,7 +467,12 @@ EOD;
 			'calendarid' => '1337',
 			'component' => 'vevent',
 		];
-
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarById')
+			->with(1337)
+			->willReturn([
+				'{urn:ietf:params:xml:ns:caldav}calendar-timezone' => null,
+			]);
 		$this->backend->expects($this->exactly(6))
 			->method('insertReminder')
 			->withConsecutive(
@@ -343,11 +484,44 @@ EOD;
 				[1337, 42, 'wej2z68l9h', true, 1467849600, false, 'fbdb2726bc0f7dfacac1d881c1453e20', '8996992118817f9f311ac5cc56d1cc97', 'EMAIL', true, 1467158400, false]
 			)
 			->willReturn(1);
-
 		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
 			->with()
-			->willReturn(\DateTime::createFromFormat(\DateTime::ATOM, '2016-06-29T00:00:00+00:00'));
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-29T00:00:00+00:00'));
+
+		$this->reminderService->onCalendarObjectCreate($objectData);
+	}
+
+	public function testOnCalendarObjectCreateWithEventTimezoneAndCalendarTimezone():void {
+		$objectData = [
+			'calendardata' => self::CALENDAR_DATA_ONE_TIME,
+			'id' => '42',
+			'calendarid' => '1337',
+			'component' => 'vevent',
+		];
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarById')
+			->with(1337)
+			->willReturn([
+				'{urn:ietf:params:xml:ns:caldav}calendar-timezone' => self::PAGO_PAGO_VTIMEZONE_ICS,
+			]);
+		$expectedReminderTimstamp = (new DateTime('2023-02-04T08:00:00', new DateTimeZone('Europe/Vienna')))->getTimestamp();
+		$this->backend->expects(self::once())
+			->method('insertReminder')
+			->withConsecutive(
+				[1337, 42, self::anything(), false, self::anything(), false, self::anything(), self::anything(), self::anything(), true, $expectedReminderTimstamp, false],
+			)
+			->willReturn(1);
+		$this->caldavBackend->expects(self::once())
+			->method('getCalendarById')
+			->with(1337)
+			->willReturn([
+				'{urn:ietf:params:xml:ns:caldav}calendar-timezone' => null,
+			]);
+		$this->timeFactory->expects($this->once())
+			->method('getDateTime')
+			->with()
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2023-02-03T13:28:00+00:00'));;
 
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
@@ -487,7 +661,7 @@ EOD;
 		$provider1->expects($this->once())
 			->method('send')
 			->with($this->callback(function ($vevent) {
-				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
+				if ($vevent->DTSTART->getDateTime()->format(DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
 				return true;
@@ -495,7 +669,7 @@ EOD;
 		$provider2->expects($this->once())
 			->method('send')
 			->with($this->callback(function ($vevent) {
-				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
+				if ($vevent->DTSTART->getDateTime()->format(DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
 				return true;
@@ -503,7 +677,7 @@ EOD;
 		$provider3->expects($this->once())
 			->method('send')
 			->with($this->callback(function ($vevent) {
-				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
+				if ($vevent->DTSTART->getDateTime()->format(DateTime::ATOM) !== '2016-06-09T00:00:00+00:00') {
 					return false;
 				}
 				return true;
@@ -511,7 +685,7 @@ EOD;
 		$provider4->expects($this->once())
 			->method('send')
 			->with($this->callback(function ($vevent) {
-				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-06-30T00:00:00+00:00') {
+				if ($vevent->DTSTART->getDateTime()->format(DateTime::ATOM) !== '2016-06-30T00:00:00+00:00') {
 					return false;
 				}
 				return true;
@@ -519,7 +693,7 @@ EOD;
 		$provider5->expects($this->once())
 			->method('send')
 			->with($this->callback(function ($vevent) {
-				if ($vevent->DTSTART->getDateTime()->format(\DateTime::ATOM) !== '2016-07-07T00:00:00+00:00') {
+				if ($vevent->DTSTART->getDateTime()->format(DateTime::ATOM) !== '2016-07-07T00:00:00+00:00') {
 					return false;
 				}
 				return true;
@@ -541,7 +715,7 @@ EOD;
 			->willReturn(99);
 
 		$this->timeFactory->method('getDateTime')
-			->willReturn(\DateTime::createFromFormat(\DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
 
 		$this->reminderService->processReminders();
 	}


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/calendar/issues/4778

## Summary

All day events contain no timezone information. Yet reminders are specified relative to the event start. Each calendar has an optional timezone. If it's set, we should use that to determine the correct UTC timestamp for the reminder. As a fallback we should use UTC.

Ref https://www.rfc-editor.org/rfc/rfc4791#section-5.2.2

>       The CALDAV:calendar-timezone property is used to
>       specify the time zone the server should rely on to resolve "date"
>       values and "date with local time" values (i.e., floating time) to
>       "date with UTC time" values.  The server will require this
>       information to determine if a calendar component scheduled with
>       "date" values or "date with local time" values overlaps a CALDAV:
>       time-range specified in a CALDAV:calendar-query REPORT.

## TODO

- [x] Test all day events when calendar has timezone set
- [x] Test all day events when calendar does not have timezone set
- [x] Test event when calendar has timezone set
- [x] Test event when calendar does not have timezone set

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
