### PR TITLE
ci(checkers): Require composer autoloaders for all shipped apps

### DIFF
--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -38,12 +38,10 @@ for app in ${REPODIR}/apps/*; do
 		continue
 	fi
     if [[ -d $app ]]; then
-        if [[ -e ${app}/composer/composer.json ]]; then
-            echo
-            echo "Regenerating composer files for ${app}"
-            $COMPOSER_COMMAND i --no-dev -d ${app}/composer
-            $COMPOSER_COMMAND dump-autoload -d ${app}/composer
-        fi
+		echo
+		echo "Regenerating composer files for ${app}"
+		$COMPOSER_COMMAND i --no-dev -d ${app}/composer || exit 1
+		$COMPOSER_COMMAND dump-autoload -d ${app}/composer || exit 1
     fi
 done
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

We recently had some shipped apps without autoloader files. Let's add a CI check to enforce the file for all apps in this repo.

## TODO

- [x] https://github.com/nextcloud/server/pull/36652
- [x] https://github.com/nextcloud/server/pull/37476

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
