### PR TITLE
Block occ commands when in maintenance mode

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -32,6 +32,7 @@ namespace OC\Console;
 
 use OC\MemoryInfo;
 use OC\NeedsUpdateException;
+use OC\ServiceUnavailableException;
 use OC_App;
 use OCP\AppFramework\QueryException;
 use OCP\App\IAppManager;
@@ -187,8 +188,9 @@ class Application {
 			$errOutput = $output->getErrorOutput();
 			$errOutput->writeln(
 				'<comment>Nextcloud is in maintenance mode, hence the database isn\'t accessible.' . PHP_EOL .
-				'Cannot perform any command except \'maintenance:mode --off\'</comment>' . PHP_EOL
+				'Cannot perform any command except \'maintenance:mode --off\' and \'status\'</comment>' . PHP_EOL
 			);
+			throw new ServiceUnavailableException();
 		}
 	}
 


### PR DESCRIPTION
## Summary
Currently, occ allows execution of commands even while in maintenance mode. The CLI does warn the admin that commands are limited but the execution still works.

This PR adds an exception to block any command that isn't `maintenance:mode --off` or `status` as executing other commands is unsafe.

(Either this, or remove the misleading sentence as commands can be executed and the database is indeed available - occ user:add for example works).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
