### PR TITLE
CORS should only be bypassed on `PublicPage` if not logged in

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -83,7 +83,7 @@ class CORSMiddleware extends Middleware {
 	public function beforeController($controller, $methodName) {
 		// ensure that @CORS annotated API routes are not used in conjunction
 		// with session authentication since this enables CSRF attack vectors
-		if ($this->reflector->hasAnnotation('CORS') && !$this->reflector->hasAnnotation('PublicPage')) {
+		if ($this->reflector->hasAnnotation('CORS') && (!$this->reflector->hasAnnotation('PublicPage') || $this->session->isLoggedIn())) {
 			$user = array_key_exists('PHP_AUTH_USER', $this->request->server) ? $this->request->server['PHP_AUTH_USER'] : null;
 			$pass = array_key_exists('PHP_AUTH_PW', $this->request->server) ? $this->request->server['PHP_AUTH_PW'] : null;
 

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -123,10 +123,12 @@ class CORSMiddlewareTest extends \Test\TestCase {
 	}
 
 	/**
+	 * CORS must not be enforced for anonymous users on public pages
+	 *
 	 * @CORS
 	 * @PublicPage
 	 */
-	public function testNoCORSShouldAllowCookieAuth() {
+	public function testNoCORSOnAnonymousPublicPage() {
 		$request = new Request(
 			[],
 			$this->createMock(IRequestId::class),
@@ -134,6 +136,9 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		);
 		$this->reflector->reflect($this, __FUNCTION__);
 		$middleware = new CORSMiddleware($request, $this->reflector, $this->session, $this->throttler);
+		$this->session->expects($this->once())
+			->method('isLoggedIn')
+			->willReturn(false);
 		$this->session->expects($this->never())
 			->method('logout');
 		$this->session->expects($this->never())
@@ -142,6 +147,35 @@ class CORSMiddlewareTest extends \Test\TestCase {
 			->willReturn(true);
 		$this->reflector->reflect($this, __FUNCTION__);
 
+		$middleware->beforeController($this->controller, __FUNCTION__);
+	}
+
+	/**
+	 * Even on public pages users logged in using session cookies,
+	 * that do not provide a valid CSRF token are disallowed
+	 *
+	 * @CORS
+	 * @PublicPage
+	 */
+	public function testCORSShouldNeverAllowCookieAuth() {
+		$request = new Request(
+			[],
+			$this->createMock(IRequestId::class),
+			$this->createMock(IConfig::class)
+		);
+		$this->reflector->reflect($this, __FUNCTION__);
+		$middleware = new CORSMiddleware($request, $this->reflector, $this->session, $this->throttler);
+		$this->session->expects($this->once())
+			->method('isLoggedIn')
+			->willReturn(true);
+		$this->session->expects($this->once())
+			->method('logout');
+		$this->session->expects($this->never())
+			->method('logClientIn')
+			->with($this->equalTo('user'), $this->equalTo('pass'))
+			->willReturn(true);
+
+		$this->expectException(SecurityException::class);
 		$middleware->beforeController($this->controller, __FUNCTION__);
 	}
 


### PR DESCRIPTION
## Summary
To prevent CSRF attack vectors CORS should only be bypassed if not logged in on `@PublicPage`.
If you add the `CORS` annotation you would expect all users to be validated even on `@PublicPage`, e.g. for APIs where anonymous users can submit data but also logged in users, currently there is no protection against CSRF on those API endpoints.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
