### PR TITLE
command for getting user file information

### DIFF
--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -37,6 +37,7 @@ use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\IUser;
 use OCP\Share\IShare;
 use OCP\Util;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -179,6 +180,18 @@ class FileUtils {
 			default:
 				return "Unknown (" . $share->getShareType() . ")";
 		}
+	}
+
+	/**
+	 * @param IUser $user
+	 * @return IMountPoint[]
+	 */
+	public function getMountsForUser(IUser $user): array {
+		$this->setupManager->setupForUser($user);
+		$prefix = "/" . $user->getUID();
+		return array_filter($this->mountManager->getAll(), function (IMountPoint $mount) use ($prefix) {
+			return str_starts_with($mount->getMountPoint(), $prefix);
+		});
 	}
 
 	/**

--- a/core/Command/Info/UserFiles.php
+++ b/core/Command/Info/UserFiles.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OC\Core\Command\Info;
+
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OCA\Circles\MountManager\CircleMount;
+use OCA\Files_External\Config\ExternalMountPoint;
+use OCA\Files_Sharing\SharedMount;
+use OCA\GroupFolders\Mount\GroupMountPoint;
+use OCP\Constants;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IHomeStorage;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\IL10N;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Share\IShare;
+use OCP\Util;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UserFiles extends Command {
+	private IRootFolder $rootFolder;
+	private IUserManager $userManager;
+	private IL10N $l10n;
+	private FileUtils $fileUtils;
+
+	public function __construct(
+		IRootFolder $rootFolder,
+		IUserManager $userManager,
+		IFactory $l10nFactory,
+		FileUtils $fileUtils
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->l10n = $l10nFactory->get("core");
+		$this->fileUtils = $fileUtils;
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('info:file:user')
+			->setDescription('get file information for a user')
+			->addArgument('user_id', InputArgument::REQUIRED, "User id")
+			->addOption('large-files', 'l', InputOption::VALUE_REQUIRED, "Number of large files and folders to show", 25);
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument('user_id');
+		$user = $this->userManager->get($userId);
+		if (!$user) {
+			$output->writeln("<error>usefr $userId not found</error>");
+			return 1;
+		}
+
+		$output->writeln($user->getUID());
+
+		$mounts = $this->fileUtils->getMountsForUser($user);
+		$output->writeln("");
+		$output->writeln("  available storages:");
+		foreach ($mounts as $mount) {
+			$storage = $mount->getStorage();
+			if (!$storage) {
+				continue;
+			}
+			$cache = $storage->getCache();
+			$free = Util::humanFileSize($storage->free_space(""));
+			$output->write("  - " . $mount->getMountPoint() . ": " . $this->fileUtils->formatMountType($mount));
+			if ($storage->instanceOfStorage(IHomeStorage::class)) {
+				$filesInfo = $cache->get("files");
+				$trashInfo = $cache->get("files_trashbin");
+				$versionsInfo = $cache->get("files_versions");
+				$used = Util::humanFileSize($filesInfo ? $filesInfo->getSize() : 0);
+				$trashUsed = Util::humanFileSize($trashInfo ? $trashInfo->getSize() : 0);
+				$versionUsed = Util::humanFileSize($versionsInfo ? $versionsInfo->getSize() : 0);
+				$output->writeln(" ($used in files, $trashUsed in trash, $versionUsed in versions, $free free)");
+			} else {
+				$rootInfo = $cache->get("");
+				$used = Util::humanFileSize($rootInfo ? $rootInfo->getSize(): -1);
+				$output->writeln(" ($used used, $free free)");
+			}
+		}
+		$output->writeln("");
+		$output->writeln("  use <info>occ info:file:space <path></info> to get more details about used space");
+
+		return 0;
+	}
+
+}

--- a/core/Command/Info/UserFiles.php
+++ b/core/Command/Info/UserFiles.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Info;
 
+use OC\Files\ObjectStore\HomeObjectStoreStorage;
 use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\Storage\Local;
 use OCA\Circles\MountManager\CircleMount;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_Sharing\SharedMount;
@@ -65,6 +67,16 @@ class UserFiles extends Command {
 		}
 
 		$output->writeln($user->getUID());
+		$output->writeln("");
+
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$userStorage = $userFolder->getStorage();
+		if ($userStorage->instanceOfStorage(Local::class)) {
+			$output->writeln("  data directory: " . $user->getHome());
+		} else if ($userStorage->instanceOfStorage(HomeObjectStoreStorage::class)) {
+			/** @var HomeObjectStoreStorage $userStorage */
+			$output->writeln("  bucket: " . $userStorage->getBucket());
+		}
 
 		$mounts = $this->fileUtils->getMountsForUser($user);
 		$output->writeln("");

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -105,6 +105,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 
 	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
 	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
+	$application->add(\OC::$server->get(OC\Core\Command\Info\UserFiles::class));
 
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -70,6 +70,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	/** @var bool */
 	protected $validateWrites = true;
 
+	private string $bucket;
+
 	public function __construct($params) {
 		if (isset($params['objectstore']) && $params['objectstore'] instanceof IObjectStore) {
 			$this->objectStore = $params['objectstore'];
@@ -90,6 +92,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		//initialize cache with root directory in cache
 		if (!$this->is_dir('/')) {
 			$this->mkdir('/');
+		}
+
+		if (isset($params['container'])) { // azure
+			$this->bucket = $params['container'];
+		} else { // s3, swift
+			$this->bucket = $params['bucket'];
 		}
 
 		$this->logger = \OC::$server->getLogger();
@@ -715,5 +723,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$cacheEntry = $this->getCache()->get($targetPath);
 		$urn = $this->getURN($cacheEntry->getId());
 		$this->objectStore->abortMultipartUpload($urn, $writeToken);
+	}
+
+	public function getBucket(): string {
+		return $this->bucket;
 	}
 }


### PR DESCRIPTION
follow up from #37525 this time focused on all files a user has access to

Currently shows

- data directory/bucket for the users home storage
- all storages a user has access to, their size and free space
- versions, trashbin sizes for home storage

example output:

```
admin

  bucket: nextcloud-35

  available storages:
  - /admin/: home storage (3.5 GB in files, 3.3 MB in trash, 164 B in versions, 271.3 GB free)
  - /admin/files/gf/: groupfolder 1 (0 B used, 271.3 GB free)
  - /admin/files/source/: external storage 1 (8.6 MB used, 1.1 TB free)
 
 use occ info:file:space <path> to get more details about used space
```