### PR TITLE
fix(encryption): don't throw on missing file

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -819,16 +819,13 @@ class Encryption extends Wrapper {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
 				$target = $this->fopen($targetInternalPath, 'w');
 				[, $result] = \OC_Helper::streamCopy($source, $target);
-				fclose($source);
-				fclose($target);
-			} catch (\Exception $e) {
+			} finally {
 				if (is_resource($source)) {
 					fclose($source);
 				}
 				if (is_resource($target)) {
 					fclose($target);
 				}
-				throw $e;
 			}
 			if ($result) {
 				if ($preserveMtime) {


### PR DESCRIPTION
* Resolves: #32818 

## Summary

If a source file not exists the first fclose in the try block will fail and thus break the entire decryption process.

When `OC_Helper::streamCopy` is presented with an invalid resource (false) it will already return false and subsequently mark the operation as failed.

By moving `fclose` and `fopen` to a finally block instead, the whole situation can be handled more gracefully and the method will return false to indicate a failed copy.

The original bug can be reproduced quite easily:
- Have some files on one user.
- Enable server side encryption.
- Run: occ encryption:encrypt-all
- Remove some file from the first user externally, e.g. through the command line or a file manager (rm data/user/files/welcome.txt).
- Run: occ encryption:decrypt-all

**With my PR:** The decryption will run without throwing exceptions.
**Without my PR:** The process will fail and leave the server in a half decrypted state.

Ref https://github.com/nextcloud/server/issues/32818#issuecomment-1159488852 for the quick fix

## TODO

- [x] Probably tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
