### PR TITLE
Do not reuse query builder objects in DAV account deletion

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -897,7 +897,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 				->executeStatement();
 
 			$qbDeleteCalendarChanges = $this->db->getQueryBuilder();
-			$qbDeleteCalendarObjects->delete('calendarchanges')
+			$qbDeleteCalendarChanges->delete('calendarchanges')
 				->where($qbDeleteCalendarChanges->expr()->eq('calendarid', $qbDeleteCalendarChanges->createNamedParameter($calendarId)))
 				->andWhere($qbDeleteCalendarChanges->expr()->eq('calendartype', $qbDeleteCalendarChanges->createNamedParameter(self::CALENDAR_TYPE_CALENDAR)))
 				->executeStatement();
@@ -905,7 +905,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$this->calendarSharingBackend->deleteAllShares($calendarId);
 
 			$qbDeleteCalendar = $this->db->getQueryBuilder();
-			$qbDeleteCalendarObjects->delete('calendars')
+			$qbDeleteCalendar->delete('calendars')
 				->where($qbDeleteCalendar->expr()->eq('id', $qbDeleteCalendar->createNamedParameter($calendarId)))
 				->executeStatement();
 

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -452,11 +452,13 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->setParameter('addressbookid', $addressBookId, IQueryBuilder::PARAM_INT)
 			->executeStatement();
 
+		$query = $this->db->getQueryBuilder();
 		$query->delete('addressbookchanges')
 			->where($query->expr()->eq('addressbookid', $query->createParameter('addressbookid')))
 			->setParameter('addressbookid', $addressBookId, IQueryBuilder::PARAM_INT)
 			->executeStatement();
 
+		$query = $this->db->getQueryBuilder();
 		$query->delete('addressbooks')
 			->where($query->expr()->eq('id', $query->createParameter('id')))
 			->setParameter('id', $addressBookId, IQueryBuilder::PARAM_INT)
@@ -464,6 +466,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		$this->sharingBackend->deleteAllShares($addressBookId);
 
+		$query = $this->db->getQueryBuilder();
 		$query->delete($this->dbCardsPropertiesTable)
 			->where($query->expr()->eq('addressbookid', $query->createNamedParameter($addressBookId, IQueryBuilder::PARAM_INT)))
 			->executeStatement();


### PR DESCRIPTION
Ref #36261 

## Summary

Every talk integration test before:
```json
{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","Code":0,"Trace":[{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/CalDAV\/CalDavBackend.php","line":901,"function":"where","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/HookManager.php","line":140,"function":"deleteCalendar","class":"OCA\\DAV\\CalDAV\\CalDavBackend","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/legacy\/OC_Hook.php","line":105,"function":"postDeleteUser","class":"OCA\\DAV\\HookManager","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Server.php","line":591,"function":"emit","class":"OC_Hook","type":"::"},{"function":"OC\\{closure}","class":"OC\\Server","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/EmitterTrait.php","line":105,"function":"call_user_func_array"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/PublicEmitter.php","line":40,"function":"emit","class":"OC\\Hooks\\BasicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/User\/User.php","line":312,"function":"emit","class":"OC\\Hooks\\PublicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/provisioning_api\/lib\/Controller\/UsersController.php","line":1095,"function":"delete","class":"OC\\User\\User","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"deleteUser","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/App.php","line":171,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Route\/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php","line":63,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v2.php","line":23,"args":["\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/DB\/QueryBuilder\/QueryBuilder.php","Line":869,"message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","exception":{},"CustomMessage":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first."}
{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","Code":0,"Trace":[{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/CalDAV\/CalDavBackend.php","line":909,"function":"where","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/HookManager.php","line":140,"function":"deleteCalendar","class":"OCA\\DAV\\CalDAV\\CalDavBackend","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/legacy\/OC_Hook.php","line":105,"function":"postDeleteUser","class":"OCA\\DAV\\HookManager","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Server.php","line":591,"function":"emit","class":"OC_Hook","type":"::"},{"function":"OC\\{closure}","class":"OC\\Server","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/EmitterTrait.php","line":105,"function":"call_user_func_array"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/PublicEmitter.php","line":40,"function":"emit","class":"OC\\Hooks\\BasicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/User\/User.php","line":312,"function":"emit","class":"OC\\Hooks\\PublicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/provisioning_api\/lib\/Controller\/UsersController.php","line":1095,"function":"delete","class":"OC\\User\\User","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"deleteUser","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/App.php","line":171,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Route\/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php","line":63,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v2.php","line":23,"args":["\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/DB\/QueryBuilder\/QueryBuilder.php","Line":869,"message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","exception":{},"CustomMessage":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first."}
{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","Code":0,"Trace":[{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/CardDAV\/CardDavBackend.php","line":456,"function":"where","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/HookManager.php","line":152,"function":"deleteAddressBook","class":"OCA\\DAV\\CardDAV\\CardDavBackend","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/legacy\/OC_Hook.php","line":105,"function":"postDeleteUser","class":"OCA\\DAV\\HookManager","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Server.php","line":591,"function":"emit","class":"OC_Hook","type":"::"},{"function":"OC\\{closure}","class":"OC\\Server","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/EmitterTrait.php","line":105,"function":"call_user_func_array"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/PublicEmitter.php","line":40,"function":"emit","class":"OC\\Hooks\\BasicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/User\/User.php","line":312,"function":"emit","class":"OC\\Hooks\\PublicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/provisioning_api\/lib\/Controller\/UsersController.php","line":1095,"function":"delete","class":"OC\\User\\User","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"deleteUser","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/App.php","line":171,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Route\/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php","line":63,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v2.php","line":23,"args":["\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/DB\/QueryBuilder\/QueryBuilder.php","Line":869,"message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","exception":{},"CustomMessage":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first."}
{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","Code":0,"Trace":[{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/CardDAV\/CardDavBackend.php","line":461,"function":"where","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/HookManager.php","line":152,"function":"deleteAddressBook","class":"OCA\\DAV\\CardDAV\\CardDavBackend","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/legacy\/OC_Hook.php","line":105,"function":"postDeleteUser","class":"OCA\\DAV\\HookManager","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Server.php","line":591,"function":"emit","class":"OC_Hook","type":"::"},{"function":"OC\\{closure}","class":"OC\\Server","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/EmitterTrait.php","line":105,"function":"call_user_func_array"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/PublicEmitter.php","line":40,"function":"emit","class":"OC\\Hooks\\BasicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/User\/User.php","line":312,"function":"emit","class":"OC\\Hooks\\PublicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/provisioning_api\/lib\/Controller\/UsersController.php","line":1095,"function":"delete","class":"OC\\User\\User","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"deleteUser","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/App.php","line":171,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Route\/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php","line":63,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v2.php","line":23,"args":["\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/DB\/QueryBuilder\/QueryBuilder.php","Line":869,"message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","exception":{},"CustomMessage":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first."}
{"Exception":"Doctrine\\DBAL\\Query\\QueryException","Message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","Code":0,"Trace":[{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/CardDAV\/CardDavBackend.php","line":468,"function":"where","class":"OC\\DB\\QueryBuilder\\QueryBuilder","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/dav\/lib\/HookManager.php","line":152,"function":"deleteAddressBook","class":"OCA\\DAV\\CardDAV\\CardDavBackend","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/legacy\/OC_Hook.php","line":105,"function":"postDeleteUser","class":"OCA\\DAV\\HookManager","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Server.php","line":591,"function":"emit","class":"OC_Hook","type":"::"},{"function":"OC\\{closure}","class":"OC\\Server","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/EmitterTrait.php","line":105,"function":"call_user_func_array"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Hooks\/PublicEmitter.php","line":40,"function":"emit","class":"OC\\Hooks\\BasicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/User\/User.php","line":312,"function":"emit","class":"OC\\Hooks\\PublicEmitter","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/apps\/provisioning_api\/lib\/Controller\/UsersController.php","line":1095,"function":"delete","class":"OC\\User\\User","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"deleteUser","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/AppFramework\/App.php","line":171,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/Route\/Router.php","line":298,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php","line":63,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v2.php","line":23,"args":["\/home\/nickv\/Nextcloud\/26\/server\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/nickv\/Nextcloud\/26\/server\/lib\/private\/DB\/QueryBuilder\/QueryBuilder.php","Line":869,"message":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.","exception":{},"CustomMessage":"Using where() on non-empty WHERE part, please verify it is intentional to not call whereAnd() or whereOr() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first."}
```

Afterwards:
```
# no output
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
