### PR TITLE
CalDavBackend, implement SharingSupport interface.

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -343,7 +343,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 	 * @return string|null
 	 */
 	public function setPublishStatus($value) {
-		$publicUri = $this->caldavBackend->setPublishStatus($value, $this);
+		$publicUri = $this->caldavBackend->setPublishStatus($this->getResourceId(), $value);
 		$this->calendarInfo['publicuri'] = $publicUri;
 		return $publicUri;
 	}


### PR DESCRIPTION
* Related: #26668

## Summary

Implement the `\Sabre\CalDAV\Backend\SharingSupport` in `\OCA\DAV\CalDAV\CalDavBackend`. The starting comment of the linked issue #26668 suggests that this might be the first step in supporting invitations for events in shared writeable calendars. However, after coding #36756 I have now the impression that the CalDAV sharing interface is orthogonal to sending invitations for events in shared calendars. It is nice to have and may help the calendar frontend (see nextcloud/calendar#4983). However, implementing the "SharingSupport" interface in the CalDAV backend does not bring us closer to sending invitations.

## TODO

- [ ] testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
