### PR TITLE
Document talk icon url definition

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -9,6 +9,7 @@
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Thomas Citharel <nextcloud@tcit.fr>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -191,6 +192,12 @@ class Definitions {
 					'required' => false,
 					'description' => 'The link to the conversation',
 					'example' => 'https://localhost/index.php/call/R4nd0mToken',
+				],
+				'icon-url' => [
+					'since' => '27.0.0',
+					'required' => false,
+					'description' => 'The icon url to use as avatar',
+					'example' => 'https://localhost/index.php/api/v1/room/R4nd0mToken/avatar'
 				],
 			],
 		],

--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -197,7 +197,7 @@ class Definitions {
 					'since' => '27.0.0',
 					'required' => false,
 					'description' => 'The icon url to use as avatar',
-					'example' => 'https://localhost/index.php/api/v1/room/R4nd0mToken/avatar'
+					'example' => 'https://localhost/ocs/v2.php/apps/spreed/api/v1/room/R4nd0mToken/avatar'
 				],
 			],
 		],


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/spreed/pull/8333 introduced an optional `icon-url` for the call objects in rich messages.

Ref: https://github.com/nextcloud/spreed/issues/8389

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
