### PR TITLE
dispatch BeforeUserLoggedInEvent

### DIFF
--- a/lib/public/User/Events/BeforeUserLoggedInEvent.php
+++ b/lib/public/User/Events/BeforeUserLoggedInEvent.php
@@ -24,27 +24,29 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCP\User\Events;
 
+use OCP\Authentication\IApacheBackend;
 use OCP\EventDispatcher\Event;
 
 /**
  * @since 18.0.0
  */
 class BeforeUserLoggedInEvent extends Event {
-	/** @var string */
-	private $username;
-
-	/** @var string */
-	private $password;
+	private string $username;
+	private ?string $password;
+	private ?IApacheBackend $backend;
 
 	/**
 	 * @since 18.0.0
+	 * @since 26.0.0 password can be null
 	 */
-	public function __construct(string $username, string $password) {
+	public function __construct(string $username, ?string $password, ?IApacheBackend $backend = null) {
 		parent::__construct();
 		$this->username = $username;
 		$this->password = $password;
+		$this->backend = $backend;
 	}
 
 	/**
@@ -58,8 +60,19 @@ class BeforeUserLoggedInEvent extends Event {
 
 	/**
 	 * @since 18.0.0
+	 * @since 26.0.0 value can be null
 	 */
-	public function getPassword(): string {
+	public function getPassword(): ?string {
 		return $this->password;
+	}
+
+	/**
+	 * return backend if available (or null)
+	 *
+	 * @return IApacheBackend|null
+	 * @since 26.0.0
+	 */
+	public function getBackend(): ?IApacheBackend {
+		return $this->backend;
 	}
 }


### PR DESCRIPTION
legacy code ...

This fix an issue with gss+saml (regreation post migration to `IEventDispatcher` as login event is not detected anymore). 
The idea is to copy the normal process available in https://github.com/nextcloud/server/blob/master/lib/private/Server.php#L615-L621 and implement it on login process on SSO 