### PR TITLE
imaginary - add tiff to supported formats

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -57,7 +57,7 @@ class Imaginary extends ProviderV2 {
 	}
 
 	public static function supportedMimeTypes(): string {
-		return '/image\/(bmp|x-bitmap|png|jpeg|gif|heic|svg|webp)/';
+		return '/image\/(bmp|x-bitmap|png|jpeg|gif|heic|svg|tiff|webp)/';
 	}
 
 	public function getCroppedThumbnail(File $file, int $maxX, int $maxY, bool $crop): ?IImage {


### PR DESCRIPTION
Reason: TIFF is supported by imaginary: https://github.com/h2non/imaginary/blob/master/Dockerfile