### PR TITLE
Fix SymfonyAdapter dispatch method typing

### DIFF
--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -77,11 +77,11 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	/**
 	 * Dispatches an event to all registered listeners.
 	 *
-	 * @param string $eventName The name of the event to dispatch. The name of
-	 *                              the event is the name of the method that is
-	 *                              invoked on listeners.
-	 * @param Event|null $event The event to pass to the event handlers/listeners
-	 *                              If not supplied, an empty Event instance is created
+	 * @param mixed $eventName The name of the event to dispatch. The name of
+	 *                         the event is the name of the method that is
+	 *                         invoked on listeners.
+	 * @param mixed $event The event to pass to the event handlers/listeners
+	 *                     If not supplied, an empty Event instance is created
 	 *
 	 * @return object the emitted event
 	 * @deprecated 20.0.0
@@ -125,7 +125,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 	 * Adds an event listener that listens on the specified events.
 	 *
 	 * @param string $eventName The event to listen on
-	 * @param callable $listener The listener
+	 * @param callable|array $listener The listener
 	 * @param int $priority The higher this value, the earlier an event
 	 *                            listener will be triggered in the chain (defaults to 0)
 	 * @deprecated 20.0.0


### PR DESCRIPTION
## Summary

Split out from https://github.com/nextcloud/server/pull/37390

Adapt it to https://github.com/symfony/event-dispatcher-contracts/blob/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd/EventDispatcherInterface.php

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
