### PR TITLE
Invitation mail: Change subject if event got updated

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -183,6 +183,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$vEvent = array_pop($modified['new']);
 		/** @var VEvent $oldVevent */
 		$oldVevent = !empty($modified['old']) && is_array($modified['old']) ? array_pop($modified['old']) : null;
+		$isModified = isset($oldVevent);
 
 		// No changed events after all - this shouldn't happen if there is significant change yet here we are
 		// The scheduling status is debatable
@@ -229,7 +230,6 @@ class IMipPlugin extends SabreIMipPlugin {
 				break;
 		}
 
-
 		$data['attendee_name'] = ($recipientName ?: $recipient);
 		$data['invitee_name'] = ($senderName ?: $sender);
 
@@ -244,7 +244,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$template = $this->mailer->createEMailTemplate('dav.calendarInvite.' . $method, $data);
 		$template->addHeader();
 
-		$this->imipService->addSubjectAndHeading($template, $method, $data['invitee_name'], $data['meeting_title']);
+		$this->imipService->addSubjectAndHeading($template, $method, $data['invitee_name'], $data['meeting_title'], $isModified);
 		$this->imipService->addBulletList($template, $vEvent, $data);
 
 		// Only add response buttons to invitation requests: Fix Issue #11230

--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -359,9 +359,10 @@ class IMipService {
 	 * @param string $sender
 	 * @param string $summary
 	 * @param string|null $partstat
+	 * @param bool $isModified
 	 */
 	public function addSubjectAndHeading(IEMailTemplate $template,
-		string $method, string $sender, string $summary): void {
+		string $method, string $sender, string $summary, bool $isModified): void {
 		if ($method === IMipPlugin::METHOD_CANCEL) {
 			// TRANSLATORS Subject for email, when an invitation is cancelled. Ex: "Cancelled: {{Event Name}}"
 			$template->setSubject($this->l10n->t('Cancelled: %1$s', [$summary]));
@@ -370,6 +371,10 @@ class IMipService {
 			// TRANSLATORS Subject for email, when an invitation is replied to. Ex: "Re: {{Event Name}}"
 			$template->setSubject($this->l10n->t('Re: %1$s', [$summary]));
 			$template->addHeading($this->l10n->t('%1$s has responded to your invitation', [$sender]));
+		} elseif ($method === IMipPlugin::METHOD_REQUEST && $isModified) {
+			// TRANSLATORS Subject for email, when an invitation is updated. Ex: "Invitation updated: {{Event Name}}"
+			$template->setSubject($this->l10n->t('Invitation updated: %1$s', [$summary]));
+			$template->addHeading($this->l10n->t('%1$s updated the event "%2$s"', [$sender, $summary]));
 		} else {
 			// TRANSLATORS Subject for email, when an invitation is sent. Ex: "Invitation: {{Event Name}}"
 			$template->setSubject($this->l10n->t('Invitation: %1$s', [$summary]));

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -204,7 +204,7 @@ class IMipPluginTest extends TestCase {
 			->method('getFrom');
 		$this->service->expects(self::once())
 			->method('addSubjectAndHeading')
-			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting without (!) Boromir');
+			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting without (!) Boromir', true);
 		$this->service->expects(self::once())
 			->method('addBulletList')
 			->with($this->emailTemplate, $newVevent, $data);
@@ -296,7 +296,7 @@ class IMipPluginTest extends TestCase {
 			->method('getFrom');
 		$this->service->expects(self::once())
 			->method('addSubjectAndHeading')
-			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Elevenses');
+			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Elevenses', false);
 		$this->service->expects(self::once())
 			->method('addBulletList')
 			->with($this->emailTemplate, $newVevent, $data);
@@ -405,7 +405,7 @@ class IMipPluginTest extends TestCase {
 			->method('getFrom');
 		$this->service->expects(self::once())
 			->method('addSubjectAndHeading')
-			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting without (!) Boromir');
+			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting without (!) Boromir', false);
 		$this->service->expects(self::once())
 			->method('addBulletList')
 			->with($this->emailTemplate, $newVevent, $data);
@@ -480,7 +480,7 @@ class IMipPluginTest extends TestCase {
 			->method('getFrom');
 		$this->service->expects(self::once())
 			->method('addSubjectAndHeading')
-			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting');
+			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting', false);
 		$this->service->expects(self::once())
 			->method('addBulletList')
 			->with($this->emailTemplate, $newVevent, $data);
@@ -553,7 +553,7 @@ class IMipPluginTest extends TestCase {
 			->method('getFrom');
 		$this->service->expects(self::once())
 			->method('addSubjectAndHeading')
-			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting');
+			->with($this->emailTemplate, 'request', 'Mr. Wizard', 'Fellowship meeting', false);
 		$this->service->expects(self::once())
 			->method('addBulletList')
 			->with($this->emailTemplate, $newVevent, $data);


### PR DESCRIPTION
* Resolves: [#36553](https://github.com/nextcloud/server/issues/36553)

## Summary

Trying to implement the attendee invitation mail that the subject of the mail changes if an event is updated.

![image](https://user-images.githubusercontent.com/757752/218106713-a7570ab2-b360-4be8-b837-a1a1c654bcbe.png)


## TODO

- [ ] Add tests?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
