### PR TITLE
fix(provisioning_api): Don't allow to configure the same additional e…

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -942,11 +942,11 @@ class UsersController extends AUserData {
 				if (filter_var($value, FILTER_VALIDATE_EMAIL) && $value !== $targetUser->getSystemEMailAddress()) {
 					$userAccount = $this->accountManager->getAccount($targetUser);
 					$mailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
-					foreach ($mailCollection->getProperties() as $property) {
-						if ($property->getValue() === $value) {
-							break;
-						}
+
+					if ($mailCollection->getPropertyByValue($value)) {
+						throw new OCSException('', 102);
 					}
+
 					$mailCollection->addPropertyWithDefaults($value);
 					$this->accountManager->updateAccount($userAccount);
 				} else {

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -52,7 +52,9 @@ use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\IAccountPropertyCollection;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -1544,7 +1546,162 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals([], $this->api->editUser('UserToEdit', 'email', 'demo@nextcloud.com')->getData());
 	}
 
+	public function testEditUserRegularUserSelfEditAddAdditionalEmailValid(): void {
+		$loggedInUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
+		$targetUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->willReturn($targetUser);
+		$targetUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
 
+		$backend = $this->createMock(UserInterface::class);
+		$targetUser
+			->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+
+		$userAccount = $this->createMock(IAccount::class);
+
+		$this->accountManager
+			->expects($this->once())
+			->method('getAccount')
+			->with($targetUser)
+			->willReturn($userAccount);
+		$this->accountManager
+			->expects($this->once())
+			->method('updateAccount')
+			->with($userAccount);
+
+		$this->assertEquals([], $this->api->editUser('UserToEdit', 'additional_mail', 'demo1@nextcloud.com')->getData());
+	}
+
+	public function testEditUserRegularUserSelfEditAddAdditionalEmailMainAddress(): void {
+		$loggedInUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
+		$targetUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->willReturn($targetUser);
+		$targetUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
+
+		$backend = $this->createMock(UserInterface::class);
+		$targetUser
+			->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+		$targetUser
+			->expects($this->any())
+			->method('getSystemEMailAddress')
+			->willReturn('demo@nextcloud.com');
+
+		$userAccount = $this->createMock(IAccount::class);
+
+		$this->accountManager
+			->expects($this->never())
+			->method('getAccount')
+			->with($targetUser)
+			->willReturn($userAccount);
+		$this->accountManager
+			->expects($this->never())
+			->method('updateAccount')
+			->with($userAccount);
+
+		$this->expectException(OCSException::class);
+		$this->expectExceptionCode(102);
+		$this->api->editUser('UserToEdit', 'additional_mail', 'demo@nextcloud.com')->getData();
+	}
+
+	public function testEditUserRegularUserSelfEditAddAdditionalEmailDuplicate(): void {
+		$loggedInUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
+		$targetUser = $this->getMockBuilder(IUser::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($loggedInUser);
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->willReturn($targetUser);
+		$targetUser
+			->expects($this->any())
+			->method('getUID')
+			->willReturn('UID');
+
+		$backend = $this->createMock(UserInterface::class);
+		$targetUser
+			->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+
+		$property = $this->createMock(IAccountProperty::class);
+		$property->method('getValue')
+			->willReturn('demo1@nextcloud.com');
+		$collection = $this->createMock(IAccountPropertyCollection::class);
+		$collection->method('getPropertyByValue')
+			->with('demo1@nextcloud.com')
+			->willReturn($property);
+
+		$userAccount = $this->createMock(IAccount::class);
+		$userAccount->method('getPropertyCollection')
+			->with(IAccountManager::COLLECTION_EMAIL)
+			->willReturn($collection);
+
+		$this->accountManager
+			->expects($this->once())
+			->method('getAccount')
+			->with($targetUser)
+			->willReturn($userAccount);
+		$this->accountManager
+			->expects($this->never())
+			->method('updateAccount')
+			->with($userAccount);
+
+		$this->expectException(OCSException::class);
+		$this->expectExceptionCode(102);
+		$this->api->editUser('UserToEdit', 'additional_mail', 'demo1@nextcloud.com')->getData();
+	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailInvalid() {
 		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -199,6 +199,28 @@ Feature: provisioning
 			| value | private |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
+		And sending "PUT" to "/cloud/users/brand-new-user" with
+			| key | email |
+			| value | no-reply@nextcloud.com |
+		And the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		# Duplicating primary address
+		And sending "PUT" to "/cloud/users/brand-new-user" with
+			| key | additional_mail |
+			| value | no-reply@nextcloud.com |
+		And the OCS status code should be "102"
+		And the HTTP status code should be "200"
+		And sending "PUT" to "/cloud/users/brand-new-user" with
+			| key | additional_mail |
+			| value | no.reply@nextcloud.com |
+		And the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		# Duplicating another additional address
+		And sending "PUT" to "/cloud/users/brand-new-user" with
+			| key | additional_mail |
+			| value | no.reply@nextcloud.com |
+		And the OCS status code should be "102"
+		And the HTTP status code should be "200"
 		Then user "brand-new-user" has
 			| id | brand-new-user |
 			| phoneScope | v2-private |

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -212,13 +212,13 @@ Feature: provisioning
 		And the HTTP status code should be "200"
 		And sending "PUT" to "/cloud/users/brand-new-user" with
 			| key | additional_mail |
-			| value | no.reply@nextcloud.com |
+			| value | no.reply2@nextcloud.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		# Duplicating another additional address
 		And sending "PUT" to "/cloud/users/brand-new-user" with
 			| key | additional_mail |
-			| value | no.reply@nextcloud.com |
+			| value | no.reply2@nextcloud.com |
 		And the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		Then user "brand-new-user" has
@@ -236,21 +236,21 @@ Feature: provisioning
     And As an "brand-new-user"
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
-      | value | no.reply@nextcloud.com |
+      | value | no.reply3@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
-      | value | noreply@nextcloud.com |
+      | value | noreply4@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
-      | key | no.reply@nextcloud.com |
+      | key | no.reply3@nextcloud.com |
       | value | v2-federated |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
-      | key | noreply@nextcloud.com |
+      | key | noreply4@nextcloud.com |
       | value | v2-published |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -282,11 +282,11 @@ Feature: provisioning
     And As an "brand-new-user"
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
-      | value | no.reply@nextcloud.com |
+      | value | no.reply5@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user/additional_mailScope" with
-      | key | no.reply@nextcloud.com |
+      | key | no.reply5@nextcloud.com |
       | value | invalid |
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
@@ -296,23 +296,23 @@ Feature: provisioning
     And As an "brand-new-user"
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
-      | value | no.reply@nextcloud.com |
+      | value | no.reply6@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
-      | value | noreply@nextcloud.com |
+      | value | noreply7@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user/additional_mail" with
-      | key | no.reply@nextcloud.com |
+      | key | no.reply6@nextcloud.com |
       | value | |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
     Then user "brand-new-user" has
-      | additional_mail | noreply@nextcloud.com |
+      | additional_mail | noreply7@nextcloud.com |
     Then user "brand-new-user" has not
-      | additional_mail | no.reply@nextcloud.com |
+      | additional_mail | no.reply6@nextcloud.com |
 
 	Scenario: An admin cannot edit user account property scopes
     Given As an "admin"


### PR DESCRIPTION
…mail multiple times

Before | After
---|---
![Bildschirmfoto vom 2023-03-24 12-36-46](https://user-images.githubusercontent.com/213943/227511414-36b5c2a4-9219-4a01-956e-d1fec54a4243.png) | ![Bildschirmfoto vom 2023-03-24 12-35-46](https://user-images.githubusercontent.com/213943/227511425-805ae880-4c52-42db-a778-39c61a4d2229.png)

Editing one of the duplicated entries removed duplicates

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
