### PR TITLE
increase imaginary timeouts as for big files the processing could take very long

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -143,6 +143,8 @@ class Imaginary extends ProviderV2 {
 					'content-type' => $file->getMimeType(),
 					'body' => $stream,
 					'nextcloud' => ['allow_local_address' => true],
+					'timeout' => 120,
+					'connect_timeout' => 3,
 				]);
 		} catch (\Exception $e) {
 			$this->logger->error('Imaginary preview generation failed: ' . $e->getMessage(), [


### PR DESCRIPTION
Reason: apparently for some bigger files on slower systems the processing can take longer than 30s. If so the process will time out. Increase to 120s in order to fix it for most cases. Confirmed to work in https://github.com/nextcloud/all-in-one/discussions/2438#discussioncomment-5797918