### PR TITLE
fix: Always create user directory when transfering files to new users

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -115,6 +115,9 @@ class OwnershipTransferService {
 
 		// setup filesystem
 		// Requesting the user folder will set it up if the user hasn't logged in before
+		// We need a setupFS for the full filesystem setup before as otherwise we will just return
+		// a lazy root folder which does not create the destination users folder
+		\OC_Util::setupFS($destinationUser->getUID());
 		\OC::$server->getUserFolder($destinationUser->getUID());
 		Filesystem::initMountPoints($sourceUid);
 		Filesystem::initMountPoints($destinationUid);


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/30953 was originally there to fix this however with the partial file system setup in 24 we no longer setup the full file system when requesting the user root. This means that the call for getUserFolder does not create the folder but returns a LazyRootFolder instead. However since further handling of transfer ownership does not go through the Nodes API the actual RootFolder handling is never triggered. Explicitly calling for a full FS setup fixes this.

Steps to reproduce:
- Create a new user that has never logged in
- call occ files:transfer-ownership admin newuser

Fixes https://github.com/nextcloud/server/issues/35111