### PR TITLE
[stable25] Fix missing files:navigation:changed when clicking on a dir in the favorites view

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -200,6 +200,7 @@
 				const isGridView = this.$showGridView.is(':checked');
 				this.currentFileList.setGridView(isGridView);
 			}
+			window._nc_event_bus.emit('files:navigation:changed')
 		},
 
 		/**


### PR DESCRIPTION
While being in the favorites view, if one clicks a directory, the `files:navigation:changed` event is not emitted so Text can't update the rich workspace visibility.

This fixes https://github.com/nextcloud/text/issues/3697 but has the side effect to emit the event twice when clicking on the "Favorites" nav item while being in the "All files" view.
As `files:navigation:changed` is only listened by Text, it does not seems too bad.

An alternative fix would be to remove the silent option from https://github.com/nextcloud/server/blob/6bb0985e59d7ba3c4cf9928d8bb766ac9975cd12/apps/files/js/favoritesplugin.js#L98
but we don't know exactly what side effect it could have.