### PR TITLE
fix: Adapt the menubar to the primary color if a custom backgorund image has been set

### DIFF
--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -115,6 +115,11 @@ trait CommonThemeTrait {
 			$variables['--background-image-invert-if-bright'] = $isDefaultPrimaryBright ? 'invert(100%)' : 'no';
 		}
 
+		// Adapt the menubar to the primary color if a custom backgorund image has been set
+		if ($this->imageManager->hasImage('background')) {
+			$variables['--background-image-invert-if-bright'] = $isDefaultPrimaryBright ? 'invert(100%)' : 'no';
+		}
+
 		if ($hasCustomLogoHeader) {
 			$variables['--image-logoheader-custom'] = 'true';
 		}


### PR DESCRIPTION

## Steps to reproduce:

- Set white as a primary color
- Set a bright background image as the admin
- Disable user theming (personal background image)

## Before

App icons where white on white

## After

App icons properly adapt to the primary color
