### PR TITLE
File modification date shine through on scroll

### DIFF
--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -6,13 +6,6 @@
 
 <div id="app-content" tabindex="0">
 
-	<input type="checkbox" class="hidden-visually" id="showgridview"
-		aria-label="<?php p($l->t('Toggle grid view'))?>"
-		<?php if ($_['showgridview']) { ?>checked="checked" <?php } ?>/>
-	<label id="view-toggle" for="showgridview" tabindex="0" class="button <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>"
-		title="<?php p($_['showgridview'] ? $l->t('Show list view') : $l->t('Show grid view'))?>"></label>
-
-
 	<!-- Legacy views -->
 	<?php foreach ($_['appContents'] as $content) { ?>
 	<div id="app-content-<?php p($content['id']) ?>" class="hidden viewcontainer">

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -12,12 +12,15 @@
 	*/ ?>
 	<input type="hidden" id="permissions" value="">
 	<input type="hidden" id="free_space" value="<?php isset($_['freeSpace']) ? p($_['freeSpace']) : '' ?>">
-	<?php if (isset($_['dirToken'])):?>
-	<input type="hidden" id="publicUploadRequestToken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
-	<input type="hidden" id="dirToken" name="dirToken" value="<?php p($_['dirToken']) ?>" />
-	<?php endif;?>
-	<input type="hidden" class="max_human_file_size"
-		   value="(max <?php isset($_['uploadMaxHumanFilesize']) ? p($_['uploadMaxHumanFilesize']) : ''; ?>)">
+	<?php if (isset($_['dirToken'])) : ?>
+		<input type="hidden" id="publicUploadRequestToken" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
+		<input type="hidden" id="dirToken" name="dirToken" value="<?php p($_['dirToken']) ?>" />
+	<?php endif; ?>
+	<input type="hidden" class="max_human_file_size" value="(max <?php isset($_['uploadMaxHumanFilesize']) ? p($_['uploadMaxHumanFilesize']) : ''; ?>)">
+	<?php if (!isset($_["isPublic"])) : ?>
+		<input type="checkbox" class="hidden-visually notPublic" id="showgridview" aria-label="<?php p($l->t('Toggle grid view')) ?>" <?php if ($_['showgridview']) { ?>checked="checked" <?php } ?> />
+		<label id="view-toggle" for="showgridview" tabindex="0" class="button notPublic <?php p($_['showgridview'] ? 'icon-toggle-filelist' : 'icon-toggle-pictures') ?>" title="<?php p($_['showgridview'] ? $l->t('Show list view') : $l->t('Show grid view')) ?>"></label>
+	<?php endif; ?>
 </div>
 <div class="filelist-header"></div>
 
@@ -32,27 +35,27 @@
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>
 	<p></p>
 </div>
-<table class="files-filestable list-container <?php p($_['showgridview'] ? 'view-grid' : '') ?>" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="250" data-preview-y="250">
+<table class="files-filestable list-container <?php p($_['showgridview'] ? 'view-grid' : '') ?>" data-allow-public-upload="<?php p($_['publicUploadEnabled']) ?>" data-preview-x="250" data-preview-y="250">
 	<thead>
 		<tr>
 			<th class="hidden column-selection">
-				<input type="checkbox" id="select_all_files" class="select-all checkbox"/>
+				<input type="checkbox" id="select_all_files" class="select-all checkbox" />
 				<label for="select_all_files">
-					<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
+					<span class="hidden-visually"><?php p($l->t('Select all')) ?></span>
 				</label>
 			</th>
 			<th class="hidden column-name">
 				<div class="column-name-container">
 					<a class="name sort columntitle" onclick="event.preventDefault()" href="#" data-sort="name">
-                        <span><?php p($l->t('Name')); ?></span>
-                        <span class="sort-indicator"></span>
+						<span><?php p($l->t('Name')); ?></span>
+						<span class="sort-indicator"></span>
 
-                    </a>
-                    <span class="selectedActions">
-                        <a href="#" onclick="event.preventDefault()" class="actions-selected">
-                            <span class="icon icon-more"></span>
-                            <span><?php p($l->t('Actions'))?></span>
-                        </a>
+					</a>
+					<span class="selectedActions">
+						<a href="#" onclick="event.preventDefault()" class="actions-selected">
+							<span class="icon icon-more"></span>
+							<span><?php p($l->t('Actions')) ?></span>
+						</a>
 					</span>
 				</div>
 			</th>
@@ -73,8 +76,8 @@
 <div class="hiddenuploadfield">
 	<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]" />
 </div>
-<div id="uploadsize-message" title="<?php p($l->t('Upload too large'))?>">
+<div id="uploadsize-message" title="<?php p($l->t('Upload too large')) ?>">
 	<p>
-	<?php p($l->t('The files you are trying to upload exceed the maximum size for file uploads on this server.'));?>
+		<?php p($l->t('The files you are trying to upload exceed the maximum size for file uploads on this server.')); ?>
 	</p>
 </div>


### PR DESCRIPTION

## Summary
Steps to reproduce: 

1. go to  files
2. make sure you have enough files to scroll
3. scroll
4. Look at the top right corner
Before :
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/40746210/233673416-e2c725df-a3a5-4d3b-8014-709a3bee21df.png">
After :
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/40746210/233673293-8b20b4cb-01f8-4a68-8f2c-1129baeb77fb.png">
## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
