### PR TITLE
also cache backend for user in memory instead of always going to redis

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1353,6 +1353,7 @@ return array(
     'OC\\Memcache\\NullCache' => $baseDir . '/lib/private/Memcache/NullCache.php',
     'OC\\Memcache\\ProfilerWrapperCache' => $baseDir . '/lib/private/Memcache/ProfilerWrapperCache.php',
     'OC\\Memcache\\Redis' => $baseDir . '/lib/private/Memcache/Redis.php',
+    'OC\\Memcache\\WithLocalCache' => $baseDir . '/lib/private/Memcache/WithLocalCache.php',
     'OC\\MemoryInfo' => $baseDir . '/lib/private/MemoryInfo.php',
     'OC\\Metadata\\Capabilities' => $baseDir . '/lib/private/Metadata/Capabilities.php',
     'OC\\Metadata\\FileEventListener' => $baseDir . '/lib/private/Metadata/FileEventListener.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1386,6 +1386,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Memcache\\NullCache' => __DIR__ . '/../../..' . '/lib/private/Memcache/NullCache.php',
         'OC\\Memcache\\ProfilerWrapperCache' => __DIR__ . '/../../..' . '/lib/private/Memcache/ProfilerWrapperCache.php',
         'OC\\Memcache\\Redis' => __DIR__ . '/../../..' . '/lib/private/Memcache/Redis.php',
+        'OC\\Memcache\\WithLocalCache' => __DIR__ . '/../../..' . '/lib/private/Memcache/WithLocalCache.php',
         'OC\\MemoryInfo' => __DIR__ . '/../../..' . '/lib/private/MemoryInfo.php',
         'OC\\Metadata\\Capabilities' => __DIR__ . '/../../..' . '/lib/private/Metadata/Capabilities.php',
         'OC\\Metadata\\FileEventListener' => __DIR__ . '/../../..' . '/lib/private/Metadata/FileEventListener.php',

--- a/lib/private/Memcache/WithLocalCache.php
+++ b/lib/private/Memcache/WithLocalCache.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace OC\Memcache;
+
+use OCP\Cache\CappedMemoryCache;
+use OCP\ICache;
+
+/**
+ * Wrap a cache instance with an extra later of local, in-memory caching
+ */
+class WithLocalCache implements ICache {
+	private ICache $inner;
+	private CappedMemoryCache $cached;
+
+	public function __construct(ICache $inner, int $localCapacity = 512) {
+		$this->inner = $inner;
+		$this->cached = new CappedMemoryCache($localCapacity);
+	}
+
+	public function get($key) {
+		if (isset($this->cached[$key])) {
+			return $this->cached[$key];
+		} else {
+			$value = $this->inner->get($key);
+			if (!is_null($value)) {
+				$this->cached[$key] = $value;
+			}
+			return $value;
+		}
+	}
+
+	public function set($key, $value, $ttl = 0) {
+		$this->cached[$key] = $value;
+		return $this->inner->set($key, $value, $ttl);
+	}
+
+	public function hasKey($key) {
+		return isset($this->cached[$key]) || $this->inner->hasKey($key);
+	}
+
+	public function remove($key) {
+		unset($this->cached[$key]);
+		return $this->inner->remove($key);
+	}
+
+	public function clear($prefix = '') {
+		$this->cached->clear();
+		return $this->inner->clear($prefix);
+	}
+
+	public static function isAvailable(): bool {
+		return false;
+	}
+}

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -34,6 +34,7 @@
 namespace OC\User;
 
 use OC\Hooks\PublicEmitter;
+use OC\Memcache\WithLocalCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
@@ -104,7 +105,7 @@ class Manager extends PublicEmitter implements IUserManager {
 								IEventDispatcher $eventDispatcher) {
 		$this->config = $config;
 		$this->dispatcher = $oldDispatcher;
-		$this->cache = $cacheFactory->createDistributed('user_backend_map');
+		$this->cache = new WithLocalCache($cacheFactory->createDistributed('user_backend_map'));
 		$cachedUsers = &$this->cachedUsers;
 		$this->listen('\OC\User', 'postDelete', function ($user) use (&$cachedUsers) {
 			/** @var \OC\User\User $user */


### PR DESCRIPTION
remote caches aren't *that* cheap.

There are probably some other cases that do this manually that can be replaced with `WithLocalCache`, but that is left as an exercise for a follow up PR.