### PR TITLE
Fix event listener race condition on login-form

### DIFF
--- a/core/js/login/authpicker.js
+++ b/core/js/login/authpicker.js
@@ -10,4 +10,6 @@ jQuery(document).ready(function() {
 		e.preventDefault();
 		document.location.href = e.target.attributes.action.value
 	})
+
+	$('#login-form input').removeAttr('disabled');
 })

--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -47,7 +47,7 @@ $urlGenerator = $_['urlGenerator'];
 
 	<p id="redirect-link">
 		<form id="login-form" action="<?php p($urlGenerator->linkToRoute('core.ClientFlowLogin.grantPage', ['stateToken' => $_['stateToken'], 'clientIdentifier' => $_['clientIdentifier'], 'oauthState' => $_['oauthState'], 'user' => $_['user'], 'direct' => $_['direct']])) ?>" method="get">
-			<input type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Log in')) ?>">
+			<input type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Log in')) ?>" disabled>
 		</form>
 	</p>
 

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -47,7 +47,7 @@ $urlGenerator = $_['urlGenerator'];
 
 	<p id="redirect-link">
 		<form id="login-form" action="<?php p($urlGenerator->linkToRouteAbsolute('core.ClientFlowLoginV2.grantPage', ['stateToken' => $_['stateToken'], 'user' => $_['user']])) ?>" method="get">
-			<input type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Log in')) ?>">
+			<input type="submit" class="login primary icon-confirm-white" value="<?php p($l->t('Log in')) ?>" disabled>
 		</form>
 	</p>
 


### PR DESCRIPTION
## Summary

We received reports about the error "State token does not match" when trying to login with talk-ios (see https://github.com/nextcloud/talk-ios/issues/1017). I have seen this error myself from time to time, but wasn't able to pinpoint it to when exactly it happens. I took a closer look at the requests / responses received and noticed, that usually we should see something like this

```
GET /index.php/login/flow/grant?stateToken=<TOKEN>&clientIdentifier=&user=&direct=0
```

but in some cases it was just like this

```
GET /index.php/login/flow/grant?
```

so without any query parameters. The login process itself (username, password) does work fine, but fails after granting access with the error mentioned above.
The page itself is rendered correctly, so the forms actions include the parameters as seen in the first request above. As this won't work natively (at least not on iOS), we need a small javascript snippet (`authpicker.js`) to to a redirect, instead of a the native browser action. Problem is that the listener for this to happen is added when the document is ready, but the user is actually able to press "Log in" before the listener is added, therefore doing a native browser action with the query parameters removed.

How to test:
* Comment out this code https://github.com/nextcloud/server/blob/791a18246feb1425170523e757b4b4e369ca0be6/core/js/login/authpicker.js#L9-L12
* Try to login using flow v1
* See that you receive "State token does not match" at the end

Because this code is still using jQuery and therefore considered legacy, I went for disabling the button until the corresponding jQuery code ran.

* Resolves: https://github.com/nextcloud/talk-ios/issues/1017
* Looks like this was introduced in 25, so backport to stable-25 ?

CC: @Ivansss 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
