### PR TITLE
Performance of WebDAV search requests with many shared files

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -88,7 +88,7 @@ class Cache extends CacheJail {
 		return $this->root;
 	}
 
-	protected function getGetUnjailedRoot() {
+	public function getGetUnjailedRoot() {
 		return $this->sourceRootInfo->getPath();
 	}
 
@@ -182,11 +182,15 @@ class Cache extends CacheJail {
 		// Not a valid action for Shared Cache
 	}
 
+	public function isFileShare() {
+		return ($this->storage->getItemType() === 'file');
+	}
+
 	public function getQueryFilterForStorage(): ISearchOperator {
 		$storageFilter = \OC\Files\Cache\Cache::getQueryFilterForStorage();
 
 		// Do the normal jail behavior for non files
-		if ($this->storage->getItemType() !== 'file') {
+		if (!$this->isFileShare()) {
 			return $this->addJailFilterQuery($storageFilter);
 		}
 

--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -88,7 +88,7 @@ class Cache extends CacheJail {
 		return $this->root;
 	}
 
-	public function getGetUnjailedRoot() {
+	protected function getGetUnjailedRoot() {
 		return $this->sourceRootInfo->getPath();
 	}
 
@@ -182,15 +182,11 @@ class Cache extends CacheJail {
 		// Not a valid action for Shared Cache
 	}
 
-	public function isFileShare(): bool {
-		return ($this->storage->getItemType() === 'file');
-	}
-
 	public function getQueryFilterForStorage(): ISearchOperator {
 		$storageFilter = \OC\Files\Cache\Cache::getQueryFilterForStorage();
 
 		// Do the normal jail behavior for non files
-		if (!$this->isFileShare()) {
+		if ($this->storage->getItemType() !== 'file') {
 			return $this->addJailFilterQuery($storageFilter);
 		}
 

--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -182,7 +182,7 @@ class Cache extends CacheJail {
 		// Not a valid action for Shared Cache
 	}
 
-	public function isFileShare() {
+	public function isFileShare(): bool {
 		return ($this->storage->getItemType() === 'file');
 	}
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -101,7 +101,6 @@ class QuerySearchHelper {
 				$storage = $a->getValue();
 				/** @psalm-suppress UndefinedInterfaceMethod */
 				$path = $b->getValue();
-				\OC::$server->getLogger()->debug("QuerySearchHelper::checkStorageAndPathFilter: storage=" . $storage . " " . "path=" . $path);
 				$storageToPathsMap[$storage][] = $path;
 				return;
 			}
@@ -134,7 +133,6 @@ class QuerySearchHelper {
 		// Create filters for single file shares
 		$singleFileFilters = [];
 		foreach ($storageToPathsMap as $storage => $paths) {
-			\OC::$server->getLogger()->debug("QuerySearchHelper::optimizeStorageFilters: storage=" . $storage . " " . "paths=" . implode(", ", $paths));
 			$singleFileFilters[] = new SearchBinaryOperator(
 				ISearchBinaryOperator::OPERATOR_AND,
 				[

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -89,6 +89,7 @@ class QuerySearchHelper {
 		$storageToPathsMap = [];
 		$otherCaches = [];
 		foreach ($caches as $cache) {
+			\OC::$server->getLogger()->debug("generateStorageFilters: cache: " . get_class($cache));
 			if (($cache instanceof \OCA\Files_Sharing\Cache) and $cache->isFileShare()) {
 				$storage = $cache->getNumericStorageId();
 				$storageToPathsMap[$storage][] = $cache->getGetUnjailedRoot();

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -97,7 +97,9 @@ class QuerySearchHelper {
 			$a = $operator->getArguments()[0];
 			$b = $operator->getArguments()[1];
 			if ($this->isCompareEqual($a, "storage") && $this->isCompareEqual($b, "path")) {
+				/** @psalm-suppress UndefinedInterfaceMethod */
 				$storage = $a->getValue();
+				/** @psalm-suppress UndefinedInterfaceMethod */
 				$path = $b->getValue();
 				\OC::$server->getLogger()->debug("QuerySearchHelper::checkStorageAndPathFilter: storage=" . $storage . " " . "path=" . $path);
 				$storageToPathsMap[$storage][] = $path;

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -38,6 +38,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -84,17 +85,17 @@ class QuerySearchHelper {
 		);
 	}
 
-	private function checkStorageAndPathFilter(ISearchBinaryOperator $operator, array &$storageToPathsMap, array &$storageOtherFilters): void {
-		if ($operator->getType() === ISearchBinaryOperator::OPERATOR_AND && count($operator->getArguments()) == 2) {
+	private function checkStorageAndPathFilter(ISearchOperator $operator, array &$storageToPathsMap, array &$storageOtherFilters): void {
+		if ($operator instanceof ISearchBinaryOperator && $operator->getType() === ISearchBinaryOperator::OPERATOR_AND && count($operator->getArguments()) == 2) {
 			$a = $operator->getArguments()[0];
 			$b = $operator->getArguments()[1];
 			if ($a instanceof ISearchComparison && $a->getField() === "storage" &&
 				$b instanceof ISearchComparison && $b->getField() === "path") {
-					$storage = $a->getValue();
-					$path = $b->getValue();
-					\OC::$server->getLogger()->debug("QuerySearchHelper::checkStorageAndPathFilter: storage=" . $storage . " " . "path=" . $path);
-					$storageToPathsMap[$storage][] = $path;
-					return;
+				$storage = $a->getValue();
+				$path = $b->getValue();
+				\OC::$server->getLogger()->debug("QuerySearchHelper::checkStorageAndPathFilter: storage=" . $storage . " " . "path=" . $path);
+				$storageToPathsMap[$storage][] = $path;
+				return;
 			}
 		}
 		$storageOtherFilters[] = $operator;
@@ -116,7 +117,7 @@ class QuerySearchHelper {
 		// Create filters for single file shares
 		$singleFileFilters = [];
 		foreach ($storageToPathsMap as $storage => $paths) {
-			\OC::$server->getLogger()->debug("QuerySearchHelper::generateStorageFilters: storage=" . $storage . " " . "paths=" . implode (", ", $paths));
+			\OC::$server->getLogger()->debug("QuerySearchHelper::generateStorageFilters: storage=" . $storage . " " . "paths=" . implode(", ", $paths));
 			$singleFileFilters[] = new SearchBinaryOperator(
 				ISearchBinaryOperator::OPERATOR_AND,
 				[

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -45,6 +45,7 @@ class SearchBuilder {
 		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'gte',
 		ISearchComparison::COMPARE_LESS_THAN => 'lt',
 		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lte',
+		ISearchComparison::COMPARE_IN => 'in',
 	];
 
 	protected static $searchOperatorNegativeMap = [
@@ -187,6 +188,7 @@ class SearchBuilder {
 			'favorite' => 'boolean',
 			'fileid' => 'integer',
 			'storage' => 'integer',
+			'path_hash' => 'array',
 		];
 		$comparisons = [
 			'mimetype' => ['eq', 'like'],
@@ -199,6 +201,7 @@ class SearchBuilder {
 			'favorite' => ['eq'],
 			'fileid' => ['eq'],
 			'storage' => ['eq'],
+			'path_hash' => ['in'],
 		];
 
 		if (!isset($types[$operator->getField()])) {
@@ -217,7 +220,9 @@ class SearchBuilder {
 		if ($value instanceof \DateTime) {
 			$value = $value->getTimestamp();
 		}
-		if (is_numeric($value)) {
+		if (is_array($value)) {
+			$type = IQueryBuilder::PARAM_STR_ARRAY;
+		} elseif (is_numeric($value)) {
 			$type = IQueryBuilder::PARAM_INT;
 		} else {
 			$type = IQueryBuilder::PARAM_STR;

--- a/lib/private/Files/Search/SearchComparison.php
+++ b/lib/private/Files/Search/SearchComparison.php
@@ -29,7 +29,7 @@ class SearchComparison implements ISearchComparison {
 	private $type;
 	/** @var string */
 	private $field;
-	/** @var string|integer|\DateTime */
+	/** @var string|integer|\DateTime|array */
 	private $value;
 	private $hints = [];
 
@@ -38,7 +38,7 @@ class SearchComparison implements ISearchComparison {
 	 *
 	 * @param string $type
 	 * @param string $field
-	 * @param \DateTime|int|string $value
+	 * @param \DateTime|int|string|array $value
 	 */
 	public function __construct($type, $field, $value) {
 		$this->type = $type;
@@ -61,7 +61,7 @@ class SearchComparison implements ISearchComparison {
 	}
 
 	/**
-	 * @return \DateTime|int|string
+	 * @return \DateTime|int|string|array
 	 */
 	public function getValue() {
 		return $this->value;

--- a/lib/public/Files/Search/ISearchComparison.php
+++ b/lib/public/Files/Search/ISearchComparison.php
@@ -34,6 +34,7 @@ interface ISearchComparison extends ISearchOperator {
 	public const COMPARE_LESS_THAN_EQUAL = 'lte';
 	public const COMPARE_LIKE = 'like';
 	public const COMPARE_LIKE_CASE_SENSITIVE = 'clike';
+	public const COMPARE_IN = 'in';
 
 	public const HINT_PATH_EQ_HASH = 'path_eq_hash'; // transform `path = "$path"` into `path_hash = md5("$path")`, on by default
 
@@ -58,7 +59,7 @@ interface ISearchComparison extends ISearchOperator {
 	/**
 	 * Get the value to compare the field with
 	 *
-	 * @return string|integer|\DateTime
+	 * @return string|integer|\DateTime|array
 	 * @since 12.0.0
 	 */
 	public function getValue();


### PR DESCRIPTION
I have noticed that when many files are shared between users (e.g. via Talk) the WebDAV search requests are quite slow. This is visible in the Photos app when entering the initial page or in the Android client when entering the Media tab. I suspect that this issue #35776 might have the same cause.

After some analysis I have found that in such situation the database query that retrieves the list of files is very complex and takes significant time to execute. For each shared file the following section is added to the SQL WHERE clause:
````
((`storage` = :dcValueNN) AND (`path_hash` = :dcValueMM)) OR 
````
In my environment I see queries with over 250 sections like this. That makes the query use over 500 separate parameters.

Since usually many files are shared between two users, the `storage` part of the filter is repeated many times. This provides an opportunity to refactor the query to use the following form (and provide all `path_hash` values for the same `storage` in an array):
````
((`storage` = :dcValueNN) AND (`path_hash` IN (:dcValueMM))) OR
````
This reduces the number of parameters significantly (in my case to about 25) and seems easier to optimize by the database engine.

In this PR I propose a change to the `QuerySearchHelper::searchInCaches` method that generates the query refactored as described above.

In my environment (MySQL database, ~250k rows in the `oc_filecache` table) I measured a very nice improvement in the query execution time (retrieval of the first 200 images in the Photos app):

- before the change: **~3700 ms**
- after the change: **~750 ms**

Comments? Thoughts?