### PR TITLE
Wrap URL string in quotes to avoid escaping issues

### DIFF
--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -1272,7 +1272,7 @@ const Dialogs = {
 				var previewUrl = OC.generateUrl('/core/preview.png?') + $.param(urlSpec)
 				img.onload = function() {
 					if (img.width > 5) {
-						$row.find('td.filename').attr('style', 'background-image:url(\"' + previewUrl + '\")')
+						$row.find('td.filename').attr('style', `background-image: url("${previewUrl}")`);
 					}
 				}
 				img.src = previewUrl

--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -1272,7 +1272,7 @@ const Dialogs = {
 				var previewUrl = OC.generateUrl('/core/preview.png?') + $.param(urlSpec)
 				img.onload = function() {
 					if (img.width > 5) {
-						$row.find('td.filename').attr('style', 'background-image:url(' + previewUrl + ')')
+						$row.find('td.filename').attr('style', 'background-image:url(\"' + previewUrl + '\")')
 					}
 				}
 				img.src = previewUrl

--- a/core/templates/filepicker.html
+++ b/core/templates/filepicker.html
@@ -45,7 +45,7 @@
 			<tbody>
 				<tr data-entryname="{filename}" data-type="{type}" tabindex="0">
 					<td class="filename"
-						style="background-image:url({icon})">
+						style="background-image:url(&quot;{icon}&quot;)">
 						<span class="filename-parts">
 							<span class="filename-parts__first">{filename1}</span>
 							<span class="filename-parts__last">{filename2}</span>


### PR DESCRIPTION
This ensures that the browser will expect that single-quotes in the url string are not the end of the string, but part of the url.

Fixes #31224
Signed-off-by: Colin Alworth <colin@colinalworth.com>


* Resolves: #31224

## Summary
The "file picker" dialog was previously not able to display previews for files if there was a `'` character in their path. This fix wraps the string passed to the css `url()` function with double-quotes, since URLs must escape double quotes (so additional quoting won't be required, whereas if the wrapping was done with a single-quote, then additional single-quotes in the URL would need to be further escaped). This is the simplest fix to ensure that properly-encoded URLs will be recognized by the browser.

## TODO

N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included (**Appears to not apply, I am not seeing testing for this kind of change, please direct me if this is incorrect**)
- [X] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required (**not required**)
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) (**N/A**)


Before:
![image](https://user-images.githubusercontent.com/241630/222572941-e08bd89c-2ee9-454a-b286-80e193db5bbc.png)

After:
![image](https://user-images.githubusercontent.com/241630/222572543-cb2b604f-039b-48bb-a3fe-6bdaab1f2968.png)

There are some other notes that js should be built and checked in, but it isn't clear to me if CI should do that. The current settings for Github CodeSpaces cannot run the `make dev-setup` command in its present configuration, and I haven't figured out the precise combination that should build without changes at current HEAD, so any change I make appears to modify every file in dist/.