### PR TITLE
fix(dav): catch MaxInstancesExceededException for recurring events without end date

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -482,49 +482,54 @@ class ReminderService {
 			return;
 		}
 
-		while ($iterator->valid()) {
-			$event = $iterator->getEventObject();
+		try {
+			while ($iterator->valid()) {
+				$event = $iterator->getEventObject();
 
-			// Recurrence-exceptions are handled separately, so just ignore them here
-			if (\in_array($event, $recurrenceExceptions, true)) {
-				$iterator->next();
-				continue;
-			}
-
-			$recurrenceId = $this->getEffectiveRecurrenceIdOfVEvent($event);
-			if ($reminder['recurrence_id'] >= $recurrenceId) {
-				$iterator->next();
-				continue;
-			}
-
-			foreach ($event->VALARM as $valarm) {
-				/** @var VAlarm $valarm */
-				$alarmHash = $this->getAlarmHash($valarm);
-				if ($alarmHash !== $reminder['alarm_hash']) {
+				// Recurrence-exceptions are handled separately, so just ignore them here
+				if (\in_array($event, $recurrenceExceptions, true)) {
+					$iterator->next();
 					continue;
 				}
 
-				$triggerTime = $valarm->getEffectiveTriggerTime();
-
-				// If effective trigger time is in the past
-				// just skip and generate for next event
-				$diff = $now->diff($triggerTime);
-				if ($diff->invert === 1) {
+				$recurrenceId = $this->getEffectiveRecurrenceIdOfVEvent($event);
+				if ($reminder['recurrence_id'] >= $recurrenceId) {
+					$iterator->next();
 					continue;
 				}
 
-				$this->backend->removeReminder($reminder['id']);
-				$alarms = $this->getRemindersForVAlarm($valarm, [
-					'calendarid' => $reminder['calendar_id'],
-					'id' => $reminder['object_id'],
-				], $reminder['event_hash'], $alarmHash, true, false);
-				$this->writeRemindersToDatabase($alarms);
+				foreach ($event->VALARM as $valarm) {
+					/** @var VAlarm $valarm */
+					$alarmHash = $this->getAlarmHash($valarm);
+					if ($alarmHash !== $reminder['alarm_hash']) {
+						continue;
+					}
 
-				// Abort generating reminders after creating one successfully
-				return;
+					$triggerTime = $valarm->getEffectiveTriggerTime();
+
+					// If effective trigger time is in the past
+					// just skip and generate for next event
+					$diff = $now->diff($triggerTime);
+					if ($diff->invert === 1) {
+						continue;
+					}
+
+					$this->backend->removeReminder($reminder['id']);
+					$alarms = $this->getRemindersForVAlarm($valarm, [
+						'calendarid' => $reminder['calendar_id'],
+						'id' => $reminder['object_id'],
+					], $reminder['event_hash'], $alarmHash, true, false);
+					$this->writeRemindersToDatabase($alarms);
+
+					// Abort generating reminders after creating one successfully
+					return;
+				}
+
+				$iterator->next();
 			}
-
-			$iterator->next();
+		} catch (MaxInstancesExceededException $e) {
+			// Using debug logger as this isn't really an error
+			$this->logger->debug('Recurrence with too many instances detected, skipping VEVENT', ['exception' => $e]);
 		}
 
 		$this->backend->removeReminder($reminder['id']);


### PR DESCRIPTION
* Resolves part of https://github.com/nextcloud/calendar/issues/4811

## Summary

The VEVENT iterator throws a `MaxInstancesExceededException` on recurring events that do not have an end date. This exception should be caught and logged as to not break the reminder service.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration]~~(https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
