### PR TITLE
Fix interned strings buffer check if 0 free bytes

### DIFF
--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -524,11 +524,11 @@ Raw output
 			}
 
 			if (
-				empty($status['interned_strings_usage']['free_memory']) ||
+				// Do not recommend to raise the interned strings buffer size above a quarter of the total OPcache size
+				($this->iniGetWrapper->getNumeric('opcache.interned_strings_buffer') < $this->iniGetWrapper->getNumeric('opcache.memory_consumption') / 4) &&
 				(
-					($status['interned_strings_usage']['used_memory'] / $status['interned_strings_usage']['free_memory'] > 9) &&
-					// Do not recommend to raise the interned strings buffer size above a quarter of the total OPcache size
-					($this->iniGetWrapper->getNumeric('opcache.interned_strings_buffer') < $this->iniGetWrapper->getNumeric('opcache.memory_consumption') / 4)
+					empty($status['interned_strings_usage']['free_memory']) ||
+					($status['interned_strings_usage']['used_memory'] / $status['interned_strings_usage']['free_memory'] > 9)
 				)
 			) {
 				$recommendations[] = $this->l10n->t('The OPcache interned strings buffer is nearly full. To assure that repeating strings can be effectively cached, it is recommended to apply <code>opcache.interned_strings_buffer</code> to your PHP configuration with a value higher than <code>%s</code>.', [($this->iniGetWrapper->getNumeric('opcache.interned_strings_buffer') ?: 'currently')]);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/31223#issuecomment-1398636892
At least this case made me review the code and see the loophole.

## Summary
With #32902 it was meant to be avoided to recommend raising the interned strings buffer size above a quarter of the total OPcache size. This works as long as there is at least 1 byte free, but does not apply if the buffer is filled completely.

This commit switches the conditions so that the interned strings buffer size must be smaller than a quarter of the total OPcache size for the warning to be shown. That the buffer must be either filled completely or by more than 90% remains untouched.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
