### PR TITLE
Fix: Make OC\Console\Application::$application public

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -49,7 +49,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class Application {
 	/** @var IConfig */
 	private $config;
-	private SymfonyApplication $application;
+	public SymfonyApplication $application;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 	/** @var IRequest */


### PR DESCRIPTION
* Resolves: https://github.com/Adphi/occweb/issues/5

## Summary

The app [OCC-Web](https://github.com/adphi/occweb) relied on this being public.

OCC-Web is technically deprecated, and this API was probably never meant to be public, but I still think it'd be useful to make this public now, considering it has been before; and OCC-Web is really convenient.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
