### PR TITLE
fix(security): Mark recording_servers key appconfig as private as it …

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -112,6 +112,7 @@ class AppConfig implements IAppConfig {
 		'spreed' => [
 			'/^bridge_bot_password$/',
 			'/^hosted-signaling-server-(.*)$/',
+			'/^recording_servers$/',
 			'/^signaling_servers$/',
 			'/^signaling_ticket_secret$/',
 			'/^signaling_token_privkey_(.*)$/',


### PR DESCRIPTION
…contains a secret

```sh
occ config:list spreed
```

### Before

```json
{
    "apps": {
        "spreed": {
            "enabled": "yes",
            "installed_version": "17.0.0-dev",
            "recording_servers": "{\"servers\":[{\"server\":\"http:\/\/172.17.0.3:8000\",\"verify\":false}],\"secret\":\"OMGmySECRETwasLEAKED\"}",
            "signaling_dev": "yes",
            "signaling_servers": "***REMOVED SENSITIVE VALUE***",
            "signaling_token_privkey_es256": "***REMOVED SENSITIVE VALUE***",
            "signaling_token_pubkey_es256": "***REMOVED SENSITIVE VALUE***",
            "sip_bridge_dialin_info": "***REMOVED SENSITIVE VALUE***",
            "sip_bridge_shared_secret": "***REMOVED SENSITIVE VALUE***",
            "types": "dav,prevent_group_restriction"
        }
    }
}
```

### After

```json
{
    "apps": {
        "spreed": {
            "enabled": "yes",
            "installed_version": "17.0.0-dev",
            "recording_servers": "***REMOVED SENSITIVE VALUE***",
            "signaling_dev": "yes",
            "signaling_servers": "***REMOVED SENSITIVE VALUE***",
            "signaling_token_privkey_es256": "***REMOVED SENSITIVE VALUE***",
            "signaling_token_pubkey_es256": "***REMOVED SENSITIVE VALUE***",
            "sip_bridge_dialin_info": "***REMOVED SENSITIVE VALUE***",
            "sip_bridge_shared_secret": "***REMOVED SENSITIVE VALUE***",
            "types": "dav,prevent_group_restriction"
        }
    }
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
