### PR TITLE
Allow php 8.2

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -36,6 +36,7 @@ jobs:
           extensions: ctype, curl, dom, fileinfo, gd, imagick, intl, json, mbstring, oci8, openssl, pdo_sqlite, posix, sqlite, xml, zip
           tools: phpunit:9
           coverage: none
+          ini-file: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
 
     services:
       oracle:

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -186,6 +186,8 @@ class Cache implements ICache {
 	 */
 	public static function cacheEntryFromData($data, IMimeTypeLoader $mimetypeLoader) {
 		//fix types
+		$data['name'] = (string)$data['name'];
+		$data['path'] = (string)$data['path'];
 		$data['fileid'] = (int)$data['fileid'];
 		$data['parent'] = (int)$data['parent'];
 		$data['size'] = 0 + $data['size'];

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -977,7 +977,12 @@ class Cache implements ICache {
 		$path = $result->fetchOne();
 		$result->closeCursor();
 
-		return $path;
+		if ($path === false) {
+			return false;
+		}
+
+		// Make sure Oracle does not continue with null for empty strings
+		return (string)$path;
 	}
 
 	/**

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -33,10 +33,10 @@ if (PHP_VERSION_ID < 80000) {
 	exit(1);
 }
 
-// Show warning if >= PHP 8.2 is used as Nextcloud is not compatible with >= PHP 8.2 for now
-if (PHP_VERSION_ID >= 80200) {
+// Show warning if >= PHP 8.3 is used as Nextcloud is not compatible with >= PHP 8.3 for now
+if (PHP_VERSION_ID >= 80300) {
 	http_response_code(500);
-	echo 'This version of Nextcloud is not compatible with PHP>=8.2.<br/>';
+	echo 'This version of Nextcloud is not compatible with PHP>=8.3.<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '.';
 	exit(1);
 }


### PR DESCRIPTION
## Summary

PHP 8.2 is now tested enough to be allowed to be used with master.
There should be no big problems with it, apart from the mailer, until the migration to symfony mailer is finished.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
