### PR TITLE
restore shared lock ttl to previous value when releasing

### DIFF
--- a/lib/private/Memcache/LoggerWrapperCache.php
+++ b/lib/private/Memcache/LoggerWrapperCache.php
@@ -167,8 +167,16 @@ class LoggerWrapperCache extends Cache implements IMemcacheTTL {
 	}
 
 	/** @inheritDoc */
-	public function setTTL($key, $ttl) {
+	public function setTTL(string $key, int $ttl) {
 		$this->wrappedCache->setTTL($key, $ttl);
+	}
+
+	public function getTTL(string $key): int|false {
+		return $this->wrappedCache->getTTL($key);
+	}
+
+	public function compareSetTTL(string $key, mixed $value, int $ttl): bool {
+		return $this->wrappedCache->compareSetTTL($key, $value, $ttl);
 	}
 
 	public static function isAvailable(): bool {

--- a/lib/private/Memcache/ProfilerWrapperCache.php
+++ b/lib/private/Memcache/ProfilerWrapperCache.php
@@ -183,8 +183,16 @@ class ProfilerWrapperCache extends AbstractDataCollector implements IMemcacheTTL
 	}
 
 	/** @inheritDoc */
-	public function setTTL($key, $ttl) {
+	public function setTTL(string $key, int $ttl) {
 		$this->wrappedCache->setTTL($key, $ttl);
+	}
+
+	public function getTTL(string $key): int|false {
+		return $this->wrappedCache->getTTL($key);
+	}
+
+	public function compareSetTTL(string $key, mixed $value, int $ttl): bool {
+		return $this->wrappedCache->compareSetTTL($key, $value, $ttl);
 	}
 
 	public function offsetExists($offset): bool {

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -181,6 +181,23 @@ class Redis extends Cache implements IMemcacheTTL {
 		$this->getCache()->expire($this->getPrefix() . $key, $ttl);
 	}
 
+	public function getTTL(string $key): int|false {
+		$ttl = $this->getCache()->ttl($this->getPrefix() . $key);
+		return $ttl > 0 ? (int)$ttl : false;
+	}
+
+	public function compareSetTTL(string $key, mixed $value, int $ttl): bool {
+		$fullKey = $this->getPrefix() . $key;
+		$redis = $this->getCache();
+		if ($this->get($key) === $value) {
+			$result = $redis->multi()
+				->expire($fullKey, $ttl)
+				->exec();
+			return $result !== false;
+		}
+		return false;
+	}
+
 	public static function isAvailable(): bool {
 		return \OC::$server->getGetRedisFactory()->isAvailable();
 	}

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -46,6 +46,10 @@ class Redis extends Cache implements IMemcacheTTL {
 			'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end',
 			'cf0e94b2e9ffc7e04395cf88f7583fc309985910',
 		],
+		'caSetTtl' => [
+			'if redis.call("get", KEYS[1]) == ARGV[1] then redis.call("expire", KEYS[1], ARGV[2]) return 1 else return 0 end',
+			'fa4acbc946d23ef41d7d3910880b60e6e4972d72',
+		],
 	];
 
 	/**
@@ -187,15 +191,9 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function compareSetTTL(string $key, mixed $value, int $ttl): bool {
-		$fullKey = $this->getPrefix() . $key;
-		$redis = $this->getCache();
-		if ($this->get($key) === $value) {
-			$result = $redis->multi()
-				->expire($fullKey, $ttl)
-				->exec();
-			return $result !== false;
-		}
-		return false;
+		$value = self::encodeValue($value);
+
+		return $this->evalLua('caSetTtl', [$key], [$value, $ttl]) > 0;
 	}
 
 	public static function isAvailable(): bool {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -173,6 +173,7 @@ use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
 use OCP\BackgroundJob\IJobList;
@@ -1079,7 +1080,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$memcacheFactory = $c->get(ICacheFactory::class);
 				$memcache = $memcacheFactory->createLocking('lock');
 				if (!($memcache instanceof \OC\Memcache\NullCache)) {
-					return new MemcacheLockingProvider($memcache, $ttl);
+					$timeFactory = $c->get(ITimeFactory::class);
+					return new MemcacheLockingProvider($memcache, $timeFactory, $ttl);
 				}
 				return new DBLockingProvider(
 					$c->get(IDBConnection::class),

--- a/lib/public/IMemcacheTTL.php
+++ b/lib/public/IMemcacheTTL.php
@@ -35,5 +35,22 @@ interface IMemcacheTTL extends IMemcache {
 	 * @param int $ttl time to live in seconds
 	 * @since 8.2.2
 	 */
-	public function setTTL($key, $ttl);
+	public function setTTL(string $key, int $ttl);
+
+	/**
+	 * Get the ttl for an existing value, in seconds till expiry
+	 *
+	 * @return int|false
+	 * @since 27
+	 */
+	public function getTTL(string $key): int|false;
+	/**
+	 * Set the ttl for an existing value if the value matches
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl time to live in seconds
+	 * @since 27
+	 */
+	public function compareSetTTL(string $key, $value, int $ttl): bool;
 }

--- a/tests/lib/Lock/MemcacheLockingProviderTest.php
+++ b/tests/lib/Lock/MemcacheLockingProviderTest.php
@@ -22,6 +22,7 @@
 namespace Test\Lock;
 
 use OC\Memcache\ArrayCache;
+use OCP\AppFramework\Utility\ITimeFactory;
 
 class MemcacheLockingProviderTest extends LockingProvider {
 	/**
@@ -34,7 +35,8 @@ class MemcacheLockingProviderTest extends LockingProvider {
 	 */
 	protected function getInstance() {
 		$this->memcache = new ArrayCache();
-		return new \OC\Lock\MemcacheLockingProvider($this->memcache);
+		$timeProvider = \OC::$server->get(ITimeFactory::class);
+		return new \OC\Lock\MemcacheLockingProvider($this->memcache, $timeProvider);
 	}
 
 	protected function tearDown(): void {

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -9,11 +9,18 @@
 
 namespace Test\Memcache;
 
+use OC\Memcache\Redis;
+
 /**
  * @group Memcache
  * @group Redis
  */
 class RedisTest extends Cache {
+	/**
+	 * @var Redis cache;
+	 */
+	protected $instance;
+
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
@@ -61,5 +68,19 @@ class RedisTest extends Cache {
 		foreach (\OC\Memcache\Redis::LUA_SCRIPTS as $script) {
 			$this->assertEquals(sha1($script[0]), $script[1]);
 		}
+	}
+
+	public function testCasTtlNotChanged() {
+		$this->instance->set('foo', 'bar', 50);
+		$this->assertTrue($this->instance->compareSetTTL('foo', 'bar', 100));
+		// allow for 1s of inaccuracy due to time moving forward
+		$this->assertLessThan(1, 100 - $this->instance->getTTL('foo'));
+	}
+
+	public function testCasTtlChanged() {
+		$this->instance->set('foo', 'bar1', 50);
+		$this->assertFalse($this->instance->compareSetTTL('foo', 'bar', 100));
+		// allow for 1s of inaccuracy due to time moving forward
+		$this->assertLessThan(1, 50 - $this->instance->getTTL('foo'));
 	}
 }


### PR DESCRIPTION
With shared locks, each time the lock is acquired, the ttl for the path is reset.

Due to this "ttl extension" when a shared lock isn't freed correctly for any reason
the lock won't expire until no shared locks are required for the path for 1h.
This can lead to a client repeatedly trying to upload a file, and failing forever
because the lock never gets the opportunity to expire.

To help the lock expire in this case, we lower the TTL back to what it was before we
took the shared lock *only* if nobody else got a shared lock after we did.

This doesn't handle all cases where multiple requests are acquiring shared locks
but it should handle some of the more common ones and not hurt things further.

Ideally each copy of a shared lock will have it's own independent TTL so locks can expire while others are still being help, but we don't have that luxury.

To test:

- setup an instance with redis file locking without applying this patch
- set a breakpoint at [acquireLock](https://github.com/nextcloud/server/blob/fcae6a68c347e2913cc29f45648be37789f09c29/lib/private/Lock/MemcacheLockingProvider.php#L60)
- upload a file called `test.txt`
- note the `$path` and `$this->memcache->prefix` used for the lock for `test.txt` (check `$readablePath` to ensure you're look at the right lock)
- remove the breakpoint
- delete `test.txt`
- open a redis-cli and run
  - `set "<$this->memcache->prefix><$path>" 1` (key should be something like `bc2af67f80d0445df3c328c2a0f08faf/lockfiles/0ca47d1e59d0cbf07f715297a70f8417`
  - `expire "<$this->memcache->prefix><$path>" 3600`
- you have now created a "leaked" lock with a TTL of 1 hour
- wait a few seconds and run `expire "<$this->memcache->prefix><$path>"` in redis-cli to check that the TTL is counting down
- try to upload `test.txt` again, this should fail due to the leaked lock
- check the TTL of the leaked lock which should have been reset to ~1h
- apply the patch
- try uploading `test.txt again
- check that the TTL of the leaked lock didn't get reset to 1h