### PR TITLE
fix default_language doc

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -165,13 +165,14 @@ $CONFIG = [
 /**
  * This sets the default language on your Nextcloud server, using ISO_639-1
  * language codes such as ``en`` for English, ``de`` for German, and ``fr`` for
- * French. It overrides automatic language detection on public pages like login
- * or shared items. User's language preferences configured under "personal ->
- * language" override this setting after they have logged in. Nextcloud has two
- * distinguished language codes for German, 'de' and 'de_DE'. 'de' is used for
- * informal German and 'de_DE' for formal German. By setting this value to 'de_DE'
- * you can enforce the formal version of German unless the user has chosen
- * something different explicitly.
+ * French. The default_language parameter is only used, when the browser does
+ * not send any language, and the user hasn’t configured own language
+ * preferences.
+ *
+ * Nextcloud has two distinguished language codes for German, 'de' and 'de_DE'.
+ * 'de' is used for informal German and 'de_DE' for formal German. By setting
+ * this value to 'de_DE' you can enforce the formal version of German unless
+ * the user has chosen something different explicitly.
  *
  * Defaults to ``en``
  */


### PR DESCRIPTION
## Summary


Since commit 0228bc6e66cbcb2848eacb41f1de6e7f63ebcb65 the browser language always is preferred.

Only doc, no code change.

## Todos

* [x] also open PR against documenation repo: https://github.com/nextcloud/documentation/pull/9990

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

