### PR TITLE
fix: Avoid throwing errors on public auth page

### DIFF
--- a/core/js/publicshareauth.js
+++ b/core/js/publicshareauth.js
@@ -47,6 +47,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
 	// Adds functionality to the request password button
 	var passwordRequestButton = document.getElementById('request-password-button-not-talk');
-	passwordRequestButton.addEventListener('click', showEmailAddressPromptForm);
+	if (passwordRequestButton) {
+		passwordRequestButton.addEventListener('click', showEmailAddressPromptForm);
+	}
 
 });

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -43,8 +43,7 @@ class CSSResourceLocator extends ResourceLocator {
 	 */
 	public function doFind($style) {
 		$app = substr($style, 0, strpos($style, '/'));
-		if (strpos($style, '3rdparty') === 0
-			&& $this->appendIfExist($this->serverroot, $style.'.css')
+		if ($this->appendIfExist($this->serverroot, $style.'.css')
 			|| $this->appendIfExist($this->serverroot, 'core/'.$style.'.css')
 		) {
 			return;


### PR DESCRIPTION
Avoid throwing errors on the public share page like:

> Cannot read properties of null (reading 'addEventListener')

https://juliushaertl.sentry.io/share/issue/2d96706d8b094bd7b5b780761c11969c/



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
