### PR TITLE
fix: Avoid log spam on 404 routes not using GET

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -80,6 +80,7 @@ use OCP\Server;
 use OCP\Share;
 use OCP\User\Events\UserChangedEvent;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use function OCP\Log\logger;
 
 require_once 'public/Constants.php';
@@ -1097,7 +1098,9 @@ class OC {
 		try {
 			Server::get(\OC\Route\Router::class)->match('/error/404');
 		} catch (\Exception $e) {
-			logger('core')->emergency($e->getMessage(), ['exception' => $e]);
+			if (!$e instanceof MethodNotAllowedException) {
+				logger('core')->emergency($e->getMessage(), ['exception' => $e]);
+			}
 			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');
 			OC_Template::printErrorPage(
 				$l->t('404'),


### PR DESCRIPTION
## Summary

Avoid error logging in cases where a 404 page is rendered on non-GET requests. Ideally we would have the /error/404 route handle all http methods but this would mean we need to add each individually to the routes file as there is no combined way in the symphony router https://github.com/symfony/symfony/issues/45218

```
[core] Fatal: Symfony\Component\Routing\Exception\MethodNotAllowedException:  at <<closure>>

0. /var/www/cloud.nextcloud.com/nextcloud/lib/private/Route/Router.php line 278
   Symfony\Component\Routing\Matcher\UrlMatcher->match("/error/404")
1. /var/www/cloud.nextcloud.com/nextcloud/lib/private/Route/Router.php line 307
   OC\Route\Router->findMatchingRoute("/error/404")
2. /var/www/cloud.nextcloud.com/nextcloud/lib/base.php line 1098
   OC\Route\Router->match("/error/404")
3. /var/www/cloud.nextcloud.com/nextcloud/index.php line 36
   OC::handleRequest()

PUT /testing-put.txt
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
