### PR TITLE
fix output for group:list command with numeric user ids

### DIFF
--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -76,6 +76,17 @@ class ListCommand extends Base {
 	}
 
 	/**
+	 * @param IGroup $group
+	 * @return string[]
+	 */
+	public function usersForGroup(IGroup $group) {
+		$users = array_keys($group->getUsers());
+		return array_map(function ($userId) {
+			return (string)$userId;
+		}, $users);
+	}
+
+	/**
 	 * @param IGroup[] $groups
 	 * @return array
 	 */
@@ -88,12 +99,12 @@ class ListCommand extends Base {
 			$values = array_map(function (IGroup $group) {
 				return [
 					'backends' => $group->getBackendNames(),
-					'users' => array_keys($group->getUsers()),
+					'users' => $this->usersForGroup($group),
 				];
 			}, $groups);
 		} else {
 			$values = array_map(function (IGroup $group) {
-				return array_keys($group->getUsers());
+				return $this->usersForGroup($group);
 			}, $groups);
 		}
 		return array_combine($keys, $values);


### PR DESCRIPTION
Ensure userids are always strings to prevent issues with any code parsing the json output