### PR TITLE
fix(files): Fix controller setup for guests

### DIFF
--- a/apps/files/lib/Service/TagService.php
+++ b/apps/files/lib/Service/TagService.php
@@ -42,24 +42,17 @@ class TagService {
 	private $userSession;
 	/** @var IManager */
 	private $activityManager;
-	/** @var ITags */
+	/** @var ITags|null */
 	private $tagger;
 	/** @var Folder */
 	private $homeFolder;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 
-	/**
-	 * @param IUserSession $userSession
-	 * @param IManager $activityManager
-	 * @param ITags $tagger
-	 * @param Folder $homeFolder
-	 * @param EventDispatcherInterface $dispatcher
-	 */
 	public function __construct(
 		IUserSession $userSession,
 		IManager $activityManager,
-		ITags $tagger,
+		?ITags $tagger,
 		Folder $homeFolder,
 		EventDispatcherInterface $dispatcher
 	) {
@@ -81,6 +74,10 @@ class TagService {
 	 * @throws \OCP\Files\NotFoundException if the file does not exist
 	 */
 	public function updateFileTags($path, $tags) {
+		if ($this->tagger === null) {
+			throw new \RuntimeException('No tagger set');
+		}
+
 		$fileId = $this->homeFolder->get($path)->getId();
 
 		$currentTags = $this->tagger->getTagsForObjects([$fileId]);


### PR DESCRIPTION

### Log

```
cat /var/www/data/nextcloud.log | grep "TagService::__construct" | wc -l
296
```

<details>

```
{
  "reqId": "DvqdkPlTS0BENDuqRSIi",
  "level": 3,
  "time": "2023-02-28T14:24:35+00:00",
  "remoteAddr": "…",
  "user": "--",
  "app": "index",
  "method": "GET",
  "url": "/apps/files/api/v1/stats",
  "message": "OCA\\Files\\Service\\TagService::__construct(): Argument #3 ($tagger) must be of type OCP\\ITags, null given, called in /var/www/cloud.nextcloud.com/nextcloud/apps/files/lib/AppInfo/Application.php on line 109",
  "userAgent": "…",
  "version": "26.0.0.7",
  "exception": {
    "Exception": "TypeError",
    "Message": "OCA\\Files\\Service\\TagService::__construct(): Argument #3 ($tagger) must be of type OCP\\ITags, null given, called in /var/www/cloud.nextcloud.com/nextcloud/apps/files/lib/AppInfo/Application.php on line 109",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/apps/files/lib/AppInfo/Application.php",
        "line": 109,
        "function": "__construct",
        "class": "OCA\\Files\\Service\\TagService",
        "type": "->",
        "args": [
          [
            "OC\\User\\Session"
          ],
          [
            "OC\\Activity\\Manager"
          ],
          null,
          null,
          [
            "OC\\EventDispatcher\\SymfonyAdapter"
          ]
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 171,
        "function": "OCA\\Files\\AppInfo\\{closure}",
        "class": "OCA\\Files\\AppInfo\\Application",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/3rdparty/pimple/pimple/src/Pimple/Container.php",
        "line": 122,
        "function": "OC\\AppFramework\\Utility\\{closure}",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 138,
        "function": "offsetGet",
        "class": "Pimple\\Container",
        "type": "->",
        "args": [
          "OCA\\Files\\Service\\TagService"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php",
        "line": 487,
        "function": "query",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "OCA\\Files\\Service\\TagService"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php",
        "line": 465,
        "function": "queryNoFallback",
        "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
        "type": "->",
        "args": [
          "OCA\\Files\\Service\\TagService"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 65,
        "function": "query",
        "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
        "type": "->",
        "args": [
          "OCA\\Files\\Service\\TagService"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/apps/files/lib/AppInfo/Application.php",
        "line": 88,
        "function": "get",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "OCA\\Files\\Service\\TagService"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 171,
        "function": "OCA\\Files\\AppInfo\\{closure}",
        "class": "OCA\\Files\\AppInfo\\Application",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/3rdparty/pimple/pimple/src/Pimple/Container.php",
        "line": 122,
        "function": "OC\\AppFramework\\Utility\\{closure}",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 138,
        "function": "offsetGet",
        "class": "Pimple\\Container",
        "type": "->",
        "args": [
          "APIController"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php",
        "line": 487,
        "function": "query",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "APIController"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/DependencyInjection/DIContainer.php",
        "line": 465,
        "function": "queryNoFallback",
        "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
        "type": "->",
        "args": [
          "APIController"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php",
        "line": 65,
        "function": "query",
        "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
        "type": "->",
        "args": [
          "APIController"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/AppFramework/App.php",
        "line": 148,
        "function": "get",
        "class": "OC\\AppFramework\\Utility\\SimpleContainer",
        "type": "->",
        "args": [
          "APIController"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/private/Route/Router.php",
        "line": 315,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "APIController",
          "getStorageStats",
          "*** sensitive parameters replaced ***",
          [
            "files.API.getStorageStats"
          ]
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/lib/base.php",
        "line": 1050,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/files/api/v1/stats"
        ]
      },
      {
        "file": "/var/www/cloud.nextcloud.com/nextcloud/index.php",
        "line": 36,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/cloud.nextcloud.com/nextcloud/apps/files/lib/Service/TagService.php",
    "Line": 59,
    "CustomMessage": "--"
  }
}

```

</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
