### PR TITLE
fix unencrypted_size for folders when scanning the filesystem with encryption enabled

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -954,9 +954,11 @@ class Cache implements ICache {
 				$unencryptedTotal = 0;
 				$unencryptedMax = 0;
 			}
-			if ($entry['size'] !== $totalSize) {
-				// only set unencrypted size for a folder if any child entries have it set, or the folder is empty
-				if ($unencryptedMax > 0 || $totalSize === 0) {
+
+			// only set unencrypted size for a folder if any child entries have it set, or the folder is empty
+			$shouldWriteUnEncryptedSize = $unencryptedMax > 0 || $totalSize === 0;
+			if ($entry['size'] !== $totalSize || ($entry['unencrypted_size'] !== $unencryptedTotal && $shouldWriteUnEncryptedSize)) {
+				if ($shouldWriteUnEncryptedSize) {
 					$this->update($id, [
 						'size' => $totalSize,
 						'unencrypted_size' => $unencryptedTotal,

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -899,8 +899,7 @@ class Cache implements ICache {
 	 * calculate the size of a folder and set it in the cache
 	 *
 	 * @param string $path
-	 * @param array $entry (optional) meta data of the folder
-	 * @param bool $ignoreUnknown don't mark the folder size as unknown if any of it's children are unknown
+	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {
@@ -912,11 +911,11 @@ class Cache implements ICache {
 	 * inner function because we can't add new params to the public function without breaking any child classes
 	 *
 	 * @param string $path
-	 * @param array $entry (optional) meta data of the folder
+	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @param bool $ignoreUnknown don't mark the folder size as unknown if any of it's children are unknown
 	 * @return int
 	 */
-	protected function calculateFolderSizeInner(string $path, array $entry = null, bool $ignoreUnknown = false) {
+	protected function calculateFolderSizeInner(string $path, $entry = null, bool $ignoreUnknown = false) {
 		$totalSize = 0;
 		if (is_null($entry) || !isset($entry['fileid'])) {
 			$entry = $this->get($path);
@@ -976,7 +975,6 @@ class Cache implements ICache {
 			$shouldWriteUnEncryptedSize = $unencryptedMax > 0 || $totalSize === 0 || $entry['unencrypted_size'] > 0;
 			if ($entry['size'] !== $totalSize || ($entry['unencrypted_size'] !== $unencryptedTotal && $shouldWriteUnEncryptedSize)) {
 				if ($shouldWriteUnEncryptedSize) {
-
 					// if all children have an unencrypted size of 0, just set the folder unencrypted size to 0 instead of summing the sizes
 					if ($unencryptedMax === 0) {
 						$unencryptedTotal = 0;

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -900,9 +900,23 @@ class Cache implements ICache {
 	 *
 	 * @param string $path
 	 * @param array $entry (optional) meta data of the folder
+	 * @param bool $ignoreUnknown don't mark the folder size as unknown if any of it's children are unknown
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {
+		return $this->calculateFolderSizeInner($path, $entry);
+	}
+
+
+	/**
+	 * inner function because we can't add new params to the public function without breaking any child classes
+	 *
+	 * @param string $path
+	 * @param array $entry (optional) meta data of the folder
+	 * @param bool $ignoreUnknown don't mark the folder size as unknown if any of it's children are unknown
+	 * @return int
+	 */
+	protected function calculateFolderSizeInner(string $path, array $entry = null, bool $ignoreUnknown = false) {
 		$totalSize = 0;
 		if (is_null($entry) || !isset($entry['fileid'])) {
 			$entry = $this->get($path);
@@ -914,6 +928,9 @@ class Cache implements ICache {
 			$query->select('size', 'unencrypted_size')
 				->from('filecache')
 				->whereParent($id);
+			if ($ignoreUnknown) {
+				$query->andWhere($query->expr()->gte('size', $query->createNamedParameter(0)));
+			}
 
 			$result = $query->execute();
 			$rows = $result->fetchAll();
@@ -956,9 +973,15 @@ class Cache implements ICache {
 			}
 
 			// only set unencrypted size for a folder if any child entries have it set, or the folder is empty
-			$shouldWriteUnEncryptedSize = $unencryptedMax > 0 || $totalSize === 0;
+			$shouldWriteUnEncryptedSize = $unencryptedMax > 0 || $totalSize === 0 || $entry['unencrypted_size'] > 0;
 			if ($entry['size'] !== $totalSize || ($entry['unencrypted_size'] !== $unencryptedTotal && $shouldWriteUnEncryptedSize)) {
 				if ($shouldWriteUnEncryptedSize) {
+
+					// if all children have an unencrypted size of 0, just set the folder unencrypted size to 0 instead of summing the sizes
+					if ($unencryptedMax === 0) {
+						$unencryptedTotal = 0;
+					}
+
 					$this->update($id, [
 						'size' => $totalSize,
 						'unencrypted_size' => $unencryptedTotal,

--- a/lib/private/Files/Cache/HomeCache.php
+++ b/lib/private/Files/Cache/HomeCache.php
@@ -35,7 +35,7 @@ class HomeCache extends Cache {
 	 * get the size of a folder and set it in the cache
 	 *
 	 * @param string $path
-	 * @param array $entry (optional) meta data of the folder
+	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -208,9 +208,17 @@ class Scanner extends BasicEmitter implements IScanner {
 								$data['etag'] = $etag;
 							}
 						}
+
+						// we only updated unencrypted_size if it's already set
+						if ($cacheData['unencrypted_size'] === 0) {
+							unset($data['unencrypted_size']);
+						}
+
 						// Only update metadata that has changed
 						$newData = array_diff_assoc($data, $cacheData->getData());
 					} else {
+						// we only updated unencrypted_size if it's already set
+						unset($data['unencrypted_size']);
 						$newData = $data;
 						$fileId = -1;
 					}

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -36,6 +36,7 @@
 namespace OC\Files\Cache;
 
 use Doctrine\DBAL\Exception;
+use OC\Files\Storage\Wrapper\Encryption;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
 use OCP\Files\Storage\IReliableEtagStorage;
@@ -219,7 +220,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						$newData['parent'] = $parentId;
 						$data['fileid'] = $this->addToCache($file, $newData, $fileId);
 					}
-					
+
 					$data['oldSize'] = ($cacheData && isset($cacheData['size'])) ? $cacheData['size'] : 0;
 
 					if ($cacheData && isset($cacheData['encrypted'])) {
@@ -390,8 +391,15 @@ class Scanner extends BasicEmitter implements IScanner {
 			}
 		}
 		$oldSize = $data['size'] ?? null;
-		if ($this->cacheActive && $oldSize !== $size) {
-			$this->cache->update($folderId, ['size' => $size]);
+
+		// for encrypted storages, we trigger a regular folder size calculation instead of using the calculated size
+		// to make sure we also updated the unencrypted-size where applicable
+		if ($this->storage->instanceOfStorage(Encryption::class)) {
+			$this->cache->calculateFolderSize($path);
+		} else {
+			if ($this->cacheActive && $oldSize !== $size) {
+				$this->cache->update($folderId, ['size' => $size]);
+			}
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'postScanFolder', [$path, $this->storageId]);
 		return $size;

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -239,7 +239,7 @@ class CacheJail extends CacheWrapper {
 	 * get the size of a folder and set it in the cache
 	 *
 	 * @param string $path
-	 * @param array $entry (optional) meta data of the folder
+	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -249,7 +249,7 @@ class CacheWrapper extends Cache {
 	 * get the size of a folder and set it in the cache
 	 *
 	 * @param string $path
-	 * @param array $entry (optional) meta data of the folder
+	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int
 	 */
 	public function calculateFolderSize($path, $entry = null) {

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -180,10 +180,12 @@ class Encryption extends Wrapper {
 		if (isset($this->unencryptedSize[$fullPath])) {
 			$data['encrypted'] = true;
 			$data['size'] = $this->unencryptedSize[$fullPath];
+			$data['unencrypted_size'] = $data['size'];
 		} else {
 			if (isset($info['fileid']) && $info['encrypted']) {
 				$data['size'] = $this->verifyUnencryptedSize($path, $info->getUnencryptedSize());
 				$data['encrypted'] = true;
+				$data['unencrypted_size'] = $data['size'];
 			}
 		}
 
@@ -494,7 +496,8 @@ class Encryption extends Wrapper {
 		$result = $unencryptedSize;
 
 		if ($unencryptedSize < 0 ||
-			($size > 0 && $unencryptedSize === $size)
+			($size > 0 && $unencryptedSize === $size) ||
+			$unencryptedSize > $size
 		) {
 			// check if we already calculate the unencrypted size for the
 			// given path to avoid recursions


### PR DESCRIPTION
To test:

- setup an instance with encryption
- create folder `test` and write some files into it
- "accidentally" mess up the `unencrypted_size` for the folder with
  
    `update oc_filecache set unencrypted_size = 100 where name = 'test';`
  
- run `occ files:scan --all` in an attempt to repair it
- check if the folder size is reported correctly