### PR TITLE
Adjust the value of the "max-parts" parameter of the object storage 'ListPart' interface to 1000

### DIFF
--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -81,7 +81,7 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 				'MaxParts' => 1000,
 				'PartNumberMarker' => $partNumberMarker
 			]);
-			$parts = array_merge($parts, $result->get('Parts'));
+			$parts = array_merge($parts, $result->get('Parts') ?? []);
 			$isTruncated = $result->get('IsTruncated');
 			$partNumberMarker = $result->get('NextPartNumberMarker');
 		}

--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -73,7 +73,7 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 			'Bucket' => $this->bucket,
 			'Key' => $urn,
 			'UploadId' => $uploadId,
-			'MaxParts' => 10000
+			'MaxParts' => 1000
 		]);
 		return $parts->get('Parts') ?? [];
 	}


### PR DESCRIPTION
## Summary
Adjust the 'max-parts' parameter of the List Parts interface in the object storage to 1000 to solve the compatibility issue of Tencent Cloud object storage.

According to the [documentation](https://cloud.tencent.com/document/product/436/7747), Tencent Cloud Object Storage (COS) does not support calls to the max parts parameter of the ListPart interface for values greater than 1000.

## Error Log

Aws\S3\Exception\S3Exception: Error executing "ListParts" on "https://cloud-xxx.cos.ap-xxx.myqcloud.com/xxxxxxxxxxxxxx&max-parts=10000"; AWS HTTP error: Client error: `GET https://cloud-xxx.cos.ap-xxx.myqcloud.com/xxxxxxxxxxxxxx&max-parts=10000` resulted in a `400 Bad Request` response: <?xml version='1.0' encoding='utf-8' ?> <Error> <Code>InvalidArgument</Code> <Message>The parameter max-parts is not v (truncated...) InvalidArgument (client): The parameter max-parts is not valid - <?xml version='1.0' encoding='utf-8' ?> <Error> <Code>InvalidArgument</Code> <Message>The parameter max-parts is not valid</Message> <Resource>/urn:xxxx</Resource> <RequestId>xxxxxxxxxxxxxxxxxxxxxxxxxxxx</RequestId> <TraceId>xxxxxxxxxxxxxxxxxxxxxxxxxxxx</TraceId> </Error>


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
