### PR TITLE
fix(caldav): harden null handling of iMip scheduling method

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -70,11 +70,15 @@ class IMipService {
 	}
 
 	/**
-	 * @param string $senderName
-	 * @param $default
+	 * @param string|null $senderName
+	 * @param string $default
 	 * @return string
 	 */
-	public function getFrom(string $senderName, $default): string {
+	public function getFrom(?string $senderName, string $default): string {
+		if ($senderName === null) {
+			return $default;
+		}
+
 		return $this->l10n->t('%1$s via %2$s', [$senderName, $default]);
 	}
 


### PR DESCRIPTION
* Ref https://github.com/nextcloud/server/pull/36898#issuecomment-1449532034

## Summary

The schedule() method of the iMip plugin poorly handles various null values. I hardened it a bit to prevent further breakage in the future.

This PR can be tested using the following patch:
```diff
diff --git a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
index ca79205c09f..8c4507b0870 100644
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -209,6 +209,9 @@ class IMipPlugin extends SabreIMipPlugin {
 			$senderName = $senderName->getValue() ?? null;
 		}
 
+		$senderName = null;
+		$this->userId = null;
+
 		// Try to get the sender name from the current user id if available.
 		if ($this->userId !== null && ($senderName === null || empty(trim($senderName)))) {
 			$senderName = $this->userManager->getDisplayName($this->userId);

```

## TODO

- [ ] Trigger backports when backports of #35743 were merged 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
