### PR TITLE
fix OC_Image: Prevent E_WARNING from getimagesize*

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -598,7 +598,7 @@ class OC_Image implements \OCP\IImage {
 	 * @return bool true if allocating is allowed, false otherwise
 	 */
 	private function checkImageSize($path) {
-		$size = getimagesize($path);
+		$size = @getimagesize($path);
 		if (!$size) {
 			return true;
 		}
@@ -619,7 +619,7 @@ class OC_Image implements \OCP\IImage {
 	 * @return bool true if allocating is allowed, false otherwise
 	 */
 	private function checkImageDataSize($data) {
-		$size = getimagesizefromstring($data);
+		$size = @getimagesizefromstring($data);
 		if (!$size) {
 			return true;
 		}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/recognize/issues/652#issuecomment-1414238625

## Summary
getimagesize and its sister throw E_WARNINGs that can't be caught with try-catch. @ silences these.

see https://github.com/nextcloud/server/pull/36420#issuecomment-1408653542
and https://github.com/nextcloud/server/pull/35932

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
