### PR TITLE
Allow settings navigation items with no route entry

### DIFF
--- a/apps/user_status/appinfo/info.xml
+++ b/apps/user_status/appinfo/info.xml
@@ -15,7 +15,6 @@
 		<navigation>
 			<id>user_status-menuitem</id>
 			<name>User status</name>
-			<route />
 			<order>1</order>
 			<type>settings</type>
 		</navigation>

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -225,6 +225,10 @@ class InfoParser {
 	 * @return bool
 	 */
 	private function isNavigationItem($data): bool {
+		// Allow settings navigation items with no route entry
+		if ($data['type'] === 'settings') {
+			return isset($data['name']);
+		}
 		return isset($data['name'], $data['route']);
 	}
 

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -226,7 +226,8 @@ class InfoParser {
 	 */
 	private function isNavigationItem($data): bool {
 		// Allow settings navigation items with no route entry
-		if ($data['type'] === 'settings') {
+		$type = $data['type'] ?? 'link';
+		if ($type === 'settings') {
 			return isset($data['name']);
 		}
 		return isset($data['name'], $data['route']);

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -305,11 +305,9 @@ class NavigationManager implements INavigationManager {
 				if (!isset($nav['name'])) {
 					continue;
 				}
-				if (!isset($nav['route'])) {
-					// Allow settings navigation items with no route entry, all other types require one
-					if ($nav['type'] !== 'settings') {
-						continue;
-					}
+				// Allow settings navigation items with no route entry, all other types require one
+				if (!isset($nav['route']) && $nav['type'] !== 'settings') {
+					continue;
 				}
 				$role = isset($nav['@attributes']['role']) ? $nav['@attributes']['role'] : 'all';
 				if ($role === 'admin' && !$this->isAdmin()) {

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -301,11 +301,15 @@ class NavigationManager implements INavigationManager {
 				continue;
 			}
 			foreach ($info['navigations']['navigation'] as $key => $nav) {
+				$nav['type'] = $nav['type'] ?? 'link';
 				if (!isset($nav['name'])) {
 					continue;
 				}
 				if (!isset($nav['route'])) {
-					continue;
+					// Allow settings navigation items with no route entry, all other types require one
+					if ($nav['type'] !== 'settings') {
+						continue;
+					}
 				}
 				$role = isset($nav['@attributes']['role']) ? $nav['@attributes']['role'] : 'all';
 				if ($role === 'admin' && !$this->isAdmin()) {
@@ -314,8 +318,8 @@ class NavigationManager implements INavigationManager {
 				$l = $this->l10nFac->get($app);
 				$id = $nav['id'] ?? $app . ($key === 0 ? '' : $key);
 				$order = isset($nav['order']) ? $nav['order'] : 100;
-				$type = isset($nav['type']) ? $nav['type'] : 'link';
-				$route = $nav['route'] !== '' ? $this->urlGenerator->linkToRoute($nav['route']) : '';
+				$type = $nav['type'];
+				$route = !empty($nav['route']) ? $this->urlGenerator->linkToRoute($nav['route']) : '';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';
 				foreach ([$icon, "$app.svg"] as $i) {
 					try {

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -446,7 +446,7 @@
         <xs:sequence>
             <xs:element name="id" type="id" minOccurs="0" maxOccurs="1"/>
             <xs:element name="name" type="non-empty-string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="route" type="route" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="route" type="route" minOccurs="0" maxOccurs="1"/>
             <xs:element name="icon" type="xs:anyURI" minOccurs="0" maxOccurs="1"/>
             <xs:element name="order" type="xs:int" minOccurs="0" maxOccurs="1"/>
             <xs:element name="type" type="navigation-type" minOccurs="0" maxOccurs="1"/>

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -442,7 +442,7 @@
         <xs:sequence>
             <xs:element name="id" type="id" minOccurs="0" maxOccurs="1"/>
             <xs:element name="name" type="non-empty-string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="route" type="route" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="route" type="route" minOccurs="0" maxOccurs="1"/>
             <xs:element name="icon" type="xs:anyURI" minOccurs="0" maxOccurs="1"/>
             <xs:element name="order" type="xs:int" minOccurs="0" maxOccurs="1"/>
             <xs:element name="type" type="navigation-type" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
## Summary

Some apps register navigation entries with extraneous empty routes e.g. https://github.com/nextcloud/server/blob/e81cb6eaf0274dcdf2402de16216e8c61826235e/apps/user_status/appinfo/info.xml#L18

Instead of adding empty routes we can allow no routes at all

This adjusts the core logic to allow no route entries and updates the XML schemas to pass `xmllint` used in https://github.com/nextcloud/.github/blob/ff4a6f1eacb53e4d3b5721e57743eb64242178a7/workflow-templates/lint-info-xml.yml

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)