### PR TITLE
Fix Cache-Control header of non-versioned assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -41,11 +41,12 @@
 
   # Add cache control for static resources
   <FilesMatch "\.(css|js|svg|gif|png|jpg|ico|wasm|tflite)$">
-    Header set Cache-Control "max-age=15778463"
-  </FilesMatch>
-
-  <FilesMatch "\.(css|js|svg|gif|png|jpg|ico|wasm|tflite)(\?v=.*)?$">
-    Header set Cache-Control "max-age=15778463, immutable"
+    <If "%{QUERY_STRING} =~ /(^|&)v=/">
+      Header set Cache-Control "max-age=15778463, immutable"
+    </If>
+    <Else>
+      Header set Cache-Control "max-age=15778463"
+    </Else>
   </FilesMatch>
 
   # Let browsers cache WOFF files for a week


### PR DESCRIPTION
* Resolves: I found no related issue, do I need to create one?

## Summary

After updating from Nextcloud 24 to Nextcloud 25 people started to complain about an empty landing page until they refreshed the page ignoring their local cache (aka Ctrl+F5).
I noticed that all assets including non-cache-busted ones (such as /dist/core-main.js) had their `Cache-Control` header set to `immutable` so the browsers didn't even send conditional requests to check if a new version was available.

## TODO

This prevents the issue for users who don't have the files cached yet but does not fix existing caches, only implementing cache-busting for all assets would solve that. Should it be added to a list of known bugs somewhere?

This was introduced by 7dddbd0c355d1b4761466f9f86b30aed8b112ba1 so should be backported to NC 24 and 25 I think.

- [x] backport to stable25
- [x] backport to stable24

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
