### PR TITLE
fix(authentication): Handle null or empty string password hash

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -113,7 +113,7 @@ class PublicKeyTokenProvider implements IProvider {
 		// We need to check against one old token to see if there is a password
 		// hash that we can reuse for detecting outdated passwords
 		$randomOldToken = $this->mapper->getFirstTokenForUser($uid);
-		$oldTokenMatches = $randomOldToken && $this->hasher->verify(sha1($password) . $password, $randomOldToken->getPasswordHash());
+		$oldTokenMatches = $randomOldToken && $randomOldToken->getPasswordHash() && $this->hasher->verify(sha1($password) . $password, $randomOldToken->getPasswordHash());
 
 		$dbToken = $this->newToken($token, $uid, $loginName, $password, $name, $type, $remember);
 


### PR DESCRIPTION
This can happen when the auth.storeCryptedPassword config is used, which previously errored with:
Hasher::verify(): Argument \#2 ($hash) must be of type string, null given

As observed in https://drone.nextcloud.com/nextcloud/spreed/11732/1/4

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
