### PR TITLE
Properly test and log when a group is not found

### DIFF
--- a/apps/user_ldap/lib/Jobs/UpdateGroups.php
+++ b/apps/user_ldap/lib/Jobs/UpdateGroups.php
@@ -44,7 +44,7 @@ use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class UpdateGroups extends TimedJob {
-    /** @var ?array<string, array{owncloudusers: string, owncloudname: string}>  */
+	/** @var ?array<string, array{owncloudusers: string, owncloudname: string}>  */
 	private ?array $groupsFromDB = null;
 	private Group_Proxy $groupBackend;
 	private IEventDispatcher $dispatcher;
@@ -157,6 +157,17 @@ class UpdateGroups extends TimedJob {
 			$hasChanged = false;
 
 			$groupObject = $this->groupManager->get($group);
+			if ($groupObject === null) {
+				/* We are not expecting the group to not be found since it was returned by $this->groupBackend->getGroups() */
+				$this->logger->error(
+					'bgJ "updateGroups" – Failed to get group {group} for update',
+					[
+						'app' => 'user_ldap',
+						'group' => $group
+					]
+				);
+				continue;
+			}
 			foreach (array_diff($knownUsers, $actualUsers) as $removedUser) {
 				$userObject = $this->userManager->get($removedUser);
 				if ($userObject instanceof IUser) {


### PR DESCRIPTION
## Summary

Avoid an error about passing null instead of IGroup to the event
 constructor, instead skip the failed group and log the problem.
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
