### PR TITLE
Add check config.php for ffmpeg_path in PreviewManager.php. fix for snap no video preview

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1194,7 +1194,7 @@ $CONFIG = [
 /**
  * custom path for ffmpeg binary
  * 
- * Defaults to ``''`` (empty string)
+ * Defaults to ``null`` and falls back to searching ``avconv`` and ``ffmpeg`` in the configured ``PATH`` environment
  */
 'preview_ffmpeg_path' => '/usr/bin/ffmpeg',	
 	

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1190,7 +1190,14 @@ $CONFIG = [
 'preview_office_cl_parameters' =>
 	' --headless --nologo --nofirststartwizard --invisible --norestore '.
 	'--convert-to png --outdir ',
-
+	
+/**
+ * custom path for ffmpeg binary
+ * 
+ * Defaults to ``''`` (empty string)
+ */
+'preview_ffmpeg_path' => '/usr/bin/ffmpeg',	
+	
 /**
  * Set the URL of the Imaginary service to send image previews to.
  * Also requires the ``OC\Preview\Imaginary`` provider to be enabled.

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -417,9 +417,8 @@ class PreviewManager implements IPreview {
 
 		// Video requires avconv or ffmpeg
 		if (in_array(Preview\Movie::class, $this->getEnabledDefaultProvider())) {
-
 			$movieBinary = $this->config->getSystemValue('preview_ffmpeg_path', null);
-			if(!is_string($movieBinary)){
+			if (!is_string($movieBinary)) {
 				$movieBinary = $this->binaryFinder->findBinaryPath('avconv');
 				if (!is_string($movieBinary)) {
 					$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -417,10 +417,15 @@ class PreviewManager implements IPreview {
 
 		// Video requires avconv or ffmpeg
 		if (in_array(Preview\Movie::class, $this->getEnabledDefaultProvider())) {
-			$movieBinary = $this->binaryFinder->findBinaryPath('avconv');
-			if (!is_string($movieBinary)) {
-				$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');
+
+			$movieBinary = $this->config->getSystemValue('preview_ffmpeg_path', null);
+			if(!is_string($movieBinary)){
+				$movieBinary = $this->binaryFinder->findBinaryPath('avconv');
+				if (!is_string($movieBinary)) {
+					$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');
+				}
 			}
+
 
 			if (is_string($movieBinary)) {
 				$this->registerCoreProvider(Preview\Movie::class, '/video\/.*/', ["movieBinary" => $movieBinary]);


### PR DESCRIPTION
add a check in config.php for a configured movieBinary path. so now it first checks in config.php if preview_ffmpeg_path is configured. this makes it possible to install the ffmpeg binary and use it with the previewprovider and get video previews in the snap package.

So to get previews in videos with this fix.
1. adding ffmpeg binary to /var/snap/nextcloud/current/[create dir 'bin']/
2. adding the following line to config.php
```
'preview_ffmpeg_path' => '/var/snap/nextcloud/current/bin/ffmpeg',
```
3. sudo snap restart nextcloud

Signed-off-by: William <william.hak57@gmail.com>


* Resolves:  https://github.com/nextcloud-snap/nextcloud-snap/issues/1046

## Summary


## TODO

- [ ]

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
