### PR TITLE
fix(files): Don't throw an error when guests access the controller

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -70,28 +70,18 @@ class ApiController extends Controller {
 	private IPreview $previewManager;
 	private IUserSession $userSession;
 	private IConfig $config;
-	private Folder $userFolder;
+	private ?Folder $userFolder;
 	private UserConfig $userConfig;
 	private ViewConfig $viewConfig;
 
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param IUserSession $userSession
-	 * @param TagService $tagService
-	 * @param IPreview $previewManager
-	 * @param IManager $shareManager
-	 * @param IConfig $config
-	 * @param Folder $userFolder
-	 */
-	public function __construct($appName,
+	public function __construct(string $appName,
 								IRequest $request,
 								IUserSession $userSession,
 								TagService $tagService,
 								IPreview $previewManager,
 								IManager $shareManager,
 								IConfig $config,
-								Folder $userFolder,
+								?Folder $userFolder,
 								UserConfig $userConfig,
 								ViewConfig $viewConfig) {
 		parent::__construct($appName, $request);
@@ -406,7 +396,7 @@ class ApiController extends Controller {
 		$node = $this->userFolder->get($folderpath);
 		return $node->getType();
 	}
-	
+
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired

--- a/apps/files/lib/Service/TagService.php
+++ b/apps/files/lib/Service/TagService.php
@@ -44,7 +44,7 @@ class TagService {
 	private $activityManager;
 	/** @var ITags|null */
 	private $tagger;
-	/** @var Folder */
+	/** @var Folder|null */
 	private $homeFolder;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
@@ -53,7 +53,7 @@ class TagService {
 		IUserSession $userSession,
 		IManager $activityManager,
 		?ITags $tagger,
-		Folder $homeFolder,
+		?Folder $homeFolder,
 		EventDispatcherInterface $dispatcher
 	) {
 		$this->userSession = $userSession;
@@ -76,6 +76,9 @@ class TagService {
 	public function updateFileTags($path, $tags) {
 		if ($this->tagger === null) {
 			throw new \RuntimeException('No tagger set');
+		}
+		if ($this->homeFolder === null) {
+			throw new \RuntimeException('No homeFolder set');
 		}
 
 		$fileId = $this->homeFolder->get($path)->getId();


### PR DESCRIPTION
## Summary

Our log was spammed quite heavily with the following log message:
```
OCA\\Files\\Service\\TagService::__construct(): Argument #4 ($homeFolder) must be of type OCP\\Files\\Folder, null given, called in …/apps/files/lib/AppInfo/Application.php on line 111
```


### Before
```
$ curl -k https://localhost/index.php/apps/files/api/v1/stats
<!DOCTYPE html>
<html class="ng-csp" data-placeholder-focus="false" lang="en" data-locale="en" translate="no" >
	…
					<div class="guest-box wide">
	<h2>Internal Server Error</h2>
	<p>The server was unable to complete your request.</p>
	<p>If this happens again, please send the technical details below to the server administrator.</p>
	<p>More details can be found in the server log.</p>

	<h3>Technical details</h3>
	<ul>
		<li>Remote Address: …</li>
		<li>Request ID: ZD_9oDM7JyuXBrh8F7kaqQAAAAw</li>
					<li>Type: TypeError</li>
			<li>Code: 0</li>
			<li>Message: OCA\Files\Service\TagService::__construct(): Argument #4 ($homeFolder) must be of type OCP\Files\Folder, null given, called in …/apps/files/lib/AppInfo/Application.php on line 113</li>
			<li>File: …/apps/files/lib/Service/TagService.php</li>
			<li>Line: 52</li>
			</ul>

			<br />
		<h3>Trace</h3>
		<pre>#0 …/apps/files/lib/AppInfo/Application.php(113): OCA\Files\Service\TagService-&gt;__construct()
#1 …/lib/private/AppFramework/Utility/SimpleContainer.php(171): OCA\Files\AppInfo\Application-&gt;OCA\Files\AppInfo\{closure}()
#2 …/3rdparty/pimple/pimple/src/Pimple/Container.php(122): OC\AppFramework\Utility\SimpleContainer-&gt;OC\AppFramework\Utility\{closure}()
#3 …/lib/private/AppFramework/Utility/SimpleContainer.php(138): Pimple\Container-&gt;offsetGet()
#4 …/lib/private/AppFramework/DependencyInjection/DIContainer.php(488): OC\AppFramework\Utility\SimpleContainer-&gt;query()
#5 …/lib/private/AppFramework/DependencyInjection/DIContainer.php(466): OC\AppFramework\DependencyInjection\DIContainer-&gt;queryNoFallback()
#6 …/lib/private/AppFramework/Utility/SimpleContainer.php(65): OC\AppFramework\DependencyInjection\DIContainer-&gt;query()
#7 …/apps/files/lib/AppInfo/Application.php(91): OC\AppFramework\Utility\SimpleContainer-&gt;get()
#8 …/lib/private/AppFramework/Utility/SimpleContainer.php(171): OCA\Files\AppInfo\Application-&gt;OCA\Files\AppInfo\{closure}()
#9 …/3rdparty/pimple/pimple/src/Pimple/Container.php(122): OC\AppFramework\Utility\SimpleContainer-&gt;OC\AppFramework\Utility\{closure}()
#10 …/lib/private/AppFramework/Utility/SimpleContainer.php(138): Pimple\Container-&gt;offsetGet()
#11 …/lib/private/AppFramework/DependencyInjection/DIContainer.php(488): OC\AppFramework\Utility\SimpleContainer-&gt;query()
#12 …/lib/private/AppFramework/DependencyInjection/DIContainer.php(466): OC\AppFramework\DependencyInjection\DIContainer-&gt;queryNoFallback()
#13 …/lib/private/AppFramework/Utility/SimpleContainer.php(65): OC\AppFramework\DependencyInjection\DIContainer-&gt;query()
#14 …/lib/private/AppFramework/App.php(148): OC\AppFramework\Utility\SimpleContainer-&gt;get()
#15 …/lib/private/Route/Router.php(315): OC\AppFramework\App::main()
#16 …/lib/base.php(1059): OC\Route\Router-&gt;match()
#17 …/index.php(36): OC::handleRequest()
#18 {main}</pre>	</div>
…
</html>

```

### After
```
$ curl -k https://localhost/index.php/apps/files/api/v1/stats
{"message":"Current user is not logged in"}
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
