### PR TITLE
Move from DEL to UNLINK

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -84,7 +84,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	public function clear($prefix = '') {
 		$prefix = $this->getPrefix() . $prefix . '*';
 		$keys = $this->getCache()->keys($prefix);
-		$deleted = $this->getCache()->unlink($keys);
+		$deleted = $this->getCache()->del($keys);
 
 		return (is_array($keys) && (count($keys) === $deleted));
 	}

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -74,7 +74,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function remove($key) {
-		if ($this->getCache()->del($this->getPrefix() . $key)) {
+		if ($this->getCache()->unlink($this->getPrefix() . $key)) {
 			return true;
 		} else {
 			return false;
@@ -84,7 +84,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	public function clear($prefix = '') {
 		$prefix = $this->getPrefix() . $prefix . '*';
 		$keys = $this->getCache()->keys($prefix);
-		$deleted = $this->getCache()->del($keys);
+		$deleted = $this->getCache()->unlink($keys);
 
 		return (is_array($keys) && (count($keys) === $deleted));
 	}
@@ -170,7 +170,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		$this->getCache()->watch($this->getPrefix() . $key);
 		if ($this->get($key) === $old) {
 			$result = $this->getCache()->multi()
-				->del($this->getPrefix() . $key)
+				->unlink($this->getPrefix() . $key)
 				->exec();
 			return $result !== false;
 		}


### PR DESCRIPTION
## Summary

TL;DR

The Redis [unlink](https://redis.io/commands/unlink) command is non-blocking and will perform the actual deletion asynchronously.

> UNLINK is a smart command: it calculates the deallocation cost of an object, and if it is very small it will just do what DEL is supposed to do and free the object ASAP. Otherwise the object is sent to the background queue for processing.

http://antirez.com/news/93

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
