### PR TITLE
Fix background color of external devices with errors on dark color theme

### DIFF
--- a/apps/files_external/css/external.css
+++ b/apps/files_external/css/external.css
@@ -1,3 +1,4 @@
 .files-filestable tbody tr.externalErroredRow {
-	background-color: #F2DEDE;
+	/* TODO: As soon as firefox supports it: color-mix(in srgb, var(--color-error) 15%, var(--color-main-background)) */
+	background-color: rgba(255, 0, 0, 0.13);
 }


### PR DESCRIPTION
* Resolves: #37373

## Summary
Currently if a external device has errors the background color of the files entry is hard coded, which will be unreadable on dark color mode.
To fix this I just overlay the background with semi transparent red color.

## Screenshots

before | after
---|---
![image](https://user-images.githubusercontent.com/1855448/232911520-3709ea67-cae3-4df2-b188-6725be5a1e1b.png) | ![image](https://user-images.githubusercontent.com/1855448/232911553-21a52cd6-6da4-4110-94e7-dc079f891407.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Screenshots before/after for front-end changes
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
