### PR TITLE
also set the node when re-using existing share on share create

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -825,7 +825,11 @@ class Manager implements IManager {
 			}
 		} catch (AlreadySharedException $e) {
 			// if a share for the same target already exists, dont create a new one, but do trigger the hooks and notifications again
+			$oldShare = $share;
+
+			// Reuse the node we already have
 			$share = $e->getExistingShare();
+			$share->setNode($oldShare->getNode());
 		}
 
 		// Post share event


### PR DESCRIPTION
This not only helps with performance by not having to get the node later, but also prevents errors if the origin share owner no longer has access to the node.