### PR TITLE
fix(database): Fix public_key_credential_id length

### DIFF
--- a/core/Migrations/Version25000Date20230217195657.php
+++ b/core/Migrations/Version25000Date20230217195657.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Zev Lee <60147316+zevlee@users.noreply.github.com>
+ *
+ * @author Zev Lee <60147316+zevlee@users.noreply.github.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version25000Date20230217195657 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		
+		$registrationsTable = $schema->getTable('webauthn');
+		/**
+		 * Fixes https://github.com/nextcloud/server/issues/34476
+		 */
+		$registrationsTable
+			->getColumn('public_key_credential_id')
+			->setLength(512);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/34476

## Summary

Increases length of column for security key so that it fits. This is essentially an identical migration step to https://github.com/nextcloud/twofactor_webauthn/pull/323.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
