### PR TITLE
add command for getting fileinfo for debugging

### DIFF
--- a/apps/files_external/lib/Config/ExternalMountPoint.php
+++ b/apps/files_external/lib/Config/ExternalMountPoint.php
@@ -40,4 +40,8 @@ class ExternalMountPoint extends MountPoint {
 	public function getMountType() {
 		return ($this->storageConfig->getAuthMechanism() instanceof SessionCredentials) ? 'external-session' : 'external';
 	}
+
+	public function getStorageConfig(): StorageConfig {
+		return $this->storageConfig;
+	}
 }

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -254,6 +254,13 @@ class SharedMount extends MountPoint implements MoveableMount {
 	}
 
 	/**
+	 * @return \OCP\Share\IShare[]
+	 */
+	public function getGroupedShares(): array {
+		return $this->groupedShares;
+	}
+
+	/**
 	 * Get the file id of the root of the storage
 	 *
 	 * @return int

--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OC\Core\Command\Info;
+
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OCA\Circles\MountManager\CircleMount;
+use OCA\Files_External\Config\ExternalMountPoint;
+use OCA\Files_Sharing\SharedMount;
+use OCA\GroupFolders\Mount\GroupMountPoint;
+use OCP\Constants;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\Share\IShare;
+use OCP\Util;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class File extends Command {
+	private IRootFolder $rootFolder;
+	private IUserMountCache $userMountCache;
+	private IL10N $l10n;
+
+	public function __construct(IRootFolder $rootFolder, IUserMountCache $userMountCache, IFactory $l10nFactory) {
+		$this->rootFolder = $rootFolder;
+		$this->userMountCache = $userMountCache;
+		$this->l10n = $l10nFactory->get("core");
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('info:file')
+			->setDescription('get information for a file')
+			->addArgument('file', InputArgument::REQUIRED, "File id or path")
+			->addOption('children', 'c', InputOption::VALUE_NONE, "List children of folders");
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$fileInput = $input->getArgument('file');
+		$showChildren = $input->getOption('children');
+		$node = $this->getNode($fileInput);
+		if (!$node) {
+			$output->writeln("<error>file $fileInput not found</error>");
+			return 1;
+		}
+
+		$output->writeln($node->getName());
+		$output->writeln("  fileid: " . $node->getId());
+		$output->writeln("  mimetype: " . $node->getMimetype());
+		$output->writeln("  modified: " . (string)$this->l10n->l("datetime", $node->getMTime()));
+		$output->writeln("  size: " . Util::humanFileSize($node->getSize()));
+		$output->writeln("  " . ($node->isEncrypted() ? "encrypted" : "not encrypted"));
+		if ($node instanceof Folder) {
+			$children = $node->getDirectoryListing();
+			if ($showChildren) {
+				$output->writeln("  children: " . count($children) . ":");
+				foreach ($children as $child) {
+					$output->writeln("  - " . $child->getName());
+				}
+			} else {
+				$output->writeln("  children: " . count($children) . " (--children to list)");
+			}
+		}
+		$this->outputStorageDetails($node->getMountPoint(), $node, $output);
+
+		$filesPerUser = $this->getFilesByUser($node);
+		$output->writeln("");
+		$output->writeln("The following users have access to the file");
+		$output->writeln("");
+		foreach ($filesPerUser as $user => $files) {
+			$output->writeln("$user:");
+			foreach ($files as $userFile) {
+				$output->writeln("  " . $userFile->getPath() . ": " . $this->formatPermissions($userFile->getType(), $userFile->getPermissions()));
+				$mount = $userFile->getMountPoint();
+				$output->writeln("    " . $this->formatMountType($mount));
+			}
+		}
+
+		return 0;
+	}
+
+	private function getNode(string $fileInput): ?Node {
+		if (is_numeric($fileInput)) {
+			$mounts = $this->userMountCache->getMountsForFileId((int)$fileInput);
+			if (!$mounts) {
+				return null;
+			}
+			$mount = $mounts[0];
+			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
+			$nodes = $userFolder->getById((int)$fileInput);
+			if (!$nodes) {
+				return null;
+			}
+			return $nodes[0];
+		} else {
+			try {
+				return $this->rootFolder->get($fileInput);
+			} catch (NotFoundException $e) {
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * @param FileInfo $file
+	 * @return array<string, Node[]>
+	 * @throws \OCP\Files\NotPermittedException
+	 * @throws \OC\User\NoUserException
+	 */
+	private function getFilesByUser(FileInfo $file): array {
+		$id = $file->getId();
+		if (!$id) {
+			return [];
+		}
+
+		$mounts = $this->userMountCache->getMountsForFileId($id);
+		$result = [];
+		foreach ($mounts as $mount) {
+			if (isset($result[$mount->getUser()->getUID()])) {
+				continue;
+			}
+
+			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
+			$result[$mount->getUser()->getUID()] = $userFolder->getById($id);
+		}
+
+		return $result;
+	}
+
+	private function formatPermissions(string $type, int $permissions): string {
+		if ($permissions == Constants::PERMISSION_ALL || ($type === 'file' && $permissions == (Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE))) {
+			return "full permissions";
+		}
+
+		$perms = [];
+		$allPerms = [Constants::PERMISSION_READ => "read", Constants::PERMISSION_UPDATE => "update", Constants::PERMISSION_CREATE => "create", Constants::PERMISSION_DELETE => "delete", Constants::PERMISSION_SHARE => "share"];
+		foreach ($allPerms as $perm => $name) {
+			if (($permissions & $perm) === $perm) {
+				$perms[] = $name;
+			}
+		}
+
+		return implode(", ", $perms);
+	}
+
+	private function formatMountType(IMountPoint $mountPoint): string {
+		$storage = $mountPoint->getStorage();
+		if ($storage && $storage->instanceOfStorage(IHomeStorage::class)) {
+			return "home storage";
+		} elseif ($mountPoint instanceof SharedMount) {
+			$share = $mountPoint->getShare();
+			$shares = $mountPoint->getGroupedShares();
+			$sharedBy = array_map(function (IShare $share) {
+				$shareType = $this->formatShareType($share);
+				if ($shareType) {
+					return $share->getSharedBy() . " (via " . $shareType . " " . $share->getSharedWith() . ")";
+				} else {
+					return $share->getSharedBy();
+				}
+			}, $shares);
+			$description = "shared by " . implode(', ', $sharedBy);
+			if ($share->getSharedBy() !== $share->getShareOwner()) {
+				$description .= " owned by " . $share->getShareOwner();
+			}
+			return $description;
+		} elseif ($mountPoint instanceof GroupMountPoint) { /** @psalm-suppress UndefinedClass */
+			return "groupfolder " . $mountPoint->getFolderId();
+		} elseif ($mountPoint instanceof ExternalMountPoint) {
+			return "external storage " . $mountPoint->getStorageConfig()->getId();
+		} elseif ($mountPoint instanceof CircleMount) {
+			return "circle";
+		}
+		return get_class($mountPoint);
+	}
+
+	private function formatShareType(IShare $share): ?string {
+		switch ($share->getShareType()) {
+			case IShare::TYPE_GROUP:
+				return "group";
+			case IShare::TYPE_CIRCLE:
+				return "circle";
+			case IShare::TYPE_DECK:
+				return "deck";
+			case IShare::TYPE_ROOM:
+				return "room";
+			case IShare::TYPE_USER:
+				return null;
+			default:
+				return "Unknown (".$share->getShareType().")";
+		}
+	}
+
+	private function outputStorageDetails(IMountPoint $mountPoint, Node $node, OutputInterface $output): void {
+		$storage = $mountPoint->getStorage();
+		if (!$storage) {
+			return;
+		}
+		if (!$storage->instanceOfStorage(IHomeStorage::class)) {
+			$output->writeln("  mounted at: " . $mountPoint->getMountPoint());
+		}
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			/** @var ObjectStoreStorage $storage */
+			$objectStoreId = $storage->getObjectStore()->getStorageId();
+			$parts = explode(':', $objectStoreId);
+			$bucket = array_pop($parts);
+			$output->writeln("  bucket: " . $bucket);
+			if ($node instanceof \OC\Files\Node\File) {
+				$output->writeln("  object id: " . $storage->getURN($node->getId()));
+				try {
+					$fh = $node->fopen('r');
+					if (!$fh) {
+						throw new NotFoundException();
+					}
+					$stat = fstat($fh);
+					fclose($fh);
+					if ($stat['size'] !== $node->getSize()) {
+						$output->writeln("  <error>warning: object had a size of " . $stat['size'] . " but cache entry has a size of " . $node->getSize() . "</error>. This should have been automatically repaired");
+					}
+				} catch (\Exception $e) {
+					$output->writeln("  <error>warning: object not found in bucket</error>");
+				}
+			}
+		} else {
+			if (!$storage->file_exists($node->getInternalPath())) {
+				$output->writeln("  <error>warning: file not found in storage</error>");
+			}
+		}
+		if ($mountPoint instanceof ExternalMountPoint) {
+			$storageConfig = $mountPoint->getStorageConfig();
+			$output->writeln("  external storage id: " . $storageConfig->getId());
+			$output->writeln("  external type: " . $storageConfig->getBackend()->getText());
+		} elseif ($mountPoint instanceof GroupMountPoint) { /** @psalm-suppress UndefinedClass */
+			$output->writeln("  groupfolder id: " . $mountPoint->getFolderId());
+		}
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -103,6 +103,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
 	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
 
+	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
+
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -941,6 +941,7 @@ return array(
     'OC\\Core\\Command\\Group\\Info' => $baseDir . '/core/Command/Group/Info.php',
     'OC\\Core\\Command\\Group\\ListCommand' => $baseDir . '/core/Command/Group/ListCommand.php',
     'OC\\Core\\Command\\Group\\RemoveUser' => $baseDir . '/core/Command/Group/RemoveUser.php',
+    'OC\\Core\\Command\\Info\\File' => $baseDir . '/core/Command/Info/File.php',
     'OC\\Core\\Command\\Integrity\\CheckApp' => $baseDir . '/core/Command/Integrity/CheckApp.php',
     'OC\\Core\\Command\\Integrity\\CheckCore' => $baseDir . '/core/Command/Integrity/CheckCore.php',
     'OC\\Core\\Command\\Integrity\\SignApp' => $baseDir . '/core/Command/Integrity/SignApp.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -974,6 +974,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Group\\Info' => __DIR__ . '/../../..' . '/core/Command/Group/Info.php',
         'OC\\Core\\Command\\Group\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/Group/ListCommand.php',
         'OC\\Core\\Command\\Group\\RemoveUser' => __DIR__ . '/../../..' . '/core/Command/Group/RemoveUser.php',
+        'OC\\Core\\Command\\Info\\File' => __DIR__ . '/../../..' . '/core/Command/Info/File.php',
         'OC\\Core\\Command\\Integrity\\CheckApp' => __DIR__ . '/../../..' . '/core/Command/Integrity/CheckApp.php',
         'OC\\Core\\Command\\Integrity\\CheckCore' => __DIR__ . '/../../..' . '/core/Command/Integrity/CheckCore.php',
         'OC\\Core\\Command\\Integrity\\SignApp' => __DIR__ . '/../../..' . '/core/Command/Integrity/SignApp.php',


### PR DESCRIPTION
Attempts to provide information that might be useful when debugging issues as well as perform some sanity checks.
This hopefully allows people without knowledge of the Nextcloud internals to access debug information that is currently only accessible trough manual database querying or other convoluted steps.

```
occ info:file <fileid or path>
```

Currently includes:

- basic file metadata
- bucket + object info when using objectstore
- validate object existence and size
- list of users with access, their permissions and how they got their access
- basic groupfolder and external storage info
- option to list contents of folder
- validate folder size against children

(Possible) future work

- [ ] validate encrypted files
- [ ] validate folder size
- [ ] option to show versions
- [ ] more details from storage backends
- [ ] anything else that might be useful that currently isn't exposed