### PR TITLE
Add label for logo link

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -62,12 +62,9 @@ p($theme->getTitle());
 			</h1>
 			<div class="header-left">
 				<a href="<?php print_unescaped($_['logoUrl'] ?: link_to('', 'index.php')); ?>"
+					aria-label="<?php p($l->t('Go to %s', [$_['logoUrl'] ?: $_['defaultAppName']])); ?>"
 					id="nextcloud">
-					<div class="logo logo-icon">
-						<span class="hidden-visually">
-							<?php p($l->t('%s homepage', [$theme->getName()])); ?>
-						</span>
-					</div>
+					<div class="logo logo-icon"></div>
 				</a>
 
 				<nav id="header-left__appmenu"></nav>

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -827,4 +827,28 @@ class AppManager implements IAppManager {
 
 		return $this->defaultEnabled;
 	}
+
+	public function getDefaultAppForUser(?IUser $user = null): string {
+		// Set fallback to always-enabled files app
+		$appId = 'files';
+		$defaultApps = explode(',', $this->config->getSystemValueString('defaultapp', 'dashboard,files'));
+
+		$user ??= $this->userSession->getUser();
+
+		if ($user !== null) {
+			$userDefaultApps = explode(',', $this->config->getUserValue($user->getUID(), 'core', 'defaultapp'));
+			$defaultApps = array_filter(array_merge($userDefaultApps, $defaultApps));
+		}
+
+		// Find the first app that is enabled for the current user
+		foreach ($defaultApps as $defaultApp) {
+			$defaultApp = \OC_App::cleanAppId(strip_tags($defaultApp));
+			if ($this->isEnabledForUser($defaultApp, $user)) {
+				$appId = $defaultApp;
+				break;
+			}
+		}
+
+		return $appId;
+	}
 }

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -119,9 +119,15 @@ class TemplateLayout extends \OC_Template {
 				$this->assign('enabledThemes', $themesService->getEnabledThemes());
 			}
 
-			// set logo link target
+			// Set logo link target
 			$logoUrl = $this->config->getSystemValueString('logo_url', '');
 			$this->assign('logoUrl', $logoUrl);
+
+			// Set default app name
+			$defaultApp = \OC::$server->getAppManager()->getDefaultAppForUser();
+			$defaultAppInfo = \OC::$server->getAppManager()->getAppInfo($defaultApp);
+			$l10n = \OC::$server->getL10NFactory()->get($defaultApp);
+			$this->assign('defaultAppName', $l10n->t($defaultAppInfo['name']));
 
 			// Add navigation entry
 			$this->assign('application', '');

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -311,23 +311,7 @@ class URLGenerator implements IURLGenerator {
 			return $this->getAbsoluteURL($defaultPage);
 		}
 
-		$appId = 'files';
-		$defaultApps = explode(',', $this->config->getSystemValue('defaultapp', 'dashboard,files'));
-
-		$userId = $this->userSession->isLoggedIn() ? $this->userSession->getUser()->getUID() : null;
-		if ($userId !== null) {
-			$userDefaultApps = explode(',', $this->config->getUserValue($userId, 'core', 'defaultapp'));
-			$defaultApps = array_filter(array_merge($userDefaultApps, $defaultApps));
-		}
-
-		// find the first app that is enabled for the current user
-		foreach ($defaultApps as $defaultApp) {
-			$defaultApp = \OC_App::cleanAppId(strip_tags($defaultApp));
-			if (\OC::$server->getAppManager()->isEnabledForUser($defaultApp)) {
-				$appId = $defaultApp;
-				break;
-			}
-		}
+		$appId = $this->getAppManager()->getDefaultAppForUser();
 
 		if ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true
 			|| getenv('front_controller_active') === 'true') {

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -242,4 +242,13 @@ interface IAppManager {
 	 * @since 17.0.0
 	 */
 	public function getAppRestriction(string $appId): array;
+
+	/**
+	 * Returns the id of the user's default app
+	 *
+	 * If `user` is not passed, the currently logged in user will be used
+	 *
+	 * @since 25.0.6
+	 */
+	public function getDefaultAppForUser(?IUser $user = null): string;
 }

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -617,4 +617,47 @@ class AppManagerTest extends TestCase {
 		$this->assertEquals([], $this->manager->getAppRestriction('test2'));
 		$this->assertEquals(['foo'], $this->manager->getAppRestriction('test3'));
 	}
+
+	public function provideDefaultApps(): array {
+		return [
+			// none specified, default to files
+			[
+				'',
+				'files',
+			],
+			// unexisting or inaccessible app specified, default to files
+			[
+				'unexist',
+				'files',
+			],
+			// non-standard app
+			[
+				'settings',
+				'settings',
+			],
+			// non-standard app with fallback
+			[
+				'unexist,settings',
+				'settings',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provideDefaultApps
+	 */
+	public function testGetDefaultAppForUser($defaultApps, $expectedApp) {
+		$user = $this->newUser('user1');
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+
+		$this->config->expects($this->once())
+			->method('getSystemValueString')
+			->with('defaultapp', $this->anything())
+			->willReturn($defaultApps);
+
+		$this->assertEquals($expectedApp, $this->manager->getDefaultAppForUser());
+	}
 }

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -13,7 +13,6 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserSession;
 
 /**
@@ -216,21 +215,16 @@ class UrlGeneratorTest extends \Test\TestCase {
 		];
 	}
 
-	private function mockLinkToDefaultPageUrl(string $defaultAppConfig = '', bool $ignoreFrontControllerConfig = false) {
-		$this->config->expects($this->exactly(2))
-			->method('getSystemValue')
-			->withConsecutive(
-				['defaultapp', $this->anything()],
-				['htaccess.IgnoreFrontController', $this->anything()],
-			)
-			->will($this->onConsecutiveCalls(
-				$defaultAppConfig,
-				$ignoreFrontControllerConfig
-			));
+	private function mockLinkToDefaultPageUrl(bool $ignoreFrontControllerConfig = false) {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('core', 'defaultpage')
 			->willReturn('');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('htaccess.IgnoreFrontController', $this->anything())
+			->willReturn($ignoreFrontControllerConfig);
 	}
 
 	public function testLinkToDefaultPageUrlWithRedirectUrlWithoutFrontController() {
@@ -246,7 +240,7 @@ class UrlGeneratorTest extends \Test\TestCase {
 		putenv('front_controller_active=false');
 
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
-		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/index.php/apps/files/', $this->urlGenerator->linkToDefaultPageUrl());
+		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/index.php/apps/dashboard/', $this->urlGenerator->linkToDefaultPageUrl());
 	}
 
 	public function testLinkToDefaultPageUrlWithRedirectUrlRedirectBypassWithFrontController() {
@@ -255,70 +249,16 @@ class UrlGeneratorTest extends \Test\TestCase {
 		putenv('front_controller_active=true');
 
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
-		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/apps/files/', $this->urlGenerator->linkToDefaultPageUrl());
+		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/apps/dashboard/', $this->urlGenerator->linkToDefaultPageUrl());
 	}
 
 	public function testLinkToDefaultPageUrlWithRedirectUrlWithIgnoreFrontController() {
 		$this->mockBaseUrl();
-		$this->mockLinkToDefaultPageUrl('', true);
+		$this->mockLinkToDefaultPageUrl(true);
 		putenv('front_controller_active=false');
 
 		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
-		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/apps/files/', $this->urlGenerator->linkToDefaultPageUrl());
-	}
-
-	/**
-	 * @dataProvider provideDefaultApps
-	 */
-	public function testLinkToDefaultPageUrlWithDefaultApps($defaultAppConfig, $expectedPath) {
-		$userId = $this->getUniqueID();
-
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IUser $userMock */
-		$userMock = $this->createMock(IUser::class);
-		$userMock->expects($this->once())
-			->method('getUID')
-			->willReturn($userId);
-
-		$this->mockBaseUrl();
-		$this->mockLinkToDefaultPageUrl($defaultAppConfig);
-
-		$this->config->expects($this->once())
-			->method('getUserValue')
-			->with($userId, 'core', 'defaultapp')
-			->willReturn('');
-		$this->userSession->expects($this->once())
-			->method('isLoggedIn')
-			->willReturn(true);
-		$this->userSession->expects($this->once())
-			->method('getUser')
-			->willReturn($userMock);
-
-		$this->assertEquals('http://localhost' . \OC::$WEBROOT . $expectedPath, $this->urlGenerator->linkToDefaultPageUrl());
-	}
-
-	public function provideDefaultApps(): array {
-		return [
-			// none specified, default to files
-			[
-				'',
-				'/index.php/apps/files/',
-			],
-			// unexisting or inaccessible app specified, default to files
-			[
-				'unexist',
-				'/index.php/apps/files/',
-			],
-			// non-standard app
-			[
-				'settings',
-				'/index.php/apps/settings/',
-			],
-			// non-standard app with fallback
-			[
-				'unexist,settings',
-				'/index.php/apps/settings/',
-			],
-		];
+		$this->assertSame('http://localhost' . \OC::$WEBROOT . '/apps/dashboard/', $this->urlGenerator->linkToDefaultPageUrl());
 	}
 
 	public function imagePathProvider(): array {


### PR DESCRIPTION
- For https://github.com/nextcloud/server/issues/36753

## Summary

Add a descriptive label for the logo link
![image](https://user-images.githubusercontent.com/24800714/228104462-0b805f1e-1739-45cc-83dc-bcad3a56ddfe.png)

To be backported to `stable25` for accessibility

## TODO

- [x] Remove extraneous `span` translated string
- [x] Fix label when going to `logoUrl`
- [x] Translate app name
- [x] Fix existing tests
- [x] Add tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)