### PR TITLE
non-static app_dir

### DIFF
--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -477,16 +477,17 @@ class OC_App {
 	 * search for an app in all app-directories
 	 *
 	 * @param string $appId
+	 * @param bool $ignoreCache ignore cache and rebuild it
 	 * @return false|string
 	 */
-	public static function findAppInDirectories(string $appId) {
+	public static function findAppInDirectories(string $appId, bool $ignoreCache = false) {
 		$sanitizedAppId = self::cleanAppId($appId);
 		if ($sanitizedAppId !== $appId) {
 			return false;
 		}
 		static $app_dir = [];
 
-		if (isset($app_dir[$appId])) {
+		if (isset($app_dir[$appId]) && !$ignoreCache) {
 			return $app_dir[$appId];
 		}
 
@@ -527,15 +528,16 @@ class OC_App {
 	 * @psalm-taint-specialize
 	 *
 	 * @param string $appId
+	 * @param bool $refreshAppPath should be set to true only during install/upgrade
 	 * @return string|false
 	 * @deprecated 11.0.0 use \OC::$server->getAppManager()->getAppPath()
 	 */
-	public static function getAppPath(string $appId) {
+	public static function getAppPath(string $appId, bool $refreshAppPath = false) {
 		if ($appId === null || trim($appId) === '') {
 			return false;
 		}
 
-		if (($dir = self::findAppInDirectories($appId)) != false) {
+		if (($dir = self::findAppInDirectories($appId, $refreshAppPath)) != false) {
 			return $dir['path'] . '/' . $appId;
 		}
 		return false;
@@ -973,7 +975,9 @@ class OC_App {
 	 * @return bool
 	 */
 	public static function updateApp(string $appId): bool {
-		$appPath = self::getAppPath($appId);
+		// for apps distributed with core, we refresh app path in case the downloaded version
+		// have been installed in custom apps and not in the default path
+		$appPath = self::getAppPath($appId, true);
 		if ($appPath === false) {
 			return false;
 		}


### PR DESCRIPTION
Fix https://github.com/nextcloud/related_resources/issues/170
Close https://github.com/nextcloud/server/issues/18673

Should fix https://github.com/nextcloud/all-in-one/discussions/1787#discussioncomment-4710650

There is an edge use case where custom apps folder seems ignored during server upgrade.

When upgrading the server:

- version of apps included with server (bundle) are compared with appstore,
- in case of new versions, last available version is downloaded,
- if custom_apps is used, the downloaded app will be installed in the writable app folder (and not the default app folder),
- unfortunately, upgrade of apps installed in custom_apps are not triggered during this process,
- upgrade finalize and an admin will need to start a second upgrading process to trigger the upgrade of apps downloaded in custom_apps.

While it seems a minor issue because it only require to initiate a second upgrading process, it locks **AIO Nextcloud** because the upgrade cannot be initiated from the webclient (but only by running `./occ upgrade`)

This PR will trigger the upgrading process of the apps installed in custom apps during the upgrading process of the server.
