### PR TITLE
Add LimitRequestBody 0 to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -95,3 +95,4 @@
 
 AddDefaultCharset utf-8
 Options -Indexes
+LimitRequestBody 0


### PR DESCRIPTION
"LimitRequestBody 0" allows uploading files bigger than 1024 MB, which seems to be the default apache webserver value. This is important as some browsers do not respect the chunking (for some of my Safari users this happens randomly) and the upload fails with the error "Expected filesize of 1207907122 bytes but read (from Nextcloud client) and wrote (to Nextcloud storage) 0 bytes.".

In addition it allows setting a chunking size bigger than 1024 MB.

* Resolves:
https://github.com/nextcloud/server/issues/37695

