### PR TITLE
Fix event moving issues

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1375,8 +1375,8 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$this->purgeProperties($sourceCalendarId, $objectId);
 			$this->updateProperties($targetCalendarId, $object['uri'], $object['calendardata'], $calendarType);
 
-			$this->addChange($sourceCalendarId, $object['uri'], 1, $calendarType);
-			$this->addChange($targetCalendarId, $object['uri'], 3, $calendarType);
+			$this->addChange($sourceCalendarId, $object['uri'], 3, $calendarType);
+			$this->addChange($targetCalendarId, $object['uri'], 1, $calendarType);
 
 			$object = $this->getCalendarObjectById($newPrincipalUri, $objectId);
 			// Calendar Object wasn't found - possibly because it was deleted in the meantime by a different client


### PR DESCRIPTION
Fixes [#4735](https://github.com/nextcloud/calendar/issues/4735),
fixes [#4538](https://github.com/nextcloud/calendar/issues/4538)
in calendar app and
fixes #34162 in server.


A wrong assignment of change types in the CalDav backend prevented proper synchronization of duplicated/moved events.