### PR TITLE
Shared calendar invitations

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2203,6 +2203,11 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$stmt->closeCursor();
 		if ($row) {
 			if ($row['principaluri'] != $principalUri) {
+				/**
+				 * This seeems to be a false positive: we have "use Sabre\Uri" and Uri\split() IS defined.
+				 *
+				 * @psalm-suppress UndefinedFunction
+				 */
 				[, $name] = Uri\split($row['principaluri']);
 				$calendarUri = $row['calendaruri'] . '_shared_by_' . $name;
 			} else {

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -167,6 +167,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 			return;
 		}
 
+		/** @var Calendar $calendarNode */
 		$calendarNode = $this->server->tree->getNodeForPath($calendarPath);
 
 		// Original code in parent class:
@@ -180,13 +181,22 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 			$calendarNode->getPrincipalURI()
 		);
 
+		/** @var VCalendar $oldObj */
 		if (!$isNew) {
+			/** @var \Sabre\CalDAV\CalendarObject $node */
 			$node = $this->server->tree->getNodeForPath($request->getPath());
 			$oldObj = Reader::read($node->get());
 		} else {
 			$oldObj = null;
 		}
 
+		/**
+		 * Sabre has several issues with faulty argument type specifications
+		 * in its doc-block comments. Passing null is ok here.
+		 *
+		 * @psalm-suppress PossiblyNullArgument
+		 * @psalm-suppress ArgumentTypeCoercion
+		 */
 		$this->processICalendarChange($oldObj, $vCal, $addresses, [], $modified);
 
 		if ($oldObj) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue --> #26668

Oh, wait a bit: this is just a study to sort things out. Hence the "Draft" attribute.

Disclaimer: this is not the answer to all problems and not "the solution". It's just a bit of code in order to test the scenario.

## Summary

As indicated in the linked issue, support for writeable shared calendars is currently sub-optimal in several respects:

- the web-frontends exhibits information which indicates that participants have been invited. But no invitations are ever send. This is a bug, the related issue in the calendar app is nextcloud/calendar#4983.
- other calendar providers (e.g. SOGo) properly support shared calendars
- the related issue #26668 is somehow "stale"; there is no progress in the bug resolution

## TODO

- [ ] tests, discussions, make it really work, whatever you like

## Checklist

I do not care ATM. This pull request is currently only "for the record" in order to support the discussions in #26668 with a little bit more than more than just words.

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

## Explanations

As discussed in the linked issue  #26668 invitations for events created in shared (then obviously writeable) calendars are not send.

There was an attempt in commit  a9c313ce451 which was then reverted in commit 98a93d5226c. The reasons for reverting were a couple of loose ends and the fact that a9c313ce451 was incomplete: it only initiated the notifications to be send to the participants but did not address the problem that the underlying Sabre Dav library was not able to process the feedback (accept, deny, maybe) of the invited parties.

This pull request is then kind of a study: can we do it somehow, starting with the original commit and fixing the problem that replies are not properly processed.

- hence the changes to CalDAV/Schedule/Plugin.php are just as before. The original commit indeed was enough to trigger sending out invitations to the participants
- the missing thing is that the replies could not be parsed by Sabre because the referenced calendar objects (i.e. the events) could not be found.

The linked issue #26668 mentions a function `getUsersOwnCalendars()` which at least nowadays is hardly used any more safe in one place. Instead, we have to inspect `getCalendarObjectByUID()` as this is the real show stopper: if you start to examine things and try to understand why the responses of the invited parties are not processed, then you finally hit this point in the Sabre library:

https://github.com/sabre-io/dav/blob/2d8f6d9b9851a3d5fec007b7033d86b1dc241663/lib/CalDAV/Schedule/Plugin.php#L492

This point is met when the invitees send back their responses (accept, decline, not yet). The problem is now that the API documentation states:

```
    * This method should only consider * objects that the principal owns, so
     * any calendars owned by other principals that also appear in this
     * collection should be ignored.
```
"unfortunately" NC sticks to this requirement, and consequently the referenced event cannot be found.

This pull-request just ignores this requirements and changes `getCalendarObjectByUID()` such that it also finds objects in shared writeable calendars and adjusts their URI to the currently used `..._shared_by_...` layout.

This seems to be enough to establish the basic functionality which unfortunately still is advertised by the Nextcloud calendar frontend but up to now just does not work and irritates (not only end-)users.

As mentioned at the start of this too-long-a-comment: I do not consider this as "the solution". Just a code study ...
