### PR TITLE
Ignore and log non integer versions

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -716,13 +716,13 @@ class Storage {
 		}
 
 		foreach ($versions as $key => $version) {
-			if (!is_int($version['version'])) {
+			if (!is_numeric($version['version'])) {
 				\OC::$server->get(LoggerInterface::class)->error(
 					'Found a non-numeric timestamp version: '. json_encode($version),
 					['app' => 'files_versions']);
 				continue;
 			}
-			if ($expiration->isExpired($version['version'], $quotaExceeded) && !isset($toDelete[$key])) {
+			if ($expiration->isExpired((int)($version['version']), $quotaExceeded) && !isset($toDelete[$key])) {
 				$size += $version['size'];
 				$toDelete[$key] = $version['path'] . '.v' . $version['version'];
 			}

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -716,6 +716,12 @@ class Storage {
 		}
 
 		foreach ($versions as $key => $version) {
+			if (!is_int($version['version'])) {
+				\OC::$server->get(LoggerInterface::class)->error(
+					'Found a non-numeric timestamp version: '. json_encode($version),
+					['app' => 'files_versions']);
+				continue;
+			}
 			if ($expiration->isExpired($version['version'], $quotaExceeded) && !isset($toDelete[$key])) {
 				$size += $version['size'];
 				$toDelete[$key] = $version['path'] . '.v' . $version['version'];


### PR DESCRIPTION
This avoids being stuck when there is one buggy file version with a
 non-numeric version. It allows the expiration process to not crash and
 continue with the other ones.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
