### PR TITLE
feat(dav): Directly access shared calendars by URI

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -169,8 +169,9 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		}
 
 		// Fallback to cover shared calendars
-		foreach ($this->caldavBackend->getCalendarsForUser($this->principalInfo['uri']) as $calendar) {
-			if ($calendar['uri'] === $name) {
+		if ($this->caldavBackend instanceof CalDavBackend) {
+			$calendar = $this->caldavBackend->getSharedCalendarByUri($this->principalInfo['uri'], $name);
+			if(!empty($calendar)) {
 				return new Calendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
 			}
 		}


### PR DESCRIPTION
Each time we access a shared calendar details (with getChild), this loads every user's calendars and iterates until the correct one is found. Now we lookup from the shared calendars which ones has the correct URI, just iterating on the possible shares (for instance a calendar can be shared directly through user-to-user share or through user-to-group share).

Didn't mesure properly the performance benefits, but should be really nice with many shared calendars.

Follow-up to https://github.com/nextcloud/server/pull/33608


## TODO

- [ ] Add some tests for this new method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
