### PR TITLE
Mark compiled CSS as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /dist/* binary
 /package-lock.json merge=binary
+/core/css/*.css* binary


### PR DESCRIPTION
## Summary

Mark compiled CSS as binary in the `.gitattributes` file as viewing the textual diff of a single long line in e.g. https://github.com/nextcloud/server/blob/4caa90dfb643aea958b10d0741a8f21be5e18f39/core/css/server.css and https://github.com/nextcloud/server/blob/4caa90dfb643aea958b10d0741a8f21be5e18f39/core/css/server.css.map is not necessary when the source SCSS files e.g. https://github.com/nextcloud/server/blob/4caa90dfb643aea958b10d0741a8f21be5e18f39/core/css/styles.scss are much more readable

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)