### PR TITLE
FIX: This fill finish -> This will finish

### DIFF
--- a/core/Command/Preview/Repair.php
+++ b/core/Command/Preview/Repair.php
@@ -149,7 +149,7 @@ class Repair extends Command {
 
 		$output->writeln("A total of $total preview files need to be migrated.");
 		$output->writeln("");
-		$output->writeln("The migration will always migrate all previews of a single file in a batch. After each batch the process can be canceled by pressing CTRL-C. This fill finish the current batch and then stop the migration. This migration can then just be started and it will continue.");
+		$output->writeln("The migration will always migrate all previews of a single file in a batch. After each batch the process can be canceled by pressing CTRL-C. This will finish the current batch and then stop the migration. This migration can then just be started and it will continue.");
 
 		if ($input->getOption('batch')) {
 			$output->writeln('Batch mode active: migration is started right away.');


### PR DESCRIPTION
Signed-off-by: sodimel <corentin@244466666.xyz>

## Summary

Fix a typo in the `occ preview:repair` command:

> Before:
> This **f**ill finish the current batch and then stop the migration.

> After:
> This **w**ill finish the current batch and then stop the migration.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
