### PR TITLE
fix: Check for wrapped retriable exceptions to handle deadlocks

### DIFF
--- a/lib/private/DB/Exceptions/DbalException.php
+++ b/lib/private/DB/Exceptions/DbalException.php
@@ -37,6 +37,7 @@ use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\RetryableException;
 use Doctrine\DBAL\Exception\ServerException;
 use Doctrine\DBAL\Exception\SyntaxErrorException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
@@ -72,6 +73,10 @@ class DbalException extends Exception {
 			is_int($original->getCode()) ? $original->getCode() : 0,
 			empty($message) ? $original->getMessage() : $message
 		);
+	}
+
+	public function isRetryable(): bool {
+		return $this->original instanceof RetryableException;
 	}
 
 	public function getReason(): ?int {

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -24,7 +24,7 @@
 
 namespace OC\Files\Cache;
 
-use Doctrine\DBAL\Exception\RetryableException;
+use OC\DB\Exceptions\DbalException;
 use OC\Files\Storage\Wrapper\Encryption;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\IPropagator;
@@ -136,7 +136,11 @@ class Propagator implements IPropagator {
 			try {
 				$builder->executeStatement();
 				break;
-			} catch (RetryableException $e) {
+			} catch (DbalException $e) {
+				if (!$e->isRetryable()) {
+					throw $e;
+				}
+
 				/** @var LoggerInterface $loggerInterface */
 				$loggerInterface = \OCP\Server::get(LoggerInterface::class);
 				$loggerInterface->warning('Retrying propagation query after retryable exception.', [ 'exception' => $e ]);


### PR DESCRIPTION
Follow-up fix for https://github.com/nextcloud/server/pull/34302 which was trying to catch an exception that was wrapped by our own exception class so the catch would never have catched.

Exact code part https://github.com/nextcloud/server/pull/34302/files#diff-9cdfa82a2275acf10161656ddc7b70be83cdbf6be8663ecfb8f963e4eb516d8eR139