### PR TITLE
[stable25] fix admin-disabled background and user pristine theming settings

### DIFF
--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -131,6 +131,7 @@ trait CommonThemeTrait {
 			&& $this->appManager->isEnabledForUser(Application::APP_ID)) {
 			$themingBackground = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background', 'default');
 			$currentVersion = (int)$this->config->getUserValue($user->getUID(), Application::APP_ID, 'userCacheBuster', '0');
+			$globalBackgroundDeleted = $this->config->getAppValue(Application::APP_ID, 'backgroundMime', '') === 'backgroundColor';
 
 			// The user uploaded a custom background
 			if ($themingBackground === 'custom') {
@@ -153,12 +154,19 @@ trait CommonThemeTrait {
 			// The user picked a static colour
 			if (substr($themingBackground, 0, 1) === '#') {
 				return [
-					'--image-background' => 'no',
+					'--image-background-plain' => 'true',
 					'--color-background-plain' => $this->themingDefaults->getColorPrimary(),
 				];
 			}
-		}
 
+			// Admin disabled the background and the user
+			// did not customized anything
+			if ($globalBackgroundDeleted) {
+				return [
+					'--image-background-plain' => 'true',
+				];
+			}
+		}
 		return [];
 	}
 }


### PR DESCRIPTION
## Summary
Only for 25, because it's a mess and we fixed in 26 already

### Reproducing the issue:
1. Install 25
2. Change admin background color
3. Remove admin background image
4. With a clean user, have the proper colour but the cloud background is applied.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [ ] ~~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~~
