### PR TITLE
fix default values and type hints for GroupManager::search

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -266,7 +266,7 @@ class Database extends ABackend implements
 	 *
 	 * Returns a list with all groups
 	 */
-	public function getGroups($search = '', $limit = null, $offset = null) {
+	public function getGroups(string $search = '', int $limit = -1, int $offset = 0) {
 		$this->fixDI();
 
 		$query = $this->dbConn->getQueryBuilder();
@@ -283,8 +283,12 @@ class Database extends ABackend implements
 			)));
 		}
 
-		$query->setMaxResults($limit)
-			->setFirstResult($offset);
+		if (!$limit > 0) {
+			$query->setMaxResults($limit);
+		}
+		if ($offset > 0) {
+			$query->setFirstResult($offset);
+		}
 		$result = $query->execute();
 
 		$groups = [];

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -283,7 +283,7 @@ class Database extends ABackend implements
 			)));
 		}
 
-		if (!$limit > 0) {
+		if ($limit > 0) {
 			$query->setMaxResults($limit);
 		}
 		if ($offset > 0) {

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -236,14 +236,14 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 	/**
 	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
+	 * @param ?int $limit
+	 * @param ?int $offset
 	 * @return \OC\Group\Group[]
 	 */
-	public function search(string $search, int $limit = -1, int $offset = 0) {
+	public function search(string $search, ?int $limit = null, ?int $offset = 0) {
 		$groups = [];
 		foreach ($this->backends as $backend) {
-			$groupIds = $backend->getGroups($search, $limit, $offset);
+			$groupIds = $backend->getGroups($search, $limit ?? -1, $offset ?? 0);
 			foreach ($groupIds as $groupId) {
 				$aGroup = $this->get($groupId);
 				if ($aGroup instanceof IGroup) {
@@ -252,7 +252,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 					$this->logger->debug('Group "' . $groupId . '" was returned by search but not found through direct access', ['app' => 'core']);
 				}
 			}
-			if ($limit === 0) {
+			if (!is_null($limit) and $limit <= 0) {
 				return array_values($groups);
 			}
 		}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -240,7 +240,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param int $offset
 	 * @return \OC\Group\Group[]
 	 */
-	public function search($search, $limit = null, $offset = null) {
+	public function search(string $search, int $limit = -1, int $offset = 0) {
 		$groups = [];
 		foreach ($this->backends as $backend) {
 			$groupIds = $backend->getGroups($search, $limit, $offset);
@@ -252,7 +252,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 					$this->logger->debug('Group "' . $groupId . '" was returned by search but not found through direct access', ['app' => 'core']);
 				}
 			}
-			if (!is_null($limit) and $limit <= 0) {
+			if ($limit === 0) {
 				return array_values($groups);
 			}
 		}

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -95,7 +95,7 @@ interface GroupInterface {
 	 *
 	 * Returns a list with all groups
 	 */
-	public function getGroups($search = '', $limit = -1, $offset = 0);
+	public function getGroups(string $search = '', int $limit = -1, int $offset = 0);
 
 	/**
 	 * check if a group exists

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -101,7 +101,7 @@ interface IGroupManager {
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function search($search, $limit = null, $offset = null);
+	public function search(string $search, int $limit = -1, int $offset = 0);
 
 	/**
 	 * @param \OCP\IUser|null $user

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -96,12 +96,12 @@ interface IGroupManager {
 
 	/**
 	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
+	 * @param ?int $limit
+	 * @param ?int $offset
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function search(string $search, int $limit = -1, int $offset = 0);
+	public function search(string $search, ?int $limit = null, ?int $offset = 0);
 
 	/**
 	 * @param \OCP\IUser|null $user


### PR DESCRIPTION
ints really are ints

Signed-off-by: Robin Appelman <robin@icewind.nl>