### PR TITLE
[db]: Remove not supported column comments for SQLite

### DIFF
--- a/lib/private/DB/SQLiteMigrator.php
+++ b/lib/private/DB/SQLiteMigrator.php
@@ -39,9 +39,13 @@ class SQLiteMigrator extends Migrator {
 		$platform->registerDoctrineTypeMapping('smallint unsigned', 'integer');
 		$platform->registerDoctrineTypeMapping('varchar ', 'string');
 
-		// with sqlite autoincrement columns is of type integer
 		foreach ($targetSchema->getTables() as $table) {
 			foreach ($table->getColumns() as $column) {
+				// column comments are not supported on SQLite
+				if ($column->getComment() !== null) {
+					$column->setComment(null);
+				}
+				// with sqlite autoincrement columns is of type integer
 				if ($column->getType() instanceof BigIntType && $column->getAutoincrement()) {
 					$column->setType(Type::getType('integer'));
 				}

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -237,6 +237,30 @@ class MigratorTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
+	/**
+	 * Test for nextcloud/server#36803
+	 */
+	public function testColumnCommentsInUpdate() {
+		$startSchema = new Schema([], [], $this->getSchemaConfig());
+		$table = $startSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer', ['autoincrement' => true, 'comment' => 'foo']);
+		$table->setPrimaryKey(['id']);
+
+		$endSchema = new Schema([], [], $this->getSchemaConfig());
+		$table = $endSchema->createTable($this->tableName);
+		$table->addColumn('id', 'integer', ['autoincrement' => true, 'comment' => 'foo']);
+		// Assert adding comments on existing tables work (or at least does not throw)
+		$table->addColumn('time', 'integer', ['comment' => 'unix-timestamp', 'notnull' => false]);
+		$table->setPrimaryKey(['id']);
+
+		$migrator = $this->getMigrator();
+		$migrator->migrate($startSchema);
+
+		$migrator->migrate($endSchema);
+
+		$this->addToAssertionCount(1);
+	}
+
 	public function testAddingForeignKey() {
 		$startSchema = new Schema([], [], $this->getSchemaConfig());
 		$table = $startSchema->createTable($this->tableName);


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/forms/pull/1479#issuecomment-1439234202

## Summary
Some times column comments are used, e.g. to make clear an integer is used as a timestamp.
For SQLite column comments are not supported and migration that use column comments will not work (see linked comment above for an example).
Somehow it works when you have a clean install, then all migrations pass, but when executing single migrations they will fail.

This solves the problem by simply removing column comments when using SQLite.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
