### PR TITLE
fix: Only try to access params for relevant routes

### DIFF
--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -324,6 +324,7 @@ class Manager implements IManager {
 	 */
 	public function isFormattingFilteredObject(): bool {
 		return $this->formattingObjectType !== null && $this->formattingObjectId !== null
+			&& $this->request->getMethod() === 'GET'
 			&& $this->formattingObjectType === $this->request->getParam('object_type')
 			&& $this->formattingObjectId === (int) $this->request->getParam('object_id');
 	}


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/blob/cf8d97c9d31fc487f9347c120145ab4d70b4d0ee/apps/systemtags/lib/Activity/Provider.php#L85-L93 could also get called on unrelated requests so we should make sure to not cause problems when trying to get params that don't exist on unrelated requests.

@nickvergessen Do we actually need that separation in the system tags provider to render them differently? My assumption is that this is then based on the activity API request, but feels like an odd place for checking the parameters there.

Fixes random errors like this:

> LogicException: "put" can only be accessed once if not application/x-www-form-urlencoded or application/json.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
