### PR TITLE
Fix primary color usage in emails and federation

### DIFF
--- a/apps/federatedfilesharing/lib/Settings/Personal.php
+++ b/apps/federatedfilesharing/lib/Settings/Personal.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017 Arthur Schiwon <blizzz@arthur-schiwon.de>
  *
@@ -29,7 +32,7 @@ namespace OCA\FederatedFileSharing\Settings;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\IL10N;
+use OCP\Defaults;
 use OCP\IUserSession;
 use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
@@ -37,22 +40,19 @@ use OCP\Settings\ISettings;
 class Personal implements ISettings {
 	private FederatedShareProvider $federatedShareProvider;
 	private IUserSession $userSession;
-	private IL10N $l;
-	private \OC_Defaults $defaults;
+	private Defaults $defaults;
 	private IInitialState $initialState;
 	private IURLGenerator $urlGenerator;
 
 	public function __construct(
-		FederatedShareProvider $federatedShareProvider, #
+		FederatedShareProvider $federatedShareProvider,
 		IUserSession $userSession,
-		IL10N $l,
-		\OC_Defaults $defaults,
+		Defaults $defaults,
 		IInitialState $initialState,
 		IURLGenerator $urlGenerator
 	) {
 		$this->federatedShareProvider = $federatedShareProvider;
 		$this->userSession = $userSession;
-		$this->l = $l;
 		$this->defaults = $defaults;
 		$this->initialState = $initialState;
 		$this->urlGenerator = $urlGenerator;
@@ -62,35 +62,25 @@ class Personal implements ISettings {
 	 * @return TemplateResponse returns the instance with all parameters set, ready to be rendered
 	 * @since 9.1
 	 */
-	public function getForm() {
+	public function getForm(): TemplateResponse {
 		$cloudID = $this->userSession->getUser()->getCloudId();
 		$url = 'https://nextcloud.com/sharing#' . $cloudID;
 
-		$parameters = [
-			'message_with_URL' => $this->l->t('Share with me through my #Nextcloud Federated Cloud ID, see %s', [$url]),
-			'message_without_URL' => $this->l->t('Share with me through my #Nextcloud Federated Cloud ID', [$cloudID]),
-			'logoPath' => $this->defaults->getLogo(),
-			'reference' => $url,
-			'cloudId' => $cloudID,
-			'color' => $this->defaults->getColorPrimary(),
-			'textColor' => "#ffffff",
-		];
-
-		$this->initialState->provideInitialState('color', $this->defaults->getColorPrimary());
-		$this->initialState->provideInitialState('textColor', '#fffff');
+		$this->initialState->provideInitialState('color', $this->defaults->getDefaultColorPrimary());
+		$this->initialState->provideInitialState('textColor', $this->defaults->getDefaultTextColorPrimary());
 		$this->initialState->provideInitialState('logoPath', $this->defaults->getLogo());
 		$this->initialState->provideInitialState('reference', $url);
 		$this->initialState->provideInitialState('cloudId', $cloudID);
 		$this->initialState->provideInitialState('docUrlFederated', $this->urlGenerator->linkToDocs('user-sharing-federated'));
 
-		return new TemplateResponse('federatedfilesharing', 'settings-personal', $parameters, '');
+		return new TemplateResponse('federatedfilesharing', 'settings-personal', [], TemplateResponse::RENDER_AS_BLANK);
 	}
 
 	/**
 	 * @return string the section ID, e.g. 'sharing'
 	 * @since 9.1
 	 */
-	public function getSection() {
+	public function getSection(): ?string {
 		if ($this->federatedShareProvider->isIncomingServer2serverShareEnabled() ||
 			$this->federatedShareProvider->isIncomingServer2serverGroupShareEnabled()) {
 			return 'sharing';
@@ -106,7 +96,7 @@ class Personal implements ISettings {
 	 * E.g.: 70
 	 * @since 9.1
 	 */
-	public function getPriority() {
+	public function getPriority(): int {
 		return 40;
 	}
 }

--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -497,6 +497,15 @@ class ThemingDefaults extends \OC_Defaults {
 	}
 
 	/**
+	 * Color of text in the header and primary buttons
+	 *
+	 * @return string
+	 */
+	public function getDefaultTextColorPrimary() {
+		return $this->util->invertTextColor($this->getDefaultColorPrimary()) ? '#000000' : '#ffffff';
+	}
+
+	/**
 	 * Has the admin disabled user customization
 	 */
 	public function isUserThemingDisabled(): bool {

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -380,7 +380,7 @@ EOF;
 		$this->headerAdded = true;
 
 		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
-		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getColorPrimary(), $logoUrl, $this->themingDefaults->getName()]);
+		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getDefaultColorPrimary(), $logoUrl, $this->themingDefaults->getName()]);
 	}
 
 	/**
@@ -555,7 +555,7 @@ EOF;
 		$this->ensureBodyIsOpened();
 		$this->ensureBodyListClosed();
 
-		$color = $this->themingDefaults->getColorPrimary();
+		$color = $this->themingDefaults->getDefaultColorPrimary();
 		$textColor = $this->themingDefaults->getTextColorPrimary();
 
 		$this->htmlBody .= vsprintf($this->buttonGroup, [$color, $color, $urlLeft, $color, $textColor, $textColor, $textLeft, $urlRight, $textRight]);
@@ -586,7 +586,7 @@ EOF;
 			$text = htmlspecialchars($text);
 		}
 
-		$color = $this->themingDefaults->getColorPrimary();
+		$color = $this->themingDefaults->getDefaultColorPrimary();
 		$textColor = $this->themingDefaults->getTextColorPrimary();
 		$this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, $textColor, $textColor, $text]);
 

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -206,6 +206,18 @@ class Defaults {
 	}
 
 	/**
+	 * Return the default color primary
+	 * @return string
+	 * @since 25.0.4
+	 */
+	public function getDefaultColorPrimary(): string {
+		if (method_exists($this->defaults, 'getDefaultColorPrimary')) {
+			return $this->defaults->getDefaultColorPrimary();
+		}
+		return $this->defaults->getColorPrimary();
+	}
+
+	/**
 	 * @param string $key
 	 * @return string URL to doc with key
 	 * @since 12.0.0
@@ -229,6 +241,18 @@ class Defaults {
 	 * @since 13.0.0
 	 */
 	public function getTextColorPrimary(): string {
+		return $this->defaults->getTextColorPrimary();
+	}
+
+	/**
+	 * Returns primary color
+	 * @return string
+	 * @since 25.0.4
+	 */
+	public function getDefaultTextColorPrimary(): string {
+		if (method_exists($this->defaults, 'getDefaultTextColorPrimary')) {
+			return $this->defaults->getDefaultTextColorPrimary();
+		}
 		return $this->defaults->getTextColorPrimary();
 	}
 }

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -63,7 +63,7 @@ class EMailTemplateTest extends TestCase {
 	public function testEMailTemplateCustomFooter() {
 		$this->defaults
 			->expects($this->any())
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn('#0082c9');
 		$this->defaults
 			->expects($this->any())
@@ -104,7 +104,7 @@ class EMailTemplateTest extends TestCase {
 	public function testEMailTemplateDefaultFooter() {
 		$this->defaults
 			->expects($this->any())
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn('#0082c9');
 		$this->defaults
 			->expects($this->any())
@@ -147,7 +147,7 @@ class EMailTemplateTest extends TestCase {
 	public function testEMailTemplateSingleButton() {
 		$this->defaults
 			->expects($this->any())
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn('#0082c9');
 		$this->defaults
 			->expects($this->any())
@@ -192,7 +192,7 @@ class EMailTemplateTest extends TestCase {
 	public function testEMailTemplateAlternativePlainTexts() {
 		$this->defaults
 			->expects($this->any())
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn('#0082c9');
 		$this->defaults
 			->expects($this->any())


### PR DESCRIPTION
* Resolves: N/A

## Summary

* Federation box to be implemented on own website also used the background image color instead of the instance theme
* Emails used the color of the triggering user, so if you invite 5 users with different custom background image to an event, you will get 5 differently colored emails instead.
2 sample emails from the same day, same instance, no settings changed on my side:

From person 1 | From person 2
---|---
![Bildschirmfoto vom 2023-01-24 17-08-23](https://user-images.githubusercontent.com/213943/214532911-cc09e5c0-55dc-4e75-9d0f-a025d422e534.png) | ![Bildschirmfoto vom 2023-01-24 17-08-29](https://user-images.githubusercontent.com/213943/214532914-ad848f4c-312c-4b47-a879-812101906e5e.png)

* https://github.com/nextcloud/server/blob/304c1b9b61b20dfa3c1f07e8a914f0661d91704d/apps/encryption/templates/mail.php#L9 is also affected, but I will instead of patching that migrate it to the proper templating mechanism => https://github.com/nextcloud/server/pull/36351

## Screenshots

* Theming color: `#DF2254`
* User custom picked theming color: `#ffffff`

Before | After
---|---
![Bildschirmfoto vom 2023-01-25 10-46-02](https://user-images.githubusercontent.com/213943/214532283-9ea82efa-349a-4e8a-8fda-8557ecc7f9ef.png) | ![Bildschirmfoto vom 2023-01-25 10-44-19](https://user-images.githubusercontent.com/213943/214532279-2126e84c-0e40-48a4-956c-cf02be9a126c.png)
![Bildschirmfoto vom 2023-01-25 10-52-59](https://user-images.githubusercontent.com/213943/214532454-bec7fa2d-e39f-4326-9d83-9c4007486307.png) | ![Bildschirmfoto vom 2023-01-25 10-39-40](https://user-images.githubusercontent.com/213943/214532318-d87c2839-c9f3-4532-a42a-b47f97a0eea0.png)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are adjusted where applicable
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
