### PR TITLE
feat(middleware): Migrate BruteForceProtection annotation to PHP Attribute and allow multiple

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -35,6 +35,7 @@ return array(
     'OCP\\AppFramework\\Db\\QBMapper' => $baseDir . '/lib/public/AppFramework/Db/QBMapper.php',
     'OCP\\AppFramework\\Db\\TTransactional' => $baseDir . '/lib/public/AppFramework/Db/TTransactional.php',
     'OCP\\AppFramework\\Http' => $baseDir . '/lib/public/AppFramework/Http.php',
+    'OCP\\AppFramework\\Http\\Attribute\\BruteForceProtection' => $baseDir . '/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php',
     'OCP\\AppFramework\\Http\\Attribute\\UseSession' => $baseDir . '/lib/public/AppFramework/Http/Attribute/UseSession.php',
     'OCP\\AppFramework\\Http\\ContentSecurityPolicy' => $baseDir . '/lib/public/AppFramework/Http/ContentSecurityPolicy.php',
     'OCP\\AppFramework\\Http\\DataDisplayResponse' => $baseDir . '/lib/public/AppFramework/Http/DataDisplayResponse.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -68,6 +68,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\AppFramework\\Db\\QBMapper' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/QBMapper.php',
         'OCP\\AppFramework\\Db\\TTransactional' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Db/TTransactional.php',
         'OCP\\AppFramework\\Http' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http.php',
+        'OCP\\AppFramework\\Http\\Attribute\\BruteForceProtection' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php',
         'OCP\\AppFramework\\Http\\Attribute\\UseSession' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/UseSession.php',
         'OCP\\AppFramework\\Http\\ContentSecurityPolicy' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/ContentSecurityPolicy.php',
         'OCP\\AppFramework\\Http\\DataDisplayResponse' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/DataDisplayResponse.php',

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -292,7 +292,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				new OC\AppFramework\Middleware\Security\BruteForceMiddleware(
 					$c->get(IControllerMethodReflector::class),
 					$c->get(OC\Security\Bruteforce\Throttler::class),
-					$c->get(IRequest::class)
+					$c->get(IRequest::class),
+					$c->get(LoggerInterface::class)
 				)
 			);
 			$dispatcher->registerMiddleware(

--- a/lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\MaxDelayReached;
+use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 
 /**
@@ -50,16 +51,12 @@ use ReflectionMethod;
  * @package OC\AppFramework\Middleware\Security
  */
 class BruteForceMiddleware extends Middleware {
-	private ControllerMethodReflector $reflector;
-	private Throttler $throttler;
-	private IRequest $request;
-
-	public function __construct(ControllerMethodReflector $controllerMethodReflector,
-								Throttler $throttler,
-								IRequest $request) {
-		$this->reflector = $controllerMethodReflector;
-		$this->throttler = $throttler;
-		$this->request = $request;
+	public function __construct(
+		protected ControllerMethodReflector $reflector,
+		protected Throttler $throttler,
+		protected IRequest $request,
+		protected LoggerInterface $logger,
+	) {
 	}
 
 	/**
@@ -116,6 +113,8 @@ class BruteForceMiddleware extends Middleware {
 							$this->throttler->registerAttempt($action, $ip, $metaData);
 						}
 					}
+				} else {
+					$this->logger->debug('Response for ' . get_class($controller) . '::' . $methodName . ' got bruteforce throttled but has no annotation nor attribute defined.');
 				}
 			}
 		}

--- a/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php
+++ b/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 /**
- * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
  *
- * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Joas Schilling <coding@schilljs.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -28,10 +28,25 @@ namespace OCP\AppFramework\Http\Attribute;
 use Attribute;
 
 /**
- * Attribute for controller methods that need to read/write PHP session data
+ * Attribute for controller methods that want to protect passwords, keys, tokens
+ * or other data against brute force
  *
- * @since 26.0.0
+ * @since 27.0.0
  */
-#[Attribute]
-class UseSession {
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class BruteForceProtection {
+	/**
+	 * @since 27.0.0
+	 */
+	public function __construct(
+		protected string $action
+	) {
+	}
+
+	/**
+	 * @since 27.0.0
+	 */
+	public function getAction(): string {
+		return $this->action;
+	}
 }


### PR DESCRIPTION
### Previously (and still supported)
```php
	/**
	 * @BruteForceProtection(action=login)
	 */
	public function testMethodWithAnnotation() {
```

### New syntax
```php
	#[BruteForceProtection(action: 'login')]
	public function testMethodWithAttribute() {
```

### Multiple attributes now supported
By specifying an `'action'` in the `throttle($metadata)` only the dedicated attribute will trigger it's BFP, if none is specified all will throttle.
This is useful e.g. in controllers that need to protect different data, e.g. Talk has the tokens and the signaling secret in the same method and needs to do a lot of manual work instead of just calling `throttle` on the response:
https://github.com/nextcloud/spreed/blob/29a442cf86d49b426ecd47776c86ab6f6de5da58/lib/Controller/SignalingController.php#L154-L179

```php
	#[BruteForceProtection(action: 'token')]
	#[BruteForceProtection(action: 'password')]
	public function testMethodWithMultipleAttributes() {
```

## 🚧 ToDo

- [x] Allow as attribute
- [x] Add multi support
- [x] Log debug when the request was throttled, but there was no Annotation nor matching Attribute
- [ ] Add a header to the response when the request is throttled(?)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required https://github.com/nextcloud/documentation/pull/9742
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
