### PR TITLE
fix(events): Log deprecated events as debug, not info

### DIFF
--- a/lib/private/EventDispatcher/GenericEventWrapper.php
+++ b/lib/private/EventDispatcher/GenericEventWrapper.php
@@ -54,7 +54,7 @@ class GenericEventWrapper extends GenericEvent {
 		}
 
 		$class = ($this->event !== null && is_object($this->event)) ? get_class($this->event) : 'null';
-		$this->logger->info(
+		$this->logger->debug(
 			'Deprecated event type for {name}: {class} is used',
 			[ 'name' => $this->eventName, 'class' => $class]
 		);

--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -105,7 +105,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 			$newEvent = $event;
 
 			// Legacy event
-			$this->logger->info(
+			$this->logger->debug(
 				'Deprecated event type for {name}: {class}',
 				['name' => $eventName, 'class' => is_object($event) ? get_class($event) : 'null']
 			);


### PR DESCRIPTION
* Ref https://github.com/nextcloud/server/issues/24380

## Summary

There is nothing an admin can. So let's not log this with info level.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
