### PR TITLE
fix: log fopen calls when stream isn't available

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -36,6 +36,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use ownCloud\TarStreamer\TarStreamer;
+use Psr\Log\LoggerInterface;
 use ZipStreamer\ZipStreamer;
 
 class Streamer {
@@ -122,10 +123,16 @@ class Streamer {
 		$dirNode = $userFolder->get($dir);
 		$files = $dirNode->getDirectoryListing();
 
+		/** @var LoggerInterface $logger */
+		$logger = \OC::$server->query(LoggerInterface::class);
 		foreach ($files as $file) {
 			if ($file instanceof File) {
 				try {
 					$fh = $file->fopen('r');
+					if ($fh === false) {
+						$logger->error('Unable to open file for stream: ' . print_r($file, true));
+						continue;
+					}
 				} catch (NotPermittedException $e) {
 					continue;
 				}


### PR DESCRIPTION
By recommendation from @icewind1991 trying this on 27 to see if the failed tests in https://github.com/nextcloud/server/pull/37284 are down to stable20 being broken or actually breaking stuff.