### PR TITLE
removed profile data from LDAP will get removed

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -286,31 +286,31 @@ class User {
 			$attr = strtolower($this->connection->ldapAttributeTwitter);
 			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_TWITTER]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - fediverse
 			$attr = strtolower($this->connection->ldapAttributeFediverse);
 			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_FEDIVERSE]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - organisation
 			$attr = strtolower($this->connection->ldapAttributeOrganisation);
 			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ORGANISATION]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - role
 			$attr = strtolower($this->connection->ldapAttributeRole);
 			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ROLE]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - headline
 			$attr = strtolower($this->connection->ldapAttributeHeadline);
 			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_HEADLINE]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - biography
 			$attr = strtolower($this->connection->ldapAttributeBiography);

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -251,7 +251,7 @@ class User {
 			$attr = strtolower($this->connection->ldapAttributePhone);
 			if (!empty($attr)) { // attribute configured
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_PHONE]
-					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
+					= $ldapEntry[$attr][0] ?? "";
 			}
 			//User Profile Field - website
 			$attr = strtolower($this->connection->ldapAttributeWebsite);

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -249,9 +249,9 @@ class User {
 			$profileValues = array();
 			//User Profile Field - Phone number
 			$attr = strtolower($this->connection->ldapAttributePhone);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) { // attribute configured
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_PHONE]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - website
 			$attr = strtolower($this->connection->ldapAttributeWebsite);
@@ -265,6 +265,8 @@ class User {
 					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE]
 						= $ldapEntry[$attr][0];
 				}
+			} elseif (!empty($attr)) {	// configured, but not defined
+				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE] = "";
 			}
 			//User Profile Field - Address
 			$attr = strtolower($this->connection->ldapAttributeAddress);
@@ -277,36 +279,38 @@ class User {
 					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS]
 						= $ldapEntry[$attr][0];
 				}
+			} elseif (!empty($attr)) {	// configured, but not defined
+				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS] = "";
 			}
 			//User Profile Field - Twitter
 			$attr = strtolower($this->connection->ldapAttributeTwitter);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_TWITTER]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - fediverse
 			$attr = strtolower($this->connection->ldapAttributeFediverse);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_FEDIVERSE]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - organisation
 			$attr = strtolower($this->connection->ldapAttributeOrganisation);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ORGANISATION]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - role
 			$attr = strtolower($this->connection->ldapAttributeRole);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ROLE]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - headline
 			$attr = strtolower($this->connection->ldapAttributeHeadline);
-			if (isset($ldapEntry[$attr])) {
+			if (!empty($attr)) {
 				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_HEADLINE]
-					= $ldapEntry[$attr][0];
+					= (isset($ldapEntry[$attr]) ? $ldapEntry[$attr][0] : "");
 			}
 			//User Profile Field - biography
 			$attr = strtolower($this->connection->ldapAttributeBiography);
@@ -319,6 +323,8 @@ class User {
 					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY]
 						= $ldapEntry[$attr][0];
 				}
+			} elseif (!empty($attr)) {	// configured, but not defined
+				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY] = "";
 			}
 			// check for changed data and cache just for TTL checking
 			$checksum = hash('sha256', json_encode($profileValues));


### PR DESCRIPTION
If attribute mapping is configured and no value present in LDAP, the according profile field is emptied. Removing an attribute e.g. phone from LDAP will cause the phone number being removed from profile.

* Resolves: no issue filed, discovered with @come-nc regarding docu [PR 9614](https://github.com/nextcloud/documentation/pull/9614#discussion_r1172337320) for [PR 36565](https://github.com/nextcloud/server/pull/36565)

## Summary

1. Removing an attribute from LDAP will empty the profile field for this user
2. Setting an nonexisting attribute will empty the corresponding profile field for all users

## TODO

- [x] checked different scenarios

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
