### PR TITLE
fix: Use shortestName instead of sequenceName for Postgres seqence migration

### DIFF
--- a/lib/private/DB/PgSqlTools.php
+++ b/lib/private/DB/PgSqlTools.php
@@ -61,13 +61,15 @@ class PgSqlTools {
 		});
 
 		foreach ($conn->getSchemaManager()->listSequences() as $sequence) {
-			$sequenceName = $sequence->getName();
+      $namespaceName = $sequence->getNamespaceName();
+      $shortestName = $sequence->getShortestName($namespaceName);
 			$sqlInfo = 'SELECT table_schema, table_name, column_name
 				FROM information_schema.columns
-				WHERE column_default = ? AND table_catalog = ?';
+				WHERE column_default = ? AND table_catalog = ? AND table_schema = ?';
 			$result = $conn->executeQuery($sqlInfo, [
-				"nextval('$sequenceName'::regclass)",
-				$databaseName
+				"nextval('$shortestName'::regclass)",
+        $databaseName,
+        $namespaceName
 			]);
 			$sequenceInfo = $result->fetchAssociative();
 			$result->free();
@@ -76,7 +78,7 @@ class PgSqlTools {
 			/** @var string $columnName */
 			$columnName = $sequenceInfo['column_name'];
 			$sqlMaxId = "SELECT MAX($columnName) FROM $tableName";
-			$sqlSetval = "SELECT setval('$sequenceName', ($sqlMaxId))";
+			$sqlSetval = "SELECT setval('$shortestName', ($sqlMaxId))";
 			$conn->executeQuery($sqlSetval);
 		}
 	}

--- a/lib/private/DB/PgSqlTools.php
+++ b/lib/private/DB/PgSqlTools.php
@@ -61,15 +61,15 @@ class PgSqlTools {
 		});
 
 		foreach ($conn->getSchemaManager()->listSequences() as $sequence) {
-      $namespaceName = $sequence->getNamespaceName();
-      $shortestName = $sequence->getShortestName($namespaceName);
+			$namespaceName = $sequence->getNamespaceName();
+			$shortestName = $sequence->getShortestName($namespaceName);
 			$sqlInfo = 'SELECT table_schema, table_name, column_name
 				FROM information_schema.columns
 				WHERE column_default = ? AND table_catalog = ? AND table_schema = ?';
 			$result = $conn->executeQuery($sqlInfo, [
 				"nextval('$shortestName'::regclass)",
-        $databaseName,
-        $namespaceName
+				$databaseName,
+				$namespaceName
 			]);
 			$sequenceInfo = $result->fetchAssociative();
 			$result->free();


### PR DESCRIPTION
* Resolves: #36789 

## Summary
Sequence migration fails on Postgres 15 because the sequenceName contains Postgres schema name which is not public.
Access to the public schema has been removed in Postgres 15. If a schema with the name of the user exists, it is going to be used per default. The sequenceName contains the schema name and it is better to use the shortestName.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
