### PR TITLE
Use proc_open to avoid spawning a shell

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -125,23 +125,30 @@ class Movie extends ProviderV2 {
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
 
 		if ($binaryType === 'avconv') {
-			$cmd = $this->binary . ' -y -ss ' . escapeshellarg((string)$second) .
-				' -i ' . escapeshellarg($absPath) .
-				' -an -f mjpeg -vframes 1 -vsync 1 ' . escapeshellarg($tmpPath) .
-				' 2>&1';
+            $cmd = [$this->binary, '-y', '-ss', (string)$second,
+                    '-i', $absPath,
+                    '-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
+                    $tmpPath];
 		} elseif ($binaryType === 'ffmpeg') {
-			$cmd = $this->binary . ' -y -ss ' . escapeshellarg((string)$second) .
-				' -i ' . escapeshellarg($absPath) .
-				' -f mjpeg -vframes 1' .
-				' ' . escapeshellarg($tmpPath) .
-				' 2>&1';
+            $cmd = [$this->binary, '-y', '-ss', (string)$second,
+                    '-i', $absPath,
+                    '-f', 'mjpeg', '-vframes', '1',
+                    $tmpPath];
 		} else {
 			// Not supported
 			unlink($tmpPath);
 			return null;
 		}
 
-		exec($cmd, $output, $returnCode);
+		$proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+		$returnCode = -1;
+		$output = "";
+		if (is_resource($proc)) {
+				$stdout = trim(stream_get_contents($pipes[1]));
+				$stderr = trim(stream_get_contents($pipes[2]));
+				$returnCode = proc_close($proc);
+				$output = $stdout . $stderr;
+		}
 
 		if ($returnCode === 0) {
 			$image = new \OCP\Image();

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -125,15 +125,15 @@ class Movie extends ProviderV2 {
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
 
 		if ($binaryType === 'avconv') {
-            $cmd = [$this->binary, '-y', '-ss', (string)$second,
-                    '-i', $absPath,
-                    '-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
-                    $tmpPath];
+			$cmd = [$this->binary, '-y', '-ss', (string)$second,
+					'-i', $absPath,
+					'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
+					$tmpPath];
 		} elseif ($binaryType === 'ffmpeg') {
-            $cmd = [$this->binary, '-y', '-ss', (string)$second,
-                    '-i', $absPath,
-                    '-f', 'mjpeg', '-vframes', '1',
-                    $tmpPath];
+			$cmd = [$this->binary, '-y', '-ss', (string)$second,
+				'-i', $absPath,
+				'-f', 'mjpeg', '-vframes', '1',
+				$tmpPath];
 		} else {
 			// Not supported
 			unlink($tmpPath);

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -126,9 +126,9 @@ class Movie extends ProviderV2 {
 
 		if ($binaryType === 'avconv') {
 			$cmd = [$this->binary, '-y', '-ss', (string)$second,
-					'-i', $absPath,
-					'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
-					$tmpPath];
+				'-i', $absPath,
+				'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
+				$tmpPath];
 		} elseif ($binaryType === 'ffmpeg') {
 			$cmd = [$this->binary, '-y', '-ss', (string)$second,
 				'-i', $absPath,
@@ -144,10 +144,10 @@ class Movie extends ProviderV2 {
 		$returnCode = -1;
 		$output = "";
 		if (is_resource($proc)) {
-				$stdout = trim(stream_get_contents($pipes[1]));
-				$stderr = trim(stream_get_contents($pipes[2]));
-				$returnCode = proc_close($proc);
-				$output = $stdout . $stderr;
+			$stdout = trim(stream_get_contents($pipes[1]));
+			$stderr = trim(stream_get_contents($pipes[2]));
+			$returnCode = proc_close($proc);
+			$output = $stdout . $stderr;
 		}
 
 		if ($returnCode === 0) {


### PR DESCRIPTION
## Summary
The use of `exec` will spawn a shell, using `/bin/sh` on POSIX platforms. But in restricted environment, such as AppArmor, this means giving execution to `/bin/sh`, which renders the execution restriction quite useless.
Using an array with `proc_open` reduces this, and paved the way for file streaming instead of temporary file.

Signed-off-by: Glandos <bugs-github@antipoul.fr>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
