### PR TITLE
add a disk_free_space check before writing config

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -285,6 +285,12 @@ class Config {
 				'This can usually be fixed by giving the webserver write access to the config directory.');
 		}
 
+		// Never write file back if disk space should be low (less than 100 KiB)
+		$df = disk_free_space($this->configDir);
+		if ($df !== false && (int)$df < 102400) {
+			throw new \Exception($this->configDir . " does not have enough space for writing the config file! Not writing it back!");
+		}
+
 		// Try to acquire a file lock
 		if (!flock($filePointer, LOCK_EX)) {
 			throw new \Exception(sprintf('Could not acquire an exclusive lock on the config file %s', $this->configFilePath));

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -285,9 +285,10 @@ class Config {
 				'This can usually be fixed by giving the webserver write access to the config directory.');
 		}
 
-		// Never write file back if disk space should be low (less than 100 KiB)
+		// Never write file back if disk space should be too low
 		$df = disk_free_space($this->configDir);
-		if ($df !== false && (int)$df < 102400) {
+		$size = strlen($content) + 10240;
+		if ($df !== false && (int)$df < $size) {
 			throw new \Exception($this->configDir . " does not have enough space for writing the config file! Not writing it back!");
 		}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/25175

Idea: the config file should simply not get written if disk space is low. Instead the current process should be exited. This should hopefully fix such issues in the future.

I am using the same logic in AIO and it works great over there.
https://github.com/nextcloud/all-in-one/blob/feffba739ae5ef2911782514fa5de367d52cf811/php/src/Data/ConfigurationManager.php#L455-L458