### PR TITLE
Add bruteforce protection to password reset page

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -128,6 +128,8 @@ class LostController extends Controller {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @BruteForceProtection(action=passwordResetEmail)
+	 * @AnonRateThrottle(limit=10, period=300)
 	 */
 	public function resetform(string $token, string $userId): TemplateResponse {
 		try {
@@ -137,12 +139,14 @@ class LostController extends Controller {
 				|| ($e instanceof InvalidTokenException
 					&& !in_array($e->getCode(), [InvalidTokenException::TOKEN_NOT_FOUND, InvalidTokenException::USER_UNKNOWN]))
 			) {
-				return new TemplateResponse(
+				$response = new TemplateResponse(
 					'core', 'error', [
 						"errors" => [["error" => $e->getMessage()]]
 					],
 					TemplateResponse::RENDER_AS_GUEST
 				);
+				$response->throttle();
+				return $response;
 			}
 			return new TemplateResponse('core', 'error', [
 				'errors' => [['error' => $this->l10n->t('Password reset is disabled')]]

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -171,6 +171,7 @@ class LostControllerTest extends TestCase {
 				]
 			],
 			'guest');
+		$expectedResponse->throttle();
 		$this->assertEquals($expectedResponse, $response);
 	}
 


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
