### PR TITLE
Avoid scss cacher reset on empty variables

### DIFF
--- a/lib/private/Template/SCSSCacher.php
+++ b/lib/private/Template/SCSSCacher.php
@@ -272,6 +272,13 @@ class SCSSCacher {
 	private function variablesChanged(): bool {
 		$cachedVariables = $this->config->getAppValue('core', 'theming.variables', '');
 		$injectedVariables = $this->getInjectedVariables($cachedVariables);
+
+		if (empty($injectedVariables)) {
+			// There might be cases where the no variables could be fetched
+			// Stay with the old ones in that case ot avoid cache reset that is not needed
+			return false;
+		}
+
 		if ($cachedVariables !== md5($injectedVariables)) {
 			$this->logger->debug('SCSSCacher::variablesChanged storedVariables: ' . json_encode($this->config->getAppValue('core', 'theming.variables')) . ' currentInjectedVariables: ' . json_encode($injectedVariables), ['app' => 'scss_cacher']);
 			$this->config->setAppValue('core', 'theming.variables', md5($injectedVariables));

--- a/tests/lib/Template/SCSSCacherTest.php
+++ b/tests/lib/Template/SCSSCacherTest.php
@@ -101,7 +101,7 @@ class SCSSCacherTest extends \Test\TestCase {
 			);
 
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
-		$this->themingDefaults->expects($this->any())->method('getScssVariables')->willReturn([]);
+		$this->themingDefaults->expects($this->any())->method('getScssVariables')->willReturn(['color-primary' => '#745bca']);
 
 		$iconsFile = $this->createMock(ISimpleFile::class);
 		$this->iconsCacher->expects($this->any())


### PR DESCRIPTION
I observed cases where the variables were empty on unrelated requests by random security scanners, which triggered random cache invalidation and scss regeneration.

Only relevant for 24 as SCSS cacher was dropped with 25.