### PR TITLE
add option to disable db user creation trough environment variable

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -57,6 +57,8 @@ abstract class AbstractDatabase {
 	protected $logger;
 	/** @var ISecureRandom */
 	protected $random;
+	/** @var bool */
+	protected $tryCreateDbUser;
 
 	public function __construct(IL10N $trans, SystemConfig $config, LoggerInterface $logger, ISecureRandom $random) {
 		$this->trans = $trans;
@@ -87,6 +89,10 @@ abstract class AbstractDatabase {
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbPort = !empty($config['dbport']) ? $config['dbport'] : '';
 		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
+
+		$createUserConfig = $this->config->getValue("setup_create_db_user", true);
+		// accept `false` both as bool and string, since setting config values from env will result in a string
+		$this->tryCreateDbUser = $createUserConfig !== false && $createUserConfig !== "false";
 
 		$this->config->setValues([
 			'dbname' => $dbName,

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -49,7 +49,14 @@ class MySQL extends AbstractDatabase {
 			$connection = $this->connect(['dbname' => null]);
 		}
 
-		$this->createSpecificUser($username, new ConnectionAdapter($connection));
+		if ($this->tryCreateDbUser) {
+			$this->createSpecificUser($username, new ConnectionAdapter($connection));
+		}
+
+		$this->config->setValues([
+			'dbuser' => $this->dbUser,
+			'dbpassword' => $this->dbPassword,
+		]);
 
 		//create the database
 		$this->createDatabase($connection);
@@ -147,8 +154,7 @@ class MySQL extends AbstractDatabase {
 			. $this->random->generate(2, ISecureRandom::CHAR_UPPER)
 			. $this->random->generate(2, ISecureRandom::CHAR_LOWER)
 			. $this->random->generate(2, ISecureRandom::CHAR_DIGITS)
-			. $this->random->generate(2, $saveSymbols)
-		;
+			. $this->random->generate(2, $saveSymbols);
 		$this->dbPassword = str_shuffle($password);
 
 		try {
@@ -196,10 +202,5 @@ class MySQL extends AbstractDatabase {
 			$this->dbUser = $rootUser;
 			$this->dbPassword = $rootPassword;
 		}
-
-		$this->config->setValues([
-			'dbuser' => $this->dbUser,
-			'dbpassword' => $this->dbPassword,
-		]);
 	}
 }


### PR DESCRIPTION
When providing root/superuser db credentials, instead of using them as-is Nextcloud uses them to create a new non-root/superuser user.

While this can be useful to protect admins against accidentally running with elevated db access, this also interferes with some setup mechanisms that want more control over what db user is used. Currently the only option for these systems is to patch out the behavior themselves (see for [NixOs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/nextcloud/patches/v26/0001-Setup-remove-custom-dbuser-creation-behavior.patch) for example).

This adds a way to disable this behavior by setting the `setup_create_db_user` config variable to `false`, this can also be done trough an environment variable (`NC_setup_create_db_user=false`) for the setup command.