### PR TITLE
provisioning_api: Add OpenAPI spec

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Provisioning_API\Controller;
 
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
@@ -67,13 +68,13 @@ class AppConfigController extends OCSController {
 	 * @param IAppConfig $appConfig
 	 */
 	public function __construct(string $appName,
-								IRequest $request,
-								IConfig $config,
-								IAppConfig $appConfig,
-								IUserSession $userSession,
-								IL10N $l10n,
-								IGroupManager $groupManager,
-								IManager $settingManager) {
+		IRequest $request,
+		IConfig $config,
+		IAppConfig $appConfig,
+		IUserSession $userSession,
+		IL10N $l10n,
+		IGroupManager $groupManager,
+		IManager $settingManager) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->appConfig = $appConfig;
@@ -84,7 +85,7 @@ class AppConfigController extends OCSController {
 	}
 
 	/**
-	 * @return DataResponse
+	 * @return DataResponse<array{data: string[]}> 200
 	 */
 	public function getApps(): DataResponse {
 		return new DataResponse([
@@ -94,7 +95,8 @@ class AppConfigController extends OCSController {
 
 	/**
 	 * @param string $app
-	 * @return DataResponse
+	 * @return DataResponse<array{data: string[]}> 200
+	 * @return DataResponse<array{data: array{message: string}}> 403
 	 */
 	public function getKeys(string $app): DataResponse {
 		try {
@@ -111,7 +113,8 @@ class AppConfigController extends OCSController {
 	 * @param string $app
 	 * @param string $key
 	 * @param string $defaultValue
-	 * @return DataResponse
+	 * @return DataResponse<array{data: string}> 200
+	 * @return DataResponse<array{data: array{message: string}}> 403
 	 */
 	public function getValue(string $app, string $key, string $defaultValue = ''): DataResponse {
 		try {
@@ -131,7 +134,8 @@ class AppConfigController extends OCSController {
 	 * @param string $app
 	 * @param string $key
 	 * @param string $value
-	 * @return DataResponse
+	 * @return DataResponse 200
+	 * @return DataResponse<array{data: array{message: string}}> 403
 	 */
 	public function setValue(string $app, string $key, string $value): DataResponse {
 		$user = $this->userSession->getUser();
@@ -158,7 +162,8 @@ class AppConfigController extends OCSController {
 	 * @PasswordConfirmationRequired
 	 * @param string $app
 	 * @param string $key
-	 * @return DataResponse
+	 * @return DataResponse 200
+	 * @return DataResponse<array{data: array{message: string}}> 403
 	 */
 	public function deleteKey(string $app, string $key): DataResponse {
 		try {

--- a/apps/provisioning_api/lib/Controller/AppsController.php
+++ b/apps/provisioning_api/lib/Controller/AppsController.php
@@ -26,9 +26,11 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\Provisioning_API\Controller;
 
 use OC_App;
+use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\DataResponse;
@@ -52,7 +54,7 @@ class AppsController extends OCSController {
 
 	/**
 	 * @param string|null $filter
-	 * @return DataResponse
+	 * @return DataResponse<array{apps: string[]}> 200
 	 * @throws OCSException
 	 */
 	public function getApps(string $filter = null): DataResponse {
@@ -81,7 +83,8 @@ class AppsController extends OCSController {
 
 	/**
 	 * @param string $app
-	 * @return DataResponse
+	 * @psalm-import-type AppInfo from ResponseDefinitions
+	 * @return DataResponse<AppInfo> 200
 	 * @throws OCSException
 	 */
 	public function getAppInfo(string $app): DataResponse {
@@ -96,7 +99,7 @@ class AppsController extends OCSController {
 	/**
 	 * @PasswordConfirmationRequired
 	 * @param string $app
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function enable(string $app): DataResponse {
@@ -111,7 +114,7 @@ class AppsController extends OCSController {
 	/**
 	 * @PasswordConfirmationRequired
 	 * @param string $app
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 */
 	public function disable(string $app): DataResponse {
 		$this->appManager->disableApp($app);

--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -32,6 +32,7 @@ declare(strict_types=1);
  */
 namespace OCA\Provisioning_API\Controller;
 
+use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
@@ -83,7 +84,7 @@ class GroupsController extends AUserData {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return DataResponse
+	 * @return DataResponse<array{groups: string[]}> 200
 	 */
 	public function getGroups(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
@@ -104,7 +105,8 @@ class GroupsController extends AUserData {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return DataResponse
+	 * @psalm-import-type GroupDetails from ResponseDefinitions
+	 * @return DataResponse<array{groups: GroupDetails[]}> 200
 	 */
 	public function getGroupsDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
@@ -127,7 +129,7 @@ class GroupsController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $groupId
-	 * @return DataResponse
+	 * @return DataResponse<array{users: string[]}> 200
 	 * @throws OCSException
 	 *
 	 * @deprecated 14 Use getGroupUsers
@@ -142,8 +144,10 @@ class GroupsController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $groupId
-	 * @return DataResponse
+	 * @return DataResponse<array{users: string[]}> 200
 	 * @throws OCSException
+	 * @throws OCSNotFoundException
+	 * @throws OCSForbiddenException
 	 */
 	public function getGroupUsers(string $groupId): DataResponse {
 		$groupId = urldecode($groupId);
@@ -183,7 +187,9 @@ class GroupsController extends AUserData {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return DataResponse
+	 *
+	 * @psalm-import-type UserDetails from ResponseDefinitions
+	 * @return DataResponse<array{users: array<string, UserDetails|array{id: string}>}> 200
 	 * @throws OCSException
 	 */
 	public function getGroupUsersDetails(string $groupId, string $search = '', int $limit = null, int $offset = 0): DataResponse {
@@ -234,7 +240,7 @@ class GroupsController extends AUserData {
 	 *
 	 * @param string $groupid
 	 * @param string $displayname
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function addGroup(string $groupid, string $displayname = ''): DataResponse {
@@ -263,7 +269,7 @@ class GroupsController extends AUserData {
 	 * @param string $groupId
 	 * @param string $key
 	 * @param string $value
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function updateGroup(string $groupId, string $key, string $value): DataResponse {
@@ -285,7 +291,7 @@ class GroupsController extends AUserData {
 	 * @PasswordConfirmationRequired
 	 *
 	 * @param string $groupId
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function deleteGroup(string $groupId): DataResponse {
@@ -304,7 +310,7 @@ class GroupsController extends AUserData {
 
 	/**
 	 * @param string $groupId
-	 * @return DataResponse
+	 * @return DataResponse<string[]> 200
 	 * @throws OCSException
 	 */
 	public function getSubAdminsOfGroup(string $groupId): DataResponse {

--- a/apps/provisioning_api/lib/Controller/PreferencesController.php
+++ b/apps/provisioning_api/lib/Controller/PreferencesController.php
@@ -58,6 +58,9 @@ class PreferencesController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 * @NoSubAdminRequired
+	 *
+	 * @return DataResponse 200
+	 * @return DataResponse 400
 	 */
 	public function setMultiplePreferences(string $appId, array $configs): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
@@ -93,6 +96,9 @@ class PreferencesController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 * @NoSubAdminRequired
+	 *
+	 * @return DataResponse 200
+	 * @return DataResponse 400
 	 */
 	public function setPreference(string $appId, string $configKey, string $configValue): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
@@ -124,6 +130,9 @@ class PreferencesController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 * @NoSubAdminRequired
+	 *
+	 * @return DataResponse 200
+	 * @return DataResponse 400
 	 */
 	public function deleteMultiplePreference(string $appId, array $configKeys): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
@@ -157,6 +166,9 @@ class PreferencesController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 * @NoSubAdminRequired
+	 *
+	 * @return DataResponse 200
+	 * @return DataResponse 400
 	 */
 	public function deletePreference(string $appId, string $configKey): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Tom Needham <tom@owncloud.com>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Kate Döen <kate.doeen@nextcloud.com>
  *
  * @license AGPL-3.0
  *
@@ -51,6 +52,7 @@ use libphonenumber\PhoneNumberUtil;
 use OC\Authentication\Token\RemoteWipe;
 use OC\KnownUser\KnownUserService;
 use OC\User\Backend;
+use OCA\Files_Sharing\ResponseDefinitions;
 use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
@@ -141,7 +143,7 @@ class UsersController extends AUserData {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
-	 * @return DataResponse
+	 * @return DataResponse<array{users: string[]}> 200
 	 */
 	public function getUsers(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$user = $this->userSession->getUser();
@@ -175,6 +177,8 @@ class UsersController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * returns a list of users and their data
+	 * @psalm-import-type UserDetails from ResponseDefinitions
+	 * @return DataResponse<array{users: array<string, UserDetails|array{id: string}>}> 200
 	 */
 	public function getUsersDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$currentUser = $this->userSession->getUser();
@@ -225,7 +229,9 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $location
 	 * @param array $search
-	 * @return DataResponse
+	 * @psalm-import-type UserDetails from ResponseDefinitions
+	 * @return DataResponse<array{users: array<string, UserDetails|array{id: string}>}> 200
+	 * @return DataResponse 400
 	 */
 	public function searchByPhoneNumbers(string $location, array $search): DataResponse {
 		$phoneUtil = PhoneNumberUtil::getInstance();
@@ -327,8 +333,9 @@ class UsersController extends AUserData {
 	 * @param array $subadmin
 	 * @param string $quota
 	 * @param string $language
-	 * @return DataResponse
+	 * @return DataResponse<array{id: string}> 200
 	 * @throws OCSException
+	 * @throws OCSForbiddenException
 	 */
 	public function addUser(
 		string $userid,
@@ -515,7 +522,8 @@ class UsersController extends AUserData {
 	 * gets user info
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @psalm-import-type UserDetails from ResponseDefinitions
+	 * @return DataResponse<UserDetails> 200
 	 * @throws OCSException
 	 */
 	public function getUser(string $userId): DataResponse {
@@ -539,7 +547,8 @@ class UsersController extends AUserData {
 	 *
 	 * gets user info from the currently logged in user
 	 *
-	 * @return DataResponse
+	 * @psalm-import-type UserDetails from ResponseDefinitions
+	 * @return DataResponse<UserDetails> 200
 	 * @throws OCSException
 	 */
 	public function getCurrentUser(): DataResponse {
@@ -560,7 +569,7 @@ class UsersController extends AUserData {
 	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
-	 * @return DataResponse
+	 * @return DataResponse<string[]> 200
 	 * @throws OCSException
 	 */
 	public function getEditableFields(): DataResponse {
@@ -577,7 +586,7 @@ class UsersController extends AUserData {
 	 * @NoSubAdminRequired
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse<string[]> 200
 	 * @throws OCSException
 	 */
 	public function getEditableFieldsForUser(string $userId): DataResponse {
@@ -636,6 +645,7 @@ class UsersController extends AUserData {
 	 * @NoSubAdminRequired
 	 * @PasswordConfirmationRequired
 	 *
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function editUserMultiValue(
@@ -733,7 +743,7 @@ class UsersController extends AUserData {
 	 * @param string $userId
 	 * @param string $key
 	 * @param string $value
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function editUser(string $userId, string $key, string $value): DataResponse {
@@ -1035,7 +1045,7 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $userId
 	 *
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 *
 	 * @throws OCSException
 	 */
@@ -1069,7 +1079,7 @@ class UsersController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function deleteUser(string $userId): DataResponse {
@@ -1104,7 +1114,7 @@ class UsersController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 * @throws OCSForbiddenException
 	 */
@@ -1117,7 +1127,7 @@ class UsersController extends AUserData {
 	 * @NoAdminRequired
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 * @throws OCSForbiddenException
 	 */
@@ -1155,7 +1165,7 @@ class UsersController extends AUserData {
 	 * @NoSubAdminRequired
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse<array{groups: string[]}> 200
 	 * @throws OCSException
 	 */
 	public function getUsersGroups(string $userId): DataResponse {
@@ -1200,7 +1210,7 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $userId
 	 * @param string $groupid
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function addToGroup(string $userId, string $groupid = ''): DataResponse {
@@ -1235,7 +1245,7 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $userId
 	 * @param string $groupid
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function removeFromGroup(string $userId, string $groupid): DataResponse {
@@ -1298,7 +1308,7 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $userId
 	 * @param string $groupid
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function addSubAdmin(string $userId, string $groupid): DataResponse {
@@ -1336,7 +1346,7 @@ class UsersController extends AUserData {
 	 *
 	 * @param string $userId
 	 * @param string $groupid
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function removeSubAdmin(string $userId, string $groupid): DataResponse {
@@ -1366,7 +1376,7 @@ class UsersController extends AUserData {
 	 * Get the groups a user is a subadmin of
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse<string[]> 200
 	 * @throws OCSException
 	 */
 	public function getUserSubAdminGroups(string $userId): DataResponse {
@@ -1381,7 +1391,7 @@ class UsersController extends AUserData {
 	 * resend welcome message
 	 *
 	 * @param string $userId
-	 * @return DataResponse
+	 * @return DataResponse 200
 	 * @throws OCSException
 	 */
 	public function resendWelcomeMessage(string $userId): DataResponse {

--- a/apps/provisioning_api/lib/ResponseDefinitions.php
+++ b/apps/provisioning_api/lib/ResponseDefinitions.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Kate Döen <kate.doeen@nextcloud.com>
+ *
+ * @author Kate Döen <kate.doeen@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing;
+
+/**
+ * @psalm-type UserDetails = array{
+ *     additional_mail: string[],
+ *     additional_mailScope: string[]|null,
+ *     address: string,
+ *     addressScope: string|null,
+ *     avatarScope: string|null,
+ *     backend: string,
+ *     backendCapabilities: array{
+ *         setDisplayName: bool,
+ *         setPassword: bool
+ *     },
+ *     biography: string,
+ *     biographyScope: string|null,
+ *     displayname: string|null,
+ *     display-name: string|null,
+ *     displaynameScope: string|null,
+ *     email: string|null,
+ *     emailScope: string|null,
+ *     enabled: bool|null,
+ *     fediverse: string|null,
+ *     fediverseScope: string|null,
+ *     groups: string[],
+ *     headline: string,
+ *     headlineScope: string|null,
+ *     id: string,
+ *     language: string,
+ *     lastLogin: int,
+ *     locale: string,
+ *     notify_email: string|null,
+ *     organisation: string,
+ *     organisationScope: string|null,
+ *     phone: string,
+ *     phoneScope: string|null,
+ *     profile_enabled: string,
+ *     profile_enabledScope: string|null,
+ *     quota: array{
+ *         free: int|null,
+ *         quota: string|int|bool,
+ *         relative: float|null,
+ *         total: int|null,
+ *         used: int,
+ *	   },
+ *     role: string,
+ *     roleScope: string|null,
+ *     storageLocation: string|null,
+ *     subadmin: string[],
+ *     twitter: string,
+ *     twitterScope: string|null,
+ *     website: string,
+ *     websiteScope: string|null,
+ * }
+ *
+ * @psalm-type AppInfoValue = string|array{}|array
+ *
+ * @psalm-type AppInfo = array{
+ *     active: bool|null,
+ *     activity: AppInfoValue|null,
+ *     author: AppInfoValue|null,
+ *     background-jobs: AppInfoValue|null,
+ *     bugs: AppInfoValue|null,
+ *     category: AppInfoValue|null,
+ *     collaboration: AppInfoValue|null,
+ *     commands: AppInfoValue|null,
+ *     default_enable: AppInfoValue|null,
+ *     dependencies: AppInfoValue|null,
+ *     description: string,
+ *     discussion: AppInfoValue|null,
+ *     documentation: AppInfoValue|null,
+ *     groups: AppInfoValue|null,
+ *     id: string,
+ *     info: AppInfoValue|null,
+ *     internal: bool|null,
+ *     level: int|null,
+ *     licence: AppInfoValue|null,
+ *     name: string,
+ *     namespace: AppInfoValue|null,
+ *     navigations: AppInfoValue|null,
+ *     preview: AppInfoValue|null,
+ *     previewAsIcon: bool|null,
+ *     public: AppInfoValue|null,
+ *     remote: AppInfoValue|null,
+ *     removable: bool|null,
+ *     repair-steps: AppInfoValue|null,
+ *     repository: AppInfoValue|null,
+ *     sabre: AppInfoValue|null,
+ *     screenshot: AppInfoValue|null,
+ *     settings: AppInfoValue|null,
+ *     summary: string,
+ *     trash: AppInfoValue|null,
+ *     two-factor-providers: AppInfoValue|null,
+ *     types: AppInfoValue|null,
+ *     version: string,
+ *     versions: AppInfoValue|null,
+ *     website: AppInfoValue|null,
+ * }
+ *
+ * @psalm-type GroupDetails = array{
+ *     id: string,
+ *     displayname: string,
+ *     usercount: bool|int,
+ *     disabled: bool|int,
+ *     canAdd: bool,
+ *     canRemove: bool,
+ * }
+ */
+class ResponseDefinitions {
+}

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -1,0 +1,3402 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Provisioning API",
+        "description": "This application enables a set of APIs that external systems can use to manage users, groups and apps.",
+        "license": {
+            "name": "agpl"
+        },
+        "version": "1.16.0"
+    },
+    "paths": {
+        "/ocs/v2.php/cloud/apps": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "get-apps",
+                "parameters": [
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "apps"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "apps": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/apps/{app}": {
+            "parameters": [
+                {
+                    "name": "app",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "apps-get-app-info",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AppInfo"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "enable-apps",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "disable-apps",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "returns a list of groups",
+                "operationId": "get-groups",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "groups"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "groups": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "creates a new group",
+                "operationId": "groups-add-group",
+                "parameters": [
+                    {
+                        "name": "groupid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "displayname",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups/details": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "Returns a list of groups details with ids and displaynames",
+                "operationId": "get-groups-details",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "groups"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "groups": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/GroupDetails"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups/{groupId}/users": {
+            "parameters": [
+                {
+                    "name": "groupId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "returns an array of users in the specified group",
+                "operationId": "groups-get-group-users",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups/{groupId}/users/details": {
+            "parameters": [
+                {
+                    "name": "groupId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "returns an array of users details in the specified group",
+                "operationId": "groups-get-group-users-details",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "$ref": "#/components/schemas/UserDetails"
+                                                                    },
+                                                                    {
+                                                                        "required": [
+                                                                            "id"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups/{groupId}/subadmins": {
+            "parameters": [
+                {
+                    "name": "groupId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "groups-get-sub-admins-of-group",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/groups/{groupId}": {
+            "parameters": [
+                {
+                    "name": "groupId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "groups-get-group",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "groups-update-group",
+                "parameters": [
+                    {
+                        "name": "key",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "groups-delete-group",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "returns a list of users",
+                "operationId": "get-users",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-add-user",
+                "parameters": [
+                    {
+                        "name": "userid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "displayName",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "groups",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "array"
+                        }
+                    },
+                    {
+                        "name": "subadmin",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "array"
+                        }
+                    },
+                    {
+                        "name": "quota",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "language",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "id"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/details": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "returns a list of users and their data",
+                "operationId": "get-users-details",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "$ref": "#/components/schemas/UserDetails"
+                                                                    },
+                                                                    {
+                                                                        "required": [
+                                                                            "id"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/search/by-phone": {
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-search-by-phone-numbers",
+                "parameters": [
+                    {
+                        "name": "location",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "array"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "users"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "users": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "$ref": "#/components/schemas/UserDetails"
+                                                                    },
+                                                                    {
+                                                                        "required": [
+                                                                            "id"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "gets user info",
+                "operationId": "users-get-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/UserDetails"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "edit users",
+                "operationId": "users-edit-user",
+                "parameters": [
+                    {
+                        "name": "key",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-delete-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/user": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "gets user info from the currently logged in user",
+                "operationId": "users-get-current-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/UserDetails"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/user/fields": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-get-editable-fields",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/user/fields/{userId}": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-get-editable-fields-for-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/{collectionName}": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "collectionName",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "put": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-edit-user-multi-value",
+                "parameters": [
+                    {
+                        "name": "key",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/wipe": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-wipe-user-devices",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/enable": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "put": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-enable-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/disable": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "put": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-disable-user",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/groups": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "get-users-groups",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "groups"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "groups": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-add-to-group",
+                "parameters": [
+                    {
+                        "name": "groupid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "users-remove-from-group",
+                "parameters": [
+                    {
+                        "name": "groupid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/subadmins": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "Get the groups a user is a subadmin of",
+                "operationId": "users-get-user-sub-admin-groups",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "Creates a subadmin",
+                "operationId": "users-add-sub-admin",
+                "parameters": [
+                    {
+                        "name": "groupid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "Removes a subadmin from a group",
+                "operationId": "users-remove-sub-admin",
+                "parameters": [
+                    {
+                        "name": "groupid",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/cloud/users/{userId}/welcome": {
+            "parameters": [
+                {
+                    "name": "userId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "resend welcome message",
+                "operationId": "users-resend-welcome-message",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/provisioning_api/api/v1/config/apps": {
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "app-config-get-apps",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}": {
+            "parameters": [
+                {
+                    "name": "app",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "app-config-get-keys",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}": {
+            "parameters": [
+                {
+                    "name": "app",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "key",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "app-config-get-value",
+                "parameters": [
+                    {
+                        "name": "defaultValue",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "app-config-set-value",
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "app-config-delete-key",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "data": {
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}": {
+            "parameters": [
+                {
+                    "name": "appId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "configKey",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "preferences-set-preference",
+                "parameters": [
+                    {
+                        "name": "configValue",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "preferences-delete-preference",
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}": {
+            "parameters": [
+                {
+                    "name": "appId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "set-multiple-preferences",
+                "parameters": [
+                    {
+                        "name": "configs",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "array"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "provisioning_api"
+                ],
+                "description": "",
+                "operationId": "preferences-delete-multiple-preference",
+                "parameters": [
+                    {
+                        "name": "configKeys",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "array"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "ocs": {
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "type": "object",
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AppInfo": {
+                "required": [
+                    "description",
+                    "id",
+                    "name",
+                    "summary",
+                    "version"
+                ],
+                "type": "object",
+                "properties": {
+                    "active": {
+                        "type": "boolean"
+                    },
+                    "activity": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "author": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "background-jobs": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "bugs": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "category": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "collaboration": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "commands": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "default_enable": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "dependencies": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "discussion": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "documentation": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "groups": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "info": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "internal": {
+                        "type": "boolean"
+                    },
+                    "level": {
+                        "type": "integer"
+                    },
+                    "licence": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "navigations": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "preview": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "previewAsIcon": {
+                        "type": "boolean"
+                    },
+                    "public": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "remote": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "removable": {
+                        "type": "boolean"
+                    },
+                    "repair-steps": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "sabre": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "screenshot": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "settings": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "trash": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "two-factor-providers": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "types": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "version": {
+                        "type": "string"
+                    },
+                    "versions": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    },
+                    "website": {
+                        "$ref": "#/components/schemas/AppInfoValue"
+                    }
+                }
+            },
+            "AppInfoValue": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    {
+                        "type": "array"
+                    }
+                ]
+            },
+            "GroupDetails": {
+                "required": [
+                    "id",
+                    "displayname",
+                    "usercount",
+                    "disabled",
+                    "canAdd",
+                    "canRemove"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "displayname": {
+                        "type": "string"
+                    },
+                    "usercount": {
+                        "oneOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "disabled": {
+                        "oneOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "canAdd": {
+                        "type": "boolean"
+                    },
+                    "canRemove": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "OCSMeta": {
+                "type": "object",
+                "required": [
+                    "status",
+                    "statuscode"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "statuscode": {
+                        "type": "integer"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "totalitems": {
+                        "type": "string"
+                    },
+                    "itemsperpage": {
+                        "type": "string"
+                    }
+                }
+            },
+            "UserDetails": {
+                "required": [
+                    "additional_mail",
+                    "address",
+                    "backend",
+                    "backendCapabilities",
+                    "biography",
+                    "groups",
+                    "headline",
+                    "id",
+                    "language",
+                    "lastLogin",
+                    "locale",
+                    "organisation",
+                    "phone",
+                    "profile_enabled",
+                    "quota",
+                    "role",
+                    "subadmin",
+                    "twitter",
+                    "website"
+                ],
+                "type": "object",
+                "properties": {
+                    "additional_mail": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "additional_mailScope": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "address": {
+                        "type": "string"
+                    },
+                    "addressScope": {
+                        "type": "string"
+                    },
+                    "avatarScope": {
+                        "type": "string"
+                    },
+                    "backend": {
+                        "type": "string"
+                    },
+                    "backendCapabilities": {
+                        "required": [
+                            "setDisplayName",
+                            "setPassword"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "setDisplayName": {
+                                "type": "boolean"
+                            },
+                            "setPassword": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "biography": {
+                        "type": "string"
+                    },
+                    "biographyScope": {
+                        "type": "string"
+                    },
+                    "displayname": {
+                        "type": "string"
+                    },
+                    "display-name": {
+                        "type": "string"
+                    },
+                    "displaynameScope": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "emailScope": {
+                        "type": "string"
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "fediverse": {
+                        "type": "string"
+                    },
+                    "fediverseScope": {
+                        "type": "string"
+                    },
+                    "groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "headline": {
+                        "type": "string"
+                    },
+                    "headlineScope": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "lastLogin": {
+                        "type": "integer"
+                    },
+                    "locale": {
+                        "type": "string"
+                    },
+                    "notify_email": {
+                        "type": "string"
+                    },
+                    "organisation": {
+                        "type": "string"
+                    },
+                    "organisationScope": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "phoneScope": {
+                        "type": "string"
+                    },
+                    "profile_enabled": {
+                        "type": "string"
+                    },
+                    "profile_enabledScope": {
+                        "type": "string"
+                    },
+                    "quota": {
+                        "required": [
+                            "quota",
+                            "used"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "free": {
+                                "type": "integer"
+                            },
+                            "quota": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    }
+                                ]
+                            },
+                            "relative": {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            "total": {
+                                "type": "integer"
+                            },
+                            "used": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "role": {
+                        "type": "string"
+                    },
+                    "roleScope": {
+                        "type": "string"
+                    },
+                    "storageLocation": {
+                        "type": "string"
+                    },
+                    "subadmin": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "twitter": {
+                        "type": "string"
+                    },
+                    "twitterScope": {
+                        "type": "string"
+                    },
+                    "website": {
+                        "type": "string"
+                    },
+                    "websiteScope": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "basic_auth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    },
+    "security": [
+        {
+            "basic_auth": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "provisioning_api"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adapts the code to make it friendly for https://github.com/nextcloud-gmbh/openapi-extractor and add the automatically generated spec.

## TODO

- [x] https://github.com/nextcloud/server/issues/36513

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
