### PR TITLE
Refactor OCP\IConfig and OCP\IAppConfig to add stronger typing

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -728,6 +728,7 @@ class KeyManager {
 	 * @throws \Exception
 	 */
 	public function getMasterKeyPassword() {
+		/** @var string $password */
 		$password = $this->config->getSystemValue('secret');
 		if (empty($password)) {
 			throw new \Exception('Can not get secret from Nextcloud instance');

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -257,7 +257,9 @@ class MountConfig {
 	 */
 	private static function getCipher() {
 		$cipher = new AES(AES::MODE_CBC);
-		$cipher->setKey(\OC::$server->getConfig()->getSystemValue('passwordsalt', null));
+		/** @var string $value */
+		$value = \OC::$server->getConfig()->getSystemValue('passwordsalt', null);
+		$cipher->setKey($value);
 		return $cipher;
 	}
 

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -306,8 +306,8 @@ class Trashbin {
 		}
 
 		$config = \OC::$server->getConfig();
-		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', '-1');
-		$userTrashbinSize = (int)$config->getUserValue($owner, 'files_trashbin', 'trashbin_size', '-1');
+		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', -1);
+		$userTrashbinSize = (int)$config->getUserValue($owner, 'files_trashbin', 'trashbin_size', -1);
 		$configuredTrashbinSize = ($userTrashbinSize < 0) ? $systemTrashbinSize : $userTrashbinSize;
 		if ($configuredTrashbinSize >= 0 && $sourceInfo->getSize() >= $configuredTrashbinSize) {
 			return false;
@@ -758,11 +758,11 @@ class Trashbin {
 	 */
 	private static function calculateFreeSpace($trashbinSize, $user) {
 		$config = \OC::$server->getConfig();
-		$userTrashbinSize = (int)$config->getUserValue($user, 'files_trashbin', 'trashbin_size', '-1');
+		$userTrashbinSize = (int)$config->getUserValue($user, 'files_trashbin', 'trashbin_size', -1);
 		if ($userTrashbinSize > -1) {
 			return $userTrashbinSize - $trashbinSize;
 		}
-		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', '-1');
+		$systemTrashbinSize = (int)$config->getAppValue('files_trashbin', 'trashbin_size', -1);
 		if ($systemTrashbinSize > -1) {
 			return $systemTrashbinSize - $trashbinSize;
 		}

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -867,7 +867,7 @@ class UsersController extends AUserData {
 					if ($quota === -1) {
 						$quota = 'none';
 					} else {
-						$maxQuota = (int) $this->config->getAppValue('files', 'max_quota', '-1');
+						$maxQuota = $this->config->getAppValue('files', 'max_quota', -1);
 						if ($maxQuota !== -1 && $quota > $maxQuota) {
 							throw new OCSException('Invalid quota value. ' . $value . ' is exceeding the maximum quota', 102);
 						}

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -355,6 +355,7 @@ class AppSettingsController extends Controller {
 			}
 
 			$currentLanguage = substr(\OC::$server->getL10NFactory()->findLanguage(), 0, 2);
+			/** @var string $enabledValue */
 			$enabledValue = $this->config->getAppValue($app['id'], 'enabled', 'no');
 			$groups = null;
 			if ($enabledValue !== 'no' && $enabledValue !== 'yes') {

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -576,7 +576,9 @@ Raw output
 	}
 
 	protected function isSqliteUsed() {
-		return strpos($this->config->getSystemValue('dbtype'), 'sqlite') !== false;
+		/** @var string $value */
+		$value = $this->config->getSystemValue('dbtype');
+		return str_contains($value, 'sqlite');
 	}
 
 	protected function isReadOnlyConfig(): bool {

--- a/apps/settings/lib/Controller/MailSettingsController.php
+++ b/apps/settings/lib/Controller/MailSettingsController.php
@@ -147,6 +147,7 @@ class MailSettingsController extends Controller {
 	 * @return DataResponse
 	 */
 	public function sendTestMail() {
+		/** @var string $email */
 		$email = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'email', '');
 		if (!empty($email)) {
 			try {

--- a/apps/testing/lib/Controller/LockingController.php
+++ b/apps/testing/lib/Controller/LockingController.php
@@ -206,13 +206,9 @@ class LockingController extends OCSController {
 			if (strpos($lock, 'locking_') === 0) {
 				$path = substr($lock, strlen('locking_'));
 
-				if ($type === ILockingProvider::LOCK_EXCLUSIVE && (int)$this->config->getAppValue('testing', $lock) === ILockingProvider::LOCK_EXCLUSIVE) {
-					$lockingProvider->releaseLock($path, (int)$this->config->getAppValue('testing', $lock));
-				} elseif ($type === ILockingProvider::LOCK_SHARED && (int)$this->config->getAppValue('testing', $lock) === ILockingProvider::LOCK_SHARED) {
-					$lockingProvider->releaseLock($path, (int)$this->config->getAppValue('testing', $lock));
-				} else {
-					$lockingProvider->releaseLock($path, (int)$this->config->getAppValue('testing', $lock));
-				}
+				/** @var ILockingProvider::LOCK_* $value */
+				$value = $this->config->getAppValue('testing', $lock);
+				$lockingProvider->releaseLock($path, $value);
 			}
 		}
 

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -139,12 +139,13 @@ class Util {
 
 	/**
 	 * @param string $color rgb color value
-	 * @return int[]
-	 * @psalm-return array{0: int, 1: int, 2: int}
+	 * @return array{0: int, 1: int, 2: int}
 	 */
 	public function hexToRGB(string $color): array {
 		$color = new Color($color);
-		return array_values($color->getRgb());
+		/** @var array{0: int, 1: int, 2: int} $rgb */
+		$rgb = array_values($color->getRgb());
+		return $rgb;
 	}
 
 	/**

--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -78,7 +78,7 @@ class Admin implements ISettings {
 	}
 
 	public function getForm(): TemplateResponse {
-		$lastUpdateCheckTimestamp = $this->config->getAppValue('core', 'lastupdatedat');
+		$lastUpdateCheckTimestamp = (int)$this->config->getAppValue('core', 'lastupdatedat');
 		$lastUpdateCheck = $this->dateTimeFormatter->formatDateTime($lastUpdateCheckTimestamp);
 
 		$channels = [
@@ -97,6 +97,7 @@ class Admin implements ISettings {
 		$notifyGroups = json_decode($this->config->getAppValue('updatenotification', 'notify_groups', '["admin"]'), true);
 
 		$defaultUpdateServerURL = 'https://updates.nextcloud.com/updater_server/';
+		/** @var string $updateServerURL */
 		$updateServerURL = $this->config->getSystemValue('updater.server.url', $defaultUpdateServerURL);
 		$defaultCustomerUpdateServerURLPrefix = 'https://updates.nextcloud.com/customers/';
 

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -360,7 +360,7 @@ class Configuration {
 
 	protected function getSystemValue(string $varName): string {
 		//FIXME: if another system value is added, softcode the default value
-		return \OC::$server->getConfig()->getSystemValue($varName, false);
+		return (string)\OC::$server->getConfig()->getSystemValue($varName, false);
 	}
 
 	protected function getValue(string $varName): string {
@@ -368,7 +368,7 @@ class Configuration {
 		if (is_null($defaults)) {
 			$defaults = $this->getDefaults();
 		}
-		return \OC::$server->getConfig()->getAppValue('user_ldap',
+		return (string)\OC::$server->getConfig()->getAppValue('user_ldap',
 			$this->configPrefix.$varName,
 			$defaults[$varName]);
 	}

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -600,6 +600,7 @@ class User {
 	 * @throws \OCP\PreConditionNotMetException
 	 */
 	public function getExtStorageHome():string {
+		/** @var string $value */
 		$value = $this->config->getUserValue($this->getUsername(), 'user_ldap', 'extStorageHome', '');
 		if ($value !== '') {
 			return $value;

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -76,7 +76,7 @@ class WhatsNewController extends OCSController {
 		if ($user === null) {
 			throw new \RuntimeException("Acting user cannot be resolved");
 		}
-		$lastRead = $this->config->getUserValue($user->getUID(), 'core', 'whatsNewLastRead', 0);
+		$lastRead = $this->config->getUserValue($user->getUID(), 'core', 'whatsNewLastRead', '0');
 		$currentVersion = $this->whatsNewService->normalizeVersion($this->config->getSystemValue('version'));
 
 		if (version_compare($lastRead, $currentVersion, '>=')) {

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -671,6 +671,7 @@ class AccountManager implements IAccountManager {
 	 * build default user record in case not data set exists yet
 	 */
 	protected function buildDefaultUserRecord(IUser $user): array {
+		/** @var array<string, string> $scopes */
 		$scopes = array_merge(self::DEFAULT_SCOPES, array_filter($this->config->getSystemValue('account_manager.default_property_scope', []), static function (string $scope, string $property) {
 			return in_array($property, self::ALLOWED_PROPERTIES, true) && in_array($scope, self::ALLOWED_SCOPES, true);
 		}, ARRAY_FILTER_USE_BOTH));

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -40,6 +40,8 @@ use OCP\PreConditionNotMetException;
 
 /**
  * Class to combine all the configuration options ownCloud offers
+ *
+ * @psalm-import-type Value from IConfig
  */
 class AllConfig implements IConfig {
 	private SystemConfig $systemConfig;
@@ -105,20 +107,21 @@ class AllConfig implements IConfig {
 	 * Sets a new system wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved
-	 * @param mixed $value the value that should be stored
+	 * @param Value $value the value that should be stored
 	 */
-	public function setSystemValue($key, $value) {
+	public function setSystemValue(string $key, mixed $value) {
 		$this->systemConfig->setValue($key, $value);
 	}
 
 	/**
 	 * Looks up a system wide defined value
 	 *
+	 * @template T of Value
 	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T the value or $default
 	 */
-	public function getSystemValue($key, $default = '') {
+	public function getSystemValue(string $key, mixed $default = ''): mixed {
 		return $this->systemConfig->getValue($key, $default);
 	}
 
@@ -167,11 +170,12 @@ class AllConfig implements IConfig {
 	/**
 	 * Looks up a system wide defined value and filters out sensitive data
 	 *
+	 * @template T of Value
 	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T the value or $default
 	 */
-	public function getFilteredSystemValue($key, $default = '') {
+	public function getFilteredSystemValue(string $key, mixed $default = ''): mixed {
 		return $this->systemConfig->getFilteredValue($key, $default);
 	}
 
@@ -180,7 +184,7 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $key the key of the value, under which it was saved
 	 */
-	public function deleteSystemValue($key) {
+	public function deleteSystemValue(string $key) {
 		$this->systemConfig->deleteValue($key);
 	}
 
@@ -190,7 +194,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @return string[] the keys stored for the app
 	 */
-	public function getAppKeys($appName) {
+	public function getAppKeys(string $appName): array {
 		return \OC::$server->get(AppConfig::class)->getKeys($appName);
 	}
 
@@ -199,21 +203,22 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key of the value, under which will be saved
-	 * @param string|float|int $value the value that should be stored
+	 * @param Value $value the value that should be stored
 	 */
-	public function setAppValue($appName, $key, $value) {
+	public function setAppValue(string $appName, string $key, mixed $value): void {
 		\OC::$server->get(AppConfig::class)->setValue($appName, $key, $value);
 	}
 
 	/**
 	 * Looks up an app wide defined value
 	 *
+	 * @template T of Value
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
-	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the saved value
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T the saved value
 	 */
-	public function getAppValue($appName, $key, $default = '') {
+	public function getAppValue(string $appName, string $key, mixed $default = ''): mixed {
 		return \OC::$server->get(AppConfig::class)->getValue($appName, $key, $default);
 	}
 
@@ -223,7 +228,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
 	 */
-	public function deleteAppValue($appName, $key) {
+	public function deleteAppValue(string $appName, string $key) {
 		\OC::$server->get(AppConfig::class)->deleteKey($appName, $key);
 	}
 
@@ -232,7 +237,7 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $appName the appName the configs are stored under
 	 */
-	public function deleteAppValues($appName) {
+	public function deleteAppValues(string $appName) {
 		\OC::$server->get(AppConfig::class)->deleteApp($appName);
 	}
 
@@ -243,12 +248,12 @@ class AllConfig implements IConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param string|float|int $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
+	 * @param Value $value the value that you want to store
+	 * @param ?string $preCondition only update if the config value was previously the value passed as $preCondition
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null) {
+	public function setUserValue(string $userId, string $appName, string $key, mixed $value, string $preCondition = null) {
 		if (!is_int($value) && !is_float($value) && !is_string($value)) {
 			throw new \UnexpectedValueException('Only integers, floats and strings are allowed as value');
 		}
@@ -265,7 +270,7 @@ class AllConfig implements IConfig {
 		if ($prevValue !== null) {
 			if ($prevValue === (string)$value) {
 				return;
-			} elseif ($preCondition !== null && $prevValue !== (string)$preCondition) {
+			} elseif ($preCondition !== null && $prevValue !== $preCondition) {
 				throw new PreConditionNotMetException();
 			} else {
 				$qb = $this->connection->getQueryBuilder();
@@ -308,16 +313,19 @@ class AllConfig implements IConfig {
 	/**
 	 * Getting a user defined value
 	 *
+	 * @template T of Value
 	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return string
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T
 	 */
-	public function getUserValue($userId, $appName, $key, $default = '') {
+	public function getUserValue(?string $userId, string $appName, string $key, mixed $default = ''): mixed {
 		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName][$key])) {
-			return $data[$appName][$key];
+			/** @var T $value */
+			$value = $data[$appName][$key];
+			return $value;
 		} else {
 			return $default;
 		}
@@ -330,7 +338,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @return string[]
 	 */
-	public function getUserKeys($userId, $appName) {
+	public function getUserKeys(string $userId, string $appName): array {
 		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName])) {
 			return array_keys($data[$appName]);
@@ -346,7 +354,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
 	 */
-	public function deleteUserValue($userId, $appName, $key) {
+	public function deleteUserValue(string $userId, string $appName, string $key) {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -367,7 +375,7 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 */
-	public function deleteAllUserValues($userId) {
+	public function deleteAllUserValues(string $userId) {
 		// TODO - FIXME
 		$this->fixDIInit();
 		$qb = $this->connection->getQueryBuilder();
@@ -383,7 +391,7 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 */
-	public function deleteAppFromAllUsers($appName) {
+	public function deleteAppFromAllUsers(string $appName) {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -401,8 +409,7 @@ class AllConfig implements IConfig {
 	 * Returns all user configs sorted by app of one user
 	 *
 	 * @param ?string $userId the user ID to get the app configs from
-	 * @psalm-return array<string, array<string, string>>
-	 * @return array[] - 2 dimensional array with the following structure:
+	 * @return array<string, array<string, Value>> - 2 dimensional array with the following structure:
 	 *     [ $appId =>
 	 *         [ $key => $value ]
 	 *     ]
@@ -442,14 +449,14 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $appName app to get the value for
 	 * @param string $key the key to get the value for
-	 * @param array $userIds the user IDs to fetch the values for
-	 * @return array Mapped values: userId => value
+	 * @param string[] $userIds the user IDs to fetch the values for
+	 * @return array<string, Value> Mapped values: userId => value
 	 */
-	public function getUserValueForUsers($appName, $key, $userIds) {
+	public function getUserValueForUsers(string $appName, string $key, array $userIds): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 
-		if (empty($userIds) || !is_array($userIds)) {
+		if (empty($userIds)) {
 			return [];
 		}
 
@@ -482,10 +489,10 @@ class AllConfig implements IConfig {
 	 *
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
-	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @param Value $value the value to get the user for
+	 * @return string[] of user IDs
 	 */
-	public function getUsersForUserValue($appName, $key, $value) {
+	public function getUsersForUserValue(string $appName, string $key, mixed $value): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -514,9 +521,9 @@ class AllConfig implements IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @return string[] of user IDs
 	 */
-	public function getUsersForUserValueCaseInsensitive($appName, $key, $value) {
+	public function getUsersForUserValueCaseInsensitive(string $appName, string $key, string $value): array {
 		// TODO - FIXME
 		$this->fixDIInit();
 
@@ -543,7 +550,7 @@ class AllConfig implements IConfig {
 		return $userIDs;
 	}
 
-	public function getSystemConfig() {
+	public function getSystemConfig(): SystemConfig {
 		return $this->systemConfig;
 	}
 }

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -616,6 +616,7 @@ class AppManager implements IAppManager {
 		}
 
 		if ($automaticDisabled) {
+			/** @var string $previousSetting */
 			$previousSetting = $this->appConfig->getValue($appId, 'enabled', 'yes');
 			if ($previousSetting !== 'yes' && $previousSetting !== 'no') {
 				$previousSetting = json_decode($previousSetting, true);
@@ -691,6 +692,7 @@ class AppManager implements IAppManager {
 		$apps = $this->getInstalledApps();
 		foreach ($apps as $appId) {
 			$appInfo = $this->getAppInfo($appId);
+			/** @var string $appDbVersion */
 			$appDbVersion = $this->appConfig->getValue($appId, 'installed_version');
 			if ($appDbVersion
 				&& isset($appInfo['version'])

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -41,6 +41,8 @@ use OCP\IConfig;
 /**
  * This class provides an easy way for apps to store config values in the
  * database.
+ *
+ * @psalm-import-type Value from IConfig
  */
 class AppConfig implements IAppConfig {
 	/** @var array[] */
@@ -160,9 +162,9 @@ class AppConfig implements IAppConfig {
 
 	/**
 	 * @param string $app
-	 * @return array
+	 * @return array<string, Value>
 	 */
-	private function getAppValues($app) {
+	private function getAppValues(string $app): array {
 		$this->loadConfigValues();
 
 		if (isset($this->cache[$app])) {
@@ -175,12 +177,12 @@ class AppConfig implements IAppConfig {
 	/**
 	 * Get all apps using the config
 	 *
-	 * @return array an array of app ids
+	 * @return string[] an array of app ids
 	 *
 	 * This function returns a list of all apps that have at least one
 	 * entry in the appconfig table.
 	 */
-	public function getApps() {
+	public function getApps(): array {
 		$this->loadConfigValues();
 
 		return $this->getSortedKeys($this->cache);
@@ -190,12 +192,12 @@ class AppConfig implements IAppConfig {
 	 * Get the available keys for an app
 	 *
 	 * @param string $app the app we are looking for
-	 * @return array an array of key names
+	 * @return string[] an array of key names
 	 *
 	 * This function gets all keys of an app. Please note that the values are
 	 * not returned.
 	 */
-	public function getKeys($app) {
+	public function getKeys(string $app): array {
 		$this->loadConfigValues();
 
 		if (isset($this->cache[$app])) {
@@ -205,7 +207,7 @@ class AppConfig implements IAppConfig {
 		return [];
 	}
 
-	public function getSortedKeys($data) {
+	public function getSortedKeys($data): array {
 		$keys = array_keys($data);
 		sort($keys);
 		return $keys;
@@ -214,15 +216,16 @@ class AppConfig implements IAppConfig {
 	/**
 	 * Gets the config value
 	 *
+	 * @template T of Value
 	 * @param string $app app
 	 * @param string $key key
-	 * @param string $default = null, default value if the key does not exist
-	 * @return string the value or $default
+	 * @param T $default = null, default value if the key does not exist
+	 * @return T the value or $default
 	 *
 	 * This function gets a value from the appconfig table. If the key does
 	 * not exist the default value will be returned
 	 */
-	public function getValue($app, $key, $default = null) {
+	public function getValue(string $app, string $key, mixed $default = null): mixed {
 		$this->loadConfigValues();
 
 		if ($this->hasKey($app, $key)) {
@@ -239,7 +242,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $key
 	 * @return bool
 	 */
-	public function hasKey($app, $key) {
+	public function hasKey(string $app, string $key): bool {
 		$this->loadConfigValues();
 
 		return isset($this->cache[$app][$key]);
@@ -250,10 +253,10 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @param string $app app
 	 * @param string $key key
-	 * @param string|float|int $value value
+	 * @param Value $value value
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
-	public function setValue($app, $key, $value) {
+	public function setValue(string $app, string $key, mixed $value): bool {
 		if (!$this->hasKey($app, $key)) {
 			$inserted = (bool) $this->conn->insertIfNotExist('*PREFIX*appconfig', [
 				'appid' => $app,
@@ -320,7 +323,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $key key
 	 * @return boolean
 	 */
-	public function deleteKey($app, $key) {
+	public function deleteKey(string $app, string $key): bool {
 		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
@@ -343,7 +346,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * Removes all keys in appconfig belonging to the app.
 	 */
-	public function deleteApp($app) {
+	public function deleteApp(string $app): bool {
 		$this->loadConfigValues();
 
 		$sql = $this->conn->getQueryBuilder();
@@ -363,7 +366,7 @@ class AppConfig implements IAppConfig {
 	 * @param string|false $key
 	 * @return array|false
 	 */
-	public function getValues($app, $key) {
+	public function getValues(mixed $app, mixed $key): array|bool {
 		if (($app !== false) === ($key !== false)) {
 			return false;
 		}
@@ -385,9 +388,9 @@ class AppConfig implements IAppConfig {
 	 * get all values of the app or and filters out sensitive data
 	 *
 	 * @param string $app
-	 * @return array
+	 * @return array<string, Value>
 	 */
-	public function getFilteredValues($app) {
+	public function getFilteredValues(string $app): array {
 		$values = $this->getValues($app, false);
 
 		if (isset($this->sensitiveValues[$app])) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -624,6 +624,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return bool
 	 */
 	private function isOverwriteCondition(string $type = ''): bool {
+		/** @var string $regex */
 		$regex = '/' . $this->config->getSystemValue('overwritecondaddr', '')  . '/';
 		$remoteAddr = isset($this->server['REMOTE_ADDR']) ? $this->server['REMOTE_ADDR'] : '';
 		return $regex === '//' || preg_match($regex, $remoteAddr) === 1
@@ -844,6 +845,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			return $host;
 		}
 
+		/** @var string[] $trustedList */
 		$trustedList = (array)$this->config->getSystemValue('trusted_domains', []);
 		if (count($trustedList) > 0) {
 			return reset($trustedList);

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -66,7 +66,7 @@ class AppConfig implements IAppConfig {
 	}
 
 	public function getUserValue(string $userId, string $key, string $default = ''): string {
-		return $this->config->getUserValue($userId, $this->appName, $key, $default);
+		return (string)$this->config->getUserValue($userId, $this->appName, $key, $default);
 	}
 
 	public function deleteUserValue(string $userId, string $key): void {

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -280,7 +280,7 @@ class Manager {
 			$sessionId = $this->session->getId();
 			$token = $this->tokenProvider->getToken($sessionId);
 			$tokenId = $token->getId();
-			$this->config->deleteUserValue($user->getUID(), 'login_token_2fa', $tokenId);
+			$this->config->deleteUserValue($user->getUID(), 'login_token_2fa', (string)$tokenId);
 
 			$dispatchEvent = new GenericEvent($user, ['provider' => $provider->getDisplayName()]);
 			$this->legacyDispatcher->dispatch(IProvider::EVENT_SUCCESS, $dispatchEvent);

--- a/lib/private/Files/Mount/CacheMountProvider.php
+++ b/lib/private/Files/Mount/CacheMountProvider.php
@@ -52,6 +52,7 @@ class CacheMountProvider implements IMountProvider {
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 */
 	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
+		/** @var string $cacheBaseDir */
 		$cacheBaseDir = $this->config->getSystemValue('cache_path', '');
 		if ($cacheBaseDir !== '') {
 			$cacheDir = rtrim($cacheBaseDir, '/') . '/' . $user->getUID();

--- a/lib/private/Files/Mount/ObjectStorePreviewCacheMountProvider.php
+++ b/lib/private/Files/Mount/ObjectStorePreviewCacheMountProvider.php
@@ -99,6 +99,7 @@ class ObjectStorePreviewCacheMountProvider implements IRootMountProvider {
 	}
 
 	protected function getMultiBucketObjectStore(int $number): array {
+		/** @var array $config */
 		$config = $this->config->getSystemValue('objectstore_multibucket');
 
 		// sanity checks
@@ -128,6 +129,7 @@ class ObjectStorePreviewCacheMountProvider implements IRootMountProvider {
 	}
 
 	protected function getMultiBucketObjectStoreForRoot(): array {
+		/** @var array $config */
 		$config = $this->config->getSystemValue('objectstore_multibucket');
 
 		// sanity checks

--- a/lib/private/Files/Mount/RootMountProvider.php
+++ b/lib/private/Files/Mount/RootMountProvider.php
@@ -42,7 +42,9 @@ class RootMountProvider implements IRootMountProvider {
 	}
 
 	public function getRootMounts(IStorageFactory $loader): array {
+		/** @var ?array $objectStore */
 		$objectStore = $this->config->getSystemValue('objectstore', null);
+		/** @var ?array $objectStoreMultiBucket */
 		$objectStoreMultiBucket = $this->config->getSystemValue('objectstore_multibucket', null);
 
 		if ($objectStoreMultiBucket) {

--- a/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
@@ -51,6 +51,7 @@ class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 			rtrim($root . '/updater', '/'),
 			rtrim($root . '/_oc_upgrade', '/'),
 		];
+		/** @var string $customDataDir */
 		$customDataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', '');
 		if ($customDataDir !== '') {
 			$excludedFolders[] = rtrim($customDataDir, '/');

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -198,6 +198,7 @@ class Factory implements IFactory {
 		if ($this->config->getSystemValue('installed', false)) {
 			$userId = !is_null($this->userSession->getUser()) ? $this->userSession->getUser()->getUID() :  null;
 			if (!is_null($userId)) {
+				/** @var ?string $userLang */
 				$userLang = $this->config->getUserValue($userId, 'core', 'lang', null);
 			} else {
 				$userLang = null;
@@ -284,6 +285,7 @@ class Factory implements IFactory {
 
 		if ($this->config->getSystemValue('installed', false)) {
 			$userId = null !== $this->userSession->getUser() ? $this->userSession->getUser()->getUID() :  null;
+			/** @var ?string $userLocale */
 			$userLocale = null;
 			if (null !== $userId) {
 				$userLocale = $this->config->getUserValue($userId, 'core', 'locale', null);

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -144,6 +144,7 @@ class Mailer implements IMailer {
 	 * @since 12.0.0
 	 */
 	public function createEMailTemplate(string $emailId, array $data = []): IEMailTemplate {
+		/** @var string $class */
 		$class = $this->config->getSystemValue('mail_template_class', '');
 
 		if ($class !== '' && class_exists($class) && is_a($class, EMailTemplate::class, true)) {
@@ -309,6 +310,7 @@ class Mailer implements IMailer {
 			$transport->setPassword($this->config->getSystemValue('mail_smtppassword', ''));
 		}
 
+		/** @var string[] $streamingOptions */
 		$streamingOptions = $this->config->getSystemValue('mail_smtpstreamoptions', []);
 		if (is_array($streamingOptions) && !empty($streamingOptions)) {
 			/** @psalm-suppress InternalMethod */

--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -171,7 +171,8 @@ class Throttler implements IThrottler {
 		$ip = inet_pton($ip);
 
 		foreach ($keys as $key) {
-			$cidr = $this->config->getAppValue('bruteForce', $key, null);
+			/** @var string $cidr */
+			$cidr = $this->config->getAppValue('bruteForce', $key, '');
 
 			$cx = explode('/', $cidr);
 			$addr = $cx[0];

--- a/lib/private/Security/VerificationToken/VerificationToken.php
+++ b/lib/private/Security/VerificationToken/VerificationToken.php
@@ -76,6 +76,7 @@ class VerificationToken implements IVerificationToken {
 			$this->throwInvalidTokenException(InvalidTokenException::USER_UNKNOWN);
 		}
 
+		/** @var ?string $encryptedToken */
 		$encryptedToken = $this->config->getUserValue($user->getUID(), 'core', $subject, null);
 		if ($encryptedToken === null) {
 			$this->throwInvalidTokenException(InvalidTokenException::TOKEN_NOT_FOUND);

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1443,7 +1443,8 @@ class Manager implements IManager {
 			throw new ShareNotFound();
 		}
 
-		[$providerId, $id] = $this->splitFullId($id);
+		[$providerId, $shareId] = $this->splitFullId($id);
+		$shareId = (int)$shareId;
 
 		try {
 			$provider = $this->factory->getProvider($providerId);
@@ -1451,7 +1452,7 @@ class Manager implements IManager {
 			throw new ShareNotFound();
 		}
 
-		$share = $provider->getShareById($id, $recipient);
+		$share = $provider->getShareById($shareId, $recipient);
 
 		$this->checkExpireDate($share);
 
@@ -1620,6 +1621,7 @@ class Manager implements IManager {
 		$provider = $this->factory->getProviderForType(IShare::TYPE_GROUP);
 		$provider->groupDeleted($gid);
 
+		/** @var string $excludedGroups */
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 		if ($excludedGroups === '') {
 			return;
@@ -1818,6 +1820,7 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function shareApiLinkEnforcePassword(bool $checkGroupMembership = true) {
+		/** @var string $excludedGroups */
 		$excludedGroups = $this->config->getAppValue('core', 'shareapi_enforce_links_password_excluded_groups', '');
 		if ($excludedGroups !== '' && $checkGroupMembership) {
 			$excludedGroups = json_decode($excludedGroups);

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -306,6 +306,7 @@ class URLGenerator implements IURLGenerator {
 			return $this->getAbsoluteURL(urldecode($_REQUEST['redirect_url']));
 		}
 
+		/** @var string $defaultPage */
 		$defaultPage = $this->config->getAppValue('core', 'defaultpage');
 		if ($defaultPage) {
 			return $this->getAbsoluteURL($defaultPage);

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -203,6 +203,7 @@ class Updater extends BasicEmitter {
 		$version = explode('.', $oldVersion);
 		$majorMinor = $version[0] . '.' . $version[1];
 
+		/** @var string $currentVendor */
 		$currentVendor = $this->config->getAppValue('core', 'vendor', '');
 
 		// Vendor was not set correctly on install, so we have to white-list known versions

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -306,7 +306,7 @@ class OC_Util {
 	 */
 	public static function getChannel() {
 		OC_Util::loadVersion();
-		return \OC::$server->getConfig()->getSystemValue('updater.release.channel', self::$versionCache['OC_Channel']);
+		return (string)\OC::$server->getConfig()->getSystemValue('updater.release.channel', self::$versionCache['OC_Channel']);
 	}
 
 	/**

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -30,6 +30,8 @@ namespace OCP;
  * This class provides an easy way for apps to store config values in the
  * database.
  * @since 7.0.0
+ *
+ * @psalm-import-type Value from IConfig
  */
 interface IAppConfig {
 	/**
@@ -39,7 +41,7 @@ interface IAppConfig {
 	 * @return bool
 	 * @since 7.0.0
 	 */
-	public function hasKey($app, $key);
+	public function hasKey(string $app, string $key): bool;
 
 	/**
 	 * get multiply values, either the app or key can be used as wildcard by setting it to false
@@ -49,24 +51,24 @@ interface IAppConfig {
 	 * @return array|false
 	 * @since 7.0.0
 	 */
-	public function getValues($app, $key);
+	public function getValues(mixed $app, mixed $key): mixed;
 
 	/**
 	 * get all values of the app or and filters out sensitive data
 	 *
 	 * @param string $app
-	 * @return array
+	 * @return array<string, Value>
 	 * @since 12.0.0
 	 */
-	public function getFilteredValues($app);
+	public function getFilteredValues(string $app): array;
 
 	/**
 	 * Get all apps using the config
-	 * @return array an array of app ids
+	 * @return string[] an array of app ids
 	 *
 	 * This function returns a list of all apps that have at least one
 	 * entry in the appconfig table.
 	 * @since 7.0.0
 	 */
-	public function getApps();
+	public function getApps(): array;
 }

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -35,6 +35,8 @@ namespace OCP;
 /**
  * Access to all the configuration options Nextcloud offers.
  * @since 6.0.0
+ *
+ * @psalm-type Value = string|float|int|bool|array|null
  */
 interface IConfig {
 	/**
@@ -56,21 +58,22 @@ interface IConfig {
 	 * Sets a new system wide value
 	 *
 	 * @param string $key the key of the value, under which will be saved
-	 * @param mixed $value the value that should be stored
+	 * @param Value $value the value that should be stored
 	 * @throws HintException if config file is read-only
 	 * @since 8.0.0
 	 */
-	public function setSystemValue($key, $value);
+	public function setSystemValue(string $key, mixed $value);
 
 	/**
 	 * Looks up a system wide defined value
 	 *
+	 * @template T of Value
 	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T the value or $default
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getSystemValue($key, $default = '');
+	public function getSystemValue(string $key, mixed $default = ''): mixed;
 
 	/**
 	 * Looks up a boolean system wide defined value
@@ -105,12 +108,13 @@ interface IConfig {
 	/**
 	 * Looks up a system wide defined value and filters out sensitive data
 	 *
+	 * @template T of Value
 	 * @param string $key the key of the value, under which it was saved
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return mixed the value or $default
+	 * @param Value $default the default value to be returned if the value isn't set
+	 * @return Value the value or $default
 	 * @since 8.2.0
 	 */
-	public function getFilteredSystemValue($key, $default = '');
+	public function getFilteredSystemValue(string $key, mixed $default = ''): mixed;
 
 	/**
 	 * Delete a system wide defined value
@@ -118,7 +122,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteSystemValue($key);
+	public function deleteSystemValue(string $key);
 
 	/**
 	 * Get all keys stored for an app
@@ -127,29 +131,30 @@ interface IConfig {
 	 * @return string[] the keys stored for the app
 	 * @since 8.0.0
 	 */
-	public function getAppKeys($appName);
+	public function getAppKeys(string $appName): array;
 
 	/**
 	 * Writes a new app wide value
 	 *
 	 * @param string $appName the appName that we want to store the value under
-	 * @param string|float|int $key the key of the value, under which will be saved
-	 * @param string $value the value that should be stored
+	 * @param string $key the key of the value, under which will be saved
+	 * @param Value $value the value that should be stored
 	 * @return void
 	 * @since 6.0.0
 	 */
-	public function setAppValue($appName, $key, $value);
+	public function setAppValue(string $appName, string $key, mixed $value): void;
 
 	/**
 	 * Looks up an app wide defined value
 	 *
+	 * @template T of Value
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key of the value, under which it was saved
-	 * @param string $default the default value to be returned if the value isn't set
-	 * @return string the saved value
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T the saved value
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getAppValue($appName, $key, $default = '');
+	public function getAppValue(string $appName, string $key, mixed $default = ''): mixed;
 
 	/**
 	 * Delete an app wide defined value
@@ -158,7 +163,7 @@ interface IConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 * @since 8.0.0
 	 */
-	public function deleteAppValue($appName, $key);
+	public function deleteAppValue(string $appName, string $key);
 
 	/**
 	 * Removes all keys in appconfig belonging to the app
@@ -166,7 +171,7 @@ interface IConfig {
 	 * @param string $appName the appName the configs are stored under
 	 * @since 8.0.0
 	 */
-	public function deleteAppValues($appName);
+	public function deleteAppValues(string $appName);
 
 
 	/**
@@ -175,36 +180,37 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param string $value the value that you want to store
-	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
+	 * @param Value $value the value that you want to store
+	 * @param ?string $preCondition only update if the config value was previously the value passed as $preCondition
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value
 	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
 	 */
-	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
+	public function setUserValue(string $userId, string $appName, string $key, mixed $value, string $preCondition = null);
 
 	/**
 	 * Shortcut for getting a user defined value
 	 *
+	 * @template T of Value
 	 * @param ?string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we stored the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param mixed $default the default value to be returned if the value isn't set
-	 * @return string
+	 * @param T $default the default value to be returned if the value isn't set
+	 * @return T
 	 * @since 6.0.0 - parameter $default was added in 7.0.0
 	 */
-	public function getUserValue($userId, $appName, $key, $default = '');
+	public function getUserValue(?string $userId, string $appName, string $key, mixed $default = ''): mixed;
 
 	/**
 	 * Fetches a mapped list of userId -> value, for a specified app and key and a list of user IDs.
 	 *
 	 * @param string $appName app to get the value for
 	 * @param string $key the key to get the value for
-	 * @param array $userIds the user IDs to fetch the values for
-	 * @return array Mapped values: userId => value
+	 * @param string[] $userIds the user IDs to fetch the values for
+	 * @return array<string, Value> Mapped values: userId => value
 	 * @since 8.0.0
 	 */
-	public function getUserValueForUsers($appName, $key, $userIds);
+	public function getUserValueForUsers(string $appName, string $key, array $userIds): array;
 
 	/**
 	 * Get the keys of all stored by an app for the user
@@ -214,14 +220,13 @@ interface IConfig {
 	 * @return string[]
 	 * @since 8.0.0
 	 */
-	public function getUserKeys($userId, $appName);
+	public function getUserKeys(string $userId, string $appName): array;
 
 	/**
 	 * Get all user configs sorted by app of one user
 	 *
 	 * @param string $userId the userId of the user that we want to get all values from
-	 * @psalm-return array<string, array<string, string>>
-	 * @return array[] - 2 dimensional array with the following structure:
+	 * @return array<string, array<string, Value>> - 2 dimensional array with the following structure:
 	 *     [ $appId =>
 	 *         [ $key => $value ]
 	 *     ]
@@ -237,7 +242,7 @@ interface IConfig {
 	 * @param string $key the key under which the value is being stored
 	 * @since 8.0.0
 	 */
-	public function deleteUserValue($userId, $appName, $key);
+	public function deleteUserValue(string $userId, string $appName, string $key);
 
 	/**
 	 * Delete all user values
@@ -245,7 +250,7 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAllUserValues($userId);
+	public function deleteAllUserValues(string $userId);
 
 	/**
 	 * Delete all user related values of one app
@@ -253,16 +258,16 @@ interface IConfig {
 	 * @param string $appName the appName of the app that we want to remove all values from
 	 * @since 8.0.0
 	 */
-	public function deleteAppFromAllUsers($appName);
+	public function deleteAppFromAllUsers(string $appName);
 
 	/**
 	 * Determines the users that have the given value set for a specific app-key-pair
 	 *
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
-	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @param Value $value the value to get the user for
+	 * @return string[] of user IDs
 	 * @since 8.0.0
 	 */
-	public function getUsersForUserValue($appName, $key, $value);
+	public function getUsersForUserValue(string $appName, string $key, mixed $value): array;
 }

--- a/public.php
+++ b/public.php
@@ -54,6 +54,7 @@ try {
 		$pathInfo = trim($pathInfo, '/');
 		[$service] = explode('/', $pathInfo);
 	}
+	/** @var string $file */
 	$file = \OC::$server->getConfig()->getAppValue('core', 'public_' . strip_tags($service));
 	if ($file === '') {
 		http_response_code(404);


### PR DESCRIPTION
## Summary

IConfig and IAppConfig use very weak and often wrong and inconsistent typing. This change is completely backwards compatible and only makes the analysis better and the interface definitions clearer.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
