### PR TITLE
fix(translation): Allow regular users to use translation api endpoints

### DIFF
--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -43,6 +43,9 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 		$this->translationManager = $translationManager;
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
 	public function languages(): DataResponse {
 		return new DataResponse([
 			'languages' => $this->translationManager->getLanguages(),
@@ -50,6 +53,9 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 		]);
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
 	public function translate(string $text, ?string $fromLanguage, string $toLanguage): DataResponse {
 		try {
 			return new DataResponse([


### PR DESCRIPTION
## Summary

Follow up to #36584 to also allow regular users to perform translation api calls.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
