### PR TITLE
Create an accessible name for logo on logged in page

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -60,7 +60,11 @@ p($theme->getTitle());
 			<div class="header-left">
 				<a href="<?php print_unescaped($_['logoUrl'] ?: link_to('', 'index.php')); ?>"
 					id="nextcloud">
-					<div class="logo logo-icon"></div>
+					<div class="logo logo-icon">
+						<span class="hidden-visually">
+							<?php p($l->t('%s homepage', [$theme->getName()])); ?>
+						</span>
+					</div>
 				</a>
 
 				<nav id="header-left__appmenu"></nav>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36632

## Summary

Create invisible accessible name for logo. No visible changes.

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-02-09 14-05-03](https://user-images.githubusercontent.com/6078378/217820792-f1f01227-4a3d-41b9-b353-c792b9715d73.png) | ![Screenshot from 2023-02-09 14-00-58](https://user-images.githubusercontent.com/6078378/217819952-7d09eb28-1e7b-4487-99c3-e937e60bf147.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
