### PR TITLE
feat(directediting): Allow opening by file id

### DIFF
--- a/apps/files/lib/Controller/DirectEditingController.php
+++ b/apps/files/lib/Controller/DirectEditingController.php
@@ -35,7 +35,6 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class DirectEditingController extends OCSController {
-
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
@@ -94,14 +93,14 @@ class DirectEditingController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function open(string $path, string $editorId = null): DataResponse {
+	public function open(string $path, string $editorId = null, ?int $fileId = null): DataResponse {
 		if (!$this->directEditingManager->isEnabled()) {
 			return new DataResponse(['message' => 'Direct editing is not enabled'], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 		$this->eventDispatcher->dispatchTyped(new RegisterDirectEditorEvent($this->directEditingManager));
 
 		try {
-			$token = $this->directEditingManager->open($path, $editorId);
+			$token = $this->directEditingManager->open($path, $editorId, $fileId);
 			return new DataResponse([
 				'url' => $this->urlGenerator->linkToRouteAbsolute('files.DirectEditingView.edit', ['token' => $token])
 			]);

--- a/apps/files/lib/DirectEditingCapabilities.php
+++ b/apps/files/lib/DirectEditingCapabilities.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
@@ -29,7 +30,6 @@ use OCP\Capabilities\IInitialStateExcludedCapability;
 use OCP\IURLGenerator;
 
 class DirectEditingCapabilities implements ICapability, IInitialStateExcludedCapability {
-
 	protected DirectEditingService $directEditingService;
 	protected IURLGenerator $urlGenerator;
 
@@ -43,7 +43,8 @@ class DirectEditingCapabilities implements ICapability, IInitialStateExcludedCap
 			'files' => [
 				'directEditing' => [
 					'url' => $this->urlGenerator->linkToOCSRouteAbsolute('files.DirectEditing.info'),
-					'etag' => $this->directEditingService->getDirectEditingETag()
+					'etag' => $this->directEditingService->getDirectEditingETag(),
+					'supportsFileId' => true,
 				]
 			],
 		];

--- a/tests/lib/DirectEditing/ManagerTest.php
+++ b/tests/lib/DirectEditing/ManagerTest.php
@@ -211,6 +211,86 @@ class ManagerTest extends TestCase {
 		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
 	}
 
+	public function testOpenByPath() {
+		$expectedToken = 'TOKEN' . time();
+		$file = $this->createMock(File::class);
+		$file->expects($this->any())
+			->method('getId')
+			->willReturn(123);
+		$file->expects($this->any())
+			->method('getPath')
+			->willReturn('/admin/files/File.txt');
+		$this->random->expects($this->once())
+			->method('generate')
+			->willReturn($expectedToken);
+		$folder = $this->createMock(Folder::class);
+		$this->userFolder
+			->method('nodeExists')
+			->withConsecutive(['/File.txt'], ['/'])
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->userFolder
+			->method('get')
+			->with('/File.txt')
+			->willReturn($file);
+		$this->userFolder
+			->method('getRelativePath')
+			->willReturn('/File.txt');
+		$this->manager->open('/File.txt', 'testeditor');
+		$firstResult = $this->manager->edit($expectedToken);
+		$secondResult = $this->manager->edit($expectedToken);
+		$this->assertInstanceOf(DataResponse::class, $firstResult);
+		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
+	}
+
+	public function testOpenById() {
+		$expectedToken = 'TOKEN' . time();
+		$fileRead = $this->createMock(File::class);
+		$fileRead->method('getPermissions')
+			->willReturn(1);
+		$fileRead->expects($this->any())
+			->method('getId')
+			->willReturn(123);
+		$fileRead->expects($this->any())
+			->method('getPath')
+			->willReturn('/admin/files/shared_file.txt');
+		$file = $this->createMock(File::class);
+		$file->method('getPermissions')
+			->willReturn(1);
+		$file->expects($this->any())
+			->method('getId')
+			->willReturn(123);
+		$file->expects($this->any())
+			->method('getPath')
+			->willReturn('/admin/files/File.txt');
+		$this->random->expects($this->once())
+			->method('generate')
+			->willReturn($expectedToken);
+		$folder = $this->createMock(Folder::class);
+		$folder->expects($this->any())
+			->method('getById')
+			->willReturn([
+				$fileRead,
+				$file
+			]);
+		$this->userFolder
+			->method('nodeExists')
+			->withConsecutive(['/File.txt'], ['/'])
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->userFolder
+			->method('get')
+			->with('/')
+			->willReturn($folder);
+		$this->userFolder
+			->method('getRelativePath')
+			->willReturn('/File.txt');
+
+		$this->manager->open('/', 'testeditor', 123);
+		$firstResult = $this->manager->edit($expectedToken);
+		$secondResult = $this->manager->edit($expectedToken);
+		$this->assertInstanceOf(DataResponse::class, $firstResult);
+		$this->assertInstanceOf(NotFoundResponse::class, $secondResult);
+	}
+
 	public function testCreateFileAlreadyExists() {
 		$this->expectException(\RuntimeException::class);
 		$this->userFolder


### PR DESCRIPTION
## Summary

Make sure that it is easy for the notes iOS/Android apps to open files by just knowing the file id. For cases where multiple files with the id are found we prefer the one with update permissions over others.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
