### PR TITLE
fix(translation): Fix several issues with the translations api

### DIFF
--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -72,9 +72,9 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 		} catch (PreConditionNotMetException) {
 			return new DataResponse(['message' => $this->l->t('No translation provider available')], Http::STATUS_PRECONDITION_FAILED);
 		} catch (InvalidArgumentException) {
-			return new DataResponse(['message' => $this->l->t('Could not detect language')], Http::STATUS_NOT_FOUND);
+			return new DataResponse(['message' => $this->l->t('Could not detect language')], Http::STATUS_BAD_REQUEST);
 		} catch (RuntimeException) {
-			return new DataResponse(['message' => $this->l->t('Unable to translate')], Http::STATUS_INTERNAL_SERVER_ERROR);
+			return new DataResponse(['message' => $this->l->t('Unable to translate')], Http::STATUS_BAD_REQUEST);
 		}
 	}
 }

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -29,6 +29,7 @@ namespace OC\Core\Controller;
 use InvalidArgumentException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\PreConditionNotMetException;
 use OCP\Translation\ITranslationManager;
@@ -36,11 +37,18 @@ use RuntimeException;
 
 class TranslationApiController extends \OCP\AppFramework\OCSController {
 	private ITranslationManager $translationManager;
+	private IL10N $l;
 
-	public function __construct($appName, IRequest $request, ITranslationManager $translationManager) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		ITranslationManager $translationManager,
+		IL10N $l,
+	) {
 		parent::__construct($appName, $request);
 
 		$this->translationManager = $translationManager;
+		$this->l = $l;
 	}
 
 	/**
@@ -62,11 +70,11 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 				'text' => $this->translationManager->translate($text, $fromLanguage, $toLanguage)
 			]);
 		} catch (PreConditionNotMetException) {
-			return new DataResponse(['message' => 'No translation provider available'], Http::STATUS_PRECONDITION_FAILED);
+			return new DataResponse(['message' => $this->l->t('No translation provider available')], Http::STATUS_PRECONDITION_FAILED);
 		} catch (InvalidArgumentException) {
-			return new DataResponse(['message' => 'Could not detect language', Http::STATUS_NOT_FOUND]);
+			return new DataResponse(['message' => $this->l->t('Could not detect language'), Http::STATUS_NOT_FOUND]);
 		} catch (RuntimeException) {
-			return new DataResponse(['message' => 'Unable to translate', Http::STATUS_INTERNAL_SERVER_ERROR]);
+			return new DataResponse(['message' => $this->l->t('Unable to translate'), Http::STATUS_INTERNAL_SERVER_ERROR]);
 		}
 	}
 }

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -72,9 +72,9 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 		} catch (PreConditionNotMetException) {
 			return new DataResponse(['message' => $this->l->t('No translation provider available')], Http::STATUS_PRECONDITION_FAILED);
 		} catch (InvalidArgumentException) {
-			return new DataResponse(['message' => $this->l->t('Could not detect language'), Http::STATUS_NOT_FOUND]);
+			return new DataResponse(['message' => $this->l->t('Could not detect language')], Http::STATUS_NOT_FOUND);
 		} catch (RuntimeException) {
-			return new DataResponse(['message' => $this->l->t('Unable to translate'), Http::STATUS_INTERNAL_SERVER_ERROR]);
+			return new DataResponse(['message' => $this->l->t('Unable to translate')], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 }

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -52,7 +52,7 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
 	 */
 	public function languages(): DataResponse {
 		return new DataResponse([
@@ -62,7 +62,9 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 * @PublicPage
+	 * @UserRateThrottle(limit=25, period=120)
+	 * @AnonRateThrottle(limit=10, period=120)
 	 */
 	public function translate(string $text, ?string $fromLanguage, string $toLanguage): DataResponse {
 		try {


### PR DESCRIPTION
## TODO

- [x] Allow guests to use translations
- [x] Translate error messages so they can be shown in the UI
- [x] Fix status code set incorrectly
- [x] Fix status codes to be properly usable as an API

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
