### PR TITLE
fix undefined method getExtStorageHome()

### DIFF
--- a/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
+++ b/apps/user_ldap/lib/Handler/ExtStorageConfigHandler.php
@@ -62,7 +62,7 @@ class ExtStorageConfigHandler extends UserContext implements IConfigHandler {
 		}
 
 		$ldapUser = $access->userManager->get($user->getUID());
-		$extHome = $ldapUser->getExtStorageHome();
+		$extHome = $ldapUser !== null ? $ldapUser->getExtStorageHome() : '';
 
 		return $this->processInput($optionValue, $extHome);
 	}

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -60,6 +60,7 @@ class OfflineUser {
 	 * @var string $foundDeleted the timestamp when the user was detected as unavailable
 	 */
 	protected $foundDeleted;
+	protected ?string $extStorageHome = null;
 	/**
 	 * @var string $email
 	 */
@@ -207,6 +208,13 @@ class OfflineUser {
 		return (int)$this->foundDeleted;
 	}
 
+	public function getExtStorageHome(): string {
+		if ($this->extStorageHome === null) {
+			$this->fetchDetails();
+		}
+		return (string)$this->extStorageHome;
+	}
+
 	/**
 	 * getter for having active shares
 	 * @return bool
@@ -227,6 +235,7 @@ class OfflineUser {
 			'uid' => 'user_ldap',
 			'homePath' => 'user_ldap',
 			'foundDeleted' => 'user_ldap',
+			'extStorageHome' => 'user_ldap',
 			'email' => 'settings',
 			'lastLogin' => 'login',
 		];


### PR DESCRIPTION
* Resolves: #34557

## Summary

- adds a type check
- defines missing method in OfflineUser

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [x] ~~Screenshots before/after for front-end changes~~
- [x] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
