### PR TITLE
fix: treat text app session parameters as sensitive values

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -100,6 +100,16 @@ class ExceptionSerializer {
 
 		// Preview providers, don't log big data strings
 		'imagecreatefromstring',
+
+		// text: PublicSessionController, SessionController and ApiService
+		'create',
+		'close',
+		'push',
+		'sync',
+		'updateSession',
+		'mention',
+		'loginSessionUser',
+
 	];
 
 	/** @var SystemConfig */


### PR DESCRIPTION
## Summary

* `PublicSessionController create` receives a share token.
* The others receive the parameters for a text session: `document_id`, `session_id`, `session_token`. Even though these are relatively short lived they could be used to retrieve content from the document when leaked.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests are not required
- ~~Screenshots before/after for front-end changes~~
- Documentation is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
