### PR TITLE
fix: Make sure that rollback hook is triggered on all version backends

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -417,12 +417,6 @@ class Storage {
 
 			$node = $userFolder->get($file);
 
-			// TODO: move away from those legacy hooks!
-			\OC_Hook::emit('\OCP\Versions', 'rollback', [
-				'path' => $filename,
-				'revision' => $revision,
-				'node' => $node,
-			]);
 			return true;
 		} elseif ($versionCreated) {
 			self::deleteVersion($users_view, $version);

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -96,7 +96,7 @@ class VersionManager implements IVersionManager, INameableVersionBackend, IDelet
 		$backend = $version->getBackend();
 		$result = $backend->rollback($version);
 		\OC_Hook::emit('\OCP\Versions', 'rollback', [
-			'path' => \OC\Files\Filesystem::getView()->getRelativePath($version->getSourceFile()->getPath()),
+			'path' => $version->getVersionPath(),
 			'revision' => $version->getRevisionId(),
 			'node' => $version->getSourceFile(),
 		]);

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -94,7 +94,13 @@ class VersionManager implements IVersionManager, INameableVersionBackend, IDelet
 
 	public function rollback(IVersion $version) {
 		$backend = $version->getBackend();
-		return $backend->rollback($version);
+		$result = $backend->rollback($version);
+		\OC_Hook::emit('\OCP\Versions', 'rollback', [
+			'path' => \OC\Files\Filesystem::getView()->getRelativePath($version->getSourceFile()->getPath()),
+			'revision' => $version->getRevisionId(),
+			'node' => $version->getSourceFile(),
+		]);
+		return $result;
 	}
 
 	public function read(IVersion $version) {

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -95,11 +95,14 @@ class VersionManager implements IVersionManager, INameableVersionBackend, IDelet
 	public function rollback(IVersion $version) {
 		$backend = $version->getBackend();
 		$result = $backend->rollback($version);
-		\OC_Hook::emit('\OCP\Versions', 'rollback', [
-			'path' => $version->getVersionPath(),
-			'revision' => $version->getRevisionId(),
-			'node' => $version->getSourceFile(),
-		]);
+		// rollback doesn't have a return type yet and some implementations don't return anything
+		if ($result === null || $result === true) {
+			\OC_Hook::emit('\OCP\Versions', 'rollback', [
+				'path' => $version->getVersionPath(),
+				'revision' => $version->getRevisionId(),
+				'node' => $version->getSourceFile(),
+			]);
+		}
 		return $result;
 	}
 

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -37,6 +37,7 @@ namespace OCA\Files_Versions\Tests;
 use OC\Files\Storage\Temporary;
 use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
+use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\Files\IMimeTypeLoader;
 use OCP\IConfig;
 use OCP\IUser;
@@ -661,6 +662,7 @@ class VersioningTest extends \Test\TestCase {
 	public function testRestoreCrossStorage() {
 		$storage2 = new Temporary([]);
 		\OC\Files\Filesystem::mount($storage2, [], self::TEST_VERSIONS_USER . '/files/sub');
+		\OC\Files\Filesystem::tearDown();
 
 		$this->doTestRestore();
 	}
@@ -822,7 +824,12 @@ class VersioningTest extends \Test\TestCase {
 		$params = [];
 		$this->connectMockHooks('rollback', $params);
 
-		$this->assertTrue(\OCA\Files_Versions\Storage::rollback('sub/test.txt', $t2, $this->user1));
+		$versionManager = \OCP\Server::get(IVersionManager::class);
+		$versions = $versionManager->getVersionsForFile($this->user1, $info1);
+		$version = array_filter($versions, function ($version) use ($t2) {
+			return $version->getRevisionId() === $t2;
+		});
+		$this->assertTrue($versionManager->rollback(current($version)));
 		$expectedParams = [
 			'path' => '/sub/test.txt',
 		];

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -662,7 +662,6 @@ class VersioningTest extends \Test\TestCase {
 	public function testRestoreCrossStorage() {
 		$storage2 = new Temporary([]);
 		\OC\Files\Filesystem::mount($storage2, [], self::TEST_VERSIONS_USER . '/files/sub');
-		\OC\Files\Filesystem::tearDown();
 
 		$this->doTestRestore();
 	}


### PR DESCRIPTION
## Summary

Alternative to https://github.com/nextcloud/groupfolders/pull/2260 to apply to any version backend.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
