### PR TITLE
Trim the user/email provided for password resets

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -200,6 +200,8 @@ class LostController extends Controller {
 			return new JSONResponse($this->error($this->l10n->t('Password reset is disabled')));
 		}
 
+		$user = trim($user);
+		
 		\OCP\Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
@@ -208,7 +210,7 @@ class LostController extends Controller {
 
 		// FIXME: use HTTP error codes
 		try {
-			$this->sendEmail(trim($user));
+			$this->sendEmail($user);
 		} catch (ResetPasswordException $e) {
 			// Ignore the error since we do not want to leak this info
 			$this->logger->warning('Could not send password reset email: ' . $e->getMessage());

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -208,7 +208,7 @@ class LostController extends Controller {
 
 		// FIXME: use HTTP error codes
 		try {
-			$this->sendEmail($user);
+			$this->sendEmail(trim($user));
 		} catch (ResetPasswordException $e) {
 			// Ignore the error since we do not want to leak this info
 			$this->logger->warning('Could not send password reset email: ' . $e->getMessage());


### PR DESCRIPTION
* Resolves: #37408 <!-- related github issue -->

## Summary

Trims the username/email address provided by the user when requesting a lost password reset. This reduces support requests from users that complain about never receiving password reset emails (because we silently - from the user perspective - dropped the request as being a bogus username/email address).

Since this is a workflow where few indicators are provided to the user (to avoid security information leakage), it seems worthwhile to handle this for the user to catch this common and easy/no-risk scenario. We know with certainty that whitespaces are never allowed at the start/end of usernames so this is safe.

## TODO

(nothing)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
