### PR TITLE
fix(SystemTagManager): Truncate overlong tag names

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -193,10 +193,12 @@ class SystemTagManager implements ISystemTagManager {
 	 * {@inheritdoc}
 	 */
 	public function createTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag {
+		// Length of name column is 64
+		$truncatedTagName = substr($tagName, 0, 64);
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::TAG_TABLE)
 			->values([
-				'name' => $query->createNamedParameter($tagName),
+				'name' => $query->createNamedParameter($truncatedTagName),
 				'visibility' => $query->createNamedParameter($userVisible ? 1 : 0),
 				'editable' => $query->createNamedParameter($userAssignable ? 1 : 0),
 			]);
@@ -205,7 +207,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query->execute();
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
-				'Tag ("' . $tagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
+				'Tag ("' . $truncatedTagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
 				0,
 				$e
 			);
@@ -215,7 +217,7 @@ class SystemTagManager implements ISystemTagManager {
 
 		$tag = new SystemTag(
 			(string)$tagId,
-			$tagName,
+			$truncatedTagName,
 			$userVisible,
 			$userAssignable
 		);

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -259,6 +259,14 @@ class SystemTagManagerTest extends TestCase {
 		$this->tagManager->createTag($name, $userVisible, $userAssignable);
 	}
 
+	public function testCreateOverlongName() {
+		try {
+			$this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
+		} catch (\Exception $e) {
+			$this->assertTrue(false, 'No exception thrown for create call');
+		}
+	}
+
 	/**
 	 * @dataProvider oneTagMultipleFlagsProvider
 	 */
@@ -281,14 +289,14 @@ class SystemTagManagerTest extends TestCase {
 		$this->assertSameTag($tag2, $tagList[$tag2->getId()]);
 	}
 
-	
+
 	public function testGetNonExistingTag() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 
 		$this->tagManager->getTag('nonexist', false, false);
 	}
 
-	
+
 	public function testGetNonExistingTagsById() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 
@@ -296,7 +304,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->tagManager->getTagsByIds([$tag1->getId(), 100, 101]);
 	}
 
-	
+
 	public function testGetInvalidTagIdFormat() {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -391,7 +399,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->assertEmpty($this->tagManager->getAllTags());
 	}
 
-	
+
 	public function testDeleteNonExistingTag() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -260,11 +260,8 @@ class SystemTagManagerTest extends TestCase {
 	}
 
 	public function testCreateOverlongName() {
-		try {
-			$this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
-		} catch (\Exception $e) {
-			$this->assertTrue(false, 'No exception thrown for create call');
-		}
+		$tag = $this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas,', $tag->getName());
 	}
 
 	/**

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -261,7 +261,7 @@ class SystemTagManagerTest extends TestCase {
 
 	public function testCreateOverlongName() {
 		$tag = $this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
-		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas,', $tag->getName());
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $tag->getName()); // 63 characters but 64 bytes due to "á"
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/recognize/issues/694

## Summary
The systemtag.name column has a length of 64 but the code never asserts the length of tag names. Thus without this patch you can get an exception when creating tags with long names.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
