### PR TITLE
Save user's first login time and output it in `occ user:info`

### DIFF
--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -79,7 +79,8 @@ class Info extends Base {
 			'storage' => $this->getStorageInfo($user),
 			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 			'user_directory' => $user->getHome(),
-			'backend' => $user->getBackendClassName()
+			'backend' => $user->getBackendClassName(),
+			'created' => date(\DateTimeInterface::Atom, $user->getFirstLogin())
 		];
 		$this->writeArrayInOutputFormat($input, $output, $data);
 		return 0;

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -80,7 +80,7 @@ class Info extends Base {
 			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName(),
-			'created' => date(\DateTimeInterface::Atom, $user->getFirstLogin())
+			'created' => date(\DateTimeInterface::ATOM, $user->getFirstLogin())
 		];
 		$this->writeArrayInOutputFormat($input, $output, $data);
 		return 0;

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -145,4 +145,12 @@ class LazyUser implements IUser {
 	public function setQuota($quota) {
 		$this->getUser()->setQuota($quota);
 	}
+
+	public function getFirstLogin() {
+		return $this->getUser()->getFirstLogin();
+	}
+
+	public function updateFirstLoginTimestamp() {
+		return $this->getUser()->updateFirstLoginTimestamp();
+	}
 }

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -150,7 +150,7 @@ class LazyUser implements IUser {
 		return $this->getUser()->getFirstLogin();
 	}
 
-	public function updateFirstLoginTimestamp() {
-		return $this->getUser()->updateFirstLoginTimestamp();
+	public function updateFirstLoginTimestamp(int $timestamp) {
+		return $this->getUser()->updateFirstLoginTimestamp($timestamp);
 	}
 }

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -560,7 +560,8 @@ class Session implements IUserSession, Emitter {
 				// read only uses
 			}
 
-			$user->updateFirstLoginTimestamp($user->getLastLogin());
+			$userObj = $this->getUser();
+			$userObj->updateFirstLoginTimestamp($userObj->getLastLogin());
 			// trigger any other initialization
 			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));
 		}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -560,6 +560,7 @@ class Session implements IUserSession, Emitter {
 				// read only uses
 			}
 
+			$user->updateFirstLoginTimestamp($user->getLastLogin());
 			// trigger any other initialization
 			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));
 		}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -254,7 +254,7 @@ class User implements IUser {
 	 */
 
 	public function getFirstLogin() {
-		if($this->firstLogin === null) {
+		if ($this->firstLogin === null) {
 			$this->firstLogin = (int) $this->config->getUserValue($this->uid, 'login', 'firstLogin', 0);
 		}
 		return (int) $this->firstLogin;

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -278,7 +278,7 @@ class User implements IUser {
 	}
 
 	/**
-	 * updates the timestamp of the most recent login of this user
+	 * updates the timestamp of the first login of this user
 	 */
 	public function updateFirstLoginTimestamp(int $timestamp) {
 		$this->firstLogin = $timestamp;

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -89,6 +89,9 @@ class User implements IUser {
 	/** @var int|null */
 	private $lastLogin;
 
+	/** @var int|null */
+	private $firstLogin;
+
 	/** @var \OCP\IConfig */
 	private $config;
 
@@ -244,6 +247,20 @@ class User implements IUser {
 	}
 
 	/**
+	 * returns the timestamp of the user's first login or 0 if the user did never
+	 * login
+	 *
+	 * @return int
+	 */
+
+	public function getFirstLogin() {
+		if($this->firstLogin === null) {
+			$this->firstLogin = (int) $this->config->getUserValue($this->uid, 'login', 'firstLogin', 0);
+		}
+		return (int) $this->firstLogin;
+	}
+
+	/**
 	 * updates the timestamp of the most recent login of this user
 	 */
 	public function updateLastLoginTimestamp() {
@@ -258,6 +275,14 @@ class User implements IUser {
 		}
 
 		return $firstTimeLogin;
+	}
+
+	/**
+	 * updates the timestamp of the most recent login of this user
+	 */
+	public function updateFirstLoginTimestamp(int $timestamp) {
+		$this->firstLogin = $timestamp;
+		$this->config->setUserValue($this->uid, 'login', 'firstLogin', (string)$this->firstLogin);
 	}
 
 	/**

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -270,4 +270,19 @@ interface IUser {
 	 * @since 9.0.0
 	 */
 	public function setQuota($quota);
+
+	/**
+	 * returns the timestamp of the user's first login or 0 if the user did never
+	 * login
+	 *
+	 * @return int
+	 * @since 27.0.0
+	 */
+	public function getFirstLogin();
+
+	/**
+	 * updates the timestamp of the first login of this user
+	 * @since 27.0.0
+	 */
+	public function updateFirstLoginTimestamp(int $timestamp);
 }

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -849,6 +849,26 @@ class UserTest extends TestCase {
 		$this->assertSame(42, $user->getLastLogin());
 	}
 
+	public function testGetFirstLogin() {
+		/**
+		 * @var Backend | MockObject $backend
+		 */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')
+			->willReturnCallback(function ($uid, $app, $key, $default) {
+				if ($uid === 'foo' && $app === 'login' && $key === 'firstLogin') {
+					return 42;
+				} else {
+					return $default;
+				}
+			});
+
+		$user = new User('foo', $backend, $this->dispatcher, null, $config);
+		$this->assertSame(42, $user->getFirstLogin());
+	}
+
 	public function testSetEnabled() {
 		/**
 		 * @var Backend | MockObject $backend


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/22640 & https://github.com/bpcurse/nextcloud-userexport/issues/52

