### PR TITLE
Add missing interface methods

### DIFF
--- a/apps/dav/lib/CalDAV/CachedSubscription.php
+++ b/apps/dav/lib/CalDAV/CachedSubscription.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV;
 
 use OCA\DAV\Exception\UnsupportedLimitOnInitialSyncException;
-use Sabre\CalDAV\Backend\BackendInterface;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
@@ -38,7 +37,7 @@ use Sabre\DAV\PropPatch;
  * Class CachedSubscription
  *
  * @package OCA\DAV\CalDAV
- * @property BackendInterface|CalDavBackend $caldavBackend
+ * @property CalDavBackend $caldavBackend
  */
 class CachedSubscription extends \Sabre\CalDAV\Calendar {
 
@@ -112,7 +111,7 @@ class CachedSubscription extends \Sabre\CalDAV\Calendar {
 		return parent::getOwner();
 	}
 
-	
+
 	public function delete() {
 		$this->caldavBackend->deleteSubscription($this->calendarInfo['id']);
 	}

--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -38,7 +38,7 @@ use Sabre\DAV\PropPatch;
  * Class AddressBook
  *
  * @package OCA\DAV\CardDAV
- * @property BackendInterface|CardDavBackend $carddavBackend
+ * @property CardDavBackend $carddavBackend
  */
 class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 

--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -66,7 +66,7 @@ abstract class AUserData extends OCSController {
 	protected $userManager;
 	/** @var IConfig */
 	protected $config;
-	/** @var IGroupManager|Manager */ // FIXME Requires a method that is not on the interface
+	/** @var Manager */
 	protected $groupManager;
 	/** @var IUserSession */
 	protected $userSession;

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -66,7 +66,7 @@ class LoginController extends Controller {
 	private IUserManager $userManager;
 	private IConfig $config;
 	private ISession $session;
-	/** @var IUserSession|Session */
+	/** @var Session */
 	private $userSession;
 	private IURLGenerator $urlGenerator;
 	private Defaults $defaults;

--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -37,7 +37,7 @@ use OCP\IDBConnection;
 use OCP\IUser;
 
 class Collection implements ICollection {
-	/** @var IManager|Manager */
+	/** @var Manager */
 	protected $manager;
 
 	/** @var IDBConnection */

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -61,7 +61,7 @@ class NavigationManager implements INavigationManager {
 	private $l10nFac;
 	/** @var IUserSession */
 	private $userSession;
-	/** @var IGroupManager|Manager */
+	/** @var Manager */
 	private $groupManager;
 	/** @var IConfig */
 	private $config;

--- a/lib/private/Repair/NC16/ClearCollectionsAccessCache.php
+++ b/lib/private/Repair/NC16/ClearCollectionsAccessCache.php
@@ -35,7 +35,7 @@ class ClearCollectionsAccessCache implements IRepairStep {
 	/** @var IConfig */
 	private $config;
 
-	/** @var IManager|Manager */
+	/** @var Manager */
 	private $manager;
 
 	public function __construct(IConfig $config, IManager $manager) {

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -40,7 +40,6 @@ declare(strict_types=1);
  */
 namespace OC;
 
-use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
@@ -274,7 +273,7 @@ class Updater extends BasicEmitter {
 		// Update the appfetchers version so it downloads the correct list from the appstore
 		\OC::$server->getAppFetcher()->setVersion($currentVersion);
 
-		/** @var IAppManager|AppManager $appManager */
+		/** @var AppManager $appManager */
 		$appManager = \OC::$server->getAppManager();
 
 		// upgrade appstore apps


### PR DESCRIPTION
## Summary

Psalm 5 shows a bunch of errors because of missing interface methods. Those methods are not on the interfaces because they should not be used by apps, but are used internally. Typing the variables as the implementation makes it work.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
