### PR TITLE
Add generic templates for DataResponse and JSONResponse

### DIFF
--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -30,17 +30,18 @@ use OCP\AppFramework\Http;
  * A generic DataResponse class that is used to return generic data responses
  * for responders to transform
  * @since 8.0.0
+ * @template T
  */
 class DataResponse extends Response {
 	/**
 	 * response data
-	 * @var array|int|float|string|bool|object
+	 * @var T
 	 */
 	protected $data;
 
 
 	/**
-	 * @param array|int|float|string|bool|object $data the object or array that should be transformed
+	 * @param T $data the object or array that should be transformed
 	 * @param int $statusCode the Http status code, defaults to 200
 	 * @param array $headers additional key value based headers
 	 * @since 8.0.0
@@ -57,7 +58,7 @@ class DataResponse extends Response {
 
 	/**
 	 * Sets values in the data json array
-	 * @param array|int|float|string|object $data an array or object which will be transformed
+	 * @param T $data an array or object which will be transformed
 	 * @return DataResponse Reference to this object
 	 * @since 8.0.0
 	 */
@@ -70,7 +71,7 @@ class DataResponse extends Response {
 
 	/**
 	 * Used to get the set parameters
-	 * @return array|int|float|string|bool|object the data
+	 * @return T the data
 	 * @since 8.0.0
 	 */
 	public function getData() {

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -32,18 +32,19 @@ use OCP\AppFramework\Http;
 /**
  * A renderer for JSON calls
  * @since 6.0.0
+ * @template T
  */
 class JSONResponse extends Response {
 	/**
 	 * response data
-	 * @var array|object
+	 * @var T
 	 */
 	protected $data;
 
 
 	/**
 	 * constructor of JSONResponse
-	 * @param array|object $data the object or array that should be transformed
+	 * @param T $data the object or array that should be transformed
 	 * @param int $statusCode the Http status code, defaults to 200
 	 * @since 6.0.0
 	 */
@@ -68,7 +69,7 @@ class JSONResponse extends Response {
 
 	/**
 	 * Sets values in the data json array
-	 * @param array|object $data an array or object which will be transformed
+	 * @param T $data an array or object which will be transformed
 	 *                             to JSON
 	 * @return JSONResponse Reference to this object
 	 * @since 6.0.0 - return value was added in 7.0.0
@@ -82,7 +83,7 @@ class JSONResponse extends Response {
 
 	/**
 	 * Used to get the set parameters
-	 * @return array the data
+	 * @return T the data
 	 * @since 6.0.0
 	 */
 	public function getData() {


### PR DESCRIPTION
## Summary

Add templates to indicate generic type. Not required, but very useful for OpenAPI.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
