### PR TITLE
Refactor OCP\Share\IShare ID to int

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -150,7 +150,7 @@ class Notifications {
 	 *
 	 * @param string $token
 	 * @param string $id remote Id
-	 * @param string $shareId internal share Id
+	 * @param int $shareId internal share Id
 	 * @param string $remote remote address of the owner
 	 * @param string $shareWith
 	 * @param int $permission
@@ -159,7 +159,7 @@ class Notifications {
 	 * @throws \OCP\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission, $filename) {
+	public function requestReShare($token, $id, int $shareId, $remote, $shareWith, $permission, $filename) {
 		$fields = [
 			'shareWith' => $shareWith,
 			'token' => $token,

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -303,15 +303,15 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	public function notificationReceived($notificationType, $providerId, array $notification) {
 		switch ($notificationType) {
 			case 'SHARE_ACCEPTED':
-				return $this->shareAccepted($providerId, $notification);
+				return $this->shareAccepted((int)$providerId, $notification);
 			case 'SHARE_DECLINED':
-				return $this->shareDeclined($providerId, $notification);
+				return $this->shareDeclined((int)$providerId, $notification);
 			case 'SHARE_UNSHARED':
 				return $this->unshare($providerId, $notification);
 			case 'REQUEST_RESHARE':
-				return $this->reshareRequested($providerId, $notification);
+				return $this->reshareRequested((int)$providerId, $notification);
 			case 'RESHARE_UNDO':
-				return $this->undoReshare($providerId, $notification);
+				return $this->undoReshare((int)$providerId, $notification);
 			case 'RESHARE_CHANGE_PERMISSION':
 				return $this->updateResharePermissions($providerId, $notification);
 		}
@@ -359,7 +359,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	/**
 	 * process notification that the recipient accepted a share
 	 *
-	 * @param string $id
+	 * @param int $id
 	 * @param array $notification
 	 * @return array
 	 * @throws ActionNotSupportedException
@@ -367,7 +367,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	 * @throws BadRequestException
 	 * @throws HintException
 	 */
-	private function shareAccepted($id, array $notification) {
+	private function shareAccepted(int $id, array $notification) {
 		if (!$this->isS2SEnabled()) {
 			throw new ActionNotSupportedException('Server does not support federated cloud sharing');
 		}
@@ -427,7 +427,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	/**
 	 * process notification that the recipient declined a share
 	 *
-	 * @param string $id
+	 * @param int $id
 	 * @param array $notification
 	 * @return array
 	 * @throws ActionNotSupportedException
@@ -437,7 +437,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	 * @throws HintException
 	 *
 	 */
-	protected function shareDeclined($id, array $notification) {
+	protected function shareDeclined(int $id, array $notification) {
 		if (!$this->isS2SEnabled()) {
 			throw new ActionNotSupportedException('Server does not support federated cloud sharing');
 		}
@@ -503,13 +503,13 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	/**
 	 * received the notification that the owner unshared a file from you
 	 *
-	 * @param string $id
+	 * @param int $id
 	 * @param array $notification
 	 * @return array
 	 * @throws AuthenticationFailedException
 	 * @throws BadRequestException
 	 */
-	private function undoReshare($id, array $notification) {
+	private function undoReshare(int $id, array $notification) {
 		if (!isset($notification['sharedSecret'])) {
 			throw new BadRequestException(['sharedSecret']);
 		}
@@ -613,7 +613,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	/**
 	 * recipient of a share request to re-share the file with another user
 	 *
-	 * @param string $id
+	 * @param int $id
 	 * @param array $notification
 	 * @return array
 	 * @throws AuthenticationFailedException
@@ -621,7 +621,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 	 * @throws ProviderCouldNotAddShareException
 	 * @throws ShareNotFound
 	 */
-	protected function reshareRequested($id, array $notification) {
+	protected function reshareRequested(int $id, array $notification) {
 		if (!isset($notification['sharedSecret'])) {
 			throw new BadRequestException(['sharedSecret']);
 		}

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -201,10 +201,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		return parent::instanceOfStorage($class);
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getShareId() {
+	public function getShareId(): int {
 		return $this->superShare->getId();
 	}
 

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -814,7 +814,7 @@ class ShareByMailProvider implements IShareProvider {
 		} catch (\Exception $e) {
 		}
 
-		$this->removeShareFromTable((int)$share->getId());
+		$this->removeShareFromTable($share->getId());
 	}
 
 	/**

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -41,7 +41,7 @@ use OCP\Share\IAttributes;
 use OCP\Share\IShare;
 
 class Share implements IShare {
-	/** @var string */
+	/** @var ?int */
 	private $id;
 	/** @var string */
 	private $providerId;
@@ -112,33 +112,33 @@ class Share implements IShare {
 	 * @inheritdoc
 	 */
 	public function setId($id) {
-		if (is_int($id)) {
-			$id = (string)$id;
+		if (is_string($id)) {
+			$id = (int)$id;
 		}
 
-		if (!is_string($id)) {
-			throw new \InvalidArgumentException('String expected.');
+		if (!is_int($id)) {
+			throw new \InvalidArgumentException('Int expected.');
 		}
 
 		if ($this->id !== null) {
 			throw new IllegalIDChangeException('Not allowed to assign a new internal id to a share');
 		}
 
-		$this->id = trim($id);
+		$this->id = $id;
 		return $this;
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getId() {
+	public function getId(): int {
 		return $this->id;
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getFullId() {
+	public function getFullId(): string {
 		if ($this->providerId === null || $this->id === null) {
 			throw new \UnexpectedValueException;
 		}

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -142,21 +142,20 @@ interface IShare {
 	 * It is only allowed to set the internal id of a share once.
 	 * Attempts to override the internal id will result in an IllegalIDChangeException
 	 *
-	 * @param string $id
 	 * @return \OCP\Share\IShare
 	 * @throws IllegalIDChangeException
 	 * @throws \InvalidArgumentException
 	 * @since 9.1.0
 	 */
-	public function setId($id);
+	public function setId(int $id);
 
 	/**
 	 * Get the internal id of the share.
 	 *
-	 * @return string
+	 * @return int
 	 * @since 9.0.0
 	 */
-	public function getId();
+	public function getId(): int;
 
 	/**
 	 * Get the full share id. This is the <providerid>:<internalid>.
@@ -166,7 +165,7 @@ interface IShare {
 	 * @since 9.0.0
 	 * @throws \UnexpectedValueException If the fullId could not be constructed
 	 */
-	public function getFullId();
+	public function getFullId(): string;
 
 	/**
 	 * Set the provider id of the share

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1146,7 +1146,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertCount(1, $share);
 
 		$share = $share[0];
-		$this->assertSame((string)$id, $share->getId());
+		$this->assertSame($id, $share->getId());
 		$this->assertSame('sharedWith', $share->getSharedWith());
 		$this->assertSame('shareOwner', $share->getShareOwner());
 		$this->assertSame('sharedBy', $share->getSharedBy());

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1603,10 +1603,10 @@ class ManagerTest extends \Test\TestCase {
 		$path = $this->createMock(Node::class);
 
 		$share->setSharedWith('sharedWith')->setNode($path)
-			->setProviderId('foo')->setId('bar');
+			->setProviderId('foo')->setId(1);
 
 		$share2->setSharedWith('sharedWith')->setNode($path)
-			->setProviderId('foo')->setId('baz');
+			->setProviderId('foo')->setId(2);
 
 		$this->defaultProvider
 			->method('getSharesByPath')
@@ -1638,13 +1638,13 @@ class ManagerTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setSharedWithDisplayName('userName')
 			->setProviderId('foo')
-			->setId('bar');
+			->setId(1);
 
 		$share2 = $this->manager->newShare();
 		$share2->setShareType(IShare::TYPE_GROUP)
 			->setShareOwner('shareOwner2')
 			->setProviderId('foo')
-			->setId('baz')
+			->setId(2)
 			->setSharedWith('group');
 
 		$group = $this->createMock(IGroup::class);
@@ -1840,12 +1840,12 @@ class ManagerTest extends \Test\TestCase {
 		$share->setSharedWith('sharedWith')
 			->setNode($path)
 			->setProviderId('foo')
-			->setId('bar');
+			->setId(1);
 
 		$share2 = $this->manager->newShare();
 		$share2->setSharedWith('sharedWith')
 			->setProviderId('foo')
-			->setId('baz');
+			->setId(2);
 
 		$this->defaultProvider->method('getSharesByPath')
 			->with($path)
@@ -2347,7 +2347,7 @@ class ManagerTest extends \Test\TestCase {
 							$share->getExpirationDate() === $date &&
 							$share->getPassword() === 'hashed' &&
 							$share->getToken() === 'token' &&
-							$share->getId() === '42' &&
+							$share->getId() === 42 &&
 							$share->getTarget() === '/target';
 					})]
 			);
@@ -2452,7 +2452,7 @@ class ManagerTest extends \Test\TestCase {
 							$share->getExpirationDate() === null &&
 							$share->getPassword() === null &&
 							$share->getToken() === 'token' &&
-							$share->getId() === '42' &&
+							$share->getId() === 42 &&
 							$share->getTarget() === '/target';
 					})],
 			);

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -73,18 +73,18 @@ class ShareTest extends \Test\TestCase {
 	}
 
 
-	public function testSetProviderIdInt() {
+	public function testSetProviderIdString() {
 		$this->expectException(\InvalidArgumentException::class);
-		$this->expectExceptionMessage('String expected.');
+		$this->expectExceptionMessage('Int expected.');
 
-		$this->share->setProviderId(42);
+		$this->share->setProviderId('bar');
 	}
 
 
-	public function testSetProviderIdString() {
+	public function testSetProviderIdInt() {
 		$this->share->setProviderId('foo');
-		$this->share->setId('bar');
-		$this->assertEquals('foo:bar', $this->share->getFullId());
+		$this->share->setId(42);
+		$this->assertEquals('foo:42', $this->share->getFullId());
 	}
 
 


### PR DESCRIPTION
## Summary

There is a lot of confusion in the code about what the type of IShare ID is. In the database it's an integer, so I switched it to int everywhere where it is possible. Sadly this doesn't apply to all places, because sometimes you get the id of a remote share and those have to be handled as strings for compatibility reasons.

I also thought that we could make everything a string and only convert it to an integer for the database queries to remove all the different types and have it only as string. IMO this is the easier solution, but also makes the code more fragile since future devs might not be aware that the ids have to be valid integers although they are typed as string everywhere.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
