### PR TITLE
Allow configuring the location of the `appdata_[instanceid]` folder

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1925,6 +1925,15 @@ $CONFIG = [
 'updatedirectory' => '',
 
 /**
+ * Override where Nextcloud stores the ``appdata_INSTANCEID`` directory. Useful
+ * when using remote object storage where local system disks provide faster data
+ * access. Defaults to `datadirectory` if unset.
+ * 
+ * The Web server user must have write access to this directory.
+ */
+'appdatadirectory' => '',
+
+/**
  * Blacklist a specific file or files and disallow the upload of files
  * with this name. ``.htaccess`` is blocked by default.
  * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.

--- a/lib/private/Files/Cache/LocalRootScanner.php
+++ b/lib/private/Files/Cache/LocalRootScanner.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
  */
 namespace OC\Files\Cache;
 
+use OC\Files\Filesystem;
+
 class LocalRootScanner extends Scanner {
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null) {
 		if ($this->shouldScanPath($file)) {
@@ -43,7 +45,11 @@ class LocalRootScanner extends Scanner {
 	}
 
 	private function shouldScanPath(string $path): bool {
+		$storageId = $this->storage->getId();
+		$mount = Filesystem::getMountManager()->findByStorageId($storageId);
+		$mountPoint = sizeof($mount) == 1 ? $mount[0]->getMountPoint() : "null";
+
 		$path = trim($path, '/');
-		return $path === '' || str_starts_with($path, 'appdata_') || str_starts_with($path, '__groupfolders');
+		return $path === '' || str_starts_with($path, 'appdata_') || str_starts_with($path, '__groupfolders') || str_starts_with($mountPoint, '/appdata_');
 	}
 }

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -38,6 +38,7 @@ class SystemConfig {
 	protected $sensitiveValues = [
 		'instanceid' => true,
 		'datadirectory' => true,
+		'appdatadirectory' => true,
 		'dbname' => true,
 		'dbhost' => true,
 		'dbpassword' => true,

--- a/tests/lib/Files/AppData/AppDataTest.php
+++ b/tests/lib/Files/AppData/AppDataTest.php
@@ -51,8 +51,10 @@ class AppDataTest extends \Test\TestCase {
 
 		$this->systemConfig->expects($this->any())
 			->method('getValue')
-			->with('instanceid', null)
-			->willReturn('iid');
+			->willReturnMap([
+				['instanceid', null, 'iid'],
+				['appdatadirectory', null, '/path'],
+			]);
 	}
 
 	private function setupAppFolder() {


### PR DESCRIPTION
Allow configuring the location of the `appdata_[instanceid]` folder

* Resolves: #12873

## Summary
This allows administrators to change the location of the `appdata_[instanceid]` folder by specifying an `appdataroot` value in `config.php`. This is especially useful when using shared storage, object storage as primary storage (storing `appdata_[instanceid]` in an object store is extremely slow), etc.

## TODO
**Resolved with commit 783ad06**

- [x] Regardless of `appdataroot` being set, the function should really return `$rootFolder` and not `$rootFolder->get($folderName)`. The current code will store files in `/appdata_[instanceid]/appdata_[instanceid]` when an `appdataroot` is provided and `/appdata_[instanceid]` in normal operation (i.e. it will create a `/appdata_[instanceid]` folder on the mount point instead of writing appdata folders to the mount point itself). Some apps such as OnlyOffice expect the `appdata_[instanceid]` folder to be a direct child of system root:
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/504884f16ce2b66e45a66579aa3cdf0fd0197330/lib/templatemanager.php#L53

~~However, I am having permission issues. The system is able to create files and folders at the mount point, but when it tries to read the folders, they don't appear to exist, and errors are thrown. I think it has something to do with the `OC\FilesView` attached to the mount point/folder, but I'm not sure. It seems to occur at this function:~~ ~~https://github.com/nextcloud/server/blob/75d7203f579f5761fc921d9506579bec48ebab74/lib/private/Files/Node/Folder.php#L161~~

If that doesn't make sense, please feel free to ask me to explain in further detail.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
