### PR TITLE
Fix OCM validation errors

### DIFF
--- a/lib/public/Federation/Exceptions/BadRequestException.php
+++ b/lib/public/Federation/Exceptions/BadRequestException.php
@@ -32,6 +32,9 @@ use OCP\HintException;
  * @since 14.0.0
  */
 class BadRequestException extends HintException {
+	/**
+	 * @var string[] $parameterList
+	 */
 	private $parameterList;
 
 	/**
@@ -55,7 +58,7 @@ class BadRequestException extends HintException {
 	 *
 	 * @since 14.0.0
 	 *
-	 * @return array
+	 * @return array{message: string, validationErrors: array{message: string, name: string}[]}
 	 */
 	public function getReturnMessage() {
 		$result = [
@@ -65,7 +68,7 @@ class BadRequestException extends HintException {
 		];
 
 		foreach ($this->parameterList as $missingParameter) {
-			$result['validationErrors'] = [
+			$result['validationErrors'][] = [
 				'name' => $missingParameter,
 				'message' => 'NOT_FOUND'
 			];


### PR DESCRIPTION
## Summary

According to the [spec](https://github.com/cs3org/OCM-API/blob/c590a3d6c2c0388bb63b76c7c4c30cc9aed5f75d/spec.yaml#L190) the `validationErrors` is an array of objects.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
