### PR TITLE
app type extended_authentication

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1027,6 +1027,7 @@ class OC {
 
 		// Always load authentication apps
 		OC_App::loadApps(['authentication']);
+		OC_App::loadApps(['extended_authentication']);
 
 		// Load minimum set of apps
 		if (!\OCP\Util::needUpgrade()

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -331,7 +331,7 @@ class Updater extends BasicEmitter {
 	 */
 	protected function doAppUpgrade(): void {
 		$apps = \OC_App::getEnabledApps();
-		$priorityTypes = ['authentication', 'filesystem', 'logging'];
+		$priorityTypes = ['authentication', 'extended_authentication', 'filesystem', 'logging'];
 		$pseudoOtherType = 'other';
 		$stacks = [$pseudoOtherType => []];
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -50,6 +50,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 try {
 	OC_App::loadApps(['session']);
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['extended_authentication']);
 
 	// load all apps to get all api routes properly setup
 	// FIXME: this should ideally appear after handleLogin but will cause

--- a/public.php
+++ b/public.php
@@ -66,6 +66,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['extended_authentication']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	if (!\OC::$server->getAppManager()->isInstalled($app)) {

--- a/remote.php
+++ b/remote.php
@@ -153,6 +153,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_App::loadApps(['extended_authentication']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	switch ($app) {

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -340,6 +340,7 @@
             <xs:element name="prelogin" minOccurs="0" maxOccurs="1"/>
             <xs:element name="filesystem" minOccurs="0" maxOccurs="1"/>
             <xs:element name="authentication" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="extended_authentication" minOccurs="0" maxOccurs="1"/>
             <xs:element name="logging" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dav" minOccurs="0" maxOccurs="1"/>
             <xs:element name="prevent_group_restriction" minOccurs="0"

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -336,6 +336,7 @@
             <xs:element name="prelogin" minOccurs="0" maxOccurs="1"/>
             <xs:element name="filesystem" minOccurs="0" maxOccurs="1"/>
             <xs:element name="authentication" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="extended_authentication" minOccurs="0" maxOccurs="1"/>
             <xs:element name="logging" minOccurs="0" maxOccurs="1"/>
             <xs:element name="dav" minOccurs="0" maxOccurs="1"/>
             <xs:element name="prevent_group_restriction" minOccurs="0"


### PR DESCRIPTION
`globalsiteselector` is a single app used in `globalscale` that redirect users and/or sessions from one instance (master) to another (slaves) while working with local account, ldap, sso and saml.

Some use-cases:

- when using SAML, then authentication of the user is done on the master, a session is opened on the assigned slave and user is redirected. In that case, the globalsiteselector will comes with its own UserBackend that needs to be loaded soon enough in the process.
- on some OCS API Request, the `globalsiteselector` app **must** be loaded before the `files` app
- when using LDAP, the authentication is done on the slave. Based on the userid, the master will create a token with uid/password and redirect the user to the assigned slave. The slave will perform the authentication and `user_ldap` needs to be loaded before `globalsiteselector`

In conclusion, `globalsiteselector` needs to be loaded once all apps `type=authentication` are loaded and before `type=filesystem`

This fix creates a new type of apps for `globalsiteselector` that is loaded right after `authentication`.



