### PR TITLE
perf(dav): Do not call general setupFS on ever dav auth

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -104,14 +104,11 @@ class Auth extends AbstractBasic {
 		if ($this->userSession->isLoggedIn() &&
 			$this->isDavAuthenticated($this->userSession->getUser()->getUID())
 		) {
-			\OC_Util::setupFS($this->userSession->getUser()->getUID());
 			$this->session->close();
 			return true;
 		} else {
-			\OC_Util::setupFS(); //login hooks may need early access to the filesystem
 			try {
 				if ($this->userSession->logClientIn($username, $password, $this->request, $this->throttler)) {
-					\OC_Util::setupFS($this->userSession->getUser()->getUID());
 					$this->session->set(self::DAV_AUTHENTICATED, $this->userSession->getUser()->getUID());
 					$this->session->close();
 					return true;

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -117,7 +117,7 @@ class AuthTest extends TestCase {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(2))
+		$user->expects($this->exactly(1))
 			->method('getUID')
 			->willReturn('MyTestUser');
 		$this->userSession
@@ -125,7 +125,7 @@ class AuthTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(true);
 		$this->userSession
-			->expects($this->exactly(2))
+			->expects($this->exactly(1))
 			->method('getUser')
 			->willReturn($user);
 		$this->session
@@ -171,7 +171,7 @@ class AuthTest extends TestCase {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(3))
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyTestUser');
 		$this->userSession
@@ -179,7 +179,7 @@ class AuthTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(true);
 		$this->userSession
-			->expects($this->exactly(3))
+			->expects($this->exactly(2))
 			->method('getUser')
 			->willReturn($user);
 		$this->session
@@ -660,11 +660,11 @@ class AuthTest extends TestCase {
 		$user = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$user->expects($this->exactly(3))
+		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyTestUser');
 		$this->userSession
-			->expects($this->exactly(4))
+			->expects($this->exactly(3))
 			->method('getUser')
 			->willReturn($user);
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);


### PR DESCRIPTION
This could save setting up the full file system and instead use setupForPath. Unsure about possible side effects, webdav works here still, but let's see what the tests have to say.

Local comparison:

<img width="541" alt="Screenshot 2023-02-09 at 08 57 22" src="https://user-images.githubusercontent.com/3404133/217751565-df563d84-3426-4493-998b-69928f885bd8.png">

## Perftesting

- Saves 12 queries (54 to 32) on the talk folder PROPFIND
- More savings if combined with https://github.com/nextcloud/server/pull/36589
  - 34 (66 down to 32) queries on a Personal folder https://blackfire.io/profiles/compare/e7b0d672-e098-441b-a3b7-edd0f4c61e89...8e62d8bd-d0ec-4ee1-bb5b-67feffb463ca/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=sql.queries&selected=&callname=main()&constraintDoc=
  - 83 (115 to 32) queries on the Talk folder https://blackfire.io/profiles/compare/b1689551-5a98-47f9-b721-8bbe8cba08fc...d6d6ce2c-5724-4e3a-a9ed-81d049b04c9d/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=sql.queries&selected=&callname=main()&constraintDoc=

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
