### PR TITLE
fix(authtoken): Store only one hash for authtokens with the current password per user

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -229,4 +229,31 @@ class PublicKeyTokenMapper extends QBMapper {
 			);
 		$update->executeStatement();
 	}
+
+	public function updateHashesForUser(string $userId, string $passwordHash): void {
+		$qb = $this->db->getQueryBuilder();
+		$update = $qb->update($this->getTableName())
+			->set('password_hash', $qb->createNamedParameter($passwordHash))
+			->where(
+				$qb->expr()->eq('uid', $qb->createNamedParameter($userId))
+			);
+		$update->executeStatement();
+	}
+
+	public function getFirstTokenForUser(string $userId): ?PublicKeyToken {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('uid', $qb->createNamedParameter($userId)))
+			->setMaxResults(1)
+			->orderBy('id');
+		$result = $qb->executeQuery();
+
+		$data = $result->fetch();
+		$result->closeCursor();
+		if ($data === false) {
+			return null;
+		}
+		return PublicKeyToken::fromRow($data);
+	}
 }


### PR DESCRIPTION
Checking auth token hashes takes quite some time. We can avoid checking each of them if we make sure that the same password also uses the same hash so we can quickly confirm that they do not need updates by just verifying one hash.

Waiting for CI at https://drone.nextcloud.com/nextcloud/spreed/11676/1/4