### PR TITLE
Unquote S3 ETag stored in oc_filecache

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -724,7 +724,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			'mimetype' => $this->mimeDetector->detectPath($object['Key']),
 			'mtime' => strtotime($object['LastModified']),
 			'storage_mtime' => strtotime($object['LastModified']),
-			'etag' => $object['ETag'],
+			'etag' => trim($object['ETag'], '"'),
 			'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE,
 			'size' => (int)($object['Size'] ?? $object['ContentLength']),
 		];


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/33785

## Summary

I have applied this patch to my own server with a fresh install. I can confirm it fixes https://github.com/nextcloud/server/issues/33785 on my end.

The ETag returned by S3 API is quoted. See https://stackoverflow.com/questions/59382789/why-does-s3-etag-have-extra-characters/59383943#59383943 However, a typical ETag stored in oc_filecache is not quoted

## TODO

- [ ] Go through the checklist. I haven't got time to go through everything yet. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
