### PR TITLE
Log a warning when a user or group is mapped with a suffix

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -589,6 +589,15 @@ class Access extends LDAPUtility {
 		$altName = $this->createAltInternalOwnCloudName($intName, $isUser);
 		if (is_string($altName)) {
 			if ($this->mapAndAnnounceIfApplicable($mapper, $fdn, $altName, $uuid, $isUser)) {
+				$this->logger->warning(
+					'Mapped {fdn} as {altName} because of a name collision on {intName}.',
+					[
+						'fdn' => $fdn,
+						'altName' => $altName,
+						'intName' => $intName,
+						'app' => 'user_ldap',
+					]
+				);
 				$newlyMapped = true;
 				return $altName;
 			}


### PR DESCRIPTION
Most of the time, this is the result of a misconfiguration by the admin
 and is not what is expected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
