### PR TITLE
[stable26] fix(references): Do not log errors on 404 responses of opengraph image fetching

### DIFF
--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OC\Collaboration\Reference;
 
 use Fusonic\OpenGraph\Consumer;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\Utils;
 use OC\Security\RateLimiting\Exception\RateLimitExceededException;
@@ -167,6 +168,8 @@ class LinkReferenceProvider implements IReferenceProvider {
 					$folder->newFile(md5($reference->getId()), $bodyStream->getContents());
 					$reference->setImageUrl($this->urlGenerator->linkToRouteAbsolute('core.Reference.preview', ['referenceId' => md5($reference->getId())]));
 				}
+			} catch (GuzzleException $e) {
+				$this->logger->info('Failed to fetch and store the open graph image for ' . $reference->getId(), ['exception' => $e]);
 			} catch (\Throwable $e) {
 				$this->logger->error('Failed to fetch and store the open graph image for ' . $reference->getId(), ['exception' => $e]);
 			}


### PR DESCRIPTION
Backport of #37198