### PR TITLE
Fix max instances exception in get vevent call

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -149,8 +149,7 @@ class ReminderService {
 
 			try {
 				$vevent = $this->getVEventByRecurrenceId($vcalendar, $reminder['recurrence_id'], $reminder['is_recurrence_exception']);
-			}
-			catch (MaxInstancesExceededException $e) {
+			} catch (MaxInstancesExceededException $e) {
 				$this->logger->debug('Recurrence with too many instances detected, skipping VEVENT', ['exception' => $e]);
 				continue;
 			}

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -151,6 +151,7 @@ class ReminderService {
 				$vevent = $this->getVEventByRecurrenceId($vcalendar, $reminder['recurrence_id'], $reminder['is_recurrence_exception']);
 			} catch (MaxInstancesExceededException $e) {
 				$this->logger->debug('Recurrence with too many instances detected, skipping VEVENT', ['exception' => $e]);
+				$this->backend->removeReminder($reminder['id']);
 				continue;
 			}
 

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -147,7 +147,14 @@ class ReminderService {
 				continue;
 			}
 
-			$vevent = $this->getVEventByRecurrenceId($vcalendar, $reminder['recurrence_id'], $reminder['is_recurrence_exception']);
+			try {
+				$vevent = $this->getVEventByRecurrenceId($vcalendar, $reminder['recurrence_id'], $reminder['is_recurrence_exception']);
+			}
+			catch (MaxInstancesExceededException $e) {
+				$this->logger->debug('Recurrence with too many instances detected, skipping VEVENT', ['exception' => $e]);
+				continue;
+			}
+
 			if (!$vevent) {
 				$this->logger->debug('Reminder {id} does not belong to a valid event', [
 					'id' => $reminder['id'],


### PR DESCRIPTION
- [This commit](https://github.com/nextcloud/server/commit/a9264b007ffa4bf4ae04069bb14f56b6b3f591ea) handles the `MaxInstancesExceededException` in most of the cases but misses one
- Fixing that in this one case as exception is causing reminders to not be fired at all in one of our servers :(