### PR TITLE
hide shared files located in group folder's trash bin

### DIFF
--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -55,6 +55,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
+use function str_starts_with;
 
 /**
  * Class DefaultShareProvider
@@ -884,6 +885,11 @@ class DefaultShareProvider implements IShareProvider {
 		// FIXME: would not detect rare md5'd home storage case properly
 		if ($pathSections[0] !== 'files'
 			&& (strpos($data['storage_string_id'], 'home::') === 0 || strpos($data['storage_string_id'], 'object::user') === 0)) {
+			return false;
+		} elseif ($pathSections[0] === '__groupfolders'
+			&& str_starts_with($pathSections[1], 'trash/')
+		) {
+			// exclude shares leading to trashbin on group folders storages
 			return false;
 		}
 		return true;


### PR DESCRIPTION
* Resolves: #12281

## Summary

- Shares from a group folder appear in the files list even if they are deleted
- the code checking whether a file is accessible was laid out only for the regular trash bin
- Needs one manual backport, because `str_starts_with` is not available in PHP 7.4

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
