### PR TITLE
fix(search): Fix settings section icon color

### DIFF
--- a/apps/settings/lib/Search/SectionSearch.php
+++ b/apps/settings/lib/Search/SectionSearch.php
@@ -143,7 +143,7 @@ class SectionSearch implements IProvider {
 					$section->getName(),
 					$subline,
 					$this->urlGenerator->linkToRouteAbsolute($routeName, ['section' => $section->getID()]),
-					'icon-settings'
+					'icon-settings-dark'
 				);
 			}
 		}


### PR DESCRIPTION
## Summary

Fix icon color of settings sections in dark mode

Before | After
---|---
![Bildschirmfoto vom 2023-01-18 07-19-50](https://user-images.githubusercontent.com/213943/213099141-c12c2144-4cd2-40f3-af99-182b527d01df.png) | ![Bildschirmfoto vom 2023-01-18 07-17-38](https://user-images.githubusercontent.com/213943/213099131-f20f001b-1986-44bb-8f60-3655020d6afb.png)
![Bildschirmfoto vom 2023-01-18 07-20-03](https://user-images.githubusercontent.com/213943/213099143-8250b7c7-49c0-41ce-be65-61d3d897686d.png) | ![Bildschirmfoto vom 2023-01-18 07-17-55](https://user-images.githubusercontent.com/213943/213099137-17e1ee90-ca9b-4822-928e-9e579bd05038.png)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
