### PR TITLE
Set recommended psalm options

### DIFF
--- a/psalm-ocp.xml
+++ b/psalm-ocp.xml
@@ -6,6 +6,8 @@
 	xmlns="https://getpsalm.org/schema/config"
 	xsi:schemaLocation="https://getpsalm.org/schema/config"
     errorBaseline="build/psalm-baseline-ocp.xml"
+	findUnusedBaselineEntry="true"
+	findUnusedCode="false"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,8 @@
 	xmlns="https://getpsalm.org/schema/config"
 	xsi:schemaLocation="https://getpsalm.org/schema/config"
     errorBaseline="build/psalm-baseline.xml"
+	findUnusedBaselineEntry="true"
+	findUnusedCode="false"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />


### PR DESCRIPTION
## Summary

Split out from https://github.com/nextcloud/server/pull/37390

Psalm 5 tells you that you should set those options because psalm 6 will enforce them.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
