### PR TITLE
fix(docs): Fix RST parsing of the sample config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -139,9 +139,9 @@ $CONFIG = [
 'dbtableprefix' => '',
 
 /**
- *  Enable persistent connexions to the database.
- *  This setting uses the "persistent" option from doctrine dbal, which in turn
- *  uses the PDO::ATTR_PERSISTENT option from de pdo driver.
+ * Enable persistent connexions to the database.
+ * This setting uses the "persistent" option from doctrine dbal, which in turn
+ * uses the PDO::ATTR_PERSISTENT option from the pdo driver.
  */
 'dbpersistent' => '',
 
@@ -790,9 +790,10 @@ $CONFIG = [
  * The channel that Nextcloud should use to look for updates
  *
  * Supported values:
- *   - ``daily``
- *   - ``beta``
- *   - ``stable``
+ *
+ * - ``daily``
+ * - ``beta``
+ * - ``stable``
  */
 'updater.release.channel' => 'stable',
 
@@ -1032,10 +1033,11 @@ $CONFIG = [
  * seen in the first-run wizard and on Personal pages.
  *
  * Defaults to:
- *  - Desktop client: ``https://nextcloud.com/install/#install-clients``
- *  - Android client: ``https://play.google.com/store/apps/details?id=com.nextcloud.client``
- *  - iOS client: ``https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8``
- *  - iOS client app id: ``1125420102``
+ *
+ * - Desktop client: ``https://nextcloud.com/install/#install-clients``
+ * - Android client: ``https://play.google.com/store/apps/details?id=com.nextcloud.client``
+ * - iOS client: ``https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8``
+ * - iOS client app id: ``1125420102``
  */
 'customclient_desktop' =>
 	'https://nextcloud.com/install/#install-clients',


### PR DESCRIPTION
## Summary

* Ref https://github.com/nextcloud/nextcloud-config-converter/pull/5

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
