### PR TITLE
fix(security)!: Use consistent HTTP status for strict cookie checks

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -570,7 +570,9 @@ class OC {
 				// Debug mode gets access to the resources without strict cookie
 				// due to the fact that the SabreDAV browser also lives there.
 				if (!$config->getSystemValue('debug', false)) {
-					http_response_code(\OCP\AppFramework\Http::STATUS_SERVICE_UNAVAILABLE);
+					http_response_code(\OCP\AppFramework\Http::STATUS_PRECONDITION_FAILED);
+					header('Content-Type: application/json');
+					echo json_encode(['error' => 'Strict Cookie has not been found in request']);
 					exit();
 				}
 			}

--- a/lib/private/AppFramework/Middleware/Security/Exceptions/StrictCookieMissingException.php
+++ b/lib/private/AppFramework/Middleware/Security/Exceptions/StrictCookieMissingException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016 Lukas Reschke <lukas@statuscode.ch>
  *


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/server/issues/37277

## Summary

Before: 503/412
Now: 412 + json body explaining the error

503 would indicate that the error is temporary. As in, the same request could succeed at a later point in time. But it doesn't. The request is invalid.

This is a breaking change. This should not be backported.

### Before

```http
HTTP/2 503 
server: nginx/1.22.1
date: Tue, 21 Mar 2023 08:22:21 GMT
content-type: text/html; charset=UTF-8
x-powered-by: PHP/8.2.3
set-cookie: oc_sessionPassphrase=jPByKo3eRwPxEwGDJwKEngrZOmTu81OaAFn%2FrPISGJfA%2BAaXMgEKj7aDgljop7aiQHpMefT4bxGgm7ynhoZq15Z0eCl2%2BvikUtp5XsD4koIQjrH7WxbS%2BmLOp0Zyx1EW; path=/; secure; HttpOnly; SameSite=Lax
set-cookie: oc4uhez60xks=2c2af6255eed0a336efd2d2fb003a53e; path=/; secure; HttpOnly; SameSite=Lax
expires: Thu, 19 Nov 1981 08:52:00 GMT
cache-control: no-store, no-cache, must-revalidate
pragma: no-cache
content-security-policy: default-src 'self'; script-src 'self' 'nonce-aVVqWjJrb1k5VlhxNE1IbkIxT2hKWlFjZFBYQkZFQkx4a3g1a2p3VDRQUT06dzNEdXRDQW9vaHlqMlBhRmFoQ1ZTODB0QUtleFVBRjd0UVFOOWw1MHJwTT0='; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *; object-src 'none'; base-uri 'self';
set-cookie: __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax
set-cookie: __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=strict

```

### After

```http
HTTP/2 412 
server: nginx/1.22.1
date: Tue, 21 Mar 2023 08:22:48 GMT
content-type: application/json
x-powered-by: PHP/8.2.3
set-cookie: oc_sessionPassphrase=xyEdE5b200oy%2FDfipFfnkpPVy7fYzVPSMoSFOx%2FpT5iWRO1erl1es3PECGdZgk0SZlOELO7qYQHAgNp3CXry2tLDxJXdWfgRfz4jPbfDb8uP0iheRbgR%2FODayxeQCXtM; path=/; secure; HttpOnly; SameSite=Lax
set-cookie: oc4uhez60xks=caf67db66e77463a64c7584416ddda15; path=/; secure; HttpOnly; SameSite=Lax
expires: Thu, 19 Nov 1981 08:52:00 GMT
cache-control: no-store, no-cache, must-revalidate
pragma: no-cache
content-security-policy: default-src 'self'; script-src 'self' 'nonce-Y1Z3blUxYjlHZWlQUjdsT0FXNW5oMmJNTlFFOHNscE9oZFpXa2hmY3ZXbz06UWpaallnUzBNcmovUGRBQU1CNFQ3eVdDWWt0UDhTc0wzWjBmKzI2MDdEMD0='; style-src 'self' 'unsafe-inline'; frame-src *; img-src * data: blob:; font-src 'self' data:; media-src *; connect-src *; object-src 'none'; base-uri 'self';
set-cookie: __Host-nc_sameSiteCookielax=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax
set-cookie: __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=strict

{"error":"Strict Cookie has not been found in request"}
``` 

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [x] https://github.com/nextcloud/documentation/pull/10518
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
