### PR TITLE
fix(dav): add string comparison for diff

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -98,7 +98,7 @@ class IMipService {
 			return $default;
 		}
 		$newstring = $vevent->$property->getValue();
-		if(isset($oldVEvent->$property)) {
+		if(isset($oldVEvent->$property) && $oldVEvent->$property->getValue() !== $newstring ) {
 			$oldstring = $oldVEvent->$property->getValue();
 			return sprintf($strikethrough, $oldstring, $newstring);
 		}
@@ -128,7 +128,7 @@ class IMipService {
 			$data['meeting_location_html'] = $this->generateDiffString($vEvent, $oldVEvent, 'LOCATION', $data['meeting_location']);
 
 			$oldUrl = self::readPropertyWithDefault($oldVEvent, 'URL', $defaultVal);
-			$data['meeting_url_html'] = !empty($oldUrl) ? sprintf('<a href="%1$s">%1$s</a>', $oldUrl) : $data['meeting_url'];
+			$data['meeting_url_html'] = !empty($oldUrl) && $oldUrl !== $data['meeting_url'] ? sprintf('<a href="%1$s">%1$s</a>', $oldUrl) : $data['meeting_url'];
 
 			$data['meeting_when_html'] =
 				($oldMeetingWhen !== $data['meeting_when'] && $oldMeetingWhen !== null)
@@ -477,7 +477,7 @@ class IMipService {
 	 */
 	public function addBulletList(IEMailTemplate $template, VEvent $vevent, $data) {
 		$template->addBodyListItem(
-			$data['meeting_title'], $this->l10n->t('Title:'),
+			$data['meeting_title_html'] ?? $data['meeting_title'], $this->l10n->t('Title:'),
 			$this->getAbsoluteImagePath('caldav/title.png'), $data['meeting_title'], '', IMipPlugin::IMIP_INDENT);
 		if ($data['meeting_when'] !== '') {
 			$template->addBodyListItem($data['meeting_when_html'] ?? $data['meeting_when'], $this->l10n->t('Time:'),


### PR DESCRIPTION
* Resolves: #37282

## Summary
The diffing didn't diff. Now it does.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/7427347/230505480-bca8cab0-a371-42ef-abc2-239b81acabff.png) | ![image](https://user-images.githubusercontent.com/7427347/230505556-0a467246-448f-47f4-828c-818dfc7770ca.png) | 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
