### PR TITLE
Add events to `QueryBuilder` class

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -219,6 +219,8 @@ return array(
     'OCP\\DB\\IPreparedStatement' => $baseDir . '/lib/public/DB/IPreparedStatement.php',
     'OCP\\DB\\IResult' => $baseDir . '/lib/public/DB/IResult.php',
     'OCP\\DB\\ISchemaWrapper' => $baseDir . '/lib/public/DB/ISchemaWrapper.php',
+    'OCP\\DB\\QueryBuilder\\Events\\BeforeQueryExecutedEvent' => $baseDir . '/lib/public/DB/QueryBuilder/Events/BeforeQueryExecutedEvent.php',
+    'OCP\\DB\\QueryBuilder\\Events\\QueryExecutedEvent' => $baseDir . '/lib/public/DB/QueryBuilder/Events/QueryExecutedEvent.php',
     'OCP\\DB\\QueryBuilder\\ICompositeExpression' => $baseDir . '/lib/public/DB/QueryBuilder/ICompositeExpression.php',
     'OCP\\DB\\QueryBuilder\\IExpressionBuilder' => $baseDir . '/lib/public/DB/QueryBuilder/IExpressionBuilder.php',
     'OCP\\DB\\QueryBuilder\\IFunctionBuilder' => $baseDir . '/lib/public/DB/QueryBuilder/IFunctionBuilder.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -252,6 +252,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\DB\\IPreparedStatement' => __DIR__ . '/../../..' . '/lib/public/DB/IPreparedStatement.php',
         'OCP\\DB\\IResult' => __DIR__ . '/../../..' . '/lib/public/DB/IResult.php',
         'OCP\\DB\\ISchemaWrapper' => __DIR__ . '/../../..' . '/lib/public/DB/ISchemaWrapper.php',
+        'OCP\\DB\\QueryBuilder\\Events\\BeforeQueryExecutedEvent' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/Events/BeforeQueryExecutedEvent.php',
+        'OCP\\DB\\QueryBuilder\\Events\\QueryExecutedEvent' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/Events/QueryExecutedEvent.php',
         'OCP\\DB\\QueryBuilder\\ICompositeExpression' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/ICompositeExpression.php',
         'OCP\\DB\\QueryBuilder\\IExpressionBuilder' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/IExpressionBuilder.php',
         'OCP\\DB\\QueryBuilder\\IFunctionBuilder' => __DIR__ . '/../../..' . '/lib/public/DB/QueryBuilder/IFunctionBuilder.php',

--- a/lib/public/DB/QueryBuilder/Events/BeforeQueryExecutedEvent.php
+++ b/lib/public/DB/QueryBuilder/Events/BeforeQueryExecutedEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Andrew Summers
+ *
+ * @author Andrew Summers
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\DB\QueryBuilder\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Doctrine\DBAL\Result;
+
+/**
+ * This event is used by apps to intercept, inspect, and potentially modify
+ * database queries prior to execution. This can be used for deep integrations,
+ * restricting user access to certain data, redacting information, etc.
+ *
+ * The result field can optionally be set by the event listener by executing the
+ * query in the event handler logic. This allows apps to inspect the results,
+ * use try/catch blocks around the query execution, and/or modify/re-execute the
+ * query if necessary. If the result field is not set, the QueryBuilder class
+ * will execute the query as expected by default.
+ *
+ * @see https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/projects.html
+ * @since 28.0.0
+ */
+class BeforeQueryExecutedEvent extends Event {
+	private IQueryBuilder $queryBuilder;
+	private $result = null;
+
+	/**
+	 * @param IQueryBuilder $queryBuilder
+	 * @since 28.0.0
+	 */
+	public function __construct(IQueryBuilder $queryBuilder) {
+		$this->queryBuilder = $queryBuilder;
+	}
+
+	/**
+	 * @return IQueryBuilder
+	 * @since 28.0.0
+	 */
+	public function getQueryBuilder(): IQueryBuilder {
+		return $this->queryBuilder;
+	}
+
+	/**
+	 * @param IQueryBuilder $queryBuilder
+	 * @since 28.0.0
+	 */
+	public function setQueryBuilder(IQueryBuilder $queryBuilder) {
+		$this->queryBuilder = $queryBuilder;
+	}
+
+	/**
+	 * @return Result|int|string
+	 * @since 28.0.0
+	 */
+	public function getResult() {
+		return $this->result;
+	}
+
+	/**
+	 * @param Result|int|string $result
+	 * @since 28.0.0
+	 */
+	public function setResult($result) {
+		$this->result = $result;
+	}
+}

--- a/lib/public/DB/QueryBuilder/Events/QueryExecutedEvent.php
+++ b/lib/public/DB/QueryBuilder/Events/QueryExecutedEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Andrew Summers
+ *
+ * @author Andrew Summers
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\DB\QueryBuilder\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Doctrine\DBAL\Result;
+
+/**
+ * This event is used by apps to intercept, inspect, and potentially modify
+ * the results of database queries after execution. This can be used for deep
+ * integrations, restricting user access to certain data, redacting information,
+ * etc.
+ *
+ * @see https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/projects.html
+ * @since 28.0.0
+ */
+class QueryExecutedEvent extends Event {
+	private IQueryBuilder $queryBuilder;
+	private $result;
+
+	/**
+	 * @param IQueryBuilder $queryBuilder
+	 * @param $result
+	 * @since 28.0.0
+	 */
+	public function __construct(IQueryBuilder $queryBuilder, $result) {
+		$this->queryBuilder = $queryBuilder;
+		$this->result = $result;
+	}
+
+	/**
+	 * @return IQueryBuilder
+	 * @since 28.0.0
+	 */
+	public function getQueryBuilder(): IQueryBuilder {
+		return $this->queryBuilder;
+	}
+
+	/**
+	 * @param IQueryBuilder $queryBuilder
+	 * @since 28.0.0
+	 */
+	public function setQueryBuilder(IQueryBuilder $queryBuilder) {
+		$this->queryBuilder = $queryBuilder;
+	}
+
+	/**
+	 * @return Result|int|string
+	 * @since 28.0.0
+	 */
+	public function getResult() {
+		return $this->result;
+	}
+
+	/**
+	 * @param Result|int|string $result
+	 * @since 28.0.0
+	 */
+	public function setResult($result) {
+		$this->result = $result;
+	}
+}


### PR DESCRIPTION
* Would provide the functionality to resolve: #13103

## Summary
This provides events before and after the execution of `QueryBuilder` objects in order to modify `QueryBuilder` elements, the query results, or both. While it may seem like this is only useful for niche applications (or potentially dangerous), there are valid instances where intercepting DB queries and results are extremely useful (or even necessary).

Being able to intercept queries and/or results in order to restrict access, redact information, or even generate query-level logs would require the ability to access the `QueryBuilder` class before and/or after execution.

One application that I have implemented for my organization is adding column-level encryption on a per-user basis. Without being able to access the `QueryBuilder` class immediately before execution, this integration would be impossible. Once this PR is accepted and my integration is tested more thoroughly in production, I plan to make my code publicly available so administrators may encrypt information in the NC database such as contact and calendar data.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
