### PR TITLE
Add back authentication checkbox for mailer settings

### DIFF
--- a/apps/settings/templates/settings/admin/additional-mail.php
+++ b/apps/settings/templates/settings/admin/additional-mail.php
@@ -1,28 +1,32 @@
 <?php
 /**
- * @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
- *
- * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+	* @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
+	*
+	* @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+	*
+	* @license GNU AGPL version 3 or any later version
+	*
+	* This program is free software: you can redistribute it and/or modify
+	* it under the terms of the GNU Affero General Public License as
+	* published by the Free Software Foundation, either version 3 of the
+	* License, or (at your option) any later version.
+	*
+	* This program is distributed in the hope that it will be useful,
+	* but WITHOUT ANY WARRANTY; without even the implied warranty of
+	* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	* GNU Affero General Public License for more details.
+	*
+	* You should have received a copy of the GNU Affero General Public License
+	* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	*
+	*/
 
 /** @var \OCP\IL10N $l */
 /** @var array $_ */
+
+$mail_smtpauthtype = [
+	'LOGIN' => $l->t('Login')
+];
 
 $mail_smtpsecure = [
 	'' => $l->t('None'),
@@ -50,9 +54,11 @@ $mail_sendmailmode = [
 	<form id="mail_general_settings_form" class="mail_settings">
 		<h2><?php p($l->t('Email server'));?></h2>
 		<a target="_blank" rel="noreferrer noopener" class="icon-info"
-		   title="<?php p($l->t('Open documentation'));?>"
-		   href="<?php p(link_to_docs('admin-email')); ?>"></a>
-		<p class="settings-hint"><?php p($l->t('It is important to set up this server to be able to send emails, like for password reset and notifications.')); ?></p>
+					title="<?php p($l->t('Open documentation'));?>"
+					href="<?php p(link_to_docs('admin-email')); ?>"></a>
+		<p class="settings-hint">
+			  <?php p($l->t('It is important to set up this server to be able to send emails, like for password reset and notifications.')); ?>
+		</p>
 		<p><span id="mail_settings_msg" class="msg"></span></p>
 
 		<p>
@@ -99,26 +105,46 @@ $mail_sendmailmode = [
 		<p>
 			<label for="mail_from_address"><?php p($l->t('From address')); ?></label>
 			<input type="text" name="mail_from_address" id="mail_from_address" placeholder="<?php p($l->t('Email'))?>"
-				   value="<?php p($_['mail_from_address']) ?>" />@
+										value="<?php p($_['mail_from_address']) ?>" />@
 			<input type="text" name="mail_domain" id="mail_domain" placeholder="example.com"
-				   value="<?php p($_['mail_domain']) ?>" />
+										value="<?php p($_['mail_domain']) ?>" />
 		</p>
 
-<!--lo-->
-
 		<p id="setting_smtphost" <?php if ($_['mail_smtpmode'] !== 'smtp') {
-						print_unescaped(' class="hidden"');
-					} ?>>
+			print_unescaped(' class="hidden"');
+		} ?>>
 			<label for="mail_smtphost"><?php p($l->t('Server address')); ?></label>
 			<input type="text" name="mail_smtphost" id="mail_smtphost" placeholder="smtp.example.com"
-				   value="<?php p($_['mail_smtphost']) ?>" />
+										value="<?php p($_['mail_smtphost']) ?>" />
 			:
 			<input type="text" inputmode="numeric" name="mail_smtpport" id="mail_smtpport" placeholder="<?php p($l->t('Port'))?>"
-				   value="<?php p($_['mail_smtpport']) ?>" />
+										value="<?php p($_['mail_smtpport']) ?>" />
+		</p>
+		<p id='setting_smtpauth' <?php if ($_['mail_smtpmode'] !== 'smtp') {
+			print_unescaped(' class="hidden"');
+		} ?>>
+			<label for='mail_smtpauthtype'><?php p($l->t('Authentication method')); ?>
+					<span class="icon-info" title="<?php p($l->t('Only applies when authentication is required')); ?>"></span>
+			</label>
+			<select name="mail_smtpauthtype" id="mail_smtpauthtype" disabled="disabled">
+				<?php foreach ($mail_smtpauthtype as $authtype => $name):
+					$selected = '';
+					if ($authtype == $_['mail_smtpauthtype']):
+						$selected = 'selected="selected"';
+					endif; ?>
+					<option value="<?php p($authtype) ?>" <?php p($selected) ?>><?php p($name) ?></option>
+				<?php endforeach; ?>
+			</select>
+
+			<input type="checkbox" name="mail_smtpauth" id="mail_smtpauth" class="checkbox" value="1"
+				<?php if ($_['mail_smtpauth']) {
+					print_unescaped('checked="checked"');
+				} ?> />
+			<label for="mail_smtpauth"><?php p($l->t('Authentication required')); ?></label>
 		</p>
 	</form>
 	<form class="mail_settings" id="mail_credentials_settings">
-		<p id="mail_credentials" <?php if ($_['mail_smtpmode'] !== 'smtp') {
+		<p id="mail_credentials" <?php if (!$_['mail_smtpauth'] || $_['mail_smtpmode'] !== 'smtp') {
 						print_unescaped(' class="hidden"');
 					} ?>>
 			<label for="mail_smtpname"><?php p($l->t('Credentials')); ?></label>


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/36502

## Summary

The symfony mailer refactor removed the authentication checkbox and caused the save for the authentication data to be buggy.

## TODO

- [x] Check if Symfony supports authenticationless sending in the first place (tested by Julius)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [ ] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
