### PR TITLE
add 'siteselector' to the app loading process

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1021,6 +1021,7 @@ class OC {
 
 		// Always load authentication apps
 		OC_App::loadApps(['authentication']);
+		OC_App::loadApps(['siteselector']);
 
 		// Load minimum set of apps
 		if (!\OCP\Util::needUpgrade()

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -332,7 +332,7 @@ class Updater extends BasicEmitter {
 	 */
 	protected function doAppUpgrade(): void {
 		$apps = \OC_App::getEnabledApps();
-		$priorityTypes = ['authentication', 'filesystem', 'logging'];
+		$priorityTypes = ['authentication', 'siteselector', 'filesystem', 'logging'];
 		$pseudoOtherType = 'other';
 		$stacks = [$pseudoOtherType => []];
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -194,7 +194,7 @@ class OC_App {
 				if ($ex instanceof ServerNotAvailableException) {
 					throw $ex;
 				}
-				if (!\OC::$server->getAppManager()->isShipped($app) && !self::isType($app, ['authentication'])) {
+				if (!\OC::$server->getAppManager()->isShipped($app) && !self::isType($app, ['authentication', 'siteselector'])) {
 					\OC::$server->getLogger()->logException($ex, [
 						'message' => "App $app threw an error during app.php load and will be disabled: " . $ex->getMessage(),
 					]);

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -50,6 +50,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 try {
 	OC_App::loadApps(['session']);
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['siteselector']);
 
 	// load all apps to get all api routes properly setup
 	// FIXME: this should ideally appear after handleLogin but will cause

--- a/public.php
+++ b/public.php
@@ -66,6 +66,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['siteselector']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	if (!\OC::$server->getAppManager()->isInstalled($app)) {

--- a/remote.php
+++ b/remote.php
@@ -153,6 +153,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['siteselector']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	switch ($app) {

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -249,6 +249,7 @@ class AppManagerTest extends TestCase {
 			['filesystem'],
 			['prelogin'],
 			['authentication'],
+			['siteselector'],
 			['logging'],
 			['prevent_group_restriction'],
 		];


### PR DESCRIPTION
This will allow to split the loading process between `user_ldap` and `globalsiteselector` as both are using the same `type` while `globalsiteselector` depends on `user_ldap` at `boot()`

the next step would be to replace `<authentication />` to `<siteselector />` in info.xml of the `globalsiteselector` app