### PR TITLE
Fix TypeError in Profiler

### DIFF
--- a/lib/private/Profiler/FileProfilerStorage.php
+++ b/lib/private/Profiler/FileProfilerStorage.php
@@ -99,7 +99,7 @@ class FileProfilerStorage {
 		$iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::CHILD_FIRST);
 
 		foreach ($iterator as $file) {
-			$file = $file->getPathInfo();
+			$file = (string)$file->getPathInfo();
 			if (is_file($file)) {
 				unlink($file);
 			} else {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/profiler/issues/194

## Summary

Fixes a TypeError in the profiler

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
