### PR TITLE
feat(dav): Add VTIMEZONE data when creating personal calendar

### DIFF
--- a/apps/dav/resources/zones.json
+++ b/apps/dav/resources/zones.json
@@ -1,0 +1,3583 @@
+{
+	"version": "2.2019c",
+	"aliases": {
+		"AUS Central Standard Time": {
+			"aliasTo": "Australia/Darwin"
+		},
+		"AUS Eastern Standard Time": {
+			"aliasTo": "Australia/Sydney"
+		},
+		"Afghanistan Standard Time": {
+			"aliasTo": "Asia/Kabul"
+		},
+		"Africa/Asmera": {
+			"aliasTo": "Africa/Asmara"
+		},
+		"Africa/Timbuktu": {
+			"aliasTo": "Africa/Bamako"
+		},
+		"Alaskan Standard Time": {
+			"aliasTo": "America/Anchorage"
+		},
+		"America/Argentina/ComodRivadavia": {
+			"aliasTo": "America/Argentina/Catamarca"
+		},
+		"America/Buenos_Aires": {
+			"aliasTo": "America/Argentina/Buenos_Aires"
+		},
+		"America/Louisville": {
+			"aliasTo": "America/Kentucky/Louisville"
+		},
+		"America/Montreal": {
+			"aliasTo": "America/Toronto"
+		},
+		"America/Santa_Isabel": {
+			"aliasTo": "America/Tijuana"
+		},
+		"Arab Standard Time": {
+			"aliasTo": "Asia/Riyadh"
+		},
+		"Arabian Standard Time": {
+			"aliasTo": "Asia/Dubai"
+		},
+		"Arabic Standard Time": {
+			"aliasTo": "Asia/Baghdad"
+		},
+		"Argentina Standard Time": {
+			"aliasTo": "America/Argentina/Buenos_Aires"
+		},
+		"Asia/Calcutta": {
+			"aliasTo": "Asia/Kolkata"
+		},
+		"Asia/Katmandu": {
+			"aliasTo": "Asia/Kathmandu"
+		},
+		"Asia/Rangoon": {
+			"aliasTo": "Asia/Yangon"
+		},
+		"Asia/Saigon": {
+			"aliasTo": "Asia/Ho_Chi_Minh"
+		},
+		"Atlantic Standard Time": {
+			"aliasTo": "America/Halifax"
+		},
+		"Atlantic/Faeroe": {
+			"aliasTo": "Atlantic/Faroe"
+		},
+		"Atlantic/Jan_Mayen": {
+			"aliasTo": "Europe/Oslo"
+		},
+		"Azerbaijan Standard Time": {
+			"aliasTo": "Asia/Baku"
+		},
+		"Azores Standard Time": {
+			"aliasTo": "Atlantic/Azores"
+		},
+		"Bahia Standard Time": {
+			"aliasTo": "America/Bahia"
+		},
+		"Bangladesh Standard Time": {
+			"aliasTo": "Asia/Dhaka"
+		},
+		"Belarus Standard Time": {
+			"aliasTo": "Europe/Minsk"
+		},
+		"Canada Central Standard Time": {
+			"aliasTo": "America/Regina"
+		},
+		"Cape Verde Standard Time": {
+			"aliasTo": "Atlantic/Cape_Verde"
+		},
+		"Caucasus Standard Time": {
+			"aliasTo": "Asia/Yerevan"
+		},
+		"Cen. Australia Standard Time": {
+			"aliasTo": "Australia/Adelaide"
+		},
+		"Central America Standard Time": {
+			"aliasTo": "America/Guatemala"
+		},
+		"Central Asia Standard Time": {
+			"aliasTo": "Asia/Almaty"
+		},
+		"Central Brazilian Standard Time": {
+			"aliasTo": "America/Cuiaba"
+		},
+		"Central Europe Standard Time": {
+			"aliasTo": "Europe/Budapest"
+		},
+		"Central European Standard Time": {
+			"aliasTo": "Europe/Warsaw"
+		},
+		"Central Pacific Standard Time": {
+			"aliasTo": "Pacific/Guadalcanal"
+		},
+		"Central Standard Time": {
+			"aliasTo": "America/Chicago"
+		},
+		"Central Standard Time (Mexico)": {
+			"aliasTo": "America/Mexico_City"
+		},
+		"China Standard Time": {
+			"aliasTo": "Asia/Shanghai"
+		},
+		"E. Africa Standard Time": {
+			"aliasTo": "Africa/Nairobi"
+		},
+		"E. Australia Standard Time": {
+			"aliasTo": "Australia/Brisbane"
+		},
+		"E. South America Standard Time": {
+			"aliasTo": "America/Sao_Paulo"
+		},
+		"Eastern Standard Time": {
+			"aliasTo": "America/New_York"
+		},
+		"Egypt Standard Time": {
+			"aliasTo": "Africa/Cairo"
+		},
+		"Ekaterinburg Standard Time": {
+			"aliasTo": "Asia/Yekaterinburg"
+		},
+		"Etc/GMT": {
+			"aliasTo": "UTC"
+		},
+		"Etc/GMT+0": {
+			"aliasTo": "UTC"
+		},
+		"Etc/UCT": {
+			"aliasTo": "UTC"
+		},
+		"Etc/UTC": {
+			"aliasTo": "UTC"
+		},
+		"Etc/Unversal": {
+			"aliasTo": "UTC"
+		},
+		"Etc/Zulu": {
+			"aliasTo": "UTC"
+		},
+		"Europe/Belfast": {
+			"aliasTo": "Europe/London"
+		},
+		"FLE Standard Time": {
+			"aliasTo": "Europe/Kiev"
+		},
+		"Fiji Standard Time": {
+			"aliasTo": "Pacific/Fiji"
+		},
+		"GMT": {
+			"aliasTo": "UTC"
+		},
+		"GMT Standard Time": {
+			"aliasTo": "Europe/London"
+		},
+		"GMT+0": {
+			"aliasTo": "UTC"
+		},
+		"GMT0": {
+			"aliasTo": "UTC"
+		},
+		"GTB Standard Time": {
+			"aliasTo": "Europe/Bucharest"
+		},
+		"Georgian Standard Time": {
+			"aliasTo": "Asia/Tbilisi"
+		},
+		"Greenland Standard Time": {
+			"aliasTo": "America/Godthab"
+		},
+		"Greenwich": {
+			"aliasTo": "UTC"
+		},
+		"Greenwich Standard Time": {
+			"aliasTo": "Atlantic/Reykjavik"
+		},
+		"Hawaiian Standard Time": {
+			"aliasTo": "Pacific/Honolulu"
+		},
+		"India Standard Time": {
+			"aliasTo": "Asia/Calcutta"
+		},
+		"Iran Standard Time": {
+			"aliasTo": "Asia/Tehran"
+		},
+		"Israel Standard Time": {
+			"aliasTo": "Asia/Jerusalem"
+		},
+		"Jordan Standard Time": {
+			"aliasTo": "Asia/Amman"
+		},
+		"Kaliningrad Standard Time": {
+			"aliasTo": "Europe/Kaliningrad"
+		},
+		"Korea Standard Time": {
+			"aliasTo": "Asia/Seoul"
+		},
+		"Libya Standard Time": {
+			"aliasTo": "Africa/Tripoli"
+		},
+		"Line Islands Standard Time": {
+			"aliasTo": "Pacific/Kiritimati"
+		},
+		"Magadan Standard Time": {
+			"aliasTo": "Asia/Magadan"
+		},
+		"Mauritius Standard Time": {
+			"aliasTo": "Indian/Mauritius"
+		},
+		"Middle East Standard Time": {
+			"aliasTo": "Asia/Beirut"
+		},
+		"Montevideo Standard Time": {
+			"aliasTo": "America/Montevideo"
+		},
+		"Morocco Standard Time": {
+			"aliasTo": "Africa/Casablanca"
+		},
+		"Mountain Standard Time": {
+			"aliasTo": "America/Denver"
+		},
+		"Mountain Standard Time (Mexico)": {
+			"aliasTo": "America/Chihuahua"
+		},
+		"Myanmar Standard Time": {
+			"aliasTo": "Asia/Rangoon"
+		},
+		"N. Central Asia Standard Time": {
+			"aliasTo": "Asia/Novosibirsk"
+		},
+		"Namibia Standard Time": {
+			"aliasTo": "Africa/Windhoek"
+		},
+		"Nepal Standard Time": {
+			"aliasTo": "Asia/Katmandu"
+		},
+		"New Zealand Standard Time": {
+			"aliasTo": "Pacific/Auckland"
+		},
+		"Newfoundland Standard Time": {
+			"aliasTo": "America/St_Johns"
+		},
+		"North Asia East Standard Time": {
+			"aliasTo": "Asia/Irkutsk"
+		},
+		"North Asia Standard Time": {
+			"aliasTo": "Asia/Krasnoyarsk"
+		},
+		"Pacific SA Standard Time": {
+			"aliasTo": "America/Santiago"
+		},
+		"Pacific Standard Time": {
+			"aliasTo": "America/Los_Angeles"
+		},
+		"Pacific Standard Time (Mexico)": {
+			"aliasTo": "America/Santa_Isabel"
+		},
+		"Pacific/Johnston": {
+			"aliasTo": "Pacific/Honolulu"
+		},
+		"Pakistan Standard Time": {
+			"aliasTo": "Asia/Karachi"
+		},
+		"Paraguay Standard Time": {
+			"aliasTo": "America/Asuncion"
+		},
+		"Romance Standard Time": {
+			"aliasTo": "Europe/Paris"
+		},
+		"Russia Time Zone 10": {
+			"aliasTo": "Asia/Srednekolymsk"
+		},
+		"Russia Time Zone 11": {
+			"aliasTo": "Asia/Kamchatka"
+		},
+		"Russia Time Zone 3": {
+			"aliasTo": "Europe/Samara"
+		},
+		"Russian Standard Time": {
+			"aliasTo": "Europe/Moscow"
+		},
+		"SA Eastern Standard Time": {
+			"aliasTo": "America/Cayenne"
+		},
+		"SA Pacific Standard Time": {
+			"aliasTo": "America/Bogota"
+		},
+		"SA Western Standard Time": {
+			"aliasTo": "America/La_Paz"
+		},
+		"SE Asia Standard Time": {
+			"aliasTo": "Asia/Bangkok"
+		},
+		"Samoa Standard Time": {
+			"aliasTo": "Pacific/Apia"
+		},
+		"Singapore Standard Time": {
+			"aliasTo": "Asia/Singapore"
+		},
+		"South Africa Standard Time": {
+			"aliasTo": "Africa/Johannesburg"
+		},
+		"Sri Lanka Standard Time": {
+			"aliasTo": "Asia/Colombo"
+		},
+		"Syria Standard Time": {
+			"aliasTo": "Asia/Damascus"
+		},
+		"Taipei Standard Time": {
+			"aliasTo": "Asia/Taipei"
+		},
+		"Tasmania Standard Time": {
+			"aliasTo": "Australia/Hobart"
+		},
+		"Tokyo Standard Time": {
+			"aliasTo": "Asia/Tokyo"
+		},
+		"Tonga Standard Time": {
+			"aliasTo": "Pacific/Tongatapu"
+		},
+		"Turkey Standard Time": {
+			"aliasTo": "Europe/Istanbul"
+		},
+		"UCT": {
+			"aliasTo": "UTC"
+		},
+		"US Eastern Standard Time": {
+			"aliasTo": "America/Indiana/Indianapolis"
+		},
+		"US Mountain Standard Time": {
+			"aliasTo": "America/Phoenix"
+		},
+		"US/Central": {
+			"aliasTo": "America/Chicago"
+		},
+		"US/Eastern": {
+			"aliasTo": "America/New_York"
+		},
+		"US/Mountain": {
+			"aliasTo": "America/Denver"
+		},
+		"US/Pacific": {
+			"aliasTo": "America/Los_Angeles"
+		},
+		"US/Pacific-New": {
+			"aliasTo": "America/Los_Angeles"
+		},
+		"Ulaanbaatar Standard Time": {
+			"aliasTo": "Asia/Ulaanbaatar"
+		},
+		"Universal": {
+			"aliasTo": "UTC"
+		},
+		"Venezuela Standard Time": {
+			"aliasTo": "America/Caracas"
+		},
+		"Vladivostok Standard Time": {
+			"aliasTo": "Asia/Vladivostok"
+		},
+		"W. Australia Standard Time": {
+			"aliasTo": "Australia/Perth"
+		},
+		"W. Central Africa Standard Time": {
+			"aliasTo": "Africa/Lagos"
+		},
+		"W. Europe Standard Time": {
+			"aliasTo": "Europe/Berlin"
+		},
+		"West Asia Standard Time": {
+			"aliasTo": "Asia/Tashkent"
+		},
+		"West Pacific Standard Time": {
+			"aliasTo": "Pacific/Port_Moresby"
+		},
+		"Yakutsk Standard Time": {
+			"aliasTo": "Asia/Yakutsk"
+		},
+		"Z": {
+			"aliasTo": "UTC"
+		},
+		"Zulu": {
+			"aliasTo": "UTC"
+		},
+		"utc": {
+			"aliasTo": "UTC"
+		}
+	},
+	"zones": {
+		"Africa/Abidjan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0051900",
+			"longitude": "-0040200"
+		},
+		"Africa/Accra": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0053300",
+			"longitude": "+0001300"
+		},
+		"Africa/Addis_Ababa": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0090200",
+			"longitude": "+0384200"
+		},
+		"Africa/Algiers": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0364700",
+			"longitude": "+0030300"
+		},
+		"Africa/Asmara": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0152000",
+			"longitude": "+0385300"
+		},
+		"Africa/Bamako": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0123900",
+			"longitude": "-0080000"
+		},
+		"Africa/Bangui": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0042200",
+			"longitude": "+0183500"
+		},
+		"Africa/Banjul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0132800",
+			"longitude": "-0163900"
+		},
+		"Africa/Bissau": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0115100",
+			"longitude": "-0153500"
+		},
+		"Africa/Blantyre": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0154700",
+			"longitude": "+0350000"
+		},
+		"Africa/Brazzaville": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0041600",
+			"longitude": "+0151700"
+		},
+		"Africa/Bujumbura": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0032300",
+			"longitude": "+0292200"
+		},
+		"Africa/Cairo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0300300",
+			"longitude": "+0311500"
+		},
+		"Africa/Casablanca": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20180325T020000\r\nRDATE:20180325T020000\r\nRDATE:20180617T020000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:20180513T030000\r\nRDATE:20180513T030000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20190609T020000\r\nRDATE:20190609T020000\r\nRDATE:20200524T020000\r\nRDATE:20210516T020000\r\nRDATE:20220508T020000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20181028T030000\r\nRDATE:20181028T030000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:20190505T030000\r\nRDATE:20190505T030000\r\nRDATE:20200419T030000\r\nRDATE:20210411T030000\r\nRDATE:20220327T030000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0333900",
+			"longitude": "-0073500"
+		},
+		"Africa/Ceuta": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0355300",
+			"longitude": "-0051900"
+		},
+		"Africa/Conakry": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0093100",
+			"longitude": "-0134300"
+		},
+		"Africa/Dakar": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0144000",
+			"longitude": "-0172600"
+		},
+		"Africa/Dar_es_Salaam": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0064800",
+			"longitude": "+0391700"
+		},
+		"Africa/Djibouti": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0113600",
+			"longitude": "+0430900"
+		},
+		"Africa/Douala": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0040300",
+			"longitude": "+0094200"
+		},
+		"Africa/El_Aaiun": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20180325T020000\r\nRDATE:20180325T020000\r\nRDATE:20180617T020000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:20180513T030000\r\nRDATE:20180513T030000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20181028T030000\r\nRDATE:20181028T030000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:20190505T030000\r\nRDATE:20190505T030000\r\nRDATE:20200419T030000\r\nRDATE:20210411T030000\r\nRDATE:20220327T030000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:+01\r\nDTSTART:20190609T020000\r\nRDATE:20190609T020000\r\nRDATE:20200524T020000\r\nRDATE:20210516T020000\r\nRDATE:20220508T020000\r\nEND:STANDARD"
+			],
+			"latitude": "+0270900",
+			"longitude": "-0131200"
+		},
+		"Africa/Freetown": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0083000",
+			"longitude": "-0131500"
+		},
+		"Africa/Gaborone": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0243900",
+			"longitude": "+0255500"
+		},
+		"Africa/Harare": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0175000",
+			"longitude": "+0310300"
+		},
+		"Africa/Johannesburg": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:SAST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0261500",
+			"longitude": "+0280000"
+		},
+		"Africa/Juba": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0045100",
+			"longitude": "+0313700"
+		},
+		"Africa/Kampala": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0001900",
+			"longitude": "+0322500"
+		},
+		"Africa/Khartoum": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0153600",
+			"longitude": "+0323200"
+		},
+		"Africa/Kigali": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0015700",
+			"longitude": "+0300400"
+		},
+		"Africa/Kinshasa": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0041800",
+			"longitude": "+0151800"
+		},
+		"Africa/Lagos": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0062700",
+			"longitude": "+0032400"
+		},
+		"Africa/Libreville": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0002300",
+			"longitude": "+0092700"
+		},
+		"Africa/Lome": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0060800",
+			"longitude": "+0011300"
+		},
+		"Africa/Luanda": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0084800",
+			"longitude": "+0131400"
+		},
+		"Africa/Lubumbashi": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0114000",
+			"longitude": "+0272800"
+		},
+		"Africa/Lusaka": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0152500",
+			"longitude": "+0281700"
+		},
+		"Africa/Malabo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0034500",
+			"longitude": "+0084700"
+		},
+		"Africa/Maputo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0255800",
+			"longitude": "+0323500"
+		},
+		"Africa/Maseru": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:SAST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0292800",
+			"longitude": "+0273000"
+		},
+		"Africa/Mbabane": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:SAST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0261800",
+			"longitude": "+0310600"
+		},
+		"Africa/Mogadishu": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0020400",
+			"longitude": "+0452200"
+		},
+		"Africa/Monrovia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0061800",
+			"longitude": "-0104700"
+		},
+		"Africa/Nairobi": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0011700",
+			"longitude": "+0364900"
+		},
+		"Africa/Ndjamena": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0120700",
+			"longitude": "+0150300"
+		},
+		"Africa/Niamey": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0133100",
+			"longitude": "+0020700"
+		},
+		"Africa/Nouakchott": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0180600",
+			"longitude": "-0155700"
+		},
+		"Africa/Ouagadougou": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0122200",
+			"longitude": "-0013100"
+		},
+		"Africa/Porto-Novo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0062900",
+			"longitude": "+0023700"
+		},
+		"Africa/Sao_Tome": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:WAT\r\nDTSTART:20180101T010000\r\nRDATE:20180101T010000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:20190101T020000\r\nRDATE:20190101T020000\r\nEND:STANDARD"
+			],
+			"latitude": "+0002000",
+			"longitude": "+0064400"
+		},
+		"Africa/Tripoli": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0325400",
+			"longitude": "+0131100"
+		},
+		"Africa/Tunis": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0364800",
+			"longitude": "+0101100"
+		},
+		"Africa/Windhoek": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:CAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0223400",
+			"longitude": "+0170600"
+		},
+		"America/Adak": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-1000\r\nTZOFFSETTO:-0900\r\nTZNAME:HDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-1000\r\nTZNAME:HST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0515248",
+			"longitude": "-1763929"
+		},
+		"America/Anchorage": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0611305",
+			"longitude": "-1495401"
+		},
+		"America/Anguilla": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0181200",
+			"longitude": "-0630400"
+		},
+		"America/Antigua": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0170300",
+			"longitude": "-0614800"
+		},
+		"America/Araguaina": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0071200",
+			"longitude": "-0481200"
+		},
+		"America/Argentina/Buenos_Aires": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0343600",
+			"longitude": "-0582700"
+		},
+		"America/Argentina/Catamarca": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0282800",
+			"longitude": "-0654700"
+		},
+		"America/Argentina/Cordoba": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0312400",
+			"longitude": "-0641100"
+		},
+		"America/Argentina/Jujuy": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0241100",
+			"longitude": "-0651800"
+		},
+		"America/Argentina/La_Rioja": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0292600",
+			"longitude": "-0665100"
+		},
+		"America/Argentina/Mendoza": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0325300",
+			"longitude": "-0684900"
+		},
+		"America/Argentina/Rio_Gallegos": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0513800",
+			"longitude": "-0691300"
+		},
+		"America/Argentina/Salta": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0244700",
+			"longitude": "-0652500"
+		},
+		"America/Argentina/San_Juan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0313200",
+			"longitude": "-0683100"
+		},
+		"America/Argentina/San_Luis": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0331900",
+			"longitude": "-0662100"
+		},
+		"America/Argentina/Tucuman": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0264900",
+			"longitude": "-0651300"
+		},
+		"America/Argentina/Ushuaia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0544800",
+			"longitude": "-0681800"
+		},
+		"America/Aruba": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0123000",
+			"longitude": "-0695800"
+		},
+		"America/Asuncion": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19701004T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700322T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=4SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0251600",
+			"longitude": "-0574000"
+		},
+		"America/Atikokan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0484531",
+			"longitude": "-0913718"
+		},
+		"America/Bahia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0125900",
+			"longitude": "-0383100"
+		},
+		"America/Bahia_Banderas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0204800",
+			"longitude": "-1051500"
+		},
+		"America/Barbados": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0130600",
+			"longitude": "-0593700"
+		},
+		"America/Belem": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0012700",
+			"longitude": "-0482900"
+		},
+		"America/Belize": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0173000",
+			"longitude": "-0881200"
+		},
+		"America/Blanc-Sablon": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0512500",
+			"longitude": "-0570700"
+		},
+		"America/Boa_Vista": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0024900",
+			"longitude": "-0604000"
+		},
+		"America/Bogota": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0043600",
+			"longitude": "-0740500"
+		},
+		"America/Boise": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0433649",
+			"longitude": "-1161209"
+		},
+		"America/Cambridge_Bay": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0690650",
+			"longitude": "-1050310"
+		},
+		"America/Campo_Grande": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:20181104T000000\r\nRDATE:20181104T000000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:20180218T000000\r\nRDATE:20180218T000000\r\nRDATE:20190217T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0202700",
+			"longitude": "-0543700"
+		},
+		"America/Cancun": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0210500",
+			"longitude": "-0864600"
+		},
+		"America/Caracas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0103000",
+			"longitude": "-0665600"
+		},
+		"America/Cayenne": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0045600",
+			"longitude": "-0522000"
+		},
+		"America/Cayman": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0191800",
+			"longitude": "-0812300"
+		},
+		"America/Chicago": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0415100",
+			"longitude": "-0873900"
+		},
+		"America/Chihuahua": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0283800",
+			"longitude": "-1060500"
+		},
+		"America/Costa_Rica": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0095600",
+			"longitude": "-0840500"
+		},
+		"America/Creston": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0490600",
+			"longitude": "-1163100"
+		},
+		"America/Cuiaba": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:20181104T000000\r\nRDATE:20181104T000000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:20180218T000000\r\nRDATE:20180218T000000\r\nRDATE:20190217T000000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0153500",
+			"longitude": "-0560500"
+		},
+		"America/Curacao": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0121100",
+			"longitude": "-0690000"
+		},
+		"America/Danmarkshavn": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0764600",
+			"longitude": "-0184000"
+		},
+		"America/Dawson": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0700\r\nTZNAME:PDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0640400",
+			"longitude": "-1392500"
+		},
+		"America/Dawson_Creek": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0594600",
+			"longitude": "-1201400"
+		},
+		"America/Denver": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0394421",
+			"longitude": "-1045903"
+		},
+		"America/Detroit": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0421953",
+			"longitude": "-0830245"
+		},
+		"America/Dominica": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0151800",
+			"longitude": "-0612400"
+		},
+		"America/Edmonton": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0533300",
+			"longitude": "-1132800"
+		},
+		"America/Eirunepe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0064000",
+			"longitude": "-0695200"
+		},
+		"America/El_Salvador": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0134200",
+			"longitude": "-0891200"
+		},
+		"America/Fort_Nelson": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0584800",
+			"longitude": "-1224200"
+		},
+		"America/Fortaleza": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0034300",
+			"longitude": "-0383000"
+		},
+		"America/Glace_Bay": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0461200",
+			"longitude": "-0595700"
+		},
+		"America/Godthab": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:19700328T220000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=24,25,26,27,28,29,30;BYDAY=SA\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19701024T230000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYMONTHDAY=24,25,26,27,28,29,30;BYDAY=SA\r\nEND:STANDARD"
+			],
+			"latitude": "+0641100",
+			"longitude": "-0514400"
+		},
+		"America/Goose_Bay": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0532000",
+			"longitude": "-0602500"
+		},
+		"America/Grand_Turk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:20181104T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:20190310T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:20180311T020000\r\nRDATE:20180311T020000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0212800",
+			"longitude": "-0710800"
+		},
+		"America/Grenada": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0120300",
+			"longitude": "-0614500"
+		},
+		"America/Guadeloupe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0161400",
+			"longitude": "-0613200"
+		},
+		"America/Guatemala": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0143800",
+			"longitude": "-0903100"
+		},
+		"America/Guayaquil": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0021000",
+			"longitude": "-0795000"
+		},
+		"America/Guyana": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0064800",
+			"longitude": "-0581000"
+		},
+		"America/Halifax": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0443900",
+			"longitude": "-0633600"
+		},
+		"America/Havana": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:CST\r\nDTSTART:19701101T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:CDT\r\nDTSTART:19700308T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0230800",
+			"longitude": "-0822200"
+		},
+		"America/Hermosillo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0290400",
+			"longitude": "-1105800"
+		},
+		"America/Indiana/Indianapolis": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0394606",
+			"longitude": "-0860929"
+		},
+		"America/Indiana/Knox": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0411745",
+			"longitude": "-0863730"
+		},
+		"America/Indiana/Marengo": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0382232",
+			"longitude": "-0862041"
+		},
+		"America/Indiana/Petersburg": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0382931",
+			"longitude": "-0871643"
+		},
+		"America/Indiana/Tell_City": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0375711",
+			"longitude": "-0864541"
+		},
+		"America/Indiana/Vevay": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0384452",
+			"longitude": "-0850402"
+		},
+		"America/Indiana/Vincennes": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0384038",
+			"longitude": "-0873143"
+		},
+		"America/Indiana/Winamac": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0410305",
+			"longitude": "-0863611"
+		},
+		"America/Inuvik": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0682059",
+			"longitude": "-1334300"
+		},
+		"America/Iqaluit": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0634400",
+			"longitude": "-0682800"
+		},
+		"America/Jamaica": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0175805",
+			"longitude": "-0764736"
+		},
+		"America/Juneau": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0581807",
+			"longitude": "-1342511"
+		},
+		"America/Kentucky/Louisville": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0381515",
+			"longitude": "-0854534"
+		},
+		"America/Kentucky/Monticello": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0364947",
+			"longitude": "-0845057"
+		},
+		"America/Kralendijk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0120903",
+			"longitude": "-0681636"
+		},
+		"America/La_Paz": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0163000",
+			"longitude": "-0680900"
+		},
+		"America/Lima": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0120300",
+			"longitude": "-0770300"
+		},
+		"America/Los_Angeles": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0700\r\nTZNAME:PDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0340308",
+			"longitude": "-1181434"
+		},
+		"America/Lower_Princes": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0180305",
+			"longitude": "-0630250"
+		},
+		"America/Maceio": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0094000",
+			"longitude": "-0354300"
+		},
+		"America/Managua": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0120900",
+			"longitude": "-0861700"
+		},
+		"America/Manaus": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0030800",
+			"longitude": "-0600100"
+		},
+		"America/Marigot": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0180400",
+			"longitude": "-0630500"
+		},
+		"America/Martinique": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0143600",
+			"longitude": "-0610500"
+		},
+		"America/Matamoros": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0255000",
+			"longitude": "-0973000"
+		},
+		"America/Mazatlan": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0231300",
+			"longitude": "-1062500"
+		},
+		"America/Menominee": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0450628",
+			"longitude": "-0873651"
+		},
+		"America/Merida": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0205800",
+			"longitude": "-0893700"
+		},
+		"America/Metlakatla": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:20191103T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:20181104T020000\r\nRDATE:20181104T020000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:20190120T020000\r\nRDATE:20190120T020000\r\nEND:STANDARD"
+			],
+			"latitude": "+0550737",
+			"longitude": "-1313435"
+		},
+		"America/Mexico_City": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0192400",
+			"longitude": "-0990900"
+		},
+		"America/Miquelon": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0470300",
+			"longitude": "-0562000"
+		},
+		"America/Moncton": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0460600",
+			"longitude": "-0644700"
+		},
+		"America/Monterrey": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0254000",
+			"longitude": "-1001900"
+		},
+		"America/Montevideo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0345433",
+			"longitude": "-0561245"
+		},
+		"America/Montserrat": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0164300",
+			"longitude": "-0621300"
+		},
+		"America/Nassau": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0250500",
+			"longitude": "-0772100"
+		},
+		"America/New_York": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0404251",
+			"longitude": "-0740023"
+		},
+		"America/Nipigon": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0490100",
+			"longitude": "-0881600"
+		},
+		"America/Nome": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0643004",
+			"longitude": "-1652423"
+		},
+		"America/Noronha": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0035100",
+			"longitude": "-0322500"
+		},
+		"America/North_Dakota/Beulah": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0471551",
+			"longitude": "-1014640"
+		},
+		"America/North_Dakota/Center": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0470659",
+			"longitude": "-1011757"
+		},
+		"America/North_Dakota/New_Salem": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0465042",
+			"longitude": "-1012439"
+		},
+		"America/Ojinaga": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0293400",
+			"longitude": "-1042500"
+		},
+		"America/Panama": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0085800",
+			"longitude": "-0793200"
+		},
+		"America/Pangnirtung": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0660800",
+			"longitude": "-0654400"
+		},
+		"America/Paramaribo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0055000",
+			"longitude": "-0551000"
+		},
+		"America/Phoenix": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0332654",
+			"longitude": "-1120424"
+		},
+		"America/Port-au-Prince": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0183200",
+			"longitude": "-0722000"
+		},
+		"America/Port_of_Spain": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0103900",
+			"longitude": "-0613100"
+		},
+		"America/Porto_Velho": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0084600",
+			"longitude": "-0635400"
+		},
+		"America/Puerto_Rico": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0182806",
+			"longitude": "-0660622"
+		},
+		"America/Punta_Arenas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0530900",
+			"longitude": "-0705500"
+		},
+		"America/Rainy_River": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0484300",
+			"longitude": "-0943400"
+		},
+		"America/Rankin_Inlet": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0624900",
+			"longitude": "-0920459"
+		},
+		"America/Recife": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0080300",
+			"longitude": "-0345400"
+		},
+		"America/Regina": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0502400",
+			"longitude": "-1043900"
+		},
+		"America/Resolute": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0744144",
+			"longitude": "-0944945"
+		},
+		"America/Rio_Branco": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0095800",
+			"longitude": "-0674800"
+		},
+		"America/Santarem": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0022600",
+			"longitude": "-0545200"
+		},
+		"America/Santiago": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:20190407T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYMONTHDAY=2,3,4,5,6,7,8;BYDAY=SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:20190908T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYMONTHDAY=2,3,4,5,6,7,8;BYDAY=SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:20180812T000000\r\nRDATE:20180812T000000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:-04\r\nDTSTART:20180513T000000\r\nRDATE:20180513T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0332700",
+			"longitude": "-0704000"
+		},
+		"America/Santo_Domingo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0182800",
+			"longitude": "-0695400"
+		},
+		"America/Sao_Paulo": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:20181104T000000\r\nRDATE:20181104T000000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:20180218T000000\r\nRDATE:20180218T000000\r\nRDATE:20190217T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:19700101T000000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0233200",
+			"longitude": "-0463700"
+		},
+		"America/Scoresbysund": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:19700329T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:-0100\r\nTZNAME:-01\r\nDTSTART:19701025T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0702900",
+			"longitude": "-0215800"
+		},
+		"America/Sitka": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0571035",
+			"longitude": "-1351807"
+		},
+		"America/St_Barthelemy": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0175300",
+			"longitude": "-0625100"
+		},
+		"America/St_Johns": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0230\r\nTZOFFSETTO:-0330\r\nTZNAME:NST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0330\r\nTZOFFSETTO:-0230\r\nTZNAME:NDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0473400",
+			"longitude": "-0524300"
+		},
+		"America/St_Kitts": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0171800",
+			"longitude": "-0624300"
+		},
+		"America/St_Lucia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0140100",
+			"longitude": "-0610000"
+		},
+		"America/St_Thomas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0182100",
+			"longitude": "-0645600"
+		},
+		"America/St_Vincent": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0130900",
+			"longitude": "-0611400"
+		},
+		"America/Swift_Current": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0501700",
+			"longitude": "-1075000"
+		},
+		"America/Tegucigalpa": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0140600",
+			"longitude": "-0871300"
+		},
+		"America/Thule": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0763400",
+			"longitude": "-0684700"
+		},
+		"America/Thunder_Bay": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0482300",
+			"longitude": "-0891500"
+		},
+		"America/Tijuana": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0700\r\nTZNAME:PDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0323200",
+			"longitude": "-1170100"
+		},
+		"America/Toronto": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0400\r\nTZNAME:EDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0500\r\nTZNAME:EST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0433900",
+			"longitude": "-0792300"
+		},
+		"America/Tortola": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0182700",
+			"longitude": "-0643700"
+		},
+		"America/Vancouver": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0700\r\nTZNAME:PDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0491600",
+			"longitude": "-1230700"
+		},
+		"America/Whitehorse": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0700\r\nTZNAME:PDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0800\r\nTZNAME:PST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0604300",
+			"longitude": "-1350300"
+		},
+		"America/Winnipeg": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:CDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:CST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0495300",
+			"longitude": "-0970900"
+		},
+		"America/Yakutat": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0800\r\nTZNAME:AKDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0900\r\nTZNAME:AKST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0593249",
+			"longitude": "-1394338"
+		},
+		"America/Yellowknife": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0700\r\nTZOFFSETTO:-0600\r\nTZNAME:MDT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0700\r\nTZNAME:MST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0622700",
+			"longitude": "-1142100"
+		},
+		"Antarctica/Casey": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:20180311T040000\r\nRDATE:20180311T040000\r\nEND:STANDARD"
+			],
+			"latitude": "-0661700",
+			"longitude": "+1103100"
+		},
+		"Antarctica/Davis": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0683500",
+			"longitude": "+0775800"
+		},
+		"Antarctica/DumontDUrville": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:+10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0664000",
+			"longitude": "+1400100"
+		},
+		"Antarctica/Macquarie": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0543000",
+			"longitude": "+1585700"
+		},
+		"Antarctica/Mawson": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0673600",
+			"longitude": "+0625300"
+		},
+		"Antarctica/McMurdo": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1300\r\nTZNAME:NZDT\r\nDTSTART:19700927T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1200\r\nTZNAME:NZST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0775000",
+			"longitude": "+1663600"
+		},
+		"Antarctica/Palmer": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0644800",
+			"longitude": "-0640600"
+		},
+		"Antarctica/Rothera": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0673400",
+			"longitude": "-0680800"
+		},
+		"Antarctica/Syowa": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0690022",
+			"longitude": "+0393524"
+		},
+		"Antarctica/Troll": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0200\r\nTZNAME:+02\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0720041",
+			"longitude": "+0023206"
+		},
+		"Antarctica/Vostok": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0782400",
+			"longitude": "+1065400"
+		},
+		"Arctic/Longyearbyen": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0780000",
+			"longitude": "+0160000"
+		},
+		"Asia/Aden": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0124500",
+			"longitude": "+0451200"
+		},
+		"Asia/Almaty": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0431500",
+			"longitude": "+0765700"
+		},
+		"Asia/Amman": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700326T235959\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1TH\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701030T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1FR\r\nEND:STANDARD"
+			],
+			"latitude": "+0315700",
+			"longitude": "+0355600"
+		},
+		"Asia/Anadyr": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0644500",
+			"longitude": "+1772900"
+		},
+		"Asia/Aqtau": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0443100",
+			"longitude": "+0501600"
+		},
+		"Asia/Aqtobe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0501700",
+			"longitude": "+0571000"
+		},
+		"Asia/Ashgabat": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0375700",
+			"longitude": "+0582300"
+		},
+		"Asia/Atyrau": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0470700",
+			"longitude": "+0515600"
+		},
+		"Asia/Baghdad": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0332100",
+			"longitude": "+0442500"
+		},
+		"Asia/Bahrain": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0262300",
+			"longitude": "+0503500"
+		},
+		"Asia/Baku": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0402300",
+			"longitude": "+0495100"
+		},
+		"Asia/Bangkok": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0134500",
+			"longitude": "+1003100"
+		},
+		"Asia/Barnaul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0532200",
+			"longitude": "+0834500"
+		},
+		"Asia/Beirut": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0335300",
+			"longitude": "+0353000"
+		},
+		"Asia/Bishkek": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0425400",
+			"longitude": "+0743600"
+		},
+		"Asia/Brunei": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0045600",
+			"longitude": "+1145500"
+		},
+		"Asia/Chita": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:+09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0520300",
+			"longitude": "+1132800"
+		},
+		"Asia/Choibalsan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0480400",
+			"longitude": "+1143000"
+		},
+		"Asia/Colombo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0530\r\nTZOFFSETTO:+0530\r\nTZNAME:+0530\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0065600",
+			"longitude": "+0795100"
+		},
+		"Asia/Damascus": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701030T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1FR\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700327T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1FR\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0333000",
+			"longitude": "+0361800"
+		},
+		"Asia/Dhaka": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0234300",
+			"longitude": "+0902500"
+		},
+		"Asia/Dili": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:+09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0083300",
+			"longitude": "+1253500"
+		},
+		"Asia/Dubai": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0251800",
+			"longitude": "+0551800"
+		},
+		"Asia/Dushanbe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0383500",
+			"longitude": "+0684800"
+		},
+		"Asia/Famagusta": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:20180325T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0350700",
+			"longitude": "+0335700"
+		},
+		"Asia/Gaza": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701031T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SA\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:20190329T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1FR\r\nEND:DAYLIGHT",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:20180324T010000\r\nRDATE:20180324T010000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0313000",
+			"longitude": "+0342800"
+		},
+		"Asia/Hebron": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701031T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SA\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:20190329T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1FR\r\nEND:DAYLIGHT",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:20180324T010000\r\nRDATE:20180324T010000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0313200",
+			"longitude": "+0350542"
+		},
+		"Asia/Ho_Chi_Minh": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0104500",
+			"longitude": "+1064000"
+		},
+		"Asia/Hong_Kong": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:HKT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0221700",
+			"longitude": "+1140900"
+		},
+		"Asia/Hovd": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0480100",
+			"longitude": "+0913900"
+		},
+		"Asia/Irkutsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0521600",
+			"longitude": "+1042000"
+		},
+		"Asia/Istanbul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0410100",
+			"longitude": "+0285800"
+		},
+		"Asia/Jakarta": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:WIB\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0061000",
+			"longitude": "+1064800"
+		},
+		"Asia/Jayapura": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:WIT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0023200",
+			"longitude": "+1404200"
+		},
+		"Asia/Jerusalem": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:IDT\r\nDTSTART:19700327T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=23,24,25,26,27,28,29;BYDAY=FR\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:IST\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0314650",
+			"longitude": "+0351326"
+		},
+		"Asia/Kabul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0430\r\nTZOFFSETTO:+0430\r\nTZNAME:+0430\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0343100",
+			"longitude": "+0691200"
+		},
+		"Asia/Kamchatka": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0530100",
+			"longitude": "+1583900"
+		},
+		"Asia/Karachi": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:PKT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0245200",
+			"longitude": "+0670300"
+		},
+		"Asia/Kathmandu": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0545\r\nTZOFFSETTO:+0545\r\nTZNAME:+0545\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0274300",
+			"longitude": "+0851900"
+		},
+		"Asia/Khandyga": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:+09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0623923",
+			"longitude": "+1353314"
+		},
+		"Asia/Kolkata": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0530\r\nTZOFFSETTO:+0530\r\nTZNAME:IST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0223200",
+			"longitude": "+0882200"
+		},
+		"Asia/Krasnoyarsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0560100",
+			"longitude": "+0925000"
+		},
+		"Asia/Kuala_Lumpur": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0031000",
+			"longitude": "+1014200"
+		},
+		"Asia/Kuching": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0013300",
+			"longitude": "+1102000"
+		},
+		"Asia/Kuwait": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0292000",
+			"longitude": "+0475900"
+		},
+		"Asia/Macau": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0221150",
+			"longitude": "+1133230"
+		},
+		"Asia/Magadan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0593400",
+			"longitude": "+1504800"
+		},
+		"Asia/Makassar": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:WITA\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0050700",
+			"longitude": "+1192400"
+		},
+		"Asia/Manila": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:PST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0143500",
+			"longitude": "+1210000"
+		},
+		"Asia/Muscat": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0233600",
+			"longitude": "+0583500"
+		},
+		"Asia/Nicosia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0351000",
+			"longitude": "+0332200"
+		},
+		"Asia/Novokuznetsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0534500",
+			"longitude": "+0870700"
+		},
+		"Asia/Novosibirsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0550200",
+			"longitude": "+0825500"
+		},
+		"Asia/Omsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0550000",
+			"longitude": "+0732400"
+		},
+		"Asia/Oral": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0511300",
+			"longitude": "+0512100"
+		},
+		"Asia/Phnom_Penh": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0113300",
+			"longitude": "+1045500"
+		},
+		"Asia/Pontianak": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:WIB\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0000200",
+			"longitude": "+1092000"
+		},
+		"Asia/Pyongyang": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0830\r\nTZNAME:KST\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0830\r\nTZOFFSETTO:+0900\r\nTZNAME:KST\r\nDTSTART:20180504T233000\r\nRDATE:20180504T233000\r\nEND:STANDARD"
+			],
+			"latitude": "+0390100",
+			"longitude": "+1254500"
+		},
+		"Asia/Qatar": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0251700",
+			"longitude": "+0513200"
+		},
+		"Asia/Qostanay": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0531200",
+			"longitude": "+0633700"
+		},
+		"Asia/Qyzylorda": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:20181221T000000\r\nRDATE:20181221T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0444800",
+			"longitude": "+0652800"
+		},
+		"Asia/Riyadh": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0243800",
+			"longitude": "+0464300"
+		},
+		"Asia/Sakhalin": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0465800",
+			"longitude": "+1424200"
+		},
+		"Asia/Samarkand": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0394000",
+			"longitude": "+0664800"
+		},
+		"Asia/Seoul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:KST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0373300",
+			"longitude": "+1265800"
+		},
+		"Asia/Shanghai": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0311400",
+			"longitude": "+1212800"
+		},
+		"Asia/Singapore": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0011700",
+			"longitude": "+1035100"
+		},
+		"Asia/Srednekolymsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0672800",
+			"longitude": "+1534300"
+		},
+		"Asia/Taipei": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:CST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0250300",
+			"longitude": "+1213000"
+		},
+		"Asia/Tashkent": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0412000",
+			"longitude": "+0691800"
+		},
+		"Asia/Tbilisi": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0414300",
+			"longitude": "+0444900"
+		},
+		"Asia/Tehran": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0330\r\nTZNAME:+0330\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0330\r\nTZOFFSETTO:+0430\r\nTZNAME:+0430\r\nDTSTART:20180321T235959\r\nRDATE:20180321T235959\r\nRDATE:20190321T235959\r\nRDATE:20200320T235959\r\nRDATE:20210321T235959\r\nRDATE:20220321T235959\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0430\r\nTZOFFSETTO:+0330\r\nTZNAME:+0330\r\nDTSTART:20180921T235959\r\nRDATE:20180921T235959\r\nRDATE:20190921T235959\r\nRDATE:20200920T235959\r\nRDATE:20210921T235959\r\nRDATE:20220921T235959\r\nEND:STANDARD"
+			],
+			"latitude": "+0354000",
+			"longitude": "+0512600"
+		},
+		"Asia/Thimphu": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0272800",
+			"longitude": "+0893900"
+		},
+		"Asia/Tokyo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:JST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0353916",
+			"longitude": "+1394441"
+		},
+		"Asia/Tomsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0563000",
+			"longitude": "+0845800"
+		},
+		"Asia/Ulaanbaatar": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:+08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0475500",
+			"longitude": "+1065300"
+		},
+		"Asia/Urumqi": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0434800",
+			"longitude": "+0873500"
+		},
+		"Asia/Ust-Nera": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:+10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0643337",
+			"longitude": "+1431336"
+		},
+		"Asia/Vientiane": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0175800",
+			"longitude": "+1023600"
+		},
+		"Asia/Vladivostok": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:+10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0431000",
+			"longitude": "+1315600"
+		},
+		"Asia/Yakutsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:+09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0620000",
+			"longitude": "+1294000"
+		},
+		"Asia/Yangon": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0630\r\nTZOFFSETTO:+0630\r\nTZNAME:+0630\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0164700",
+			"longitude": "+0961000"
+		},
+		"Asia/Yekaterinburg": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0565100",
+			"longitude": "+0603600"
+		},
+		"Asia/Yerevan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0401100",
+			"longitude": "+0443000"
+		},
+		"Atlantic/Azores": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0100\r\nTZOFFSETTO:+0000\r\nTZNAME:+00\r\nDTSTART:19700329T000000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:-0100\r\nTZNAME:-01\r\nDTSTART:19701025T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0374400",
+			"longitude": "-0254000"
+		},
+		"Atlantic/Bermuda": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0300\r\nTZNAME:ADT\r\nDTSTART:19700308T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0400\r\nTZNAME:AST\r\nDTSTART:19701101T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0321700",
+			"longitude": "-0644600"
+		},
+		"Atlantic/Canary": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:WEST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:WET\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0280600",
+			"longitude": "-0152400"
+		},
+		"Atlantic/Cape_Verde": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0100\r\nTZOFFSETTO:-0100\r\nTZNAME:-01\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0145500",
+			"longitude": "-0233100"
+		},
+		"Atlantic/Faroe": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:WEST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:WET\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0620100",
+			"longitude": "-0064600"
+		},
+		"Atlantic/Madeira": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:WEST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:WET\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0323800",
+			"longitude": "-0165400"
+		},
+		"Atlantic/Reykjavik": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0640900",
+			"longitude": "-0215100"
+		},
+		"Atlantic/South_Georgia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0200\r\nTZOFFSETTO:-0200\r\nTZNAME:-02\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0541600",
+			"longitude": "-0363200"
+		},
+		"Atlantic/St_Helena": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0155500",
+			"longitude": "-0054200"
+		},
+		"Atlantic/Stanley": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0300\r\nTZOFFSETTO:-0300\r\nTZNAME:-03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0514200",
+			"longitude": "-0575100"
+		},
+		"Australia/Adelaide": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1030\r\nTZOFFSETTO:+0930\r\nTZNAME:ACST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0930\r\nTZOFFSETTO:+1030\r\nTZNAME:ACDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0345500",
+			"longitude": "+1383500"
+		},
+		"Australia/Brisbane": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0272800",
+			"longitude": "+1530200"
+		},
+		"Australia/Broken_Hill": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1030\r\nTZOFFSETTO:+0930\r\nTZNAME:ACST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0930\r\nTZOFFSETTO:+1030\r\nTZNAME:ACDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0315700",
+			"longitude": "+1412700"
+		},
+		"Australia/Currie": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1100\r\nTZNAME:AEDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0395600",
+			"longitude": "+1435200"
+		},
+		"Australia/Darwin": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0930\r\nTZOFFSETTO:+0930\r\nTZNAME:ACST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0122800",
+			"longitude": "+1305000"
+		},
+		"Australia/Eucla": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0845\r\nTZOFFSETTO:+0845\r\nTZNAME:+0845\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0314300",
+			"longitude": "+1285200"
+		},
+		"Australia/Hobart": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1100\r\nTZNAME:AEDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0425300",
+			"longitude": "+1471900"
+		},
+		"Australia/Lindeman": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0201600",
+			"longitude": "+1490000"
+		},
+		"Australia/Lord_Howe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1030\r\nTZNAME:+1030\r\nDTSTART:19700405T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1030\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0313300",
+			"longitude": "+1590500"
+		},
+		"Australia/Melbourne": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1100\r\nTZNAME:AEDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0374900",
+			"longitude": "+1445800"
+		},
+		"Australia/Perth": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0800\r\nTZOFFSETTO:+0800\r\nTZNAME:AWST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0315700",
+			"longitude": "+1155100"
+		},
+		"Australia/Sydney": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1000\r\nTZNAME:AEST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1100\r\nTZNAME:AEDT\r\nDTSTART:19701004T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0335200",
+			"longitude": "+1511300"
+		},
+		"Europe/Amsterdam": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0522200",
+			"longitude": "+0045400"
+		},
+		"Europe/Andorra": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0423000",
+			"longitude": "+0013100"
+		},
+		"Europe/Astrakhan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0462100",
+			"longitude": "+0480300"
+		},
+		"Europe/Athens": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0375800",
+			"longitude": "+0234300"
+		},
+		"Europe/Belgrade": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0445000",
+			"longitude": "+0203000"
+		},
+		"Europe/Berlin": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0523000",
+			"longitude": "+0132200"
+		},
+		"Europe/Bratislava": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0480900",
+			"longitude": "+0170700"
+		},
+		"Europe/Brussels": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0505000",
+			"longitude": "+0042000"
+		},
+		"Europe/Bucharest": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0442600",
+			"longitude": "+0260600"
+		},
+		"Europe/Budapest": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0473000",
+			"longitude": "+0190500"
+		},
+		"Europe/Busingen": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0474200",
+			"longitude": "+0084100"
+		},
+		"Europe/Chisinau": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0470000",
+			"longitude": "+0285000"
+		},
+		"Europe/Copenhagen": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0554000",
+			"longitude": "+0123500"
+		},
+		"Europe/Dublin": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:IST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0532000",
+			"longitude": "-0061500"
+		},
+		"Europe/Gibraltar": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0360800",
+			"longitude": "-0052100"
+		},
+		"Europe/Guernsey": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:BST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0492717",
+			"longitude": "-0023210"
+		},
+		"Europe/Helsinki": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0601000",
+			"longitude": "+0245800"
+		},
+		"Europe/Isle_of_Man": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:BST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0540900",
+			"longitude": "-0042800"
+		},
+		"Europe/Istanbul": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0410100",
+			"longitude": "+0285800"
+		},
+		"Europe/Jersey": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:BST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0491101",
+			"longitude": "-0020624"
+		},
+		"Europe/Kaliningrad": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0544300",
+			"longitude": "+0203000"
+		},
+		"Europe/Kiev": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0502600",
+			"longitude": "+0303100"
+		},
+		"Europe/Kirov": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0583600",
+			"longitude": "+0493900"
+		},
+		"Europe/Lisbon": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:WET\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:WEST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0384300",
+			"longitude": "-0090800"
+		},
+		"Europe/Ljubljana": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0460300",
+			"longitude": "+0143100"
+		},
+		"Europe/London": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0100\r\nTZNAME:BST\r\nDTSTART:19700329T010000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0000\r\nTZNAME:GMT\r\nDTSTART:19701025T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0513030",
+			"longitude": "+0000731"
+		},
+		"Europe/Luxembourg": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0493600",
+			"longitude": "+0060900"
+		},
+		"Europe/Madrid": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0402400",
+			"longitude": "-0034100"
+		},
+		"Europe/Malta": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0355400",
+			"longitude": "+0143100"
+		},
+		"Europe/Mariehamn": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0600600",
+			"longitude": "+0195700"
+		},
+		"Europe/Minsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0535400",
+			"longitude": "+0273400"
+		},
+		"Europe/Monaco": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0434200",
+			"longitude": "+0072300"
+		},
+		"Europe/Moscow": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:MSK\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0554521",
+			"longitude": "+0373704"
+		},
+		"Europe/Nicosia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "+0351000",
+			"longitude": "+0332200"
+		},
+		"Europe/Oslo": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0595500",
+			"longitude": "+0104500"
+		},
+		"Europe/Paris": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0485200",
+			"longitude": "+0022000"
+		},
+		"Europe/Podgorica": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0422600",
+			"longitude": "+0191600"
+		},
+		"Europe/Prague": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0500500",
+			"longitude": "+0142600"
+		},
+		"Europe/Riga": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0565700",
+			"longitude": "+0240600"
+		},
+		"Europe/Rome": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0415400",
+			"longitude": "+0122900"
+		},
+		"Europe/Samara": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0531200",
+			"longitude": "+0500900"
+		},
+		"Europe/San_Marino": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0435500",
+			"longitude": "+0122800"
+		},
+		"Europe/Sarajevo": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0435200",
+			"longitude": "+0182500"
+		},
+		"Europe/Saratov": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0513400",
+			"longitude": "+0460200"
+		},
+		"Europe/Simferopol": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:MSK\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0445700",
+			"longitude": "+0340600"
+		},
+		"Europe/Skopje": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0415900",
+			"longitude": "+0212600"
+		},
+		"Europe/Sofia": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0424100",
+			"longitude": "+0231900"
+		},
+		"Europe/Stockholm": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0592000",
+			"longitude": "+0180300"
+		},
+		"Europe/Tallinn": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0592500",
+			"longitude": "+0244500"
+		},
+		"Europe/Tirane": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0412000",
+			"longitude": "+0195000"
+		},
+		"Europe/Ulyanovsk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0542000",
+			"longitude": "+0482400"
+		},
+		"Europe/Uzhgorod": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0483700",
+			"longitude": "+0221800"
+		},
+		"Europe/Vaduz": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0470900",
+			"longitude": "+0093100"
+		},
+		"Europe/Vatican": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0415408",
+			"longitude": "+0122711"
+		},
+		"Europe/Vienna": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0481300",
+			"longitude": "+0162000"
+		},
+		"Europe/Vilnius": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0544100",
+			"longitude": "+0251900"
+		},
+		"Europe/Volgograd": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:20181028T020000\r\nRDATE:20181028T020000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0300\r\nTZNAME:+03\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0484400",
+			"longitude": "+0442500"
+		},
+		"Europe/Warsaw": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0521500",
+			"longitude": "+0210000"
+		},
+		"Europe/Zagreb": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0454800",
+			"longitude": "+0155800"
+		},
+		"Europe/Zaporozhye": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0300\r\nTZNAME:EEST\r\nDTSTART:19700329T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0200\r\nTZNAME:EET\r\nDTSTART:19701025T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0475000",
+			"longitude": "+0351000"
+		},
+		"Europe/Zurich": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nTZNAME:CEST\r\nDTSTART:19700329T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nTZNAME:CET\r\nDTSTART:19701025T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\nEND:STANDARD"
+			],
+			"latitude": "+0472300",
+			"longitude": "+0083200"
+		},
+		"Indian/Antananarivo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0185500",
+			"longitude": "+0473100"
+		},
+		"Indian/Chagos": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0600\r\nTZOFFSETTO:+0600\r\nTZNAME:+06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0072000",
+			"longitude": "+0722500"
+		},
+		"Indian/Christmas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0700\r\nTZOFFSETTO:+0700\r\nTZNAME:+07\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0102500",
+			"longitude": "+1054300"
+		},
+		"Indian/Cocos": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0630\r\nTZOFFSETTO:+0630\r\nTZNAME:+0630\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0121000",
+			"longitude": "+0965500"
+		},
+		"Indian/Comoro": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0114100",
+			"longitude": "+0431600"
+		},
+		"Indian/Kerguelen": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0492110",
+			"longitude": "+0701303"
+		},
+		"Indian/Mahe": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0044000",
+			"longitude": "+0552800"
+		},
+		"Indian/Maldives": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0500\r\nTZOFFSETTO:+0500\r\nTZNAME:+05\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0041000",
+			"longitude": "+0733000"
+		},
+		"Indian/Mauritius": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0201000",
+			"longitude": "+0573000"
+		},
+		"Indian/Mayotte": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0300\r\nTZOFFSETTO:+0300\r\nTZNAME:EAT\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0124700",
+			"longitude": "+0451400"
+		},
+		"Indian/Reunion": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0400\r\nTZOFFSETTO:+0400\r\nTZNAME:+04\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0205200",
+			"longitude": "+0552800"
+		},
+		"Pacific/Apia": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1400\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:19700405T040000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1400\r\nTZNAME:+14\r\nDTSTART:19700927T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=-1SU\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0135000",
+			"longitude": "-1714400"
+		},
+		"Pacific/Auckland": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1300\r\nTZNAME:NZDT\r\nDTSTART:19700927T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1200\r\nTZNAME:NZST\r\nDTSTART:19700405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0365200",
+			"longitude": "+1744600"
+		},
+		"Pacific/Bougainville": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0061300",
+			"longitude": "+1553400"
+		},
+		"Pacific/Chatham": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1245\r\nTZOFFSETTO:+1345\r\nTZNAME:+1345\r\nDTSTART:19700927T024500\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=-1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1345\r\nTZOFFSETTO:+1245\r\nTZNAME:+1245\r\nDTSTART:19700405T034500\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD"
+			],
+			"latitude": "-0435700",
+			"longitude": "-1763300"
+		},
+		"Pacific/Chuuk": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:+10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0072500",
+			"longitude": "+1514700"
+		},
+		"Pacific/Easter": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:-06\r\nDTSTART:20190406T220000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SA\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:20190907T220000\r\nRRULE:FREQ=YEARLY;BYMONTH=9;BYDAY=1SA\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:-06\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0500\r\nTZNAME:-05\r\nDTSTART:20180811T220000\r\nRDATE:20180811T220000\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0500\r\nTZOFFSETTO:-0600\r\nTZNAME:-06\r\nDTSTART:20180512T220000\r\nRDATE:20180512T220000\r\nEND:STANDARD"
+			],
+			"latitude": "-0270900",
+			"longitude": "-1092600"
+		},
+		"Pacific/Efate": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0174000",
+			"longitude": "+1682500"
+		},
+		"Pacific/Enderbury": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0030800",
+			"longitude": "-1710500"
+		},
+		"Pacific/Fakaofo": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0092200",
+			"longitude": "-1711400"
+		},
+		"Pacific/Fiji": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700118T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=12,13,14,15,16,17,18;BYDAY=SU\r\nEND:STANDARD",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:20191110T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=2SU\r\nEND:DAYLIGHT",
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:20181104T020000\r\nRDATE:20181104T020000\r\nEND:DAYLIGHT"
+			],
+			"latitude": "-0180800",
+			"longitude": "+1782500"
+		},
+		"Pacific/Funafuti": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0083100",
+			"longitude": "+1791300"
+		},
+		"Pacific/Galapagos": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0600\r\nTZOFFSETTO:-0600\r\nTZNAME:-06\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0005400",
+			"longitude": "-0893600"
+		},
+		"Pacific/Gambier": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0900\r\nTZOFFSETTO:-0900\r\nTZNAME:-09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0230800",
+			"longitude": "-1345700"
+		},
+		"Pacific/Guadalcanal": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0093200",
+			"longitude": "+1601200"
+		},
+		"Pacific/Guam": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:ChST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0132800",
+			"longitude": "+1444500"
+		},
+		"Pacific/Honolulu": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1000\r\nTZOFFSETTO:-1000\r\nTZNAME:HST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0211825",
+			"longitude": "-1575130"
+		},
+		"Pacific/Kiritimati": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1400\r\nTZOFFSETTO:+1400\r\nTZNAME:+14\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0015200",
+			"longitude": "-1572000"
+		},
+		"Pacific/Kosrae": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0051900",
+			"longitude": "+1625900"
+		},
+		"Pacific/Kwajalein": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0090500",
+			"longitude": "+1672000"
+		},
+		"Pacific/Majuro": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0070900",
+			"longitude": "+1711200"
+		},
+		"Pacific/Marquesas": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0930\r\nTZOFFSETTO:-0930\r\nTZNAME:-0930\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0090000",
+			"longitude": "-1393000"
+		},
+		"Pacific/Midway": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1100\r\nTZOFFSETTO:-1100\r\nTZNAME:SST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0281300",
+			"longitude": "-1772200"
+		},
+		"Pacific/Nauru": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0003100",
+			"longitude": "+1665500"
+		},
+		"Pacific/Niue": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1100\r\nTZOFFSETTO:-1100\r\nTZNAME:-11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0190100",
+			"longitude": "-1695500"
+		},
+		"Pacific/Norfolk": {
+			"ics": [
+				"BEGIN:DAYLIGHT\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:20191006T020000\r\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU\r\nEND:DAYLIGHT",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:20200405T030000\r\nRRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1130\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD",
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:20190701T000000\r\nRDATE:20190701T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0290300",
+			"longitude": "+1675800"
+		},
+		"Pacific/Noumea": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0221600",
+			"longitude": "+1662700"
+		},
+		"Pacific/Pago_Pago": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1100\r\nTZOFFSETTO:-1100\r\nTZNAME:SST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0141600",
+			"longitude": "-1704200"
+		},
+		"Pacific/Palau": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+0900\r\nTZOFFSETTO:+0900\r\nTZNAME:+09\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0072000",
+			"longitude": "+1342900"
+		},
+		"Pacific/Pitcairn": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-0800\r\nTZOFFSETTO:-0800\r\nTZNAME:-08\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0250400",
+			"longitude": "-1300500"
+		},
+		"Pacific/Pohnpei": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1100\r\nTZOFFSETTO:+1100\r\nTZNAME:+11\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0065800",
+			"longitude": "+1581300"
+		},
+		"Pacific/Port_Moresby": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:+10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0093000",
+			"longitude": "+1471000"
+		},
+		"Pacific/Rarotonga": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1000\r\nTZOFFSETTO:-1000\r\nTZNAME:-10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0211400",
+			"longitude": "-1594600"
+		},
+		"Pacific/Saipan": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1000\r\nTZOFFSETTO:+1000\r\nTZNAME:ChST\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0151200",
+			"longitude": "+1454500"
+		},
+		"Pacific/Tahiti": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:-1000\r\nTZOFFSETTO:-1000\r\nTZNAME:-10\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0173200",
+			"longitude": "-1493400"
+		},
+		"Pacific/Tarawa": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0012500",
+			"longitude": "+1730000"
+		},
+		"Pacific/Tongatapu": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1300\r\nTZOFFSETTO:+1300\r\nTZNAME:+13\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0211000",
+			"longitude": "-1751000"
+		},
+		"Pacific/Wake": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "+0191700",
+			"longitude": "+1663700"
+		},
+		"Pacific/Wallis": {
+			"ics": [
+				"BEGIN:STANDARD\r\nTZOFFSETFROM:+1200\r\nTZOFFSETTO:+1200\r\nTZNAME:+12\r\nDTSTART:19700101T000000\r\nEND:STANDARD"
+			],
+			"latitude": "-0131800",
+			"longitude": "-1761000"
+		}
+	}
+}


### PR DESCRIPTION
The personal calendar created at the user's first login does not hold a timezone property. This leads to reminders being sent using server time instead of the user's timezone, since the calendar has no tz information.
See https://github.com/nextcloud/calendar/issues/4778 for extra context.

The vtimezone ICS data comes from the @nextcloud/calendar-js library, https://github.com/nextcloud/calendar-js/tree/main/resources/timezones, which uses a python script to generate the vtimezone files from the data produced by https://github.com/libical/vzic (which in turn uses data from IANA's tzdata).

A few months ago, Mozilla switched to using
https://hg.mozilla.org/comm-central/rev/2b430305eaf46970d62e9569e1800d5c4be9071c ICU4C directly (see icu::VTimeZone::createVTimeZoneByID), and seems to produce data dynamically instead (with a cache). This allows them to avoid manual intervention to refresh data, and they say it also includes more valid timezones. See https://bugzilla.mozilla.org/show_bug.cgi?id=1794029

In any case, we need a proper way to update the timezone database regularly (this data is already 4 years old).

## TODO

- [ ] Fix tests
- [ ] Check other uses of `createCalendar`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
