### PR TITLE
fix DBAL exception handling in setValues

### DIFF
--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -24,6 +24,9 @@ declare(strict_types=1);
 
 namespace Test\Security;
 
+use OCP\Security\ICredentialsManager;
+use OCP\Server;
+
 /**
  * @group DB
  */
@@ -32,7 +35,7 @@ class CredentialsManagerTest extends \Test\TestCase {
 	 * @dataProvider credentialsProvider
 	 */
 	public function testWithDB($userId, $identifier) {
-		$credentialsManager = \OC::$server->getCredentialsManager();
+		$credentialsManager = Server::get(ICredentialsManager::class);
 
 		$secrets = 'Open Sesame';
 
@@ -45,7 +48,23 @@ class CredentialsManagerTest extends \Test\TestCase {
 		$this->assertSame(1, $removedRows);
 	}
 
-	public function credentialsProvider() {
+	/**
+	 * @dataProvider credentialsProvider
+	 */
+	public function testUpdate($userId, $identifier): void {
+		$credentialsManager = Server::get(ICredentialsManager::class);
+
+		$secrets = 'Open Sesame';
+		$secretsRev = strrev($secrets);
+
+		$credentialsManager->store($userId, $identifier, $secrets);
+		$credentialsManager->store($userId, $identifier, $secretsRev);
+		$received = $credentialsManager->retrieve($userId, $identifier);
+
+		$this->assertSame($secretsRev, $received);
+	}
+
+	public function credentialsProvider(): array {
 		return [
 			[
 				'alice',


### PR DESCRIPTION
* ~~Might be related to post-close comments in #6343~~

## Summary

This seems to be a left over after abstracting DBAL. Nowadays, IQueryBuilder::executeStatement() only throws a \OCP\DB\Exception, where previously original DBAL exceptions where thrown. These are now wrapped, the orignal classes are now mapped to a reason.

(This is a by-catch of testing ldap_contacts_backend and wondering/debugging why its occ edit command was failing).

P.S.: There might be more opportunities for adjustment in this file, did not check further.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
