### PR TITLE
add the server roots and version info hash to apcu prefix

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -68,7 +68,6 @@ declare(strict_types=1);
 
 use OC\Encryption\HookManager;
 use OC\EventDispatcher\SymfonyAdapter;
-use OC\Files\Filesystem;
 use OC\Share20\Hooks;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
@@ -114,6 +113,8 @@ class OC {
 	public static array $APPSROOTS = [];
 
 	public static string $configDir;
+
+	public static int $VERSION_MTIME = 0;
 
 	/**
 	 * requested app
@@ -601,7 +602,8 @@ class OC {
 
 		// Add default composer PSR-4 autoloader
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
-		self::$composerAutoloader->setApcuPrefix('composer_autoload_' . md5(OC::$SERVERROOT . '_' . filemtime(OC::$SERVERROOT . '/version.php')));
+		OC::$VERSION_MTIME = filemtime(OC::$SERVERROOT . '/version.php');
+		self::$composerAutoloader->setApcuPrefix('composer_autoload_' . md5(OC::$SERVERROOT . '_' . OC::$VERSION_MTIME));
 
 		try {
 			self::initPaths();

--- a/lib/base.php
+++ b/lib/base.php
@@ -601,7 +601,7 @@ class OC {
 
 		// Add default composer PSR-4 autoloader
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
-		self::$composerAutoloader->setApcuPrefix('composer_autoload');
+		self::$composerAutoloader->setApcuPrefix('composer_autoload_' . md5(OC::$SERVERROOT . '_' . filemtime(OC::$SERVERROOT . '/version.php')));
 
 		try {
 			self::initPaths();

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -65,7 +65,6 @@
  */
 
 use bantu\IniGetWrapper\IniGetWrapper;
-use OC\AppFramework\Http\Request;
 use OC\Files\SetupManager;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
@@ -327,10 +326,9 @@ class OC_Util {
 			return;
 		}
 
-		$timestamp = filemtime(OC::$SERVERROOT . '/version.php');
 		require OC::$SERVERROOT . '/version.php';
 		/** @var int $timestamp */
-		self::$versionCache['OC_Version_Timestamp'] = $timestamp;
+		self::$versionCache['OC_Version_Timestamp'] = \OC::$VERSION_MTIME;
 		/** @var string $OC_Version */
 		self::$versionCache['OC_Version'] = $OC_Version;
 		/** @var string $OC_VersionString */


### PR DESCRIPTION
* Resolves: #37610 

## Summary

fixes collisions when more than one instance is running on the same system

For the memcaches we use a more complex prefix, where version and instance ID are incorporated. We do not have this data at hand at this point of time. But we can get the mtime of the version.php file relatively cheap.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
