### PR TITLE
Remove PHP 7 rules from .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -55,17 +55,6 @@
   </FilesMatch>
 </IfModule>
 
-# PHP 7.x
-<IfModule mod_php7.c>
-  php_value mbstring.func_overload 0
-  php_value default_charset 'UTF-8'
-  php_value output_buffering 0
-  <IfModule mod_env.c>
-    SetEnv htaccessWorking true
-  </IfModule>
-</IfModule>
-
-# PHP 8+
 <IfModule mod_php.c>
   php_value mbstring.func_overload 0
   php_value default_charset 'UTF-8'


### PR DESCRIPTION
## Summary
Following https://github.com/nextcloud/server/pull/34997

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)