### PR TITLE
Make it possible to strong type Entity properties

### DIFF
--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -38,7 +38,7 @@ interface IToken extends JsonSerializable {
 	/**
 	 * Get the token ID
 	 */
-	public function getId(): ?int;
+	public function getId(): int;
 
 	/**
 	 * Get the user UID

--- a/lib/private/Authentication/Token/IToken.php
+++ b/lib/private/Authentication/Token/IToken.php
@@ -37,10 +37,8 @@ interface IToken extends JsonSerializable {
 
 	/**
 	 * Get the token ID
-	 *
-	 * @return int
 	 */
-	public function getId(): int;
+	public function getId(): ?int;
 
 	/**
 	 * Get the user UID
@@ -74,6 +72,7 @@ interface IToken extends JsonSerializable {
 	 * Set the timestamp of the last password check
 	 *
 	 * @param int $time
+	 * @return void
 	 */
 	public function setLastCheck(int $time);
 
@@ -95,6 +94,7 @@ interface IToken extends JsonSerializable {
 	 * Set the authentication scope for this token
 	 *
 	 * @param array $scope
+	 * @return void
 	 */
 	public function setScope($scope);
 
@@ -115,6 +115,7 @@ interface IToken extends JsonSerializable {
 	 * Set the token
 	 *
 	 * @param string $token
+	 * @return void
 	 */
 	public function setToken(string $token);
 
@@ -122,6 +123,7 @@ interface IToken extends JsonSerializable {
 	 * Set the password
 	 *
 	 * @param string $password
+	 * @return void
 	 */
 	public function setPassword(string $password);
 
@@ -129,6 +131,7 @@ interface IToken extends JsonSerializable {
 	 * Set the expiration time of the token
 	 *
 	 * @param int|null $expires
+	 * @return void
 	 */
 	public function setExpires($expires);
 }

--- a/lib/private/Authentication/Token/PublicKeyToken.php
+++ b/lib/private/Authentication/Token/PublicKeyToken.php
@@ -118,7 +118,7 @@ class PublicKeyToken extends Entity implements INamedToken, IWipeableToken {
 		$this->addType('passwordInvalid', 'bool');
 	}
 
-	public function getId(): int {
+	public function getId(): ?int {
 		return $this->id;
 	}
 

--- a/lib/private/Authentication/Token/PublicKeyToken.php
+++ b/lib/private/Authentication/Token/PublicKeyToken.php
@@ -118,8 +118,12 @@ class PublicKeyToken extends Entity implements INamedToken, IWipeableToken {
 		$this->addType('passwordInvalid', 'bool');
 	}
 
-	public function getId(): ?int {
-		return $this->id;
+	public function getId(): int {
+		if ($this->id !== null) {
+			return $this->id;
+		} else {
+			throw new \InvalidArgumentException('Cannot call getId on an token which was not inserted yet');
+		}
 	}
 
 	public function getUID(): string {

--- a/lib/private/Tagging/Tag.php
+++ b/lib/private/Tagging/Tag.php
@@ -36,22 +36,12 @@ use OCP\AppFramework\Db\Entity;
  * @method void setName(string $name)
  */
 class Tag extends Entity {
-	protected $owner;
-	protected $type;
-	protected $name;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string $owner The tag's owner
-	 * @param string $type The type of item this tag is used for
-	 * @param string $name The tag's name
-	 */
-	public function __construct($owner = null, $type = null, $name = null) {
-		$this->setOwner($owner);
-		$this->setType($type);
-		$this->setName($name);
-	}
+	/** @psalm-suppress PropertyNotSetInConstructor */
+	protected string $owner;
+	/** @psalm-suppress PropertyNotSetInConstructor */
+	protected string $type;
+	/** @psalm-suppress PropertyNotSetInConstructor */
+	protected string $name;
 
 	/**
 	 * Transform a database columnname to a property

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -304,7 +304,7 @@ class Tags implements ITags {
 			return false;
 		}
 		try {
-			$tag = new Tag($this->user, $this->type, $name);
+			$tag = Tag::fromParams(['owner' => $this->user, 'type' => $this->type, 'name' => $name]);
 			$tag = $this->mapper->insert($tag);
 			$this->tags[] = $tag;
 		} catch (\Exception $e) {
@@ -314,8 +314,8 @@ class Tags implements ITags {
 			]);
 			return false;
 		}
-		$this->logger->debug(__METHOD__ . ' Added an tag with ' . $tag->getId(), ['app' => 'core']);
-		return $tag->getId();
+		$this->logger->debug(__METHOD__ . ' Added an tag with ' . ($tag->getId() ?? ''), ['app' => 'core']);
+		return $tag->getId() ?? false;
 	}
 
 	/**
@@ -382,7 +382,7 @@ class Tags implements ITags {
 		$newones = [];
 		foreach ($names as $name) {
 			if (!$this->hasTag($name) && $name !== '') {
-				$newones[] = new Tag($this->user, $this->type, $name);
+				$newones[] = Tag::fromParams(['owner' => $this->user, 'type' => $this->type, 'name' => $name]);
 			}
 			if (!is_null($id)) {
 				// Insert $objectid, $categoryid  pairs if not exist.

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -29,7 +29,7 @@ use function lcfirst;
 use function substr;
 
 /**
- * @method int getId()
+ * @method ?int getId()
  * @method void setId(int $id)
  * @since 7.0.0
  * @psalm-consistent-constructor

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -105,7 +105,7 @@ abstract class Entity {
 	protected function setter(string $name, array $args): void {
 		// setters should only work for existing attributes
 		if (property_exists($this, $name)) {
-			if (isset($this->name) && $this->$name === $args[0]) {
+			if (isset($this->$name) && $this->$name === $args[0]) {
 				return;
 			}
 			$this->markFieldUpdated($name);

--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -36,9 +36,9 @@ use function substr;
  */
 abstract class Entity {
 	/**
-	 * @var int
+	 * @var ?int
 	 */
-	public $id;
+	public $id = null;
 
 	private array $_updatedFields = [];
 	private array $_fieldTypes = ['id' => 'integer'];
@@ -105,7 +105,7 @@ abstract class Entity {
 	protected function setter(string $name, array $args): void {
 		// setters should only work for existing attributes
 		if (property_exists($this, $name)) {
-			if ($this->$name === $args[0]) {
+			if (isset($this->name) && $this->$name === $args[0]) {
 				return;
 			}
 			$this->markFieldUpdated($name);


### PR DESCRIPTION
PropertyNotSetInConstructor still have to be suppressed because properties are
 actually set in fromRow/fromParams methods, and the init path is too
 convoluted anyway.

* Resolves: # <!-- related github issue -->

## Summary

I tried several solutions to improve typing for QBMapper/Entity, I could not find a clean way to type properties without suppressing PropertyNotSetInConstructor manually and adding the @method annotations by hand as well.
But at least we can now type those properties and have psalm-compliant entities.
Also id property is actually nullable and null by default for autoincrement, made that clear in the code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
