### PR TITLE
Log to `error_log` in fatal case

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -359,6 +359,7 @@ class Log implements ILogger, IDataLogger {
 			$context['level'] = $level;
 		} catch (Throwable $e) {
 			// make sure we dont hard crash if logging fails
+			error_log('Error when trying to log exception: ' . $e->getMessage() . ' ' . $e->getTraceAsString());
 		}
 	}
 


### PR DESCRIPTION
## Summary

Write a log message via [`error_log`](https://www.php.net/manual/en/function.error-log.php) in case we can't regularly write to our logfile. This improves troubleshooting.

## Use case

**Example:**
We forgot to install the `php-apcu` module but configured it in `config.php`. This could happen for example when upgrading the PHP version or when not properly reading the manual.

**Before:**
When trying to access NC, we're presented with a generic error message. 

```
Internal Server Error

The server encountered an internal error and was unable to complete your request.
Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.
More details can be found in the server log.
```

Neither `nextcloud.log` nor `/var/log/apache2/error.log` (or something similar) is written. As an admin we absolutely don't know what's going on (Btw: I only solved this by debugging via XDebug).

**After:**
There is a log entry in `/var/log/apache2/error.log` telling us:

```
[Mon Jan 23 17:57:01.559577 2023] [php:notice] [pid 189438] [client ::1:48076] Error when trying to log exception: Memcache \\OC\\Memcache\\APCu not available for local cache 
#0 /var/www/html/nextcloud/lib/private/Server.php(745): OC\\Memcache\\Factory->__construct()
#1 /var/www/html/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(162): OC\\Server->OC\\{closure}()
#2 /var/www/html/nextcloud/3rdparty/pimple/pimple/src/Pimple/Container.php(122): OC\\AppFramework\\Utility\\SimpleContainer->OC\\AppFramework\\Utility\\{closure}()
#3 /var/www/html/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(129): Pimple\\Container->offsetGet()
...
```

This is not formatted nicely but it tells the admin what's the problem and why the NC server instance is down.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included - not needed
- [x] Screenshots before/after for front-end changes - no changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required - no doc changes
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) - non critical
