### PR TITLE
fix(occ): Fix comment formatting of maintenance:repair command

### DIFF
--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -136,7 +136,7 @@ class Repair extends Command {
 		} elseif ($event instanceof RepairInfoEvent) {
 			$this->output->writeln('<info>     - ' . $event->getMessage() . '</info>');
 		} elseif ($event instanceof RepairWarningEvent) {
-			$this->output->writeln('<comment>     - WARNING: ' . $event->getMessage()) . '</comment>';
+			$this->output->writeln('<comment>     - WARNING: ' . $event->getMessage() . '</comment>');
 		} elseif ($event instanceof RepairErrorEvent) {
 			$this->output->writeln('<error>     - ERROR: ' . $event->getMessage() . '</error>');
 		}


### PR DESCRIPTION
## Summary

Leftover/regression of https://github.com/nextcloud/server/pull/33640 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
