### PR TITLE
Specify the profiler app branch to test with

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -41,7 +41,7 @@ jobs:
           blueprint: tests/blueprints/basic.toml
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Run before measurements
-        uses: nextcloud/profiler@fa03a1e6864fcb63fb92b8940fa72f5191baffbe
+        uses: nextcloud/profiler@1e66a9de5f76a01e9d1db4f0153bcc1cbf989b3d
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
@@ -50,6 +50,7 @@ jobs:
             curl -s -u test:test -T README.md http://localhost:8080/remote.php/dav/files/test/new_file.txt
             curl -s -u test:test -X DELETE http://localhost:8080/remote.php/dav/files/test/new_file.txt
           output: before.json
+          profiler-branch: master
 
       - name: Apply PR
         run: |
@@ -62,7 +63,7 @@ jobs:
 
       - name: Run after measurements
         id: compare
-        uses: nextcloud/profiler@fa03a1e6864fcb63fb92b8940fa72f5191baffbe
+        uses: nextcloud/profiler@1e66a9de5f76a01e9d1db4f0153bcc1cbf989b3d
         with:
           run: |
             curl -s -X PROPFIND -u test:test http://localhost:8080/remote.php/dav/files/test
@@ -71,6 +72,7 @@ jobs:
             curl -s -u test:test -T README.md http://localhost:8080/remote.php/dav/files/test/new_file.txt
             curl -s -u test:test -X DELETE http://localhost:8080/remote.php/dav/files/test/new_file.txt
           output: after.json
+          profiler-branch: master
           compare-with: before.json
 
       - name: Upload profiles


### PR DESCRIPTION
So we can test in stable25 with a matching profiler version instead of master

## Summary

* This will allow us to make the performance action green in stable25: https://github.com/nextcloud/server/pull/36246

## TODO

- [ ] https://github.com/nextcloud/profiler/pull/138
- [ ] Update to merge commit sha when ^ is in

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
