### PR TITLE
fix(app-framework): Specify return type of Middleware::beforeController

### DIFF
--- a/lib/public/AppFramework/Middleware.php
+++ b/lib/public/AppFramework/Middleware.php
@@ -42,6 +42,7 @@ abstract class Middleware {
 	 * @param Controller $controller the controller that is being called
 	 * @param string $methodName the name of the method that will be called on
 	 *                           the controller
+	 * @return void
 	 * @since 6.0.0
 	 */
 	public function beforeController($controller, $methodName) {


### PR DESCRIPTION
Resolves: n/a

## Summary

The abstract class has no defined return type. Adding one makes it easier to write a correct subclass override for that method.

We can not add a PHP return type yet because that would potentially cause trouble with untyped subclasses: https://3v4l.org/dRU5Q

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
