### PR TITLE
ci(checkers): Fix autoloader (re)generation for extraneous apps

### DIFF
--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -22,6 +22,11 @@ echo "Regenerating main autoloader"
 $COMPOSER_COMMAND dump-autoload -d $REPODIR
 
 for app in ${REPODIR}/apps/*; do
+	if git check-ignore ${app} -q ; then
+		echo
+		echo "${app} is not shipped. Ignoring autoloader regeneration"
+		continue
+	fi
     if [[ -d $app ]]; then
         if [[ -e ${app}/composer/composer.json ]]; then
             echo


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Running ``./build/autoloaderchecker.sh`` should only touch apps that are part of this repo.

## TODO

- [x] Fix the script

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
