### PR TITLE
Getting rid of openssl_seal and rc4 in server side encryption

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -185,14 +185,9 @@ class Crypt {
 	}
 
 	/**
-	 * @param string $plainContent
-	 * @param string $passPhrase
-	 * @param int $version
-	 * @param int $position
-	 * @return false|string
 	 * @throws EncryptionFailedException
 	 */
-	public function symmetricEncryptFileContent($plainContent, $passPhrase, $version, $position) {
+	public function symmetricEncryptFileContent(string $plainContent, string $passPhrase, int $version, string $position): string|false {
 		if (!$plainContent) {
 			$this->logger->error('Encryption Library, symmetrical encryption failed no content given',
 				['app' => 'encryption']);
@@ -409,7 +404,7 @@ class Crypt {
 			$privateKey,
 			$hash,
 			0,
-			0
+			'0'
 		);
 
 		return $encryptedKey;
@@ -537,12 +532,8 @@ class Crypt {
 
 	/**
 	 * create signature
-	 *
-	 * @param string $data
-	 * @param string $passPhrase
-	 * @return string
 	 */
-	private function createSignature($data, $passPhrase) {
+	private function createSignature(string $data, string $passPhrase): string {
 		$passPhrase = hash('sha512', $passPhrase . 'a', true);
 		return hash_hmac('sha256', $data, $passPhrase);
 	}

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -718,6 +718,7 @@ class Crypt {
 	}
 
 	/**
+	 * @param array<string,\OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string> $keyFiles
 	 * @throws MultiKeyEncryptException
 	 */
 	public function multiKeyEncrypt(string $plainContent, array $keyFiles): array {
@@ -763,6 +764,7 @@ class Crypt {
 	 * @param array $keyFiles
 	 * @return array
 	 * @throws MultiKeyEncryptException
+	 * @deprecated 27.0.0 use multiKeyEncrypt
 	 */
 	public function multiKeyEncryptLegacy($plainContent, array $keyFiles) {
 		// openssl_seal returns false without errors if plaincontent is empty
@@ -853,6 +855,7 @@ class Crypt {
 	/**
 	 * Custom implementation of openssl_seal()
 	 *
+	 * @deprecated 27.0.0 use multiKeyEncrypt
 	 * @throws EncryptionFailedException
 	 */
 	private function opensslSeal(string $data, string &$sealed_data, array &$encrypted_keys, array $public_key, string $cipher_algo): int|false {

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -516,7 +516,7 @@ class Encryption implements IEncryptionModule {
 	 * @throws DecryptionFailedException
 	 */
 	public function isReadable($path, $uid) {
-		$fileKey = $this->keyManager->getFileKey($path, $uid);
+		$fileKey = $this->keyManager->getFileKey($path, $uid, null);
 		if (empty($fileKey)) {
 			$owner = $this->util->getOwner($path);
 			if ($owner !== $uid) {

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -485,7 +485,7 @@ class KeyManager {
 					$privateKey);
 			}
 		}
-		if ($useLegacyFileKey ?? false) {
+		if (!($useLegacyFileKey ?? false)) {
 			if ($shareKey && $privateKey) {
 				return $this->crypt->multiKeyDecrypt($shareKey, $privateKey);
 			}

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -44,7 +44,6 @@ use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
 
 class KeyManager {
-
 	/**
 	 * @var Session
 	 */
@@ -443,15 +442,18 @@ class KeyManager {
 	 * @param $uid
 	 * @return string
 	 */
-	public function getFileKey($path, $uid) {
+	public function getFileKey(string $path, ?string $uid, bool $useLegacyFileKey): string {
 		if ($uid === '') {
 			$uid = null;
 		}
 		$publicAccess = is_null($uid);
-		$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
 
-		if (empty($encryptedFileKey)) {
-			return '';
+		if ($useLegacyFileKey) {
+			$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
+
+			if (empty($encryptedFileKey)) {
+				return '';
+			}
 		}
 
 		if ($this->util->isMasterKeyEnabled()) {
@@ -475,10 +477,16 @@ class KeyManager {
 			$privateKey = $this->session->getPrivateKey();
 		}
 
-		if ($encryptedFileKey && $shareKey && $privateKey) {
-			return $this->crypt->multiKeyDecrypt($encryptedFileKey,
-				$shareKey,
-				$privateKey);
+		if ($useLegacyFileKey) {
+			if ($encryptedFileKey && $shareKey && $privateKey) {
+				return $this->crypt->multiKeyDecryptLegacy($encryptedFileKey,
+					$shareKey,
+					$privateKey);
+			}
+		} else {
+			if ($shareKey && $privateKey) {
+				return $this->crypt->multiKeyDecrypt($shareKey, $privateKey);
+			}
 		}
 
 		return '';

--- a/apps/encryption/lib/Recovery.php
+++ b/apps/encryption/lib/Recovery.php
@@ -35,8 +35,6 @@ use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
 
 class Recovery {
-
-
 	/**
 	 * @var null|IUser
 	 */
@@ -102,7 +100,7 @@ class Recovery {
 		}
 
 		if ($keyManager->checkRecoveryPassword($password)) {
-			$appConfig->setAppValue('encryption', 'recoveryAdminEnabled', 1);
+			$appConfig->setAppValue('encryption', 'recoveryAdminEnabled', '1');
 			return true;
 		}
 
@@ -140,7 +138,7 @@ class Recovery {
 
 		if ($keyManager->checkRecoveryPassword($recoveryPassword)) {
 			// Set recoveryAdmin as disabled
-			$this->config->setAppValue('encryption', 'recoveryAdminEnabled', 0);
+			$this->config->setAppValue('encryption', 'recoveryAdminEnabled', '0');
 			return true;
 		}
 		return false;
@@ -169,7 +167,7 @@ class Recovery {
 	 * @return bool
 	 */
 	public function isRecoveryKeyEnabled() {
-		$enabled = $this->config->getAppValue('encryption', 'recoveryAdminEnabled', 0);
+		$enabled = $this->config->getAppValue('encryption', 'recoveryAdminEnabled', '0');
 
 		return ($enabled === '1');
 	}
@@ -199,16 +197,15 @@ class Recovery {
 
 	/**
 	 * add recovery key to all encrypted files
-	 * @param string $path
 	 */
-	private function addRecoveryKeys($path) {
+	private function addRecoveryKeys(string $path): void {
 		$dirContent = $this->view->getDirectoryContent($path);
 		foreach ($dirContent as $item) {
 			$filePath = $item->getPath();
 			if ($item['type'] === 'dir') {
 				$this->addRecoveryKeys($filePath . '/');
 			} else {
-				$fileKey = $this->keyManager->getFileKey($filePath, $this->user->getUID());
+				$fileKey = $this->keyManager->getFileKey($filePath, $this->user->getUID(), null);
 				if (!empty($fileKey)) {
 					$accessList = $this->file->getAccessList($filePath);
 					$publicKeys = [];
@@ -218,8 +215,11 @@ class Recovery {
 
 					$publicKeys = $this->keyManager->addSystemKeys($accessList, $publicKeys, $this->user->getUID());
 
-					$encryptedKeyfiles = $this->crypt->multiKeyEncrypt($fileKey, $publicKeys);
-					$this->keyManager->setAllFileKeys($filePath, $encryptedKeyfiles);
+					$shareKeys = $this->crypt->multiKeyEncrypt($fileKey, $publicKeys);
+					$this->keyManager->deleteLegacyFileKey($filePath);
+					foreach ($shareKeys as $uid => $keyFile) {
+						$this->keyManager->setShareKey($filePath, $uid, $keyFile);
+					}
 				}
 			}
 		}
@@ -227,9 +227,8 @@ class Recovery {
 
 	/**
 	 * remove recovery key to all encrypted files
-	 * @param string $path
 	 */
-	private function removeRecoveryKeys($path) {
+	private function removeRecoveryKeys(string $path): void {
 		$dirContent = $this->view->getDirectoryContent($path);
 		foreach ($dirContent as $item) {
 			$filePath = $item->getPath();
@@ -243,11 +242,8 @@ class Recovery {
 
 	/**
 	 * recover users files with the recovery key
-	 *
-	 * @param string $recoveryPassword
-	 * @param string $user
 	 */
-	public function recoverUsersFiles($recoveryPassword, $user) {
+	public function recoverUsersFiles(string $recoveryPassword, string $user): void {
 		$encryptedKey = $this->keyManager->getSystemPrivateKey($this->keyManager->getRecoveryKeyId());
 
 		$privateKey = $this->crypt->decryptPrivateKey($encryptedKey, $recoveryPassword);
@@ -258,12 +254,8 @@ class Recovery {
 
 	/**
 	 * recover users files
-	 *
-	 * @param string $path
-	 * @param string $privateKey
-	 * @param string $uid
 	 */
-	private function recoverAllFiles($path, $privateKey, $uid) {
+	private function recoverAllFiles(string $path, string $privateKey, string $uid): void {
 		$dirContent = $this->view->getDirectoryContent($path);
 
 		foreach ($dirContent as $item) {
@@ -279,19 +271,17 @@ class Recovery {
 
 	/**
 	 * recover file
-	 *
-	 * @param string $path
-	 * @param string $privateKey
-	 * @param string $uid
 	 */
-	private function recoverFile($path, $privateKey, $uid) {
+	private function recoverFile(string $path, string $privateKey, string $uid): void {
 		$encryptedFileKey = $this->keyManager->getEncryptedFileKey($path);
 		$shareKey = $this->keyManager->getShareKey($path, $this->keyManager->getRecoveryKeyId());
 
 		if ($encryptedFileKey && $shareKey && $privateKey) {
-			$fileKey = $this->crypt->multiKeyDecrypt($encryptedFileKey,
+			$fileKey = $this->crypt->multiKeyDecryptLegacy($encryptedFileKey,
 				$shareKey,
 				$privateKey);
+		} elseif ($shareKey && $privateKey) {
+			$fileKey = $this->crypt->multiKeyDecrypt($shareKey, $privateKey);
 		}
 
 		if (!empty($fileKey)) {
@@ -303,8 +293,11 @@ class Recovery {
 
 			$publicKeys = $this->keyManager->addSystemKeys($accessList, $publicKeys, $uid);
 
-			$encryptedKeyfiles = $this->crypt->multiKeyEncrypt($fileKey, $publicKeys);
-			$this->keyManager->setAllFileKeys($path, $encryptedKeyfiles);
+			$shareKeys = $this->crypt->multiKeyEncrypt($fileKey, $publicKeys);
+			$this->keyManager->deleteLegacyFileKey($path);
+			foreach ($shareKeys as $uid => $keyFile) {
+				$this->keyManager->setShareKey($path, $uid, $keyFile);
+			}
 		}
 	}
 }

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -34,8 +34,6 @@ use OCP\IUserSession;
 use Test\TestCase;
 
 class CryptTest extends TestCase {
-
-
 	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
@@ -155,7 +153,7 @@ class CryptTest extends TestCase {
 			->method('warning')
 			->with('Unsupported cipher (Not-Existing-Cipher) defined in config.php supported. Falling back to AES-256-CTR');
 
-		$this->assertSame('AES-256-CTR',  $this->crypt->getCipher());
+		$this->assertSame('AES-256-CTR', $this->crypt->getCipher());
 	}
 
 	/**
@@ -396,7 +394,7 @@ class CryptTest extends TestCase {
 	public function testDecryptPrivateKey($header, $privateKey, $expectedCipher, $isValidKey, $expected) {
 		$this->config->method('getSystemValueBool')
 			->withConsecutive(['encryption.legacy_format_support', false],
-					  ['encryption.use_legacy_base64_encoding', false])
+				['encryption.use_legacy_base64_encoding', false])
 			->willReturnOnConsecutiveCalls(true, false);
 
 		/** @var \OCA\Encryption\Crypto\Crypt | \PHPUnit\Framework\MockObject\MockObject $crypt */
@@ -463,6 +461,19 @@ class CryptTest extends TestCase {
 		// invalid private key
 		$this->assertFalse(
 			$this->invokePrivate($this->crypt, 'isValidPrivateKey', ['foo'])
+		);
+	}
+
+	public function testMultiKeyEncrypt() {
+		$res = openssl_pkey_new();
+		openssl_pkey_export($res, $privateKey);
+		$publicKeyPem = openssl_pkey_get_details($res)['key'];
+		$publicKey = openssl_pkey_get_public($publicKeyPem);
+
+		$shareKeys = $this->crypt->multiKeyEncrypt('content', ['user1' => $publicKey]);
+		$this->assertEquals(
+			'content',
+			$this->crypt->multiKeyDecrypt($shareKeys['user1'], $privateKey)
 		);
 	}
 }

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -42,7 +42,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EncryptionTest extends TestCase {
-
 	/** @var Encryption */
 	private $instance;
 
@@ -156,7 +155,7 @@ class EncryptionTest extends TestCase {
 			->willReturnCallback([$this, 'addSystemKeysCallback']);
 		$this->cryptMock->expects($this->any())
 			->method('multiKeyEncrypt')
-			->willReturn(true);
+			->willReturn([]);
 
 		$this->instance->end('/foo/bar');
 	}
@@ -276,7 +275,7 @@ class EncryptionTest extends TestCase {
 			->with($path, $recoveryKeyId)
 			->willReturn($recoveryShareKey);
 		$this->cryptMock->expects($this->once())
-			->method('multiKeyDecrypt')
+			->method('multiKeyDecryptLegacy')
 			->with('encryptedFileKey', $recoveryShareKey, $decryptAllKey)
 			->willReturn($fileKey);
 
@@ -378,6 +377,7 @@ class EncryptionTest extends TestCase {
 				function ($fileKey, $publicKeys) {
 					$this->assertEmpty($publicKeys);
 					$this->assertSame('fileKey', $fileKey);
+					return [];
 				}
 			);
 

--- a/apps/encryption/tests/RecoveryTest.php
+++ b/apps/encryption/tests/RecoveryTest.php
@@ -211,7 +211,8 @@ class RecoveryTest extends TestCase {
 			->willReturn([]);
 
 		$this->cryptMock->expects($this->once())
-			->method('decryptPrivateKey');
+			->method('decryptPrivateKey')
+			->willReturn('privateKey');
 		$this->instance->recoverUsersFiles('password', 'admin');
 		$this->addToAssertionCount(1);
 	}
@@ -226,8 +227,8 @@ class RecoveryTest extends TestCase {
 			->willReturn(true);
 
 		$this->cryptMock->expects($this->once())
-			->method('multiKeyDecrypt')
-			->willReturn(true);
+			->method('multiKeyDecryptLegacy')
+			->willReturn('multiKeyDecryptLegacyResult');
 
 		$this->fileMock->expects($this->once())
 			->method('getAccessList')
@@ -244,10 +245,13 @@ class RecoveryTest extends TestCase {
 
 
 		$this->cryptMock->expects($this->once())
-			->method('multiKeyEncrypt');
+			->method('multiKeyEncrypt')
+			->willReturn(['admin' => 'shareKey']);
 
 		$this->keyManagerMock->expects($this->once())
-			->method('setAllFileKeys');
+			->method('deleteLegacyFileKey');
+		$this->keyManagerMock->expects($this->once())
+			->method('setShareKey');
 
 		$this->assertNull(self::invokePrivate($this->instance,
 			'recoverFile',

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -60,7 +60,7 @@ interface IEncryptionModule {
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
 	 *
-	 * $return array $header contain data as key-value pairs which should be
+	 * @return array $header contain data as key-value pairs which should be
 	 *                       written to the header, in case of a write operation
 	 *                       or if no additional data is needed return a empty array
 	 * @since 8.1.0


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Get rid of the intermediate fileKey and the obsolete RC4 encryption used on it.
Also used the opportunity to change the padding used to OAEP.
Files encrypted with previous version can still be read but upon write they will get migrated to the new encryption.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
