### PR TITLE
Remove EOL software from drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -271,44 +271,6 @@ trigger:
 
 ---
 kind: pipeline
-name: mariadb10.2-php8.0
-
-steps:
-- name: submodules
-  image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
-  commands:
-    - git submodule update --init
-- name: mariadb10.2-php8.0
-  image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
-  commands:
-    - bash tests/drone-run-php-tests.sh || exit 0
-    - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mariadb
-
-services:
-- name: cache
-  image: ghcr.io/nextcloud/continuous-integration-redis:latest
-- name: mariadb
-  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.2:10.2
-  environment:
-    MYSQL_ROOT_PASSWORD: owncloud
-    MYSQL_USER: oc_autotest
-    MYSQL_PASSWORD: owncloud
-    MYSQL_DATABASE: oc_autotest
-  command:
-    - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
-  tmpfs:
-    - /var/lib/mysql
-
-trigger:
-  branch:
-    - master
-    - stable*
-  event:
-    - pull_request
-    - push
-
----
-kind: pipeline
 name: mariadb10.4-php8.0
 
 steps:
@@ -413,42 +375,6 @@ services:
     MYSQL_DATABASE: oc_autotest
   tmpfs:
     - /var/lib/mysql
-
-trigger:
-  branch:
-    - master
-    - stable*
-  event:
-    - pull_request
-    - push
-
----
-kind: pipeline
-name: postgres10-php8.0
-
-steps:
-- name: submodules
-  image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
-  commands:
-    - git submodule update --init
-- name: postgres-php8.0
-  image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
-  commands:
-    - bash tests/drone-run-php-tests.sh || exit 0
-    - sleep 10 # gives the database enough time to initialize
-    - POSTGRES=10 NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh pgsql
-
-services:
-- name: cache
-  image: ghcr.io/nextcloud/continuous-integration-redis:latest
-- name: postgres-10
-  image: ghcr.io/nextcloud/continuous-integration-postgres-10:postgres-10
-  environment:
-    POSTGRES_USER: oc_autotest
-    POSTGRES_DB: oc_autotest
-    POSTGRES_PASSWORD: owncloud
-  tmpfs:
-    - /var/lib/postgresql/data
 
 trigger:
   branch:


### PR DESCRIPTION
## Summary

Removes:
- MariaDB 10.2 - https://mariadb.org/about/#maintenance-policy
- Postgres 10 - https://www.postgresql.org/support/versioning/

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)