### PR TITLE
fix: always use proper path on node api when calling the view

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -91,11 +91,13 @@ abstract class Node implements \Sabre\DAV\INode {
 		if ($info instanceof Folder || $info instanceof File) {
 			$this->node = $info;
 		} else {
+			// The Node API assumes that the view passed doesn't have a fake root
+			$rootView = \OC::$server->get(View::class);
 			$root = \OC::$server->get(IRootFolder::class);
 			if ($info->getType() === FileInfo::TYPE_FOLDER) {
-				$this->node = new Folder($root, $view, $this->path, $info);
+				$this->node = new Folder($root, $rootView, $this->fileView->getAbsolutePath($this->path), $info);
 			} else {
-				$this->node = new File($root, $view, $this->path, $info);
+				$this->node = new File($root, $rootView, $this->fileView->getAbsolutePath($this->path), $info);
 			}
 		}
 	}
@@ -107,10 +109,11 @@ abstract class Node implements \Sabre\DAV\INode {
 		}
 		$this->info = $info;
 		$root = \OC::$server->get(IRootFolder::class);
+		$rootView = \OC::$server->get(View::class);
 		if ($this->info->getType() === FileInfo::TYPE_FOLDER) {
-			$this->node = new Folder($root, $this->fileView, $this->path, $this->info);
+			$this->node = new Folder($root, $rootView, $this->path, $this->info);
 		} else {
-			$this->node = new File($root, $this->fileView, $this->path, $this->info);
+			$this->node = new File($root, $rootView, $this->path, $this->info);
 		}
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -29,9 +29,12 @@
 namespace OCA\DAV\Tests\Unit\Connector\Sabre;
 
 use OC\Files\FileInfo;
+use OC\Files\Filesystem;
 use OC\Files\Node\Node;
 use OC\Files\Storage\Wrapper\Quota;
+use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCP\Constants;
 use OCP\Files\ForbiddenException;
 use OCP\Files\Mount\IMountPoint;
 use Test\Traits\UserTrait;
@@ -91,6 +94,10 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturn(Node::TYPE_FOLDER);
 		$this->info->method('getName')
 			->willReturn("folder");
+		$this->info->method('getPath')
+			->willReturn("/admin/files/folder");
+		$this->info->method('getPermissions')
+			->willReturn(Constants::PERMISSION_READ);
 	}
 
 	private function getDir($path = '/') {
@@ -207,12 +214,21 @@ class DirectoryTest extends \Test\TestCase {
 
 		$this->view->expects($this->once())
 			->method('getDirectoryContent')
-			->with('')
 			->willReturn([$info1, $info2]);
 
 		$this->view->expects($this->any())
 			->method('getRelativePath')
-			->willReturn('');
+			->willReturnCallback(function($path) {
+				return str_replace('/admin/files/', '', $path);
+			});
+
+		$this->view->expects($this->any())
+			->method('getAbsolutePath')
+			->willReturnCallback(function($path) {
+				return Filesystem::normalizePath('/admin/files' . $path);
+			});
+
+		$this->overwriteService(View::class, $this->view);
 
 		$dir = new Directory($this->view, $this->info);
 		$nodes = $dir->getChildren();

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -218,13 +218,13 @@ class DirectoryTest extends \Test\TestCase {
 
 		$this->view->expects($this->any())
 			->method('getRelativePath')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				return str_replace('/admin/files/', '', $path);
 			});
 
 		$this->view->expects($this->any())
 			->method('getAbsolutePath')
-			->willReturnCallback(function($path) {
+			->willReturnCallback(function ($path) {
 				return Filesystem::normalizePath('/admin/files' . $path);
 			});
 

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -86,9 +86,11 @@ class FileSearchBackendTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->view = $this->createMock(View::class);
+
+		$this->view->expects($this->any())
+			->method('getRoot')
+			->willReturn('');
 
 		$this->view->expects($this->any())
 			->method('getRelativePath')

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -37,6 +37,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Lock\LockedException;
+use OCP\PreConditionNotMetException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 // FIXME: this class really should be abstract
@@ -52,7 +53,7 @@ class Node implements \OCP\Files\Node {
 	protected $root;
 
 	/**
-	 * @var string $path
+	 * @var string $path Absolute path to the node (e.g. /admin/files/folder/file)
 	 */
 	protected $path;
 
@@ -72,6 +73,9 @@ class Node implements \OCP\Files\Node {
 	 * @param FileInfo $fileInfo
 	 */
 	public function __construct($root, $view, $path, $fileInfo = null, ?Node $parent = null, bool $infoHasSubMountsIncluded = true) {
+		if (Filesystem::normalizePath($view->getRoot()) !== '/') {
+			throw new PreConditionNotMetException('The view passed to the node should not have any fake root set');
+		}
 		$this->view = $view;
 		$this->root = $root;
 		$this->path = $path;

--- a/tests/lib/Files/Node/FileTest.php
+++ b/tests/lib/Files/Node/FileTest.php
@@ -185,7 +185,7 @@ class FileTest extends NodeTest {
 
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
-			new $this->view,
+			$this->view,
 			$this->user,
 			$this->userMountCache,
 			$this->logger,
@@ -277,7 +277,7 @@ class FileTest extends NodeTest {
 
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
-			new $this->view,
+			$this->view,
 			$this->user,
 			$this->userMountCache,
 			$this->logger,

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -81,6 +81,8 @@ class FolderTest extends NodeTest {
 			]);
 		$view->method('getFileInfo')
 			->willReturn($this->createMock(FileInfo::class));
+		$view->method('getRelativePath')
+			->willReturn('/bar/foo');
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$children = $node->getDirectoryListing();

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -54,6 +54,9 @@ abstract class NodeTest extends \Test\TestCase {
 		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$this->view->expects($this->any())
+			->method('getRoot')
+			->willReturn('');
 		$this->userMountCache = $this->getMockBuilder('\OCP\Files\Config\IUserMountCache')
 			->disableOriginalConstructor()
 			->getMock();
@@ -63,6 +66,17 @@ abstract class NodeTest extends \Test\TestCase {
 		$this->root = $this->getMockBuilder('\OC\Files\Node\Root')
 			->setConstructorArgs([$this->manager, $this->view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->eventDispatcher])
 			->getMock();
+	}
+
+	/**
+	 * @return \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+	 */
+	protected function getRootViewMock() {
+		$view = $this->createMock(View::class);
+		$view->expects($this->any())
+			->method('getRoot')
+			->willReturn('');
+		return $view;
 	}
 
 	/**

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -52,6 +52,17 @@ class RootTest extends \Test\TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 	}
 
+	/**
+	 * @return \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+	 */
+	protected function getRootViewMock() {
+		$view = $this->createMock(View::class);
+		$view->expects($this->any())
+			->method('getRoot')
+			->willReturn('');
+		return $view;
+	}
+
 	protected function getFileInfo($data) {
 		return new FileInfo('', null, '', $data, null);
 	}
@@ -63,12 +74,7 @@ class RootTest extends \Test\TestCase {
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()
 			->getMock();
-		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
-		 */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->getRootViewMock();
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
 			$view,
@@ -100,12 +106,7 @@ class RootTest extends \Test\TestCase {
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()
 			->getMock();
-		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
-		 */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->getRootViewMock();
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
 			$view,
@@ -129,12 +130,7 @@ class RootTest extends \Test\TestCase {
 	public function testGetInvalidPath() {
 		$this->expectException(\OCP\Files\NotPermittedException::class);
 
-		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
-		 */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->getRootViewMock();
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
 			$view,
@@ -152,12 +148,7 @@ class RootTest extends \Test\TestCase {
 	public function testGetNoStorages() {
 		$this->expectException(\OCP\Files\NotFoundException::class);
 
-		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
-		 */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->getRootViewMock();
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
 			$view,
@@ -174,7 +165,7 @@ class RootTest extends \Test\TestCase {
 	public function testGetUserFolder() {
 		$root = new \OC\Files\Node\Root(
 			$this->manager,
-			$this->createMock(View::class),
+			$this->getRootViewMock(),
 			$this->user,
 			$this->userMountCache,
 			$this->logger,
@@ -215,7 +206,7 @@ class RootTest extends \Test\TestCase {
 
 		$root = new \OC\Files\Node\Root(
 			$this->createMock(Manager::class),
-			$this->createMock(View::class),
+			$this->getRootViewMock(),
 			null,
 			$this->userMountCache,
 			$this->logger,


### PR DESCRIPTION
Make sure that the nodes API always uses the full path and root view.

This is only noticeable on places where the dav app already uses the new nodes api but could cause trouble in the future.

Seen this being an issue when the dav app passes a relative path and fake root view for the user but the full file system setup was dropped by #36589 when:

- Incoming share was moved to a subfolder A/B/share
- Perform the following query: `curl -X PROPFIND http://admin:admin@nextcloud.dev.local/remote.php/webdav/A -H 'Depth: 2'`