### PR TITLE
fix: Avoid failing with duplicate checks

### DIFF
--- a/apps/workflowengine/lib/Check/FileMimeType.php
+++ b/apps/workflowengine/lib/Check/FileMimeType.php
@@ -107,13 +107,7 @@ class FileMimeType extends AbstractStringCheck implements IFileCheck {
 	 * @return bool
 	 */
 	public function executeCheck($operator, $value) {
-		$actualValue = $this->getActualValue();
-		$plainMimetypeResult = $this->executeStringCheck($operator, $value, $actualValue);
-		if ($actualValue === 'httpd/unix-directory') {
-			return $plainMimetypeResult;
-		}
-		$detectMimetypeBasedOnFilenameResult = $this->executeStringCheck($operator, $value, $this->mimeTypeDetector->detectPath($this->path));
-		return $plainMimetypeResult || $detectMimetypeBasedOnFilenameResult;
+		return $this->executeStringCheck($operator, $value, $this->getActualValue());
 	}
 
 	/**

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -127,7 +127,7 @@ class FileMimeTypeTest extends TestCase {
 		$check = new FileMimeType($this->l10n, $this->request, $this->mimeDetector);
 		$check->setFileInfo($storage, 'foo/bar.txt');
 
-		$this->assertTrue($check->executeCheck('is', 'text/plain-path-detected'));
+		$this->assertTrue($check->executeCheck('is', 'text/plain-content-detected'));
 	}
 
 	public function testFallback() {
@@ -142,7 +142,7 @@ class FileMimeTypeTest extends TestCase {
 	public function testFromCacheCached() {
 		$storage = new Temporary([]);
 		$storage->mkdir('foo');
-		$storage->file_put_contents('foo/bar.txt', 'asd');
+		$storage->file_put_contents('foo/bar.txt', 'text-content');
 		$storage->getScanner()->scan('');
 
 		$check = new FileMimeType($this->l10n, $this->request, $this->mimeDetector);
@@ -156,7 +156,7 @@ class FileMimeTypeTest extends TestCase {
 
 		$newCheck = new FileMimeType($this->l10n, $this->request, $this->mimeDetector);
 		$newCheck->setFileInfo($storage, 'foo/bar.txt');
-		$this->assertTrue($newCheck->executeCheck('is', 'text/plain-path-detected'));
+		$this->assertTrue($newCheck->executeCheck('is', 'text/plain-content-detected'));
 	}
 
 	public function testExistsCached() {


### PR DESCRIPTION
## Summary

When receiving a share the workflow mimetype check the patch was always checked but was an empty string (considered as application/octet-stream then).

There is no need for performing this check anymore here since it is covered within getActualValue these days.

Steps to reproduce:

- Block access with files_accesscontrol with the followin rules
	- If not mimetype httpd/directory
	- If not mimetype application/pdf
- Uplaod a pdf file and share it to user B

Before this the file was not visible to the recipient

Note this seems to occur only after https://github.com/nextcloud/server/pull/25768

Covered with integration tests by https://github.com/nextcloud/files_accesscontrol/pull/321

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
