### PR TITLE
fix the contacts-menu vcf-contact avatars

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -287,7 +287,13 @@ class ContactsStore implements IContactsStore {
 		if (isset($contact['UID'])) {
 			$uid = $contact['UID'];
 			$entry->setId($uid);
-			$avatar = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $uid, 'size' => 64]);
+			if (isset($contact['isLocalSystemBook'])) {
+				$avatar = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $uid, 'size' => 64]);
+			} elseif (isset($contact['FN'])) {
+				$avatar = $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $contact['FN'], 'size' => 64]);
+			} else {
+				$avatar = $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $uid, 'size' => 64]);
+			}
 			$entry->setAvatar($avatar);
 		}
 

--- a/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ContactsStoreTest.php
@@ -142,7 +142,7 @@ class ContactsStoreTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$this->urlGenerator->expects($this->any())
 			->method('linkToRouteAbsolute')
-			->with('core.avatar.getAvatar', $this->anything())
+			->with('core.GuestAvatar.getAvatar', $this->anything())
 			->willReturn('https://urlToNcAvatar.test');
 		$this->contactsManager->expects($this->once())
 			->method('search')


### PR DESCRIPTION
Regression of https://github.com/nextcloud/server/pull/32635

Fixes avatars in the contacts-menu of vcf-contacts

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/219171720-5293c0c9-cd16-4465-b00c-a175e6185351.png) | ![image](https://user-images.githubusercontent.com/42591237/219171421-9c8eed6d-e8ce-4d21-9906-15880bdb76ea.png) |