### PR TITLE
Add maintenance:repair step for file size of unencrypted files

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -83,6 +83,7 @@ use OC\Repair\RemoveLinkShares;
 use OC\Repair\RepairDavShares;
 use OC\Repair\RepairInvalidShares;
 use OC\Repair\RepairMimeTypes;
+use OC\Repair\RepairUnencryptedSize;
 use OC\Repair\SqliteAutoincrement;
 use OC\Template\JSCombiner;
 use Psr\Log\LoggerInterface;
@@ -176,6 +177,7 @@ class Repair implements IOutput {
 		return [
 			new Collation(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->getDatabaseConnection(), false),
 			new RepairMimeTypes(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
+			new RepairUnencryptedSize(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new MoveUpdaterStepFile(\OC::$server->getConfig()),

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -38,18 +38,17 @@ class RepairUnencryptedSize implements IRepairStep {
 		return 'Repair file size of unencrypted files';
 	}
 
-    /**
+	/**
 	 * Fix unencrypted file size
 	 */
 	public function run(IOutput $output) {
-
-        $update = $this->connection->getQueryBuilder();
+		$update = $this->connection->getQueryBuilder();
 		$update->update('filecache')
 			->set('unencrypted_size', "0")
-			->where($update->expr()->eq('encrypted',"0", IQueryBuilder::PARAM_INT));
+			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT));
 
-        if ($update->execute()) {
-            $output->info('Fixed file size of unencrypted files');
-        }
+		if ($update->execute()) {
+			$output->info('Fixed file size of unencrypted files');
+		}
 	}
 }

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -45,8 +45,8 @@ class RepairUnencryptedSize implements IRepairStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('filecache')
 			->set('unencrypted_size', "0")
-			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT))
-			->andWhere($update->expr()->neq('unencrypted_size', "0", IQueryBuilder::PARAM_INT));
+			->where($update->expr()->gt('unencrypted_size', "0", IQueryBuilder::PARAM_INT))
+			->andWhere($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT));
 
 		if ($update->execute()) {
 			$output->info('Fixed file size of unencrypted files');

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Nextcloud GmbH.
+ *
+ * @author Simon Spannagel <simonspa@kth.se>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Repair;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class RepairUnencryptedSize implements IRepairStep {
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function getName() {
+		return 'Repair file size of unencrypted files';
+	}
+
+    /**
+	 * Fix unencrypted file size
+	 */
+	public function run(IOutput $out) {
+
+        $update = $this->connection->getQueryBuilder();
+		$update->update('filecache')
+			->set('unencrypted_size', 0)
+			->where($update->expr()->eq('encrypted',0, IQueryBuilder::PARAM_INT));
+
+    	$count = $update->execute();
+	}
+}

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -41,13 +41,15 @@ class RepairUnencryptedSize implements IRepairStep {
     /**
 	 * Fix unencrypted file size
 	 */
-	public function run(IOutput $out) {
+	public function run(IOutput $output) {
 
         $update = $this->connection->getQueryBuilder();
 		$update->update('filecache')
-			->set('unencrypted_size', 0)
-			->where($update->expr()->eq('encrypted',0, IQueryBuilder::PARAM_INT));
+			->set('unencrypted_size', "0")
+			->where($update->expr()->eq('encrypted',"0", IQueryBuilder::PARAM_INT));
 
-    	$count = $update->execute();
+        if ($update->execute()) {
+            $output->info('Fixed file size of unencrypted files');
+        }
 	}
 }

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -45,7 +45,8 @@ class RepairUnencryptedSize implements IRepairStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('filecache')
 			->set('unencrypted_size', "0")
-			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT));
+			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT)
+			->andWhere($update->expr()->neq('unencrypted_size', "0", IQueryBuilder::PARAM_INT);
 
 		if ($update->execute()) {
 			$output->info('Fixed file size of unencrypted files');

--- a/lib/private/Repair/RepairUnencryptedSize.php
+++ b/lib/private/Repair/RepairUnencryptedSize.php
@@ -45,8 +45,8 @@ class RepairUnencryptedSize implements IRepairStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('filecache')
 			->set('unencrypted_size', "0")
-			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT)
-			->andWhere($update->expr()->neq('unencrypted_size', "0", IQueryBuilder::PARAM_INT);
+			->where($update->expr()->eq('encrypted', "0", IQueryBuilder::PARAM_INT))
+			->andWhere($update->expr()->neq('unencrypted_size', "0", IQueryBuilder::PARAM_INT));
 
 		if ($update->execute()) {
 			$output->info('Fixed file size of unencrypted files');


### PR DESCRIPTION
* Related: #25283

## Summary

This resets the `unencrypted_size` of files with `encryption = 0` to `0`. As described in the linked issue at length, there seem to be setups that either have or had encryption enabled in the past, where even for unencrypted files the `unencrypted_size` column shows non-zero values.

These seem to completely confuse the quota calculation and result in partially unusable systems because users might have a huge quota usage reported while the actual used size is just a few MB.

## TODO

- [ ] Add tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
