### PR TITLE
[stable20] Remove inefficient fed share scanner

### DIFF
--- a/apps/files_sharing/lib/External/Scanner.php
+++ b/apps/files_sharing/lib/External/Scanner.php
@@ -36,13 +36,9 @@ class Scanner extends \OC\Files\Cache\Scanner {
 	/** @var \OCA\Files_Sharing\External\Storage */
 	protected $storage;
 
-	/** {@inheritDoc} */
 	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
-		if (!$this->storage->remoteIsOwnCloud()) {
-			return parent::scan($path, $recursive, $recursive, $lock);
-		}
-
-		$this->scanAll();
+		// Disable locking for federated shares
+		parent::scan($path, $recursive, $reuse, false);
 	}
 
 	/**
@@ -60,7 +56,7 @@ class Scanner extends \OC\Files\Cache\Scanner {
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null) {
 		try {
-			return parent::scanFile($file, $reuseExisting);
+			return parent::scanFile($file, $reuseExisting, $parentId, $cacheData, $lock, $data);
 		} catch (ForbiddenException $e) {
 			$this->storage->checkStorageAvailability();
 		} catch (NotFoundException $e) {
@@ -72,58 +68,6 @@ class Scanner extends \OC\Files\Cache\Scanner {
 			$this->storage->checkStorageAvailability();
 		} catch (StorageNotAvailableException $e) {
 			$this->storage->checkStorageAvailability();
-		}
-	}
-
-	/**
-	 * Checks the remote share for changes.
-	 * If changes are available, scan them and update
-	 * the cache.
-	 * @throws NotFoundException
-	 * @throws StorageInvalidException
-	 * @throws \Exception
-	 */
-	public function scanAll() {
-		try {
-			$data = $this->storage->getShareInfo();
-		} catch (\Exception $e) {
-			$this->storage->checkStorageAvailability();
-			throw new \Exception(
-				'Error while scanning remote share: "' .
-				$this->storage->getRemote() . '" ' .
-				$e->getMessage()
-			);
-		}
-		if ($data['status'] === 'success') {
-			$this->addResult($data['data'], '');
-		} else {
-			throw new \Exception(
-				'Error while scanning remote share: "' .
-				$this->storage->getRemote() . '"'
-			);
-		}
-	}
-
-	/**
-	 * @param array $data
-	 * @param string $path
-	 */
-	private function addResult($data, $path) {
-		$id = $this->cache->put($path, $data);
-		if (isset($data['children'])) {
-			$children = [];
-			foreach ($data['children'] as $child) {
-				$children[$child['name']] = true;
-				$this->addResult($child, ltrim($path . '/' . $child['name'], '/'));
-			}
-
-			$existingCache = $this->cache->getFolderContentsById($id);
-			foreach ($existingCache as $existingChild) {
-				// if an existing child is not in the new data, remove it
-				if (!isset($children[$existingChild['name']])) {
-					$this->cache->remove(ltrim($path . '/' . $existingChild['name'], '/'));
-				}
-			}
 		}
 	}
 }

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -51,18 +51,6 @@ class ScannerTest extends TestCase {
 		$this->scanner = new Scanner($this->storage);
 	}
 
-	public function testScanAll() {
-		$this->storage->expects($this->any())
-			->method('getShareInfo')
-			->willReturn(['status' => 'success', 'data' => []]);
-
-		// FIXME add real tests, we are currently only checking for
-		// Declaration of OCA\Files_Sharing\External\Scanner::*() should be
-		// compatible with OC\Files\Cache\Scanner::*()
-		$this->scanner->scanAll();
-		$this->addToAssertionCount(1);
-	}
-
 	public function testScan() {
 		$this->storage->expects($this->any())
 			->method('getShareInfo')


### PR DESCRIPTION
backport of #32852 for running CI

- [ ] Check share info `curl --location --request POST 'https://nextcloud.dev.local/index.php/apps/files_sharing/shareinfo?t=TOKEN'`
- [x] Smoke test federated sharing
  - Works, size is pending until fully scanned but that is expected
