### PR TITLE
Allow to catch `IMapperException` by implementing `Throwable`

### DIFF
--- a/lib/public/AppFramework/Db/IMapperException.php
+++ b/lib/public/AppFramework/Db/IMapperException.php
@@ -29,5 +29,5 @@ namespace OCP\AppFramework\Db;
 /**
  * @since 16.0.0
  */
-interface IMapperException {
+interface IMapperException extends \Throwable {
 }


### PR DESCRIPTION
## Summary
Currently it is not possible to catch `IMapperException`, you must catch `DoesNotExistException` or `MultipleObjectsReturnedException` explicitly because `IMapperException` is not implementing the `Throwable` interface.
(Doing so will cause psalm issues).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
