### PR TITLE
Fix theming: Theme specific variables must be set on the root node

### DIFF
--- a/apps/theming/src/UserThemes.vue
+++ b/apps/theming/src/UserThemes.vue
@@ -242,13 +242,13 @@ export default {
 			const enabledFontsIDs = this.fonts.filter(font => font.enabled === true).map(font => font.id)
 
 			this.themes.forEach(theme => {
-				document.body.toggleAttribute(`data-theme-${theme.id}`, theme.enabled)
+				document.documentElement.toggleAttribute(`data-theme-${theme.id}`, theme.enabled)
 			})
 			this.fonts.forEach(font => {
-				document.body.toggleAttribute(`data-theme-${font.id}`, font.enabled)
+				document.documentElement.toggleAttribute(`data-theme-${font.id}`, font.enabled)
 			})
 
-			document.body.setAttribute('data-themes', [...enabledThemesIDs, ...enabledFontsIDs].join(','))
+			document.documentElement.setAttribute('data-themes', [...enabledThemesIDs, ...enabledFontsIDs].join(','))
 		},
 
 		/**

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -13,7 +13,10 @@ $getUserAvatar = static function (int $size) use ($_): string {
 }
 
 ?><!DOCTYPE html>
-<html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" data-locale="<?php p($_['locale']); ?>" translate="no" >
+<html class="ng-csp" data-placeholder-focus="false" lang="<?php p($_['language']); ?>" data-locale="<?php p($_['locale']); ?>" translate="no"
+<?php foreach ($_['enabledThemes'] as $themeId) {
+	p("data-theme-$themeId ");
+}?> data-themes=<?php p(join(',', $_['enabledThemes'])) ?>>
 	<head data-user="<?php p($_['user_uid']); ?>" data-user-displayname="<?php p($_['user_displayname']); ?>" data-requesttoken="<?php p($_['requesttoken']); ?>">
 		<meta charset="utf-8">
 		<title>
@@ -42,9 +45,7 @@ p($theme->getTitle());
 		<?php emit_script_loading_tags($_); ?>
 		<?php print_unescaped($_['headers']); ?>
 	</head>
-	<body id="<?php p($_['bodyid']);?>" <?php foreach ($_['enabledThemes'] as $themeId) {
-		p("data-theme-$themeId ");
-	}?> data-themes=<?php p(join(',', $_['enabledThemes'])) ?>>
+	<body id="<?php p($_['bodyid']);?>">
 	<?php include 'layout.noscript.warning.php'; ?>
 
 		<?php foreach ($_['initialStates'] as $app => $initialState) { ?>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/text/issues/3369

## Summary
Currently if you use a css variable which links to an other css variable, like `--color-main-background` and a theme is enabled, the theme is not used for the variable. See linked issue (same e.g. on forms, see https://github.com/nextcloud/forms/pull/1471#pullrequestreview-1277505842).

The problem is the css variable evaluation order, e.g. consider the browser requests dark color theme but the user selected the bright nextcloud theme, then:
* HTML tag
  * defines `--color-main-background` for dark color theme (as requested by the browser)
  * defines `--table-color-background` to be the same as `--color-main-background`
* Body tag
  * redefines `--color-main-background` to match the theme (because `data-theme-light` is set on the body tag)
* Table tag
  * Uses `--table-color-background` which evaluates to `HTML-Tag`::`--color-main-background` and in the context it is set to dark instead of bright.

So the solution is to set `data-theme-light`  on the HTML tag rather than the body tag.

## Screenshots
System uses dark color theme, but nextcloud is configured to use the bright theme.
You can see the `NcSelect` has the wrong background color:
| before (currently) | after (with this PR) |
|---|---|
| ![dark background on bright color theme, hard to read](https://user-images.githubusercontent.com/1855448/215860046-9cada499-cd09-424a-a224-46fd47bc8339.png) | ![correct bright background on bright color theme, good to read](https://user-images.githubusercontent.com/1855448/215860096-25ed29b2-5541-4f35-821c-d2098b5acc32.png) |


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
