### PR TITLE
Reset theming in cypress test

### DIFF
--- a/cypress/e2e/theming/user-background.cy.ts
+++ b/cypress/e2e/theming/user-background.cy.ts
@@ -19,15 +19,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import type { User } from '@nextcloud/cypress'
+import { User } from '@nextcloud/cypress'
 
 import { pickRandomColor, validateBodyThemingCss } from './themingUtils'
 
 const defaultPrimary = '#006aa3'
 const defaultBackground = 'kamil-porembinski-clouds.jpg'
+const admin = new User('admin', 'admin')
 
 describe('User default background settings', function() {
 	before(function() {
+		cy.resetAdminTheming()
+		cy.resetUserTheming(admin)
 		cy.createRandomUser().then((user: User) => {
 			cy.login(user)
 		})


### PR DESCRIPTION
The test in `admin-settings` does not reset the theming. So when it is run before `user-background`, the `"Default cloud background is not rendered"` test fails.

This makes sure that the theming is reset before running `"User default background settings"`.

@skjnldsv please tell me if I missed something.

Here are two examples:

- :red_circle:  Failing: https://github.com/nextcloud/server/actions/runs/4044870936/jobs/6974051507 because both tests are run one after the other.
- :heavy_check_mark: Succeeding: https://github.com/nextcloud/server/actions/runs/4053245003/jobs/6973699491 because both tests are run separately.