### PR TITLE
fix(logging): Debounce deprecation logs to once per 5m

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -664,6 +664,7 @@ class OC {
 		if (!defined('PHPUNIT_RUN')) {
 			$errorHandler = new OC\Log\ErrorHandler(
 				\OCP\Server::get(\Psr\Log\LoggerInterface::class),
+				\OCP\Server::get(\OCP\ICacheFactory::class),
 			);
 			$exceptionHandler = [$errorHandler, 'onException'];
 			if ($config->getSystemValue('debug', false)) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary



## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
