### PR TITLE
fix(navigation): Request user avatar in 64px/512px

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -83,14 +83,14 @@ p($theme->getTitle());
 							 data-displayname="<?php p($_['user_displayname']); ?>"
 			<?php
 						if ($_['userAvatarSet']) {
-							$avatar32 = $getUserAvatar(32); ?> data-avatar="<?php p($avatar32); ?>"
+							$avatar64 = $getUserAvatar(64); ?> data-avatar="<?php p($avatar64); ?>"
 			<?php
 						} ?>>
 							<?php
 										if ($_['userAvatarSet']) {?>
 								<img alt="" width="32" height="32"
-								src="<?php p($avatar32);?>"
-								srcset="<?php p($getUserAvatar(64));?> 2x, <?php p($getUserAvatar(128));?> 4x"
+								src="<?php p($avatar64);?>"
+								srcset="<?php p($getUserAvatar(512));?> 8x"
 								>
 							<?php } ?>
 						</div>


### PR DESCRIPTION
Resolves: 

```json
{"reqId":"wfo0ZhmZNBDzXGliaakN","level":0,"time":"2023-01-26T09:32:37+00:00","remoteAddr":"127.0.0.1","user":"admin","app":"core","method":"GET","url":"/avatar/admin/32?v=4","message":"Avatar requested in deprecated size 32","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0","version":"26.0.0.2","data":{"app":"core"}}
``` 

## Summary

Leftover of https://github.com/nextcloud/server/pull/33752.

## TODO

- [x] Fix the deprecation log message

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
