### PR TITLE
chore(dav): Add void return type to test methods

### DIFF
--- a/apps/dav/tests/unit/AppInfo/ApplicationTest.php
+++ b/apps/dav/tests/unit/AppInfo/ApplicationTest.php
@@ -35,7 +35,7 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\Unit\AppInfo
  */
 class ApplicationTest extends TestCase {
-	public function test() {
+	public function test(): void {
 		$app = new Application();
 		$c = $app->getContainer();
 

--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -40,7 +40,7 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\Unit\AppInfo
  */
 class PluginManagerTest extends TestCase {
-	public function test() {
+	public function test(): void {
 		$server = $this->createMock(ServerContainer::class);
 
 

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -49,7 +49,7 @@ class AvatarHomeTest extends TestCase {
 	/**
 	 * @dataProvider providesForbiddenMethods
 	 */
-	public function testForbiddenMethods($method) {
+	public function testForbiddenMethods($method): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->home->$method('');
@@ -64,7 +64,7 @@ class AvatarHomeTest extends TestCase {
 		];
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$n = $this->home->getName();
 		self::assertEquals('admin', $n);
 	}
@@ -82,7 +82,7 @@ class AvatarHomeTest extends TestCase {
 	/**
 	 * @dataProvider providesTestGetChild
 	 */
-	public function testGetChild($expectedException, $hasAvatar, $path) {
+	public function testGetChild($expectedException, $hasAvatar, $path): void {
 		if ($expectedException !== null) {
 			$this->expectException($expectedException);
 		}
@@ -95,7 +95,7 @@ class AvatarHomeTest extends TestCase {
 		$this->assertInstanceOf(AvatarNode::class, $avatarNode);
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$avatarNodes = $this->home->getChildren();
 		self::assertEquals(0, count($avatarNodes));
 
@@ -109,7 +109,7 @@ class AvatarHomeTest extends TestCase {
 	/**
 	 * @dataProvider providesTestGetChild
 	 */
-	public function testChildExists($expectedException, $hasAvatar, $path) {
+	public function testChildExists($expectedException, $hasAvatar, $path): void {
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->method('exists')->willReturn($hasAvatar);
 
@@ -118,7 +118,7 @@ class AvatarHomeTest extends TestCase {
 		$this->assertEquals($hasAvatar, $childExists);
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		self::assertNull($this->home->getLastModified());
 	}
 }

--- a/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
@@ -27,14 +27,14 @@ use OCP\IAvatar;
 use Test\TestCase;
 
 class AvatarNodeTest extends TestCase {
-	public function testGetName() {
+	public function testGetName(): void {
 		/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject $a */
 		$a = $this->createMock(IAvatar::class);
 		$n = new AvatarNode(1024, 'png', $a);
 		$this->assertEquals('1024.png', $n->getName());
 	}
 
-	public function testGetContentType() {
+	public function testGetContentType(): void {
 		/** @var IAvatar | \PHPUnit\Framework\MockObject\MockObject $a */
 		$a = $this->createMock(IAvatar::class);
 		$n = new AvatarNode(1024, 'png', $a);

--- a/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
@@ -55,7 +55,7 @@ class CleanupInvitationTokenJobTest extends TestCase {
 			$this->dbConnection, $this->timeFactory);
 	}
 
-	public function testRun() {
+	public function testRun(): void {
 		$this->timeFactory->expects($this->once())
 			->method('getTime')
 			->with()

--- a/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
@@ -63,7 +63,7 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 		);
 	}
 
-	public function testRun() {
+	public function testRun(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -85,7 +85,7 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 		$this->backgroundJob->run(['userId' => 'user123']);
 	}
 
-	public function testRunAndReset() {
+	public function testRunAndReset(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -107,7 +107,7 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 		$this->backgroundJob->run(['userId' => 'user123', 'purgeBeforeGenerating' => true]);
 	}
 
-	public function testRunGloballyDisabled() {
+	public function testRunGloballyDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -122,7 +122,7 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 		$this->backgroundJob->run(['userId' => 'user123']);
 	}
 
-	public function testRunUserDisabled() {
+	public function testRunUserDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')

--- a/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
@@ -73,7 +73,7 @@ class PruneOutdatedSyncTokensJobTest extends TestCase {
 	/**
 	 * @dataProvider dataForTestRun
 	 */
-	public function testRun(string $configValue, int $actualLimit, int $deletedCalendarSyncTokens, int $deletedAddressBookSyncTokens) {
+	public function testRun(string $configValue, int $actualLimit, int $deletedCalendarSyncTokens, int $deletedAddressBookSyncTokens): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with(Application::APP_ID, 'totalNumberOfSyncTokensToKeep', '10000')

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -74,7 +74,7 @@ class RefreshWebcalJobTest extends TestCase {
 	 *
 	 * @dataProvider runDataProvider
 	 */
-	public function testRun(int $lastRun, int $time, bool $process) {
+	public function testRun(int $lastRun, int $time, bool $process): void {
 		$backgroundJob = new RefreshWebcalJob($this->refreshWebcalService, $this->config, $this->logger, $this->timeFactory);
 		$backgroundJob->setId(42);
 

--- a/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RegisterRegenerateBirthdayCalendarsTest.php
@@ -63,10 +63,10 @@ class RegisterRegenerateBirthdayCalendarsTest extends TestCase {
 		);
 	}
 
-	public function testRun() {
+	public function testRun(): void {
 		$this->userManager->expects($this->once())
 			->method('callForSeenUsers')
-			->willReturnCallback(function ($closure) {
+			->willReturnCallback(function ($closure): void {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->willReturn('uid1');
 				$user2 = $this->createMock(IUser::class);

--- a/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJobTest.php
@@ -116,7 +116,7 @@ class UpdateCalendarResourcesRoomsBackgroundJobTest extends TestCase {
 	 *  [backend4, res9, Beamer2, {}] - []
 	 */
 
-	public function testRun() {
+	public function testRun(): void {
 		$this->createTestResourcesInCache();
 
 		$backend2 = $this->createMock(IBackend::class);

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -134,7 +134,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 		parent::tearDown();
 	}
 
-	public function cleanUpBackend() {
+	public function cleanUpBackend(): void {
 		if (is_null($this->backend)) {
 			return;
 		}

--- a/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
@@ -108,11 +108,11 @@ class BackendTest extends TestCase {
 	 * @param string $expectedSubject
 	 * @param array $expectedPayload
 	 */
-	public function testCallTriggerCalendarActivity($method, array $payload, $expectedSubject, array $expectedPayload) {
+	public function testCallTriggerCalendarActivity($method, array $payload, $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerCalendarActivity']);
 		$backend->expects($this->once())
 			->method('triggerCalendarActivity')
-			->willReturnCallback(function () use ($expectedPayload, $expectedSubject) {
+			->willReturnCallback(function () use ($expectedPayload, $expectedSubject): void {
 				$arguments = func_get_args();
 				$this->assertSame($expectedSubject, array_shift($arguments));
 				$this->assertEquals($expectedPayload, $arguments);
@@ -213,7 +213,7 @@ class BackendTest extends TestCase {
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
-	public function testTriggerCalendarActivity($action, array $data, array $shares, array $changedProperties, $currentUser, $author, $shareUsers, array $users) {
+	public function testTriggerCalendarActivity($action, array $data, array $shares, array $changedProperties, $currentUser, $author, $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
 		if ($shareUsers === null) {
@@ -280,7 +280,7 @@ class BackendTest extends TestCase {
 		$this->invokePrivate($backend, 'triggerCalendarActivity', [$action, $data, $shares, $changedProperties]);
 	}
 
-	public function testUserDeletionDoesNotCreateActivity() {
+	public function testUserDeletionDoesNotCreateActivity(): void {
 		$backend = $this->getBackend();
 
 		$this->userManager->expects($this->once())
@@ -347,7 +347,7 @@ class BackendTest extends TestCase {
 	 * @param array $groups
 	 * @param array $expected
 	 */
-	public function testGetUsersForShares(array $shares, array $groups, array $expected) {
+	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 
 		$getGroups = [];

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
@@ -55,7 +55,7 @@ class CalendarTest extends TestCase {
 		);
 	}
 
-	public function testGetIcon() {
+	public function testGetIcon(): void {
 		$this->url->expects($this->once())
 			->method('imagePath')
 			->with('core', 'places/calendar.svg')
@@ -83,7 +83,7 @@ class CalendarTest extends TestCase {
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
-	public function testFilterTypes($types, $expected) {
+	public function testFilterTypes($types, $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -43,7 +43,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testImplementsInterface($filterClass) {
+	public function testImplementsInterface($filterClass): void {
 		$filter = \OC::$server->query($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
@@ -52,7 +52,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testGetIdentifier($filterClass) {
+	public function testGetIdentifier($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$this->assertIsString($filter->getIdentifier());
@@ -62,7 +62,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testGetName($filterClass) {
+	public function testGetName($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$this->assertIsString($filter->getName());
@@ -72,7 +72,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testGetPriority($filterClass) {
+	public function testGetPriority($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$priority = $filter->getPriority();
@@ -85,7 +85,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testGetIcon($filterClass) {
+	public function testGetIcon($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$this->assertIsString($filter->getIcon());
@@ -96,7 +96,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testFilterTypes($filterClass) {
+	public function testFilterTypes($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
@@ -106,7 +106,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataFilters
 	 * @param string $filterClass
 	 */
-	public function testAllowedApps($filterClass) {
+	public function testAllowedApps($filterClass): void {
 		/** @var IFilter $filter */
 		$filter = \OC::$server->query($filterClass);
 		$this->assertIsArray($filter->allowedApps());

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
@@ -54,7 +54,7 @@ class TodoTest extends TestCase {
 		);
 	}
 
-	public function testGetIcon() {
+	public function testGetIcon(): void {
 		$this->url->expects($this->once())
 			->method('imagePath')
 			->with('core', 'actions/checkmark.svg')
@@ -82,7 +82,7 @@ class TodoTest extends TestCase {
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
-	public function testFilterTypes($types, $expected) {
+	public function testFilterTypes($types, $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
@@ -77,7 +77,7 @@ class BaseTest extends TestCase {
 	 * @param array $parameters
 	 * @param string $parsedSubject
 	 */
-	public function testSetSubjects(string $subject, array $parameters, string $parsedSubject) {
+	public function testSetSubjects(string $subject, array $parameters, string $parsedSubject): void {
 		$event = $this->createMock(IEvent::class);
 		$event->expects($this->once())
 			->method('setRichSubject')
@@ -103,7 +103,7 @@ class BaseTest extends TestCase {
 	 * @param array $data
 	 * @param string $name
 	 */
-	public function testGenerateCalendarParameter(array $data, string $name) {
+	public function testGenerateCalendarParameter(array $data, string $name): void {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
 			->method('t')
@@ -130,7 +130,7 @@ class BaseTest extends TestCase {
 	 * @param int $id
 	 * @param string $name
 	 */
-	public function testGenerateLegacyCalendarParameter(int $id, string $name) {
+	public function testGenerateLegacyCalendarParameter(int $id, string $name): void {
 		$this->assertEquals([
 			'type' => 'calendar',
 			'id' => $id,
@@ -149,7 +149,7 @@ class BaseTest extends TestCase {
 	 * @dataProvider dataGenerateGroupParameter
 	 * @param string $gid
 	 */
-	public function testGenerateGroupParameter(string $gid) {
+	public function testGenerateGroupParameter(string $gid): void {
 		$this->assertEquals([
 			'type' => 'user-group',
 			'id' => $gid,

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -107,7 +107,7 @@ class EventTest extends TestCase {
 	 * @param array|null $link
 	 * @param bool $calendarAppEnabled
 	 */
-	public function testGenerateObjectParameter(int $id, string $name, ?array $link, bool $calendarAppEnabled = true) {
+	public function testGenerateObjectParameter(int $id, string $name, ?array $link, bool $calendarAppEnabled = true): void {
 		if ($link) {
 			$generatedLink = [
 				'view' => 'dayGridMonth',
@@ -155,7 +155,7 @@ class EventTest extends TestCase {
 	 * @param mixed $eventData
 	 * @param string $exception
 	 */
-	public function testGenerateObjectParameterThrows($eventData, string $exception = InvalidArgumentException::class) {
+	public function testGenerateObjectParameterThrows($eventData, string $exception = InvalidArgumentException::class): void {
 		$this->expectException($exception);
 
 		$this->invokePrivate($this->provider, 'generateObjectParameter', [$eventData]);

--- a/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
@@ -42,7 +42,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testImplementsInterface($settingClass) {
+	public function testImplementsInterface($settingClass): void {
 		$setting = \OC::$server->query($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
@@ -51,7 +51,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testGetIdentifier($settingClass) {
+	public function testGetIdentifier($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsString($setting->getIdentifier());
@@ -61,7 +61,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testGetName($settingClass) {
+	public function testGetName($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsString($setting->getName());
@@ -71,7 +71,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testGetPriority($settingClass) {
+	public function testGetPriority($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$priority = $setting->getPriority();
@@ -84,7 +84,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testCanChangeStream($settingClass) {
+	public function testCanChangeStream($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
@@ -94,7 +94,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testIsDefaultEnabledStream($settingClass) {
+	public function testIsDefaultEnabledStream($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
@@ -104,7 +104,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testCanChangeMail($settingClass) {
+	public function testCanChangeMail($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
@@ -114,7 +114,7 @@ class GenericTest extends TestCase {
 	 * @dataProvider dataSettings
 	 * @param string $settingClass
 	 */
-	public function testIsDefaultEnabledMail($settingClass) {
+	public function testIsDefaultEnabledMail($settingClass): void {
 		/** @var ISetting $setting */
 		$setting = \OC::$server->query($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledMail());

--- a/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
@@ -69,15 +69,15 @@ class EnablePluginTest extends TestCase {
 		$this->response = $this->createMock(\Sabre\HTTP\ResponseInterface::class);
 	}
 
-	public function testGetFeatures() {
+	public function testGetFeatures(): void {
 		$this->assertEquals(['nc-enable-birthday-calendar'], $this->plugin->getFeatures());
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals('nc-enable-birthday-calendar', $this->plugin->getPluginName());
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		$server = $this->createMock(\Sabre\DAV\Server::class);
 
 		$plugin = new EnablePlugin($this->config, $this->birthdayService);
@@ -89,7 +89,7 @@ class EnablePluginTest extends TestCase {
 		$plugin->initialize($server);
 	}
 
-	public function testHttpPostNoCalendarHome() {
+	public function testHttpPostNoCalendarHome(): void {
 		$calendar = $this->createMock(Calendar::class);
 
 		$this->server->expects($this->once())
@@ -109,7 +109,7 @@ class EnablePluginTest extends TestCase {
 		$this->plugin->httpPost($this->request, $this->response);
 	}
 
-	public function testHttpPostWrongRequest() {
+	public function testHttpPostWrongRequest(): void {
 		$calendarHome = $this->createMock(CalendarHome::class);
 
 		$this->server->expects($this->once())
@@ -130,7 +130,7 @@ class EnablePluginTest extends TestCase {
 
 		$this->server->xml->expects($this->once())
 			->method('parse')
-			->willReturnCallback(function ($requestBody, $url, &$documentType) {
+			->willReturnCallback(function ($requestBody, $url, &$documentType): void {
 				$documentType = '{http://nextcloud.com/ns}disable-birthday-calendar';
 			});
 
@@ -143,7 +143,7 @@ class EnablePluginTest extends TestCase {
 		$this->plugin->httpPost($this->request, $this->response);
 	}
 
-	public function testHttpPost() {
+	public function testHttpPost(): void {
 		$calendarHome = $this->createMock(CalendarHome::class);
 
 		$this->server->expects($this->once())
@@ -168,7 +168,7 @@ class EnablePluginTest extends TestCase {
 
 		$this->server->xml->expects($this->once())
 			->method('parse')
-			->willReturnCallback(function ($requestBody, $url, &$documentType) {
+			->willReturnCallback(function ($requestBody, $url, &$documentType): void {
 				$documentType = '{http://nextcloud.com/ns}enable-birthday-calendar';
 			});
 

--- a/apps/dav/tests/unit/CalDAV/CachedSubscriptionObjectTest.php
+++ b/apps/dav/tests/unit/CalDAV/CachedSubscriptionObjectTest.php
@@ -28,7 +28,7 @@ use OCA\DAV\CalDAV\CachedSubscriptionObject;
 use OCA\DAV\CalDAV\CalDavBackend;
 
 class CachedSubscriptionObjectTest extends \Test\TestCase {
-	public function testGet() {
+	public function testGet(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -52,7 +52,7 @@ class CachedSubscriptionObjectTest extends \Test\TestCase {
 	}
 
 	
-	public function testPut() {
+	public function testPut(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('Creating objects in a cached subscription is not allowed');
 
@@ -72,7 +72,7 @@ class CachedSubscriptionObjectTest extends \Test\TestCase {
 	}
 
 	
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('Deleting objects in a cached subscription is not allowed');
 

--- a/apps/dav/tests/unit/CalDAV/CachedSubscriptionTest.php
+++ b/apps/dav/tests/unit/CalDAV/CachedSubscriptionTest.php
@@ -30,7 +30,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use Sabre\DAV\PropPatch;
 
 class CachedSubscriptionTest extends \Test\TestCase {
-	public function testGetACL() {
+	public function testGetACL(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -64,7 +64,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		], $calendar->getACL());
 	}
 
-	public function testGetChildACL() {
+	public function testGetChildACL(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -93,7 +93,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		], $calendar->getChildACL());
 	}
 
-	public function testGetOwner() {
+	public function testGetOwner(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -106,7 +106,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$this->assertEquals('user1', $calendar->getOwner());
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -123,7 +123,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$calendar->delete();
 	}
 
-	public function testPropPatch() {
+	public function testPropPatch(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -142,7 +142,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 		$this->expectExceptionMessage('Calendar object not found');
 
@@ -176,7 +176,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$calendar->getChild('foo2');
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -207,7 +207,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$this->assertInstanceOf(CachedSubscriptionObject::class, $res[1]);
 	}
 
-	public function testGetMultipleChildren() {
+	public function testGetMultipleChildren(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -239,7 +239,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 	}
 
 
-	public function testCreateFile() {
+	public function testCreateFile(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('Creating objects in cached subscription is not allowed');
 
@@ -255,7 +255,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$calendar->createFile('foo', []);
 	}
 
-	public function testChildExists() {
+	public function testChildExists(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',
@@ -284,7 +284,7 @@ class CachedSubscriptionTest extends \Test\TestCase {
 		$this->assertEquals(false, $calendar->childExists('foo2'));
 	}
 
-	public function testCalendarQuery() {
+	public function testCalendarQuery(): void {
 		$backend = $this->createMock(CalDavBackend::class);
 		$calendarInfo = [
 			'{http://owncloud.org/ns}owner-principal' => 'user1',

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -52,7 +52,7 @@ use Sabre\DAVACL\IACL;
  * @package OCA\DAV\Tests\unit\CalDAV
  */
 class CalDavBackendTest extends AbstractCalDavBackend {
-	public function testCalendarOperations() {
+	public function testCalendarOperations(): void {
 		$calendarId = $this->createTestCalendar();
 
 		// update its display name
@@ -124,7 +124,7 @@ class CalDavBackendTest extends AbstractCalDavBackend {
 	/**
 	 * @dataProvider providesSharingData
 	 */
-	public function testCalendarSharing($userCanRead, $userCanWrite, $groupCanRead, $groupCanWrite, $add) {
+	public function testCalendarSharing($userCanRead, $userCanWrite, $groupCanRead, $groupCanWrite, $add): void {
 
 		/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject $l10n */
 		$l10n = $this->createMock(IL10N::class);
@@ -204,7 +204,7 @@ EOD;
 		self::assertEmpty($calendars);
 	}
 
-	public function testCalendarObjectsOperations() {
+	public function testCalendarObjectsOperations(): void {
 		$calendarId = $this->createTestCalendar();
 
 		// create a card
@@ -279,7 +279,7 @@ EOD;
 	}
 
 
-	public function testMultipleCalendarObjectsWithSameUID() {
+	public function testMultipleCalendarObjectsWithSameUID(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Calendar object with uid already exists in this calendar collection.');
 
@@ -308,7 +308,7 @@ EOD;
 		$this->backend->createCalendarObject($calendarId, $uri1, $calData);
 	}
 
-	public function testMultiCalendarObjects() {
+	public function testMultiCalendarObjects(): void {
 		$calendarId = $this->createTestCalendar();
 
 		// create an event
@@ -417,7 +417,7 @@ EOD;
 	/**
 	 * @dataProvider providesCalendarQueryParameters
 	 */
-	public function testCalendarQuery($expectedEventsInResult, $propFilters, $compFilter) {
+	public function testCalendarQuery($expectedEventsInResult, $propFilters, $compFilter): void {
 		$calendarId = $this->createTestCalendar();
 		$events = [];
 		$events[0] = $this->createEvent($calendarId, '20130912T130000Z', '20130912T140000Z');
@@ -437,7 +437,7 @@ EOD;
 		$this->assertEqualsCanonicalizing($expectedEventsInResult, $result);
 	}
 
-	public function testGetCalendarObjectByUID() {
+	public function testGetCalendarObjectByUID(): void {
 		$calendarId = $this->createTestCalendar();
 		$uri = static::getUniqueID('calobj');
 		$calData = <<<'EOD'
@@ -475,7 +475,7 @@ EOD;
 		];
 	}
 
-	public function testSyncSupport() {
+	public function testSyncSupport(): void {
 		$calendarId = $this->createTestCalendar();
 
 		// fist call without synctoken
@@ -490,7 +490,7 @@ EOD;
 		$this->assertEquals($event, $changes['added'][0]);
 	}
 
-	public function testPublications() {
+	public function testPublications(): void {
 		$this->dispatcher->expects(self::atLeastOnce())
 			->method('dispatchTyped');
 
@@ -522,7 +522,7 @@ EOD;
 		$this->backend->getPublicCalendar($publicCalendarURI);
 	}
 
-	public function testSubscriptions() {
+	public function testSubscriptions(): void {
 		$id = $this->backend->createSubscription(self::UNIT_TEST_USER, 'Subscription', [
 			'{http://calendarserver.org/ns/}source' => new Href('test-source'),
 			'{http://apple.com/ns/ical/}calendar-color' => '#1C4587',
@@ -629,7 +629,7 @@ EOS;
 	 * @dataProvider providesSchedulingData
 	 * @param $objectData
 	 */
-	public function testScheduling($objectData) {
+	public function testScheduling($objectData): void {
 		$this->backend->createSchedulingObject(self::UNIT_TEST_USER, 'Sample Schedule', $objectData);
 
 		$sos = $this->backend->getSchedulingObjects(self::UNIT_TEST_USER);
@@ -647,7 +647,7 @@ EOS;
 	/**
 	 * @dataProvider providesCalDataForGetDenormalizedData
 	 */
-	public function testGetDenormalizedData($expected, $key, $calData) {
+	public function testGetDenormalizedData($expected, $key, $calData): void {
 		$actual = $this->backend->getDenormalizedData($calData);
 		$this->assertEquals($expected, $actual[$key]);
 	}
@@ -666,7 +666,7 @@ EOS;
 		];
 	}
 
-	public function testCalendarSearch() {
+	public function testCalendarSearch(): void {
 		$calendarId = $this->createTestCalendar();
 
 		$uri = static::getUniqueID('calobj');
@@ -799,7 +799,7 @@ EOD;
 	/**
 	 * @dataProvider searchDataProvider
 	 */
-	public function testSearch(bool $isShared, array $searchOptions, int $count) {
+	public function testSearch(bool $isShared, array $searchOptions, int $count): void {
 		$calendarId = $this->createTestCalendar();
 
 		$uris = [];
@@ -906,7 +906,7 @@ EOD;
 		];
 	}
 
-	public function testSameUriSameIdForDifferentCalendarTypes() {
+	public function testSameUriSameIdForDifferentCalendarTypes(): void {
 		$calendarId = $this->createTestCalendar();
 		$subscriptionId = $this->createTestSubscription();
 
@@ -952,7 +952,7 @@ EOD;
 		$this->assertEquals($calData2, $this->backend->getCalendarObject($subscriptionId, $uri, CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION)['calendardata']);
 	}
 
-	public function testPurgeAllCachedEventsForSubscription() {
+	public function testPurgeAllCachedEventsForSubscription(): void {
 		$subscriptionId = $this->createTestSubscription();
 		$uri = static::getUniqueID('calobj');
 		$calData = <<<EOD
@@ -978,7 +978,7 @@ EOD;
 		$this->assertEquals(null, $this->backend->getCalendarObject($subscriptionId, $uri, CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION));
 	}
 
-	public function testCalendarMovement() {
+	public function testCalendarMovement(): void {
 		$this->backend->createCalendar(self::UNIT_TEST_USER, 'Example', []);
 
 		$this->assertCount(1, $this->backend->getCalendarsForUser(self::UNIT_TEST_USER));

--- a/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
@@ -78,7 +78,7 @@ class CalendarHomeTest extends TestCase {
 		$reflectionProperty->setValue($this->calendarHome, $this->pluginManager);
 	}
 
-	public function testCreateCalendarValidName() {
+	public function testCreateCalendarValidName(): void {
 		/** @var MkCol | MockObject $mkCol */
 		$mkCol = $this->createMock(MkCol::class);
 
@@ -95,7 +95,7 @@ class CalendarHomeTest extends TestCase {
 		$this->calendarHome->createExtendedCollection('name123', $mkCol);
 	}
 
-	public function testCreateCalendarReservedName() {
+	public function testCreateCalendarReservedName(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('The resource you tried to create has a reserved name');
 
@@ -105,7 +105,7 @@ class CalendarHomeTest extends TestCase {
 		$this->calendarHome->createExtendedCollection('contact_birthdays', $mkCol);
 	}
 
-	public function testCreateCalendarReservedNameAppGenerated() {
+	public function testCreateCalendarReservedNameAppGenerated(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 		$this->expectExceptionMessage('The resource you tried to create has a reserved name');
 

--- a/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarImplTest.php
@@ -72,19 +72,19 @@ class CalendarImplTest extends \Test\TestCase {
 	}
 
 
-	public function testGetKey() {
+	public function testGetKey(): void {
 		$this->assertEquals($this->calendarImpl->getKey(), 'fancy_id_123');
 	}
 
-	public function testGetDisplayname() {
+	public function testGetDisplayname(): void {
 		$this->assertEquals($this->calendarImpl->getDisplayName(), 'user readable name 123');
 	}
 
-	public function testGetDisplayColor() {
+	public function testGetDisplayColor(): void {
 		$this->assertEquals($this->calendarImpl->getDisplayColor(), '#AABBCC');
 	}
 
-	public function testSearch() {
+	public function testSearch(): void {
 		$this->backend->expects($this->once())
 			->method('search')
 			->with($this->calendarInfo, 'abc', ['def'], ['ghi'], 42, 1337)
@@ -94,7 +94,7 @@ class CalendarImplTest extends \Test\TestCase {
 		$this->assertEquals($result, ['SEARCHRESULTS']);
 	}
 
-	public function testGetPermissionRead() {
+	public function testGetPermissionRead(): void {
 		$this->calendar->expects($this->once())
 			->method('getACL')
 			->with()
@@ -105,7 +105,7 @@ class CalendarImplTest extends \Test\TestCase {
 		$this->assertEquals(1, $this->calendarImpl->getPermissions());
 	}
 
-	public function testGetPermissionWrite() {
+	public function testGetPermissionWrite(): void {
 		$this->calendar->expects($this->once())
 			->method('getACL')
 			->with()
@@ -116,7 +116,7 @@ class CalendarImplTest extends \Test\TestCase {
 		$this->assertEquals(6, $this->calendarImpl->getPermissions());
 	}
 
-	public function testGetPermissionReadWrite() {
+	public function testGetPermissionReadWrite(): void {
 		$this->calendar->expects($this->once())
 			->method('getACL')
 			->with()
@@ -128,7 +128,7 @@ class CalendarImplTest extends \Test\TestCase {
 		$this->assertEquals(7, $this->calendarImpl->getPermissions());
 	}
 
-	public function testGetPermissionAll() {
+	public function testGetPermissionAll(): void {
 		$this->calendar->expects($this->once())
 			->method('getACL')
 			->with()

--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -66,7 +66,7 @@ class CalendarManagerTest extends \Test\TestCase {
 		);
 	}
 
-	public function testSetupCalendarProvider() {
+	public function testSetupCalendarProvider(): void {
 		$this->backend->expects($this->once())
 			->method('getCalendarsForUser')
 			->with('principals/users/user123')
@@ -79,7 +79,7 @@ class CalendarManagerTest extends \Test\TestCase {
 		$calendarManager = $this->createMock(Manager::class);
 		$calendarManager->expects($this->at(0))
 			->method('registerCalendar')
-			->willReturnCallback(function () {
+			->willReturnCallback(function (): void {
 				$parameter = func_get_arg(0);
 				$this->assertInstanceOf(CalendarImpl::class, $parameter);
 				$this->assertEquals(123, $parameter->getKey());
@@ -87,7 +87,7 @@ class CalendarManagerTest extends \Test\TestCase {
 
 		$calendarManager->expects($this->at(1))
 			->method('registerCalendar')
-			->willReturnCallback(function () {
+			->willReturnCallback(function (): void {
 				$parameter = func_get_arg(0);
 				$this->assertInstanceOf(CalendarImpl::class, $parameter);
 				$this->assertEquals(456, $parameter->getKey());

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -64,7 +64,7 @@ class CalendarTest extends TestCase {
 			});
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
@@ -82,7 +82,7 @@ class CalendarTest extends TestCase {
 	}
 
 
-	public function testDeleteFromGroup() {
+	public function testDeleteFromGroup(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		/** @var MockObject | CalDavBackend $backend */
@@ -101,7 +101,7 @@ class CalendarTest extends TestCase {
 		$c->delete();
 	}
 
-	public function testDeleteOwn() {
+	public function testDeleteOwn(): void {
 		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->createMock(CalDavBackend::class);
 		$backend->expects($this->never())->method('updateShares');
@@ -122,7 +122,7 @@ class CalendarTest extends TestCase {
 		$c->delete();
 	}
 
-	public function testDeleteBirthdayCalendar() {
+	public function testDeleteBirthdayCalendar(): void {
 		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->createMock(CalDavBackend::class);
 		$backend->expects($this->once())->method('deleteCalendar')
@@ -173,7 +173,7 @@ class CalendarTest extends TestCase {
 	/**
 	 * @dataProvider dataPropPatch
 	 */
-	public function testPropPatch($ownerPrincipal, $principalUri, $mutations, $shared) {
+	public function testPropPatch($ownerPrincipal, $principalUri, $mutations, $shared): void {
 		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$calendarInfo = [
@@ -197,7 +197,7 @@ class CalendarTest extends TestCase {
 	/**
 	 * @dataProvider providesReadOnlyInfo
 	 */
-	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default') {
+	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default'): void {
 		/** @var MockObject | CalDavBackend $backend */
 		$backend = $this->getMockBuilder(CalDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);
@@ -300,7 +300,7 @@ class CalendarTest extends TestCase {
 	 * @param int $expectedChildren
 	 * @param bool $isShared
 	 */
-	public function testPrivateClassification($expectedChildren, $isShared) {
+	public function testPrivateClassification($expectedChildren, $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
@@ -342,7 +342,7 @@ class CalendarTest extends TestCase {
 	 * @param int $expectedChildren
 	 * @param bool $isShared
 	 */
-	public function testConfidentialClassification($expectedChildren, $isShared) {
+	public function testConfidentialClassification($expectedChildren, $isShared): void {
 		$start = '20160609';
 		$end = '20160610';
 

--- a/apps/dav/tests/unit/CalDAV/OutboxTest.php
+++ b/apps/dav/tests/unit/CalDAV/OutboxTest.php
@@ -43,7 +43,7 @@ class OutboxTest extends TestCase {
 		$this->outbox = new Outbox($this->config, 'user-principal-123');
 	}
 
-	public function testGetACLFreeBusyEnabled() {
+	public function testGetACLFreeBusyEnabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'disableFreeBusy', 'no')
@@ -78,7 +78,7 @@ class OutboxTest extends TestCase {
 		], $this->outbox->getACL());
 	}
 
-	public function testGetACLFreeBusyDisabled() {
+	public function testGetACLFreeBusyDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'disableFreeBusy', 'no')

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -61,11 +61,11 @@ class PluginTest extends TestCase {
 	 * @param $input
 	 * @param $expected
 	 */
-	public function testGetCalendarHomeForPrincipal($input, $expected) {
+	public function testGetCalendarHomeForPrincipal($input, $expected): void {
 		$this->assertSame($expected, $this->plugin->getCalendarHomeForPrincipal($input));
 	}
 
-	public function testGetCalendarHomeForUnknownPrincipal() {
+	public function testGetCalendarHomeForUnknownPrincipal(): void {
 		$this->assertNull($this->plugin->getCalendarHomeForPrincipal('FOO/BAR/BLUB'));
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -131,12 +131,12 @@ class PublicCalendarRootTest extends TestCase {
 		}
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$name = $this->publicCalendarRoot->getName();
 		$this->assertEquals('public-calendars', $name);
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$calendar = $this->createPublicCalendar();
 
 		$publicCalendars = $this->backend->getPublicCalendars();
@@ -149,7 +149,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->assertEquals($calendar, $calendarResult);
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->createPublicCalendar();
 		$calendarResults = $this->publicCalendarRoot->getChildren();
 		$this->assertSame([], $calendarResults);

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -39,7 +39,7 @@ class PublicCalendarTest extends CalendarTest {
 	 * @param int $expectedChildren
 	 * @param bool $isShared
 	 */
-	public function testPrivateClassification($expectedChildren, $isShared) {
+	public function testPrivateClassification($expectedChildren, $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
 		$calObject2 = ['uri' => 'event-2', 'classification' => CalDavBackend::CLASSIFICATION_PRIVATE];
@@ -82,7 +82,7 @@ class PublicCalendarTest extends CalendarTest {
 	 * @param int $expectedChildren
 	 * @param bool $isShared
 	 */
-	public function testConfidentialClassification($expectedChildren, $isShared) {
+	public function testConfidentialClassification($expectedChildren, $isShared): void {
 		$start = '20160609';
 		$end = '20160610';
 

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
@@ -32,7 +32,7 @@ use Test\TestCase;
 class PublisherTest extends TestCase {
 	public const NS_CALENDARSERVER = 'http://calendarserver.org/ns/';
 
-	public function testSerializePublished() {
+	public function testSerializePublished(): void {
 		$publish = new Publisher('urltopublish', true);
 
 		$xml = $this->write([
@@ -48,7 +48,7 @@ class PublisherTest extends TestCase {
 			</x1:publish-url>', $xml);
 	}
 
-	public function testSerializeNotPublished() {
+	public function testSerializeNotPublished(): void {
 		$publish = new Publisher('urltopublish', false);
 
 		$xml = $this->write([

--- a/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublishingTest.php
@@ -77,7 +77,7 @@ class PublishingTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testPublishing() {
+	public function testPublishing(): void {
 		$this->book->expects($this->once())->method('setPublishStatus')->with(true);
 
 		// setup request
@@ -88,7 +88,7 @@ class PublishingTest extends TestCase {
 		$this->plugin->httpPost($request, $response);
 	}
 
-	public function testUnPublishing() {
+	public function testUnPublishing(): void {
 		$this->book->expects($this->once())->method('setPublishStatus')->with(false);
 
 		// setup request

--- a/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
@@ -249,7 +249,7 @@ class BackendTest extends TestCase {
 		]);
 	}
 
-	public function testUpdateReminder() {
+	public function testUpdateReminder(): void {
 		$query = self::$realDatabase->getQueryBuilder();
 		$rows = $query->select('*')
 			->from('calendar_reminders')

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
@@ -125,7 +125,7 @@ class NotifierTest extends TestCase {
 	}
 
 
-	public function testPrepareWrongSubject() {
+	public function testPrepareWrongSubject(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Unknown subject');
 

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
@@ -83,7 +83,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$query->delete('calendar_rooms_md')->execute();
 	}
 
-	public function testGetPrincipalsByPrefix() {
+	public function testGetPrincipalsByPrefix(): void {
 		$actual = $this->principalBackend->getPrincipalsByPrefix($this->principalPrefix);
 
 		$this->assertEquals([
@@ -131,12 +131,12 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		], $actual);
 	}
 
-	public function testGetNoPrincipalsByPrefixForWrongPrincipalPrefix() {
+	public function testGetNoPrincipalsByPrefixForWrongPrincipalPrefix(): void {
 		$actual = $this->principalBackend->getPrincipalsByPrefix('principals/users');
 		$this->assertEquals([], $actual);
 	}
 
-	public function testGetPrincipalByPath() {
+	public function testGetPrincipalByPath(): void {
 		$actual = $this->principalBackend->getPrincipalByPath($this->principalPrefix . '/backend2-res3');
 		$this->assertEquals([
 			'uri' => $this->principalPrefix . '/backend2-res3',
@@ -148,22 +148,22 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		], $actual);
 	}
 
-	public function testGetPrincipalByPathNotFound() {
+	public function testGetPrincipalByPathNotFound(): void {
 		$actual = $this->principalBackend->getPrincipalByPath($this->principalPrefix . '/db-123');
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testGetPrincipalByPathWrongPrefix() {
+	public function testGetPrincipalByPathWrongPrefix(): void {
 		$actual = $this->principalBackend->getPrincipalByPath('principals/users/foo-bar');
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testGetGroupMemberSet() {
+	public function testGetGroupMemberSet(): void {
 		$actual = $this->principalBackend->getGroupMemberSet($this->principalPrefix . '/backend1-res1');
 		$this->assertEquals([], $actual);
 	}
 
-	public function testGetGroupMemberSetProxyRead() {
+	public function testGetGroupMemberSetProxyRead(): void {
 		$proxy1 = new Proxy();
 		$proxy1->setProxyId('proxyId1');
 		$proxy1->setPermissions(1);
@@ -185,7 +185,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(['proxyId1'], $actual);
 	}
 
-	public function testGetGroupMemberSetProxyWrite() {
+	public function testGetGroupMemberSetProxyWrite(): void {
 		$proxy1 = new Proxy();
 		$proxy1->setProxyId('proxyId1');
 		$proxy1->setPermissions(1);
@@ -207,7 +207,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(['proxyId2', 'proxyId3'], $actual);
 	}
 
-	public function testGetGroupMembership() {
+	public function testGetGroupMembership(): void {
 		$proxy1 = new Proxy();
 		$proxy1->setOwnerId('proxyId1');
 		$proxy1->setPermissions(1);
@@ -226,7 +226,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(['proxyId1/calendar-proxy-read', 'proxyId2/calendar-proxy-write'], $actual);
 	}
 
-	public function testSetGroupMemberSet() {
+	public function testSetGroupMemberSet(): void {
 		$this->proxyMapper->expects($this->once())
 			->method('getProxiesOf')
 			->with($this->principalPrefix . '/backend1-res1')
@@ -268,7 +268,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->principalBackend->setGroupMemberSet($this->principalPrefix . '/backend1-res1/calendar-proxy-write', [$this->principalPrefix . '/backend1-res2', $this->principalPrefix . '/backend2-res3']);
 	}
 
-	public function testUpdatePrincipal() {
+	public function testUpdatePrincipal(): void {
 		$propPatch = $this->createMock(PropPatch::class);
 		$actual = $this->principalBackend->updatePrincipal($this->principalPrefix . '/foo-bar', $propPatch);
 
@@ -278,7 +278,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 	/**
 	 * @dataProvider dataSearchPrincipals
 	 */
-	public function testSearchPrincipals($expected, $test) {
+	public function testSearchPrincipals($expected, $test): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -318,7 +318,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		];
 	}
 
-	public function testSearchPrincipalsByMetadataKey() {
+	public function testSearchPrincipalsByMetadataKey(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -338,7 +338,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		], $actual);
 	}
 
-	public function testSearchPrincipalsByCalendarUserAddressSet() {
+	public function testSearchPrincipalsByCalendarUserAddressSet(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->method('getUser')
 			->with()
@@ -358,7 +358,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 			$actual);
 	}
 
-	public function testSearchPrincipalsEmptySearchProperties() {
+	public function testSearchPrincipalsEmptySearchProperties(): void {
 		$this->userSession->expects($this->never())
 			->method('getUser');
 		$this->groupManager->expects($this->never())
@@ -367,7 +367,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->principalBackend->searchPrincipals($this->principalPrefix, []);
 	}
 
-	public function testSearchPrincipalsWrongPrincipalPrefix() {
+	public function testSearchPrincipalsWrongPrincipalPrefix(): void {
 		$this->userSession->expects($this->never())
 			->method('getUser');
 		$this->groupManager->expects($this->never())
@@ -378,7 +378,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		]);
 	}
 
-	public function testFindByUriByEmail() {
+	public function testFindByUriByEmail(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -393,7 +393,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals($this->principalPrefix . '/backend1-res1', $actual);
 	}
 
-	public function testFindByUriByEmailForbiddenResource() {
+	public function testFindByUriByEmailForbiddenResource(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -408,7 +408,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testFindByUriByEmailNotFound() {
+	public function testFindByUriByEmailNotFound(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -423,7 +423,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testFindByUriByPrincipal() {
+	public function testFindByUriByPrincipal(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -438,7 +438,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals($this->principalPrefix . '/backend3-res6', $actual);
 	}
 
-	public function testFindByUriByPrincipalForbiddenResource() {
+	public function testFindByUriByPrincipalForbiddenResource(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -453,7 +453,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testFindByUriByPrincipalNotFound() {
+	public function testFindByUriByPrincipalNotFound(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -468,7 +468,7 @@ abstract class AbstractPrincipalBackendTest extends TestCase {
 		$this->assertEquals(null, $actual);
 	}
 
-	public function testFindByUriByUnknownUri() {
+	public function testFindByUriByUnknownUri(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -131,7 +131,7 @@ class IMipPluginTest extends TestCase {
 		$this->plugin = new IMipPlugin($this->config, $this->mailer, $logger, $this->timeFactory, $l10nFactory, $urlGenerator, $defaults, $random, $db, $this->userManager, 'user123');
 	}
 
-	public function testDelivery() {
+	public function testDelivery(): void {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
@@ -146,7 +146,7 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
 
-	public function testFailedDelivery() {
+	public function testFailedDelivery(): void {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
@@ -164,7 +164,7 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('5.0', $message->getScheduleStatus());
 	}
 
-	public function testInvalidEmailDelivery() {
+	public function testInvalidEmailDelivery(): void {
 		$this->mailer->method('validateMailAddress')->willReturn(false);
 
 		$message = $this->_testMessage();
@@ -172,7 +172,7 @@ class IMipPluginTest extends TestCase {
 		$this->assertEquals('5.0', $message->getScheduleStatus());
 	}
 
-	public function testDeliveryWithNoCommonName() {
+	public function testDeliveryWithNoCommonName(): void {
 		$this->config
 			->expects($this->any())
 			->method('getAppValue')
@@ -197,7 +197,7 @@ class IMipPluginTest extends TestCase {
 	/**
 	 * @dataProvider dataNoMessageSendForPastEvents
 	 */
-	public function testNoMessageSendForPastEvents(array $veventParams, bool $expectsMail) {
+	public function testNoMessageSendForPastEvents(array $veventParams, bool $expectsMail): void {
 		$this->config
 			->method('getAppValue')
 			->willReturn('yes');
@@ -234,7 +234,7 @@ class IMipPluginTest extends TestCase {
 	/**
 	 * @dataProvider dataIncludeResponseButtons
 	 */
-	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons) {
+	public function testIncludeResponseButtons(string $config_setting, string $recipient, bool $has_buttons): void {
 		$message = $this->_testMessage([], $recipient);
 		$this->mailer->method('validateMailAddress')->willReturn(true);
 
@@ -263,7 +263,7 @@ class IMipPluginTest extends TestCase {
 		];
 	}
 
-	public function testMessageSendWhenEventWithoutName() {
+	public function testMessageSendWhenEventWithoutName(): void {
 		$this->config
 			->method('getAppValue')
 			->willReturn('yes');
@@ -297,7 +297,7 @@ class IMipPluginTest extends TestCase {
 	}
 
 
-	private function _expectSend(string $recipient = 'frodo@hobb.it', bool $expectSend = true, bool $expectButtons = true, string $subject = 'Invitation: Fellowship meeting') {
+	private function _expectSend(string $recipient = 'frodo@hobb.it', bool $expectSend = true, bool $expectButtons = true, string $subject = 'Invitation: Fellowship meeting'): void {
 		// if the event is in the past, we skip out
 		if (!$expectSend) {
 			$this->mailer

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -79,7 +79,7 @@ class PluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		$plugin = new Plugin($this->config, $this->logger);
 
 		$this->server->expects($this->exactly(10))
@@ -102,7 +102,7 @@ class PluginTest extends TestCase {
 		$plugin->initialize($this->server);
 	}
 
-	public function testGetAddressesForPrincipal() {
+	public function testGetAddressesForPrincipal(): void {
 		$href = $this->createMock(Href::class);
 		$href
 			->expects($this->once())
@@ -126,7 +126,7 @@ class PluginTest extends TestCase {
 	}
 
 
-	public function testGetAddressesForPrincipalEmpty() {
+	public function testGetAddressesForPrincipalEmpty(): void {
 		$this->server
 			->expects($this->once())
 			->method('getProperties')
@@ -142,12 +142,12 @@ class PluginTest extends TestCase {
 		$this->assertSame([], $result);
 	}
 
-	public function testStripOffMailTo() {
+	public function testStripOffMailTo(): void {
 		$this->assertEquals('test@example.com', $this->invokePrivate($this->plugin, 'stripOffMailTo', ['test@example.com']));
 		$this->assertEquals('test@example.com', $this->invokePrivate($this->plugin, 'stripOffMailTo', ['mailto:test@example.com']));
 	}
 
-	public function testGetAttendeeRSVP() {
+	public function testGetAttendeeRSVP(): void {
 		$property1 = $this->createMock(CalAddress::class);
 		$parameter1 = $this->createMock(Parameter::class);
 		$property1->expects($this->once())
@@ -271,7 +271,7 @@ class PluginTest extends TestCase {
 	 * @param bool $exists
 	 * @param bool $propertiesForPath
 	 */
-	public function testPropFindDefaultCalendarUrl(string $principalUri, ?string $calendarHome, bool $isResource, string $calendarUri, string $displayName, bool $exists, bool $hasExistingCalendars = false, bool $propertiesForPath = true) {
+	public function testPropFindDefaultCalendarUrl(string $principalUri, ?string $calendarHome, bool $isResource, string $calendarUri, string $displayName, bool $exists, bool $hasExistingCalendars = false, bool $propertiesForPath = true): void {
 		/** @var PropFind $propFind */
 		$propFind = new PropFind(
 			$principalUri,

--- a/apps/dav/tests/unit/CalDAV/Search/Request/CalendarSearchReportTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/Request/CalendarSearchReportTest.php
@@ -34,7 +34,7 @@ class CalendarSearchReportTest extends TestCase {
 			'OCA\\DAV\\CalDAV\\Search\\Xml\\Request\\CalendarSearchReport',
 	];
 
-	public function testFoo() {
+	public function testFoo(): void {
 		$xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <nc:calendar-search xmlns:nc="http://nextcloud.com/ns" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:">
@@ -90,7 +90,7 @@ XML;
 		);
 	}
 
-	public function testNoLimitOffset() {
+	public function testNoLimitOffset(): void {
 		$xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <nc:calendar-search xmlns:nc="http://nextcloud.com/ns" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:">
@@ -132,7 +132,7 @@ XML;
 	}
 
 	
-	public function testRequiresCompFilter() {
+	public function testRequiresCompFilter(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('{http://nextcloud.com/ns}prop-filter or {http://nextcloud.com/ns}param-filter given without any {http://nextcloud.com/ns}comp-filter');
 
@@ -159,7 +159,7 @@ XML;
 	}
 
 	
-	public function testRequiresFilter() {
+	public function testRequiresFilter(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('The {http://nextcloud.com/ns}filter element is required for this request');
 
@@ -177,7 +177,7 @@ XML;
 	}
 
 	
-	public function testNoSearchTerm() {
+	public function testNoSearchTerm(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('{http://nextcloud.com/ns}search-term is required for this request');
 
@@ -205,7 +205,7 @@ XML;
 	}
 
 	
-	public function testCompOnly() {
+	public function testCompOnly(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('At least one{http://nextcloud.com/ns}prop-filter or {http://nextcloud.com/ns}param-filter is required for this request');
 
@@ -247,7 +247,7 @@ XML;
 		);
 	}
 
-	public function testPropOnly() {
+	public function testPropOnly(): void {
 		$xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <nc:calendar-search xmlns:nc="http://nextcloud.com/ns" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:">
@@ -288,7 +288,7 @@ XML;
 		);
 	}
 
-	public function testParamOnly() {
+	public function testParamOnly(): void {
 		$xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <nc:calendar-search xmlns:nc="http://nextcloud.com/ns" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:">

--- a/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
@@ -48,15 +48,15 @@ class SearchPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testGetFeatures() {
+	public function testGetFeatures(): void {
 		$this->assertEquals(['nc-calendar-search'], $this->plugin->getFeatures());
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals('nc-calendar-search', $this->plugin->getPluginName());
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		$server = $this->createMock(\Sabre\DAV\Server::class);
 
 		$plugin = new SearchPlugin();
@@ -74,13 +74,13 @@ class SearchPluginTest extends TestCase {
 		);
 	}
 
-	public function testReportUnknown() {
+	public function testReportUnknown(): void {
 		$result = $this->plugin->report('{urn:ietf:params:xml:ns:caldav}calendar-query', 'REPORT', null);
 		$this->assertEquals($result, null);
 		$this->assertNotEquals($this->server->transactionType, 'report-nc-calendar-search');
 	}
 
-	public function testReport() {
+	public function testReport(): void {
 		$report = $this->createMock(CalendarSearchReport::class);
 		$report->filters = [];
 		$calendarHome = $this->createMock(CalendarHome::class);
@@ -108,7 +108,7 @@ class SearchPluginTest extends TestCase {
 		$this->plugin->report('{http://nextcloud.com/ns}calendar-search', $report, '');
 	}
 
-	public function testSupportedReportSetNoCalendarHome() {
+	public function testSupportedReportSetNoCalendarHome(): void {
 		$this->server->tree->expects($this->once())
 			->method('getNodeForPath')
 			->with('/foo/bar')
@@ -118,7 +118,7 @@ class SearchPluginTest extends TestCase {
 		$this->assertEquals([], $reports);
 	}
 
-	public function testSupportedReportSet() {
+	public function testSupportedReportSet(): void {
 		$calendarHome = $this->createMock(CalendarHome::class);
 
 		$this->server->tree->expects($this->once())

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
@@ -27,7 +27,7 @@ use OCA\DAV\CalDAV\WebcalCaching\Plugin;
 use OCP\IRequest;
 
 class PluginTest extends \Test\TestCase {
-	public function testDisabled() {
+	public function testDisabled(): void {
 		$request = $this->createMock(IRequest::class);
 		$request->expects($this->once())
 			->method('isUserAgent')
@@ -44,7 +44,7 @@ class PluginTest extends \Test\TestCase {
 		$this->assertEquals(false, $plugin->isCachingEnabledForThisRequest());
 	}
 
-	public function testEnabled() {
+	public function testEnabled(): void {
 		$request = $this->createMock(IRequest::class);
 		$request->expects($this->once())
 			->method('isUserAgent')

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -72,7 +72,7 @@ class RefreshWebcalServiceTest extends TestCase {
 	 *
 	 * @dataProvider runDataProvider
 	 */
-	public function testRun(string $body, string $contentType, string $result) {
+	public function testRun(string $body, string $contentType, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getRandomCalendarObjectUri'])
 			->setConstructorArgs([$this->caldavBackend, $this->clientService, $this->config, $this->logger])
@@ -152,7 +152,7 @@ class RefreshWebcalServiceTest extends TestCase {
 	 *
 	 * @dataProvider runDataProvider
 	 */
-	public function testRunCreateCalendarNoException(string $body, string $contentType, string $result) {
+	public function testRunCreateCalendarNoException(string $body, string $contentType, string $result): void {
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
@@ -229,7 +229,7 @@ class RefreshWebcalServiceTest extends TestCase {
 	 *
 	 * @dataProvider runDataProvider
 	 */
-	public function testRunCreateCalendarBadRequest(string $body, string $contentType, string $result) {
+	public function testRunCreateCalendarBadRequest(string $body, string $contentType, string $result): void {
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
@@ -325,7 +325,7 @@ class RefreshWebcalServiceTest extends TestCase {
 	/**
 	 * @dataProvider runLocalURLDataProvider
 	 */
-	public function testRunLocalURL(string $source) {
+	public function testRunLocalURL(string $source): void {
 		$refreshWebcalService = new RefreshWebcalService(
 			$this->caldavBackend,
 			$this->clientService,
@@ -391,7 +391,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		];
 	}
 
-	public function testInvalidUrl() {
+	public function testInvalidUrl(): void {
 		$refreshWebcalService = new RefreshWebcalService($this->caldavBackend,
 			$this->clientService, $this->config, $this->logger);
 

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -31,7 +31,7 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit
  */
 class CapabilitiesTest extends TestCase {
-	public function testGetCapabilities() {
+	public function testGetCapabilities(): void {
 		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getSystemValueBool')
@@ -46,7 +46,7 @@ class CapabilitiesTest extends TestCase {
 		$this->assertSame($expected, $capabilities->getCapabilities());
 	}
 
-	public function testGetCapabilitiesWithBulkUpload() {
+	public function testGetCapabilitiesWithBulkUpload(): void {
 		$config = $this->createMock(IConfig::class);
 		$config->expects($this->once())
 			->method('getSystemValueBool')

--- a/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
@@ -102,11 +102,11 @@ class BackendTest extends TestCase {
 	/**
 	 * @dataProvider dataCallTriggerAddressBookActivity
 	 */
-	public function testCallTriggerAddressBookActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload) {
+	public function testCallTriggerAddressBookActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerAddressbookActivity']);
 		$backend->expects($this->once())
 			->method('triggerAddressbookActivity')
-			->willReturnCallback(function () use ($expectedPayload, $expectedSubject) {
+			->willReturnCallback(function () use ($expectedPayload, $expectedSubject): void {
 				$arguments = func_get_args();
 				$this->assertSame($expectedSubject, array_shift($arguments));
 				$this->assertEquals($expectedPayload, $arguments);
@@ -189,7 +189,7 @@ class BackendTest extends TestCase {
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
-	public function testTriggerAddressBookActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users) {
+	public function testTriggerAddressBookActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
 		if ($shareUsers === null) {
@@ -263,7 +263,7 @@ class BackendTest extends TestCase {
 		$this->assertEmpty($this->invokePrivate($backend, 'triggerAddressbookActivity', [Addressbook::SUBJECT_ADD, ['principaluri' => 'principals/system/system'], [], [], '', '', null, []]));
 	}
 
-	public function testUserDeletionDoesNotCreateActivity() {
+	public function testUserDeletionDoesNotCreateActivity(): void {
 		$backend = $this->getBackend();
 
 		$this->userManager->expects($this->once())
@@ -359,7 +359,7 @@ class BackendTest extends TestCase {
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
-	public function testTriggerCardActivity(string $action, array $addressBookData, array $shares, array $cardData, string $currentUser, string $author, ?array $shareUsers, array $users) {
+	public function testTriggerCardActivity(string $action, array $addressBookData, array $shares, array $cardData, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
 		if ($shareUsers === null) {
@@ -478,7 +478,7 @@ class BackendTest extends TestCase {
 	 * @param array $groups
 	 * @param array $expected
 	 */
-	public function testGetUsersForShares(array $shares, array $groups, array $expected) {
+	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 
 		$getGroups = [];

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -82,17 +82,17 @@ class AddressBookImplTest extends TestCase {
 		);
 	}
 
-	public function testGetKey() {
+	public function testGetKey(): void {
 		$this->assertSame($this->addressBookInfo['id'],
 			$this->addressBookImpl->getKey());
 	}
 
-	public function testGetDisplayName() {
+	public function testGetDisplayName(): void {
 		$this->assertSame($this->addressBookInfo['{DAV:}displayname'],
 			$this->addressBookImpl->getDisplayName());
 	}
 
-	public function testSearch() {
+	public function testSearch(): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
@@ -136,7 +136,7 @@ class AddressBookImplTest extends TestCase {
 	 *
 	 * @param array $properties
 	 */
-	public function testCreate($properties) {
+	public function testCreate($properties): void {
 		$uid = 'uid';
 
 		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
@@ -184,7 +184,7 @@ class AddressBookImplTest extends TestCase {
 		];
 	}
 
-	public function testUpdate() {
+	public function testUpdate(): void {
 		$uid = 'uid';
 		$uri = 'bla.vcf';
 		$properties = ['URI' => $uri, 'UID' => $uid, 'FN' => 'John Doe'];
@@ -219,7 +219,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertTrue($addressBookImpl->createOrUpdate($properties));
 	}
 
-	public function testUpdateWithTypes() {
+	public function testUpdateWithTypes(): void {
 		$uid = 'uid';
 		$uri = 'bla.vcf';
 		$properties = ['URI' => $uri, 'UID' => $uid, 'FN' => 'John Doe', 'ADR' => [['type' => 'HOME', 'value' => ';;street;city;;;country']]];
@@ -260,7 +260,7 @@ class AddressBookImplTest extends TestCase {
 	 * @param array $permissions
 	 * @param int $expected
 	 */
-	public function testGetPermissions($permissions, $expected) {
+	public function testGetPermissions($permissions, $expected): void {
 		$this->addressBook->expects($this->once())->method('getACL')
 			->willReturn($permissions);
 
@@ -283,7 +283,7 @@ class AddressBookImplTest extends TestCase {
 		];
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$cardId = 1;
 		$cardUri = 'cardUri';
 		$this->backend->expects($this->once())->method('getCardUri')
@@ -295,7 +295,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertTrue($this->addressBookImpl->delete($cardId));
 	}
 
-	public function testReadCard() {
+	public function testReadCard(): void {
 		$vCard = new VCard();
 		$vCard->add(new Text($vCard, 'UID', 'uid'));
 		$vCardSerialized = $vCard->serialize();
@@ -306,7 +306,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertSame($vCardSerialized, $resultSerialized);
 	}
 
-	public function testCreateUid() {
+	public function testCreateUid(): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject | AddressBookImpl $addressBookImpl */
 		$addressBookImpl = $this->getMockBuilder(AddressBookImpl::class)
 			->setConstructorArgs(
@@ -340,7 +340,7 @@ class AddressBookImplTest extends TestCase {
 		);
 	}
 
-	public function testCreateEmptyVCard() {
+	public function testCreateEmptyVCard(): void {
 		$uid = 'uid';
 		$expectedVCard = new VCard();
 		$expectedVCard->UID = $uid;
@@ -352,7 +352,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertSame($expectedVCardSerialized, $resultSerialized);
 	}
 
-	public function testVCard2Array() {
+	public function testVCard2Array(): void {
 		$vCard = new VCard();
 
 		$vCard->add($vCard->createProperty('FN', 'Full Name'));
@@ -419,7 +419,7 @@ class AddressBookImplTest extends TestCase {
 		], $array);
 	}
 
-	public function testVCard2ArrayWithTypes() {
+	public function testVCard2ArrayWithTypes(): void {
 		$vCard = new VCard();
 
 		$vCard->add($vCard->createProperty('FN', 'Full Name'));

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -32,7 +32,7 @@ use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 class AddressBookTest extends TestCase {
-	public function testDelete() {
+	public function testDelete(): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('updateShares');
@@ -52,7 +52,7 @@ class AddressBookTest extends TestCase {
 	}
 
 
-	public function testDeleteFromGroup() {
+	public function testDeleteFromGroup(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
@@ -74,7 +74,7 @@ class AddressBookTest extends TestCase {
 	}
 
 
-	public function testPropPatch() {
+	public function testPropPatch(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
@@ -94,7 +94,7 @@ class AddressBookTest extends TestCase {
 	/**
 	 * @dataProvider providesReadOnlyInfo
 	 */
-	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet) {
+	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject | CardDavBackend $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->any())->method('applyShareAcl')->willReturnArgument(1);

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -84,7 +84,7 @@ class BirthdayServiceTest extends TestCase {
 	 * @param string|null $expectedReminder
 	 * @param string | null $data
 	 */
-	public function testBuildBirthdayFromContact($expectedSummary, $expectedDTStart, $expectedFieldType, $expectedUnknownYear, $expectedOriginalYear, $expectedReminder, $data, $fieldType, $prefix, $supports4Bytes, $configuredReminder) {
+	public function testBuildBirthdayFromContact($expectedSummary, $expectedDTStart, $expectedFieldType, $expectedUnknownYear, $expectedOriginalYear, $expectedReminder, $data, $fieldType, $prefix, $supports4Bytes, $configuredReminder): void {
 		$this->dbConnection->method('supports4ByteText')->willReturn($supports4Bytes);
 		$cal = $this->service->buildDateFromContact($data, $fieldType, $prefix, $configuredReminder);
 
@@ -113,7 +113,7 @@ class BirthdayServiceTest extends TestCase {
 		}
 	}
 
-	public function testOnCardDeleteGloballyDisabled() {
+	public function testOnCardDeleteGloballyDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -124,7 +124,7 @@ class BirthdayServiceTest extends TestCase {
 		$this->service->onCardDeleted(666, 'gump.vcf');
 	}
 
-	public function testOnCardDeleteUserDisabled() {
+	public function testOnCardDeleteUserDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -148,7 +148,7 @@ class BirthdayServiceTest extends TestCase {
 		$this->service->onCardDeleted(666, 'gump.vcf');
 	}
 
-	public function testOnCardDeleted() {
+	public function testOnCardDeleted(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -182,7 +182,7 @@ class BirthdayServiceTest extends TestCase {
 		$this->service->onCardDeleted(666, 'gump.vcf');
 	}
 
-	public function testOnCardChangedGloballyDisabled() {
+	public function testOnCardChangedGloballyDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -198,7 +198,7 @@ class BirthdayServiceTest extends TestCase {
 		$service->onCardChanged(666, 'gump.vcf', '');
 	}
 
-	public function testOnCardChangedUserDisabled() {
+	public function testOnCardChangedUserDisabled(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -230,7 +230,7 @@ class BirthdayServiceTest extends TestCase {
 	/**
 	 * @dataProvider providesCardChanges
 	 */
-	public function testOnCardChanged($expectedOp) {
+	public function testOnCardChanged($expectedOp): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes')
@@ -306,12 +306,12 @@ class BirthdayServiceTest extends TestCase {
 	 * @param $old
 	 * @param $new
 	 */
-	public function testBirthdayEvenChanged($expected, $old, $new) {
+	public function testBirthdayEvenChanged($expected, $old, $new): void {
 		$new = Reader::read($new);
 		$this->assertEquals($expected, $this->service->birthdayEvenChanged($old, $new));
 	}
 
-	public function testGetAllAffectedPrincipals() {
+	public function testGetAllAffectedPrincipals(): void {
 		$this->cardDav->expects($this->once())->method('getShares')->willReturn([
 			[
 				'{http://owncloud.org/ns}group-share' => false,
@@ -350,7 +350,7 @@ class BirthdayServiceTest extends TestCase {
 		], $users);
 	}
 
-	public function testBirthdayCalendarHasComponentEvent() {
+	public function testBirthdayCalendarHasComponentEvent(): void {
 		$this->calDav->expects($this->once())
 			->method('createCalendar')
 			->with('principal001', 'contact_birthdays', [
@@ -361,7 +361,7 @@ class BirthdayServiceTest extends TestCase {
 		$this->service->ensureCalendarExists('principal001');
 	}
 
-	public function testResetForUser() {
+	public function testResetForUser(): void {
 		$this->calDav->expects($this->once())
 			->method('getCalendarByUri')
 			->with('principals/users/user123', 'contact_birthdays')

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -181,7 +181,7 @@ class CardDavBackendTest extends TestCase {
 		}
 	}
 
-	public function testAddressBookOperations() {
+	public function testAddressBookOperations(): void {
 		// create a new address book
 		$this->backend->createAddressBook(self::UNIT_TEST_USER, 'Example', []);
 
@@ -209,7 +209,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals(0, count($books));
 	}
 
-	public function testAddressBookSharing() {
+	public function testAddressBookSharing(): void {
 		$this->userManager->expects($this->any())
 			->method('userExists')
 			->willReturn(true);
@@ -240,7 +240,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals(0, count($books));
 	}
 
-	public function testCardOperations() {
+	public function testCardOperations(): void {
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)
 				->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
@@ -296,7 +296,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals(0, count($cards));
 	}
 
-	public function testMultiCard() {
+	public function testMultiCard(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->setMethods(['updateProperties'])->getMock();
@@ -349,7 +349,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals(0, count($cards));
 	}
 
-	public function testMultipleUIDOnDifferentAddressbooks() {
+	public function testMultipleUIDOnDifferentAddressbooks(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->onlyMethods(['updateProperties'])->getMock();
@@ -371,7 +371,7 @@ class CardDavBackendTest extends TestCase {
 		$this->backend->createCard($bookId1, $uri1, $this->vcardTest0);
 	}
 
-	public function testMultipleUIDDenied() {
+	public function testMultipleUIDDenied(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->setMethods(['updateProperties'])->getMock();
@@ -392,7 +392,7 @@ class CardDavBackendTest extends TestCase {
 		$test = $this->backend->createCard($bookId, $uri1, $this->vcardTest0);
 	}
 
-	public function testNoValidUID() {
+	public function testNoValidUID(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->setMethods(['updateProperties'])->getMock();
@@ -409,7 +409,7 @@ class CardDavBackendTest extends TestCase {
 		$test = $this->backend->createCard($bookId, $uri1, $this->vcardTestNoUID);
 	}
 
-	public function testDeleteWithoutCard() {
+	public function testDeleteWithoutCard(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->onlyMethods([
@@ -449,7 +449,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertTrue($this->backend->deleteCard($bookId, $uri));
 	}
 
-	public function testSyncSupport() {
+	public function testSyncSupport(): void {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
 			->setConstructorArgs([$this->db, $this->principal, $this->userManager, $this->groupManager, $this->dispatcher])
 			->setMethods(['updateProperties'])->getMock();
@@ -473,7 +473,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals($uri0, $changes['added'][0]);
 	}
 
-	public function testSharing() {
+	public function testSharing(): void {
 		$this->userManager->expects($this->any())
 			->method('userExists')
 			->willReturn(true);
@@ -511,7 +511,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEquals(0, count($books));
 	}
 
-	public function testUpdateProperties() {
+	public function testUpdateProperties(): void {
 		$bookId = 42;
 		$cardUri = 'card-uri';
 		$cardId = 2;
@@ -569,7 +569,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertSame($cardId, (int)$result[0]['cardid']);
 	}
 
-	public function testPurgeProperties() {
+	public function testPurgeProperties(): void {
 		$query = $this->db->getQueryBuilder();
 		$query->insert('cards_properties')
 			->values(
@@ -611,7 +611,7 @@ class CardDavBackendTest extends TestCase {
 		$this->assertSame(2, (int)$result[0]['cardid']);
 	}
 
-	public function testGetCardId() {
+	public function testGetCardId(): void {
 		$query = $this->db->getQueryBuilder();
 
 		$query->insert('cards')
@@ -633,7 +633,7 @@ class CardDavBackendTest extends TestCase {
 	}
 
 
-	public function testGetCardIdFailed() {
+	public function testGetCardIdFailed(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$this->invokePrivate($this->backend, 'getCardId', [1, 'uri']);
@@ -647,7 +647,7 @@ class CardDavBackendTest extends TestCase {
 	 * @param array $options
 	 * @param array $expected
 	 */
-	public function testSearch($pattern, $properties, $options, $expected) {
+	public function testSearch($pattern, $properties, $options, $expected): void {
 		/** @var VCard $vCards */
 		$vCards = [];
 		$vCards[0] = new VCard();
@@ -767,7 +767,7 @@ class CardDavBackendTest extends TestCase {
 		];
 	}
 
-	public function testGetCardUri() {
+	public function testGetCardUri(): void {
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsTable)
 				->values(
@@ -788,13 +788,13 @@ class CardDavBackendTest extends TestCase {
 	}
 
 
-	public function testGetCardUriFailed() {
+	public function testGetCardUriFailed(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$this->backend->getCardUri(1);
 	}
 
-	public function testGetContact() {
+	public function testGetContact(): void {
 		$query = $this->db->getQueryBuilder();
 		for ($i = 0; $i < 2; $i++) {
 			$query->insert($this->dbCardsTable)
@@ -825,11 +825,11 @@ class CardDavBackendTest extends TestCase {
 		$this->assertEmpty($result);
 	}
 
-	public function testGetContactFail() {
+	public function testGetContactFail(): void {
 		$this->assertEmpty($this->backend->getContact(0, 'uri'));
 	}
 
-	public function testCollectCardProperties() {
+	public function testCollectCardProperties(): void {
 		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -33,7 +33,7 @@ use OCP\IURLGenerator;
 use Test\TestCase;
 
 class ContactsManagerTest extends TestCase {
-	public function test() {
+	public function test(): void {
 		/** @var IManager | \PHPUnit\Framework\MockObject\MockObject $cm */
 		$cm = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
 		$cm->expects($this->exactly(2))->method('registerAddressBook');

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -94,7 +94,7 @@ class ConverterTest extends TestCase {
 	/**
 	 * @dataProvider providesNewUsers
 	 */
-	public function testCreation($expectedVCard, $displayName = null, $eMailAddress = null, $cloudId = null) {
+	public function testCreation($expectedVCard, $displayName = null, $eMailAddress = null, $cloudId = null): void {
 		$user = $this->getUserMock((string)$displayName, $eMailAddress, $cloudId);
 		$accountManager = $this->getAccountManager($user);
 
@@ -183,7 +183,7 @@ class ConverterTest extends TestCase {
 	 * @param $expected
 	 * @param $fullName
 	 */
-	public function testNameSplitter($expected, $fullName) {
+	public function testNameSplitter($expected, $fullName): void {
 		$converter = new Converter($this->accountManager);
 		$r = $converter->splitFullName($fullName);
 		$r = implode(';', $r);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -73,7 +73,7 @@ class ImageExportPluginTest extends TestCase {
 	 * @dataProvider providesQueryParams
 	 * @param $param
 	 */
-	public function testQueryParams($param) {
+	public function testQueryParams($param): void {
 		$this->request->expects($this->once())->method('getQueryParameters')->willReturn($param);
 		$result = $this->plugin->httpGet($this->request, $this->response);
 		$this->assertTrue($result);
@@ -87,7 +87,7 @@ class ImageExportPluginTest extends TestCase {
 		];
 	}
 
-	public function testNoCard() {
+	public function testNoCard(): void {
 		$this->request->method('getQueryParameters')
 			->willReturn([
 				'photo'
@@ -119,7 +119,7 @@ class ImageExportPluginTest extends TestCase {
 	 * @param $size
 	 * @param bool $photo
 	 */
-	public function testCard($size, $photo) {
+	public function testCard($size, $photo): void {
 		$query = ['photo' => null];
 		if ($size !== null) {
 			$query['size'] = $size;

--- a/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/Sharing/PluginTest.php
@@ -67,7 +67,7 @@ class PluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testSharing() {
+	public function testSharing(): void {
 		$this->book->expects($this->once())->method('updateShares')->with([[
 			'href' => 'principal:principals/admin',
 			'commonName' => null,

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -37,7 +37,7 @@ use Sabre\VObject\Component\VCard;
 use Test\TestCase;
 
 class SyncServiceTest extends TestCase {
-	public function testEmptySync() {
+	public function testEmptySync(): void {
 		$backend = $this->getBackendMock(0, 0, 0);
 
 		$ss = $this->getSyncServiceMock($backend, []);
@@ -45,7 +45,7 @@ class SyncServiceTest extends TestCase {
 		$this->assertEquals('sync-token-1', $return);
 	}
 
-	public function testSyncWithNewElement() {
+	public function testSyncWithNewElement(): void {
 		$backend = $this->getBackendMock(1, 0, 0);
 		$backend->method('getCard')->willReturn(false);
 
@@ -54,7 +54,7 @@ class SyncServiceTest extends TestCase {
 		$this->assertEquals('sync-token-1', $return);
 	}
 
-	public function testSyncWithUpdatedElement() {
+	public function testSyncWithUpdatedElement(): void {
 		$backend = $this->getBackendMock(0, 1, 0);
 		$backend->method('getCard')->willReturn(true);
 
@@ -63,7 +63,7 @@ class SyncServiceTest extends TestCase {
 		$this->assertEquals('sync-token-1', $return);
 	}
 
-	public function testSyncWithDeletedElement() {
+	public function testSyncWithDeletedElement(): void {
 		$backend = $this->getBackendMock(0, 0, 1);
 
 		$ss = $this->getSyncServiceMock($backend, ['0' => [404 => '']]);
@@ -71,7 +71,7 @@ class SyncServiceTest extends TestCase {
 		$this->assertEquals('sync-token-1', $return);
 	}
 
-	public function testEnsureSystemAddressBookExists() {
+	public function testEnsureSystemAddressBookExists(): void {
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->exactly(1))->method('createAddressBook');
@@ -107,7 +107,7 @@ class SyncServiceTest extends TestCase {
 	 * @param integer $deleteCalls
 	 * @return void
 	 */
-	public function testUpdateAndDeleteUser($activated, $createCalls, $updateCalls, $deleteCalls) {
+	public function testUpdateAndDeleteUser($activated, $createCalls, $updateCalls, $deleteCalls): void {
 		/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$logger = $this->getMockBuilder(LoggerInterface::class)->disableOriginalConstructor()->getMock();

--- a/apps/dav/tests/unit/Command/DeleteCalendarTest.php
+++ b/apps/dav/tests/unit/Command/DeleteCalendarTest.php
@@ -80,7 +80,7 @@ class DeleteCalendarTest extends TestCase {
 		);
 	}
 
-	public function testInvalidUser() {
+	public function testInvalidUser(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage(
 			'User <' . self::USER . '> is unknown.');
@@ -97,7 +97,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testNoCalendarName() {
+	public function testNoCalendarName(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage(
 			'Please specify a calendar name or --birthday');
@@ -113,7 +113,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testInvalidCalendar() {
+	public function testInvalidCalendar(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage(
 			'User <' . self::USER . '> has no calendar named <' . self::NAME .  '>.');
@@ -137,7 +137,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$id = 1234;
 		$calendar = [
 			'id' => $id,
@@ -167,7 +167,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testForceDelete() {
+	public function testForceDelete(): void {
 		$id = 1234;
 		$calendar = [
 			'id' => $id,
@@ -198,7 +198,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testDeleteBirthday() {
+	public function testDeleteBirthday(): void {
 		$id = 1234;
 		$calendar = [
 			'id' => $id,
@@ -228,7 +228,7 @@ class DeleteCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testBirthdayHasPrecedence() {
+	public function testBirthdayHasPrecedence(): void {
 		$calendar = [
 			'id' => 1234,
 			'principaluri' => 'principals/users/' . self::USER,

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -63,7 +63,7 @@ class ListCalendarsTest extends TestCase {
 		);
 	}
 
-	public function testWithBadUser() {
+	public function testWithBadUser(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$this->userManager->expects($this->once())
@@ -78,7 +78,7 @@ class ListCalendarsTest extends TestCase {
 		$this->assertStringContainsString("User <" . self::USERNAME . "> in unknown", $commandTester->getDisplay());
 	}
 
-	public function testWithCorrectUserWithNoCalendars() {
+	public function testWithCorrectUserWithNoCalendars(): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')
 			->with(self::USERNAME)
@@ -106,7 +106,7 @@ class ListCalendarsTest extends TestCase {
 	/**
 	 * @dataProvider dataExecute
 	 */
-	public function testWithCorrectUser(bool $readOnly, string $output) {
+	public function testWithCorrectUser(bool $readOnly, string $output): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')
 			->with(self::USERNAME)

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -104,7 +104,7 @@ class MoveCalendarTest extends TestCase {
 	 * @param $userOriginExists
 	 * @param $userDestinationExists
 	 */
-	public function testWithBadUserOrigin($userOriginExists, $userDestinationExists) {
+	public function testWithBadUserOrigin($userOriginExists, $userDestinationExists): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$this->userManager->expects($this->exactly($userOriginExists ? 2 : 1))
@@ -127,7 +127,7 @@ class MoveCalendarTest extends TestCase {
 	}
 
 
-	public function testMoveWithInexistantCalendar() {
+	public function testMoveWithInexistantCalendar(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('User <user> has no calendar named <personal>. You can run occ dav:list-calendars to list calendars URIs for this user.');
 
@@ -152,7 +152,7 @@ class MoveCalendarTest extends TestCase {
 	}
 
 
-	public function testMoveWithExistingDestinationCalendar() {
+	public function testMoveWithExistingDestinationCalendar(): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('User <user2> already has a calendar named <personal>.');
 
@@ -182,7 +182,7 @@ class MoveCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testMove() {
+	public function testMove(): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
 			->withConsecutive(
@@ -228,7 +228,7 @@ class MoveCalendarTest extends TestCase {
 	/**
 	 * @dataProvider dataTestMoveWithDestinationNotPartOfGroup
 	 */
-	public function testMoveWithDestinationNotPartOfGroup(bool $shareWithGroupMembersOnly) {
+	public function testMoveWithDestinationNotPartOfGroup(bool $shareWithGroupMembersOnly): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
 			->withConsecutive(
@@ -272,7 +272,7 @@ class MoveCalendarTest extends TestCase {
 		]);
 	}
 
-	public function testMoveWithDestinationPartOfGroup() {
+	public function testMoveWithDestinationPartOfGroup(): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
 			->withConsecutive(
@@ -318,7 +318,7 @@ class MoveCalendarTest extends TestCase {
 		$this->assertStringContainsString("[OK] Calendar <personal> was moved from user <user> to <user2>", $commandTester->getDisplay());
 	}
 
-	public function testMoveWithDestinationNotPartOfGroupAndForce() {
+	public function testMoveWithDestinationNotPartOfGroupAndForce(): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
 			->withConsecutive(
@@ -376,7 +376,7 @@ class MoveCalendarTest extends TestCase {
 	/**
 	 * @dataProvider dataTestMoveWithCalendarAlreadySharedToDestination
 	 */
-	public function testMoveWithCalendarAlreadySharedToDestination(bool $force) {
+	public function testMoveWithCalendarAlreadySharedToDestination(bool $force): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
 			->withConsecutive(

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -48,7 +48,7 @@ class RemoveInvalidSharesTest extends TestCase {
 		]);
 	}
 
-	public function test() {
+	public function test(): void {
 		$db = \OC::$server->getDatabaseConnection();
 		/** @var Principal | \PHPUnit\Framework\MockObject\MockObject $principal */
 		$principal = $this->createMock(Principal::class);

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -75,7 +75,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		);
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -108,7 +108,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteForbidden() {
+	public function testDeleteForbidden(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$user = $this->getMockBuilder(IUser::class)
@@ -140,7 +140,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->node->delete();
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$id = '19';
 		$this->comment->expects($this->once())
 			->method('getId')
@@ -150,17 +150,17 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
 		$this->node->setName('666');
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$this->assertSame($this->node->getLastModified(), null);
 	}
 
-	public function testUpdateComment() {
+	public function testUpdateComment(): void {
 		$msg = 'Hello Earth';
 
 		$user = $this->getMockBuilder(IUser::class)
@@ -195,7 +195,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateCommentLogException() {
+	public function testUpdateCommentLogException(): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('buh!');
 
@@ -236,7 +236,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateCommentMessageTooLongException() {
+	public function testUpdateCommentMessageTooLongException(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Message exceeds allowed character limit of');
 
@@ -275,7 +275,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateForbiddenByUser() {
+	public function testUpdateForbiddenByUser(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$msg = 'HaXX0r';
@@ -310,7 +310,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateForbiddenByType() {
+	public function testUpdateForbiddenByType(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$msg = 'HaXX0r';
@@ -340,7 +340,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateForbiddenByNotLoggedIn() {
+	public function testUpdateForbiddenByNotLoggedIn(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$msg = 'HaXX0r';
@@ -362,7 +362,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->node->updateComment($msg);
 	}
 
-	public function testPropPatch() {
+	public function testPropPatch(): void {
 		$propPatch = $this->getMockBuilder(PropPatch::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -374,7 +374,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->node->propPatch($propPatch);
 	}
 
-	public function testGetProperties() {
+	public function testGetProperties(): void {
 		$ns = '{http://owncloud.org/ns}';
 		$expected = [
 			$ns . 'id' => '123',
@@ -519,7 +519,7 @@ class CommentsNodeTest extends \Test\TestCase {
 	 * @dataProvider readCommentProvider
 	 * @param $expected
 	 */
-	public function testGetPropertiesUnreadProperty($creationDT, $readDT, $expected) {
+	public function testGetPropertiesUnreadProperty($creationDT, $readDT, $expected): void {
 		$this->comment->expects($this->any())
 			->method('getCreationDateTime')
 			->willReturn($creationDT);

--- a/apps/dav/tests/unit/Comments/CommentsPluginTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsPluginTest.php
@@ -75,7 +75,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->plugin = new CommentsPluginImplementation($this->commentsManager, $this->userSession);
 	}
 
-	public function testCreateComment() {
+	public function testCreateComment(): void {
 		$commentData = [
 			'actorType' => 'users',
 			'verb' => 'comment',
@@ -171,7 +171,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateCommentInvalidObject() {
+	public function testCreateCommentInvalidObject(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$commentData = [
@@ -253,7 +253,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateCommentInvalidActor() {
+	public function testCreateCommentInvalidActor(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$commentData = [
@@ -341,7 +341,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateCommentUnsupportedMediaType() {
+	public function testCreateCommentUnsupportedMediaType(): void {
 		$this->expectException(\Sabre\DAV\Exception\UnsupportedMediaType::class);
 
 		$commentData = [
@@ -429,7 +429,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateCommentInvalidPayload() {
+	public function testCreateCommentInvalidPayload(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$commentData = [
@@ -523,7 +523,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateCommentMessageTooLong() {
+	public function testCreateCommentMessageTooLong(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Message exceeds allowed character limit of');
 
@@ -617,7 +617,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testOnReportInvalidNode() {
+	public function testOnReportInvalidNode(): void {
 		$this->expectException(\Sabre\DAV\Exception\ReportNotSupported::class);
 
 		$path = 'totally/unrelated/13';
@@ -640,7 +640,7 @@ class CommentsPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testOnReportInvalidReportName() {
+	public function testOnReportInvalidReportName(): void {
 		$this->expectException(\Sabre\DAV\Exception\ReportNotSupported::class);
 
 		$path = 'comments/files/42';
@@ -662,7 +662,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->plugin->onReport('{whoever}whatever', [], '/' . $path);
 	}
 
-	public function testOnReportDateTimeEmpty() {
+	public function testOnReportDateTimeEmpty(): void {
 		$path = 'comments/files/42';
 
 		$parameters = [
@@ -717,7 +717,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->plugin->onReport(CommentsPluginImplementation::REPORT_NAME, $parameters, '/' . $path);
 	}
 
-	public function testOnReport() {
+	public function testOnReport(): void {
 		$path = 'comments/files/42';
 
 		$parameters = [

--- a/apps/dav/tests/unit/Comments/EntityCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityCollectionTest.php
@@ -71,11 +71,11 @@ class EntityCollectionTest extends \Test\TestCase {
 		);
 	}
 
-	public function testGetId() {
+	public function testGetId(): void {
 		$this->assertSame($this->collection->getId(), '19');
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
@@ -90,7 +90,7 @@ class EntityCollectionTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildException() {
+	public function testGetChildException(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->commentsManager->expects($this->once())
@@ -101,7 +101,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->collection->getChild('55');
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->commentsManager->expects($this->once())
 			->method('getForObject')
 			->with('files', '19')
@@ -117,7 +117,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
 	}
 
-	public function testFindChildren() {
+	public function testFindChildren(): void {
 		$dt = new \DateTime('2016-01-10 18:48:00');
 		$this->commentsManager->expects($this->once())
 			->method('getForObject')
@@ -134,11 +134,11 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
 	}
 
-	public function testChildExistsTrue() {
+	public function testChildExistsTrue(): void {
 		$this->assertTrue($this->collection->childExists('44'));
 	}
 
-	public function testChildExistsFalse() {
+	public function testChildExistsFalse(): void {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('44')

--- a/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
@@ -75,16 +75,16 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 		);
 	}
 
-	public function testChildExistsYes() {
+	public function testChildExistsYes(): void {
 		$this->childMap[17] = true;
 		$this->assertTrue($this->collection->childExists('17'));
 	}
 
-	public function testChildExistsNo() {
+	public function testChildExistsNo(): void {
 		$this->assertFalse($this->collection->childExists('17'));
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$this->childMap[17] = true;
 
 		$ec = $this->collection->getChild('17');
@@ -92,14 +92,14 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildException() {
+	public function testGetChildException(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->collection->getChild('17');
 	}
 
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
 		$this->collection->getChildren();

--- a/apps/dav/tests/unit/Comments/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/RootCollectionTest.php
@@ -99,7 +99,7 @@ class RootCollectionTest extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($this->user);
 
-		$this->dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function (CommentsEntityEvent $event) {
+		$this->dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function (CommentsEntityEvent $event): void {
 			$event->addEntityCollection('files', function () {
 				return true;
 			});
@@ -107,27 +107,27 @@ class RootCollectionTest extends \Test\TestCase {
 	}
 
 
-	public function testCreateFile() {
+	public function testCreateFile(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->collection->createFile('foo');
 	}
 
 
-	public function testCreateDirectory() {
+	public function testCreateDirectory(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->collection->createDirectory('foo');
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$this->prepareForInitCollections();
 		$etc = $this->collection->getChild('files');
 		$this->assertTrue($etc instanceof EntityTypeCollectionImplementation);
 	}
 
 
-	public function testGetChildInvalid() {
+	public function testGetChildInvalid(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->prepareForInitCollections();
@@ -135,13 +135,13 @@ class RootCollectionTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildNoAuth() {
+	public function testGetChildNoAuth(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 
 		$this->collection->getChild('files');
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->prepareForInitCollections();
 		$children = $this->collection->getChildren();
 		$this->assertFalse(empty($children));
@@ -151,48 +151,48 @@ class RootCollectionTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildrenNoAuth() {
+	public function testGetChildrenNoAuth(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 
 		$this->collection->getChildren();
 	}
 
-	public function testChildExistsYes() {
+	public function testChildExistsYes(): void {
 		$this->prepareForInitCollections();
 		$this->assertTrue($this->collection->childExists('files'));
 	}
 
-	public function testChildExistsNo() {
+	public function testChildExistsNo(): void {
 		$this->prepareForInitCollections();
 		$this->assertFalse($this->collection->childExists('robots'));
 	}
 
 
-	public function testChildExistsNoAuth() {
+	public function testChildExistsNoAuth(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 
 		$this->collection->childExists('files');
 	}
 
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->collection->delete();
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertSame('comments', $this->collection->getName());
 	}
 
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->collection->setName('foobar');
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$this->assertSame(null, $this->collection->getLastModified());
 	}
 }

--- a/apps/dav/tests/unit/Connector/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/PublicAuthTest.php
@@ -93,7 +93,7 @@ class PublicAuthTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
-	public function testNoShare() {
+	public function testNoShare(): void {
 		$this->shareManager->expects($this->once())
 			->method('getShareByToken')
 			->willThrowException(new ShareNotFound());
@@ -103,7 +103,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertFalse($result);
 	}
 
-	public function testShareNoPassword() {
+	public function testShareNoPassword(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -118,7 +118,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testSharePasswordFancyShareType() {
+	public function testSharePasswordFancyShareType(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -135,7 +135,7 @@ class PublicAuthTest extends \Test\TestCase {
 	}
 
 
-	public function testSharePasswordRemote() {
+	public function testSharePasswordRemote(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -151,7 +151,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testSharePasswordLinkValidPassword() {
+	public function testSharePasswordLinkValidPassword(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -173,7 +173,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testSharePasswordMailValidPassword() {
+	public function testSharePasswordMailValidPassword(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -195,7 +195,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testSharePasswordLinkValidSession() {
+	public function testSharePasswordLinkValidSession(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -221,7 +221,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->assertTrue($result);
 	}
 
-	public function testSharePasswordLinkInvalidSession() {
+	public function testSharePasswordLinkInvalidSession(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -248,7 +248,7 @@ class PublicAuthTest extends \Test\TestCase {
 	}
 
 
-	public function testSharePasswordMailInvalidSession() {
+	public function testSharePasswordMailInvalidSession(): void {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -83,7 +83,7 @@ class AuthTest extends TestCase {
 		);
 	}
 
-	public function testIsDavAuthenticatedWithoutDavSession() {
+	public function testIsDavAuthenticatedWithoutDavSession(): void {
 		$this->session
 			->expects($this->once())
 			->method('get')
@@ -93,7 +93,7 @@ class AuthTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
-	public function testIsDavAuthenticatedWithWrongDavSession() {
+	public function testIsDavAuthenticatedWithWrongDavSession(): void {
 		$this->session
 			->expects($this->exactly(2))
 			->method('get')
@@ -103,7 +103,7 @@ class AuthTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
-	public function testIsDavAuthenticatedWithCorrectDavSession() {
+	public function testIsDavAuthenticatedWithCorrectDavSession(): void {
 		$this->session
 			->expects($this->exactly(2))
 			->method('get')
@@ -113,7 +113,7 @@ class AuthTest extends TestCase {
 		$this->assertTrue($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
-	public function testValidateUserPassOfAlreadyDAVAuthenticatedUser() {
+	public function testValidateUserPassOfAlreadyDAVAuthenticatedUser(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -140,7 +140,7 @@ class AuthTest extends TestCase {
 		$this->assertTrue($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
-	public function testValidateUserPassOfInvalidDAVAuthenticatedUser() {
+	public function testValidateUserPassOfInvalidDAVAuthenticatedUser(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -167,7 +167,7 @@ class AuthTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
-	public function testValidateUserPassOfInvalidDAVAuthenticatedUserWithValidPassword() {
+	public function testValidateUserPassOfInvalidDAVAuthenticatedUserWithValidPassword(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -203,7 +203,7 @@ class AuthTest extends TestCase {
 		$this->assertTrue($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
-	public function testValidateUserPassWithInvalidPassword() {
+	public function testValidateUserPassWithInvalidPassword(): void {
 		$this->userSession
 			->expects($this->once())
 			->method('isLoggedIn')
@@ -221,7 +221,7 @@ class AuthTest extends TestCase {
 	}
 
 
-	public function testValidateUserPassWithPasswordLoginForbidden() {
+	public function testValidateUserPassWithPasswordLoginForbidden(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden::class);
 
 		$this->userSession
@@ -240,7 +240,7 @@ class AuthTest extends TestCase {
 		$this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']);
 	}
 
-	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGet() {
+	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGet(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 				->disableOriginalConstructor()
 				->getMock();
@@ -283,7 +283,7 @@ class AuthTest extends TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndCorrectlyDavAuthenticated() {
+	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndCorrectlyDavAuthenticated(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -330,7 +330,7 @@ class AuthTest extends TestCase {
 	}
 
 
-	public function testAuthenticateAlreadyLoggedInWithoutTwoFactorChallengePassed() {
+	public function testAuthenticateAlreadyLoggedInWithoutTwoFactorChallengePassed(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('2FA challenge not passed.');
 
@@ -384,7 +384,7 @@ class AuthTest extends TestCase {
 	}
 
 
-	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndIncorrectlyDavAuthenticated() {
+	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndIncorrectlyDavAuthenticated(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('CSRF check not passed.');
 
@@ -433,7 +433,7 @@ class AuthTest extends TestCase {
 		$this->auth->check($request, $response);
 	}
 
-	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGetAndDesktopClient() {
+	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGetAndDesktopClient(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -480,7 +480,7 @@ class AuthTest extends TestCase {
 		$this->auth->check($request, $response);
 	}
 
-	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForGet() {
+	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForGet(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -515,7 +515,7 @@ class AuthTest extends TestCase {
 		$this->assertEquals([true, 'principals/users/MyWrongDavUser'], $response);
 	}
 
-	public function testAuthenticateAlreadyLoggedInWithCsrfTokenForGet() {
+	public function testAuthenticateAlreadyLoggedInWithCsrfTokenForGet(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -550,7 +550,7 @@ class AuthTest extends TestCase {
 		$this->assertEquals([true, 'principals/users/MyWrongDavUser'], $response);
 	}
 
-	public function testAuthenticateNoBasicAuthenticateHeadersProvided() {
+	public function testAuthenticateNoBasicAuthenticateHeadersProvided(): void {
 		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -565,7 +565,7 @@ class AuthTest extends TestCase {
 	}
 
 
-	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjax() {
+	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjax(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('Cannot authenticate over ajax calls');
 
@@ -589,7 +589,7 @@ class AuthTest extends TestCase {
 		$this->auth->check($httpRequest, $httpResponse);
 	}
 
-	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn() {
+	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn(): void {
 		/** @var \Sabre\HTTP\RequestInterface $httpRequest */
 		$httpRequest = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
@@ -631,7 +631,7 @@ class AuthTest extends TestCase {
 		);
 	}
 
-	public function testAuthenticateValidCredentials() {
+	public function testAuthenticateValidCredentials(): void {
 		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -671,7 +671,7 @@ class AuthTest extends TestCase {
 		$this->assertEquals([true, 'principals/users/MyTestUser'], $response);
 	}
 
-	public function testAuthenticateInvalidCredentials() {
+	public function testAuthenticateInvalidCredentials(): void {
 		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -60,11 +60,11 @@ class BearerAuthTest extends TestCase {
 		);
 	}
 
-	public function testValidateBearerTokenNotLoggedIn() {
+	public function testValidateBearerTokenNotLoggedIn(): void {
 		$this->assertFalse($this->bearerAuth->validateBearerToken('Token'));
 	}
 
-	public function testValidateBearerToken() {
+	public function testValidateBearerToken(): void {
 		$this->userSession
 			->expects($this->exactly(2))
 			->method('isLoggedIn')
@@ -85,7 +85,7 @@ class BearerAuthTest extends TestCase {
 		$this->assertSame('principals/users/admin', $this->bearerAuth->validateBearerToken('Token'));
 	}
 
-	public function testChallenge() {
+	public function testChallenge(): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject|RequestInterface $request */
 		$request = $this->createMock(RequestInterface::class);
 		/** @var \PHPUnit\Framework\MockObject\MockObject|ResponseInterface $response */

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -67,7 +67,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 * @dataProvider oldDesktopClientProvider
 	 * @param string $userAgent
 	 */
-	public function testBeforeHandlerException($userAgent) {
+	public function testBeforeHandlerException($userAgent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('Unsupported client version.');
 
@@ -105,7 +105,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 * @dataProvider newAndAlternateDesktopClientProvider
 	 * @param string $userAgent
 	 */
-	public function testBeforeHandlerSuccess($userAgent) {
+	public function testBeforeHandlerSuccess($userAgent): void {
 		/** @var \Sabre\HTTP\RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
 		$request
@@ -123,7 +123,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
 	}
 
-	public function testBeforeHandlerNoUserAgent() {
+	public function testBeforeHandlerNoUserAgent(): void {
 		/** @var \Sabre\HTTP\RequestInterface | \PHPUnit\Framework\MockObject\MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
 		$request

--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -78,7 +78,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	 * @param $node
 	 * @param $expectedSuccessful
 	 */
-	public function testHandleGetProperties($node, $expectedSuccessful) {
+	public function testHandleGetProperties($node, $expectedSuccessful): void {
 		$propFind = $this->getMockBuilder(PropFind::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -108,7 +108,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	 * @param $fid
 	 * @param $expectedHref
 	 */
-	public function testGetCommentsLink($baseUri, $fid, $expectedHref) {
+	public function testGetCommentsLink($baseUri, $fid, $expectedHref): void {
 		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -139,7 +139,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 	 * @dataProvider userProvider
 	 * @param $user
 	 */
-	public function testGetUnreadCount($user) {
+	public function testGetUnreadCount($user): void {
 		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
@@ -57,7 +57,7 @@ class CopyEtagHeaderPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testCopyEtag() {
+	public function testCopyEtag(): void {
 		$request = new \Sabre\Http\Request('GET', 'dummy.file');
 		$response = new \Sabre\Http\Response();
 		$response->setHeader('Etag', 'abcd');
@@ -67,7 +67,7 @@ class CopyEtagHeaderPluginTest extends TestCase {
 		$this->assertEquals('abcd', $response->getHeader('OC-Etag'));
 	}
 
-	public function testNoopWhenEmpty() {
+	public function testNoopWhenEmpty(): void {
 		$request = new \Sabre\Http\Request('GET', 'dummy.file');
 		$response = new \Sabre\Http\Response();
 
@@ -89,7 +89,7 @@ class CopyEtagHeaderPluginTest extends TestCase {
 		// Nothing to assert, we are just testing if the exception is handled
 	}
 
-	public function testAfterMove() {
+	public function testAfterMove(): void {
 		$node = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -122,7 +122,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 		return $node;
 	}
 
-	private function applyDefaultProps($path = '/dummypath') {
+	private function applyDefaultProps($path = '/dummypath'): void {
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch([
 			'customprop' => 'value1',
@@ -146,7 +146,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	/**
 	 * Test that propFind on a missing file soft fails
 	 */
-	public function testPropFindMissingFileSoftFail() {
+	public function testPropFindMissingFileSoftFail(): void {
 		$propFind = new \Sabre\DAV\PropFind(
 			'/dummypath',
 			[
@@ -174,7 +174,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	/**
 	 * Test setting/getting properties
 	 */
-	public function testSetGetPropertiesForFile() {
+	public function testSetGetPropertiesForFile(): void {
 		$this->applyDefaultProps();
 
 		$propFind = new \Sabre\DAV\PropFind(
@@ -200,7 +200,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	/**
 	 * Test getting properties from directory
 	 */
-	public function testGetPropertiesForDirectory() {
+	public function testGetPropertiesForDirectory(): void {
 		$this->applyDefaultProps('/dummypath');
 		$this->applyDefaultProps('/dummypath/test.txt');
 
@@ -247,7 +247,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	/**
 	 * Test delete property
 	 */
-	public function testDeleteProperty() {
+	public function testDeleteProperty(): void {
 		$this->applyDefaultProps();
 
 		$propPatch = new \Sabre\DAV\PropPatch([

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -107,7 +107,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteRootFolderFails() {
+	public function testDeleteRootFolderFails(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->info->expects($this->any())
@@ -120,7 +120,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteForbidden() {
+	public function testDeleteForbidden(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
 
 		// deletion allowed
@@ -139,7 +139,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteFolderWhenAllowed() {
+	public function testDeleteFolderWhenAllowed(): void {
 		// deletion allowed
 		$this->info->expects($this->once())
 			->method('isDeletable')
@@ -156,7 +156,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteFolderFailsWhenNotAllowed() {
+	public function testDeleteFolderFailsWhenNotAllowed(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->info->expects($this->once())
@@ -168,7 +168,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteFolderThrowsWhenDeletionFailed() {
+	public function testDeleteFolderThrowsWhenDeletionFailed(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		// deletion allowed
@@ -186,7 +186,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->delete();
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$info1 = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -226,7 +226,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildrenNoPermission() {
+	public function testGetChildrenNoPermission(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$info = $this->createMock(FileInfo::class);
@@ -239,7 +239,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildNoPermission() {
+	public function testGetChildNoPermission(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->info->expects($this->any())
@@ -251,7 +251,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildThrowStorageNotAvailableException() {
+	public function testGetChildThrowStorageNotAvailableException(): void {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 
 		$this->view->expects($this->once())
@@ -263,7 +263,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testGetChildThrowInvalidPath() {
+	public function testGetChildThrowInvalidPath(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
 		$this->view->expects($this->once())
@@ -276,7 +276,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir->getChild('.');
 	}
 
-	public function testGetQuotaInfoUnlimited() {
+	public function testGetQuotaInfoUnlimited(): void {
 		self::createUser('user', 'password');
 		self::loginAsUser('user');
 		$mountPoint = $this->createMock(IMountPoint::class);
@@ -319,7 +319,7 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertEquals([200, -3], $dir->getQuotaInfo()); //200 used, unlimited
 	}
 
-	public function testGetQuotaInfoSpecific() {
+	public function testGetQuotaInfoSpecific(): void {
 		self::createUser('user', 'password');
 		self::loginAsUser('user');
 		$mountPoint = $this->createMock(IMountPoint::class);
@@ -366,7 +366,7 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveFailedProvider
 	 */
-	public function testMoveFailed($source, $destination, $updatables, $deletables) {
+	public function testMoveFailed($source, $destination, $updatables, $deletables): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
@@ -375,7 +375,7 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveSuccessProvider
 	 */
-	public function testMoveSuccess($source, $destination, $updatables, $deletables) {
+	public function testMoveSuccess($source, $destination, $updatables, $deletables): void {
 		$this->moveTest($source, $destination, $updatables, $deletables);
 		$this->addToAssertionCount(1);
 	}
@@ -383,7 +383,7 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveFailedInvalidCharsProvider
 	 */
-	public function testMoveFailedInvalidChars($source, $destination, $updatables, $deletables) {
+	public function testMoveFailedInvalidChars($source, $destination, $updatables, $deletables): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
@@ -419,7 +419,7 @@ class DirectoryTest extends \Test\TestCase {
 	 * @param $destination
 	 * @param $updatables
 	 */
-	private function moveTest($source, $destination, $updatables, $deletables) {
+	private function moveTest($source, $destination, $updatables, $deletables): void {
 		$view = new TestViewDirectory($updatables, $deletables);
 
 		$sourceInfo = new FileInfo($source, null, null, [
@@ -441,7 +441,7 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 
-	public function testFailingMove() {
+	public function testFailingMove(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('Could not copy directory b, target exists');
 

--- a/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
@@ -46,7 +46,7 @@ class DummyGetResponsePluginTest extends TestCase {
 		$this->dummyGetResponsePlugin = new DummyGetResponsePlugin();
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		/** @var Server $server */
 		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
@@ -60,7 +60,7 @@ class DummyGetResponsePluginTest extends TestCase {
 	}
 
 
-	public function testHttpGet() {
+	public function testHttpGet(): void {
 		/** @var \Sabre\HTTP\RequestInterface $request */
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
@@ -25,7 +25,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\Exception;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 
 class ForbiddenTest extends \Test\TestCase {
-	public function testSerialization() {
+	public function testSerialization(): void {
 
 		// create xml doc
 		$DOM = new \DOMDocument('1.0','utf-8');

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
@@ -26,7 +26,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\Exception;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 
 class InvalidPathTest extends \Test\TestCase {
-	public function testSerialization() {
+	public function testSerialization(): void {
 
 		// create xml doc
 		$DOM = new \DOMDocument('1.0','utf-8');

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -50,7 +50,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 	/** @var LoggerInterface | \PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
-	private function init() {
+	private function init(): void {
 		$config = $this->createMock(SystemConfig::class);
 		$config->expects($this->any())
 			->method('getValue')
@@ -72,7 +72,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 	/**
 	 * @dataProvider providesExceptions
 	 */
-	public function testLogging(string $expectedLogLevel, \Throwable $e) {
+	public function testLogging(string $expectedLogLevel, \Throwable $e): void {
 		$this->init();
 
 		$this->logger->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
@@ -50,7 +50,7 @@ class FakeLockerPluginTest extends TestCase {
 		$this->fakeLockerPlugin = new FakeLockerPlugin();
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		/** @var Server $server */
 		$server = $this->getMockBuilder(Server::class)
 			->disableOriginalConstructor()
@@ -68,7 +68,7 @@ class FakeLockerPluginTest extends TestCase {
 		$this->fakeLockerPlugin->initialize($server);
 	}
 
-	public function testGetHTTPMethods() {
+	public function testGetHTTPMethods(): void {
 		$expected = [
 			'LOCK',
 			'UNLOCK',
@@ -76,14 +76,14 @@ class FakeLockerPluginTest extends TestCase {
 		$this->assertSame($expected, $this->fakeLockerPlugin->getHTTPMethods('Test'));
 	}
 
-	public function testGetFeatures() {
+	public function testGetFeatures(): void {
 		$expected = [
 			2,
 		];
 		$this->assertSame($expected, $this->fakeLockerPlugin->getFeatures());
 	}
 
-	public function testPropFind() {
+	public function testPropFind(): void {
 		$propFind = $this->getMockBuilder(PropFind::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -143,7 +143,7 @@ class FakeLockerPluginTest extends TestCase {
 	 * @param array $input
 	 * @param array $expected
 	 */
-	public function testValidateTokens(array $input, array $expected) {
+	public function testValidateTokens(array $input, array $expected): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -151,7 +151,7 @@ class FakeLockerPluginTest extends TestCase {
 		$this->assertSame($expected, $input);
 	}
 
-	public function testFakeLockProvider() {
+	public function testFakeLockProvider(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -171,7 +171,7 @@ class FakeLockerPluginTest extends TestCase {
 		$this->assertXmlStringEqualsXmlString($expectedXml, $response->getBody());
 	}
 
-	public function testFakeUnlockProvider() {
+	public function testFakeUnlockProvider(): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -178,7 +178,7 @@ class FileTest extends TestCase {
 	/**
 	 * @dataProvider fopenFailuresProvider
 	 */
-	public function testSimplePutFails($thrownException, $expectedException, $checkPreviousClass = true) {
+	public function testSimplePutFails($thrownException, $expectedException, $checkPreviousClass = true): void {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
 			->setMethods(['writeStream'])
@@ -239,7 +239,7 @@ class FileTest extends TestCase {
 	 *
 	 * @dataProvider fopenFailuresProvider
 	 */
-	public function testChunkedPutFails($thrownException, $expectedException, $checkPreviousClass = false) {
+	public function testChunkedPutFails($thrownException, $expectedException, $checkPreviousClass = false): void {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
 			->setMethods(['fopen'])
@@ -357,7 +357,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test putting a single file
 	 */
-	public function testPutSingleFile() {
+	public function testPutSingleFile(): void {
 		$this->assertNotEmpty($this->doPut('/foo.txt'));
 	}
 
@@ -418,7 +418,7 @@ class FileTest extends TestCase {
 	 * Test putting a file with string Mtime
 	 * @dataProvider legalMtimeProvider
 	 */
-	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime) {
+	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime): void {
 		$request = new Request([
 			'server' => [
 				'HTTP_X_OC_MTIME' => $requestMtime,
@@ -441,7 +441,7 @@ class FileTest extends TestCase {
 	 * Test putting a file with string Mtime using chunking
 	 * @dataProvider legalMtimeProvider
 	 */
-	public function testChunkedPutLegalMtime($requestMtime, $resultMtime) {
+	public function testChunkedPutLegalMtime($requestMtime, $resultMtime): void {
 		$request = new Request([
 			'server' => [
 				'HTTP_X_OC_MTIME' => $requestMtime,
@@ -466,7 +466,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test putting a file using chunking
 	 */
-	public function testChunkedPut() {
+	public function testChunkedPut(): void {
 		$_SERVER['HTTP_OC_CHUNKED'] = true;
 		$this->assertNull($this->doPut('/test.txt-chunking-12345-2-0'));
 		$this->assertNotEmpty($this->doPut('/test.txt-chunking-12345-2-1'));
@@ -475,7 +475,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test that putting a file triggers create hooks
 	 */
-	public function testPutSingleFileTriggersHooks() {
+	public function testPutSingleFileTriggersHooks(): void {
 		HookHelper::setUpHooks();
 
 		$this->assertNotEmpty($this->doPut('/foo.txt'));
@@ -506,7 +506,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test that putting a file triggers update hooks
 	 */
-	public function testPutOverwriteFileTriggersHooks() {
+	public function testPutOverwriteFileTriggersHooks(): void {
 		$view = \OC\Files\Filesystem::getView();
 		$view->file_put_contents('/foo.txt', 'some content that will be replaced');
 
@@ -542,7 +542,7 @@ class FileTest extends TestCase {
 	 * if the passed view was chrooted (can happen with public webdav
 	 * where the root is the share root)
 	 */
-	public function testPutSingleFileTriggersHooksDifferentRoot() {
+	public function testPutSingleFileTriggersHooksDifferentRoot(): void {
 		$view = \OC\Files\Filesystem::getView();
 		$view->mkdir('noderoot');
 
@@ -577,7 +577,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test that putting a file with chunks triggers create hooks
 	 */
-	public function testPutChunkedFileTriggersHooks() {
+	public function testPutChunkedFileTriggersHooks(): void {
 		HookHelper::setUpHooks();
 
 		$_SERVER['HTTP_OC_CHUNKED'] = true;
@@ -610,7 +610,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test that putting a chunked file triggers update hooks
 	 */
-	public function testPutOverwriteChunkedFileTriggersHooks() {
+	public function testPutOverwriteChunkedFileTriggersHooks(): void {
 		$view = \OC\Files\Filesystem::getView();
 		$view->file_put_contents('/foo.txt', 'some content that will be replaced');
 
@@ -643,7 +643,7 @@ class FileTest extends TestCase {
 		);
 	}
 
-	public static function cancellingHook($params) {
+	public static function cancellingHook($params): void {
 		self::$hookCalls[] = [
 			'signal' => Filesystem::signal_post_create,
 			'params' => $params
@@ -653,7 +653,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test put file with cancelled hook
 	 */
-	public function testPutSingleFileCancelPreHook() {
+	public function testPutSingleFileCancelPreHook(): void {
 		\OCP\Util::connectHook(
 			Filesystem::CLASSNAME,
 			Filesystem::signal_create,
@@ -676,7 +676,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test exception when the uploaded size did not match
 	 */
-	public function testSimplePutFailsSizeCheck() {
+	public function testSimplePutFailsSizeCheck(): void {
 		// setup
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['rename', 'getRelativePath', 'filesize'])
@@ -724,7 +724,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test exception during final rename in simple upload mode
 	 */
-	public function testSimplePutFailsMoveFromStorage() {
+	public function testSimplePutFailsMoveFromStorage(): void {
 		$view = new \OC\Files\View('/' . $this->user . '/files');
 
 		// simulate situation where the target file is locked
@@ -758,7 +758,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test exception during final rename in chunk upload mode
 	 */
-	public function testChunkedPutFailsFinalRename() {
+	public function testChunkedPutFailsFinalRename(): void {
 		$view = new \OC\Files\View('/' . $this->user . '/files');
 
 		// simulate situation where the target file is locked
@@ -798,7 +798,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test put file with invalid chars
 	 */
-	public function testSimplePutInvalidChars() {
+	public function testSimplePutInvalidChars(): void {
 		// setup
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['getRelativePath'])
@@ -835,7 +835,7 @@ class FileTest extends TestCase {
 	 * Test setting name with setName() with invalid chars
 	 *
 	 */
-	public function testSetNameInvalidChars() {
+	public function testSetNameInvalidChars(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
 		// setup
@@ -856,7 +856,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testUploadAbort() {
+	public function testUploadAbort(): void {
 		// setup
 		$view = $this->getMockBuilder(View::class)
 			->setMethods(['rename', 'getRelativePath', 'filesize'])
@@ -901,7 +901,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testDeleteWhenAllowed() {
+	public function testDeleteWhenAllowed(): void {
 		// setup
 		$view = $this->getMockBuilder(View::class)
 			->getMock();
@@ -922,7 +922,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testDeleteThrowsWhenDeletionNotAllowed() {
+	public function testDeleteThrowsWhenDeletionNotAllowed(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		// setup
@@ -941,7 +941,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testDeleteThrowsWhenDeletionFailed() {
+	public function testDeleteThrowsWhenDeletionFailed(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		// setup
@@ -965,7 +965,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testDeleteThrowsWhenDeletionThrows() {
+	public function testDeleteThrowsWhenDeletionThrows(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
 
 		// setup
@@ -1007,7 +1007,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test whether locks are set before and after the operation
 	 */
-	public function testPutLocking() {
+	public function testPutLocking(): void {
 		$view = new \OC\Files\View('/' . $this->user . '/files/');
 
 		$path = 'test-locking.txt';
@@ -1044,7 +1044,7 @@ class FileTest extends TestCase {
 		$eventHandler->expects($this->once())
 			->method('writeCallback')
 			->willReturnCallback(
-				function () use ($view, $path, &$wasLockedPre) {
+				function () use ($view, $path, &$wasLockedPre): void {
 					$wasLockedPre = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
 					$wasLockedPre = $wasLockedPre && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 				}
@@ -1052,7 +1052,7 @@ class FileTest extends TestCase {
 		$eventHandler->expects($this->once())
 			->method('postWriteCallback')
 			->willReturnCallback(
-				function () use ($view, $path, &$wasLockedPost) {
+				function () use ($view, $path, &$wasLockedPost): void {
 					$wasLockedPost = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
 					$wasLockedPost = $wasLockedPost && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
 				}
@@ -1139,7 +1139,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testGetFopenFails() {
+	public function testGetFopenFails(): void {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 
 		$view = $this->getMockBuilder(View::class)
@@ -1160,7 +1160,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testGetFopenThrows() {
+	public function testGetFopenThrows(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
 
 		$view = $this->getMockBuilder(View::class)
@@ -1181,7 +1181,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function testGetThrowsIfNoPermission() {
+	public function testGetThrowsIfNoPermission(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$view = $this->getMockBuilder(View::class)
@@ -1200,7 +1200,7 @@ class FileTest extends TestCase {
 		$file->get();
 	}
 
-	public function testSimplePutNoCreatePermissions() {
+	public function testSimplePutNoCreatePermissions(): void {
 		$this->logout();
 
 		$storage = new Temporary([]);
@@ -1231,7 +1231,7 @@ class FileTest extends TestCase {
 		$this->assertEquals('new content', $view->file_get_contents('root/file.txt'));
 	}
 
-	public function testPutLockExpired() {
+	public function testPutLockExpired(): void {
 		$view = new \OC\Files\View('/' . $this->user . '/files/');
 
 		$path = 'test-locking.txt';

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -180,7 +180,7 @@ class FilesPluginTest extends TestCase {
 		return $node;
 	}
 
-	public function testGetPropertiesForFile() {
+	public function testGetPropertiesForFile(): void {
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
@@ -237,7 +237,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals([self::SIZE_PROPERTYNAME], $propFind->get404Properties());
 	}
 
-	public function testGetPropertiesStorageNotAvailable() {
+	public function testGetPropertiesStorageNotAvailable(): void {
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
@@ -261,7 +261,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals(null, $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
 	}
 
-	public function testGetPublicPermissions() {
+	public function testGetPublicPermissions(): void {
 		$this->plugin = new FilesPlugin(
 			$this->tree,
 			$this->config,
@@ -295,7 +295,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('DWCKR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 	}
 
-	public function testGetPropertiesForDirectory() {
+	public function testGetPropertiesForDirectory(): void {
 		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
 
@@ -330,7 +330,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals([self::DOWNLOADURL_PROPERTYNAME], $propFind->get404Properties());
 	}
 
-	public function testGetPropertiesForRootDirectory() {
+	public function testGetPropertiesForRootDirectory(): void {
 		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
@@ -362,7 +362,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('my_fingerprint', $propFind->get(self::DATA_FINGERPRINT_PROPERTYNAME));
 	}
 
-	public function testGetPropertiesWhenNoPermission() {
+	public function testGetPropertiesWhenNoPermission(): void {
 		// No read permissions can be caused by files access control.
 		// But we still want to load the directory list, so this is okay for us.
 		// $this->expectException(\Sabre\DAV\Exception\NotFound::class);
@@ -398,7 +398,7 @@ class FilesPluginTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	public function testUpdateProps() {
+	public function testUpdateProps(): void {
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
 		$testDate = 'Fri, 13 Feb 2015 00:01:02 GMT';
@@ -439,7 +439,7 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals(200, $result[self::CREATIONDATE_PROPERTYNAME]);
 	}
 
-	public function testUpdatePropsForbidden() {
+	public function testUpdatePropsForbidden(): void {
 		$propPatch = new PropPatch([
 			self::OWNER_ID_PROPERTYNAME => 'user2',
 			self::OWNER_DISPLAY_NAME_PROPERTYNAME => 'User Two',
@@ -478,7 +478,7 @@ class FilesPluginTest extends TestCase {
 	 * Thus moving /FolderA/test.txt to /test.txt should fail already on that check
 	 *
 	 */
-	public function testMoveSrcNotDeletable() {
+	public function testMoveSrcNotDeletable(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('FolderA/test.txt cannot be deleted');
 
@@ -502,7 +502,7 @@ class FilesPluginTest extends TestCase {
 		$this->plugin->checkMove('FolderA/test.txt', 'test.txt');
 	}
 
-	public function testMoveSrcDeletable() {
+	public function testMoveSrcDeletable(): void {
 		$fileInfoFolderATestTXT = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -524,7 +524,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 
-	public function testMoveSrcNotExist() {
+	public function testMoveSrcNotExist(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 		$this->expectExceptionMessage('FolderA/test.txt does not exist');
 
@@ -557,7 +557,7 @@ class FilesPluginTest extends TestCase {
 	/**
 	 * @dataProvider downloadHeadersProvider
 	 */
-	public function testDownloadHeaders($isClumsyAgent, $contentDispositionHeader) {
+	public function testDownloadHeaders($isClumsyAgent, $contentDispositionHeader): void {
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -600,7 +600,7 @@ class FilesPluginTest extends TestCase {
 		$this->plugin->httpGet($request, $response);
 	}
 
-	public function testHasPreview() {
+	public function testHasPreview(): void {
 		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
 

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -153,7 +153,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		);
 	}
 
-	public function testOnReportInvalidNode() {
+	public function testOnReportInvalidNode(): void {
 		$path = 'totally/unrelated/13';
 
 		$this->tree->expects($this->any())
@@ -173,7 +173,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertNull($this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, [], '/' . $path));
 	}
 
-	public function testOnReportInvalidReportName() {
+	public function testOnReportInvalidReportName(): void {
 		$path = 'test';
 
 		$this->tree->expects($this->any())
@@ -193,7 +193,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertNull($this->plugin->onReport('{whoever}whatever', [], '/' . $path));
 	}
 
-	public function testOnReport() {
+	public function testOnReport(): void {
 		$path = 'test';
 
 		$parameters = [
@@ -282,7 +282,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertFalse($this->plugin->onReport(FilesReportPluginImplementation::REPORT_NAME, $parameters, '/' . $path));
 	}
 
-	public function testFindNodesByFileIdsRoot() {
+	public function testFindNodesByFileIdsRoot(): void {
 		$filesNode1 = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -325,7 +325,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals('second node', $result[1]->getName());
 	}
 
-	public function testFindNodesByFileIdsSubDir() {
+	public function testFindNodesByFileIdsSubDir(): void {
 		$filesNode1 = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -378,7 +378,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals('second node', $result[1]->getName());
 	}
 
-	public function testPrepareResponses() {
+	public function testPrepareResponses(): void {
 		$requestedProps = ['{DAV:}getcontentlength', '{http://owncloud.org/ns}fileid', '{DAV:}resourcetype'];
 
 		$fileInfo = $this->createMock(FileInfo::class);
@@ -447,7 +447,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertCount(0, $props2[200]['{DAV:}resourcetype']->getValue());
 	}
 
-	public function testProcessFilterRulesSingle() {
+	public function testProcessFilterRulesSingle(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -468,7 +468,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals(['111', '222'], $this->invokePrivate($this->plugin, 'processFilterRules', [$rules]));
 	}
 
-	public function testProcessFilterRulesAndCondition() {
+	public function testProcessFilterRulesAndCondition(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -492,7 +492,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
 	}
 
-	public function testProcessFilterRulesAndConditionWithOneEmptyResult() {
+	public function testProcessFilterRulesAndConditionWithOneEmptyResult(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -516,7 +516,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
 	}
 
-	public function testProcessFilterRulesAndConditionWithFirstEmptyResult() {
+	public function testProcessFilterRulesAndConditionWithFirstEmptyResult(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -540,7 +540,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
 	}
 
-	public function testProcessFilterRulesAndConditionWithEmptyMidResult() {
+	public function testProcessFilterRulesAndConditionWithEmptyMidResult(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -567,7 +567,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
 	}
 
-	public function testProcessFilterRulesInvisibleTagAsAdmin() {
+	public function testProcessFilterRulesInvisibleTagAsAdmin(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(true);
@@ -616,7 +616,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 	}
 
 
-	public function testProcessFilterRulesInvisibleTagAsUser() {
+	public function testProcessFilterRulesInvisibleTagAsUser(): void {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 
 		$this->groupManager->expects($this->any())
@@ -656,7 +656,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->invokePrivate($this->plugin, 'processFilterRules', [$rules]);
 	}
 
-	public function testProcessFilterRulesVisibleTagAsUser() {
+	public function testProcessFilterRulesVisibleTagAsUser(): void {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn(false);
@@ -705,7 +705,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
 	}
 
-	public function testProcessFavoriteFilter() {
+	public function testProcessFavoriteFilter(): void {
 		$rules = [
 			['name' => '{http://owncloud.org/ns}favorite', 'value' => '1'],
 		];
@@ -730,7 +730,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider filesBaseUriProvider
 	 */
-	public function testFilesBaseUri($uri, $reportPath, $expectedUri) {
+	public function testFilesBaseUri($uri, $reportPath, $expectedUri): void {
 		$this->assertEquals($expectedUri, $this->invokePrivate($this->plugin, 'getFilesBaseUri', [$uri, $reportPath]));
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
@@ -53,7 +53,7 @@ class MaintenancePluginTest extends TestCase {
 	}
 
 
-	public function testMaintenanceMode() {
+	public function testMaintenanceMode(): void {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 		$this->expectExceptionMessage('System is in maintenance mode.');
 

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -63,7 +63,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider davPermissionsProvider
 	 */
-	public function testDavPermissions($permissions, $type, $shared, $mounted, $expected) {
+	public function testDavPermissions($permissions, $type, $shared, $mounted, $expected): void {
 		$info = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
 			->setMethods(['getPermissions', 'isShared', 'isMounted', 'getType'])
@@ -131,7 +131,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharePermissionsProvider
 	 */
-	public function testSharePermissions($type, $user, $permissions, $expected) {
+	public function testSharePermissions($type, $user, $permissions, $expected): void {
 		$storage = $this->getMockBuilder(Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -172,7 +172,7 @@ class NodeTest extends \Test\TestCase {
 		$this->assertEquals($expected, $node->getSharePermissions($user));
 	}
 
-	public function testShareAttributes() {
+	public function testShareAttributes(): void {
 		$storage = $this->getMockBuilder(SharedStorage::class)
 			->disableOriginalConstructor()
 			->setMethods(['getShare'])
@@ -207,7 +207,7 @@ class NodeTest extends \Test\TestCase {
 		$this->assertEquals($attributes->toArray(), $node->getShareAttributes());
 	}
 
-	public function testShareAttributesNonShare() {
+	public function testShareAttributesNonShare(): void {
 		$storage = $this->getMockBuilder(Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -241,7 +241,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sanitizeMtimeProvider
 	 */
-	public function testSanitizeMtime($mtime, $expected) {
+	public function testSanitizeMtime($mtime, $expected): void {
 		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -263,7 +263,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider invalidSanitizeMtimeProvider
 	 */
-	public function testInvalidSanitizeMtime($mtime) {
+	public function testInvalidSanitizeMtime($mtime): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$view = $this->getMockBuilder(View::class)

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -58,7 +58,7 @@ class ObjectTreeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider copyDataProvider
 	 */
-	public function testCopy($sourcePath, $targetPath, $targetParent) {
+	public function testCopy($sourcePath, $targetPath, $targetParent): void {
 		$view = $this->createMock(View::class);
 		$view->expects($this->once())
 			->method('verifyPath')
@@ -103,7 +103,7 @@ class ObjectTreeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider copyDataProvider
 	 */
-	public function testCopyFailNotCreatable($sourcePath, $targetPath, $targetParent) {
+	public function testCopyFailNotCreatable($sourcePath, $targetPath, $targetParent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$view = $this->createMock(View::class);
@@ -150,7 +150,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$outputFileName,
 		$type,
 		$enableChunkingHeader
-	) {
+	): void {
 		if ($enableChunkingHeader) {
 			$_SERVER['HTTP_OC_CHUNKED'] = true;
 		}
@@ -265,7 +265,7 @@ class ObjectTreeTest extends \Test\TestCase {
 	}
 
 
-	public function testGetNodeForPathInvalidPath() {
+	public function testGetNodeForPathInvalidPath(): void {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
 		$path = '/foo\bar';
@@ -293,7 +293,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$tree->getNodeForPath($path);
 	}
 
-	public function testGetNodeForPathRoot() {
+	public function testGetNodeForPathRoot(): void {
 		$path = '/';
 
 

--- a/apps/dav/tests/unit/Connector/Sabre/PropfindCompressionPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropfindCompressionPluginTest.php
@@ -40,7 +40,7 @@ class PropfindCompressionPluginTest extends TestCase {
 		$this->plugin = new PropfindCompressionPlugin();
 	}
 
-	public function testNoHeader() {
+	public function testNoHeader(): void {
 		$request = $this->createMock(Request::class);
 		$response = $this->createMock(Response::class);
 
@@ -55,7 +55,7 @@ class PropfindCompressionPluginTest extends TestCase {
 		$this->assertSame($response, $result);
 	}
 
-	public function testHeaderButNoGzip() {
+	public function testHeaderButNoGzip(): void {
 		$request = $this->createMock(Request::class);
 		$response = $this->createMock(Response::class);
 
@@ -70,7 +70,7 @@ class PropfindCompressionPluginTest extends TestCase {
 		$this->assertSame($response, $result);
 	}
 
-	public function testHeaderGzipButNoStringBody() {
+	public function testHeaderGzipButNoStringBody(): void {
 		$request = $this->createMock(Request::class);
 		$response = $this->createMock(Response::class);
 
@@ -86,7 +86,7 @@ class PropfindCompressionPluginTest extends TestCase {
 	}
 
 
-	public function testProperGzip() {
+	public function testProperGzip(): void {
 		$request = $this->createMock(Request::class);
 		$response = $this->createMock(Response::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -49,7 +49,7 @@ class QuotaPluginTest extends TestCase {
 	/** @var \OCA\DAV\Connector\Sabre\QuotaPlugin | \PHPUnit\Framework\MockObject\MockObject */
 	private $plugin;
 
-	private function init($quota, $checkedPath = '') {
+	private function init($quota, $checkedPath = ''): void {
 		$view = $this->buildFileViewMock($quota, $checkedPath);
 		$this->server = new \Sabre\DAV\Server();
 		$this->plugin = $this->getMockBuilder(QuotaPlugin::class)
@@ -62,7 +62,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider lengthProvider
 	 */
-	public function testLength($expected, $headers) {
+	public function testLength($expected, $headers): void {
 		$this->init(0);
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
@@ -74,7 +74,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider quotaOkayProvider
 	 */
-	public function testCheckQuota($quota, $headers) {
+	public function testCheckQuota($quota, $headers): void {
 		$this->init($quota);
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
@@ -87,7 +87,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider quotaExceededProvider
 	 */
-	public function testCheckExceededQuota($quota, $headers) {
+	public function testCheckExceededQuota($quota, $headers): void {
 		$this->expectException(\Sabre\DAV\Exception\InsufficientStorage::class);
 
 		$this->init($quota);
@@ -101,7 +101,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider quotaOkayProvider
 	 */
-	public function testCheckQuotaOnPath($quota, $headers) {
+	public function testCheckQuotaOnPath($quota, $headers): void {
 		$this->init($quota, 'sub/test.txt');
 		$this->plugin->expects($this->never())
 			->method('getFileChunking');
@@ -176,7 +176,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider quotaChunkedOkProvider
 	 */
-	public function testCheckQuotaChunkedOk($quota, $chunkTotalSize, $headers) {
+	public function testCheckQuotaChunkedOk($quota, $chunkTotalSize, $headers): void {
 		$this->init($quota, 'sub/test.txt');
 
 		$mockChunking = $this->getMockBuilder(\OC_FileChunking::class)
@@ -211,7 +211,7 @@ class QuotaPluginTest extends TestCase {
 	/**
 	 * @dataProvider quotaChunkedFailProvider
 	 */
-	public function testCheckQuotaChunkedFail($quota, $chunkTotalSize, $headers) {
+	public function testCheckQuotaChunkedFail($quota, $chunkTotalSize, $headers): void {
 		$this->expectException(\Sabre\DAV\Exception\InsufficientStorage::class);
 
 		$this->init($quota, 'sub/test.txt');

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
@@ -113,7 +113,7 @@ class Auth implements BackendInterface {
 	 * @param ResponseInterface $response
 	 * @return void
 	 */
-	public function challenge(RequestInterface $request, ResponseInterface $response) {
+	public function challenge(RequestInterface $request, ResponseInterface $response): void {
 		// TODO: Implement challenge() method.
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -32,7 +32,7 @@ use OCP\AppFramework\Http;
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
 class DeleteTest extends RequestTestCase {
-	public function testBasicUpload() {
+	public function testBasicUpload(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
@@ -35,7 +35,7 @@ use OCP\Lock\ILockingProvider;
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
 class DownloadTest extends RequestTestCase {
-	public function testDownload() {
+	public function testDownload(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -46,7 +46,7 @@ class DownloadTest extends RequestTestCase {
 		$this->assertEquals(stream_get_contents($response->getBody()), 'bar');
 	}
 
-	public function testDownloadWriteLocked() {
+	public function testDownloadWriteLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -58,7 +58,7 @@ class DownloadTest extends RequestTestCase {
 		$this->assertEquals(Http::STATUS_LOCKED, $result->getStatus());
 	}
 
-	public function testDownloadReadLocked() {
+	public function testDownloadReadLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
@@ -29,7 +29,7 @@ class ExceptionPlugin extends \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin {
 	 */
 	protected $exceptions = [];
 
-	public function logException(\Throwable $ex) {
+	public function logException(\Throwable $ex): void {
 		$exceptionClass = get_class($ex);
 		if (!isset($this->nonFatalExceptions[$exceptionClass])) {
 			$this->exceptions[] = $ex;

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/Sapi.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/Sapi.php
@@ -55,7 +55,7 @@ class Sapi {
 	 * @param \Sabre\HTTP\Response $response
 	 * @return void
 	 */
-	public function sendResponse(Response $response) {
+	public function sendResponse(Response $response): void {
 		// we need to copy the body since we close the source stream
 		$copyStream = fopen('php://temp', 'r+');
 		if (is_string($response->getBody())) {

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
@@ -35,7 +35,7 @@ use OCP\Lock\ILockingProvider;
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
 class UploadTest extends RequestTestCase {
-	public function testBasicUpload() {
+	public function testBasicUpload(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -51,7 +51,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(3, $info->getSize());
 	}
 
-	public function testUploadOverWrite() {
+	public function testUploadOverWrite(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -67,7 +67,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(3, $info->getSize());
 	}
 
-	public function testUploadOverWriteReadLocked() {
+	public function testUploadOverWriteReadLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -79,7 +79,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(Http::STATUS_LOCKED, $result->getStatus());
 	}
 
-	public function testUploadOverWriteWriteLocked() {
+	public function testUploadOverWriteWriteLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 		$this->loginAsUser($user);
@@ -92,7 +92,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(Http::STATUS_LOCKED, $result->getStatus());
 	}
 
-	public function testChunkedUpload() {
+	public function testChunkedUpload(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -114,7 +114,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(6, $info->getSize());
 	}
 
-	public function testChunkedUploadOverWrite() {
+	public function testChunkedUploadOverWrite(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -135,7 +135,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(6, $info->getSize());
 	}
 
-	public function testChunkedUploadOutOfOrder() {
+	public function testChunkedUploadOutOfOrder(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -157,7 +157,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(6, $info->getSize());
 	}
 
-	public function testChunkedUploadOutOfOrderReadLocked() {
+	public function testChunkedUploadOutOfOrderReadLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
@@ -180,7 +180,7 @@ class UploadTest extends RequestTestCase {
 		$this->assertEquals(Http::STATUS_LOCKED, $result->getStatus());
 	}
 
-	public function testChunkedUploadOutOfOrderWriteLocked() {
+	public function testChunkedUploadOutOfOrderWriteLocked(): void {
 		$user = $this->getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -95,7 +95,7 @@ class SharesPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharesGetPropertiesDataProvider
 	 */
-	public function testGetProperties($shareTypes) {
+	public function testGetProperties($shareTypes): void {
 		$sabreNode = $this->getMockBuilder(Node::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -154,7 +154,7 @@ class SharesPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharesGetPropertiesDataProvider
 	 */
-	public function testPreloadThenGetProperties($shareTypes) {
+	public function testPreloadThenGetProperties($shareTypes): void {
 		$sabreNode1 = $this->createMock(File::class);
 		$sabreNode1->method('getId')
 			->willReturn(111);

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -96,7 +96,7 @@ class TagsPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagsGetPropertiesDataProvider
 	 */
-	public function testGetProperties($tags, $requestedProperties, $expectedProperties) {
+	public function testGetProperties($tags, $requestedProperties, $expectedProperties): void {
 		$node = $this->getMockBuilder(Node::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -135,7 +135,7 @@ class TagsPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagsGetPropertiesDataProvider
 	 */
-	public function testPreloadThenGetProperties($tags, $requestedProperties, $expectedProperties) {
+	public function testPreloadThenGetProperties($tags, $requestedProperties, $expectedProperties): void {
 		$node1 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -289,7 +289,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->assertCount(2, $result[404]);
 	}
 
-	public function testUpdateTags() {
+	public function testUpdateTags(): void {
 		// this test will replace the existing tags "tagremove" with "tag1" and "tag2"
 		// and keep "tagkeep"
 		$node = $this->getMockBuilder(Node::class)
@@ -342,7 +342,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->assertFalse(isset($result[self::FAVORITE_PROPERTYNAME]));
 	}
 
-	public function testUpdateTagsFromScratch() {
+	public function testUpdateTagsFromScratch(): void {
 		$node = $this->getMockBuilder(Node::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -388,7 +388,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->assertFalse(false, isset($result[self::FAVORITE_PROPERTYNAME]));
 	}
 
-	public function testUpdateFav() {
+	public function testUpdateFav(): void {
 		// this test will replace the existing tags "tagremove" with "tag1" and "tag2"
 		// and keep "tagkeep"
 		$node = $this->getMockBuilder(Node::class)

--- a/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
+++ b/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
@@ -76,14 +76,14 @@ class BirthdayCalendarControllerTest extends TestCase {
 			$this->userManager, $this->caldav);
 	}
 
-	public function testEnable() {
+	public function testEnable(): void {
 		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'yes');
 
 		$this->userManager->expects($this->once())
 			->method('callForSeenUsers')
-			->willReturnCallback(function ($closure) {
+			->willReturnCallback(function ($closure): void {
 				$user1 = $this->createMock(IUser::class);
 				$user1->method('getUID')->willReturn('uid1');
 				$user2 = $this->createMock(IUser::class);
@@ -108,7 +108,7 @@ class BirthdayCalendarControllerTest extends TestCase {
 		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
 	}
 
-	public function testDisable() {
+	public function testDisable(): void {
 		$this->config->expects($this->once())
 			->method('setAppValue')
 			->with('dav', 'generateBirthdayCalendar', 'no');

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -120,7 +120,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected): void {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -184,7 +184,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected): void {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -249,7 +249,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected): void {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -277,7 +277,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	public function testAcceptTokenNotFound() {
+	public function testAcceptTokenNotFound(): void {
 		$this->buildQueryExpects('TOKEN123', null, 1337);
 
 		$response = $this->controller->accept('TOKEN123');
@@ -286,7 +286,7 @@ EOF;
 		$this->assertEquals([], $response->getParams());
 	}
 
-	public function testAcceptExpiredToken() {
+	public function testAcceptExpiredToken(): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
 			'uid' => 'this-is-the-events-uid',
@@ -340,7 +340,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected): void {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -368,7 +368,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	public function testOptions() {
+	public function testOptions(): void {
 		$response = $this->controller->options('TOKEN123');
 		$this->assertInstanceOf(TemplateResponse::class, $response);
 		$this->assertEquals('schedule-response-options', $response->getTemplateName());
@@ -416,7 +416,7 @@ EOF;
 		$called = false;
 		$this->responseServer->expects($this->once())
 			->method('handleITipMessage')
-			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected) {
+			->willReturnCallback(function (Message $iTipMessage) use (&$called, $isExternalAttendee, $expected): void {
 				$called = true;
 				$this->assertEquals('this-is-the-events-uid', $iTipMessage->uid);
 				$this->assertEquals('VEVENT', $iTipMessage->component);
@@ -445,7 +445,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	private function buildQueryExpects($token, $return, $time) {
+	private function buildQueryExpects($token, $return, $time): void {
 		$queryBuilder = $this->createMock(IQueryBuilder::class);
 		$stmt = $this->createMock(IResult::class);
 		$expr = $this->createMock(IExpressionBuilder::class);

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -50,49 +50,49 @@ class AnonymousOptionsTest extends TestCase {
 		return $server->httpResponse;
 	}
 
-	public function testAnonymousOptionsRoot() {
+	public function testAnonymousOptionsRoot(): void {
 		$response = $this->sendRequest('OPTIONS', '');
 
 		$this->assertEquals(401, $response->getStatus());
 	}
 
-	public function testAnonymousOptionsNonRoot() {
+	public function testAnonymousOptionsNonRoot(): void {
 		$response = $this->sendRequest('OPTIONS', 'foo');
 
 		$this->assertEquals(401, $response->getStatus());
 	}
 
-	public function testAnonymousOptionsNonRootSubDir() {
+	public function testAnonymousOptionsNonRootSubDir(): void {
 		$response = $this->sendRequest('OPTIONS', 'foo/bar');
 
 		$this->assertEquals(401, $response->getStatus());
 	}
 
-	public function testAnonymousOptionsRootOffice() {
+	public function testAnonymousOptionsRootOffice(): void {
 		$response = $this->sendRequest('OPTIONS', '', 'Microsoft Office does strange things');
 
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testAnonymousOptionsNonRootOffice() {
+	public function testAnonymousOptionsNonRootOffice(): void {
 		$response = $this->sendRequest('OPTIONS', 'foo', 'Microsoft Office does strange things');
 
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testAnonymousOptionsNonRootSubDirOffice() {
+	public function testAnonymousOptionsNonRootSubDirOffice(): void {
 		$response = $this->sendRequest('OPTIONS', 'foo/bar', 'Microsoft Office does strange things');
 
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testAnonymousHead() {
+	public function testAnonymousHead(): void {
 		$response = $this->sendRequest('HEAD', '', 'Microsoft Office does strange things');
 
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testAnonymousHeadNoOffice() {
+	public function testAnonymousHeadNoOffice(): void {
 		$response = $this->sendRequest('HEAD', '');
 
 		$this->assertEquals(401, $response->getStatus(), 'curl');
@@ -105,6 +105,6 @@ class SapiMock extends Sapi {
 	 *
 	 * @return void
 	 */
-	public static function sendResponse(ResponseInterface $response) {
+	public static function sendResponse(ResponseInterface $response): void {
 	}
 }

--- a/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
@@ -34,7 +34,7 @@ class BrowserErrorPagePluginTest extends \Test\TestCase {
 	 * @param $expectedCode
 	 * @param $exception
 	 */
-	public function test($expectedCode, $exception) {
+	public function test($expectedCode, $exception): void {
 		/** @var BrowserErrorPagePlugin | \PHPUnit\Framework\MockObject\MockObject $plugin */
 		$plugin = $this->getMockBuilder(BrowserErrorPagePlugin::class)->setMethods(['sendResponse', 'generateBody'])->getMock();
 		$plugin->expects($this->once())->method('generateBody')->willReturn(':boom:');

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -119,7 +119,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		return $data;
 	}
 
-	public function testPropFindNoDbCalls() {
+	public function testPropFindNoDbCalls(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$backend = new CustomPropertiesBackend(
 			$this->tree,
@@ -144,7 +144,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$backend->propFind('foo_bar_path_1337_0', $propFind);
 	}
 
-	public function testPropFindCalendarCall() {
+	public function testPropFindCalendarCall(): void {
 		$propFind = $this->createMock(PropFind::class);
 		$propFind->method('get404Properties')
 			->with()
@@ -178,7 +178,7 @@ class CustomPropertiesBackendTest extends TestCase {
 
 		$setProps = [];
 		$propFind->method('set')
-			->willReturnCallback(function ($name, $value, $status) use (&$setProps) {
+			->willReturnCallback(function ($name, $value, $status) use (&$setProps): void {
 				$setProps[$name] = $value;
 			});
 
@@ -189,7 +189,7 @@ class CustomPropertiesBackendTest extends TestCase {
 	/**
 	 * @dataProvider propPatchProvider
 	 */
-	public function testPropPatch(string $path, array $existing, array $props, array $result) {
+	public function testPropPatch(string $path, array $existing, array $props, array $result): void {
 		$this->insertProps($this->user->getUID(), $path, $existing);
 		$propPatch = new PropPatch($props);
 
@@ -213,7 +213,7 @@ class CustomPropertiesBackendTest extends TestCase {
 	/**
 	 * @dataProvider deleteProvider
 	 */
-	public function testDelete(string $path) {
+	public function testDelete(string $path): void {
 		$this->insertProps('dummy_user_42', $path, ['foo' => 'bar']);
 		$this->backend->delete($path);
 		$this->assertEquals([], $this->getProps('dummy_user_42', $path));
@@ -229,7 +229,7 @@ class CustomPropertiesBackendTest extends TestCase {
 	/**
 	 * @dataProvider moveProvider
 	 */
-	public function testMove(string $source, string $target) {
+	public function testMove(string $source, string $target): void {
 		$this->insertProps('dummy_user_42', $source, ['foo' => 'bar']);
 		$this->backend->move($source, $target);
 		$this->assertEquals([], $this->getProps('dummy_user_42', $source));

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -72,12 +72,12 @@ class GroupPrincipalTest extends \Test\TestCase {
 		parent::setUp();
 	}
 
-	public function testGetPrincipalsByPrefixWithoutPrefix() {
+	public function testGetPrincipalsByPrefixWithoutPrefix(): void {
 		$response = $this->connector->getPrincipalsByPrefix('');
 		$this->assertSame([], $response);
 	}
 
-	public function testGetPrincipalsByPrefixWithUsers() {
+	public function testGetPrincipalsByPrefixWithUsers(): void {
 		$group1 = $this->mockGroup('foo');
 		$group2 = $this->mockGroup('bar');
 		$this->groupManager
@@ -102,7 +102,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testGetPrincipalsByPrefixEmpty() {
+	public function testGetPrincipalsByPrefixEmpty(): void {
 		$this->groupManager
 			->expects($this->once())
 			->method('search')
@@ -113,7 +113,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame([], $response);
 	}
 
-	public function testGetPrincipalsByPathWithoutMail() {
+	public function testGetPrincipalsByPathWithoutMail(): void {
 		$group1 = $this->mockGroup('foo');
 		$this->groupManager
 			->expects($this->once())
@@ -130,7 +130,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testGetPrincipalsByPathWithMail() {
+	public function testGetPrincipalsByPathWithMail(): void {
 		$fooUser = $this->mockGroup('foo');
 		$this->groupManager
 			->expects($this->once())
@@ -147,7 +147,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testGetPrincipalsByPathEmpty() {
+	public function testGetPrincipalsByPathEmpty(): void {
 		$this->groupManager
 			->expects($this->once())
 			->method('get')
@@ -158,7 +158,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame(null, $response);
 	}
 
-	public function testGetPrincipalsByPathGroupWithSlash() {
+	public function testGetPrincipalsByPathGroupWithSlash(): void {
 		$group1 = $this->mockGroup('foo/bar');
 		$this->groupManager
 			->expects($this->once())
@@ -175,7 +175,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testGetPrincipalsByPathGroupWithHash() {
+	public function testGetPrincipalsByPathGroupWithHash(): void {
 		$group1 = $this->mockGroup('foo#bar');
 		$this->groupManager
 			->expects($this->once())
@@ -192,33 +192,33 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame($expectedResponse, $response);
 	}
 
-	public function testGetGroupMemberSet() {
+	public function testGetGroupMemberSet(): void {
 		$response = $this->connector->getGroupMemberSet('principals/groups/foo');
 		$this->assertSame([], $response);
 	}
 
-	public function testGetGroupMembership() {
+	public function testGetGroupMembership(): void {
 		$response = $this->connector->getGroupMembership('principals/groups/foo');
 		$this->assertSame([], $response);
 	}
 
 
-	public function testSetGroupMembership() {
+	public function testSetGroupMembership(): void {
 		$this->expectException(\Sabre\DAV\Exception::class);
 		$this->expectExceptionMessage('Setting members of the group is not supported yet');
 
 		$this->connector->setGroupMemberSet('principals/groups/foo', ['foo']);
 	}
 
-	public function testUpdatePrincipal() {
+	public function testUpdatePrincipal(): void {
 		$this->assertSame(0, $this->connector->updatePrincipal('foo', new PropPatch([])));
 	}
 
-	public function testSearchPrincipalsWithEmptySearchProperties() {
+	public function testSearchPrincipalsWithEmptySearchProperties(): void {
 		$this->assertSame([], $this->connector->searchPrincipals('principals/groups', []));
 	}
 
-	public function testSearchPrincipalsWithWrongPrefixPath() {
+	public function testSearchPrincipalsWithWrongPrefixPath(): void {
 		$this->assertSame([], $this->connector->searchPrincipals('principals/users',
 			['{DAV:}displayname' => 'Foo']));
 	}

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -61,7 +61,7 @@ class HookManagerTest extends TestCase {
 			});
 	}
 
-	public function test() {
+	public function test(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -110,7 +110,7 @@ class HookManagerTest extends TestCase {
 		$hm->firstLogin($user);
 	}
 
-	public function testWithExisting() {
+	public function testWithExisting(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -149,7 +149,7 @@ class HookManagerTest extends TestCase {
 		$hm->firstLogin($user);
 	}
 
-	public function testWithBirthdayCalendar() {
+	public function testWithBirthdayCalendar(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -197,7 +197,7 @@ class HookManagerTest extends TestCase {
 		$hm->firstLogin($user);
 	}
 
-	public function testDeleteCalendar() {
+	public function testDeleteCalendar(): void {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
@@ -69,7 +69,7 @@ class PluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testSharing() {
+	public function testSharing(): void {
 		$this->book->expects($this->once())->method('updateShares')->with([[
 			'href' => 'principal:principals/admin',
 			'commonName' => null,

--- a/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
@@ -35,7 +35,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	 * @param $expected
 	 * @param $prefix
 	 */
-	public function testGetPrincipalsByPrefix($expected, $prefix) {
+	public function testGetPrincipalsByPrefix($expected, $prefix): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalsByPrefix($prefix);
 		$this->assertEquals($expected, $result);
@@ -61,7 +61,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	 * @param $expected
 	 * @param $path
 	 */
-	public function testGetPrincipalByPath($expected, $path) {
+	public function testGetPrincipalByPath($expected, $path): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalByPath($path);
 		$this->assertEquals($expected, $result);
@@ -85,7 +85,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	 * @param string $principal
 	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMemberSetExceptional($principal) {
+	public function testGetGroupMemberSetExceptional($principal): void {
 		$this->expectException(\Sabre\DAV\Exception::class);
 		$this->expectExceptionMessage('Principal not found');
 
@@ -103,7 +103,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	/**
 	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMemberSet() {
+	public function testGetGroupMemberSet(): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getGroupMemberSet('principals/system/system');
 		$this->assertEquals(['principals/system/system'], $result);
@@ -115,7 +115,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	 * @param string $principal
 	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMembershipExceptional($principal) {
+	public function testGetGroupMembershipExceptional($principal): void {
 		$this->expectException(\Sabre\DAV\Exception::class);
 		$this->expectExceptionMessage('Principal not found');
 
@@ -132,7 +132,7 @@ class SystemPrincipalBackendTest extends TestCase {
 	/**
 	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMembership() {
+	public function testGetGroupMembership(): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getGroupMembership('principals/system/system');
 		$this->assertEquals([], $result);

--- a/apps/dav/tests/unit/Direct/DirectFileTest.php
+++ b/apps/dav/tests/unit/Direct/DirectFileTest.php
@@ -82,57 +82,57 @@ class DirectFileTest extends TestCase {
 		$this->directFile = new DirectFile($this->direct, $this->rootFolder, $this->eventDispatcher);
 	}
 
-	public function testPut() {
+	public function testPut(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directFile->put('foo');
 	}
 
-	public function testGet() {
+	public function testGet(): void {
 		$this->file->expects($this->once())
 			->method('fopen')
 			->with('rb');
 		$this->directFile->get();
 	}
 
-	public function testGetContentType() {
+	public function testGetContentType(): void {
 		$this->file->method('getMimeType')
 			->willReturn('direct/type');
 
 		$this->assertSame('direct/type', $this->directFile->getContentType());
 	}
 
-	public function testGetETag() {
+	public function testGetETag(): void {
 		$this->file->method('getEtag')
 			->willReturn('directEtag');
 
 		$this->assertSame('directEtag', $this->directFile->getETag());
 	}
 
-	public function testGetSize() {
+	public function testGetSize(): void {
 		$this->file->method('getSize')
 			->willReturn(42);
 
 		$this->assertSame(42, $this->directFile->getSize());
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directFile->delete();
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertSame('directToken', $this->directFile->getName());
 	}
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directFile->setName('foobar');
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$this->file->method('getMTime')
 			->willReturn(42);
 

--- a/apps/dav/tests/unit/Direct/DirectHomeTest.php
+++ b/apps/dav/tests/unit/Direct/DirectHomeTest.php
@@ -92,49 +92,49 @@ class DirectHomeTest extends TestCase {
 		);
 	}
 
-	public function testCreateFile() {
+	public function testCreateFile(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directHome->createFile('foo', 'bar');
 	}
 
-	public function testCreateDirectory() {
+	public function testCreateDirectory(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directHome->createDirectory('foo');
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->expectException(MethodNotAllowed::class);
 
 		$this->directHome->getChildren();
 	}
 
-	public function testChildExists() {
+	public function testChildExists(): void {
 		$this->assertFalse($this->directHome->childExists('foo'));
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directHome->delete();
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertSame('direct', $this->directHome->getName());
 	}
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(Forbidden::class);
 
 		$this->directHome->setName('foo');
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$this->assertSame(0, $this->directHome->getLastModified());
 	}
 
-	public function testGetChildValid() {
+	public function testGetChildValid(): void {
 		$direct = Direct::fromParams([
 			'expiration' => 100,
 		]);
@@ -150,7 +150,7 @@ class DirectHomeTest extends TestCase {
 		$this->assertInstanceOf(DirectFile::class, $result);
 	}
 
-	public function testGetChildExpired() {
+	public function testGetChildExpired(): void {
 		$direct = Direct::fromParams([
 			'expiration' => 41,
 		]);
@@ -167,7 +167,7 @@ class DirectHomeTest extends TestCase {
 		$this->directHome->getChild('longtoken');
 	}
 
-	public function testGetChildInvalid() {
+	public function testGetChildInvalid(): void {
 		$this->directMapper->method('getByToken')
 			->with('longtoken')
 			->willThrowException(new DoesNotExistException('not found'));

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -115,7 +115,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->search = new FileSearchBackend($this->tree, $this->user, $this->rootFolder, $this->shareManager, $this->view);
 	}
 
-	public function testSearchFilename() {
+	public function testSearchFilename(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -144,7 +144,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEquals('/files/test/test/path', $result[0]->href);
 	}
 
-	public function testSearchMimetype() {
+	public function testSearchMimetype(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -173,7 +173,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEquals('/files/test/test/path', $result[0]->href);
 	}
 
-	public function testSearchSize() {
+	public function testSearchSize(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -202,7 +202,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEquals('/files/test/test/path', $result[0]->href);
 	}
 
-	public function testSearchMtime() {
+	public function testSearchMtime(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -231,7 +231,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEquals('/files/test/test/path', $result[0]->href);
 	}
 
-	public function testSearchIsCollection() {
+	public function testSearchIsCollection(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -261,7 +261,7 @@ class FileSearchBackendTest extends TestCase {
 	}
 
 
-	public function testSearchInvalidProp() {
+	public function testSearchInvalidProp(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$this->tree->expects($this->any())
@@ -298,7 +298,7 @@ class FileSearchBackendTest extends TestCase {
 	}
 
 
-	public function testSearchNonFolder() {
+	public function testSearchNonFolder(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$davNode = $this->createMock(File::class);
@@ -311,7 +311,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->search->search($query);
 	}
 
-	public function testSearchLimitOwnerBasic() {
+	public function testSearchLimitOwnerBasic(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -340,7 +340,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEmpty($operator->getArguments());
 	}
 
-	public function testSearchLimitOwnerNested() {
+	public function testSearchLimitOwnerNested(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);
@@ -388,7 +388,7 @@ class FileSearchBackendTest extends TestCase {
 		$this->assertEmpty($operator->getArguments());
 	}
 
-	public function testSearchOperatorLimit() {
+	public function testSearchOperatorLimit(): void {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->willReturn($this->davFolder);

--- a/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
+++ b/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
@@ -80,7 +80,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test validation of the request's body type
 	 */
-	public function testBodyTypeValidation() {
+	public function testBodyTypeValidation(): void {
 		$bodyStream = "I am not a stream, but pretend to be";
 		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
 			->disableOriginalConstructor()
@@ -101,7 +101,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * - valid file content
 	 * - valid file path
 	 */
-	public function testValidRequest() {
+	public function testValidRequest(): void {
 		$multipartParser = $this->getMultipartParser(
 			$this->getValidBodyObject()
 		);
@@ -118,7 +118,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with invalid md5 hash.
 	 */
-	public function testInvalidMd5Hash() {
+	public function testInvalidMd5Hash(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$bodyObject["0"]["headers"]["X-File-MD5"] = "f2377b4d911f7ec46325fe603c3af03";
 		$multipartParser = $this->getMultipartParser(
@@ -132,7 +132,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a null md5 hash.
 	 */
-	public function testNullMd5Hash() {
+	public function testNullMd5Hash(): void {
 		$bodyObject = $this->getValidBodyObject();
 		unset($bodyObject["0"]["headers"]["X-File-MD5"]);
 		$multipartParser = $this->getMultipartParser(
@@ -146,7 +146,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a null Content-Length.
 	 */
-	public function testNullContentLength() {
+	public function testNullContentLength(): void {
 		$bodyObject = $this->getValidBodyObject();
 		unset($bodyObject["0"]["headers"]["Content-Length"]);
 		$multipartParser = $this->getMultipartParser(
@@ -160,7 +160,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a lower Content-Length.
 	 */
-	public function testLowerContentLength() {
+	public function testLowerContentLength(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$bodyObject["0"]["headers"]["Content-Length"] = 6;
 		$multipartParser = $this->getMultipartParser(
@@ -174,7 +174,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a higher Content-Length.
 	 */
-	public function testHigherContentLength() {
+	public function testHigherContentLength(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$bodyObject["0"]["headers"]["Content-Length"] = 8;
 		$multipartParser = $this->getMultipartParser(
@@ -188,7 +188,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with wrong boundary in body.
 	 */
-	public function testWrongBoundary() {
+	public function testWrongBoundary(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
@@ -202,7 +202,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with no boundary in request headers.
 	 */
-	public function testNoBoundaryInHeader() {
+	public function testNoBoundaryInHeader(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$this->expectExceptionMessage('Error while parsing boundary in Content-Type header.');
 		$this->getMultipartParser(
@@ -214,7 +214,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with no boundary in the request's headers.
 	 */
-	public function testNoBoundaryInBody() {
+	public function testNoBoundaryInBody(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
@@ -229,7 +229,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a boundary with quotes in the request's headers.
 	 */
-	public function testBoundaryWithQuotes() {
+	public function testBoundaryWithQuotes(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
@@ -245,7 +245,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a wrong Content-Type in the request's headers.
 	 */
-	public function testWrongContentType() {
+	public function testWrongContentType(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$this->expectExceptionMessage('Content-Type must be multipart/related');
 		$this->getMultipartParser(
@@ -257,7 +257,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a wrong key after the content type in the request's headers.
 	 */
-	public function testWrongKeyInContentType() {
+	public function testWrongKeyInContentType(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$this->expectExceptionMessage('Boundary is invalid');
 		$this->getMultipartParser(
@@ -269,7 +269,7 @@ class MultipartRequestParserTest extends TestCase {
 	/**
 	 * Test with a null Content-Type in the request's headers.
 	 */
-	public function testNullContentType() {
+	public function testNullContentType(): void {
 		$bodyObject = $this->getValidBodyObject();
 		$this->expectExceptionMessage('Content-Type can not be null');
 		$this->getMultipartParser(

--- a/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
@@ -64,7 +64,7 @@ class FilesDropPluginTest extends TestCase {
 			->method($this->anything());
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		$this->server->expects($this->once())
 			->method('on')
 			->with(
@@ -76,7 +76,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testNotEnabled() {
+	public function testNotEnabled(): void {
 		$this->view->expects($this->never())
 			->method($this->anything());
 
@@ -86,7 +86,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}
 
-	public function testValid() {
+	public function testValid(): void {
 		$this->plugin->enable();
 		$this->plugin->setView($this->view);
 
@@ -110,7 +110,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}
 
-	public function testFileAlreadyExistsValid() {
+	public function testFileAlreadyExistsValid(): void {
 		$this->plugin->enable();
 		$this->plugin->setView($this->view);
 
@@ -139,7 +139,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}
 
-	public function testNoMKCOL() {
+	public function testNoMKCOL(): void {
 		$this->plugin->enable();
 		$this->plugin->setView($this->view);
 
@@ -151,7 +151,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}
 
-	public function testNoSubdirPut() {
+	public function testNoSubdirPut(): void {
 		$this->plugin->enable();
 		$this->plugin->setView($this->view);
 

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -99,7 +99,7 @@ END:VCALENDAR';
 		$this->output = $this->createMock(IOutput::class);
 	}
 
-	public function testRunAllValid() {
+	public function testRunAllValid(): void {
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
@@ -123,7 +123,7 @@ END:VCALENDAR';
 		$step->run($this->output);
 	}
 
-	public function testRunInvalid() {
+	public function testRunInvalid(): void {
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
@@ -166,7 +166,7 @@ END:VCALENDAR';
 		$step->run($this->output);
 	}
 
-	public function testRunValid() {
+	public function testRunValid(): void {
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
@@ -208,7 +208,7 @@ END:VCALENDAR';
 		$step->run($this->output);
 	}
 
-	public function testRunStillInvalid() {
+	public function testRunStillInvalid(): void {
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([

--- a/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
+++ b/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
@@ -54,11 +54,11 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 		$this->migration = new RefreshWebcalJobRegistrar($this->db, $this->jobList);
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals($this->migration->getName(), 'Registering background jobs to update cache for webcal calendars');
 	}
 
-	public function testRun() {
+	public function testRun(): void {
 		$output = $this->createMock(IOutput::class);
 
 		$queryBuilder = $this->createMock(IQueryBuilder::class);

--- a/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
@@ -54,14 +54,14 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 			$this->config);
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals(
 			'Regenerating birthday calendars to use new icons and fix old birthday events without year',
 			$this->migration->getName()
 		);
 	}
 
-	public function testRun() {
+	public function testRun(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'regeneratedBirthdayCalendarsForYearFix')
@@ -83,7 +83,7 @@ class RegenerateBirthdayCalendarsTest extends TestCase {
 		$this->migration->run($output);
 	}
 
-	public function testRunSecondTime() {
+	public function testRunSecondTime(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'regeneratedBirthdayCalendarsForYearFix')

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
@@ -43,31 +43,31 @@ class AppleProvisioningNodeTest extends TestCase {
 		$this->node = new AppleProvisioningNode($this->timeFactory);
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals('apple-provisioning.mobileconfig', $this->node->getName());
 	}
 
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('Renaming apple-provisioning.mobileconfig is forbidden');
 
 		$this->node->setName('foo');
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$this->assertEquals(null, $this->node->getLastModified());
 	}
 
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('apple-provisioning.mobileconfig may not be deleted');
 
 		$this->node->delete();
 	}
 
-	public function testGetProperties() {
+	public function testGetProperties(): void {
 		$this->timeFactory->expects($this->once())
 			->method('getDateTime')
 			->willReturn(new \DateTime('2000-01-01'));
@@ -79,7 +79,7 @@ class AppleProvisioningNodeTest extends TestCase {
 	}
 
 
-	public function testGetPropPatch() {
+	public function testGetPropPatch(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('apple-provisioning.mobileconfig\'s properties may not be altered.');
 

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -87,12 +87,12 @@ class AppleProvisioningPluginTest extends TestCase {
 		$this->sabreResponse = $this->createMock(\Sabre\HTTP\ResponseInterface::class);
 	}
 
-	public function testInitialize() {
+	public function testInitialize(): void {
 		$server = $this->createMock(\Sabre\DAV\Server::class);
 
 		$plugin = new AppleProvisioningPlugin($this->userSession,
 			$this->urlGenerator, $this->themingDefaults, $this->request, $this->l10n,
-			function () {
+			function (): void {
 			});
 
 		$server->expects($this->once())
@@ -102,7 +102,7 @@ class AppleProvisioningPluginTest extends TestCase {
 		$plugin->initialize($server);
 	}
 
-	public function testHttpGetOnHttp() {
+	public function testHttpGetOnHttp(): void {
 		$this->sabreRequest->expects($this->once())
 			->method('getPath')
 			->with()
@@ -141,7 +141,7 @@ class AppleProvisioningPluginTest extends TestCase {
 		$this->assertFalse($returnValue);
 	}
 
-	public function testHttpGetOnHttps() {
+	public function testHttpGetOnHttps(): void {
 		$this->sabreRequest->expects($this->once())
 			->method('getPath')
 			->with()

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -41,7 +41,7 @@ class ServerTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesUris
 	 */
-	public function test($uri, array $plugins) {
+	public function test($uri, array $plugins): void {
 		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $r */
 		$r = $this->createMock(IRequest::class);
 		$r->expects($this->any())->method('getRequestUri')->willReturn($uri);

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -56,7 +56,7 @@ class CalDAVSettingsTest extends TestCase {
 		$this->settings = new CalDAVSettings($this->config, $this->initialState, $this->urlGenerator);
 	}
 
-	public function testGetForm() {
+	public function testGetForm(): void {
 		$this->config->method('getAppValue')
 		   ->withConsecutive(
 			   ['dav', 'sendInvitations', 'yes'],
@@ -85,11 +85,11 @@ class CalDAVSettingsTest extends TestCase {
 		$this->assertInstanceOf(TemplateResponse::class, $result);
 	}
 
-	public function testGetSection() {
+	public function testGetSection(): void {
 		$this->assertEquals('groupware', $this->settings->getSection());
 	}
 
-	public function testGetPriority() {
+	public function testGetPriority(): void {
 		$this->assertEquals(10, $this->settings->getPriority());
 	}
 }

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -74,7 +74,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		);
 	}
 
-	public function testGetters() {
+	public function testGetters(): void {
 		$tag = new SystemTag(1, 'Test', true, false);
 		$node = $this->getMappingNode($tag);
 		$this->assertEquals('1', $node->getName());
@@ -83,7 +83,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		$this->assertEquals('files', $node->getObjectType());
 	}
 
-	public function testDeleteTag() {
+	public function testDeleteTag(): void {
 		$node = $this->getMappingNode();
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -120,7 +120,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagNodeDeleteProviderPermissionException
 	 */
-	public function testDeleteTagExpectedException(ISystemTag $tag, $expectedException) {
+	public function testDeleteTagExpectedException(ISystemTag $tag, $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
 			->with($tag)
@@ -145,7 +145,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 	}
 
 	
-	public function testDeleteTagNotFound() {
+	public function testDeleteTagNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		// assuming the tag existed at the time the node was created,

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -73,7 +73,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider adminFlagProvider
 	 */
-	public function testGetters($isAdmin) {
+	public function testGetters($isAdmin): void {
 		$tag = new SystemTag('1', 'Test', true, true);
 		$node = $this->getTagNode($isAdmin, $tag);
 		$this->assertEquals('1', $node->getName());
@@ -81,7 +81,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
 		$this->getTagNode()->setName('2');
@@ -113,7 +113,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagNodeProvider
 	 */
-	public function testUpdateTag($isAdmin, ISystemTag $originalTag, $changedArgs) {
+	public function testUpdateTag($isAdmin, ISystemTag $originalTag, $changedArgs): void {
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
 			->with($originalTag)
@@ -173,7 +173,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagNodeProviderPermissionException
 	 */
-	public function testUpdateTagPermissionException(ISystemTag $originalTag, $changedArgs, $expectedException = null) {
+	public function testUpdateTagPermissionException(ISystemTag $originalTag, $changedArgs, $expectedException = null): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
 			->with($originalTag)
@@ -198,7 +198,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateTagAlreadyExists() {
+	public function testUpdateTagAlreadyExists(): void {
 		$this->expectException(\Sabre\DAV\Exception\Conflict::class);
 
 		$tag = new SystemTag(1, 'tag1', true, true);
@@ -218,7 +218,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testUpdateTagNotFound() {
+	public function testUpdateTagNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$tag = new SystemTag(1, 'tag1', true, true);
@@ -240,7 +240,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider adminFlagProvider
 	 */
-	public function testDeleteTag($isAdmin) {
+	public function testDeleteTag($isAdmin): void {
 		$tag = new SystemTag(1, 'tag1', true, true);
 		$this->tagManager->expects($isAdmin ? $this->once() : $this->never())
 			->method('canUserSeeTag')
@@ -273,7 +273,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider tagNodeDeleteProviderPermissionException
 	 */
-	public function testDeleteTagPermissionException(ISystemTag $tag, $expectedException) {
+	public function testDeleteTagPermissionException(ISystemTag $tag, $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
 			->with($tag)
@@ -286,7 +286,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 	}
 
 
-	public function testDeleteTagNotFound() {
+	public function testDeleteTagNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$tag = new SystemTag(1, 'tag1', true, true);

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -186,7 +186,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider getPropertiesDataProvider
 	 */
-	public function testGetProperties(ISystemTag $systemTag, $groups, $requestedProperties, $expectedProperties) {
+	public function testGetProperties(ISystemTag $systemTag, $groups, $requestedProperties, $expectedProperties): void {
 		$this->user->expects($this->any())
 			->method('getUID')
 			->willReturn('admin');
@@ -234,7 +234,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetPropertiesForbidden() {
+	public function testGetPropertiesForbidden(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$systemTag = new SystemTag(1, 'Test', true, false);
@@ -275,7 +275,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		);
 	}
 
-	public function testUpdatePropertiesAdmin() {
+	public function testUpdatePropertiesAdmin(): void {
 		$systemTag = new SystemTag(1, 'Test', true, false);
 		$this->user->expects($this->any())
 			->method('getUID')
@@ -331,7 +331,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testUpdatePropertiesForbidden() {
+	public function testUpdatePropertiesForbidden(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$systemTag = new SystemTag(1, 'Test', true, false);
@@ -385,7 +385,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider createTagInsufficientPermissionsProvider
 	 */
-	public function testCreateNotAssignableTagAsRegularUser($userVisible, $userAssignable, $groups) {
+	public function testCreateNotAssignableTagAsRegularUser($userVisible, $userAssignable, $groups): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Not sufficient permissions');
 
@@ -444,7 +444,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->plugin->httpPost($request, $response);
 	}
 
-	public function testCreateTagInByIdCollectionAsRegularUser() {
+	public function testCreateTagInByIdCollectionAsRegularUser(): void {
 		$systemTag = new SystemTag(1, 'Test', true, false);
 
 		$requestData = json_encode([
@@ -508,7 +508,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider createTagProvider
 	 */
-	public function testCreateTagInByIdCollection($userVisible, $userAssignable, $groups) {
+	public function testCreateTagInByIdCollection($userVisible, $userAssignable, $groups): void {
 		$this->user->expects($this->once())
 			->method('getUID')
 			->willReturn('admin');
@@ -591,7 +591,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		];
 	}
 
-	public function testCreateTagInMappingCollection() {
+	public function testCreateTagInMappingCollection(): void {
 		$this->user->expects($this->once())
 			->method('getUID')
 			->willReturn('admin');
@@ -659,7 +659,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	}
 
 	
-	public function testCreateTagToUnknownNode() {
+	public function testCreateTagToUnknownNode(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$node = $this->getMockBuilder(SystemTagsObjectMappingCollection::class)
@@ -693,7 +693,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider nodeClassProvider
 	 */
-	public function testCreateTagConflict($nodeClass) {
+	public function testCreateTagConflict($nodeClass): void {
 		$this->expectException(\Sabre\DAV\Exception\Conflict::class);
 
 		$this->user->expects($this->once())

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -80,20 +80,20 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testForbiddenCreateFile() {
+	public function testForbiddenCreateFile(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->getNode()->createFile('555');
 	}
 
 	
-	public function testForbiddenCreateDirectory() {
+	public function testForbiddenCreateDirectory(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->getNode()->createDirectory('789');
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$tag = new SystemTag(123, 'Test', true, false);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -113,7 +113,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildInvalidName() {
+	public function testGetChildInvalidName(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$this->tagManager->expects($this->once())
@@ -125,7 +125,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildNotFound() {
+	public function testGetChildNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->tagManager->expects($this->once())
@@ -137,7 +137,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildUserNotVisible() {
+	public function testGetChildUserNotVisible(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$tag = new SystemTag(123, 'Test', false, false);
@@ -150,7 +150,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->getNode(false)->getChild('123');
 	}
 
-	public function testGetChildrenAdmin() {
+	public function testGetChildrenAdmin(): void {
 		$tag1 = new SystemTag(123, 'One', true, false);
 		$tag2 = new SystemTag(456, 'Two', true, true);
 
@@ -169,7 +169,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->assertEquals($tag2, $children[1]->getSystemTag());
 	}
 
-	public function testGetChildrenNonAdmin() {
+	public function testGetChildrenNonAdmin(): void {
 		$tag1 = new SystemTag(123, 'One', true, false);
 		$tag2 = new SystemTag(456, 'Two', true, true);
 
@@ -188,7 +188,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->assertEquals($tag2, $children[1]->getSystemTag());
 	}
 
-	public function testGetChildrenEmpty() {
+	public function testGetChildrenEmpty(): void {
 		$this->tagManager->expects($this->once())
 			->method('getAllTags')
 			->with(null)
@@ -206,7 +206,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	/**
 	 * @dataProvider childExistsProvider
 	 */
-	public function testChildExists($userVisible, $expectedResult) {
+	public function testChildExists($userVisible, $expectedResult): void {
 		$tag = new SystemTag(123, 'One', $userVisible, false);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -221,7 +221,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, $this->getNode()->childExists('123'));
 	}
 
-	public function testChildExistsNotFound() {
+	public function testChildExistsNotFound(): void {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['123'])
@@ -231,7 +231,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testChildExistsBadRequest() {
+	public function testChildExistsBadRequest(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$this->tagManager->expects($this->once())

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -70,7 +70,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		);
 	}
 
-	public function testAssignTag() {
+	public function testAssignTag(): void {
 		$tag = new SystemTag('1', 'Test', true, true);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -104,7 +104,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	/**
 	 * @dataProvider permissionsProvider
 	 */
-	public function testAssignTagNoPermission($userVisible, $userAssignable, $expectedException) {
+	public function testAssignTagNoPermission($userVisible, $userAssignable, $expectedException): void {
 		$tag = new SystemTag('1', 'Test', $userVisible, $userAssignable);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -133,7 +133,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testAssignTagNotFound() {
+	public function testAssignTagNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\PreconditionFailed::class);
 
 		$this->tagManager->expects($this->once())
@@ -145,13 +145,13 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testForbiddenCreateDirectory() {
+	public function testForbiddenCreateDirectory(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->getNode()->createDirectory('789');
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$tag = new SystemTag(555, 'TheTag', true, false);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -175,7 +175,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildNonVisible() {
+	public function testGetChildNonVisible(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$tag = new SystemTag(555, 'TheTag', false, false);
@@ -198,7 +198,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildRelationNotFound() {
+	public function testGetChildRelationNotFound(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->tagMapper->expects($this->once())
@@ -210,7 +210,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildInvalidId() {
+	public function testGetChildInvalidId(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$this->tagMapper->expects($this->once())
@@ -222,7 +222,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildTagDoesNotExist() {
+	public function testGetChildTagDoesNotExist(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->tagMapper->expects($this->once())
@@ -233,7 +233,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->getNode()->getChild('777');
 	}
 
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$tag1 = new SystemTag(555, 'TagOne', true, false);
 		$tag2 = new SystemTag(556, 'TagTwo', true, true);
 		$tag3 = new SystemTag(557, 'InvisibleTag', false, true);
@@ -270,7 +270,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->assertEquals($tag2, $children[1]->getSystemTag());
 	}
 
-	public function testChildExistsWithVisibleTag() {
+	public function testChildExistsWithVisibleTag(): void {
 		$tag = new SystemTag(555, 'TagOne', true, false);
 
 		$this->tagMapper->expects($this->once())
@@ -291,7 +291,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->assertTrue($this->getNode()->childExists('555'));
 	}
 
-	public function testChildExistsWithInvisibleTag() {
+	public function testChildExistsWithInvisibleTag(): void {
 		$tag = new SystemTag(555, 'TagOne', false, false);
 
 		$this->tagMapper->expects($this->once())
@@ -307,7 +307,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->assertFalse($this->getNode()->childExists('555'));
 	}
 
-	public function testChildExistsNotFound() {
+	public function testChildExistsNotFound(): void {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', '555')
@@ -316,7 +316,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->assertFalse($this->getNode()->childExists('555'));
 	}
 
-	public function testChildExistsTagNotFound() {
+	public function testChildExistsTagNotFound(): void {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', '555')
@@ -326,7 +326,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testChildExistsInvalidId() {
+	public function testChildExistsInvalidId(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 
 		$this->tagMapper->expects($this->once())
@@ -338,20 +338,20 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->getNode()->delete();
 	}
 
 	
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->getNode()->setName('somethingelse');
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals('111', $this->getNode()->getName());
 	}
 }

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -99,20 +99,20 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testForbiddenCreateFile() {
+	public function testForbiddenCreateFile(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->node->createFile('555');
 	}
 
 	
-	public function testForbiddenCreateDirectory() {
+	public function testForbiddenCreateDirectory(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->node->createDirectory('789');
 	}
 
-	public function testGetChild() {
+	public function testGetChild(): void {
 		$this->userFolder->expects($this->once())
 			->method('getById')
 			->with('555')
@@ -124,7 +124,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildWithoutAccess() {
+	public function testGetChildWithoutAccess(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
 		$this->userFolder->expects($this->once())
@@ -135,13 +135,13 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testGetChildren() {
+	public function testGetChildren(): void {
 		$this->expectException(\Sabre\DAV\Exception\MethodNotAllowed::class);
 
 		$this->node->getChildren();
 	}
 
-	public function testChildExists() {
+	public function testChildExists(): void {
 		$this->userFolder->expects($this->once())
 			->method('getById')
 			->with('123')
@@ -149,7 +149,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 		$this->assertTrue($this->node->childExists('123'));
 	}
 
-	public function testChildExistsWithoutAccess() {
+	public function testChildExistsWithoutAccess(): void {
 		$this->userFolder->expects($this->once())
 			->method('getById')
 			->with('555')
@@ -158,20 +158,20 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 	}
 
 	
-	public function testDelete() {
+	public function testDelete(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->node->delete();
 	}
 
 	
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->node->setName('somethingelse');
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$this->assertEquals('files', $this->node->getName());
 	}
 }

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -35,7 +35,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesNodes()
 	 */
-	public function testGetContents($expected, $nodes) {
+	public function testGetContents($expected, $nodes): void {
 		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
 		$content = stream_get_contents($stream);
 
@@ -45,7 +45,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesNodes()
 	 */
-	public function testGetContentsFread($expected, $nodes) {
+	public function testGetContentsFread($expected, $nodes): void {
 		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
 
 		$content = '';
@@ -59,7 +59,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesNodes()
 	 */
-	public function testSeek($expected, $nodes) {
+	public function testSeek($expected, $nodes): void {
 		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
 
 		$offset = floor(strlen($expected) * 0.6);

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -75,7 +75,7 @@ class ChunkingPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	public function testBeforeMoveFutureFileSkip() {
+	public function testBeforeMoveFutureFileSkip(): void {
 		$node = $this->createMock(Directory::class);
 
 		$this->tree->expects($this->any())
@@ -88,7 +88,7 @@ class ChunkingPluginTest extends TestCase {
 		$this->assertNull($this->plugin->beforeMove('source', 'target'));
 	}
 
-	public function testBeforeMoveDestinationIsDirectory() {
+	public function testBeforeMoveDestinationIsDirectory(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('The given destination target is a directory.');
 
@@ -111,7 +111,7 @@ class ChunkingPluginTest extends TestCase {
 		$this->assertNull($this->plugin->beforeMove('source', 'target'));
 	}
 
-	public function testBeforeMoveFutureFileSkipNonExisting() {
+	public function testBeforeMoveFutureFileSkipNonExisting(): void {
 		$sourceNode = $this->createMock(FutureFile::class);
 		$sourceNode->expects($this->once())
 			->method('getSize')
@@ -145,7 +145,7 @@ class ChunkingPluginTest extends TestCase {
 		$this->assertFalse($this->plugin->beforeMove('source', 'target'));
 	}
 
-	public function testBeforeMoveFutureFileMoveIt() {
+	public function testBeforeMoveFutureFileMoveIt(): void {
 		$sourceNode = $this->createMock(FutureFile::class);
 		$sourceNode->expects($this->once())
 			->method('getSize')
@@ -185,7 +185,7 @@ class ChunkingPluginTest extends TestCase {
 	}
 
 
-	public function testBeforeMoveSizeIsWrong() {
+	public function testBeforeMoveSizeIsWrong(): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Chunks on server do not sum up to 4 but to 3 bytes');
 

--- a/apps/dav/tests/unit/Upload/FutureFileTest.php
+++ b/apps/dav/tests/unit/Upload/FutureFileTest.php
@@ -28,38 +28,38 @@ namespace OCA\DAV\Tests\unit\Upload;
 use OCA\DAV\Connector\Sabre\Directory;
 
 class FutureFileTest extends \Test\TestCase {
-	public function testGetContentType() {
+	public function testGetContentType(): void {
 		$f = $this->mockFutureFile();
 		$this->assertEquals('application/octet-stream', $f->getContentType());
 	}
 
-	public function testGetETag() {
+	public function testGetETag(): void {
 		$f = $this->mockFutureFile();
 		$this->assertEquals('1234567890', $f->getETag());
 	}
 
-	public function testGetName() {
+	public function testGetName(): void {
 		$f = $this->mockFutureFile();
 		$this->assertEquals('foo.txt', $f->getName());
 	}
 
-	public function testGetLastModified() {
+	public function testGetLastModified(): void {
 		$f = $this->mockFutureFile();
 		$this->assertEquals(12121212, $f->getLastModified());
 	}
 
-	public function testGetSize() {
+	public function testGetSize(): void {
 		$f = $this->mockFutureFile();
 		$this->assertEquals(0, $f->getSize());
 	}
 
-	public function testGet() {
+	public function testGet(): void {
 		$f = $this->mockFutureFile();
 		$stream = $f->get();
 		$this->assertTrue(is_resource($stream));
 	}
 
-	public function testDelete() {
+	public function testDelete(): void {
 		$d = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->setMethods(['delete'])
@@ -73,7 +73,7 @@ class FutureFileTest extends \Test\TestCase {
 	}
 
 	
-	public function testPut() {
+	public function testPut(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$f = $this->mockFutureFile();
@@ -81,7 +81,7 @@ class FutureFileTest extends \Test\TestCase {
 	}
 
 	
-	public function testSetName() {
+	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$f = $this->mockFutureFile();


### PR DESCRIPTION
Resolves: :broom: 

## Summary

:broom: 

## TODO

- [x] :broom: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
