### PR TITLE
Update AppFrameworkTainter to use non-deprecated interface

### DIFF
--- a/build/psalm/AppFrameworkTainter.php
+++ b/build/psalm/AppFrameworkTainter.php
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 use Psalm\CodeLocation;
 use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
@@ -29,27 +30,29 @@ use Psalm\Type\TaintKindGroup;
 
 class AppFrameworkTainter implements AfterFunctionLikeAnalysisInterface {
 	public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): ?bool {
-		if ($event->getStatementsSource()->getFQCLN() !== null) {
-			if ($event->getCodebase()->classExtendsOrImplements($event->getStatementsSource()->getFQCLN(), \OCP\AppFramework\Controller::class)) {
-				if ($event->getStmt() instanceof PhpParser\Node\Stmt\ClassMethod) {
-					if ($event->getStmt()->isPublic() && !$event->getStmt()->isMagic()) {
-						foreach ($event->getStmt()->params as $i => $param) {
-							$expr_type = new Psalm\Type\Union([new Psalm\Type\Atomic\TString()]);
-							$expr_identifier = (strtolower($event->getStatementsSource()->getFQCLN()) . '::' . strtolower($event->getFunctionlikeStorage()->cased_name) . '#' . ($i + 1));
-
-							if ($expr_type) {
-								$event->getCodebase()->addTaintSource(
-									$expr_type,
-									$expr_identifier,
-									TaintKindGroup::ALL_INPUT,
-									new CodeLocation($event->getStatementsSource(), $param)
-								);
-							}
-						}
-					}
-				}
-			}
+		if ($event->getStatementsSource()->getFQCLN() === null) {
+			return null;
 		}
+		if (!$event->getCodebase()->classExtendsOrImplements($event->getStatementsSource()->getFQCLN(), \OCP\AppFramework\Controller::class)) {
+			return null;
+		}
+		if (!($event->getStmt() instanceof PhpParser\Node\Stmt\ClassMethod)) {
+			return null;
+		}
+		if (!$event->getStmt()->isPublic() || $event->getStmt()->isMagic()) {
+			return null;
+		}
+		foreach ($event->getStmt()->params as $i => $param) {
+			$expr_type = new Psalm\Type\Union([new Psalm\Type\Atomic\TString()]);
+			$expr_identifier = (strtolower($event->getStatementsSource()->getFQCLN()) . '::' . strtolower($event->getFunctionlikeStorage()->cased_name) . '#' . ($i + 1));
+			$event->getCodebase()->addTaintSource(
+				$expr_type,
+				$expr_identifier,
+				TaintKindGroup::ALL_INPUT,
+				new CodeLocation($event->getStatementsSource(), $param)
+			);
+		}
+
 		return null;
 	}
 }

--- a/build/psalm/AppFrameworkTainter.php
+++ b/build/psalm/AppFrameworkTainter.php
@@ -23,31 +23,26 @@
  * SOFTWARE.
  */
 use Psalm\CodeLocation;
-use Psalm\Plugin\Hook\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
 use Psalm\Type\TaintKindGroup;
 
 class AppFrameworkTainter implements AfterFunctionLikeAnalysisInterface {
-	public static function afterStatementAnalysis(
-		PhpParser\Node\FunctionLike $stmt,
-		Psalm\Storage\FunctionLikeStorage $classlike_storage,
-		Psalm\StatementsSource $statements_source,
-		Psalm\Codebase $codebase,
-		array &$file_replacements = []
-	): ?bool {
-		if ($statements_source->getFQCLN() !== null) {
-			if ($codebase->classExtendsOrImplements($statements_source->getFQCLN(), \OCP\AppFramework\Controller::class)) {
-				if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod) {
-					if ($stmt->isPublic() && !$stmt->isMagic()) {
-						foreach ($stmt->params as $i => $param) {
+	public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): ?bool {
+		if ($event->getStatementsSource()->getFQCLN() !== null) {
+			if ($event->getCodebase()->classExtendsOrImplements($event->getStatementsSource()->getFQCLN(), \OCP\AppFramework\Controller::class)) {
+				if ($event->getStmt() instanceof PhpParser\Node\Stmt\ClassMethod) {
+					if ($event->getStmt()->isPublic() && !$event->getStmt()->isMagic()) {
+						foreach ($event->getStmt()->params as $i => $param) {
 							$expr_type = new Psalm\Type\Union([new Psalm\Type\Atomic\TString()]);
-							$expr_identifier = (strtolower($statements_source->getFQCLN()) . '::' . strtolower($classlike_storage->cased_name) . '#' . ($i + 1));
+							$expr_identifier = (strtolower($event->getStatementsSource()->getFQCLN()) . '::' . strtolower($event->getFunctionlikeStorage()->cased_name) . '#' . ($i + 1));
 
 							if ($expr_type) {
-								$codebase->addTaintSource(
+								$event->getCodebase()->addTaintSource(
 									$expr_type,
 									$expr_identifier,
 									TaintKindGroup::ALL_INPUT,
-									new CodeLocation($statements_source, $param)
+									new CodeLocation($event->getStatementsSource(), $param)
 								);
 							}
 						}


### PR DESCRIPTION
## Summary

Split out from https://github.com/nextcloud/server/pull/37390

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
