### PR TITLE
Correct the name of logo

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -62,7 +62,7 @@ p($theme->getTitle());
 					id="nextcloud">
 					<div class="logo logo-icon">
 						<span class="hidden-visually">
-							<?php p($l->t('%s homepage', [$theme->getName()])); ?>
+							<?php p($l->t('%s - go to dashboard', [$theme->getName()])); ?>
 						</span>
 					</div>
 				</a>


### PR DESCRIPTION
* Resolves:  https://github.com/nextcloud/server/issues/36753

## Summary

Correct the name of logo to "Nextcloud - go to dashboard".

Structure: 

![Screenshot from 2023-02-27 14-28-43](https://user-images.githubusercontent.com/6078378/221577868-815660af-925a-4e8b-a7b9-cbbc8036e09e.png)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
