### PR TITLE
Do not open the sidebar automatically on small widths

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -433,7 +433,9 @@
 							OCA.Files.Files.handleDownload(url);
 						}
 
-						OCA.Files.Sidebar.open(fileInfo.path);
+						if (document.documentElement.clientWidth > 1024) {
+							OCA.Files.Sidebar.open(fileInfo.path);
+						}
 					} catch (error) {
 						console.error(`Failed to trigger default action on the file for URL: ${location.href}`, error)
 					}
@@ -3340,7 +3342,9 @@
 			}
 			if (file.length === 1) {
 				_.defer(function() {
-					this.showDetailsView(file[0]);
+					if (document.documentElement.clientWidth > 1024) {
+						this.showDetailsView(file[0]);
+					}
 				}.bind(this));
 			}
 			this.highlightFiles(file, function($tr) {


### PR DESCRIPTION
<details>
<summary>For my own testing</summary>

```
docker run -it \
--name nextcloud-easy-test \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.24.128 \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
-e SERVER_BRANCH=enh/noid/dont-automatically-open-sidebar-on-mobile \
-e VIEWER_BRANCH=master \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>