### PR TITLE
Fix: Filter out empty IP addresses in dnsResolve method

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -101,7 +101,8 @@ class DnsPinMiddleware {
 			}
 		}
 
-		return $targetIps;
+		// Filter out empty IP addresses before returning the result
+		return array_filter($targetIps);
 	}
 
 	public function addDnsPinning() {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36178

## Summary

This commit resolves an issue where empty IP addresses could be returned by the dnsResolve method due to CNAME recursion. The fix filters out empty IP addresses before returning the result, ensuring that only valid, non-empty IP addresses are used in the addDnsPinning method.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
