### PR TITLE
update wording for disabled web updater

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -100,7 +100,7 @@ class FeedBackHandler {
 if (\OCP\Util::needUpgrade()) {
 	$config = \OC::$server->getSystemConfig();
 	if ($config->getValue('upgrade.disable-web', false)) {
-		$eventSource->send('failure', $l->t('Please use the command line updater because automatic updating is disabled in the config.php.'));
+		$eventSource->send('failure', $l->t('Please use the command line updater because updating via the browser is disabled in your config.php.'));
 		$eventSource->close();
 		exit();
 	}


### PR DESCRIPTION
Resolves a misleading wording: not auto-updating is disabled but updating via the web.