### PR TITLE
Fix broken user:setting command unit test

### DIFF
--- a/tests/Core/Command/User/SettingTest.php
+++ b/tests/Core/Command/User/SettingTest.php
@@ -212,8 +212,11 @@ class SettingTest extends TestCase {
 
 		if ($user !== false) {
 			$this->userManager->expects($this->once())
-				->method('userExists')
+				->method('get')
 				->willReturn($user);
+		} else {
+			$this->userManager->expects($this->never())
+				->method('get');
 		}
 
 		$command = $this->getCommand();


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/36123#issuecomment-1398036725

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
