### PR TITLE
Fix WHERE condition when selecting user's availability for the status…

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -176,7 +176,7 @@ class UserStatusAutomation extends TimedJob {
 			->from('properties')
 			->where($query->expr()->eq('userid', $query->createNamedParameter($userId)))
 			->andWhere($query->expr()->eq('propertypath', $query->createNamedParameter($propertyPath)))
-			->where($query->expr()->eq('propertyname', $query->createNamedParameter($propertyName)))
+			->andWhere($query->expr()->eq('propertyname', $query->createNamedParameter($propertyName)))
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();


### PR DESCRIPTION
… automation

## Summary

Over some time now I noticed that my user status was not toggling correctly with my working schedule.
Since I had quite a "complex" time schedule I assumed the math/checking of IN or OUT is not working.
But after trying to extract my data from our instance to replay it locally, I found the root-cause and it's so much simpler.

Since this is not the first time we have a where-whereOr/whereAnd-where situation, I wonder if we should add some safety net by logging an error when `where` is being used on a query builder while the current where is not empty. But it reduces reusability of QueryBuilder objects (a pattern I dislike anyway 😅)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
