### PR TITLE
Fix default value for files_no_background_scan

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2223,7 +2223,7 @@ $CONFIG = [
  * scan to sync filesystem and database. Only users with unscanned files
  * (size < 0 in filecache) are included. Maximum 500 users per job.
  *
- * Defaults to ``true``
+ * Defaults to ``false``
  */
 'files_no_background_scan' => false,
 


### PR DESCRIPTION
The value is read in https://github.com/nextcloud/server/blob/b888c6146327d842e21988b0d90d6ade4f3a9435/apps/files/lib/BackgroundJob/ScanFiles.php#L105 and the default value is false.

## Summary

The documented default value for `files_no_background_scan` was wrong.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
