### PR TITLE
Avoid db connections when logging db connection errors

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,13 +29,17 @@
  *
  */
 require_once __DIR__ . '/lib/versioncheck.php';
+use Psr\Log\LoggerInterface;
 
 try {
 	require_once __DIR__ . '/lib/base.php';
 
 	OC::handleRequest();
 } catch (\OC\ServiceUnavailableException $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'index',
+		'exception' => $ex,
+	]);
 
 	//show the user a detailed error page
 	OC_Template::printExceptionErrorPage($ex, 503);
@@ -44,8 +48,14 @@ try {
 		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint(), 503);
 	} catch (Exception $ex2) {
 		try {
-			\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
-			\OC::$server->getLogger()->logException($ex2, ['app' => 'index']);
+			\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+				'app' => 'index',
+				'exception' => $ex,
+			]);
+			\OC::$server->get(LoggerInterface::class)->error($ex2->getMessage(), [
+				'app' => 'index',
+				'exception' => $ex2,
+			]);
 		} catch (Throwable $e) {
 			// no way to log it properly - but to avoid a white page of death we try harder and ignore this one here
 		}
@@ -68,13 +78,19 @@ try {
 	}
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage(), 401);
 } catch (Exception $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'index',
+		'exception' => $ex,
+	]);
 
 	//show the user a detailed error page
 	OC_Template::printExceptionErrorPage($ex, 500);
 } catch (Error $ex) {
 	try {
-		\OC::$server->getLogger()->logException($ex, ['app' => 'index']);
+		\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+			'app' => 'index',
+			'exception' => $ex,
+		]);
 	} catch (Error $e) {
 		http_response_code(500);
 		header('Content-Type: text/plain; charset=utf-8');

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -730,7 +730,13 @@ class Server extends ServerContainer implements IServerContainer {
 
 			if ($config->getSystemValueBool('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				if (!$config->getSystemValueBool('log_query')) {
-					$v = \OC_App::getAppVersions();
+					try {
+						$v = \OC_App::getAppVersions();
+					} catch (\Doctrine\DBAL\Exception $e) {
+						// Database service probably unavailable
+						// Probably related to https://github.com/nextcloud/server/issues/37424
+						return $arrayCacheFactory;
+					}
 				} else {
 					// If the log_query is enabled, we can not get the app versions
 					// as that does a query, which will be logged and the logging


### PR DESCRIPTION
`\OC\Log\LogDetails::logDetails` depends on `\OC_App::getAppVersions()` which makes a database connection causing the logger to break when the database service is unavaiable.

Resolves: #37424 





