### PR TITLE
Add back missing dashboard version

### DIFF
--- a/apps/dashboard/appinfo/info.xml
+++ b/apps/dashboard/appinfo/info.xml
@@ -8,6 +8,7 @@
 
 The Nextcloud Dashboard is your starting point of the day, giving you an overview of your upcoming appointments, urgent emails, chat messages, incoming tickets, latest tweets and much more! Users can add the widgets they like and change the background to their liking.]]>
 	</description>
+	<version>7.7.0</version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>Dashboard</namespace>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/37415

## Summary

Add back the version that was accidentally deleted in https://github.com/nextcloud/server/commit/6f9ee2277de7b1c77b340344d3f52b9b6eb269ee

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
