### PR TITLE
fix(client-login-flow): Handle missing stateToken gracefully

### DIFF
--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -150,7 +150,10 @@ class ClientFlowLoginV2Controller extends Controller {
 	 * @NoSameSiteCookieRequired
 	 */
 	#[UseSession]
-	public function grantPage(string $stateToken): StandaloneTemplateResponse {
+	public function grantPage(?string $stateToken): StandaloneTemplateResponse {
+		if ($stateToken === null) {
+			return $this->stateTokenMissingResponse();
+		}
 		if (!$this->isValidStateToken($stateToken)) {
 			return $this->stateTokenForbiddenResponse();
 		}
@@ -182,7 +185,11 @@ class ClientFlowLoginV2Controller extends Controller {
 	/**
 	 * @PublicPage
 	 */
-	public function apptokenRedirect(string $stateToken, string $user, string $password) {
+	public function apptokenRedirect(?string $stateToken, string $user, string $password) {
+		if ($stateToken === null) {
+			return $this->loginTokenForbiddenResponse();
+		}
+
 		if (!$this->isValidStateToken($stateToken)) {
 			return $this->stateTokenForbiddenResponse();
 		}
@@ -225,7 +232,10 @@ class ClientFlowLoginV2Controller extends Controller {
 	 * @NoAdminRequired
 	 */
 	#[UseSession]
-	public function generateAppPassword(string $stateToken): Response {
+	public function generateAppPassword(?string $stateToken): Response {
+		if ($stateToken === null) {
+			return $this->stateTokenMissingResponse();
+		}
 		if (!$this->isValidStateToken($stateToken)) {
 			return $this->stateTokenForbiddenResponse();
 		}
@@ -296,6 +306,19 @@ class ClientFlowLoginV2Controller extends Controller {
 			return false;
 		}
 		return hash_equals($currentToken, $stateToken);
+	}
+
+	private function stateTokenMissingResponse(): StandaloneTemplateResponse {
+		$response = new StandaloneTemplateResponse(
+			$this->appName,
+			'403',
+			[
+				'message' => $this->l10n->t('State token missing'),
+			],
+			'guest'
+		);
+		$response->setStatus(Http::STATUS_FORBIDDEN);
+		return $response;
 	}
 
 	private function stateTokenForbiddenResponse(): StandaloneTemplateResponse {

--- a/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
@@ -187,6 +187,12 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 		$this->controller->showAuthPickerPage();
 	}
 
+	public function testGrantPageNoStateToken(): void {
+		$result = $this->controller->grantPage(null);
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+	}
+
 	public function testGrantPageInvalidStateToken() {
 		$this->session->method('get')
 			->willReturnCallback(function ($name) {


### PR DESCRIPTION
* Resolves: ``OC\\Core\\Controller\\ClientFlowLoginV2Controller::grantPage(): Argument #1 ($stateToken) must be of type string, null given``

## Summary

1) Open `/login/v2/grant`

Master: :boom: 
Here: :sunglasses: 

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
