### PR TITLE
Avoid extra parenthesis around SQL in IN expressions

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -660,7 +660,7 @@ class Manager {
 
 
 		$query->delete('federated_reshares')
-			->where($query->expr()->in('share_id', $query->createFunction('(' . $select . ')')));
+			->where($query->expr()->in('share_id', $query->createFunction($select)));
 		$query->execute();
 
 		$deleteReShares = $this->connection->getQueryBuilder();
@@ -730,10 +730,10 @@ class Manager {
 			// delete group share entry and matching sub-entries
 			$qb->delete('share_external')
 			   ->where(
-				   $qb->expr()->orX(
-					   $qb->expr()->eq('id', $qb->createParameter('share_id')),
-					   $qb->expr()->eq('parent', $qb->createParameter('share_parent_id'))
-				   )
+			   	$qb->expr()->orX(
+			   		$qb->expr()->eq('id', $qb->createParameter('share_id')),
+			   		$qb->expr()->eq('parent', $qb->createParameter('share_parent_id'))
+			   	)
 			   );
 
 			foreach ($shares as $share) {

--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -126,7 +126,7 @@ class RemoveLinkShares implements IRepairStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select($query->func()->count('*', 'total'))
 			->from('share')
-			->where($query->expr()->in('id', $query->createFunction('(' . $subQuery->getSQL() . ')')));
+			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
 
 		$result = $query->execute();
 		$data = $result->fetch();


### PR DESCRIPTION
## Summary

The expression builder already suround the SQL with parenthesis when
 using in(), so we must not add another pair, this confuses at least
 sqlite.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
