### PR TITLE
dont delegate Mount\Manager::getByNumericId to getByStorageId

### DIFF
--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -184,8 +184,13 @@ class Manager implements IMountManager {
 	 * @return IMountPoint[]
 	 */
 	public function findByNumericId(int $id): array {
-		$storageId = \OC\Files\Cache\Storage::getStorageId($id);
-		return $this->findByStorageId($storageId);
+		$result = [];
+		foreach ($this->mounts as $mount) {
+			if ($mount->getNumericStorageId() === $id) {
+				$result[] = $mount;
+			}
+		}
+		return $result;
 	}
 
 	/**

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -196,11 +196,15 @@ class MountPoint implements IMountPoint {
 	}
 
 	/**
-	 * @return string
+	 * @return string|null
 	 */
 	public function getStorageId() {
 		if (!$this->storageId) {
-			$this->storageId = $this->getStorage()->getId();
+			$storage = $this->getStorage();
+			if (is_null($storage)) {
+				return null;
+			}
+			$this->storageId = $storage->getId();
 			if (strlen($this->storageId) > 64) {
 				$this->storageId = md5($this->storageId);
 			}
@@ -213,7 +217,11 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getNumericStorageId() {
 		if (is_null($this->numericStorageId)) {
-			$this->numericStorageId = $this->getStorage()->getStorageCache()->getNumericId();
+			$storage = $this->getStorage();
+			if (is_null($storage)) {
+				return -1;
+			}
+			$this->numericStorageId = $storage->getStorageCache()->getNumericId();
 		}
 		return $this->numericStorageId;
 	}

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -44,6 +44,7 @@ class MountPoint implements IMountPoint {
 	protected $storage = null;
 	protected $class;
 	protected $storageId;
+	protected $numericStorageId = null;
 	protected $rootId = null;
 
 	/**
@@ -211,7 +212,10 @@ class MountPoint implements IMountPoint {
 	 * @return int
 	 */
 	public function getNumericStorageId() {
-		return $this->getStorage()->getStorageCache()->getNumericId();
+		if (is_null($this->numericStorageId)) {
+			$this->numericStorageId = $this->getStorage()->getStorageCache()->getNumericId();
+		}
+		return $this->numericStorageId;
 	}
 
 	/**

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -199,15 +199,7 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getStorageId() {
 		if (!$this->storageId) {
-			if (is_null($this->storage)) {
-				$storage = $this->createStorage(); //FIXME: start using exceptions
-				if (is_null($storage)) {
-					return null;
-				}
-
-				$this->storage = $storage;
-			}
-			$this->storageId = $this->storage->getId();
+			$this->storageId = $this->getStorage()->getId();
 			if (strlen($this->storageId) > 64) {
 				$this->storageId = md5($this->storageId);
 			}

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -55,7 +55,7 @@ interface IMountPoint {
 	/**
 	 * Get the id of the storages
 	 *
-	 * @return string
+	 * @return string|null
 	 * @since 8.0.0
 	 */
 	public function getStorageId();
@@ -63,7 +63,7 @@ interface IMountPoint {
 	/**
 	 * Get the id of the storages
 	 *
-	 * @return int
+	 * @return int|null
 	 * @since 9.1.0
 	 */
 	public function getNumericStorageId();

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1590,6 +1590,9 @@ class ViewTest extends \Test\TestCase {
 				->setConstructorArgs([[]])
 				->getMock();
 			$storage->method('getId')->willReturn('non-null-id');
+			$storage->method('getStorageCache')->willReturnCallback(function () use ($storage) {
+				return new \OC\Files\Cache\Storage($storage);
+			});
 
 			$mounts[] = $this->getMockBuilder(TestMoveableMountPoint::class)
 				->setMethods(['moveMount'])


### PR DESCRIPTION
Should be faster than getting the string storage id

Also includes a bonus cleanup of `getByStorageId`