### PR TITLE
Add parent index on filecache

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -132,6 +132,10 @@ class Application extends App {
 					if (!$table->hasIndex('fs_storage_path_prefix') && !$schema->getDatabasePlatform() instanceof PostgreSQL94Platform) {
 						$subject->addHintForMissingSubject($table->getName(), 'fs_storage_path_prefix');
 					}
+
+					if (!$table->hasIndex('fs_parent')) {
+						$subject->addHintForMissingSubject($table->getName(), 'fs_parent');
+					}
 				}
 
 				if ($schema->hasTable('twofactor_providers')) {

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -182,6 +182,16 @@ class AddMissingIndices extends Command {
 				$updated = true;
 				$output->writeln('<info>Filecache table updated successfully.</info>');
 			}
+			if (!$table->hasIndex('fs_parent')) {
+				$output->writeln('<info>Adding additional parent index to the filecache table, this can take some time...</info>');
+				$table->addIndex(['parent'], 'fs_parent');
+				$sqlQueries = $this->connection->migrateToSchema($schema->getWrappedSchema(), $dryRun);
+				if ($dryRun && $sqlQueries !== null) {
+					$output->writeln($sqlQueries);
+				}
+				$updated = true;
+				$output->writeln('<info>Filecache table updated successfully.</info>');
+			}
 		}
 
 		$output->writeln('<info>Check indices of the twofactor_providers table.</info>');

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -262,6 +262,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage', 'mimepart'], 'fs_storage_mimepart');
 			$table->addIndex(['storage', 'size', 'fileid'], 'fs_storage_size');
 			$table->addIndex(['fileid', 'storage', 'size'], 'fs_id_storage_size');
+			$table->addIndex(['parent'], 'fs_parent');
 			$table->addIndex(['mtime'], 'fs_mtime');
 			$table->addIndex(['size'], 'fs_size');
 			if (!$schema->getDatabasePlatform() instanceof PostgreSQL94Platform) {


### PR DESCRIPTION
To speed up:
https://github.com/nextcloud/server/blob/fd2afe604ef1d8ef6d5ae9d497b0f01ae159b2f6/lib/private/Files/Cache/Cache.php#L878-L880

The current query uses the `parent_name_hash` index, which is not optimal with long names.

|               | id  | select_type | table        | type | possible_keys                           | key                 | key_len | ref   | rows |
| ------------- | --- | ----------- | ------------ | ---- | --------------------------------------- | ------------------- | ------- | ----- | ---- |
| **Without index** | 1   | SIMPLE      | oc_filecache | ref  | fs_parent_name_hash                     | fs_parent_name_hash | 8       | const | 5    |
| **With index**    | 1   | SIMPLE      | oc_filecache | ref  | fs_parent_name_hash,oc_filecache_parent | oc_filecache_parent | 8       | const | 5    |