### PR TITLE
Dedupe last used tags

### DIFF
--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -245,7 +245,7 @@ class Listener {
 		$lastUsedTags = json_decode($lastUsedTags, true);
 
 		array_unshift($lastUsedTags, $tag->getId());
-		array_unique($lastUsedTags);
+		$lastUsedTags = array_unique($lastUsedTags);
 		$lastUsedTags = array_slice($lastUsedTags, 0, 10);
 
 		$this->config->setUserValue($actor, 'systemtags', 'last_used', json_encode($lastUsedTags));


### PR DESCRIPTION
## Summary

[`array_unique`](https://www.php.net/manual/en/function.array-unique.php) returns a new array rather than mutating the original array in-place

Before | After
--- | ---
`["5","2","4","4","3","3","2","2","1","1"]` | `["5","2","4","3","1"]`

Technically the array will not be made unique until the next time the user selects a tag but it’s probably not worth adding a background job for this as the existing frontend code still sorts the tags correctly

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)