### PR TITLE
[stable23] fix possible PHP warning

### DIFF
--- a/apps/workflowengine/lib/Check/FileSystemTags.php
+++ b/apps/workflowengine/lib/Check/FileSystemTags.php
@@ -120,6 +120,9 @@ class FileSystemTags implements ICheck, IFileCheck {
 			}
 		}
 
+		if (!$systemTags) {
+			return [];
+		}
 		$systemTags = call_user_func_array('array_merge', $systemTags);
 		$systemTags = array_unique($systemTags);
 		return $systemTags;


### PR DESCRIPTION
Not applicable to newer NC versions. Patch originally by @icewind1991. Fixes a `Warning: array_merge() expects at least 1 parameter`  warning and unexpected return value against PHP 7.3.