### PR TITLE
invalidate oauth2 tokens only for seen users

### DIFF
--- a/apps/oauth2/lib/Controller/SettingsController.php
+++ b/apps/oauth2/lib/Controller/SettingsController.php
@@ -69,7 +69,7 @@ class SettingsController extends Controller {
 	public function deleteClient(int $id): JSONResponse {
 		$client = $this->clientMapper->getByUid($id);
 
-		$this->userManager->callForAllUsers(function (IUser $user) use ($client) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($client) {
 			$this->tokenProvider->invalidateTokensOfUser($user->getUID(), $client->getName());
 		});
 

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -123,10 +123,13 @@ class SettingsControllerTest extends TestCase {
 		// count other users in the db before adding our own
 		$count = 0;
 		$function = function (IUser $user) use (&$count) {
-			$count++;
+			if ($user->getLastLogin() > 0) {
+				$count++;
+			}
 		};
 		$userManager->callForAllUsers($function);
 		$user1 = $userManager->createUser('test101', 'test101');
+		$user1->updateLastLoginTimestamp();
 		$tokenProviderMock = $this->getMockBuilder(IAuthTokenProvider::class)->getMock();
 
 		// expect one call per user and ensure the correct client name


### PR DESCRIPTION
* Resolves: #35068

## Summary
This is a follow-up PR for #36033 to make sure tokens are deleted only for seen users, see discussion in https://github.com/nextcloud/server/pull/37230#discussion_r1137100074

CC @blizzz 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
   - stable26: https://github.com/nextcloud/server/pull/37230
   - stable25: https://github.com/nextcloud/server/pull/37231