### PR TITLE
fix(dav): check if principal has email address before accessing it

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -617,8 +617,8 @@ class Principal implements BackendInterface {
 	public function getEmailAddressesOfPrincipal(array $principal): array {
 		$emailAddresses = [];
 
-		if (($primaryAddress = $principal['{http://sabredav.org/ns}email-address'])) {
-			$emailAddresses[] = $primaryAddress;
+		if (isset($principal['{http://sabredav.org/ns}email-address'])) {
+			$emailAddresses[] = $principal['{http://sabredav.org/ns}email-address'];
 		}
 
 		if (isset($principal['{DAV:}alternate-URI-set'])) {


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/issues/4811

## Summary

A principal might not have an email address if the user didn't configure one. The existing check is semantically doing the same but throws an exception if the key is missing from the array.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
