### PR TITLE
Stop spamming deprecation messages

### DIFF
--- a/core/src/globals.js
+++ b/core/src/globals.js
@@ -86,11 +86,15 @@ const setDeprecatedProp = (global, cb, msg) => {
 		}
 		Object.defineProperty(window, global, {
 			get: () => {
+				let value;
 				if (msg) {
-					warnIfNotTesting(`${global} is deprecated: ${msg}`)
+					value = warnIfNotTesting(`${global} is deprecated: ${msg}`)
 				} else {
-					warnIfNotTesting(`${global} is deprecated`)
+					value = warnIfNotTesting(`${global} is deprecated`)
 				}
+				
+				delete window[global];
+				window[global] = value;
 
 				return cb()
 			},


### PR DESCRIPTION
Stops flooding the browser dev tools console every time a deprecated global function is called, by only logging a specific deprecation notice once.


* Resolves: #31763

## Issue

Nextcloud logs every time a deprecated global function in the frontend is called. If a Browser Dev Tool is attached to the browser tab it will save all these logs to the RAM to show them in the "Console" tab.

For my instance this results in about 1000 deprecation notices PER SECOND, no that is not a typo, that is 3 zeros.

To demonstrate I attached a Dev Tools debugger to a Dev Tools debugger debugging Nextcloud files. Yes the Chrome Dev Tools are implemented in html and js, so they can be debugged with another instance of themself :)

Screenshot 1, after about the 1 Minute it took me to set up the debugger debugger and screenshot: 
![1](https://user-images.githubusercontent.com/28999431/226014424-a402e93b-78d9-43cd-81aa-d1d15fc2be37.png)

Screenshot 2, exactly 65 seconds later:

![2](https://user-images.githubusercontent.com/28999431/226018358-3847233f-26be-4ad7-baf5-6c65482f279f.png)
(different deprecation logs disrupted the log messages collapse, because of that the collapse number in the last line is smaller)

As you can see the dev tools memory usage grew by about at least 0,4 GB in 65 SECONDS of having the debugger open.

But it is actually worse, because the debugger ist not just using a lot of RAM, it is basically completely unusable, because it uses a lot of CPU. For example executing a js command in that console, that is busy with showing the deprecation warnings has a latency of 20 seconds or so. This also applies to the communication between the two debuggers, so the actual RAM usage is actually higher, because the RAM usage shown in the debugger debugger is delayed quite a bit. From looking at the process table in the system monitor it actually looks like that browser process of the debugger is using 1,9 GB at the time of screenshot 2.

I would like to show you a longer duration, but shortly after screenshot 2 the debugger OOMed.


- Is it embarrassing, that the Chrome Dev Tools Debugger is not capable of discarding old logs, in order to keep itself from OOMing ?

  Yes, but can we please still stop spamming it with 1000 log messages per seconds, ok thx


- Does this happen when not debugging the debugger ?

  Yes


- Is it really the logs ? 

  Yes, see here with these deprecation logs disabled (using window.TESTING = true) after 3 minutes:
![3](https://user-images.githubusercontent.com/28999431/226027229-aeb74813-ed30-4fd7-9781-f92adbf88d33.png)


- Does this issue occur without any apps installed ?

  I don't think the core itself throws (enough) deprecation warnings to cause the RAM usage issue. I am not sure which app exactly (I have a lot of them) uses this deprectaed stuff so often.
  
  It is likely, that this issue does not occur this extreme on most instances, since it depends on the installed apps and something is clearly wrong with one app, if it calls jquery 1000 times a second, but without causing a log every time, it is not actually a performance issue.
  
  On most instances this PR is just going to solve the annoyance of constant error messages in the Console, as described in the linked issue #31763.

- On which Browsers does this happen ?

  The screenshots are from Brave Browser on Fedora. I have also tested it with Chrome on Windows.

- What Hardware was this was tested on ?

  CPU: AMD Ryzen 5 3600 (12 Threads)
  RAM: 16 GB

- How often did this issue cause your system to lock up completely ?

  5 times, or about 5 times too often for my sanity 😐 (OOM on Fedora is weird)

## The Fix:

Only thowing a specific deprecation warning once, so it can still throw multiple issues, if multiple different deprecated globals are being used, but each one only once.
This can be achieved, by using the lazy getter pattern described by MDN [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#smart_self-overwriting_lazy_getters).

## TODO

- [x] Easy fix (only logging a specific deprecation notice once)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
