### PR TITLE
fix(CI): Fix acceptance test password field selector after @nextcloud…

### DIFF
--- a/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
+++ b/tests/acceptance/features/bootstrap/FilesAppSharingContext.php
@@ -303,7 +303,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function passwordProtectField($shareLinkMenuTriggerElement) {
-		return Locator::forThe()->css(".share-link-password input.action-input__input")->descendantOf(self::shareLinkMenu($shareLinkMenuTriggerElement))->
+		return Locator::forThe()->css(".share-link-password input.input-field__input")->descendantOf(self::shareLinkMenu($shareLinkMenuTriggerElement))->
 				describedAs("Password protect field in the details view in Files app");
 	}
 
@@ -311,7 +311,7 @@ class FilesAppSharingContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function disabledPasswordProtectField($shareLinkMenuTriggerElement) {
-		return Locator::forThe()->css(".share-link-password input.action-input__input[disabled]")->descendantOf(self::shareLinkMenu($shareLinkMenuTriggerElement))->
+		return Locator::forThe()->css(".share-link-password input.input-field__input[disabled]")->descendantOf(self::shareLinkMenu($shareLinkMenuTriggerElement))->
 				describedAs("Disabled password protect field in the details view in Files app");
 	}
 


### PR DESCRIPTION
…/vue lib update

Regression from #37005 

Before | After
---|---
![grafik](https://user-images.githubusercontent.com/213943/223366229-fd3683ed-068d-4642-9f72-7a208f8d6947.png) | ![grafik](https://user-images.githubusercontent.com/213943/223367436-243a44ca-bcb2-48f5-8970-c83d52df9c58.png)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
