### PR TITLE
perf(app-framework): Make app middleware registration even lazier

### DIFF
--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -153,7 +153,6 @@ class Coordinator {
 		$this->registrationContext->delegateDashboardPanelRegistrations($this->dashboardManager);
 		$this->registrationContext->delegateEventListenerRegistrations($this->eventDispatcher);
 		$this->registrationContext->delegateContainerRegistrations($apps);
-		$this->registrationContext->delegateMiddlewareRegistrations($apps);
 	}
 
 	public function getRegistrationContext(): ?RegistrationContext {

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -617,29 +617,10 @@ class RegistrationContext {
 	}
 
 	/**
-	 * @param App[] $apps
+	 * @return ServiceRegistration<Middleware>[]
 	 */
-	public function delegateMiddlewareRegistrations(array $apps): void {
-		while (($middleware = array_shift($this->middlewares)) !== null) {
-			$appId = $middleware->getAppId();
-			if (!isset($apps[$appId])) {
-				// If we land here something really isn't right. But at least we caught the
-				// notice that is otherwise emitted for the undefined index
-				$this->logger->error("App $appId not loaded for the container middleware registration");
-
-				continue;
-			}
-
-			try {
-				$apps[$appId]
-					->getContainer()
-					->registerMiddleWare($middleware->getService());
-			} catch (Throwable $e) {
-				$this->logger->error("Error during capability registration of $appId: " . $e->getMessage(), [
-					'exception' => $e,
-				]);
-			}
-		}
+	public function getMiddlewareRegistrations(): array {
+		return $this->middlewares;
 	}
 
 	/**

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -315,6 +315,17 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c->get(\OC\AppFramework\Middleware\AdditionalScriptsMiddleware::class)
 			);
 
+			/** @var \OC\AppFramework\Bootstrap\Coordinator $coordinator */
+			$coordinator = $c->get(\OC\AppFramework\Bootstrap\Coordinator::class);
+			$registrationContext = $coordinator->getRegistrationContext();
+			if ($registrationContext !== null) {
+				$appId = $this->getAppName();
+				foreach ($registrationContext->getMiddlewareRegistrations() as $middlewareRegistration) {
+					if ($middlewareRegistration->getAppId() === $appId) {
+						$dispatcher->registerMiddleware($c->get($middlewareRegistration->getService()));
+					}
+				}
+			}
 			foreach ($this->middleWares as $middleWare) {
 				$dispatcher->registerMiddleware($c->get($middleWare));
 			}

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -27,6 +27,7 @@ namespace lib\AppFramework\Bootstrap;
 
 use OC\AppFramework\Bootstrap\RegistrationContext;
 use OC\AppFramework\Bootstrap\ServiceRegistration;
+use OC\Core\Middleware\TwoFactorMiddleware;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -145,24 +146,6 @@ class RegistrationContextTest extends TestCase {
 		]);
 	}
 
-	public function testRegisterMiddleware(): void {
-		$app = $this->createMock(App::class);
-		$name = 'abc';
-		$container = $this->createMock(IAppContainer::class);
-		$app->method('getContainer')
-			->willReturn($container);
-		$container->expects($this->once())
-			->method('registerMiddleware')
-			->with($name);
-		$this->logger->expects($this->never())
-			->method('error');
-
-		$this->context->for('myapp')->registerMiddleware($name);
-		$this->context->delegateMiddlewareRegistrations([
-			'myapp' => $app,
-		]);
-	}
-
 	public function testRegisterUserMigrator(): void {
 		$appIdA = 'myapp';
 		$migratorClassA = 'OCA\App\UserMigration\AppMigrator';
@@ -194,5 +177,15 @@ class RegistrationContextTest extends TestCase {
 			[true],
 			[false]
 		];
+	}
+
+	public function testGetMiddlewareRegistrations(): void {
+		$this->context->registerMiddleware('core', TwoFactorMiddleware::class);
+
+		$registrations = $this->context->getMiddlewareRegistrations();
+
+		self::assertNotEmpty($registrations);
+		self::assertSame('core', $registrations[0]->getAppId());
+		self::assertSame(TwoFactorMiddleware::class, $registrations[0]->getService());
 	}
 }

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -25,9 +25,13 @@
 
 namespace Test\AppFramework\DependencyInjection;
 
+use OC\AppFramework\Bootstrap\Coordinator;
+use OC\AppFramework\Bootstrap\RegistrationContext;
+use OC\AppFramework\Bootstrap\ServiceRegistration;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
+use OCP\AppFramework\Middleware;
 use OCP\AppFramework\QueryException;
 use OCP\IConfig;
 use OCP\IRequestId;
@@ -82,6 +86,38 @@ class DIContainerTest extends \Test\TestCase {
 		}
 
 		$this->assertTrue($found);
+	}
+
+	public function testMiddlewareDispatcherIncludesBootstrapMiddlewares(): void {
+		$coordinator = $this->createMock(Coordinator::class);
+		$this->container[Coordinator::class] = $coordinator;
+		$this->container['Request'] = $this->createMock(Request::class);
+		$registrationContext = $this->createMock(RegistrationContext::class);
+		$registrationContext->method('getMiddlewareRegistrations')
+			->willReturn([
+				new ServiceRegistration($this->container['appName'], 'foo'),
+				new ServiceRegistration('otherapp', 'bar'),
+			]);
+		$this->container['foo'] = new class extends Middleware {
+		};
+		$this->container['bar'] = new class extends Middleware {
+		};
+		$coordinator->method('getRegistrationContext')->willReturn($registrationContext);
+
+		$dispatcher = $this->container['MiddlewareDispatcher'];
+
+		$middlewares = $dispatcher->getMiddlewares();
+		self::assertNotEmpty($middlewares);
+		foreach ($middlewares as $middleware) {
+			if ($middleware === $this->container['bar']) {
+				$this->fail('Container must not register this middleware');
+			}
+			if ($middleware === $this->container['foo']) {
+				// It is done
+				return;
+			}
+		}
+		$this->fail('Bootstrap registered middleware not found');
 	}
 
 	public function testInvalidAppClass() {


### PR DESCRIPTION
## Summary

Before this patch, app middlewares were registered on the DI container of each app loaded in a Nextcloud process. With the patch the registration is moved to a later point. Only middlewares of the created dispatcher will be loaded.

This allows me to work on a new middleware feature: https://github.com/nextcloud/server/pull/36310

## Benchmarks

Blackfire and wall time measurements show no improvements. After all we are just moving around class names. That stuff is fast.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
