### PR TITLE
fix(preview-generator): Throw exception before dividing by zero when generating previews

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -170,6 +170,10 @@ class Generator {
 
 		[$maxWidth, $maxHeight] = $this->getPreviewSize($maxPreview, $previewVersion);
 
+		if ($maxWidth <= 0 || $maxHeight <= 0) {
+			throw new NotFoundException('The maximum preview sizes are zero or less pixels');
+		}
+
 		$preview = null;
 
 		foreach ($specifications as $specification) {


### PR DESCRIPTION
If the maximum preview generated gives some kind of invalid IImage, it's dimensions and filename can be set to zero. And then later we do a division by zero to keep the aspect ratio of the previews.

```
ErrorException: Warning: Division by zero
#11 /var/www/nc/nextcloud-25.0.1/lib/private/Preview/Generator.php(516): OC\Preview\Generator::generatePreview
#10 /var/www/nc/nextcloud-25.0.1/lib/private/Preview/Generator.php(208): OC\Preview\Generator::generatePreviews
#9 /var/www/nc/nextcloud-25.0.1/lib/private/Preview/Generator.php(114): OC\Preview\Generator::getPreview
#8 /var/www/nc/nextcloud-25.0.1/lib/private/PreviewManager.php(185): OC\PreviewManager::getPreview
#7 /var/www/nc/nextcloud-25.0.1/core/Controller/PreviewController.php(144): OC\Core\Controller\PreviewController::fetchPreview
#6 /var/www/nc/nextcloud-25.0.1/core/Controller/PreviewController.php(113): OC\Core\Controller\PreviewController::getPreviewByFileId
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
