### PR TITLE
fix(dav): Handle no next potential toggle in availability detection

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -139,6 +139,13 @@ class UserStatusAutomation extends TimedJob {
 			}
 		}
 
+		if (empty($nextPotentialToggles)) {
+			$this->logger->info('Removing ' . self::class . ' background job for user "' . $userId . '" because the user has no valid availability rules set');
+			$this->jobList->remove(self::class, $argument);
+			$this->manager->revertUserStatus($userId, IUserStatus::MESSAGE_AVAILABILITY, IUserStatus::DND);
+			return;
+		}
+
 		$nextAutomaticToggle = min($nextPotentialToggles);
 		$this->setLastRunToNextToggleTime($userId, $nextAutomaticToggle - 1);
 


### PR DESCRIPTION
Fixes: `min(): Array must contain at least one element at /var/www/nc/nextcloud/apps/dav/lib/BackgroundJob/UserStatusAutomation.php#142`

It's possible there's something more appropriate to do.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
