### PR TITLE
fix: Wrap filesystem LockedExceptions for holding the readable path

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -764,6 +764,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		try {
 			$provider->acquireLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type, $this->getId() . '::' . $path);
 		} catch (LockedException $e) {
+			$e = new LockedException($e->getPath(), $e, $e->getExistingLock(), $path);
 			if ($logger) {
 				$logger->info($e->getMessage(), ['exception' => $e]);
 			}
@@ -796,6 +797,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		try {
 			$provider->releaseLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
 		} catch (LockedException $e) {
+			$e = new LockedException($e->getPath(), $e, $e->getExistingLock(), $path);
 			if ($logger) {
 				$logger->info($e->getMessage(), ['exception' => $e]);
 			}
@@ -828,6 +830,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		try {
 			$provider->changeLock('files/' . md5($this->getId() . '::' . trim($path, '/')), $type);
 		} catch (LockedException $e) {
+			$e = new LockedException($e->getPath(), $e, $e->getExistingLock(), $path);
 			if ($logger) {
 				$logger->info($e->getMessage(), ['exception' => $e]);
 			}


### PR DESCRIPTION

## Summary

Provide more useful readable paths when exceptions occur during locking

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
