### PR TITLE
Prevent scrolling hover .files-controls

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -481,6 +481,11 @@ var dragOptions={
 		$('.crumbmenu').removeClass('canDropChildren');
 	},
 	drag: function(event, ui) {
+		// Prevent scrolling when hovering .files-controls
+		if ($(event.originalEvent.target).parents('.files-controls').length > 0) {
+			return
+		}
+
 		/** @type {JQuery<HTMLDivElement>} */
 		const scrollingArea = FileList.$container;
 


### PR DESCRIPTION
## Summary

Follow up of https://github.com/nextcloud/server/pull/36024

When dragging a file, it does not make sense to automatically scroll up when hovering the .files-controls header.

This PR makes sure that we do not react when hovering .files-controls.