### PR TITLE
Remove failing test that works with mocks only anyway

### DIFF
--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -4,8 +4,6 @@ namespace Test\Encryption;
 
 use OC\Encryption\Util;
 use OC\Files\View;
-use OCA\Files_External\Lib\StorageConfig;
-use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\Encryption\IEncryptionModule;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -179,44 +177,5 @@ class UtilTest extends TestCase {
 			['/foo/test.txt.ocTransferId7567846853.part', '/foo/test.txt'],
 			['/foo/test.txt.ocTransferId7567.part', '/foo/test.txt'],
 		];
-	}
-
-	public function dataTestIsSystemWideMountPoint() {
-		return [
-			[false, 'non-matching mount point name', [], [], '/mp_another'],
-			[true, 'applicable to all', [], []],
-			[true, 'applicable to user directly', ['user1'], []],
-			[true, 'applicable to group directly', [], ['group1']],
-			[false, 'non-applicable to current user', ['user2'], []],
-			[false, 'non-applicable to current user\'s group', [], ['group2']],
-			[true, 'mount point without leading slash', [], [], 'mp'],
-		];
-	}
-
-	/**
-	 * @dataProvider dataTestIsSystemWideMountPoint
-	 */
-	public function testIsSystemWideMountPoint($expectedResult, $expectationText, $applicableUsers, $applicableGroups, $mountPointName = '/mp') {
-		$this->groupManager->method('isInGroup')
-			 ->will($this->returnValueMap([
-			 	['user1', 'group1', true], // user is only in group1
-			 	['user1', 'group2', false],
-			 ]));
-
-		$storages = [];
-
-		$storageConfig = $this->createMock(StorageConfig::class);
-		$storageConfig->method('getMountPoint')->willReturn($mountPointName);
-		$storageConfig->method('getApplicableUsers')->willReturn($applicableUsers);
-		$storageConfig->method('getApplicableGroups')->willReturn($applicableGroups);
-		$storages[] = $storageConfig;
-
-		$storagesServiceMock = $this->createMock(GlobalStoragesService::class);
-		$storagesServiceMock->expects($this->atLeastOnce())->method('getAllStorages')
-			->willReturn($storages);
-
-		$this->overwriteService(GlobalStoragesService::class, $storagesServiceMock);
-
-		$this->assertEquals($expectedResult, $this->util->isSystemWideMountPoint('/files/mp', 'user1'), 'Test case: ' . $expectationText);
 	}
 }


### PR DESCRIPTION
Since PHPUnit 9.5 this test fails. However the function is so plain:
https://github.com/nextcloud/server/blob/f5c361cf44739058b79f322576a1bad2d8c142d9/lib/private/Encryption/Util.php#L296-L299

That testing it with mocks doesn't really make a lot of sense.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
