### PR TITLE
fix(updater): Don't warn about missing appstore updates for apps depl…

### DIFF
--- a/apps/updatenotification/lib/Controller/APIController.php
+++ b/apps/updatenotification/lib/Controller/APIController.php
@@ -130,6 +130,15 @@ class APIController extends OCSController {
 
 		$this->language = $this->l10nFactory->getUserLanguage($this->userSession->getUser());
 
+		// Ignore apps that are deployed from git
+		$installedApps = array_filter($installedApps, function(string $appId) {
+			try {
+				return !file_exists($this->appManager->getAppPath($appId) . '/.git');
+			} catch (AppPathNotFoundException $e) {
+				return true;
+			}
+		});
+
 		$missing = array_diff($installedApps, $availableApps);
 		$missing = array_map([$this, 'getAppDetails'], $missing);
 		sort($missing);


### PR DESCRIPTION
…oyed from git

* Resolves: #12475

## Summary

From our cloud

Before | After
---|---
![Bildschirmfoto vom 2023-02-01 21-35-23](https://user-images.githubusercontent.com/213943/216158833-df06b20b-1089-4538-b345-01d0cf4f9ae3.png) | ![Bildschirmfoto vom 2023-02-01 21-35-40](https://user-images.githubusercontent.com/213943/216158476-93741936-be51-4a4d-aaca-f841751fb2e0.png) 



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
