### PR TITLE
Make sure to never trigger files hooks on a null path

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -422,14 +422,15 @@ class File extends Node implements IFile {
 		}
 	}
 
-	/**
-	 * @param string $path
-	 */
-	private function emitPreHooks($exists, $path = null) {
+	private function emitPreHooks(bool $exists, ?string $path = null): bool {
 		if (is_null($path)) {
 			$path = $this->path;
 		}
 		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($path));
+		if ($hookPath === null) {
+			// We only trigger hooks from inside default view
+			return true;
+		}
 		$run = true;
 
 		if (!$exists) {
@@ -450,14 +451,15 @@ class File extends Node implements IFile {
 		return $run;
 	}
 
-	/**
-	 * @param string $path
-	 */
-	private function emitPostHooks($exists, $path = null) {
+	private function emitPostHooks(bool $exists, ?string $path = null): void {
 		if (is_null($path)) {
 			$path = $this->path;
 		}
 		$hookPath = Filesystem::getView()->getRelativePath($this->fileView->getAbsolutePath($path));
+		if ($hookPath === null) {
+			// We only trigger hooks from inside default view
+			return;
+		}
 		if (!$exists) {
 			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_create, [
 				\OC\Files\Filesystem::signal_param_path => $hookPath

--- a/lib/private/Files/Node/HookConnector.php
+++ b/lib/private/Files/Node/HookConnector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -223,7 +226,7 @@ class HookConnector {
 		$this->dispatcher->dispatchTyped($event);
 	}
 
-	private function getNodeForPath($path) {
+	private function getNodeForPath(string $path): Node {
 		$info = Filesystem::getView()->getFileInfo($path);
 		if (!$info) {
 			$fullPath = Filesystem::getView()->getAbsolutePath($path);


### PR DESCRIPTION
* Resolves: #34932 

## Summary

File pre/post operation events should only be triggered for files inside the default view.
For other files a bogus event with a null path was fired, this avoids that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
