### PR TITLE
fix(profile): Set profile config cache directly after writing it to DB

### DIFF
--- a/lib/private/Profile/ProfileManager.php
+++ b/lib/private/Profile/ProfileManager.php
@@ -347,6 +347,7 @@ class ProfileManager implements IProfileManager {
 				$this->filterNotStoredProfileConfig($config->getConfigArray()),
 			));
 			$this->configMapper->update($config);
+			$this->configCache[$targetUser->getUID()] = $config;
 			$configArray = $config->getConfigArray();
 		} catch (DoesNotExistException $e) {
 			// Create a new default config if it does not exist
@@ -354,6 +355,7 @@ class ProfileManager implements IProfileManager {
 			$config->setUserId($targetUser->getUID());
 			$config->setConfigArray($defaultProfileConfig);
 			$this->configMapper->insert($config);
+			$this->configCache[$targetUser->getUID()] = $config;
 			$configArray = $config->getConfigArray();
 		}
 


### PR DESCRIPTION
In `ProfileManager::getProfileParams` we make a lot of indirect calls to `ProfileManager::getProfileConfig`. The first time we get the call we get into the catch and insert data, and the next time we miss the cache and do the select. There's a possibility of read-after-write issue here (the database r/o-mirror doesn't have the inserted config yet), which leads to conflicts when it tries to reinsert the config. To avoid that, let's put the config value in the configcache directly when it's written.

Fixes:
```
OC\DB\Exceptions\DbalException

An exception occurred while executing a query: SQLSTATE[23505]: Unique violation: 7 ERREUR:  la valeur d'une clé dupliquée rompt la contrainte unique « profile_config_user_id_idx »
DETAIL:  La clé « (user_id)=(Directrice) » existe déjà.
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
