### PR TITLE
unmark deleted users if their last login date is more recent than deleted date

### DIFF
--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -56,7 +56,12 @@ class DeletedUsersIndex {
 
 		$userObjects = [];
 		foreach ($deletedUsers as $user) {
-			$userObjects[] = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);
+			$userObject = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);;
+			if ($userObject->getLastLogin() > $userObject->getDetectedOn()) {
+				$userObject->unmark();
+			} else {
+				$userObjects[] = $userObject;
+			}
 		}
 		$this->deletedUsers = $userObjects;
 

--- a/apps/user_ldap/lib/User/DeletedUsersIndex.php
+++ b/apps/user_ldap/lib/User/DeletedUsersIndex.php
@@ -56,7 +56,7 @@ class DeletedUsersIndex {
 
 		$userObjects = [];
 		foreach ($deletedUsers as $user) {
-			$userObject = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);;
+			$userObject = new OfflineUser($user, $this->config, $this->mapping, $this->shareManager);
 			if ($userObject->getLastLogin() > $userObject->getDetectedOn()) {
 				$userObject->unmark();
 			} else {


### PR DESCRIPTION
If the user didn't get unmarked on login for some reason we can at least unmark them when listing the deleted users.