### PR TITLE
Fix loading classes for occ commands with authoritative class maps

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -104,7 +104,7 @@ class SharedMount extends MountPoint implements MoveableMount {
 		array $mountpoints,
 		CappedMemoryCache $folderExistCache
 	) {
-		$cacheKey = $this->user->getUID() . '/' . $share->getId();
+		$cacheKey = $this->user->getUID() . '/' . $share->getTarget();
 		$cached = $this->cache->get($cacheKey);
 		if ($cached !== null) {
 			return $cached;

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -124,6 +124,7 @@ class Application {
 						if ($appPath === false) {
 							continue;
 						}
+						OC_App::loadApp($app);
 						// load commands using info.xml
 						$info = $appManager->getAppInfo($app);
 						if (isset($info['commands'])) {


### PR DESCRIPTION

## Summary

Found when trying to use an authoritative class map with richdocuments

https://github.com/nextcloud/richdocuments/pull/2768

CI currently running there should proove the fix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
