### PR TITLE
Do not send a pagination control with size = 0 if cookie is empty

### DIFF
--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -190,14 +190,18 @@ class LDAP implements ILDAPWrapper {
 	 * {@inheritDoc}
 	 */
 	public function search($link, $baseDN, $filter, $attr, $attrsOnly = 0, $limit = 0, int $pageSize = 0, string $cookie = '') {
-		$serverControls = [[
-			'oid' => LDAP_CONTROL_PAGEDRESULTS,
-			'value' => [
-				'size' => $pageSize,
-				'cookie' => $cookie,
-			],
-			'iscritical' => false,
-		]];
+		if ($pageSize > 0 || $cookie !== '') {
+			$serverControls = [[
+				'oid' => LDAP_CONTROL_PAGEDRESULTS,
+				'value' => [
+					'size' => $pageSize,
+					'cookie' => $cookie,
+				],
+				'iscritical' => false,
+			]];
+		} else {
+			$serverControls = [];
+		}
 
 		$oldHandler = set_error_handler(function ($no, $message, $file, $line) use (&$oldHandler) {
 			if (strpos($message, 'Partial search results returned: Sizelimit exceeded') !== false) {
@@ -387,7 +391,7 @@ class LDAP implements ILDAPWrapper {
 		if ($this->isResource($this->curArgs[0])) {
 			$resource = $this->curArgs[0];
 		} elseif (
-			   $functionName === 'ldap_search'
+			$functionName === 'ldap_search'
 			&& is_array($this->curArgs[0])
 			&& $this->isResource($this->curArgs[0][0])
 		) {


### PR DESCRIPTION
* Resolves: #37180 

## Summary

It only makes sense to send a pagination control with size 0 with a
 cookie to abandon a paged search.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
