### PR TITLE
Set <h1> headings for navigation through files app

### DIFF
--- a/apps/files/js/navigation.js
+++ b/apps/files/js/navigation.js
@@ -166,6 +166,8 @@
 					})
 				);
 			}
+			var currentItemName = this.$el.find('li[data-id="' + itemId + '"] > a').text();
+			window.OCP.Accessibility.setPageHeading(currentItemName);
 		},
 
 		/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36911

**This solution is only for NC25**
## Summary

Until now there were no headings for navigation pages. Correct `<h1>` headings are important for accessibility. 

**After (no visible changes):**

![Screenshot from 2023-03-10 17-38-13](https://user-images.githubusercontent.com/6078378/224373923-e76dfb37-bcc8-4d58-a0e7-70f4c5b347d5.png)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
