### PR TITLE
fix(autotest): Fix PHPUNIT version check in autotest files

### DIFF
--- a/autotest-external.sh
+++ b/autotest-external.sh
@@ -39,8 +39,8 @@ PHPUNIT_VERSION=$("$PHPUNIT" --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f2)
 
-if ! [ $PHPUNIT_MAJOR_VERSION -gt 4 -o \( $PHPUNIT_MAJOR_VERSION -eq 4 -a $PHPUNIT_MINOR_VERSION -ge 8 \) ]; then
-	echo "phpunit version >= 4.8 required. Version found: $PHPUNIT_VERSION" >&2
+if ! [ $PHPUNIT_MAJOR_VERSION -gt 9 -o \( $PHPUNIT_MAJOR_VERSION -eq 9 -a $PHPUNIT_MINOR_VERSION -ge 0 \) ]; then
+	echo "phpunit version >= 9.0 required. Version found: $PHPUNIT_VERSION" >&2
 	exit 4
 fi
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -77,7 +77,7 @@ PHPUNIT_VERSION=$($PHPUNIT --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f2)
 
-if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 6 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 9 -a "$PHPUNIT_MINOR_VERSION" -ge 0 \) ]; then
+if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 9 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 9 -a "$PHPUNIT_MINOR_VERSION" -ge 0 \) ]; then
 	echo "phpunit version >= 9.0 required. Version found: $PHPUNIT_VERSION" >&2
 	exit 4
 fi


### PR DESCRIPTION
## Summary

autotest.sh allowed PHPUnit 7+ by accident and autotest-external.sh even 4.8

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
