### PR TITLE
[stable25] Fix 32bit support and add workflow for 32bits testing

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -44,14 +44,13 @@ use OCP\Files\DavUtil;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\Files\StorageNotAvailableException;
-use OCP\Share\IShare;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 
 abstract class Node implements \Sabre\DAV\INode {
 
 	/**
-	 * @var \OC\Files\View
+	 * @var View
 	 */
 	protected $fileView;
 
@@ -70,7 +69,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	protected $property_cache = null;
 
 	/**
-	 * @var \OCP\Files\FileInfo
+	 * @var FileInfo
 	 */
 	protected $info;
 
@@ -84,8 +83,8 @@ abstract class Node implements \Sabre\DAV\INode {
 	/**
 	 * Sets up the node, expects a full path name
 	 *
-	 * @param \OC\Files\View $view
-	 * @param \OCP\Files\FileInfo $info
+	 * @param View $view
+	 * @param FileInfo $info
 	 * @param IManager $shareManager
 	 */
 	public function __construct(View $view, FileInfo $info, IManager $shareManager = null) {
@@ -111,8 +110,12 @@ abstract class Node implements \Sabre\DAV\INode {
 		}
 	}
 
-	protected function refreshInfo() {
-		$this->info = $this->fileView->getFileInfo($this->path);
+	protected function refreshInfo(): void {
+		$info = $this->fileView->getFileInfo($this->path);
+		if ($info === false) {
+			throw new \Sabre\DAV\Exception('Failed to get fileinfo for '. $this->path);
+		}
+		$this->info = $info;
 		$root = \OC::$server->get(IRootFolder::class);
 		$rootView = \OC::$server->get(View::class);
 		if ($this->info->getType() === FileInfo::TYPE_FOLDER) {
@@ -236,7 +239,8 @@ abstract class Node implements \Sabre\DAV\INode {
 	/**
 	 * Returns the size of the node, in bytes
 	 *
-	 * @return integer
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
 	 */
 	public function getSize() {
 		return $this->info->getSize();

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -178,7 +178,7 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	 * This method is called before any HTTP method and validates there is enough free space to store the file
 	 *
 	 * @param string $path relative to the users home
-	 * @param int $length
+	 * @param int|float|null $length
 	 * @throws InsufficientStorage
 	 * @return bool
 	 */

--- a/apps/dav/lib/Direct/DirectFile.php
+++ b/apps/dav/lib/Direct/DirectFile.php
@@ -77,6 +77,10 @@ class DirectFile implements IFile {
 		return $this->file->getEtag();
 	}
 
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
 	public function getSize() {
 		$this->getFile();
 

--- a/apps/dav/lib/Upload/UploadFile.php
+++ b/apps/dav/lib/Upload/UploadFile.php
@@ -29,7 +29,6 @@ use OCA\DAV\Connector\Sabre\File;
 use Sabre\DAV\IFile;
 
 class UploadFile implements IFile {
-
 	/**  @var File */
 	private $file;
 
@@ -53,6 +52,10 @@ class UploadFile implements IFile {
 		return $this->file->getETag();
 	}
 
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
 	public function getSize() {
 		return $this->file->getSize();
 	}

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -423,7 +423,12 @@ EOD;
 		$events[0] = $this->createEvent($calendarId, '20130912T130000Z', '20130912T140000Z');
 		$events[1] = $this->createEvent($calendarId, '20130912T150000Z', '20130912T170000Z');
 		$events[2] = $this->createEvent($calendarId, '20130912T173000Z', '20130912T220000Z');
-		$events[3] = $this->createEvent($calendarId, '21130912T130000Z', '22130912T130000Z');
+		if (PHP_INT_SIZE > 8) {
+			$events[3] = $this->createEvent($calendarId, '21130912T130000Z', '22130912T130000Z');
+		} else {
+			/* On 32bit we do not support events after 2038 */
+			$events[3] = $this->createEvent($calendarId, '20370912T130000Z', '20370912T130000Z');
+		}
 
 		$result = $this->backend->calendarQuery($calendarId, [
 			'name' => '',
@@ -471,7 +476,7 @@ EOD;
 			'only-events' => [[0, 1, 2, 3], [], [['name' => 'VEVENT', 'is-not-defined' => false, 'comp-filters' => [], 'time-range' => ['start' => null, 'end' => null], 'prop-filters' => []]],],
 			'start' => [[1, 2, 3], [], [['name' => 'VEVENT', 'is-not-defined' => false, 'comp-filters' => [], 'time-range' => ['start' => new DateTime('2013-09-12 14:00:00', new DateTimeZone('UTC')), 'end' => null], 'prop-filters' => []]],],
 			'end' => [[0], [], [['name' => 'VEVENT', 'is-not-defined' => false, 'comp-filters' => [], 'time-range' => ['start' => null, 'end' => new DateTime('2013-09-12 14:00:00', new DateTimeZone('UTC'))], 'prop-filters' => []]],],
-			'future' => [[3], [], [['name' => 'VEVENT', 'is-not-defined' => false, 'comp-filters' => [], 'time-range' => ['start' => new DateTime('2099-09-12 14:00:00', new DateTimeZone('UTC')), 'end' => null], 'prop-filters' => []]],],
+			'future' => [[3], [], [['name' => 'VEVENT', 'is-not-defined' => false, 'comp-filters' => [], 'time-range' => ['start' => new DateTime('2036-09-12 14:00:00', new DateTimeZone('UTC')), 'end' => null], 'prop-filters' => []]],],
 		];
 	}
 
@@ -648,8 +653,15 @@ EOS;
 	 * @dataProvider providesCalDataForGetDenormalizedData
 	 */
 	public function testGetDenormalizedData($expected, $key, $calData) {
-		$actual = $this->backend->getDenormalizedData($calData);
-		$this->assertEquals($expected, $actual[$key]);
+		try {
+			$actual = $this->backend->getDenormalizedData($calData);
+			$this->assertEquals($expected, $actual[$key]);
+		} catch (\ValueError $e) {
+			if (($e->getMessage() === 'Epoch doesn\'t fit in a PHP integer') && (PHP_INT_SIZE < 8)) {
+				$this->markTestSkipped('This fail on 32bits because of PHP limitations in DateTime');
+			}
+			throw $e;
+		}
 	}
 
 	public function providesCalDataForGetDenormalizedData() {

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -228,13 +228,13 @@ class FilesPluginTest extends TestCase {
 		$this->assertEquals('00000123instanceid', $propFind->get(self::FILEID_PROPERTYNAME));
 		$this->assertEquals('123', $propFind->get(self::INTERNAL_FILEID_PROPERTYNAME));
 		$this->assertEquals('1973-11-29T21:33:09+00:00', $propFind->get(self::CREATIONDATE_PROPERTYNAME));
-		$this->assertEquals(null, $propFind->get(self::SIZE_PROPERTYNAME));
+		$this->assertEquals(0, $propFind->get(self::SIZE_PROPERTYNAME));
 		$this->assertEquals('DWCKMSR', $propFind->get(self::PERMISSIONS_PROPERTYNAME));
 		$this->assertEquals('http://example.com/', $propFind->get(self::DOWNLOADURL_PROPERTYNAME));
 		$this->assertEquals('foo', $propFind->get(self::OWNER_ID_PROPERTYNAME));
 		$this->assertEquals('M. Foo', $propFind->get(self::OWNER_DISPLAY_NAME_PROPERTYNAME));
 		$this->assertEquals('my_fingerprint', $propFind->get(self::DATA_FINGERPRINT_PROPERTYNAME));
-		$this->assertEquals([self::SIZE_PROPERTYNAME], $propFind->get404Properties());
+		$this->assertEquals([], $propFind->get404Properties());
 	}
 
 	public function testGetPropertiesStorageNotAvailable() {

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -259,6 +259,8 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$filesNode2 = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$filesNode2->method('getSize')
+			->willReturn(10);
 
 		$this->userFolder->expects($this->at(0))
 			->method('getById')

--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -40,7 +40,7 @@ namespace OCA\Files\AppInfo;
 use OCA\Files\Controller\OpenLocalEditorController;
 
 /** @var Application $application */
-$application = \OC::$server->query(Application::class);
+$application = \OC::$server->get(Application::class);
 $application->registerRoutes(
 	$this,
 	[

--- a/apps/files/tests/HelperTest.php
+++ b/apps/files/tests/HelperTest.php
@@ -93,7 +93,10 @@ class HelperTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sortDataProvider
 	 */
-	public function testSortByName($sort, $sortDescending, $expectedOrder) {
+	public function testSortByName(string $sort, bool $sortDescending, array $expectedOrder) {
+		if (($sort === 'mtime') && (PHP_INT_SIZE < 8)) {
+			$this->markTestSkipped('Skip mtime sorting on 32bit');
+		}
 		$files = self::getTestFileList();
 		$files = \OCA\Files\Helper::sortFiles($files, $sort, $sortDescending);
 		$fileNames = [];

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -140,6 +140,9 @@ class FTP extends Common {
 		}
 	}
 
+	/**
+	 * @return false|int|float
+	 */
 	public function filesize($path) {
 		$result = $this->getConnection()->size($this->buildPath($path));
 		if ($result === -1) {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -205,6 +205,9 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
+	/**
+	 * @group RoutingWeirdness
+	 */
 	public function testCreateShareLink() {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
@@ -228,6 +231,9 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 	}
 
+	/**
+	 * @group RoutingWeirdness
+	 */
 	public function testCreateShareLinkPublicUpload() {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'true');
@@ -420,6 +426,7 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @medium
+	 * @group RoutingWeirdness
 	 */
 	public function testPublicLinkUrl() {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -1291,6 +1298,7 @@ class ApiTest extends TestCase {
 	 * Make sure only ISO 8601 dates are accepted
 	 *
 	 * @dataProvider datesProvider
+	 * @group RoutingWeirdness
 	 */
 	public function testPublicLinkExpireDate($date, $valid) {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -1321,6 +1329,9 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share);
 	}
 
+	/**
+	 * @group RoutingWeirdness
+	 */
 	public function testCreatePublicLinkExpireDateValid() {
 		$config = \OC::$server->getConfig();
 

--- a/apps/files_trashbin/lib/Sabre/AbstractTrash.php
+++ b/apps/files_trashbin/lib/Sabre/AbstractTrash.php
@@ -57,7 +57,11 @@ abstract class AbstractTrash implements ITrash {
 		return $this->data;
 	}
 
-	public function getSize(): int {
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
+	public function getSize() {
 		return $this->data->getSize();
 	}
 

--- a/apps/files_trashbin/lib/Sabre/ITrash.php
+++ b/apps/files_trashbin/lib/Sabre/ITrash.php
@@ -39,6 +39,10 @@ interface ITrash {
 
 	public function getDeletionTime(): int;
 
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
 	public function getSize();
 
 	public function getFileId(): int;

--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -33,7 +33,6 @@ use OCP\IConfig;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
-use Psr\Log\LoggerInterface;
 
 class ExpireTrashTest extends TestCase {
 	/** @var IConfig|MockObject */
@@ -61,7 +60,7 @@ class ExpireTrashTest extends TestCase {
 
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')
-			->willReturn(99999999999);
+			->willReturn(999999999);
 
 		$this->jobList->expects($this->once())
 			->method('setLastRun');

--- a/apps/files_versions/lib/Sabre/VersionFile.php
+++ b/apps/files_versions/lib/Sabre/VersionFile.php
@@ -65,7 +65,11 @@ class VersionFile implements IFile {
 		return (string)$this->version->getRevisionId();
 	}
 
-	public function getSize(): int {
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
+	public function getSize() {
 		return $this->version->getSize();
 	}
 

--- a/apps/files_versions/lib/Versions/IVersion.php
+++ b/apps/files_versions/lib/Versions/IVersion.php
@@ -65,10 +65,10 @@ interface IVersion {
 	/**
 	 * Get the size of this version
 	 *
-	 * @return int
+	 * @return int|float
 	 * @since 15.0.0
 	 */
-	public function getSize(): int;
+	public function getSize();
 
 	/**
 	 * Get the name of the source file at the time of making this version

--- a/apps/files_versions/lib/Versions/Version.php
+++ b/apps/files_versions/lib/Versions/Version.php
@@ -38,7 +38,7 @@ class Version implements IVersion {
 	/** @var string */
 	private $name;
 
-	/** @var int */
+	/** @var int|float */
 	private $size;
 
 	/** @var string */
@@ -56,11 +56,14 @@ class Version implements IVersion {
 	/** @var IUser */
 	private $user;
 
+	/**
+	 * @param int|float $size
+	 */
 	public function __construct(
 		int $timestamp,
 		$revisionId,
 		string $name,
-		int $size,
+		$size,
 		string $mimetype,
 		string $path,
 		FileInfo $sourceFileInfo,
@@ -94,7 +97,11 @@ class Version implements IVersion {
 		return $this->timestamp;
 	}
 
-	public function getSize(): int {
+	/**
+	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
+	 * @return int|float
+	 */
+	public function getSize() {
 		return $this->size;
 	}
 

--- a/apps/files_versions/tests/BackgroundJob/ExpireVersionsTest.php
+++ b/apps/files_versions/tests/BackgroundJob/ExpireVersionsTest.php
@@ -33,7 +33,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ExpireVersionsTest extends TestCase {
-
 	/** @var IConfig|MockObject */
 	private $config;
 
@@ -70,7 +69,7 @@ class ExpireVersionsTest extends TestCase {
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$timeFactory->method('getTime')
 			->with()
-			->willReturn(99999999999);
+			->willReturn(999999999);
 
 		$job = new ExpireVersions($this->config, $this->userManager, $this->expiration, $timeFactory);
 		$job->start($this->jobList);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -73,7 +73,6 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class UsersControllerTest extends TestCase {
-
 	/** @var IUserManager|MockObject */
 	protected $userManager;
 	/** @var IConfig|MockObject */
@@ -497,7 +496,7 @@ class UsersControllerTest extends TestCase {
 			->method('generate')
 			->with(10)
 			->willReturnCallback(function () {
-				return (string)rand(1000000000, 9999999999);
+				return (string)rand(100000000, 999999999);
 			});
 
 		$this->assertTrue(key_exists(

--- a/core/Command/Log/File.php
+++ b/core/Command/Log/File.php
@@ -122,7 +122,6 @@ class File extends Command implements Completion\CompletionAwareInterface {
 		if ($rotateSize === false) {
 			throw new \InvalidArgumentException('Error parsing log rotation file size');
 		}
-		$rotateSize = (int) $rotateSize;
 		if ($rotateSize < 0) {
 			throw new \InvalidArgumentException('Log rotation file size must be non-negative');
 		}

--- a/lib/private/Archive/Archive.php
+++ b/lib/private/Archive/Archive.php
@@ -50,7 +50,7 @@ abstract class Archive {
 
 	/**
 	 * get the uncompressed size of a file in the archive
-	 * @return int|false
+	 * @return int|float|false
 	 */
 	abstract public function filesize(string $path);
 

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -166,7 +166,7 @@ class TAR extends Archive {
 	/**
 	 * get the uncompressed size of a file in the archive
 	 *
-	 * @return int|false
+	 * @return int|float|false
 	 */
 	public function filesize(string $path) {
 		$stat = $this->getHeader($path);

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -91,7 +91,7 @@ class ZIP extends Archive {
 
 	/**
 	 * get the uncompressed size of a file in the archive
-	 * @return int|false
+	 * @return int|float|false
 	 */
 	public function filesize(string $path) {
 		$stat = $this->zip->statName($path);

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -82,7 +82,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	/**
 	 * The size of the file/folder without any sub mount
 	 *
-	 * @var int
+	 * @var int|float
 	 */
 	private $rawSize = 0;
 
@@ -207,7 +207,8 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
-	 * @return int
+	 * @param bool $includeMounts
+	 * @return int|float
 	 */
 	public function getSize($includeMounts = true) {
 		if ($includeMounts) {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -213,7 +213,7 @@ class Node implements \OCP\Files\Node {
 
 	/**
 	 * @param bool $includeMounts
-	 * @return int
+	 * @return int|float
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */

--- a/lib/private/Files/Node/NonExistingFile.php
+++ b/lib/private/Files/Node/NonExistingFile.php
@@ -65,6 +65,10 @@ class NonExistingFile extends File {
 		}
 	}
 
+	/**
+	 * @param bool $includeMounts
+	 * @return int|float
+	 */
 	public function getSize($includeMounts = true) {
 		if ($this->fileInfo) {
 			return parent::getSize($includeMounts);

--- a/lib/private/Files/Node/NonExistingFolder.php
+++ b/lib/private/Files/Node/NonExistingFolder.php
@@ -66,6 +66,10 @@ class NonExistingFolder extends Folder {
 		}
 	}
 
+	/**
+	 * @param bool $includeMounts
+	 * @return int|float
+	 */
 	public function getSize($includeMounts = true) {
 		if ($this->fileInfo) {
 			return parent::getSize($includeMounts);

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -290,7 +290,7 @@ class Root extends Folder implements IRootFolder {
 
 	/**
 	 * @param bool $includeMounts
-	 * @return int
+	 * @return int|float
 	 */
 	public function getSize($includeMounts = true) {
 		return 0;

--- a/lib/private/Files/SimpleFS/NewSimpleFile.php
+++ b/lib/private/Files/SimpleFS/NewSimpleFile.php
@@ -55,8 +55,10 @@ class NewSimpleFile implements ISimpleFile {
 
 	/**
 	 * Get the size in bytes
+	 *
+	 * @return int|float
 	 */
-	public function getSize(): int {
+	public function getSize() {
 		if ($this->file) {
 			return $this->file->getSize();
 		} else {

--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -45,8 +45,10 @@ class SimpleFile implements ISimpleFile {
 
 	/**
 	 * Get the size in bytes
+	 *
+	 * @return int|float
 	 */
-	public function getSize(): int {
+	public function getSize() {
 		return $this->file->getSize();
 	}
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -698,9 +698,9 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		$result = $this->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, true);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {
-				$result = $result && $sourceStorage->rmdir($sourceInternalPath);
+				$result = $sourceStorage->rmdir($sourceInternalPath);
 			} else {
-				$result = $result && $sourceStorage->unlink($sourceInternalPath);
+				$result = $sourceStorage->unlink($sourceInternalPath);
 			}
 		}
 		return $result;

--- a/lib/private/Files/Storage/FailedStorage.php
+++ b/lib/private/Files/Storage/FailedStorage.php
@@ -81,6 +81,9 @@ class FailedStorage extends Common {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
+	/**
+	 * @return false|int|float
+	 */
 	public function filesize($path) {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -242,6 +242,9 @@ class Local extends \OC\Files\Storage\Common {
 		return $filetype;
 	}
 
+	/**
+	 * @return false|int|float
+	 */
 	public function filesize($path) {
 		if (!$this->is_file($path)) {
 			return 0;

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -130,7 +130,7 @@ class Encryption extends Wrapper {
 	 * The result for filesize when called on a folder is required to be 0
 	 *
 	 * @param string $path
-	 * @return int
+	 * @return false|int|float
 	 */
 	public function filesize($path) {
 		$fullPath = $this->getFullPath($path);

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -144,8 +144,8 @@ class Encryption extends Wrapper {
 	 * @param \OC\Encryption\Util $util
 	 * @param \OC\Encryption\File $file
 	 * @param string $mode
-	 * @param int $size
-	 * @param int $unencryptedSize
+	 * @param int|float $size
+	 * @param int|float $unencryptedSize
 	 * @param int $headerSize
 	 * @param bool $signed
 	 * @param string $wrapper stream wrapper class
@@ -159,7 +159,7 @@ class Encryption extends Wrapper {
 								\OC\Files\Storage\Storage $storage,
 								\OC\Files\Storage\Wrapper\Encryption $encStorage,
 								\OC\Encryption\Util $util,
-								 \OC\Encryption\File $file,
+								\OC\Encryption\File $file,
 								$mode,
 								$size,
 								$unencryptedSize,

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -409,7 +409,7 @@ class View {
 	 * @param string $path
 	 * @return mixed
 	 */
-	public function filesize($path) {
+	public function filesize(string $path) {
 		return $this->basicOperation('filesize', $path);
 	}
 
@@ -1371,9 +1371,8 @@ class View {
 	 * get the filesystem info
 	 *
 	 * @param string $path
-	 * @param boolean|string $includeMountPoints true to add mountpoint sizes,
+	 * @param bool|string $includeMountPoints true to add mountpoint sizes,
 	 * 'ext' to add only ext storage mount point sizes. Defaults to true.
-	 * defaults to true
 	 * @return \OC\Files\FileInfo|false False if file does not exist
 	 */
 	public function getFileInfo($path, $includeMountPoints = true) {

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -65,6 +65,9 @@ class NullStorage extends Common {
 		return ($path === '') ? 'dir' : false;
 	}
 
+	/**
+	 * @return false|int|float
+	 */
 	public function filesize($path) {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}

--- a/lib/private/MemoryInfo.php
+++ b/lib/private/MemoryInfo.php
@@ -24,7 +24,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OC;
+
+use OCP\Util;
 
 /**
  * Helper class that covers memory info.
@@ -45,14 +48,14 @@ class MemoryInfo {
 	/**
 	 * Returns the php memory limit.
 	 *
-	 * @return int The memory limit in bytes.
+	 * @return int|float The memory limit in bytes.
 	 */
-	public function getMemoryLimit(): int {
+	public function getMemoryLimit() {
 		$iniValue = trim(ini_get('memory_limit'));
 		if ($iniValue === '-1') {
 			return -1;
-		} elseif (is_numeric($iniValue) === true) {
-			return (int)$iniValue;
+		} elseif (is_numeric($iniValue)) {
+			return Util::numericToNumber($iniValue);
 		} else {
 			return $this->memoryLimitToBytes($iniValue);
 		}
@@ -62,11 +65,16 @@ class MemoryInfo {
 	 * Converts the ini memory limit to bytes.
 	 *
 	 * @param string $memoryLimit The "memory_limit" ini value
-	 * @return int
+	 * @return int|float
 	 */
-	private function memoryLimitToBytes(string $memoryLimit): int {
+	private function memoryLimitToBytes(string $memoryLimit) {
 		$last = strtolower(substr($memoryLimit, -1));
-		$memoryLimit = (int)substr($memoryLimit, 0, -1);
+		$number = substr($memoryLimit, 0, -1);
+		if (is_numeric($number)) {
+			$memoryLimit = Util::numericToNumber($number);
+		} else {
+			throw new \InvalidArgumentException($number.' is not a valid numeric string (in memory_limit ini directive)');
+		}
 
 		// intended fall through
 		switch ($last) {

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -40,7 +40,7 @@ use ZipStreamer\ZipStreamer;
 
 class Streamer {
 	// array of regexp. Matching user agents will get tar instead of zip
-	private $preferTarFor = [ '/macintosh|mac os x/i' ];
+	private array $preferTarFor = [ '/macintosh|mac os x/i' ];
 
 	// streamer instance
 	private $streamerInstance;
@@ -49,11 +49,11 @@ class Streamer {
 	 * Streamer constructor.
 	 *
 	 * @param IRequest $request
-	 * @param int $size The size of the files in bytes
+	 * @param int|float $size The size of the files in bytes
 	 * @param int $numberOfFiles The number of files (and directories) that will
 	 *        be included in the streamed file
 	 */
-	public function __construct(IRequest $request, int $size, int $numberOfFiles) {
+	public function __construct(IRequest $request, $size, int $numberOfFiles) {
 
 		/**
 		 * zip32 constraints for a basic (without compression, volumes nor
@@ -150,11 +150,11 @@ class Streamer {
 	 *
 	 * @param resource $stream Stream to read data from
 	 * @param string $internalName Filepath and name to be used in the archive.
-	 * @param int $size Filesize
-	 * @param int|bool $time File mtime as int, or false
+	 * @param int|float $size Filesize
+	 * @param int|false $time File mtime as int, or false
 	 * @return bool $success
 	 */
-	public function addFileFromStream($stream, string $internalName, int $size, $time): bool {
+	public function addFileFromStream($stream, string $internalName, $size, $time): bool {
 		$options = [];
 		if ($time) {
 			$options = [

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -514,13 +514,17 @@ class User implements IUser {
 	 *
 	 * @param string $quota
 	 * @return void
+	 * @throws InvalidArgumentException
 	 * @since 9.0.0
 	 */
 	public function setQuota($quota) {
 		$oldQuota = $this->config->getUserValue($this->uid, 'files', 'quota', '');
 		if ($quota !== 'none' and $quota !== 'default') {
-			$quota = OC_Helper::computerFileSize($quota);
-			$quota = OC_Helper::humanFileSize((int)$quota);
+			$bytesQuota = OC_Helper::computerFileSize($quota);
+			if ($bytesQuota === false) {
+				throw new InvalidArgumentException('Failed to set quota to invalid value '.$quota);
+			}
+			$quota = OC_Helper::humanFileSize($bytesQuota);
 		}
 		if ($quota !== $oldQuota) {
 			$this->config->setUserValue($this->uid, 'files', 'quota', $quota);

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -59,7 +59,7 @@ class OC_Files {
 	public const UPLOAD_MIN_LIMIT_BYTES = 1048576; // 1 MiB
 
 
-	private static $multipartBoundary = '';
+	private static string $multipartBoundary = '';
 
 	/**
 	 * @return string
@@ -247,7 +247,7 @@ class OC_Files {
 
 	/**
 	 * @param string $rangeHeaderPos
-	 * @param int $fileSize
+	 * @param int|float $fileSize
 	 * @return array $rangeArray ('from'=>int,'to'=>int), ...
 	 */
 	private static function parseHttpRangeHeader($rangeHeaderPos, $fileSize) {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -49,6 +49,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IBinaryFinder;
 use OCP\IUser;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -59,12 +60,12 @@ class OC_Helper {
 
 	/**
 	 * Make a human file size
-	 * @param int $bytes file size in bytes
+	 * @param int|float $bytes file size in bytes
 	 * @return string a human readable file size
 	 *
 	 * Makes 2048 to 2 kB.
 	 */
-	public static function humanFileSize($bytes) {
+	public static function humanFileSize($bytes): string {
 		if ($bytes < 0) {
 			return "?";
 		}
@@ -387,8 +388,8 @@ class OC_Helper {
 	 * calculates the maximum upload size respecting system settings, free space and user quota
 	 *
 	 * @param string $dir the current folder where the user currently operates
-	 * @param int $freeSpace the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
-	 * @return int number of bytes representing
+	 * @param int|float $freeSpace the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
+	 * @return int|float number of bytes representing
 	 */
 	public static function maxUploadFilesize($dir, $freeSpace = null) {
 		if (is_null($freeSpace) || $freeSpace < 0) {
@@ -401,7 +402,7 @@ class OC_Helper {
 	 * Calculate free space left within user quota
 	 *
 	 * @param string $dir the current folder where the user currently operates
-	 * @return int number of bytes representing
+	 * @return int|float number of bytes representing
 	 */
 	public static function freeSpace($dir) {
 		$freeSpace = \OC\Files\Filesystem::free_space($dir);
@@ -416,12 +417,12 @@ class OC_Helper {
 	/**
 	 * Calculate PHP upload limit
 	 *
-	 * @return int PHP upload file size limit
+	 * @return int|float PHP upload file size limit
 	 */
 	public static function uploadLimit() {
 		$ini = \OC::$server->get(IniGetWrapper::class);
-		$upload_max_filesize = (int)OCP\Util::computerFileSize($ini->get('upload_max_filesize'));
-		$post_max_size = (int)OCP\Util::computerFileSize($ini->get('post_max_size'));
+		$upload_max_filesize = Util::computerFileSize($ini->get('upload_max_filesize')) ?: 0;
+		$post_max_size = Util::computerFileSize($ini->get('post_max_size')) ?: 0;
 		if ($upload_max_filesize === 0 && $post_max_size === 0) {
 			return INF;
 		} elseif ($upload_max_filesize === 0 || $post_max_size === 0) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -145,7 +145,7 @@ class OC_Util {
 	/**
 	 * check if share API enforces a default expire date
 	 *
-	 * @return boolean
+	 * @return bool
 	 * @suppress PhanDeprecatedFunction
 	 */
 	public static function isDefaultExpireDateEnforced() {

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -84,7 +84,7 @@ interface FileInfo {
 	 * Get the size in bytes for the file or folder
 	 *
 	 * @param bool $includeMounts whether or not to include the size of any sub mounts, since 16.0.0
-	 * @return int
+	 * @return int|float
 	 * @since 7.0.0
 	 */
 	public function getSize($includeMounts = true);

--- a/lib/public/Files/Node.php
+++ b/lib/public/Files/Node.php
@@ -145,7 +145,7 @@ interface Node extends FileInfo {
 	 * Get the size of the file or folder in bytes
 	 *
 	 * @param bool $includeMounts
-	 * @return int
+	 * @return int|float
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 * @since 6.0.0

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -48,9 +48,10 @@ interface ISimpleFile {
 	/**
 	 * Get the size in bytes
 	 *
+	 * @return int|float
 	 * @since 11.0.0
 	 */
-	public function getSize(): int;
+	public function getSize();
 
 	/**
 	 * Get the ETag

--- a/lib/public/Files/SimpleFS/InMemoryFile.php
+++ b/lib/public/Files/SimpleFS/InMemoryFile.php
@@ -68,7 +68,7 @@ class InMemoryFile implements ISimpleFile {
 	 * @inheritdoc
 	 * @since 16.0.0
 	 */
-	public function getSize(): int {
+	public function getSize() {
 		return strlen($this->contents);
 	}
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -361,24 +361,35 @@ class Util {
 	}
 
 	/**
+	 * Converts string to int or float depending if it fits an int
+	 * @param numeric-string|float|int $number numeric string
+	 * @return int|float int if it fits, float if it is too big
+	 * @since 25.0.7
+	 */
+	public static function numericToNumber($number) {
+		/* This is a hack to cast to (int|float) */
+		return 0 + (string)$number;
+	}
+
+	/**
 	 * Make a human file size (2048 to 2 kB)
-	 * @param int $bytes file size in bytes
+	 * @param int|float $bytes file size in bytes
 	 * @return string a human readable file size
 	 * @since 4.0.0
 	 */
-	public static function humanFileSize($bytes) {
+	public static function humanFileSize($bytes): string {
 		return \OC_Helper::humanFileSize($bytes);
 	}
 
 	/**
 	 * Make a computer file size (2 kB to 2048)
 	 * @param string $str file size in a fancy format
-	 * @return float|false a file size in bytes
+	 * @return false|int|float a file size in bytes
 	 *
 	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
 	 * @since 4.0.0
 	 */
-	public static function computerFileSize($str) {
+	public static function computerFileSize(string $str) {
 		return \OC_Helper::computerFileSize($str);
 	}
 
@@ -495,18 +506,18 @@ class Util {
 	 * calculates the maximum upload size respecting system settings, free space and user quota
 	 *
 	 * @param string $dir the current folder where the user currently operates
-	 * @param int $free the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
-	 * @return int number of bytes representing
+	 * @param int|float|null $free the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
+	 * @return int|float number of bytes representing
 	 * @since 5.0.0
 	 */
-	public static function maxUploadFilesize($dir, $free = null) {
+	public static function maxUploadFilesize(string $dir, $free = null) {
 		return \OC_Helper::maxUploadFilesize($dir, $free);
 	}
 
 	/**
 	 * Calculate free space left within user quota
 	 * @param string $dir the current folder where the user currently operates
-	 * @return int number of bytes representing
+	 * @return int|float number of bytes representing
 	 * @since 7.0.0
 	 */
 	public static function freeSpace($dir) {
@@ -516,7 +527,7 @@ class Util {
 	/**
 	 * Calculate PHP upload limit
 	 *
-	 * @return int number of bytes representing
+	 * @return int|float number of bytes representing
 	 * @since 7.0.0
 	 */
 	public static function uploadLimit() {

--- a/tests/lib/Memcache/APCuTest.php
+++ b/tests/lib/Memcache/APCuTest.php
@@ -9,6 +9,10 @@
 
 namespace Test\Memcache;
 
+/**
+ * @group Memcache
+ * @group APCu
+ */
 class APCuTest extends Cache {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Memcache/ArrayCacheTest.php
+++ b/tests/lib/Memcache/ArrayCacheTest.php
@@ -9,6 +9,9 @@
 
 namespace Test\Memcache;
 
+/**
+ * @group Memcache
+ */
 class ArrayCacheTest extends Cache {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Memcache/CasTraitTest.php
+++ b/tests/lib/Memcache/CasTraitTest.php
@@ -23,6 +23,9 @@ namespace Test\Memcache;
 
 use Test\TestCase;
 
+/**
+ * @group Memcache
+ */
 class CasTraitTest extends TestCase {
 	/**
 	 * @return \OC\Memcache\CasTrait

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -61,6 +61,9 @@ class Test_Factory_Unavailable_Cache2 extends NullCache {
 	}
 }
 
+/**
+ * @group Memcache
+ */
 class FactoryTest extends \Test\TestCase {
 	public const AVAILABLE1 = '\\Test\\Memcache\\Test_Factory_Available_Cache1';
 	public const AVAILABLE2 = '\\Test\\Memcache\\Test_Factory_Available_Cache2';

--- a/tests/lib/Memcache/MemcachedTest.php
+++ b/tests/lib/Memcache/MemcachedTest.php
@@ -9,6 +9,10 @@
 
 namespace Test\Memcache;
 
+/**
+ * @group Memcache
+ * @group Memcached
+ */
 class MemcachedTest extends Cache {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -9,6 +9,10 @@
 
 namespace Test\Memcache;
 
+/**
+ * @group Memcache
+ * @group Redis
+ */
 class RedisTest extends Cache {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();

--- a/tests/lib/MemoryInfoTest.php
+++ b/tests/lib/MemoryInfoTest.php
@@ -71,10 +71,10 @@ class MemoryInfoTest extends TestCase {
 	 * Tests that getMemoryLimit works as expected.
 	 *
 	 * @param string $iniValue The "memory_limit" ini data.
-	 * @param int $expected The expected detected memory limit.
+	 * @param int|float $expected The expected detected memory limit.
 	 * @dataProvider getMemoryLimitTestData
 	 */
-	public function testMemoryLimit($iniValue, int $expected) {
+	public function testMemoryLimit(string $iniValue, $expected) {
 		ini_set('memory_limit', $iniValue);
 		$memoryInfo = new MemoryInfo();
 		self::assertEquals($expected, $memoryInfo->getMemoryLimit());

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -30,12 +30,20 @@ use Test\TestCase;
 /**
  * Class RouterTest
  *
+ * @group RoutingWeirdness
+ *
  * @package Test\Route
  */
 class RouterTest extends TestCase {
 	public function testGenerateConsecutively(): void {
 		/** @var LoggerInterface $logger */
 		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('info')
+			->willReturnCallback(
+				function (string $message, array $data) {
+					$this->fail('Unexpected info log: '.(string)($data['exception'] ?? $message));
+				}
+			);
 		$router = new Router($logger);
 
 		$this->assertEquals('/index.php/apps/files/', $router->generate('files.view.index'));


### PR DESCRIPTION
* Resolves: #35734 (the PR did not really fix it)

## Summary
This backports most changes from:
https://github.com/nextcloud/server/pull/36120

Excludes union type, supported by PHP 8.x only
replaced with phpdoc in case.

## TODO

- [ ] Verify that all types are aligned, since there was some conflicting quota related solution with `float` only instead of `int|float`.
- [ ] Discuss whether the new `Utils` function is fine here.
- [ ] Verify that nothing was backported which depends on other changes on NC26.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
