### PR TITLE
fix(dav): Parse sender PARTSTAT in REPLYs

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -217,10 +217,12 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$sender = substr($iTipMessage->sender, 7);
 
+		$replyingAttendee = null;
 		switch (strtolower($iTipMessage->method)) {
 			case self::METHOD_REPLY:
 				$method = self::METHOD_REPLY;
 				$data = $this->imipService->buildBodyData($vEvent, $oldVevent);
+				$replyingAttendee = $this->imipService->getReplyingAttendee($iTipMessage);
 				break;
 			case self::METHOD_CANCEL:
 				$method = self::METHOD_CANCEL;
@@ -256,7 +258,7 @@ class IMipPlugin extends SabreIMipPlugin {
 		$template = $this->mailer->createEMailTemplate('dav.calendarInvite.' . $method, $data);
 		$template->addHeader();
 
-		$this->imipService->addSubjectAndHeading($template, $method, $data['invitee_name'], $data['meeting_title'], $isModified);
+		$this->imipService->addSubjectAndHeading($template, $method, $data['invitee_name'], $data['meeting_title'], $isModified, $replyingAttendee);
 		$this->imipService->addBulletList($template, $vEvent, $data);
 
 		// Only add response buttons to invitation requests: Fix Issue #11230


### PR DESCRIPTION
* Resolves: #36554

## Summary

Parse the PARTSTAT of the sender if the iMIP method is `REPLY`. Will make iMIP emails more fancy and tell the recipient if the attendee has accepted, declined or tentatively accepted in the mail itself:

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/7427347/230615651-e918e7e0-cde5-4138-9130-36198ce3354f.png) | ![image](https://user-images.githubusercontent.com/7427347/230614756-43a1d565-1ae8-4ab1-b06c-7a5fbe709230.png) | 

(Strings need to be translated yet)
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
