### PR TITLE
enh: Allow prefetch-src self in CSP

### DIFF
--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -446,6 +446,7 @@ class EmptyContentSecurityPolicy {
 		$policy = "default-src 'none';";
 		$policy .= "base-uri 'none';";
 		$policy .= "manifest-src 'self';";
+		$policy .= "prefetch-src 'self';";
 
 		if (!empty($this->allowedScriptDomains) || $this->inlineScriptAllowed || $this->evalScriptAllowed) {
 			$policy .= 'script-src ';

--- a/tests/lib/AppFramework/Controller/ControllerTest.php
+++ b/tests/lib/AppFramework/Controller/ControllerTest.php
@@ -113,7 +113,7 @@ class ControllerTest extends \Test\TestCase {
 			'test' => 'something',
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
 			'Content-Type' => 'application/json; charset=utf-8',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'",
 			'Feature-Policy' => "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'",
 			'X-Request-Id' => $this->request->getId(),
 			'X-Robots-Tag' => 'none',

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -25,19 +25,19 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDefault() {
-		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 		$this->assertSame($defaultPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com www.owncloud.org;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' www.owncloud.com www.owncloud.org;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
@@ -45,7 +45,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
@@ -53,7 +53,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
@@ -61,7 +61,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
@@ -69,14 +69,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' www.owncloud.com 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineScript(true);
@@ -84,7 +84,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptDisallowInlineAndEval() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->allowInlineScript(false);
 		$this->contentSecurityPolicy->allowEvalScript(false);
@@ -92,14 +92,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
@@ -107,7 +107,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
@@ -115,7 +115,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
@@ -123,7 +123,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
@@ -131,35 +131,35 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDisallowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(false);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com www.owncloud.org;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com www.owncloud.org;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
@@ -167,7 +167,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
@@ -175,7 +175,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
@@ -183,7 +183,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
@@ -191,14 +191,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
@@ -206,7 +206,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
@@ -214,7 +214,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
@@ -222,7 +222,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
@@ -230,14 +230,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
@@ -245,7 +245,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
@@ -253,7 +253,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
@@ -261,7 +261,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
@@ -269,14 +269,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
@@ -284,7 +284,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
@@ -292,7 +292,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
@@ -300,7 +300,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
@@ -308,14 +308,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
@@ -323,7 +323,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
@@ -331,7 +331,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
@@ -339,7 +339,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
@@ -347,14 +347,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
@@ -362,7 +362,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
@@ -370,7 +370,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
@@ -378,7 +378,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
@@ -386,14 +386,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
@@ -401,7 +401,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
@@ -409,7 +409,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
@@ -417,7 +417,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
@@ -427,14 +427,14 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 
 
 	public function testGetAllowedFrameAncestorDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' sub.nextcloud.com;form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' sub.nextcloud.com;form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('sub.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameAncestorValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' sub.nextcloud.com foo.nextcloud.com;form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' sub.nextcloud.com foo.nextcloud.com;form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('sub.nextcloud.com');
 		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('foo.nextcloud.com');
@@ -442,7 +442,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameAncestorDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->disallowFrameAncestorDomain('www.nextcloud.com');
@@ -450,7 +450,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameAncestorDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' www.nextcloud.com;form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self' www.nextcloud.com;form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameAncestorDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->disallowFrameAncestorDomain('www.nextcloud.org');
@@ -458,7 +458,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameAncestorDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
@@ -466,7 +466,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyUnsafeEval() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->allowEvalScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
@@ -474,7 +474,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 
 	public function testGetPolicyNonce() {
 		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
@@ -482,7 +482,7 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 
 	public function testGetPolicyNonceStrictDynamic() {
 		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->useStrictDynamic(true);

--- a/tests/lib/AppFramework/Http/DataResponseTest.php
+++ b/tests/lib/AppFramework/Http/DataResponseTest.php
@@ -65,7 +65,7 @@ class DataResponseTest extends \Test\TestCase {
 
 		$expectedHeaders = [
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
-			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'",
+			'Content-Security-Policy' => "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'",
 			'Feature-Policy' => "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'",
 			'X-Robots-Tag' => 'none',
 			'X-Request-Id' => \OC::$server->get(IRequest::class)->getId(),

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -25,19 +25,19 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDefault() {
-		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$defaultPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 		$this->assertSame($defaultPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
@@ -45,7 +45,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
@@ -53,7 +53,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
@@ -61,7 +61,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
@@ -69,14 +69,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src  'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineScript(true);
@@ -84,7 +84,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptAllowInlineAndEval() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'unsafe-inline' 'unsafe-eval';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src  'unsafe-inline' 'unsafe-eval';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineScript(true);
 		$this->contentSecurityPolicy->allowEvalScript(true);
@@ -92,14 +92,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';style-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
@@ -107,7 +107,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
@@ -115,7 +115,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
@@ -123,7 +123,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
@@ -131,14 +131,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src  'unsafe-inline';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';style-src  'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';style-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->allowInlineStyle(true);
@@ -146,21 +146,21 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDisallowInline() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->allowInlineStyle(false);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';img-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
@@ -168,7 +168,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
@@ -176,7 +176,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
@@ -184,7 +184,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
@@ -192,14 +192,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';font-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
@@ -207,7 +207,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
@@ -215,7 +215,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
@@ -223,7 +223,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
@@ -231,14 +231,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';connect-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
@@ -246,7 +246,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
@@ -254,7 +254,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
@@ -262,7 +262,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
@@ -270,14 +270,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';media-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
@@ -285,7 +285,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
@@ -293,7 +293,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
@@ -301,7 +301,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
@@ -309,14 +309,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
@@ -324,7 +324,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
@@ -332,7 +332,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
@@ -340,7 +340,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
@@ -348,14 +348,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
@@ -363,7 +363,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
@@ -371,7 +371,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
@@ -379,7 +379,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
@@ -387,14 +387,14 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';child-src child.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
@@ -402,7 +402,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
@@ -410,7 +410,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';child-src www.owncloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
@@ -418,7 +418,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
 		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
@@ -426,7 +426,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithJsNonceAndScriptDomains() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
@@ -435,7 +435,7 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithJsNonceAndSelfScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'nonce-TXlKc05vbmNl';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
@@ -443,21 +443,21 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithoutJsNonceAndSelfScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self';frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithReportUri() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com";
 
 		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithMultipleReportUri() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com https://my-other-report-uri.com";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none';report-uri https://my-report-uri.com https://my-other-report-uri.com";
 
 		$this->contentSecurityPolicy->addReportTo("https://my-report-uri.com");
 		$this->contentSecurityPolicy->addReportTo("https://my-other-report-uri.com");

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -56,7 +56,7 @@ class ResponseTest extends \Test\TestCase {
 
 		$this->childResponse->setHeaders($expected);
 		$headers = $this->childResponse->getHeaders();
-		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
+		$expected['Content-Security-Policy'] = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';frame-ancestors 'none'";
 		$expected['Feature-Policy'] = "autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'";
 
 		$this->assertEquals($expected, $headers);

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -75,7 +75,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$expected->addAllowedImageDomain('anotherdomain.de');
 		$expected->addAllowedImageDomain('example.org');
 		$expected->addAllowedChildSrcDomain('childdomain');
-		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self';form-action 'self' thirdDomain";
+		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self';form-action 'self' thirdDomain";
 
 		$this->assertEquals($expected, $this->contentSecurityPolicyManager->getDefaultPolicy());
 		$this->assertSame($expectedStringPolicy, $this->contentSecurityPolicyManager->getDefaultPolicy()->buildPolicy());
@@ -120,7 +120,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 		$expected->addAllowedChildSrcDomain('childdomain');
 		$expected->addAllowedFormActionDomain('thirdDomain');
 		$expected->useStrictDynamic(true);
-		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self';form-action 'self' thirdDomain";
+		$expectedStringPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';prefetch-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: anotherdomain.de example.org;font-src 'self' data: mydomain.com example.com anotherFontDomain;connect-src 'self';media-src 'self';child-src childdomain;frame-ancestors 'self';form-action 'self' thirdDomain";
 
 		$this->assertEquals($expected, $this->contentSecurityPolicyManager->getDefaultPolicy());
 		$this->assertSame($expectedStringPolicy, $this->contentSecurityPolicyManager->getDefaultPolicy()->buildPolicy());


### PR DESCRIPTION
## Summary

Make sure that we can prefetch resources from our own domain e.g. with [webpack module prefetching](https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
