### PR TITLE
feat(dav): expose system address book

### DIFF
--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -10,6 +10,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Thomas Citharel <nextcloud@tcit.fr>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Anna Larch <anna.larch@gmx.net>
  *
  * @license AGPL-3.0
  *
@@ -72,7 +73,7 @@ $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend)
 $principalCollection->disableListing = !$debugging; // Disable listing
 
 $pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
-$addressBookRoot = new AddressBookRoot($principalBackend, $cardDavBackend, $pluginManager);
+$addressBookRoot = new AddressBookRoot($principalBackend, $cardDavBackend, $pluginManager, \OC::$server->getUserSession()->getUser(), \OC::$server->get(\OCP\IGroupManager::class));
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
 $nodes = [

--- a/apps/dav/lib/CardDAV/AddressBookRoot.php
+++ b/apps/dav/lib/CardDAV/AddressBookRoot.php
@@ -5,6 +5,7 @@
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Anna Larch <anna.larch@gmx.net>
  *
  * @license AGPL-3.0
  *
@@ -24,11 +25,15 @@
 namespace OCA\DAV\CardDAV;
 
 use OCA\DAV\AppInfo\PluginManager;
+use OCP\IGroupManager;
+use OCP\IUser;
 
 class AddressBookRoot extends \Sabre\CardDAV\AddressBookRoot {
 
 	/** @var PluginManager */
 	private $pluginManager;
+	private ?IUser $user;
+	private ?IGroupManager $groupManager;
 
 	/**
 	 * @param \Sabre\DAVACL\PrincipalBackend\BackendInterface $principalBackend
@@ -38,9 +43,13 @@ class AddressBookRoot extends \Sabre\CardDAV\AddressBookRoot {
 	public function __construct(\Sabre\DAVACL\PrincipalBackend\BackendInterface $principalBackend,
 								\Sabre\CardDAV\Backend\BackendInterface $carddavBackend,
 								PluginManager $pluginManager,
-								$principalPrefix = 'principals') {
+								?IUser $user,
+								?IGroupManager $groupManager,
+								string $principalPrefix = 'principals') {
 		parent::__construct($principalBackend, $carddavBackend, $principalPrefix);
 		$this->pluginManager = $pluginManager;
+		$this->user = $user;
+		$this->groupManager = $groupManager;
 	}
 
 	/**
@@ -55,7 +64,7 @@ class AddressBookRoot extends \Sabre\CardDAV\AddressBookRoot {
 	 * @return \Sabre\DAV\INode
 	 */
 	public function getChildForPrincipal(array $principal) {
-		return new UserAddressBooks($this->carddavBackend, $principal['uri'], $this->pluginManager);
+		return new UserAddressBooks($this->carddavBackend, $principal['uri'], $this->pluginManager, $this->user, $this->groupManager);
 	}
 
 	public function getName() {

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -311,6 +311,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			'{http://sabredav.org/ns}sync-token' => $row['synctoken'] ?: '0',
 		];
 
+		// system address books are always read only
+		if ($principal === 'principals/system/system') {
+			$addressBook['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only'] = true;
+		}
+
 		$this->addOwnerPrincipal($addressBook);
 
 		return $addressBook;

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -10,6 +10,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Thomas Citharel <nextcloud@tcit.fr>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Anna Larch <anna.larch@gmx.net>
  *
  * @license AGPL-3.0
  *
@@ -209,10 +210,8 @@ class SyncService {
 	public function updateUser(IUser $user) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
 		$addressBookId = $systemAddressBook['id'];
-		$name = $user->getBackendClassName();
-		$userId = $user->getUID();
 
-		$cardId = "$name:$userId.vcf";
+		$cardId = self::getCardUri($user);
 		if ($user->isEnabled()) {
 			$card = $this->backend->getCard($addressBookId, $cardId);
 			if ($card === false) {
@@ -239,10 +238,7 @@ class SyncService {
 	public function deleteUser($userOrCardId) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
 		if ($userOrCardId instanceof IUser) {
-			$name = $userOrCardId->getBackendClassName();
-			$userId = $userOrCardId->getUID();
-
-			$userOrCardId = "$name:$userId.vcf";
+			$userOrCardId = self::getCardUri($userOrCardId);
 		}
 		$this->backend->deleteCard($systemAddressBook['id'], $userOrCardId);
 	}
@@ -280,5 +276,13 @@ class SyncService {
 				$this->deleteUser($card['uri']);
 			}
 		}
+	}
+
+	/**
+	 * @param IUser $user
+	 * @return string
+	 */
+	public static function getCardUri(IUser $user): string {
+		return $user->getBackendClassName() . ':' . $user->getUID() . '.vcf';
 	}
 }

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -50,6 +50,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\SimpleCollection;
 
@@ -144,11 +145,11 @@ class RootCollection extends SimpleCollection {
 
 		$pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
 		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher);
-		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, $pluginManager, 'principals/users');
+		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, $pluginManager, $userSession->getUser(), $groupManager, 'principals/users');
 		$usersAddressBookRoot->disableListing = $disableListing;
 
 		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher);
-		$systemAddressBookRoot = new AddressBookRoot(new SystemPrincipalBackend(), $systemCardDavBackend, $pluginManager, 'principals/system');
+		$systemAddressBookRoot = new AddressBookRoot(new SystemPrincipalBackend(), $systemCardDavBackend, $pluginManager, $userSession->getUser(), $groupManager, 'principals/system');
 		$systemAddressBookRoot->disableListing = $disableListing;
 
 		$uploadCollection = new Upload\RootCollection(

--- a/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/SystemAddressBookTest.php
@@ -32,6 +32,7 @@ use OCP\Accounts\IAccountManager;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\VObject\Component\VCard;
@@ -44,6 +45,7 @@ class SystemAddressBookTest extends TestCase {
 	private array $addressBookInfo;
 	private IL10N|MockObject $l10n;
 	private IConfig|MockObject $config;
+	private IUserSession $userSession;
 	private IRequest|MockObject $request;
 	private array $server;
 	private TrustedServers|MockObject $trustedServers;
@@ -60,6 +62,7 @@ class SystemAddressBookTest extends TestCase {
 		];
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->request = $this->createMock(Request::class);
 		$this->server = [
 			'PHP_AUTH_USER' => 'system',
@@ -73,8 +76,10 @@ class SystemAddressBookTest extends TestCase {
 			$this->addressBookInfo,
 			$this->l10n,
 			$this->config,
+			$this->userSession,
 			$this->request,
 			$this->trustedServers,
+			null,
 		);
 	}
 

--- a/apps/settings/templates/settings/admin/sharing.php
+++ b/apps/settings/templates/settings/admin/sharing.php
@@ -209,7 +209,7 @@
 				<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-			<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog'));?></label><br />
+			<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog and allow access to the system address book'));?></label><br />
 		</p>
 
 		<p id="shareapi_restrict_user_enumeration_to_group_setting" class="indent <?php if ($_['shareAPIEnabled'] === 'no' || $_['allowShareDialogUserEnumeration'] === 'no') {
@@ -219,7 +219,7 @@
 				<?php if ($_['restrictUserEnumerationToGroup'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-			<label for="shareapi_restrict_user_enumeration_to_group"><?php p($l->t('Allow username autocompletion to users within the same groups'));?></label><br />
+			<label for="shareapi_restrict_user_enumeration_to_group"><?php p($l->t('Allow username autocompletion to users within the same groups and limit system address books to users in the same groups'));?></label><br />
 		</p>
 
 		<p id="shareapi_restrict_user_enumeration_to_phone_setting" class="indent <?php if ($_['shareAPIEnabled'] === 'no' || $_['allowShareDialogUserEnumeration'] === 'no') {


### PR DESCRIPTION
* Fixes #37797

## Summary
Expose the system address book

## How to test

Enable share enumeration in the backend

![image](https://user-images.githubusercontent.com/7427347/234040063-dbf1a8dd-a142-4499-bfe9-3d1dfb5f0f49.png)

to see all users.

In the contacts app, the users will have the address book "system":

![image](https://user-images.githubusercontent.com/7427347/234042341-9b5a6f8a-8a91-4b17-8e1e-51ee101393ff.png)


Disable it to see the logged in user only:

| With enumeration | Without enumeration |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/7427347/234042618-6e8bc88b-0b19-48d6-9c55-7e93722acd62.png) | ![image](https://user-images.githubusercontent.com/7427347/234042714-a83dbe0f-38c0-40fa-b5c7-57b87994ef74.png) | 

You can also check the DAV url <your-url>/remote.php/dav/addressbooks/users/<your-username> to see the new system address book:

![image](https://user-images.githubusercontent.com/7427347/234042233-08976e88-2446-449e-89bb-f781d04c3530.png)

## To Do
- [x] check if renaming address book to something else but "system" for the new user principal collection is possible to avoid naming conflicts
- [x] Rename the principal collection Display name to "Accounts" for the sabre collection.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] https://github.com/nextcloud/documentation/issues/10021
- [x] https://github.com/nextcloud/documentation/issues/10020
