### PR TITLE
Move heading to the main content

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -57,9 +57,6 @@ p($theme->getTitle());
 		</div>
 
 		<header role="banner" id="header">
-			<h1 class="hidden-visually" id="page-heading-level-1">
-				<?php p(!empty($_['pageTitle'])?$_['pageTitle']:$theme->getName()); ?>
-			</h1>
 			<div class="header-left">
 				<a href="<?php print_unescaped($_['logoUrl'] ?: link_to('', 'index.php')); ?>"
 					aria-label="<?php p($l->t('Go to %s', [$_['logoUrl'] ?: $_['defaultAppName']])); ?>"
@@ -89,6 +86,9 @@ p($theme->getTitle());
 		</form>
 
 		<main id="content" class="app-<?php p($_['appid']) ?>">
+			<h1 class="hidden-visually" id="page-heading-level-1">
+				<?php p(!empty($_['pageTitle'])?$_['pageTitle']:$theme->getName()); ?>
+			</h1>
 			<?php print_unescaped($_['content']); ?>
 		</main>
 		<div id="profiler-toolbar"></div>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36911

## Summary

Move `<h1>` heading in the main landmark instead of the `<header>`.
By jumping directly to the h1 heading the user would be able to navigate through the main content of the page immediately.
See https://github.com/nextcloud/server/issues/36911#issuecomment-1492439336

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-04-05 10-47-51](https://user-images.githubusercontent.com/6078378/230030511-7eb2b4a4-dbe3-4732-b4f8-ac58e674a3db.png) |![Screenshot from 2023-04-05 10-34-01](https://user-images.githubusercontent.com/6078378/230026908-a33447e2-4025-47e4-bae5-9fbba322558a.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
