### PR TITLE
Fix cypress tests for files_versions 

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         # run multiple copies of the current job in parallel
-        containers: ['component', 1, 2]
+        containers: ["component", 1, 2]
 
     name: runner ${{ matrix.containers }}
 
@@ -90,6 +90,17 @@ jobs:
           TESTING: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Extract NC logs
+        if: always()
+        run: docker-compose --project-directory cypress logs > nextcloud.log
+
+      - name: Upload NC logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: nc_logs_${{ matrix.containers }}
+          path: nextcloud.log
 
   summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,7 +92,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
       - name: Extract NC logs
-        if: ${{ matrix.containers != 'component' }}
+        if: ( success() || failure() ) && matrix.containers != 'component'
         run: docker logs nextcloud-cypress-tests-server > nextcloud.log
 
       - name: Upload NC logs

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,12 +92,12 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
       - name: Extract NC logs
-        if: always()
-        run: docker-compose --project-directory cypress logs > nextcloud.log
+        if: ${{ matrix.containers != 'component' }}
+        run: docker logs nextcloud-cypress-tests-server > nextcloud.log
 
       - name: Upload NC logs
         uses: actions/upload-artifact@v3
-        if: always()
+        if: ${{ matrix.containers != 'component' }}
         with:
           name: nc_logs_${{ matrix.containers }}
           path: nextcloud.log

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -102,6 +102,17 @@ jobs:
           name: nc_logs_${{ matrix.containers }}
           path: nextcloud.log
 
+      - name: Create data dir archive
+        if: ( success() || failure() ) && matrix.containers != 'component'
+        run: docker exec nextcloud-cypress-tests-server tar -cvjf - data > data.tar
+
+      - name: Upload data dir archive
+        uses: actions/upload-artifact@v3
+        if: ( success() || failure() ) && matrix.containers != 'component'
+        with:
+          name: nc_data_${{ matrix.containers }}
+          path: data.tar
+
   summary:
     runs-on: ubuntu-latest
     needs: [init, cypress]

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload NC logs
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.containers != 'component' }}
+        if: ( success() || failure() ) && matrix.containers != 'component'
         with:
           name: nc_logs_${{ matrix.containers }}
           path: nextcloud.log

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,23 +92,23 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
       - name: Extract NC logs
-        if: ( success() || failure() ) && matrix.containers != 'component'
+        if: failure() && matrix.containers != 'component'
         run: docker logs nextcloud-cypress-tests-server > nextcloud.log
 
       - name: Upload NC logs
         uses: actions/upload-artifact@v3
-        if: ( success() || failure() ) && matrix.containers != 'component'
+        if: failure() && matrix.containers != 'component'
         with:
           name: nc_logs_${{ matrix.containers }}
           path: nextcloud.log
 
       - name: Create data dir archive
-        if: ( success() || failure() ) && matrix.containers != 'component'
+        if: failure() && matrix.containers != 'component'
         run: docker exec nextcloud-cypress-tests-server tar -cvjf - data > data.tar
 
       - name: Upload data dir archive
         uses: actions/upload-artifact@v3
-        if: ( success() || failure() ) && matrix.containers != 'component'
+        if: failure() && matrix.containers != 'component'
         with:
           name: nc_data_${{ matrix.containers }}
           path: data.tar

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -71,7 +71,9 @@ export default defineConfig({
 
 			// Remove container after run
 			on('after:run', () => {
-				stopNextcloud()
+				if (!process.env.CI) {
+					stopNextcloud()
+				}
 			})
 
 			// Before the browser launches

--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -122,7 +122,6 @@ export const configureNextcloud = async function() {
 	await runExec(container, ['php', 'occ', 'config:system:set', 'default_locale', '--value', 'en_US'], true)
 	await runExec(container, ['php', 'occ', 'config:system:set', 'force_locale', '--value', 'en_US'], true)
 	await runExec(container, ['php', 'occ', 'config:system:set', 'enforce_theme', '--value', 'light'], true)
-	await runExec(container, ['php', 'occ', 'config:system:set', 'versions_retention_obligation', '--value', '0, 0'], true)
 
 	console.log('└─ Nextcloud is now ready to use 🎉')
 }

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -21,16 +21,17 @@
  */
 
 import path from "path"
+import type { User } from "@nextcloud/cypress"
 
-export function uploadThreeVersions(user) {
+export function uploadThreeVersions(user: User, fileName: string) {
 	// A new version will not be created if the changes occur
 	// within less than one second of each other.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
-	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-		.wait(10000)
-		.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-		.wait(10000)
-		.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', `/${fileName}`)
+		.wait(1100)
+		.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', `/${fileName}`)
+		.wait(1100)
+		.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', `/${fileName}`)
 	cy.login(user)
 }
 
@@ -72,13 +73,13 @@ export function nameVersion(index: number, name: string) {
 	cy.get(':focused').type(`${name}{enter}`)
 }
 
-export function assertVersionContent(index: number, expectedContent: string) {
+export function assertVersionContent(filename: string, index: number, expectedContent: string) {
 	const downloadsFolder = Cypress.config('downloadsFolder')
 
 	openVersionMenu(index)
 	clickPopperAction('Download version')
 
-	return cy.readFile(path.join(downloadsFolder, 'test.txt'))
+	return cy.readFile(path.join(downloadsFolder, filename))
 		.then((versionContent) => expect(versionContent).to.equal(expectedContent))
-		.then(() => cy.exec(`rm ${downloadsFolder}/test.txt`))
+		.then(() => cy.exec(`rm ${downloadsFolder}/${filename}`))
 }

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -27,9 +27,9 @@ export function uploadThreeVersions(user) {
 	// within less than one second of each other.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
 	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-		.wait(1500)
+		.wait(10000)
 		.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-		.wait(1500)
+		.wait(10000)
 		.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
 	cy.login(user)
 }

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -23,15 +23,14 @@
 import path from "path"
 
 export function uploadThreeVersions(user) {
-	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
 	// A new version will not be created if the changes occur
 	// within less than one second of each other.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
-	cy.wait(1500)
-	cy.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-	// eslint-disable-next-line cypress/no-unnecessary-waiting
-	cy.wait(1500)
-	cy.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+		.wait(1500)
+		.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+		.wait(1500)
+		.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
 	cy.login(user)
 }
 
@@ -56,7 +55,7 @@ export function openVersionMenu(index: number) {
 		cy.get('[data-files-versions-version]')
 			.eq(index).within(() => {
 				cy.get('.action-item__menutoggle').filter(':visible')
-				.click()
+					.click()
 			})
 	})
 }
@@ -69,7 +68,7 @@ export function clickPopperAction(actionName: string) {
 
 export function nameVersion(index: number, name: string) {
 	openVersionMenu(index)
-	clickPopperAction("Name this version")
+	clickPopperAction('Name this version')
 	cy.get(':focused').type(`${name}{enter}`)
 }
 
@@ -77,7 +76,7 @@ export function assertVersionContent(index: number, expectedContent: string) {
 	const downloadsFolder = Cypress.config('downloadsFolder')
 
 	openVersionMenu(index)
-	clickPopperAction("Download version")
+	clickPopperAction('Download version')
 
 	return cy.readFile(path.join(downloadsFolder, 'test.txt'))
 		.then((versionContent) => expect(versionContent).to.equal(expectedContent))

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -24,8 +24,12 @@ import path from "path"
 
 export function uploadThreeVersions(user) {
 	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+	// A new version will not be created if the changes occur
+	// within less than one second of each other.
+	// eslint-disable-next-line cypress/no-unnecessary-waiting
 	cy.wait(1500)
 	cy.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
+	// eslint-disable-next-line cypress/no-unnecessary-waiting
 	cy.wait(1500)
 	cy.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
 	cy.login(user)

--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -24,9 +24,9 @@ import path from "path"
 
 export function uploadThreeVersions(user) {
 	cy.uploadContent(user, new Blob(['v1'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-	cy.wait(1000)
+	cy.wait(1500)
 	cy.uploadContent(user, new Blob(['v2'], { type: 'text/plain' }), 'text/plain', '/test.txt')
-	cy.wait(1000)
+	cy.wait(1500)
 	cy.uploadContent(user, new Blob(['v3'], { type: 'text/plain' }), 'text/plain', '/test.txt')
 	cy.login(user)
 }

--- a/cypress/e2e/files_versions/version_creation.cy.ts
+++ b/cypress/e2e/files_versions/version_creation.cy.ts
@@ -23,18 +23,22 @@
 import { openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
 
 describe('Versions creation', () => {
+	let randomFileName = ''
+
 	before(() => {
+		randomFileName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+
 		cy.createRandomUser()
 			.then((user) => {
-				uploadThreeVersions(user)
+				uploadThreeVersions(user, randomFileName)
 				cy.login(user)
 				cy.visit('/apps/files')
-				openVersionsPanel('test.txt')
+				openVersionsPanel(randomFileName)
 			})
 	})
 
 	it('Opens the versions panel and sees the versions', () => {
-		openVersionsPanel('test.txt')
+		openVersionsPanel(randomFileName)
 
 		cy.get('#tab-version_vue').within(() => {
 			cy.get('[data-files-versions-version]').should('have.length', 3)

--- a/cypress/e2e/files_versions/version_download.cy.ts
+++ b/cypress/e2e/files_versions/version_download.cy.ts
@@ -23,19 +23,23 @@
 import { assertVersionContent, openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
 
 describe('Versions download', () => {
+	let randomFileName = ''
+
 	before(() => {
+		randomFileName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+
 		cy.createRandomUser()
 			.then((user) => {
-				uploadThreeVersions(user)
+				uploadThreeVersions(user, randomFileName)
 				cy.login(user)
 				cy.visit('/apps/files')
-				openVersionsPanel('test.txt')
+				openVersionsPanel(randomFileName)
 			})
 	})
 
 	it('Download versions and assert there content', () => {
-		assertVersionContent(0, 'v3')
-		assertVersionContent(1, 'v2')
-		assertVersionContent(2, 'v1')
+		assertVersionContent(randomFileName, 0, 'v3')
+		assertVersionContent(randomFileName, 1, 'v2')
+		assertVersionContent(randomFileName, 2, 'v1')
 	})
 })

--- a/cypress/e2e/files_versions/version_expiration.cy.ts
+++ b/cypress/e2e/files_versions/version_expiration.cy.ts
@@ -23,27 +23,31 @@
 import { assertVersionContent, nameVersion, openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
 
 describe('Versions expiration', () => {
+	let randomFileName = ''
+
 	beforeEach(() => {
+		randomFileName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+
 		cy.createRandomUser()
 			.then((user) => {
-				uploadThreeVersions(user)
+				uploadThreeVersions(user, randomFileName)
 				cy.login(user)
 				cy.visit('/apps/files')
-				openVersionsPanel('test.txt')
+				openVersionsPanel(randomFileName)
 			})
 	})
 
 	it('Expire all versions', () => {
 		cy.runOccCommand('versions:expire')
 		cy.visit('/apps/files')
-		openVersionsPanel('test.txt')
+		openVersionsPanel(randomFileName)
 
 		cy.get('#tab-version_vue').within(() => {
 			cy.get('[data-files-versions-version]').should('have.length', 1)
 			cy.get('[data-files-versions-version]').eq(0).contains('Current version')
 		})
 
-		assertVersionContent(0, 'v3')
+		assertVersionContent(randomFileName, 0, 'v3')
 	})
 
 	it('Expire versions v2', () => {
@@ -51,7 +55,7 @@ describe('Versions expiration', () => {
 
 		cy.runOccCommand('versions:expire')
 		cy.visit('/apps/files')
-		openVersionsPanel('test.txt')
+		openVersionsPanel(randomFileName)
 
 		cy.get('#tab-version_vue').within(() => {
 			cy.get('[data-files-versions-version]').should('have.length', 2)
@@ -59,7 +63,7 @@ describe('Versions expiration', () => {
 			cy.get('[data-files-versions-version]').eq(1).contains('v1')
 		})
 
-		assertVersionContent(0, 'v3')
-		assertVersionContent(1, 'v1')
+		assertVersionContent(randomFileName, 0, 'v3')
+		assertVersionContent(randomFileName, 1, 'v1')
 	})
 })

--- a/cypress/e2e/files_versions/version_expiration.cy.ts
+++ b/cypress/e2e/files_versions/version_expiration.cy.ts
@@ -38,7 +38,9 @@ describe('Versions expiration', () => {
 	})
 
 	it('Expire all versions', () => {
+		cy.runOccCommand('config:system:set versions_retention_obligation --value "0, 0"')
 		cy.runOccCommand('versions:expire')
+		cy.runOccCommand('config:system:set versions_retention_obligation --value auto')
 		cy.visit('/apps/files')
 		openVersionsPanel(randomFileName)
 
@@ -53,7 +55,9 @@ describe('Versions expiration', () => {
 	it('Expire versions v2', () => {
 		nameVersion(2, 'v1')
 
+		cy.runOccCommand('config:system:set versions_retention_obligation --value "0, 0"')
 		cy.runOccCommand('versions:expire')
+		cy.runOccCommand('config:system:set versions_retention_obligation --value auto')
 		cy.visit('/apps/files')
 		openVersionsPanel(randomFileName)
 

--- a/cypress/e2e/files_versions/version_naming.cy.ts
+++ b/cypress/e2e/files_versions/version_naming.cy.ts
@@ -23,13 +23,17 @@
 import { nameVersion, openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
 
 describe('Versions naming', () => {
+	let randomFileName = ''
+
 	before(() => {
+		randomFileName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+
 		cy.createRandomUser()
 			.then((user) => {
-				uploadThreeVersions(user)
+				uploadThreeVersions(user, randomFileName)
 				cy.login(user)
 				cy.visit('/apps/files')
-				openVersionsPanel('test.txt')
+				openVersionsPanel(randomFileName)
 			})
 	})
 

--- a/cypress/e2e/files_versions/version_restoration.cy.ts
+++ b/cypress/e2e/files_versions/version_restoration.cy.ts
@@ -24,7 +24,7 @@ import { assertVersionContent, clickPopperAction, openVersionMenu, openVersionsP
 
 function restoreVersion(index: number) {
 	openVersionMenu(index)
-	clickPopperAction("Restore version")
+	clickPopperAction('Restore version')
 }
 
 describe('Versions restoration', () => {

--- a/cypress/e2e/files_versions/version_restoration.cy.ts
+++ b/cypress/e2e/files_versions/version_restoration.cy.ts
@@ -28,13 +28,17 @@ function restoreVersion(index: number) {
 }
 
 describe('Versions restoration', () => {
+	let randomFileName = ''
+
 	before(() => {
+		randomFileName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+
 		cy.createRandomUser()
 			.then((user) => {
-				uploadThreeVersions(user)
+				uploadThreeVersions(user, randomFileName)
 				cy.login(user)
 				cy.visit('/apps/files')
-				openVersionsPanel('test.txt')
+				openVersionsPanel(randomFileName)
 			})
 	})
 
@@ -48,8 +52,8 @@ describe('Versions restoration', () => {
 	})
 
 	it('Downloads versions and assert there content', () => {
-		assertVersionContent(0, 'v1')
-		assertVersionContent(1, 'v3')
-		assertVersionContent(2, 'v2')
+		assertVersionContent(randomFileName, 0, 'v1')
+		assertVersionContent(randomFileName, 1, 'v3')
+		assertVersionContent(randomFileName, 2, 'v2')
 	})
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -99,33 +99,32 @@ Cypress.Commands.add('uploadFile', (user, fixture = 'image.jpg', mimeType = 'ima
  */
 Cypress.Commands.add('uploadContent', (user, blob, mimeType, target) => {
 	cy.clearCookies()
-	.then(async () => {
-		const fileName = basename(target)
+		.then(async () => {
+			const fileName = basename(target)
 
-		// Process paths
-		const rootPath = `${Cypress.env('baseUrl')}/remote.php/dav/files/${encodeURIComponent(user.userId)}`
-		const filePath = target.split('/').map(encodeURIComponent).join('/')
-		try {
-		const file = new File([blob], fileName, { type: mimeType })
-			await axios({
-				url: `${rootPath}${filePath}`,
-				method: 'PUT',
-				data: file,
-				headers: {
-					'Content-Type': mimeType,
-				},
-				auth: {
-					username: user.userId,
-					password: user.password,
-				},
-			}).then(response => {
+			// Process paths
+			const rootPath = `${Cypress.env('baseUrl')}/remote.php/dav/files/${encodeURIComponent(user.userId)}`
+			const filePath = target.split('/').map(encodeURIComponent).join('/')
+			try {
+				const file = new File([blob], fileName, { type: mimeType })
+				const response = await axios({
+					url: `${rootPath}${filePath}`,
+					method: 'PUT',
+					data: file,
+					headers: {
+						'Content-Type': mimeType,
+					},
+					auth: {
+						username: user.userId,
+						password: user.password,
+					},
+				})
 				cy.log(`Uploaded content as ${fileName}`, response)
-			})
-		} catch (error) {
-			cy.log('error', error)
-			throw new Error(`Unable to process fixture`)
-		}
-	})
+			} catch (error) {
+				cy.log('error', error)
+				throw new Error('Unable to process fixture')
+			}
+		})
 })
 
 /**


### PR DESCRIPTION
~~In files_versions cypress tests, we wait for 1000ms between each versions uploads to make sure that the server properly create a version. Under 1s the serve does not create a version.~~

~~This commit increases the wait time as it might help to ensure that the time span is enough between two uploads.~~

The automatic versions expiration process was kicking in during the tests, making some versions unavailable. I changed the tests to isolate expiration process testing from other tests.