### PR TITLE
[stable25] fix(files_sharing): Allow file actions other than download for hide download shares

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -217,7 +217,7 @@ OCA.Sharing.PublicApp = {
 					// Remove the link. This means that files without a default action fail hard
 					$tr.find('a.name').attr('href', '#');
 
-					this.fileActions.actions.all = {};
+					delete this.fileActions.actions.all.Download;
 				}
 				return $tr;
 			};


### PR DESCRIPTION
Backport of #37168