### PR TITLE
fix(security): Log failing strict cookie check

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -561,6 +561,7 @@ class OC {
 
 			// All other endpoints require the lax and the strict cookie
 			if (!$request->passesStrictCookieCheck()) {
+				logger('core')->warning('Request does not pass strict cookie check');
 				self::sendSameSiteCookies();
 				// Debug mode gets access to the resources without strict cookie
 				// due to the fact that the SabreDAV browser also lives there.


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

The error is silent otherwise and makes it very hard to debug on a production system. Debugging https://github.com/nextcloud/server/issues/37277 would have been a lot easier.

```json
{"reqId":"lkEo49QzUvwMOymVOPBO","level":2,"time":"2023-03-20T15:24:35+00:00","remoteAddr":"127.0.0.1","user":"--","app":"no app in context","method":"REPORT","url":"/remote.php/dav/calendars/admin/personal","message":"Request does not pass strict cookie check","userAgent":"curl/7.88.1","version":"26.0.0.10","data":[]}
```

## TODO

- [x] Log

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
