### PR TITLE
Fix integer overflow on 32-bit systems when testing free space for wr…

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -288,7 +288,7 @@ class Config {
 		// Never write file back if disk space should be too low
 		$df = disk_free_space($this->configDir);
 		$size = strlen($content) + 10240;
-		if ($df !== false && (int)$df < $size) {
+		if ($df !== false && $df < (float)$size) {
 			throw new \Exception($this->configDir . " does not have enough space for writing the config file! Not writing it back!");
 		}
 


### PR DESCRIPTION
…iting a config file.

## Summary

This trivial commit fixes integer overflow on 32-bit systems when trying to write back config.php on upgrade.

The bug is introduced recently, in commit https://github.com/nextcloud/server/commit/9b6e5c6674e1dd8bf332a76ea1572fec5876f532

