### PR TITLE
ci(psalm): Generate base analysis on pushes so we can compare to upda…

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -2,6 +2,10 @@ name: Psalm static code analysis
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
+      - stable*
 
 jobs:
   static-code-analysis:


### PR DESCRIPTION
This should fix the constant red psalm reports.
The problem is new CI never ran on master and even after that we always compared to the last build that was created instead of a current one, which is not too good.
So adding that back.