### PR TITLE
Add security information (IP and browser) to the password reset email

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -308,12 +308,37 @@ class LostController extends Controller {
 			htmlspecialchars($this->l10n->t('Click the following button to reset your password. If you have not requested the password reset, then ignore this email.')),
 			$this->l10n->t('Click the following link to reset your password. If you have not requested the password reset, then ignore this email.')
 		);
-
 		$emailTemplate->addBodyButton(
 			htmlspecialchars($this->l10n->t('Reset your password')),
 			$link,
 			false
 		);
+
+		if ($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_ANDROID])) {
+			$platform = $this->l10n->t('Android client');
+		} elseif ($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_IOS])) {
+			$platform = $this->l10n->t('iOS client');
+		} elseif ($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_DESKTOP])) {
+			$platform = $this->l10n->t('desktop client');
+		} elseif ($this->request->isUserAgent(['/Firefox\//'])) {
+			$platform = 'Firefox';
+		} elseif ($this->request->isUserAgent(['/Chromium\//'])) {
+			$platform = 'Chromium';
+		} elseif ($this->request->isUserAgent(['/Safari\//'])) {
+			$platform = 'Safari';
+		} elseif ($this->request->isUserAgent(['/(OPR|Opera)\//'])) {
+			$platform = 'Opera';
+		} elseif ($this->request->isUserAgent(['/Edg.*\//'])) {
+			$platform = 'Edge';
+		} elseif ($this->request->isUserAgent(['/Chrome\//'])) {
+			$platform = 'Chrome';
+		} else {
+			$platform = $this->l10n->t('unknown');
+		}
+		$emailTemplate->addBodyText(
+			htmlspecialchars($this->l10n->t('Security notice: This password reset was requested from %1$s (IP address) using %2$s.', [ $this->request->getRemoteAddress(), $platform ]))
+		);
+
 		$emailTemplate->addFooter();
 
 		try {


### PR DESCRIPTION
* Resolves: #4345

## Summary
Add some metadata like the IP address and the browser type to the password reset mail for fraud detection.

## Screenshots

before | after
---|---
![image](https://user-images.githubusercontent.com/1855448/232927414-d08f654b-90b3-4885-afe0-9015b68533d5.png) | ![image](https://user-images.githubusercontent.com/1855448/232927855-95dcd9fc-1989-4a0c-adb6-235051bcb78c.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Screenshots before/after for front-end changes
