### PR TITLE
fix(querybuilder): Log a warning if where() is called again on a quer…

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -865,6 +865,12 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function where(...$predicates) {
+		if ($this->getQueryPart('where') !== null && $this->systemConfig->getValue('debug', false)) {
+			// Only logging a warning, not throwing for now.
+			$e = new QueryException('Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart(\'where\') first.');
+			$this->logger->warning($e->getMessage(), ['exception' => $e]);
+		}
+
 		call_user_func_array(
 			[$this->queryBuilder, 'where'],
 			$predicates


### PR DESCRIPTION
…y builder object

## Summary

* Ref https://github.com/nextcloud/server/pull/36260
* Since this is not the first time we have a where-whereOr/whereAnd-where situation as a bug, I think it's time to add a safety net by logging a warning (or even an error?) when `where()` is being used on a query builder while the current where is not empty. But it reduces reusability of QueryBuilder objects (a pattern I dislike anyway 😅)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
