### PR TITLE
Add some tests for input trimming in LostController.php

### DIFF
--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * @author Lukas Reschke <lukas@owncloud.com>
+ * @author Joshua Trees <me@jtrees.io>
  *
  * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @copyright Copyright (c) 2023, Joshua Trees <me@jtrees.io>
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -720,5 +722,39 @@ class LostControllerTest extends TestCase {
 
 		$result = self::invokePrivate($this->lostController, 'findUserByIdOrMail', ['test@example.com']);
 		$this->assertInstanceOf(IUser::class, $result);
+	}
+
+	public function testTrimEmailInput() {
+		$this->userManager
+				->expects($this->once())
+				->method('getByEmail')
+				->with('test@example.com')
+				->willReturn([$this->existingUser]);
+
+		$this->mailer
+			->expects($this->once())
+			->method('send');
+
+		$response = $this->lostController->email('  test@example.com  ');
+		$expectedResponse = new JSONResponse(['status' => 'success']);
+		$expectedResponse->throttle();
+		$this->assertEquals($expectedResponse, $response);
+	}
+
+	public function testUsernameInput() {
+		$this->userManager
+				->expects($this->once())
+				->method('get')
+				->with('ExistingUser')
+				->willReturn($this->existingUser);
+
+		$this->mailer
+			->expects($this->once())
+			->method('send');
+
+		$response = $this->lostController->email('  ExistingUser  ');
+		$expectedResponse = new JSONResponse(['status' => 'success']);
+		$expectedResponse->throttle();
+		$this->assertEquals($expectedResponse, $response);
 	}
 }


### PR DESCRIPTION
## Summary

Provides tests for the changes made in #37495 (thanks @joshtrichards).

Note: This is my first code contribution to nextcloud. Let me know if I should be doing something differently.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
