### PR TITLE
fix(provisionning_api): Remove parameters that are not set into template

### DIFF
--- a/core/templates/confirmation.php
+++ b/core/templates/confirmation.php
@@ -8,15 +8,12 @@
 /** @var \OCP\Defaults $theme */
 ?>
 <div class="update">
-	<form method="POST" action="<?php print_unescaped($_['targetUrl']);?>">
+	<form method="POST">
 		<h2><?php p($_['title']) ?></h2>
 		<p><?php p($_['message']) ?></p>
 		<div class="buttons">
 			<input type="submit" class="primary" value="<?php p($_['action']); ?>">
 		</div>
-		<?php foreach ($_['parameters'] as $name => $value) {?>
-			<input type="hidden" name="<?php p($name); ?>" value="<?php p($value); ?>">
-		<?php } ?>
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
 	</form>
 </div>


### PR DESCRIPTION
## Summary

Fixes
* `Notice: Undefined index: parameters`
* `Warning: Invalid argument supplied for foreach()`
* `Undefined index: targetUrl at /var/www/nc/nextcloud/core/templates/confirmation.php#9`

The template is only called by the Provisioning API in `apps/provisioning_api/lib/Controller/VerificationController.php`, brought in https://github.com/nextcloud/server/pull/28422.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
