### PR TITLE
Allow empty route for navigation entries

### DIFF
--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -469,8 +469,8 @@
     </xs:simpleType>
 
     <xs:simpleType name="route">
-        <xs:restriction base="non-empty-string">
-            <xs:pattern value="[0-9a-zA-Z_]+(\.[0-9a-zA-Z_]+){2}"/>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([0-9a-zA-Z_]+(\.[0-9a-zA-Z_]+){2})?"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -465,8 +465,8 @@
     </xs:simpleType>
 
     <xs:simpleType name="route">
-        <xs:restriction base="non-empty-string">
-            <xs:pattern value="[0-9a-zA-Z_]+(\.[0-9a-zA-Z_]+){2}"/>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([0-9a-zA-Z_]+(\.[0-9a-zA-Z_]+){2})?"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
## Summary

Some apps register navigation entries with empty routes e.g. https://github.com/nextcloud/server/blob/9035be6b81fc527a57dcbbbb424dc9a84aef832b/apps/user_status/appinfo/info.xml#L18

This allows these entries to pass `xmllint` used in https://github.com/nextcloud/.github/blob/ff4a6f1eacb53e4d3b5721e57743eb64242178a7/workflow-templates/lint-info-xml.yml

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)