### PR TITLE
 feat(app-framework): Add support for global middlewares

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -664,6 +664,7 @@ return array(
     'OC\\AppFramework\\Bootstrap\\Coordinator' => $baseDir . '/lib/private/AppFramework/Bootstrap/Coordinator.php',
     'OC\\AppFramework\\Bootstrap\\EventListenerRegistration' => $baseDir . '/lib/private/AppFramework/Bootstrap/EventListenerRegistration.php',
     'OC\\AppFramework\\Bootstrap\\FunctionInjector' => $baseDir . '/lib/private/AppFramework/Bootstrap/FunctionInjector.php',
+    'OC\\AppFramework\\Bootstrap\\MiddlewareRegistration' => $baseDir . '/lib/private/AppFramework/Bootstrap/MiddlewareRegistration.php',
     'OC\\AppFramework\\Bootstrap\\ParameterRegistration' => $baseDir . '/lib/private/AppFramework/Bootstrap/ParameterRegistration.php',
     'OC\\AppFramework\\Bootstrap\\PreviewProviderRegistration' => $baseDir . '/lib/private/AppFramework/Bootstrap/PreviewProviderRegistration.php',
     'OC\\AppFramework\\Bootstrap\\RegistrationContext' => $baseDir . '/lib/private/AppFramework/Bootstrap/RegistrationContext.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -697,6 +697,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\AppFramework\\Bootstrap\\Coordinator' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/Coordinator.php',
         'OC\\AppFramework\\Bootstrap\\EventListenerRegistration' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/EventListenerRegistration.php',
         'OC\\AppFramework\\Bootstrap\\FunctionInjector' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/FunctionInjector.php',
+        'OC\\AppFramework\\Bootstrap\\MiddlewareRegistration' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/MiddlewareRegistration.php',
         'OC\\AppFramework\\Bootstrap\\ParameterRegistration' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/ParameterRegistration.php',
         'OC\\AppFramework\\Bootstrap\\PreviewProviderRegistration' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/PreviewProviderRegistration.php',
         'OC\\AppFramework\\Bootstrap\\RegistrationContext' => __DIR__ . '/../../..' . '/lib/private/AppFramework/Bootstrap/RegistrationContext.php',

--- a/lib/private/AppFramework/Bootstrap/MiddlewareRegistration.php
+++ b/lib/private/AppFramework/Bootstrap/MiddlewareRegistration.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OC\AppFramework\Bootstrap;
+
+use OCP\AppFramework\Middleware;
+
+/**
+ * @psalm-immutable
+ * @template-extends ServiceRegistration<Middleware>
+ */
+class MiddlewareRegistration extends ServiceRegistration {
+	private bool $global;
+
+	public function __construct(string $appId, string $service, bool $global) {
+		parent::__construct($appId, $service);
+		$this->global = $global;
+	}
+
+	public function isGlobal(): bool {
+		return $this->global;
+	}
+}

--- a/lib/private/AppFramework/Bootstrap/RegistrationContext.php
+++ b/lib/private/AppFramework/Bootstrap/RegistrationContext.php
@@ -94,7 +94,7 @@ class RegistrationContext {
 	/** @var EventListenerRegistration[] */
 	private $eventListeners = [];
 
-	/** @var ServiceRegistration<Middleware>[] */
+	/** @var MiddlewareRegistration[] */
 	private $middlewares = [];
 
 	/** @var ServiceRegistration<IProvider>[] */
@@ -205,10 +205,11 @@ class RegistrationContext {
 				);
 			}
 
-			public function registerMiddleware(string $class): void {
+			public function registerMiddleware(string $class, bool $global = false): void {
 				$this->context->registerMiddleware(
 					$this->appId,
-					$class
+					$class,
+					$global,
 				);
 			}
 
@@ -368,8 +369,8 @@ class RegistrationContext {
 	/**
 	 * @psalm-param class-string<Middleware> $class
 	 */
-	public function registerMiddleware(string $appId, string $class): void {
-		$this->middlewares[] = new ServiceRegistration($appId, $class);
+	public function registerMiddleware(string $appId, string $class, bool $global): void {
+		$this->middlewares[] = new MiddlewareRegistration($appId, $class, $global);
 	}
 
 	public function registerSearchProvider(string $appId, string $class) {
@@ -617,7 +618,7 @@ class RegistrationContext {
 	}
 
 	/**
-	 * @return ServiceRegistration<Middleware>[]
+	 * @return MiddlewareRegistration[]
 	 */
 	public function getMiddlewareRegistrations(): array {
 		return $this->middlewares;

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -321,7 +321,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			if ($registrationContext !== null) {
 				$appId = $this->getAppName();
 				foreach ($registrationContext->getMiddlewareRegistrations() as $middlewareRegistration) {
-					if ($middlewareRegistration->getAppId() === $appId) {
+					if ($middlewareRegistration->getAppId() === $appId
+						|| $middlewareRegistration->isGlobal()) {
 						$dispatcher->registerMiddleware($c->get($middlewareRegistration->getService()));
 					}
 				}

--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -138,14 +138,16 @@ interface IRegistrationContext {
 
 	/**
 	 * @param string $class
+	 * @param bool $global load this middleware also for requests of other apps? Added in Nextcloud 26
 	 * @psalm-param class-string<\OCP\AppFramework\Middleware> $class
 	 *
 	 * @return void
 	 * @see IAppContainer::registerMiddleWare()
 	 *
 	 * @since 20.0.0
+	 * @since 26.0.0 Added optional argument $global
 	 */
-	public function registerMiddleware(string $class): void;
+	public function registerMiddleware(string $class, bool $global = false): void;
 
 	/**
 	 * Register a search provider for the unified search

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -180,7 +180,7 @@ class RegistrationContextTest extends TestCase {
 	}
 
 	public function testGetMiddlewareRegistrations(): void {
-		$this->context->registerMiddleware('core', TwoFactorMiddleware::class);
+		$this->context->registerMiddleware('core', TwoFactorMiddleware::class, false);
 
 		$registrations = $this->context->getMiddlewareRegistrations();
 

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -26,8 +26,8 @@
 namespace Test\AppFramework\DependencyInjection;
 
 use OC\AppFramework\Bootstrap\Coordinator;
+use OC\AppFramework\Bootstrap\MiddlewareRegistration;
 use OC\AppFramework\Bootstrap\RegistrationContext;
-use OC\AppFramework\Bootstrap\ServiceRegistration;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
@@ -95,8 +95,40 @@ class DIContainerTest extends \Test\TestCase {
 		$registrationContext = $this->createMock(RegistrationContext::class);
 		$registrationContext->method('getMiddlewareRegistrations')
 			->willReturn([
-				new ServiceRegistration($this->container['appName'], 'foo'),
-				new ServiceRegistration('otherapp', 'bar'),
+				new MiddlewareRegistration($this->container['appName'], 'foo', false),
+				new MiddlewareRegistration('otherapp', 'bar', false),
+			]);
+		$this->container['foo'] = new class extends Middleware {
+		};
+		$this->container['bar'] = new class extends Middleware {
+		};
+		$coordinator->method('getRegistrationContext')->willReturn($registrationContext);
+
+		$dispatcher = $this->container['MiddlewareDispatcher'];
+
+		$middlewares = $dispatcher->getMiddlewares();
+		self::assertNotEmpty($middlewares);
+		foreach ($middlewares as $middleware) {
+			if ($middleware === $this->container['bar']) {
+				$this->fail('Container must not register this middleware');
+			}
+			if ($middleware === $this->container['foo']) {
+				// It is done
+				return;
+			}
+		}
+		$this->fail('Bootstrap registered middleware not found');
+	}
+
+	public function testMiddlewareDispatcherIncludesGlobalBootstrapMiddlewares(): void {
+		$coordinator = $this->createMock(Coordinator::class);
+		$this->container[Coordinator::class] = $coordinator;
+		$this->container['Request'] = $this->createMock(Request::class);
+		$registrationContext = $this->createMock(RegistrationContext::class);
+		$registrationContext->method('getMiddlewareRegistrations')
+			->willReturn([
+				new MiddlewareRegistration('otherapp', 'foo', true),
+				new MiddlewareRegistration('otherapp', 'bar', false),
 			]);
 		$this->container['foo'] = new class extends Middleware {
 		};


### PR DESCRIPTION
Resolves: an idea I had in my mind for years

## Summary

This allows apps to register middlewares that always register, not just for the app's own requests. Example: https://github.com/ChristophWurst/nextcloud_sentry/issues/329 and a middleware that monitors the performance of other apps' controller methods.

## TODO

- [x] Finish https://github.com/nextcloud/server/pull/36298

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not 
required
  - [x] https://github.com/nextcloud/documentation/pull/9588
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
