### PR TITLE
Replace "Edit" by "Open" because opening locally does not necessarily mean "editing" (but simply "viewing")

### DIFF
--- a/apps/files/src/actions/openLocallyAction.spec.ts
+++ b/apps/files/src/actions/openLocallyAction.spec.ts
@@ -7,7 +7,7 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import axios from '@nextcloud/axios'
 import * as nextcloudDialogs from '@nextcloud/dialogs'
-import { action } from './editLocallyAction'
+import { action } from './openLocallyAction'
 
 vi.mock('@nextcloud/auth')
 vi.mock('@nextcloud/axios')
@@ -25,18 +25,18 @@ beforeAll(() => {
 	(window as any).OCA = { Viewer: { open: vi.fn() } }
 })
 
-describe('Edit locally action conditions tests', () => {
+describe('Open locally action conditions tests', () => {
 	test('Default values', () => {
 		expect(action).toBeInstanceOf(FileAction)
 		expect(action.id).toBe('edit-locally')
-		expect(action.displayName([], view)).toBe('Edit locally')
+		expect(action.displayName([], view)).toBe('Open locally')
 		expect(action.iconSvgInline([], view)).toMatch(/<svg.+<\/svg>/)
 		expect(action.default).toBeUndefined()
 		expect(action.order).toBe(25)
 	})
 })
 
-describe('Edit locally action enabled tests', () => {
+describe('Open locally action enabled tests', () => {
 	test('Enabled for file with UPDATE permission', () => {
 		const file = new File({
 			id: 1,
@@ -108,7 +108,7 @@ describe('Edit locally action enabled tests', () => {
 	})
 })
 
-describe('Edit locally action execute tests', () => {
+describe('Open locally action execute tests', () => {
 	let spyShowDialog
 	beforeEach(() => {
 		vi.resetAllMocks()
@@ -116,7 +116,7 @@ describe('Edit locally action execute tests', () => {
 			.mockImplementation(() => Promise.resolve())
 	})
 
-	test('Edit locally opens proper URL', async () => {
+	test('Open locally opens proper URL', async () => {
 		vi.spyOn(axios, 'post').mockImplementation(async () => ({
 			data: { ocs: { data: { token: 'foobar' } } },
 		}))
@@ -143,7 +143,7 @@ describe('Edit locally action execute tests', () => {
 		expect(windowOpenSpy).toBeCalledWith('nc://open/test@nextcloud.local/foobar.txt?token=foobar', '_self')
 	})
 
-	test('Edit locally fails and shows error', async () => {
+	test('Open locally fails and shows error', async () => {
 		vi.spyOn(axios, 'post').mockImplementation(async () => ({}))
 		const showError = vi.spyOn(nextcloudDialogs, 'showError')
 

--- a/apps/files/src/actions/openLocallyAction.ts
+++ b/apps/files/src/actions/openLocallyAction.ts
@@ -19,7 +19,7 @@ const confirmLocalEditDialog = (
 	let callbackCalled = false
 
 	return (new DialogBuilder())
-		.setName(t('files', 'Edit file locally'))
+		.setName(t('files', 'Open file locally'))
 		.setText(t('files', 'The file should now open on your device. If it doesn\'t, please check that you have the desktop app installed.'))
 		.setButtons([
 			{
@@ -31,7 +31,7 @@ const confirmLocalEditDialog = (
 				},
 			},
 			{
-				label: t('files', 'Edit online'),
+				label: t('files', 'Open online'),
 				icon: IconWeb,
 				type: 'primary',
 				callback: () => {
@@ -80,7 +80,7 @@ const openLocalClient = async function(path: string) {
 
 export const action = new FileAction({
 	id: 'edit-locally',
-	displayName: () => t('files', 'Edit locally'),
+	displayName: () => t('files', 'Open locally'),
 	iconSvgInline: () => LaptopSvg,
 
 	// Only works on single files

--- a/apps/files/src/init.ts
+++ b/apps/files/src/init.ts
@@ -6,7 +6,7 @@ import { addNewFileMenuEntry, registerDavProperty, registerFileAction } from '@n
 
 import { action as deleteAction } from './actions/deleteAction'
 import { action as downloadAction } from './actions/downloadAction'
-import { action as editLocallyAction } from './actions/editLocallyAction'
+import { action as editLocallyAction } from './actions/openLocallyAction.ts'
 import { action as favoriteAction } from './actions/favoriteAction'
 import { action as moveOrCopyAction } from './actions/moveOrCopyAction'
 import { action as openFolderAction } from './actions/openFolderAction'


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Fixes #37058 

## Summary

The term "edit" is too restrictive, as many file types are only "edited" in rare cases. E.g.: Videos, PDF documents, audio files, etc. Frank Karlitschek said at the Nextcloud Conf in Berlin that this local opening feature can work with any file whose MIME type is linked to software on the computer. Therefore, it is important to have a more general wording that is suitable for both viewing and editing.

![2023-02-23_13-42](https://user-images.githubusercontent.com/33763786/220909100-acd7b8c1-a009-458c-9ed6-1a4617ae239d.png)

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
