### PR TITLE
chore(deps): Declare ext-openssl as required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"ext-json": "*",
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
+		"ext-openssl": "*",
 		"ext-pdo": "*",
 		"ext-simplexml": "*",
 		"ext-xmlreader": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c30ab0b39c073da15c133396d55da957",
+    "content-hash": "503972be0f0c78458677d4c4e4e8a486",
     "packages": [],
     "packages-dev": [
         {
@@ -75,6 +75,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-openssl": "*",
         "ext-pdo": "*",
         "ext-simplexml": "*",
         "ext-xmlreader": "*",


### PR DESCRIPTION
* Resolves: PHPStorm telling me `'ext-openssl' is missing in composer.json`

## Summary

Nextcloud requires openssl: https://docs.nextcloud.com/server/20/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

## TODO

- [x] Fix composer.json

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
