### PR TITLE
[stable24] fix(SystemTagManager): Truncate overlong tag names

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -193,10 +193,12 @@ class SystemTagManager implements ISystemTagManager {
 	 * {@inheritdoc}
 	 */
 	public function createTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag {
+		// Length of name column is 64
+		$truncatedTagName = substr($tagName, 0, 64);
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::TAG_TABLE)
 			->values([
-				'name' => $query->createNamedParameter($tagName),
+				'name' => $query->createNamedParameter($truncatedTagName),
 				'visibility' => $query->createNamedParameter($userVisible ? 1 : 0),
 				'editable' => $query->createNamedParameter($userAssignable ? 1 : 0),
 			]);
@@ -205,7 +207,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query->execute();
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
-				'Tag ("' . $tagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
+				'Tag ("' . $truncatedTagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
 				0,
 				$e
 			);
@@ -215,7 +217,7 @@ class SystemTagManager implements ISystemTagManager {
 
 		$tag = new SystemTag(
 			(string)$tagId,
-			$tagName,
+			$truncatedTagName,
 			$userVisible,
 			$userAssignable
 		);

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -260,6 +260,11 @@ class SystemTagManagerTest extends TestCase {
 		$this->tagManager->createTag($name, $userVisible, $userAssignable);
 	}
 
+	public function testCreateOverlongName() {
+		$tag = $this->tagManager->createTag('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas, Salão de Física, Torre Sineira, Paço Velho e Jardim Botânico)', true, true);
+		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $tag->getName()); // 63 characters but 64 bytes due to "á"
+	}
+
 	/**
 	 * @dataProvider oneTagMultipleFlagsProvider
 	 */
@@ -282,14 +287,14 @@ class SystemTagManagerTest extends TestCase {
 		$this->assertSameTag($tag2, $tagList[$tag2->getId()]);
 	}
 
-	
+
 	public function testGetNonExistingTag() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 
 		$this->tagManager->getTag('nonexist', false, false);
 	}
 
-	
+
 	public function testGetNonExistingTagsById() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 
@@ -297,7 +302,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->tagManager->getTagsByIds([$tag1->getId(), 100, 101]);
 	}
 
-	
+
 	public function testGetInvalidTagIdFormat() {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -392,7 +397,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->assertEmpty($this->tagManager->getAllTags());
 	}
 
-	
+
 	public function testDeleteNonExistingTag() {
 		$this->expectException(\OCP\SystemTag\TagNotFoundException::class);
 


### PR DESCRIPTION
backport of #36837 