### PR TITLE
fix: Skip registering mount points for missing owner node

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -33,6 +33,7 @@ use OC\Files\View;
 use OCA\Files_Sharing\Event\ShareMountedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
+use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -129,6 +130,13 @@ class MountProvider implements IMountProvider {
 				if (!isset($ownerViews[$owner])) {
 					$ownerViews[$owner] = new View('/' . $parentShare->getShareOwner() . '/files');
 				}
+
+				try {
+					$ownerViews[$owner]->getPath($parentShare->getNodeId());
+				} catch (NotFoundException $e) {
+					continue;
+				}
+
 				$mount = new SharedMount(
 					'\OCA\Files_Sharing\SharedStorage',
 					$mounts,


### PR DESCRIPTION
Make sure that we don't show share mount points where the owner node is not available anymore.

steps to reproduce:
* share a file with user1 (share_with) as user2 (uid_initiator) owned by user3 (uid_owner)
* create group1
* add user2 and user3 as members to group1
* create groupfolder for group1
* as user3, move the file into the new groupfolder 
* the share still has user1 as share_with, user2 as uid_initiator and user3 as uid_owner and is accessible
* remove user3 from group1

🛑 the shared file is still shown but user1 cannot access the file anymore


This still leaves an orphaned share entry but so far I had no luck finding a proper sql query so that we could add this to https://github.com/nextcloud/server/blob/a0f6a6545b59b1061e96e7d17d8ec6d6f32e615e/apps/files_sharing/lib/DeleteOrphanedSharesJob.php#L33 however skipping the share mount will at least avoid broken files being shown to users.