### PR TITLE
Handle reminders where calendar name is null

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/INotificationProvider.php
@@ -42,13 +42,13 @@ interface INotificationProvider {
 	 * Send notification
 	 *
 	 * @param VEvent $vevent
-	 * @param string $calendarDisplayName
+	 * @param string|null $calendarDisplayName
 	 * @param string[] $principalEmailAddresses All email addresses associated to the principal owning the calendar object
 	 * @param IUser[] $users
 	 * @return void
 	 */
 	public function send(VEvent $vevent,
-						 string $calendarDisplayName,
+						 ?string $calendarDisplayName,
 						 array  $principalEmailAddresses,
 						 array $users = []): void;
 }

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php
@@ -82,13 +82,13 @@ abstract class AbstractProvider implements INotificationProvider {
 	 * Send notification
 	 *
 	 * @param VEvent $vevent
-	 * @param string $calendarDisplayName
+	 * @param string|null $calendarDisplayName
 	 * @param string[] $principalEmailAddresses
 	 * @param IUser[] $users
 	 * @return void
 	 */
 	abstract public function send(VEvent $vevent,
-						   string $calendarDisplayName,
+						   ?string $calendarDisplayName,
 						   array $principalEmailAddresses,
 						   array $users = []): void;
 
@@ -184,5 +184,9 @@ abstract class AbstractProvider implements INotificationProvider {
 		}
 
 		return clone $vevent->DTSTART;
+	}
+
+	protected function getCalendarDisplayNameFallback(string $lang): string {
+		return $this->getL10NForLang($lang)->t('Untitled calendar');
 	}
 }

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -70,13 +70,13 @@ class EmailProvider extends AbstractProvider {
 	 * Send out notification via email
 	 *
 	 * @param VEvent $vevent
-	 * @param string $calendarDisplayName
+	 * @param string|null $calendarDisplayName
 	 * @param string[] $principalEmailAddresses
 	 * @param array $users
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
-						 string $calendarDisplayName,
+						 ?string $calendarDisplayName,
 						 array $principalEmailAddresses,
 						 array $users = []):void {
 		$fallbackLanguage = $this->getFallbackLanguage();
@@ -115,7 +115,7 @@ class EmailProvider extends AbstractProvider {
 			$template = $this->mailer->createEMailTemplate('dav.calendarReminder');
 			$template->addHeader();
 			$this->addSubjectAndHeading($template, $l10n, $vevent);
-			$this->addBulletList($template, $l10n, $calendarDisplayName, $vevent);
+			$this->addBulletList($template, $l10n, $calendarDisplayName ?? $this->getCalendarDisplayNameFallback($lang), $vevent);
 			$template->addFooter();
 
 			foreach ($emailAddresses as $emailAddress) {

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -73,13 +73,13 @@ class PushProvider extends AbstractProvider {
 	 * Send push notification to all users.
 	 *
 	 * @param VEvent $vevent
-	 * @param string $calendarDisplayName
+	 * @param string|null $calendarDisplayName
 	 * @param string[] $principalEmailAddresses
 	 * @param IUser[] $users
 	 * @throws \Exception
 	 */
 	public function send(VEvent $vevent,
-						 string $calendarDisplayName,
+						 ?string $calendarDisplayName,
 						 array $principalEmailAddresses,
 						 array $users = []):void {
 		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'no') !== 'yes') {
@@ -87,7 +87,6 @@ class PushProvider extends AbstractProvider {
 		}
 
 		$eventDetails = $this->extractEventDetails($vevent);
-		$eventDetails['calendar_displayname'] = $calendarDisplayName;
 		$eventUUID = (string) $vevent->UID;
 		if (!$eventUUID) {
 			return;
@@ -95,6 +94,8 @@ class PushProvider extends AbstractProvider {
 		$eventUUIDHash = hash('sha256', $eventUUID, false);
 
 		foreach ($users as $user) {
+			$eventDetails['calendar_displayname'] = $calendarDisplayName ?? $this->getCalendarDisplayNameFallback($this->l10nFactory->getUserLanguage($user));
+
 			/** @var INotification $notification */
 			$notification = $this->manager->createNotification();
 			$notification->setApp(Application::APP_ID)


### PR DESCRIPTION
This adds an interface change, but that's not a public API. Backports should be acceptable, unless the new string to translate is not.

We're handling this in the providers and not in ReminderService because the fallback is translated with the user's language.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
