### PR TITLE
Send Clear-Site-Data header and let browsers ignore it if unsupported

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -34,7 +34,6 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\AppFramework\Http\Request;
 use OC\Authentication\Login\Chain;
 use OC\Authentication\Login\LoginData;
 use OC\Authentication\WebAuthn\Manager as WebAuthnManager;
@@ -125,7 +124,8 @@ class LoginController extends Controller {
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
 
-		if (!$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
+		if ($this->request->getServerProtocol() === 'https') {
+			// This feature is available only in secure contexts
 			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
 		}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -143,9 +143,8 @@ class LoginControllerTest extends TestCase {
 			->with('nc_token')
 			->willReturn(null);
 		$this->request
-			->expects($this->once())
-			->method('isUserAgent')
-			->willReturn(false);
+			->method('getServerProtocol')
+			->willReturn('https');
 		$this->config
 			->expects($this->never())
 			->method('deleteUserValue');
@@ -160,26 +159,6 @@ class LoginControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
-	public function testLogoutNoClearSiteData() {
-		$this->request
-			->expects($this->once())
-			->method('getCookie')
-			->with('nc_token')
-			->willReturn(null);
-		$this->request
-			->expects($this->once())
-			->method('isUserAgent')
-			->willReturn(true);
-		$this->urlGenerator
-			->expects($this->once())
-			->method('linkToRouteAbsolute')
-			->with('core.login.showLoginForm')
-			->willReturn('/login');
-
-		$expected = new RedirectResponse('/login');
-		$this->assertEquals($expected, $this->loginController->logout());
-	}
-
 	public function testLogoutWithToken() {
 		$this->request
 			->expects($this->once())
@@ -188,8 +167,8 @@ class LoginControllerTest extends TestCase {
 			->willReturn('MyLoginToken');
 		$this->request
 			->expects($this->once())
-			->method('isUserAgent')
-			->willReturn(false);
+			->method('getServerProtocol')
+			->willReturn('https');
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())


### PR DESCRIPTION
## Summary

According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#browser_compatibility only Safari don't support it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
