### PR TITLE
Fix wrong class name in CSS for UserList

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -1378,14 +1378,14 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 			// Scroll if too much groups
 			&:not(.row--editable) {
 				.groups,
-				.subadmins {
+				.subAdminsGroups {
 					overflow: auto;
 					max-height: 100%;
 				}
 			}
 
 			.groups,
-			.subadmins,
+			.subAdminsGroups,
 			.quota {
 				min-width: $grid-col-min-width;
 


### PR DESCRIPTION
Class name is .subAdminsGroups not .subadmins