### PR TITLE
feat(files) Update quota when updating storage statistics

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -31,6 +31,7 @@
 				state.dir = null;
 				state.call = null;
 				Files.updateMaxUploadFilesize(response);
+				Files.updateQuota(response);
 			});
 		},
 		// update quota


### PR DESCRIPTION
* Resolves: #36300 

## Summary

It's free to update the quota at the same time as the storage statistics. This is very useful for folders with different quotas (like groupfolders)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
