### PR TITLE
feat(BackgroundJobs): Allow preventing parallel runs for a job class

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -117,6 +117,7 @@ return array(
     'OCP\\AutoloadNotAllowedException' => $baseDir . '/lib/public/AutoloadNotAllowedException.php',
     'OCP\\BackgroundJob\\IJob' => $baseDir . '/lib/public/BackgroundJob/IJob.php',
     'OCP\\BackgroundJob\\IJobList' => $baseDir . '/lib/public/BackgroundJob/IJobList.php',
+    'OCP\\BackgroundJob\\IParallelAwareJob' => $baseDir . '/lib/public/BackgroundJob/IParallelAwareJob.php',
     'OCP\\BackgroundJob\\Job' => $baseDir . '/lib/public/BackgroundJob/Job.php',
     'OCP\\BackgroundJob\\QueuedJob' => $baseDir . '/lib/public/BackgroundJob/QueuedJob.php',
     'OCP\\BackgroundJob\\TimedJob' => $baseDir . '/lib/public/BackgroundJob/TimedJob.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -150,6 +150,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\AutoloadNotAllowedException' => __DIR__ . '/../../..' . '/lib/public/AutoloadNotAllowedException.php',
         'OCP\\BackgroundJob\\IJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJob.php',
         'OCP\\BackgroundJob\\IJobList' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJobList.php',
+        'OCP\\BackgroundJob\\IParallelAwareJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IParallelAwareJob.php',
         'OCP\\BackgroundJob\\Job' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/Job.php',
         'OCP\\BackgroundJob\\QueuedJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/QueuedJob.php',
         'OCP\\BackgroundJob\\TimedJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/TimedJob.php',

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -396,7 +396,8 @@ class JobList implements IJobList {
 		}
 
 		try {
-			return $query->executeQuery()->rowCount() > 0;
+			$result = $query->executeQuery();
+			return count($result->fetchAll()) > 0;
 		} catch (Exception $e) {
 			return false;
 		}

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -39,16 +39,19 @@ use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
 
 class JobList implements IJobList {
 	protected IDBConnection $connection;
 	protected IConfig $config;
 	protected ITimeFactory $timeFactory;
+	protected LoggerInterface $logger;
 
-	public function __construct(IDBConnection $connection, IConfig $config, ITimeFactory $timeFactory) {
+	public function __construct(IDBConnection $connection, IConfig $config, ITimeFactory $timeFactory, LoggerInterface $logger) {
 		$this->connection = $connection;
 		$this->config = $config;
 		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -401,6 +404,7 @@ class JobList implements IJobList {
 			$result->closeCursor();
 			return $hasReservedJobs;
 		} catch (Exception $e) {
+			$this->logger->debug('Querying reserved jobs failed', ['exception' => $e]);
 			return false;
 		}
 	}

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -388,7 +388,8 @@ class JobList implements IJobList {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')
-			->where($query->expr()->neq('reserved_at', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->neq('reserved_at', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->setMaxResults(1);
 
 		if ($className !== null) {
 			$query->andWhere($query->expr()->eq('class', $query->createNamedParameter($className)));

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -384,7 +384,7 @@ class JobList implements IJobList {
 		$query->executeStatement();
 	}
 
-	public function hasReservedJob(?string $className): bool {
+	public function hasReservedJob(?string $className = null): bool {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('jobs')

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -397,7 +397,9 @@ class JobList implements IJobList {
 
 		try {
 			$result = $query->executeQuery();
-			return count($result->fetchAll()) > 0;
+			$hasReservedJobs = $result->fetch() !== false;
+			$result->closeCursor();
+			return $hasReservedJobs;
 		} catch (Exception $e) {
 			return false;
 		}

--- a/lib/private/SpeechToText/TranscriptionJob.php
+++ b/lib/private/SpeechToText/TranscriptionJob.php
@@ -49,6 +49,7 @@ class TranscriptionJob extends QueuedJob {
 		private LoggerInterface $logger,
 	) {
 		parent::__construct($timeFactory);
+		$this->setAllowParallelRuns(false);
 	}
 
 

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -145,4 +145,13 @@ interface IJobList {
 	 * @since 23.0.0
 	 */
 	public function resetBackgroundJob(IJob $job): void;
+
+	/**
+	 * Checks whether a job of the passed class is reserved to run
+	 *
+	 * @param string|null $className
+	 * @return bool
+	 * @since 27.0.0
+	 */
+	public function hasReservedJob(?string $className): bool;
 }

--- a/lib/public/BackgroundJob/IParallelAwareJob.php
+++ b/lib/public/BackgroundJob/IParallelAwareJob.php
@@ -1,7 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
+
+/**
+ * @copyright Copyright (c) 2023, Marcel Klehr <mklehr@gmx.net>
+ *
+ * @author Marcel Klehr <mklehr@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 namespace OCP\BackgroundJob;
 
+/**
+ * @since 27.0.0
+ */
 interface IParallelAwareJob {
 	/**
 	 * Set this to false to prevent two Jobs from the same class from running in parallel

--- a/lib/public/BackgroundJob/IParallelAwareJob.php
+++ b/lib/public/BackgroundJob/IParallelAwareJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OCP\BackgroundJob;
+
+interface IParallelAwareJob {
+	/**
+	 * Set this to false to prevent two Jobs from the same class from running in parallel
+	 *
+	 * @param bool $allow
+	 * @return void
+	 * @since 27.0.0
+	 */
+	public function setAllowParallelRuns(bool $allow): void;
+
+	/**
+	 * @return bool
+	 * @since 27.0.0
+	 */
+	public function getAllowParallelRuns(): bool;
+}

--- a/lib/public/BackgroundJob/Job.php
+++ b/lib/public/BackgroundJob/Job.php
@@ -38,7 +38,7 @@ use Psr\Log\LoggerInterface;
  *
  * @since 15.0.0
  */
-abstract class Job implements IJob {
+abstract class Job implements IJob, IParallelAwareJob {
 	protected int $id = 0;
 	protected int $lastRun = 0;
 	protected $argument;
@@ -145,7 +145,7 @@ abstract class Job implements IJob {
 	 * @return void
 	 * @since 27.0.0
 	 */
-	public function setAllowParallelRuns(bool $allow) {
+	public function setAllowParallelRuns(bool $allow): void {
 		$this->allowParallelRuns = $allow;
 	}
 

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -21,6 +21,11 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	 */
 	private array $jobs = [];
 
+	/**
+	 * @var bool[]
+	 */
+	private array $reserved = [];
+
 	private int $last = 0;
 
 	public function __construct() {
@@ -133,6 +138,14 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 
 	public function setLastRun(IJob $job): void {
 		$job->setLastRun(time());
+	}
+
+	public function hasReservedJob(?string $className = null): bool {
+		return $this->reserved[$className];
+	}
+
+	public function setHasReservedJob(?string $className, bool $hasReserved): void {
+		$this->reserved[$className] = $hasReserved;
 	}
 
 	public function setExecutionTime(IJob $job, $timeTaken): void {

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -141,11 +141,11 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	}
 
 	public function hasReservedJob(?string $className = null): bool {
-		return $this->reserved[$className];
+		return $this->reserved[$className ?? ''];
 	}
 
 	public function setHasReservedJob(?string $className, bool $hasReserved): void {
-		$this->reserved[$className] = $hasReserved;
+		$this->reserved[$className ?? ''] = $hasReserved;
 	}
 
 	public function setExecutionTime(IJob $job, $timeTaken): void {

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -12,6 +12,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 /**
@@ -44,7 +45,8 @@ class JobListTest extends TestCase {
 		$this->instance = new \OC\BackgroundJob\JobList(
 			$this->connection,
 			$this->config,
-			$this->timeFactory
+			$this->timeFactory,
+			\OC::$server->get(LoggerInterface::class),
 		);
 	}
 

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -32,6 +32,7 @@ class JobListTest extends TestCase {
 
 	/** @var \OCP\AppFramework\Utility\ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
+	private bool $ran = false;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -247,7 +248,10 @@ class JobListTest extends TestCase {
 
 	public function testHasReservedJobs() {
 		$this->clearJobsList();
-		$job = new TestJob();
+		$job = new TestJob($this->timeFactory, $this, function () {
+			$this->assertTrue($this->instance->hasReservedJob());
+			$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
+		});
 		$this->instance->add($job);
 
 		$this->assertFalse($this->instance->hasReservedJob());
@@ -255,7 +259,10 @@ class JobListTest extends TestCase {
 
 		$job->start($this->instance);
 
-		$this->assertTrue($this->instance->hasReservedJob());
-		$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
+		$this->assertTrue($this->ran);
+	}
+
+	public function markRun() {
+		$this->ran = true;
 	}
 }

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -244,4 +244,17 @@ class JobListTest extends TestCase {
 		$this->assertGreaterThanOrEqual($timeStart, $addedJob->getLastRun());
 		$this->assertLessThanOrEqual($timeEnd, $addedJob->getLastRun());
 	}
+
+	public function testHasReservedJobs() {
+		$job = new TestJob();
+		$this->instance->add($job);
+
+		$this->assertFalse($this->instance->hasReservedJob());
+		$this->assertFalse($this->instance->hasReservedJob(TestJob::class));
+
+		$job->start($this->instance);
+
+		$this->assertTrue($this->instance->hasReservedJob());
+		$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
+	}
 }

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -246,6 +246,7 @@ class JobListTest extends TestCase {
 	}
 
 	public function testHasReservedJobs() {
+		$this->clearJobsList();
 		$job = new TestJob();
 		$this->instance->add($job);
 

--- a/tests/lib/BackgroundJob/JobTest.php
+++ b/tests/lib/BackgroundJob/JobTest.php
@@ -63,27 +63,6 @@ class JobTest extends \Test\TestCase {
 		$this->assertCount(1, $jobList->getAll());
 	}
 
-	public function testRemoveAfterError() {
-		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function () {
-			$test = null;
-			$test->someMethod();
-		});
-		$jobList->add($job);
-
-		$logger = $this->getMockBuilder(ILogger::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$logger->expects($this->once())
-			->method('logException')
-			->with($this->isInstanceOf(\Throwable::class));
-
-		$this->assertCount(1, $jobList->getAll());
-		$job->execute($jobList, $logger);
-		$this->assertTrue($this->run);
-		$this->assertCount(1, $jobList->getAll());
-	}
-
 	public function testDisallowParallelRunsWithNoOtherJobs() {
 		$jobList = new DummyJobList();
 		$job = new TestJob($this->timeFactory, $this);

--- a/tests/lib/BackgroundJob/JobTest.php
+++ b/tests/lib/BackgroundJob/JobTest.php
@@ -33,8 +33,7 @@ class JobTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$logger->expects($this->once())
-			->method('logException')
-			->with($e);
+			->method('error');
 
 		$this->assertCount(1, $jobList->getAll());
 		$job->execute($jobList, $logger);
@@ -54,8 +53,7 @@ class JobTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$logger->expects($this->once())
-			->method('logException')
-			->with($this->isInstanceOf(\Throwable::class));
+			->method('error');
 
 		$this->assertCount(1, $jobList->getAll());
 		$job->execute($jobList, $logger);
@@ -65,7 +63,8 @@ class JobTest extends \Test\TestCase {
 
 	public function testDisallowParallelRunsWithNoOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this);
+		$job = new TestJob($this->timeFactory, $this, function() {
+		});
 		$job->setAllowParallelRuns(false);
 		$jobList->add($job);
 
@@ -77,7 +76,8 @@ class JobTest extends \Test\TestCase {
 
 	public function testAllowParallelRunsWithNoOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this);
+		$job = new TestJob($this->timeFactory, $this, function() {
+		});
 		$job->setAllowParallelRuns(true);
 		$jobList->add($job);
 
@@ -89,7 +89,8 @@ class JobTest extends \Test\TestCase {
 
 	public function testAllowParallelRunsWithOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this);
+		$job = new TestJob($this->timeFactory, $this, function() {
+		});
 		$job->setAllowParallelRuns(true);
 		$jobList->add($job);
 
@@ -101,7 +102,8 @@ class JobTest extends \Test\TestCase {
 
 	public function testDisallowParallelRunsWithOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this);
+		$job = new TestJob($this->timeFactory, $this, function() {
+		});
 		$job->setAllowParallelRuns(false);
 		$jobList->add($job);
 

--- a/tests/lib/BackgroundJob/JobTest.php
+++ b/tests/lib/BackgroundJob/JobTest.php
@@ -63,7 +63,7 @@ class JobTest extends \Test\TestCase {
 
 	public function testDisallowParallelRunsWithNoOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function() {
+		$job = new TestJob($this->timeFactory, $this, function () {
 		});
 		$job->setAllowParallelRuns(false);
 		$jobList->add($job);
@@ -76,7 +76,7 @@ class JobTest extends \Test\TestCase {
 
 	public function testAllowParallelRunsWithNoOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function() {
+		$job = new TestJob($this->timeFactory, $this, function () {
 		});
 		$job->setAllowParallelRuns(true);
 		$jobList->add($job);
@@ -89,7 +89,7 @@ class JobTest extends \Test\TestCase {
 
 	public function testAllowParallelRunsWithOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function() {
+		$job = new TestJob($this->timeFactory, $this, function () {
 		});
 		$job->setAllowParallelRuns(true);
 		$jobList->add($job);
@@ -102,7 +102,7 @@ class JobTest extends \Test\TestCase {
 
 	public function testDisallowParallelRunsWithOtherJobs() {
 		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function() {
+		$job = new TestJob($this->timeFactory, $this, function () {
 		});
 		$job->setAllowParallelRuns(false);
 		$jobList->add($job);

--- a/tests/lib/BackgroundJob/TestJob.php
+++ b/tests/lib/BackgroundJob/TestJob.php
@@ -8,7 +8,9 @@
 
 namespace Test\BackgroundJob;
 
-class TestJob extends \OC\BackgroundJob\Job {
+use OCP\AppFramework\Utility\ITimeFactory;
+
+class TestJob extends \OCP\BackgroundJob\Job {
 	private $testCase;
 
 	/**
@@ -20,7 +22,8 @@ class TestJob extends \OC\BackgroundJob\Job {
 	 * @param JobTest $testCase
 	 * @param callable $callback
 	 */
-	public function __construct($testCase = null, $callback = null) {
+	public function __construct(ITimeFactory $time = null, $testCase = null, $callback = null) {
+		parent::__construct($time ?? \OC::$server->get(ITimeFactory::class));
 		$this->testCase = $testCase;
 		$this->callback = $callback;
 	}


### PR DESCRIPTION
* Related: #37674 
 
## Summary
This PR adds a setAllowParallelRuns() method to the BackgroundJob\Job abstract class in order to allow jobs to disallow parallel runs.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
