### PR TITLE
fix(initial-state): Log an error when initial-state can not be JSON e…

### DIFF
--- a/lib/private/InitialStateService.php
+++ b/lib/private/InitialStateService.php
@@ -64,7 +64,11 @@ class InitialStateService implements IInitialStateService {
 			if (!isset($this->states[$appName])) {
 				$this->states[$appName] = [];
 			}
-			$this->states[$appName][$key] = json_encode($data);
+			try {
+				$this->states[$appName][$key] = json_encode($data, JSON_THROW_ON_ERROR);
+			} catch (\JsonException $e) {
+				$this->logger->error('Invalid '. $key . ' data provided to provideInitialState by ' . $appName, ['exception' => $e]);
+			}
 			return;
 		}
 


### PR DESCRIPTION
…ncoded

## Summary

* Helps to discover cases like https://github.com/nextcloud/spreed/issues/9181
* Provide data that can not be json encoded (e.g. `INF`) as initial state breaks the state.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
