### PR TITLE
Enhance quota exceeded logging for admins

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -41,6 +41,14 @@ use Test\TestCase;
  * later.
  * See the COPYING-README file.
  */
+
+/**
+ * Class QuotaPluginTest
+ *
+ * @group DB
+ *
+ */
+
 class QuotaPluginTest extends TestCase {
 
 	/** @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject */


### PR DESCRIPTION
* Resolves: #37519 <!-- related github issue -->

## Summary

Enhances quota exceeded server-side logging for administrators by adding:
* target folder owner name (i.e. when shared)
 * indicator of user quota (vs disk space) issue

Context: The existing `Insufficient space` error logging doesn't indicate the folder owner (which is important since the sharee path is what's logged). In addition, quota issues are addressed differently than, say, disk space issues so administrators benefit from quickly noting the type of `Insufficient space` issue occurring.

Applies to file/folder operations: uploads, moves, copies

Also:
* improves - indirectly - the user-facing messaging when uploading (only*)
* Doesn't include the owner when it's useless (i.e. not shared)

Addresses backend portion of #37519 

*Currently working on independent (but related) PRs to unify frontend messaging with same target folder owner inclusion (when applicable)

## TODO

- [x] Review code

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
