### PR TITLE
perf(federation): Only request root share info for checking availability

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareInfoController.php
+++ b/apps/files_sharing/lib/Controller/ShareInfoController.php
@@ -65,7 +65,7 @@ class ShareInfoController extends ApiController {
 	 * @param ?string $dir
 	 * @return JSONResponse
 	 */
-	public function info(string $t, ?string $password = null, ?string $dir = null, int $depth = -1) {
+	public function info(string $t, ?string $password = null, ?string $dir = null, int $depth = -1): JSONResponse {
 		try {
 			$share = $this->shareManager->getShareByToken($t);
 		} catch (ShareNotFound $e) {
@@ -99,18 +99,19 @@ class ShareInfoController extends ApiController {
 		return new JSONResponse($this->parseNode($node, $permissionMask, $depth));
 	}
 
-	private function parseNode(Node $node, int $permissionMask, int $depth) {
+	private function parseNode(Node $node, int $permissionMask, int $depth): array {
 		if ($node instanceof File) {
 			return $this->parseFile($node, $permissionMask);
 		}
+		/** @var Folder $node */
 		return $this->parseFolder($node, $permissionMask, $depth);
 	}
 
-	private function parseFile(File $file, int $permissionMask) {
+	private function parseFile(File $file, int $permissionMask): array {
 		return $this->format($file, $permissionMask);
 	}
 
-	private function parseFolder(Folder $folder, int $permissionMask, int $depth) {
+	private function parseFolder(Folder $folder, int $permissionMask, int $depth): array {
 		$data = $this->format($folder, $permissionMask);
 
 		if ($depth === 0) {
@@ -127,7 +128,7 @@ class ShareInfoController extends ApiController {
 		return $data;
 	}
 
-	private function format(Node $node, int $permissionMask) {
+	private function format(Node $node, int $permissionMask): array {
 		$entry = [];
 
 		$entry['id'] = $node->getId();

--- a/apps/files_sharing/lib/Controller/ShareInfoController.php
+++ b/apps/files_sharing/lib/Controller/ShareInfoController.php
@@ -65,7 +65,7 @@ class ShareInfoController extends ApiController {
 	 * @param ?string $dir
 	 * @return JSONResponse
 	 */
-	public function info(string $t, ?string $password = null, ?string $dir = null) {
+	public function info(string $t, ?string $password = null, ?string $dir = null, int $depth = -1) {
 		try {
 			$share = $this->shareManager->getShareByToken($t);
 		} catch (ShareNotFound $e) {
@@ -96,28 +96,32 @@ class ShareInfoController extends ApiController {
 			}
 		}
 
-		return new JSONResponse($this->parseNode($node, $permissionMask));
+		return new JSONResponse($this->parseNode($node, $permissionMask, $depth));
 	}
 
-	private function parseNode(Node $node, int $permissionMask) {
+	private function parseNode(Node $node, int $permissionMask, int $depth) {
 		if ($node instanceof File) {
 			return $this->parseFile($node, $permissionMask);
 		}
-		return $this->parseFolder($node, $permissionMask);
+		return $this->parseFolder($node, $permissionMask, $depth);
 	}
 
 	private function parseFile(File $file, int $permissionMask) {
 		return $this->format($file, $permissionMask);
 	}
 
-	private function parseFolder(Folder $folder, int $permissionMask) {
+	private function parseFolder(Folder $folder, int $permissionMask, int $depth) {
 		$data = $this->format($folder, $permissionMask);
+
+		if ($depth === 0) {
+			return $data;
+		}
 
 		$data['children'] = [];
 
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
-			$data['children'][] = $this->parseNode($node, $permissionMask);
+			$data['children'][] = $this->parseNode($node, $permissionMask, $depth <= -1 ? -1 : $depth - 1);
 		}
 
 		return $data;

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -214,7 +214,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 	public function checkStorageAvailability() {
 		// see if we can find out why the share is unavailable
 		try {
-			$this->getShareInfo();
+			$this->getShareInfo(0);
 		} catch (NotFoundException $e) {
 			// a 404 can either mean that the share no longer exists or there is no Nextcloud on the remote
 			if ($this->testRemote()) {
@@ -308,7 +308,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 	 * @throws NotFoundException
 	 * @throws \Exception
 	 */
-	public function getShareInfo() {
+	public function getShareInfo(int $depth = -1) {
 		$remote = $this->getRemote();
 		$token = $this->getToken();
 		$password = $this->getPassword();
@@ -331,7 +331,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$client = \OC::$server->getHTTPClientService()->newClient();
 		try {
 			$response = $client->post($url, [
-				'body' => ['password' => $password],
+				'body' => ['password' => $password, 'depth' => $depth],
 				'timeout' => 10,
 				'connect_timeout' => 10,
 			]);


### PR DESCRIPTION
## Summary

Otherwise this would request a full recursive dirctory listing while the result is never being used

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
