### PR TITLE
fix(mailer): remove value comparison for smtp_authtype as there is only one option

### DIFF
--- a/apps/settings/templates/settings/admin/additional-mail.php
+++ b/apps/settings/templates/settings/admin/additional-mail.php
@@ -127,12 +127,8 @@ $mail_sendmailmode = [
 					<span class="icon-info" title="<?php p($l->t('Only applies when authentication is required')); ?>"></span>
 			</label>
 			<select name="mail_smtpauthtype" id="mail_smtpauthtype" disabled="disabled">
-				<?php foreach ($mail_smtpauthtype as $authtype => $name):
-					$selected = '';
-					if ($authtype == $_['mail_smtpauthtype']):
-						$selected = 'selected="selected"';
-					endif; ?>
-					<option value="<?php p($authtype) ?>" <?php p($selected) ?>><?php p($name) ?></option>
+				<?php foreach ($mail_smtpauthtype as $authtype => $name): ?>
+						<option value="<?php p($authtype) ?>"><?php p($name) ?></option>
 				<?php endforeach; ?>
 			</select>
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/37329

## Summary

The `mail_smtpauth` parameter is never passed to the template and thus always 0. There is only the LOGIN option anyway so I removed the check completely.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
