### PR TITLE
fix(performance): Only search for auth tokens when the provided login…

### DIFF
--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -93,7 +93,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testGenerateToken() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -115,7 +115,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testGenerateTokenNoPassword(): void {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -138,7 +138,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testGenerateTokenLongPassword() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = '';
@@ -157,7 +157,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testGenerateTokenInvalidName() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -222,7 +222,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testGetPassword() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -253,7 +253,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	public function testGetPasswordInvalidToken() {
 		$this->expectException(\OC\Authentication\Exceptions\InvalidTokenException::class);
 
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -270,7 +270,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testSetPassword() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -291,13 +291,13 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper->expects($this->once())
 			->method('update')
 			->with($this->callback(function ($token) use ($newpass) {
-				return $newpass === $this->tokenProvider->getPassword($token, 'token');
+				return $newpass === $this->tokenProvider->getPassword($token, 'tokentokentokentokentoken');
 			}));
 
 
 		$this->tokenProvider->setPassword($actual, $token, $newpass);
 
-		$this->assertSame($newpass, $this->tokenProvider->getPassword($actual, 'token'));
+		$this->assertSame($newpass, $this->tokenProvider->getPassword($actual, 'tokentokentokentokentoken'));
 	}
 
 
@@ -312,12 +312,12 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testInvalidateToken() {
-		$this->mapper->expects($this->at(0))
+		$this->mapper->expects($this->exactly(2))
 			->method('invalidate')
-			->with(hash('sha512', 'token7'.'1f4h9s'));
-		$this->mapper->expects($this->at(1))
-			->method('invalidate')
-			->with(hash('sha512', 'token7'));
+			->withConsecutive(
+				[hash('sha512', 'token7'.'1f4h9s')],
+				[hash('sha512', 'token7')]
+			);
 
 		$this->tokenProvider->invalidateToken('token7');
 	}
@@ -352,7 +352,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testRenewSessionTokenWithoutPassword() {
-		$token = 'oldId';
+		$token = 'oldIdtokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = null;
@@ -364,7 +364,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper
 			->expects($this->once())
 			->method('getToken')
-			->with(hash('sha512', 'oldId' . '1f4h9s'))
+			->with(hash('sha512', 'oldIdtokentokentokentoken' . '1f4h9s'))
 			->willReturn($oldToken);
 		$this->mapper
 			->expects($this->once())
@@ -384,11 +384,11 @@ class PublicKeyTokenProviderTest extends TestCase {
 				return $token === $oldToken;
 			}));
 
-		$this->tokenProvider->renewSessionToken('oldId', 'newId');
+		$this->tokenProvider->renewSessionToken('oldIdtokentokentokentoken', 'newIdtokentokentokentoken');
 	}
 
 	public function testRenewSessionTokenWithPassword(): void {
-		$token = 'oldId';
+		$token = 'oldIdtokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'password';
@@ -404,7 +404,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper
 			->expects($this->once())
 			->method('getToken')
-			->with(hash('sha512', 'oldId' . '1f4h9s'))
+			->with(hash('sha512', 'oldIdtokentokentokentoken' . '1f4h9s'))
 			->willReturn($oldToken);
 		$this->mapper
 			->expects($this->once())
@@ -416,7 +416,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 					$token->getType() === IToken::DO_NOT_REMEMBER &&
 					$token->getLastActivity() === $this->time &&
 					$token->getPassword() !== null &&
-					$this->tokenProvider->getPassword($token, 'newId') === 'password';
+					$this->tokenProvider->getPassword($token, 'newIdtokentokentokentoken') === 'password';
 			}));
 		$this->mapper
 			->expects($this->once())
@@ -425,7 +425,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 				return $token === $oldToken;
 			}));
 
-		$this->tokenProvider->renewSessionToken('oldId', 'newId');
+		$this->tokenProvider->renewSessionToken('oldIdtokentokentokentoken', 'newIdtokentokentokentoken');
 	}
 
 	public function testGetToken(): void {
@@ -438,37 +438,32 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper->method('getToken')
 			->with(
 				$this->callback(function (string $token) {
-					return hash('sha512', 'unhashedToken'.'1f4h9s') === $token;
+					return hash('sha512', 'unhashedTokentokentokentokentoken'.'1f4h9s') === $token;
 				})
 			)->willReturn($token);
 
-		$this->assertSame($token, $this->tokenProvider->getToken('unhashedToken'));
+		$this->assertSame($token, $this->tokenProvider->getToken('unhashedTokentokentokentokentoken'));
 	}
 
 	public function testGetInvalidToken() {
 		$this->expectException(InvalidTokenException::class);
 
-		$this->mapper->expects($this->at(0))
+		$this->mapper->expects($this->exactly(2))
 			->method('getToken')
-			->with(
-				$this->callback(function (string $token): bool {
-					return hash('sha512', 'unhashedToken'.'1f4h9s') === $token;
-				})
+			->withConsecutive(
+				[$this->callback(function (string $token): bool {
+					return hash('sha512', 'unhashedTokentokentokentokentoken'.'1f4h9s') === $token;
+				})],
+				[$this->callback(function (string $token): bool {
+					return hash('sha512', 'unhashedTokentokentokentokentoken') === $token;
+				})]
 			)->willThrowException(new DoesNotExistException('nope'));
 
-		$this->mapper->expects($this->at(1))
-			->method('getToken')
-			->with(
-				$this->callback(function (string $token): bool {
-					return hash('sha512', 'unhashedToken') === $token;
-				})
-			)->willThrowException(new DoesNotExistException('nope'));
-
-		$this->tokenProvider->getToken('unhashedToken');
+		$this->tokenProvider->getToken('unhashedTokentokentokentokentoken');
 	}
 
 	public function testGetExpiredToken() {
-		$token = 'token';
+		$token = 'tokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'passme';
@@ -481,12 +476,12 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->mapper->method('getToken')
 			->with(
 				$this->callback(function (string $token) {
-					return hash('sha512', 'token'.'1f4h9s') === $token;
+					return hash('sha512', 'tokentokentokentokentoken'.'1f4h9s') === $token;
 				})
 			)->willReturn($actual);
 
 		try {
-			$this->tokenProvider->getToken('token');
+			$this->tokenProvider->getToken('tokentokentokentokentoken');
 			$this->fail();
 		} catch (ExpiredTokenException $e) {
 			$this->assertSame($actual, $e->getToken());
@@ -533,7 +528,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	}
 
 	public function testRotate() {
-		$token = 'oldtoken';
+		$token = 'oldtokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = 'password';
@@ -546,13 +541,13 @@ class PublicKeyTokenProviderTest extends TestCase {
 			]);
 		$actual = $this->tokenProvider->generateToken($token, $uid, $user, $password, $name, $type, IToken::DO_NOT_REMEMBER);
 
-		$new = $this->tokenProvider->rotate($actual, 'oldtoken', 'newtoken');
+		$new = $this->tokenProvider->rotate($actual, 'oldtokentokentokentokentoken', 'newtokentokentokentokentoken');
 
-		$this->assertSame('password', $this->tokenProvider->getPassword($new, 'newtoken'));
+		$this->assertSame('password', $this->tokenProvider->getPassword($new, 'newtokentokentokentokentoken'));
 	}
 
 	public function testRotateNoPassword() {
-		$token = 'oldtoken';
+		$token = 'oldtokentokentokentokentoken';
 		$uid = 'user';
 		$user = 'User';
 		$password = null;
@@ -563,7 +558,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 
 		$oldPrivate = $actual->getPrivateKey();
 
-		$new = $this->tokenProvider->rotate($actual, 'oldtoken', 'newtoken');
+		$new = $this->tokenProvider->rotate($actual, 'oldtokentokentokentokentoken', 'newtokentokentokentokentoken');
 
 		$newPrivate = $new->getPrivateKey();
 
@@ -595,7 +590,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 	public function testUpdatePasswords() {
 		$uid = 'myUID';
 		$token1 = $this->tokenProvider->generateToken(
-			'foo',
+			'foobetokentokentokentoken',
 			$uid,
 			$uid,
 			'bar',
@@ -603,7 +598,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 			IToken::PERMANENT_TOKEN,
 			IToken::REMEMBER);
 		$token2 = $this->tokenProvider->generateToken(
-			'foobar',
+			'foobartokentokentokentoken',
 			$uid,
 			$uid,
 			'bar',


### PR DESCRIPTION
… is long enough

## Summary

All our generated auth tokens have a a fixed length (apart from session id based one which has a minimum). So it's save to assume that shorter strings are not actually valid apptokens we need to look up but the password when basic auth is used.
Additionally a min length check was added to help developers on generating new tokens in the future.

## Query count of notifications app integration tests

* Ref https://github.com/nextcloud/notifications/pull/1452

Before | After
---|---
https://github.com/nextcloud/notifications/actions/runs/4108063021/jobs/7088301789 | https://github.com/nextcloud/notifications/actions/runs/4128695573/jobs/7133455445
10354 | 9150

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
