### PR TITLE
perf(DI): Use static closures for DI service factories

### DIFF
--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -33,7 +33,6 @@ declare(strict_types=1);
  */
 namespace OCA\AdminAudit\AppInfo;
 
-use Closure;
 use OC\Files\Filesystem;
 use OC\Files\Node\File;
 use OC\Group\Manager as GroupManager;
@@ -82,7 +81,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		$context->registerService(IAuditLogger::class, function (ContainerInterface $c) {
+		$context->registerService(IAuditLogger::class, static function (ContainerInterface $c) {
 			return new AuditLogger($c->get(ILogFactory::class), $c->get(Iconfig::class));
 		});
 
@@ -170,15 +169,15 @@ class Application extends App implements IBootstrap {
 
 	private function appHooks(IAuditLogger $logger,
 							  EventDispatcherInterface $eventDispatcher): void {
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE, function (ManagerEvent $event) use ($logger) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE, static function (ManagerEvent $event) use ($logger) {
 			$appActions = new AppManagement($logger);
 			$appActions->enableApp($event->getAppID());
 		});
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, function (ManagerEvent $event) use ($logger) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_ENABLE_FOR_GROUPS, static function (ManagerEvent $event) use ($logger) {
 			$appActions = new AppManagement($logger);
 			$appActions->enableAppForGroups($event->getAppID(), $event->getGroups());
 		});
-		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_DISABLE, function (ManagerEvent $event) use ($logger) {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_APP_DISABLE, static function (ManagerEvent $event) use ($logger) {
 			$appActions = new AppManagement($logger);
 			$appActions->disableApp($event->getAppID());
 		});
@@ -186,7 +185,7 @@ class Application extends App implements IBootstrap {
 
 	private function consoleHooks(IAuditLogger $logger,
 								  EventDispatcherInterface $eventDispatcher): void {
-		$eventDispatcher->addListener(ConsoleEvent::EVENT_RUN, function (ConsoleEvent $event) use ($logger) {
+		$eventDispatcher->addListener(ConsoleEvent::EVENT_RUN, static function (ConsoleEvent $event) use ($logger) {
 			$appActions = new Console($logger);
 			$appActions->runCommand($event->getArguments());
 		});
@@ -197,7 +196,7 @@ class Application extends App implements IBootstrap {
 		$fileActions = new Files($logger);
 		$eventDispatcher->addListener(
 			IPreview::EVENT,
-			function (GenericEvent $event) use ($fileActions) {
+			static function (GenericEvent $event) use ($fileActions) {
 				/** @var File $file */
 				$file = $event->getSubject();
 				$fileActions->preview([
@@ -268,11 +267,11 @@ class Application extends App implements IBootstrap {
 
 	private function securityHooks(IAuditLogger $logger,
 								   EventDispatcherInterface $eventDispatcher): void {
-		$eventDispatcher->addListener(IProvider::EVENT_SUCCESS, function (GenericEvent $event) use ($logger) {
+		$eventDispatcher->addListener(IProvider::EVENT_SUCCESS, static function (GenericEvent $event) use ($logger) {
 			$security = new Security($logger);
 			$security->twofactorSuccess($event->getSubject(), $event->getArguments());
 		});
-		$eventDispatcher->addListener(IProvider::EVENT_FAILED, function (GenericEvent $event) use ($logger) {
+		$eventDispatcher->addListener(IProvider::EVENT_FAILED, static function (GenericEvent $event) use ($logger) {
 			$security = new Security($logger);
 			$security->twofactorFailed($event->getSubject(), $event->getArguments());
 		});

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -44,7 +44,6 @@ use OCA\DAV\CalDAV\Reminder\NotificationProviderManager;
 use OCA\DAV\CalDAV\Reminder\Notifier;
 
 use OCA\DAV\Capabilities;
-use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
 use OCA\DAV\CardDAV\PhotoCache;
 use OCA\DAV\CardDAV\SyncService;
@@ -118,10 +117,9 @@ class Application extends App implements IBootstrap {
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerServiceAlias('CardDAVSyncService', SyncService::class);
-		$context->registerService(PhotoCache::class, function (ContainerInterface $c) {
+		$context->registerService(PhotoCache::class, static function (ContainerInterface $c) {
 			/** @var IServerContainer $server */
 			$server = $c->get(IServerContainer::class);
-
 			return new PhotoCache(
 				$server->getAppDataDir('dav-photocache'),
 				$c->get(LoggerInterface::class)
@@ -217,13 +215,13 @@ class Application extends App implements IBootstrap {
 		$hm->setup();
 
 		// first time login event setup
-		$dispatcher->addListener(IUser::class . '::firstLogin', function ($event) use ($hm) {
+		$dispatcher->addListener(IUser::class . '::firstLogin', static function ($event) use ($hm) {
 			if ($event instanceof GenericEvent) {
 				$hm->firstLogin($event->getSubject());
 			}
 		});
 
-		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) use ($container) {
+		$dispatcher->addListener('OC\AccountManager::userUpdated', static function (GenericEvent $event) use ($container) {
 			$user = $event->getSubject();
 			/** @var SyncService $syncService */
 			$syncService = $container->query(SyncService::class);
@@ -231,7 +229,7 @@ class Application extends App implements IBootstrap {
 		});
 
 
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateShares', function (GenericEvent $event) use ($container) {
+		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateShares', static function (GenericEvent $event) use ($container) {
 			/** @var Backend $backend */
 			$backend = $container->query(Backend::class);
 			$backend->onCalendarUpdateShares(
@@ -240,11 +238,10 @@ class Application extends App implements IBootstrap {
 				$event->getArgument('add'),
 				$event->getArgument('remove')
 			);
-
 			// Here we should recalculate if reminders should be sent to new or old sharees
 		});
 
-		$eventHandler = function () use ($container, $serverContainer): void {
+		$eventHandler = static function () use ($container, $serverContainer) : void {
 			try {
 				/** @var UpdateCalendarResourcesRoomsBackgroundJob $job */
 				$job = $container->query(UpdateCalendarResourcesRoomsBackgroundJob::class);

--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -91,17 +91,17 @@ class Application extends \OCP\AppFramework\App {
 		$encryptionManager->registerEncryptionModule(
 			Encryption::ID,
 			Encryption::DISPLAY_NAME,
-			function () use ($container) {
+			static function () use ($container) {
 				return new Encryption(
-				$container->query(Crypt::class),
-				$container->query(KeyManager::class),
-				$container->query(Util::class),
-				$container->query(Session::class),
-				$container->query(EncryptAll::class),
-				$container->query(DecryptAll::class),
-				$container->getServer()->getLogger(),
-				$container->getServer()->getL10N($container->getAppName())
-			);
+					$container->query(Crypt::class),
+					$container->query(KeyManager::class),
+					$container->query(Util::class),
+					$container->query(Session::class),
+					$container->query(EncryptAll::class),
+					$container->query(DecryptAll::class),
+					$container->getServer()->getLogger(),
+					$container->getServer()->getL10N($container->getAppName())
+				);
 			});
 	}
 }

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -56,7 +56,7 @@ class Application extends App implements IBootstrap {
 													 IAppContainer $appContainer): void {
 		$manager->addCloudFederationProvider('file',
 			'Federated Files Sharing',
-			function () use ($appContainer): CloudFederationProviderFiles {
+			static function () use ($appContainer) : CloudFederationProviderFiles {
 				return $appContainer->get(CloudFederationProviderFiles::class);
 			});
 	}

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -77,10 +77,9 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Controllers
 		 */
-		$context->registerService('APIController', function (ContainerInterface $c) {
+		$context->registerService('APIController', static function (ContainerInterface $c) {
 			/** @var IServerContainer $server */
 			$server = $c->get(IServerContainer::class);
-
 			return new ApiController(
 				$c->get('AppName'),
 				$c->get(IRequest::class),
@@ -97,10 +96,9 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Services
 		 */
-		$context->registerService(TagService::class, function (ContainerInterface $c) {
+		$context->registerService(TagService::class, static function (ContainerInterface $c) {
 			/** @var IServerContainer $server */
 			$server = $c->get(IServerContainer::class);
-
 			return new TagService(
 				$c->get(IUserSession::class),
 				$c->get(IActivityManager::class),
@@ -149,7 +147,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	private function registerNavigation(IL10N $l10n): void {
-		\OCA\Files\App::getNavigationManager()->add(function () use ($l10n) {
+		\OCA\Files\App::getNavigationManager()->add(static function () use ($l10n) {
 			return [
 				'id' => 'files',
 				'appname' => 'files',
@@ -158,7 +156,7 @@ class Application extends App implements IBootstrap {
 				'name' => $l10n->t('All files')
 			];
 		});
-		\OCA\Files\App::getNavigationManager()->add(function () use ($l10n) {
+		\OCA\Files\App::getNavigationManager()->add(static function () use ($l10n) {
 			return [
 				'id' => 'recent',
 				'appname' => 'files',
@@ -167,7 +165,7 @@ class Application extends App implements IBootstrap {
 				'name' => $l10n->t('Recent')
 			];
 		});
-		\OCA\Files\App::getNavigationManager()->add(function () use ($l10n) {
+		\OCA\Files\App::getNavigationManager()->add(static function () use ($l10n) {
 			return [
 				'id' => 'favorites',
 				'appname' => 'files',

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -94,10 +94,10 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (IMountProviderCollection $mountProviderCollection, ConfigAdapter $configAdapter) {
+		$context->injectFn(static function (IMountProviderCollection $mountProviderCollection, ConfigAdapter $configAdapter) {
 			$mountProviderCollection->registerProvider($configAdapter);
 		});
-		\OCA\Files\App::getNavigationManager()->add(function () {
+		\OCA\Files\App::getNavigationManager()->add(static function () {
 			$l = \OC::$server->getL10N('files_external');
 			return [
 				'id' => 'extstoragemounts',
@@ -110,7 +110,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$context->injectFn(function (BackendService $backendService, UserPlaceholderHandler $userConfigHandler) {
 			$backendService->registerBackendProvider($this);
 			$backendService->registerAuthMechanismProvider($this);
-			$backendService->registerConfigHandler('user', function () use ($userConfigHandler) {
+			$backendService->registerConfigHandler('user', static function () use ($userConfigHandler) {
 				return $userConfigHandler;
 			});
 		});

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -69,7 +69,7 @@ class Application extends App implements IBootstrap {
 		// pre and post-rename, disable trash logic for the copy+unlink case
 		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Trashbin\Trashbin', 'ensureFileScannedHook');
 
-		\OCA\Files\App::getNavigationManager()->add(function () {
+		\OCA\Files\App::getNavigationManager()->add(static function () {
 			$l = \OC::$server->getL10N(self::APP_ID);
 			return [
 				'id' => 'trashbin',

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -70,7 +70,7 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Register $principalBackend for the DAV collection
 		 */
-		$context->registerService('principalBackend', function (ContainerInterface $c) {
+		$context->registerService('principalBackend', static function (ContainerInterface $c) {
 			/** @var IServerContainer $server */
 			$server = $c->get(IServerContainer::class);
 			return new Principal(
@@ -87,7 +87,7 @@ class Application extends App implements IBootstrap {
 			);
 		});
 
-		$context->registerService(IVersionManager::class, function () {
+		$context->registerService(IVersionManager::class, static function () {
 			return new VersionManager();
 		});
 

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -58,10 +58,9 @@ class Application extends App implements IBootstrap {
 	 */
 	private function registerEventListeners(EventDispatcher $dispatcher,
 											IAppContainer $appContainer): void {
-		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) use ($appContainer) {
+		$dispatcher->addListener('OC\AccountManager::userUpdated', static function (GenericEvent $event) use ($appContainer) {
 			/** @var IUser $user */
 			$user = $event->getSubject();
-
 			/** @var UpdateLookupServer $updateLookupServer */
 			$updateLookupServer = $appContainer->get(UpdateLookupServer::class);
 			$updateLookupServer->userUpdated($user);

--- a/apps/provisioning_api/lib/AppInfo/Application.php
+++ b/apps/provisioning_api/lib/AppInfo/Application.php
@@ -61,7 +61,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 
-		$context->registerService(NewUserMailHelper::class, function (ContainerInterface $c) {
+		$context->registerService(NewUserMailHelper::class, static function (ContainerInterface $c) {
 			return new NewUserMailHelper(
 				$c->get(Defaults::class),
 				$c->get(IURLGenerator::class),
@@ -74,18 +74,16 @@ class Application extends App implements IBootstrap {
 				Util::getDefaultEmailAddress('no-reply')
 			);
 		});
-		$context->registerService(ProvisioningApiMiddleware::class, function (ContainerInterface $c) {
+		$context->registerService(ProvisioningApiMiddleware::class, static function (ContainerInterface $c) {
 			$user = $c->get(IUserManager::class)->get($c->get('UserId'));
 			$isAdmin = false;
 			$isSubAdmin = false;
-
 			if ($user instanceof IUser) {
 				$groupManager = $c->get(IGroupManager::class);
 				assert($groupManager instanceof GroupManager);
 				$isAdmin = $groupManager->isAdmin($user->getUID());
 				$isSubAdmin = $groupManager->getSubAdmin()->isSubAdmin($user);
 			}
-
 			return new ProvisioningApiMiddleware(
 				$c->get(IControllerMethodReflector::class),
 				$isAdmin,

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -93,11 +93,11 @@ class Application extends App implements IBootstrap {
 		 * Core class wrappers
 		 */
 		/** FIXME: Remove once OC_User is non-static and mockable */
-		$context->registerService('isAdmin', function () {
+		$context->registerService('isAdmin', static function () {
 			return \OC_User::isAdminUser(\OC_User::getUser());
 		});
 		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
-		$context->registerService('isSubAdmin', function () {
+		$context->registerService('isSubAdmin', static function () {
 			$userObject = \OC::$server->getUserSession()->getUser();
 			$isSubAdmin = false;
 			if ($userObject !== null) {
@@ -105,23 +105,22 @@ class Application extends App implements IBootstrap {
 			}
 			return $isSubAdmin;
 		});
-		$context->registerService(IProvider::class, function (IAppContainer $appContainer) {
+		$context->registerService(IProvider::class, static function (IAppContainer $appContainer) {
 			/** @var IServerContainer $serverContainer */
 			$serverContainer = $appContainer->query(IServerContainer::class);
 			return $serverContainer->query(IProvider::class);
 		});
-		$context->registerService(IManager::class, function (IAppContainer $appContainer) {
+		$context->registerService(IManager::class, static function (IAppContainer $appContainer) {
 			/** @var IServerContainer $serverContainer */
 			$serverContainer = $appContainer->query(IServerContainer::class);
 			return $serverContainer->getSettingsManager();
 		});
 
-		$context->registerService(NewUserMailHelper::class, function (IAppContainer $appContainer) {
+		$context->registerService(NewUserMailHelper::class, static function (IAppContainer $appContainer) {
 			/** @var Server $server */
 			$server = $appContainer->query(IServerContainer::class);
 			/** @var Defaults $defaults */
 			$defaults = $server->query(Defaults::class);
-
 			return new NewUserMailHelper(
 				$defaults,
 				$server->getURLGenerator(),

--- a/apps/systemtags/lib/AppInfo/Application.php
+++ b/apps/systemtags/lib/AppInfo/Application.php
@@ -47,19 +47,18 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (EventDispatcher $dispatcher) use ($context) {
+		$context->injectFn(static function (EventDispatcher $dispatcher) use ($context) {
 			/*
 			 * @todo move the OCP events and then move the registration to `register`
 			 */
 			$dispatcher->addListener(
 				'OCA\Files::loadAdditionalScripts',
-				function () {
+				static function () {
 					\OCP\Util::addScript('core', 'systemtags');
 					\OCP\Util::addScript(self::APP_ID, 'systemtags');
 				}
 			);
-
-			$managerListener = function (ManagerEvent $event) use ($context) {
+			$managerListener = static function (ManagerEvent $event) use ($context) {
 				/** @var \OCA\SystemTags\Activity\Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->event($event);
@@ -67,8 +66,7 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(ManagerEvent::EVENT_CREATE, $managerListener);
 			$dispatcher->addListener(ManagerEvent::EVENT_DELETE, $managerListener);
 			$dispatcher->addListener(ManagerEvent::EVENT_UPDATE, $managerListener);
-
-			$mapperListener = function (MapperEvent $event) use ($context) {
+			$mapperListener = static function (MapperEvent $event) use ($context) {
 				/** @var \OCA\SystemTags\Activity\Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->mapperEvent($event);
@@ -77,7 +75,7 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(MapperEvent::EVENT_UNASSIGN, $mapperListener);
 		});
 
-		\OCA\Files\App::getNavigationManager()->add(function () {
+		\OCA\Files\App::getNavigationManager()->add(static function () {
 			$l = \OC::$server->getL10N(self::APP_ID);
 			return [
 				'id' => 'systemtagsfilter',

--- a/apps/updatenotification/lib/AppInfo/Application.php
+++ b/apps/updatenotification/lib/AppInfo/Application.php
@@ -55,23 +55,16 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (IConfig $config,
-									 IUserSession $userSession,
-									 IAppManager $appManager,
-									 IGroupManager $groupManager,
-									 IAppContainer $appContainer,
-									 ILogger $logger) {
+		$context->injectFn(static function (IConfig $config, IUserSession $userSession, IAppManager $appManager, IGroupManager $groupManager, IAppContainer $appContainer, ILogger $logger) {
 			if ($config->getSystemValue('updatechecker', true) !== true) {
 				// Updater check is disabled
 				return;
 			}
-
 			$user = $userSession->getUser();
 			if (!$user instanceof IUser) {
 				// Nothing to do for guests
 				return;
 			}
-
 			if (!$appManager->isEnabledForUser('notifications') &&
 				$groupManager->isAdmin($user->getUID())) {
 				try {
@@ -80,7 +73,7 @@ class Application extends App implements IBootstrap {
 					$logger->logException($e);
 					return;
 				}
-
+   
 				if ($updateChecker->getUpdateState() !== []) {
 					Util::addScript('updatenotification', 'legacy-notification');
 					\OC_Hook::connect('\OCP\Config', 'js', $updateChecker, 'populateJavaScriptVariables');

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -69,10 +69,9 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Controller
 		 */
-		$container->registerService('RenewPasswordController', function (IAppContainer $appContainer) {
+		$container->registerService('RenewPasswordController', static function (IAppContainer $appContainer) {
 			/** @var IServerContainer $server */
 			$server = $appContainer->get(IServerContainer::class);
-
 			return new RenewPasswordController(
 				$appContainer->get('AppName'),
 				$server->getRequest(),
@@ -84,10 +83,9 @@ class Application extends App implements IBootstrap {
 			);
 		});
 
-		$container->registerService(ILDAPWrapper::class, function (IAppContainer $appContainer) {
+		$container->registerService(ILDAPWrapper::class, static function (IAppContainer $appContainer) {
 			/** @var IServerContainer $server */
 			$server = $appContainer->get(IServerContainer::class);
-
 			return new LDAP(
 				$server->getConfig()->getSystemValueString('ldap_log_file')
 			);
@@ -99,7 +97,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerService(
 			Manager::class,
-			function (ContainerInterface $c) {
+			static function (ContainerInterface $c) {
 				return new Manager(
 					$c->get(IConfig::class),
 					$c->get(FilesystemHelper::class),
@@ -117,24 +115,15 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (
-			INotificationManager $notificationManager,
-			IAppContainer $appContainer,
-			EventDispatcherInterface $legacyDispatcher,
-			IEventDispatcher $dispatcher,
-			IGroupManager $groupManager,
-			User_Proxy $userBackend,
-			Group_Proxy $groupBackend,
-			Helper $helper
-		) {
+		$context->injectFn(static function (INotificationManager $notificationManager, IAppContainer $appContainer, EventDispatcherInterface $legacyDispatcher, IEventDispatcher $dispatcher, IGroupManager $groupManager, User_Proxy $userBackend, Group_Proxy $groupBackend, Helper $helper) {
 			$configPrefixes = $helper->getServerConfigurationPrefixes(true);
 			if (count($configPrefixes) > 0) {
 				$userPluginManager = $appContainer->get(UserPluginManager::class);
 				$groupPluginManager = $appContainer->get(GroupPluginManager::class);
-
+   
 				\OC_User::useBackend($userBackend);
 				$groupManager->addBackend($groupBackend);
-
+   
 				$userBackendRegisteredEvent = new UserBackendRegistered($userBackend, $userPluginManager);
 				$legacyDispatcher->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', $userBackendRegisteredEvent);
 				$dispatcher->dispatchTyped($userBackendRegisteredEvent);
@@ -156,9 +145,9 @@ class Application extends App implements IBootstrap {
 	private function registerBackendDependents(IAppContainer $appContainer, EventDispatcherInterface $dispatcher) {
 		$dispatcher->addListener(
 			'OCA\\Files_External::loadAdditionalBackends',
-			function () use ($appContainer) {
+			static function () use ($appContainer) {
 				$storagesBackendService = $appContainer->get(BackendService::class);
-				$storagesBackendService->registerConfigHandler('home', function () use ($appContainer) {
+				$storagesBackendService->registerConfigHandler('home', static function () use ($appContainer) {
 					return $appContainer->get(ExtStorageConfigHandler::class);
 				});
 			}

--- a/apps/user_status/lib/AppInfo/Application.php
+++ b/apps/user_status/lib/AppInfo/Application.php
@@ -47,7 +47,6 @@ use OCP\UserStatus\IManager;
  * @package OCA\UserStatus\AppInfo
  */
 class Application extends App implements IBootstrap {
-
 	/** @var string */
 	public const APP_ID = 'user_status';
 

--- a/apps/weather_status/lib/AppInfo/Application.php
+++ b/apps/weather_status/lib/AppInfo/Application.php
@@ -41,7 +41,6 @@ use OCP\Util;
  * @package OCA\WeatherStatus\AppInfo
  */
 class Application extends App implements IBootstrap {
-
 	/** @var string */
 	public const APP_ID = 'weather_status';
 
@@ -54,7 +53,7 @@ class Application extends App implements IBootstrap {
 		parent::__construct(self::APP_ID, $urlParams);
 
 		$dispatcher = $this->getContainer()->query(IEventDispatcher::class);
-		$dispatcher->addListener(RegisterWidgetEvent::class, function (Event $e) {
+		$dispatcher->addListener(RegisterWidgetEvent::class, static function (Event $e) {
 			Util::addScript(self::APP_ID, 'weather-status');
 		});
 	}

--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -76,31 +76,31 @@ class Application extends App implements IBootstrap {
 
 		foreach ($configuredEvents as $operationClass => $events) {
 			foreach ($events as $entityClass => $eventNames) {
-				array_map(function (string $eventName) use ($manager, $container, $dispatcher, $logger, $operationClass, $entityClass) {
+				array_map(static function (string $eventName) use ($manager, $container, $dispatcher, $logger, $operationClass, $entityClass) {
 					$dispatcher->addListener(
 						$eventName,
-						function ($event) use ($manager, $container, $eventName, $logger, $operationClass, $entityClass) {
+						static function ($event) use ($manager, $container, $eventName, $logger, $operationClass, $entityClass) {
 							$ruleMatcher = $manager->getRuleMatcher();
 							try {
 								/** @var IEntity $entity */
 								$entity = $container->query($entityClass);
 								/** @var IOperation $operation */
 								$operation = $container->query($operationClass);
-
+	  
 								$ruleMatcher->setEventName($eventName);
 								$ruleMatcher->setEntity($entity);
 								$ruleMatcher->setOperation($operation);
-
+	  
 								$ctx = new LogContext();
 								$ctx
-									->setOperation($operation)
-									->setEntity($entity)
-									->setEventName($eventName);
-
+										  ->setOperation($operation)
+										  ->setEntity($entity)
+										  ->setEventName($eventName);
+	  
 								/** @var Logger $flowLogger */
 								$flowLogger = $container->query(Logger::class);
 								$flowLogger->logEventInit($ctx);
-
+	  
 								if ($event instanceof Event) {
 									$entity->prepareRuleMatcher($ruleMatcher, $eventName, $event);
 									$operation->onEvent($eventName, $event, $ruleMatcher);

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -138,7 +138,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 
 		// Log wrappers
-		$this->registerService(LoggerInterface::class, function (ContainerInterface $c) {
+		$this->registerService(LoggerInterface::class, static function (ContainerInterface $c) {
 			return new ScopedPsrLogger(
 				$c->get(PsrLoggerAdapter::class),
 				$c->get('AppName')
@@ -153,36 +153,36 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 		$this->registerAlias('ServerContainer', IServerContainer::class);
 
-		$this->registerService(\OCP\WorkflowEngine\IManager::class, function (ContainerInterface $c) {
+		$this->registerService(\OCP\WorkflowEngine\IManager::class, static function (ContainerInterface $c) {
 			return $c->get(Manager::class);
 		});
 
-		$this->registerService(ContainerInterface::class, function (ContainerInterface $c) {
+		$this->registerService(ContainerInterface::class, static function (ContainerInterface $c) {
 			return $c;
 		});
 		$this->registerAlias(IAppContainer::class, ContainerInterface::class);
 
 		// commonly used attributes
-		$this->registerService('userId', function (ContainerInterface $c) {
+		$this->registerService('userId', static function (ContainerInterface $c) {
 			return $c->get(IUserSession::class)->getSession()->get('user_id');
 		});
 
-		$this->registerService('webRoot', function (ContainerInterface $c) {
+		$this->registerService('webRoot', static function (ContainerInterface $c) {
 			return $c->get(IServerContainer::class)->getWebRoot();
 		});
 
-		$this->registerService('OC_Defaults', function (ContainerInterface $c) {
+		$this->registerService('OC_Defaults', static function (ContainerInterface $c) {
 			return $c->get(IServerContainer::class)->getThemingDefaults();
 		});
 
-		$this->registerService('Protocol', function (ContainerInterface $c) {
+		$this->registerService('Protocol', static function (ContainerInterface $c) {
 			/** @var \OC\Server $server */
 			$server = $c->get(IServerContainer::class);
 			$protocol = $server->getRequest()->getHttpProtocol();
 			return new Http($_SERVER, $protocol);
 		});
 
-		$this->registerService('Dispatcher', function (ContainerInterface $c) {
+		$this->registerService('Dispatcher', static function (ContainerInterface $c) {
 			return new Dispatcher(
 				$c->get('Protocol'),
 				$c->get(MiddlewareDispatcher::class),
@@ -328,13 +328,13 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			return $dispatcher;
 		});
 
-		$this->registerService(IAppConfig::class, function (ContainerInterface $c) {
+		$this->registerService(IAppConfig::class, static function (ContainerInterface $c) {
 			return new OC\AppFramework\Services\AppConfig(
 				$c->get(IConfig::class),
 				$c->get('AppName')
 			);
 		});
-		$this->registerService(IInitialState::class, function (ContainerInterface $c) {
+		$this->registerService(IInitialState::class, static function (ContainerInterface $c) {
 			return new OC\AppFramework\Services\InitialState(
 				$c->get(IInitialStateService::class),
 				$c->get('AppName')

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -50,6 +50,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
@@ -275,7 +276,6 @@ use OC\Profiler\Profiler;
  * TODO: hookup all manager classes
  */
 class Server extends ServerContainer implements IServerContainer {
-
 	/** @var string */
 	private $webRoot;
 
@@ -291,10 +291,10 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerParameter('isCLI', \OC::$CLI);
 		$this->registerParameter('serverRoot', \OC::$SERVERROOT);
 
-		$this->registerService(ContainerInterface::class, function (ContainerInterface $c) {
+		$this->registerService(ContainerInterface::class, static function (ContainerInterface $c) {
 			return $c;
 		});
-		$this->registerService(\OCP\IServerContainer::class, function (ContainerInterface $c) {
+		$this->registerService(\OCP\IServerContainer::class, static function (ContainerInterface $c) {
 			return $c;
 		});
 
@@ -319,11 +319,11 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(IActionFactory::class, ActionFactory::class);
 
-		$this->registerService(View::class, function (Server $c) {
+		$this->registerService(View::class, static function (Server $c) {
 			return new View();
 		}, false);
 
-		$this->registerService(IPreview::class, function (ContainerInterface $c) {
+		$this->registerService(IPreview::class, static function (ContainerInterface $c) {
 			return new PreviewManager(
 				$c->get(\OCP\IConfig::class),
 				$c->get(IRootFolder::class),
@@ -343,7 +343,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('PreviewManager', IPreview::class);
 
-		$this->registerService(\OC\Preview\Watcher::class, function (ContainerInterface $c) {
+		$this->registerService(\OC\Preview\Watcher::class, static function (ContainerInterface $c) {
 			return new \OC\Preview\Watcher(
 				new \OC\Preview\Storage\Root(
 					$c->get(IRootFolder::class),
@@ -352,11 +352,11 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(IProfiler::class, function (Server $c) {
+		$this->registerService(IProfiler::class, static function (Server $c) {
 			return new Profiler($c->get(SystemConfig::class));
 		});
 
-		$this->registerService(\OCP\Encryption\IManager::class, function (Server $c): Encryption\Manager {
+		$this->registerService(\OCP\Encryption\IManager::class, static function (Server $c): Encryption\Manager {
 			$view = new View();
 			$util = new Encryption\Util(
 				$view,
@@ -378,7 +378,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		/** @deprecated 21.0.0 */
 		$this->registerDeprecatedAlias('EncryptionFileHelper', IFile::class);
-		$this->registerService(IFile::class, function (ContainerInterface $c) {
+		$this->registerService(IFile::class, static function (ContainerInterface $c) {
 			$util = new Encryption\Util(
 				new View(),
 				$c->get(IUserManager::class),
@@ -394,7 +394,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		/** @deprecated 21.0.0 */
 		$this->registerDeprecatedAlias('EncryptionKeyStorage', IStorage::class);
-		$this->registerService(IStorage::class, function (ContainerInterface $c) {
+		$this->registerService(IStorage::class, static function (ContainerInterface $c) {
 			$view = new View();
 			$util = new Encryption\Util(
 				$view,
@@ -402,7 +402,6 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IGroupManager::class),
 				$c->get(\OCP\IConfig::class)
 			);
-
 			return new Encryption\Keys\Storage(
 				$view,
 				$util,
@@ -423,13 +422,13 @@ class Server extends ServerContainer implements IServerContainer {
 			$factoryClass = $config->getSystemValue('systemtags.managerFactory', SystemTagManagerFactory::class);
 			return new $factoryClass($this);
 		});
-		$this->registerService(ISystemTagManager::class, function (ContainerInterface $c) {
+		$this->registerService(ISystemTagManager::class, static function (ContainerInterface $c) {
 			return $c->get('SystemTagManagerFactory')->getManager();
 		});
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SystemTagManager', ISystemTagManager::class);
 
-		$this->registerService(ISystemTagObjectMapper::class, function (ContainerInterface $c) {
+		$this->registerService(ISystemTagObjectMapper::class, static function (ContainerInterface $c) {
 			return $c->get('SystemTagManagerFactory')->getObjectMapper();
 		});
 		$this->registerService('RootFolder', function (ContainerInterface $c) {
@@ -453,7 +452,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return $root;
 		});
-		$this->registerService(HookConnector::class, function (ContainerInterface $c) {
+		$this->registerService(HookConnector::class, static function (ContainerInterface $c) {
 			return new HookConnector(
 				$c->get(IRootFolder::class),
 				new View(),
@@ -465,8 +464,8 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('SystemTagObjectMapper', ISystemTagObjectMapper::class);
 
-		$this->registerService(IRootFolder::class, function (ContainerInterface $c) {
-			return new LazyRoot(function () use ($c) {
+		$this->registerService(IRootFolder::class, static function (ContainerInterface $c) {
+			return new LazyRoot(static function () use ($c) {
 				return $c->get('RootFolder');
 			});
 		});
@@ -477,7 +476,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('UserManager', \OC\User\Manager::class);
 		$this->registerAlias(\OCP\IUserManager::class, \OC\User\Manager::class);
 
-		$this->registerService(DisplayNameCache::class, function (ContainerInterface $c) {
+		$this->registerService(DisplayNameCache::class, static function (ContainerInterface $c) {
 			return $c->get(\OC\User\Manager::class)->getDisplayNameCache();
 		});
 
@@ -533,7 +532,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('GroupManager', \OCP\IGroupManager::class);
 
-		$this->registerService(Store::class, function (ContainerInterface $c) {
+		$this->registerService(Store::class, static function (ContainerInterface $c) {
 			$session = $c->get(ISession::class);
 			if (\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {
 				$tokenProvider = $c->get(IProvider::class);
@@ -572,22 +571,22 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IEventDispatcher::class)
 			);
 			/** @deprecated 21.0.0 use BeforeUserCreatedEvent event with the IEventDispatcher instead */
-			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
+			$userSession->listen('\OC\User', 'preCreateUser', static function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});
 			/** @deprecated 21.0.0 use UserCreatedEvent event with the IEventDispatcher instead */
-			$userSession->listen('\OC\User', 'postCreateUser', function ($user, $password) {
+			$userSession->listen('\OC\User', 'postCreateUser', static function ($user, $password) {
 				/** @var \OC\User\User $user */
 				\OC_Hook::emit('OC_User', 'post_createUser', ['uid' => $user->getUID(), 'password' => $password]);
 			});
 			/** @deprecated 21.0.0 use BeforeUserDeletedEvent event with the IEventDispatcher instead */
-			$userSession->listen('\OC\User', 'preDelete', function ($user) use ($legacyDispatcher) {
+			$userSession->listen('\OC\User', 'preDelete', static function ($user) use ($legacyDispatcher) {
 				/** @var \OC\User\User $user */
 				\OC_Hook::emit('OC_User', 'pre_deleteUser', ['run' => true, 'uid' => $user->getUID()]);
 				$legacyDispatcher->dispatch('OCP\IUser::preDelete', new GenericEvent($user));
 			});
 			/** @deprecated 21.0.0 use UserDeletedEvent event with the IEventDispatcher instead */
-			$userSession->listen('\OC\User', 'postDelete', function ($user) {
+			$userSession->listen('\OC\User', 'postDelete', static function ($user) {
 				/** @var \OC\User\User $user */
 				\OC_Hook::emit('OC_User', 'post_deleteUser', ['uid' => $user->getUID()]);
 			});
@@ -671,7 +670,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('AllConfig', \OC\AllConfig::class);
 		$this->registerAlias(\OCP\IConfig::class, \OC\AllConfig::class);
 
-		$this->registerService(\OC\SystemConfig::class, function ($c) use ($config) {
+		$this->registerService(\OC\SystemConfig::class, static function ($c) use ($config) {
 			return new \OC\SystemConfig($config);
 		});
 		/** @deprecated 19.0.0 */
@@ -681,7 +680,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('AppConfig', \OC\AppConfig::class);
 		$this->registerAlias(IAppConfig::class, \OC\AppConfig::class);
 
-		$this->registerService(IFactory::class, function (Server $c) {
+		$this->registerService(IFactory::class, static function (Server $c) {
 			return new \OC\L10N\Factory(
 				$c->get(\OCP\IConfig::class),
 				$c->getRequest(),
@@ -702,13 +701,13 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CategoryFetcher', CategoryFetcher::class);
 
-		$this->registerService(ICache::class, function ($c) {
+		$this->registerService(ICache::class, static function ($c) {
 			return new Cache\File();
 		});
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserCache', ICache::class);
 
-		$this->registerService(Factory::class, function (Server $c) {
+		$this->registerService(Factory::class, static function (Server $c) {
 			$profiler = $c->get(IProfiler::class);
 			$arrayCacheFactory = new \OC\Memcache\Factory('', $c->get(LoggerInterface::class),
 				$profiler,
@@ -718,7 +717,6 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 			/** @var \OCP\IConfig $config */
 			$config = $c->get(\OCP\IConfig::class);
-
 			if ($config->getSystemValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				if (!$config->getSystemValueBool('log_query')) {
 					$v = \OC_App::getAppVersions();
@@ -750,7 +748,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('MemCacheFactory', Factory::class);
 		$this->registerAlias(ICacheFactory::class, Factory::class);
 
-		$this->registerService('RedisFactory', function (Server $c) {
+		$this->registerService('RedisFactory', static function (Server $c) {
 			$systemConfig = $c->get(SystemConfig::class);
 			return new RedisFactory($systemConfig, $c->getEventLogger());
 		});
@@ -768,14 +766,14 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ActivityManager', \OCP\Activity\IManager::class);
 
-		$this->registerService(\OCP\Activity\IEventMerger::class, function (Server $c) {
+		$this->registerService(\OCP\Activity\IEventMerger::class, static function (Server $c) {
 			return new \OC\Activity\EventMerger(
 				$c->getL10N('lib')
 			);
 		});
 		$this->registerAlias(IValidator::class, Validator::class);
 
-		$this->registerService(AvatarManager::class, function (Server $c) {
+		$this->registerService(AvatarManager::class, static function (Server $c) {
 			return new AvatarManager(
 				$c->get(IUserSession::class),
 				$c->get(\OC\User\Manager::class),
@@ -818,7 +816,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('JobList', IJobList::class);
 
-		$this->registerService(Router::class, function (Server $c) {
+		$this->registerService(Router::class, static function (Server $c) {
 			$cacheFactory = $c->get(ICacheFactory::class);
 			$logger = $c->get(LoggerInterface::class);
 			if ($cacheFactory->isLocalCacheAvailable()) {
@@ -872,7 +870,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('CredentialsManager', ICredentialsManager::class);
 
 		$this->registerAlias(IDBConnection::class, ConnectionAdapter::class);
-		$this->registerService(Connection::class, function (Server $c) {
+		$this->registerService(Connection::class, static function (Server $c) {
 			$systemConfig = $c->get(SystemConfig::class);
 			$factory = new \OC\DB\ConnectionFactory($systemConfig);
 			$type = $systemConfig->getValue('dbtype', 'sqlite');
@@ -888,19 +886,19 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(ICertificateManager::class, CertificateManager::class);
 		$this->registerAlias(IClientService::class, ClientService::class);
-		$this->registerService(NegativeDnsCache::class, function (ContainerInterface $c) {
+		$this->registerService(NegativeDnsCache::class, static function (ContainerInterface $c) {
 			return new NegativeDnsCache(
 				$c->get(ICacheFactory::class),
 			);
 		});
 		$this->registerDeprecatedAlias('HttpClientService', IClientService::class);
-		$this->registerService(IEventLogger::class, function (ContainerInterface $c) {
+		$this->registerService(IEventLogger::class, static function (ContainerInterface $c) {
 			return new EventLogger($c->get(SystemConfig::class), $c->get(LoggerInterface::class), $c->get(Log::class));
 		});
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('EventLogger', IEventLogger::class);
 
-		$this->registerService(IQueryLogger::class, function (ContainerInterface $c) {
+		$this->registerService(IQueryLogger::class, static function (ContainerInterface $c) {
 			$queryLogger = new QueryLogger();
 			if ($c->get(SystemConfig::class)->getValue('debug', false)) {
 				// In debug mode, module is being activated by default
@@ -915,7 +913,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('TempManager', TempManager::class);
 		$this->registerAlias(ITempManager::class, TempManager::class);
 
-		$this->registerService(AppManager::class, function (ContainerInterface $c) {
+		$this->registerService(AppManager::class, static function (ContainerInterface $c) {
 			// TODO: use auto-wiring
 			return new \OC\App\AppManager(
 				$c->get(IUserSession::class),
@@ -935,9 +933,8 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('DateTimeZone', IDateTimeZone::class);
 
-		$this->registerService(IDateTimeFormatter::class, function (Server $c) {
+		$this->registerService(IDateTimeFormatter::class, static function (Server $c) {
 			$language = $c->get(\OCP\IConfig::class)->getUserValue($c->get(ISession::class)->get('user_id'), 'core', 'lang', null);
-
 			return new DateTimeFormatter(
 				$c->get(IDateTimeZone::class)->getTimeZone(),
 				$c->getL10N('lib', $language)
@@ -946,7 +943,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('DateTimeFormatter', IDateTimeFormatter::class);
 
-		$this->registerService(IUserMountCache::class, function (ContainerInterface $c) {
+		$this->registerService(IUserMountCache::class, static function (ContainerInterface $c) {
 			$mountCache = new UserMountCache(
 				$c->get(IDBConnection::class),
 				$c->get(IUserManager::class),
@@ -959,13 +956,11 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('UserMountCache', IUserMountCache::class);
 
-		$this->registerService(IMountProviderCollection::class, function (ContainerInterface $c) {
+		$this->registerService(IMountProviderCollection::class, static function (ContainerInterface $c) {
 			$loader = \OC\Files\Filesystem::getLoader();
 			$mountCache = $c->get(IUserMountCache::class);
 			$manager = new \OC\Files\Config\MountProviderCollection($loader, $mountCache);
-
 			// builtin providers
-
 			$config = $c->get(\OCP\IConfig::class);
 			$logger = $c->get(LoggerInterface::class);
 			$manager->registerProvider(new CacheMountProvider($config));
@@ -973,7 +968,6 @@ class Server extends ServerContainer implements IServerContainer {
 			$manager->registerHomeProvider(new ObjectHomeMountProvider($config));
 			$manager->registerRootProvider(new RootMountProvider($config, $c->get(LoggerInterface::class)));
 			$manager->registerRootProvider(new ObjectStorePreviewCacheMountProvider($logger, $config));
-
 			return $manager;
 		});
 		/** @deprecated 19.0.0 */
@@ -981,7 +975,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		/** @deprecated 20.0.0 */
 		$this->registerDeprecatedAlias('IniWrapper', IniGetWrapper::class);
-		$this->registerService(IBus::class, function (ContainerInterface $c) {
+		$this->registerService(IBus::class, static function (ContainerInterface $c) {
 			$busClass = $c->get(\OCP\IConfig::class)->getSystemValue('commandbus');
 			if ($busClass) {
 				[$app, $class] = explode('::', $busClass, 2);
@@ -1003,7 +997,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Throttler', Throttler::class);
 		$this->registerAlias(IThrottler::class, Throttler::class);
-		$this->registerService('IntegrityCodeChecker', function (ContainerInterface $c) {
+		$this->registerService('IntegrityCodeChecker', static function (ContainerInterface $c) {
 			// IConfig and IAppManager requires a working database. This code
 			// might however be called when ownCloud is not yet setup.
 			if (\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {
@@ -1013,7 +1007,6 @@ class Server extends ServerContainer implements IServerContainer {
 				$config = null;
 				$appManager = null;
 			}
-
 			return new Checker(
 				new EnvironmentHelper(),
 				new FileAccessHelper(),
@@ -1068,7 +1061,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(IMailer::class, function (Server $c) {
+		$this->registerService(IMailer::class, static function (Server $c) {
 			return new Mailer(
 				$c->get(\OCP\IConfig::class),
 				$c->get(LoggerInterface::class),
@@ -1094,11 +1087,11 @@ class Server extends ServerContainer implements IServerContainer {
 			/** @var \OCP\LDAP\ILDAPProviderFactory $factory */
 			return new $factoryClass($this);
 		});
-		$this->registerService(ILDAPProvider::class, function (ContainerInterface $c) {
+		$this->registerService(ILDAPProvider::class, static function (ContainerInterface $c) {
 			$factory = $c->get(ILDAPProviderFactory::class);
 			return $factory->getLDAPProvider();
 		});
-		$this->registerService(ILockingProvider::class, function (ContainerInterface $c) {
+		$this->registerService(ILockingProvider::class, static function (ContainerInterface $c) {
 			$ini = $c->get(IniGetWrapper::class);
 			$config = $c->get(\OCP\IConfig::class);
 			$ttl = $config->getSystemValue('filelocking.ttl', max(3600, $ini->getNumeric('max_execution_time')));
@@ -1121,12 +1114,12 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('LockingProvider', ILockingProvider::class);
 
-		$this->registerService(ILockManager::class, function (Server $c): LockManager {
+		$this->registerService(ILockManager::class, static function (Server $c): LockManager {
 			return new LockManager();
 		});
 
 		$this->registerAlias(ILockdownManager::class, 'LockdownManager');
-		$this->registerService(SetupManager::class, function ($c) {
+		$this->registerService(SetupManager::class, static function ($c) {
 			// create the setupmanager through the mount manager to resolve the cyclic dependency
 			return $c->get(\OC\Files\Mount\Manager::class)->getSetupManager();
 		});
@@ -1134,7 +1127,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MountManager', IMountManager::class);
 
-		$this->registerService(IMimeTypeDetector::class, function (ContainerInterface $c) {
+		$this->registerService(IMimeTypeDetector::class, static function (ContainerInterface $c) {
 			return new \OC\Files\Type\Detection(
 				$c->get(IURLGenerator::class),
 				$c->get(LoggerInterface::class),
@@ -1155,15 +1148,15 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('NotificationManager', \OCP\Notification\IManager::class);
 
-		$this->registerService(CapabilitiesManager::class, function (ContainerInterface $c) {
+		$this->registerService(CapabilitiesManager::class, static function (ContainerInterface $c) {
 			$manager = new CapabilitiesManager($c->get(LoggerInterface::class));
-			$manager->registerCapability(function () use ($c) {
+			$manager->registerCapability(static function () use ($c) {
 				return new \OC\OCS\CoreCapabilities($c->get(\OCP\IConfig::class));
 			});
-			$manager->registerCapability(function () use ($c) {
+			$manager->registerCapability(static function () use ($c) {
 				return $c->get(\OC\Security\Bruteforce\Capabilities::class);
 			});
-			$manager->registerCapability(function () use ($c) {
+			$manager->registerCapability(static function () use ($c) {
 				return $c->get(MetadataCapabilities::class);
 			});
 			return $manager;
@@ -1178,7 +1171,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$factory = new $factoryClass($this);
 			$manager = $factory->getManager();
 
-			$manager->registerDisplayNameResolver('user', function ($id) use ($c) {
+			$manager->registerDisplayNameResolver('user', static function ($id) use ($c) {
 				$manager = $c->get(IUserManager::class);
 				$userDisplayName = $manager->getDisplayName($id);
 				if ($userDisplayName === null) {
@@ -1245,7 +1238,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerDeprecatedAlias('EventDispatcher', \OC\EventDispatcher\SymfonyAdapter::class);
 		$this->registerAlias(EventDispatcherInterface::class, \OC\EventDispatcher\SymfonyAdapter::class);
 
-		$this->registerService('CryptoWrapper', function (ContainerInterface $c) {
+		$this->registerService('CryptoWrapper', static function (ContainerInterface $c) {
 			// FIXME: Instantiated here due to cyclic dependency
 			$request = new Request(
 				[
@@ -1262,7 +1255,6 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IRequestId::class),
 				$c->get(\OCP\IConfig::class)
 			);
-
 			return new CryptoWrapper(
 				$c->get(\OCP\IConfig::class),
 				$c->get(ICrypto::class),
@@ -1272,7 +1264,7 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('CsrfTokenManager', CsrfTokenManager::class);
-		$this->registerService(SessionStorage::class, function (ContainerInterface $c) {
+		$this->registerService(SessionStorage::class, static function (ContainerInterface $c) {
 			return new SessionStorage($c->get(ISession::class));
 		});
 		$this->registerAlias(\OCP\Security\IContentSecurityPolicyManager::class, ContentSecurityPolicyManager::class);
@@ -1311,16 +1303,14 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ShareManager', \OCP\Share\IManager::class);
 
-		$this->registerService(\OCP\Collaboration\Collaborators\ISearch::class, function (Server $c) {
+		$this->registerService(\OCP\Collaboration\Collaborators\ISearch::class, static function (Server $c) {
 			$instance = new Collaboration\Collaborators\Search($c);
-
 			// register default plugins
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_USER', 'class' => UserPlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_GROUP', 'class' => GroupPlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_EMAIL', 'class' => MailPlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE', 'class' => RemotePlugin::class]);
 			$instance->registerPlugin(['shareType' => 'SHARE_TYPE_REMOTE_GROUP', 'class' => RemoteGroupPlugin::class]);
-
 			return $instance;
 		});
 		/** @deprecated 19.0.0 */
@@ -1336,27 +1326,27 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerDeprecatedAlias('SettingsManager', \OC\Settings\Manager::class);
 		$this->registerAlias(\OCP\Settings\IManager::class, \OC\Settings\Manager::class);
-		$this->registerService(\OC\Files\AppData\Factory::class, function (ContainerInterface $c) {
+		$this->registerService(\OC\Files\AppData\Factory::class, static function (ContainerInterface $c) {
 			return new \OC\Files\AppData\Factory(
 				$c->get(IRootFolder::class),
 				$c->get(SystemConfig::class)
 			);
 		});
 
-		$this->registerService('LockdownManager', function (ContainerInterface $c) {
-			return new LockdownManager(function () use ($c) {
+		$this->registerService('LockdownManager', static function (ContainerInterface $c) {
+			return new LockdownManager(static function () use ($c) {
 				return $c->get(ISession::class);
 			});
 		});
 
-		$this->registerService(\OCP\OCS\IDiscoveryService::class, function (ContainerInterface $c) {
+		$this->registerService(\OCP\OCS\IDiscoveryService::class, static function (ContainerInterface $c) {
 			return new DiscoveryService(
 				$c->get(ICacheFactory::class),
 				$c->get(IClientService::class)
 			);
 		});
 
-		$this->registerService(ICloudIdManager::class, function (ContainerInterface $c) {
+		$this->registerService(ICloudIdManager::class, static function (ContainerInterface $c) {
 			return new CloudIdManager(
 				$c->get(\OCP\Contacts\IManager::class),
 				$c->get(IURLGenerator::class),
@@ -1368,7 +1358,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerAlias(\OCP\GlobalScale\IConfig::class, \OC\GlobalScale\Config::class);
 
-		$this->registerService(ICloudFederationProviderManager::class, function (ContainerInterface $c) {
+		$this->registerService(ICloudFederationProviderManager::class, static function (ContainerInterface $c) {
 			return new CloudFederationProviderManager(
 				$c->get(IAppManager::class),
 				$c->get(IClientService::class),
@@ -1377,7 +1367,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(ICloudFederationFactory::class, function (Server $c) {
+		$this->registerService(ICloudFederationFactory::class, static function (Server $c) {
 			return new CloudFederationFactory();
 		});
 
@@ -1389,7 +1379,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('TimeFactory', \OCP\AppFramework\Utility\ITimeFactory::class);
 
-		$this->registerService(Defaults::class, function (Server $c) {
+		$this->registerService(Defaults::class, static function (Server $c) {
 			return new Defaults(
 				$c->getThemingDefaults()
 			);
@@ -1397,17 +1387,17 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('Defaults', \OCP\Defaults::class);
 
-		$this->registerService(\OCP\ISession::class, function (ContainerInterface $c) {
+		$this->registerService(\OCP\ISession::class, static function (ContainerInterface $c) {
 			return $c->get(\OCP\IUserSession::class)->getSession();
 		}, false);
 
-		$this->registerService(IShareHelper::class, function (ContainerInterface $c) {
+		$this->registerService(IShareHelper::class, static function (ContainerInterface $c) {
 			return new ShareHelper(
 				$c->get(\OCP\Share\IManager::class)
 			);
 		});
 
-		$this->registerService(Installer::class, function (ContainerInterface $c) {
+		$this->registerService(Installer::class, static function (ContainerInterface $c) {
 			return new Installer(
 				$c->get(AppFetcher::class),
 				$c->get(IClientService::class),
@@ -1418,11 +1408,11 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 
-		$this->registerService(IApiFactory::class, function (ContainerInterface $c) {
+		$this->registerService(IApiFactory::class, static function (ContainerInterface $c) {
 			return new ApiFactory($c->get(IClientService::class));
 		});
 
-		$this->registerService(IInstanceFactory::class, function (ContainerInterface $c) {
+		$this->registerService(IInstanceFactory::class, static function (ContainerInterface $c) {
 			$memcacheFactory = $c->get(ICacheFactory::class);
 			return new InstanceFactory($memcacheFactory->createLocal('remoteinstance.'), $c->get(IClientService::class));
 		});
@@ -1551,8 +1541,8 @@ class Server extends ServerContainer implements IServerContainer {
 	/**
 	 * Returns the tag manager which can get and set tags for different object types
 	 *
-	 * @see \OCP\ITagManager::load()
 	 * @return ITagManager
+	 * @see \OCP\ITagManager::load()
 	 * @deprecated 20.0.0
 	 */
 	public function getTagManager() {
@@ -1619,6 +1609,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * Returns a view to ownCloud's files folder
 	 *
 	 * @param string $userId user ID
+	 *
 	 * @return \OCP\Files\Folder|null
 	 * @deprecated 20.0.0
 	 */
@@ -1730,6 +1721,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 *
 	 * @param string $app appid
 	 * @param string $lang
+	 *
 	 * @return IL10N
 	 * @deprecated 20.0.0
 	 */
@@ -2358,7 +2350,7 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	private function registerDeprecatedAlias(string $alias, string $target) {
-		$this->registerService($alias, function (ContainerInterface $container) use ($target, $alias) {
+		$this->registerService($alias, static function (ContainerInterface $container) use ($target, $alias) {
 			try {
 				/** @var LoggerInterface $logger */
 				$logger = $container->get(LoggerInterface::class);
@@ -2366,7 +2358,6 @@ class Server extends ServerContainer implements IServerContainer {
 			} catch (ContainerExceptionInterface $e) {
 				// Could not get logger. Continue
 			}
-
 			return $container->get($target);
 		}, false);
 	}


### PR DESCRIPTION
* Resolves: potential :snail: 

## Summary

Static closures do not capture `$this` and therefore allow the PHP garbage collector to free the surrounding object.

Ref https://stackoverflow.com/questions/19899468/php-closures-why-the-static-in-the-anonymous-function-declaration-when-bindin

Ref https://3v4l.org/0bpD8 vs https://3v4l.org/b3UHp

## Benchmarks

Honestly not a lot:

![Bildschirmfoto vom 2023-01-20 09-32-25](https://user-images.githubusercontent.com/1374172/213651161-edb6cac1-8053-4edd-8ffa-b5796a36955e.png)

On the other hand this change has no disadvantage either.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
