### PR TITLE
Fix MigrateBackgroundImages on oracle

### DIFF
--- a/apps/theming/lib/Jobs/MigrateBackgroundImages.php
+++ b/apps/theming/lib/Jobs/MigrateBackgroundImages.php
@@ -30,6 +30,7 @@ use OCA\Theming\AppInfo\Application;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\QueuedJob;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
@@ -92,7 +93,7 @@ class MigrateBackgroundImages extends QueuedJob {
 				->from('preferences')
 				->where($selector->expr()->eq('appid', $selector->createNamedParameter('theming')))
 				->andWhere($selector->expr()->eq('configkey', $selector->createNamedParameter('background')))
-				->andWhere($selector->expr()->eq('configvalue', $selector->createNamedParameter('custom')))
+				->andWhere($selector->expr()->eq('configvalue', $selector->createNamedParameter('custom', IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR))
 				->executeQuery();
 
 			$userIds = $result->fetchAll(\PDO::FETCH_COLUMN);

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -132,6 +132,24 @@ class ExpressionBuilderDBTest extends TestCase {
 		$this->assertEquals(1, $result);
 	}
 
+	public function testLongText(): void {
+		$appId = $this->getUniqueID('testing');
+		$this->createConfig($appId, 'mykey', 'myvalue');
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('*')
+			->from('appconfig')
+			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
+			->andWhere($query->expr()->eq('configkey', $query->createNamedParameter('mykey')))
+			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter('myvalue', IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
+
+		$result = $query->executeQuery();
+		$entries = $result->fetchAll();
+		$result->closeCursor();
+		self::assertCount(1, $entries);
+		self::assertEquals('myvalue', $entries[0]['configvalue']);
+	}
+
 	protected function createConfig($appId, $key, $value) {
 		$query = $this->connection->getQueryBuilder();
 		$query->insert('appconfig')


### PR DESCRIPTION


## Summary

https://github.com/nextcloud/server/blob/09099cfaeceada44dd4454a400d4753e2cc2f0b0/apps/theming/lib/Jobs/MigrateBackgroundImages.php#L95 fails on oracle as configvalue is a longtext which is not allowed in where clauses without casting.

This is the same approach also used in https://github.com/nextcloud/server/blob/361e69f19fd3af632452dbe586065ab42103cf47/lib/private/AllConfig.php#L497-L499



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
