### PR TITLE
Fix a height of the landscape format

### DIFF
--- a/apps/files_sharing/css/public.scss
+++ b/apps/files_sharing/css/public.scss
@@ -40,10 +40,6 @@ $download-button-section-height: 200px;
     min-width: 100px;
 }
 
-#imgframe video {
-	max-height: calc(100vh - var(--header-height) - #{$footer-height} - #{$download-button-section-height} - #{$footer-padding-height});
-}
-
 #imgframe .plyr:fullscreen video {
     max-height: unset;
 }


### PR DESCRIPTION
* Resolves: resolves a part of the customer issue 44701 regarding landscape format.
Remove height rule for video viewer.

## Summary

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-04-17 11-31-24](https://user-images.githubusercontent.com/6078378/232444696-cd51114e-56f1-4686-9f82-603ffcba4c72.png) | ![image](https://user-images.githubusercontent.com/6078378/232444551-1d929afd-fdeb-4b92-bac8-24ff22ad91ec.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
