### PR TITLE
fix(sharing): Remove casting to int from INF

### DIFF
--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -139,7 +139,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 			if ($freeSpace < FileInfo::SPACE_UNLIMITED) {
 				$freeSpace = (int)max($freeSpace, 0);
 			} else {
-				$freeSpace = (int)((INF > 0) ? INF: PHP_INT_MAX); // work around https://bugs.php.net/bug.php?id=69188
+				$freeSpace = (INF > 0) ? INF: PHP_INT_MAX; // work around https://bugs.php.net/bug.php?id=69188
 			}
 
 			$hideFileList = !($share->getPermissions() & Constants::PERMISSION_READ);


### PR DESCRIPTION
Regression from nextcloud/server#35736
INF is a **the** float value `INF`, casting it to integer will make it 0
https://3v4l.org/IH4Xc

* Resolves: #36510 

Before | After
---|---
❌ Red acceptance/features/app-files-sharing-link.feature | 🟢 Green acceptance/features/app-files-sharing-link.feature
![Bildschirmfoto vom 2023-02-03 15-53-33](https://user-images.githubusercontent.com/213943/216634111-a77f4e34-fd46-4337-82d7-d5b59125790d.png) | ![Bildschirmfoto vom 2023-02-03 15-53-23](https://user-images.githubusercontent.com/213943/216634114-31fd6b1d-2880-42c9-84e2-e324f874dc5b.png)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
