### PR TITLE
feat(app-framework): Add native argument types for middleware

### DIFF
--- a/lib/public/AppFramework/Middleware.php
+++ b/lib/public/AppFramework/Middleware.php
@@ -25,6 +25,7 @@
  */
 namespace OCP\AppFramework;
 
+use Exception;
 use OCP\AppFramework\Http\Response;
 
 /**
@@ -45,7 +46,7 @@ abstract class Middleware {
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function beforeController($controller, $methodName) {
+	public function beforeController(Controller $controller, string $methodName) {
 	}
 
 
@@ -59,12 +60,12 @@ abstract class Middleware {
 	 * @param Controller $controller the controller that is being called
 	 * @param string $methodName the name of the method that will be called on
 	 *                           the controller
-	 * @param \Exception $exception the thrown exception
-	 * @throws \Exception the passed in exception if it can't handle it
+	 * @param Exception $exception the thrown exception
+	 * @throws Exception the passed in exception if it can't handle it
 	 * @return Response a Response object in case that the exception was handled
 	 * @since 6.0.0
 	 */
-	public function afterException($controller, $methodName, \Exception $exception) {
+	public function afterException(Controller $controller, string $methodName, Exception $exception) {
 		throw $exception;
 	}
 
@@ -80,7 +81,7 @@ abstract class Middleware {
 	 * @return Response a Response object
 	 * @since 6.0.0
 	 */
-	public function afterController($controller, $methodName, Response $response) {
+	public function afterController(Controller $controller, string $methodName, Response $response) {
 		return $response;
 	}
 
@@ -96,7 +97,7 @@ abstract class Middleware {
 	 * @return string the output that should be printed
 	 * @since 6.0.0
 	 */
-	public function beforeOutput($controller, $methodName, $output) {
+	public function beforeOutput(Controller $controller, string $methodName, string $output) {
 		return $output;
 	}
 }

--- a/tests/lib/AppFramework/Middleware/MiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/MiddlewareTest.php
@@ -70,27 +70,27 @@ class MiddlewareTest extends \Test\TestCase {
 	}
 
 
-	public function testBeforeController() {
-		$this->middleware->beforeController($this->controller, null);
+	public function testBeforeController(): void {
+		$this->middleware->beforeController($this->controller, '');
 		$this->assertNull(null);
 	}
 
 
-	public function testAfterExceptionRaiseAgainWhenUnhandled() {
+	public function testAfterExceptionRaiseAgainWhenUnhandled(): void {
 		$this->expectException(\Exception::class);
-		$this->middleware->afterException($this->controller, null, $this->exception);
+		$this->middleware->afterException($this->controller, '', $this->exception);
 	}
 
 
-	public function testAfterControllerReturnResponseWhenUnhandled() {
-		$response = $this->middleware->afterController($this->controller, null, $this->response);
+	public function testAfterControllerReturnResponseWhenUnhandled(): void {
+		$response = $this->middleware->afterController($this->controller, '', $this->response);
 
 		$this->assertEquals($this->response, $response);
 	}
 
 
-	public function testBeforeOutputReturnOutputhenUnhandled() {
-		$output = $this->middleware->beforeOutput($this->controller, null, 'test');
+	public function testBeforeOutputReturnOutputhenUnhandled(): void {
+		$output = $this->middleware->beforeOutput($this->controller, '', 'test');
 
 		$this->assertEquals('test', $output);
 	}


### PR DESCRIPTION
Resolves: n/a

## Summary

PHP allows us to add types to a base class that is extended elsewhere without breaking an interface: https://3v4l.org/JDX4H. So let's make use of this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
