### PR TITLE
fix(session): Fix DAVx5 sync problems by partial reverting session changes

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -411,13 +411,17 @@ class OC {
 
 	public static function initSession(): void {
 		$request = Server::get(IRequest::class);
-		$isDavRequest = strpos($request->getRequestUri(), '/remote.php/dav') === 0 || strpos($request->getRequestUri(), '/remote.php/webdav') === 0;
-		if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest && !isset($_COOKIE['nc_session_id'])) {
-			setcookie('cookie_test', 'test', time() + 3600);
-			// Do not initialize the session if a request is authenticated directly
-			// unless there is a session cookie already sent along
-			return;
-		}
+
+		// TODO: Temporary disabled again to solve issues with CalDAV/CardDAV clients like DAVx5 that use cookies
+		// TODO: See https://github.com/nextcloud/server/issues/37277#issuecomment-1476366147 and the other comments
+		// TODO: for further information.
+		// $isDavRequest = strpos($request->getRequestUri(), '/remote.php/dav') === 0 || strpos($request->getRequestUri(), '/remote.php/webdav') === 0;
+		// if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest && !isset($_COOKIE['nc_session_id'])) {
+		// setcookie('cookie_test', 'test', time() + 3600);
+		// // Do not initialize the session if a request is authenticated directly
+		// // unless there is a session cookie already sent along
+		// return;
+		// }
 
 		if ($request->getServerProtocol() === 'https') {
 			ini_set('session.cookie_secure', 'true');


### PR DESCRIPTION
* Resolves: #37277 

## Summary

Temporary disabled the short cut again to solve issues with CalDAV/CardDAV clients like DAVx5 that use cookies and need a session. See https://github.com/nextcloud/server/issues/37277#issuecomment-1476366147 and the other comments for further information.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
