### PR TITLE
Fix multiple LDAP configuration support by fixing AccessFactory

### DIFF
--- a/apps/user_ldap/lib/AccessFactory.php
+++ b/apps/user_ldap/lib/AccessFactory.php
@@ -50,6 +50,7 @@ class AccessFactory {
 	}
 
 	public function get(Connection $connection): Access {
+		/* Each Access instance gets its own Manager instance, see OCA\User_LDAP\AppInfo\Application::register() */
 		return new Access(
 			$connection,
 			$this->ldap,

--- a/apps/user_ldap/lib/AccessFactory.php
+++ b/apps/user_ldap/lib/AccessFactory.php
@@ -26,11 +26,11 @@ namespace OCA\User_LDAP;
 use OCA\User_LDAP\User\Manager;
 use OCP\IConfig;
 use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class AccessFactory {
 	private ILDAPWrapper $ldap;
-	private Manager $userManager;
 	private Helper $helper;
 	private IConfig $config;
 	private IUserManager $ncUserManager;
@@ -38,13 +38,11 @@ class AccessFactory {
 
 	public function __construct(
 		ILDAPWrapper $ldap,
-		Manager $userManager,
 		Helper $helper,
 		IConfig $config,
 		IUserManager $ncUserManager,
 		LoggerInterface $logger) {
 		$this->ldap = $ldap;
-		$this->userManager = $userManager;
 		$this->helper = $helper;
 		$this->config = $config;
 		$this->ncUserManager = $ncUserManager;
@@ -55,7 +53,7 @@ class AccessFactory {
 		return new Access(
 			$connection,
 			$this->ldap,
-			$this->userManager,
+			Server::get(Manager::class),
 			$this->helper,
 			$this->config,
 			$this->ncUserManager,

--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -31,7 +31,6 @@ use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Mapping\UserMapping;
-use OCA\User_LDAP\User\Manager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IAvatarManager;
@@ -48,8 +47,6 @@ class Sync extends TimedJob {
 	protected $ldapHelper;
 	/** @var  LDAP */
 	protected $ldap;
-	/** @var  Manager */
-	protected $userManager;
 	/** @var UserMapping */
 	protected $mapper;
 	/** @var  IConfig */
@@ -69,9 +66,8 @@ class Sync extends TimedJob {
 	/** @var AccessFactory */
 	protected $accessFactory;
 
-	public function __construct(Manager  $userManager, ITimeFactory $time) {
+	public function __construct(ITimeFactory $time) {
 		parent::__construct($time);
-		$this->userManager = $userManager;
 		$this->setInterval(
 			(int)\OC::$server->getConfig()->getAppValue(
 				'user_ldap',
@@ -350,10 +346,6 @@ class Sync extends TimedJob {
 			$this->notificationManager = \OC::$server->getNotificationManager();
 		}
 
-		if (isset($argument['userManager'])) {
-			$this->userManager = $argument['userManager'];
-		}
-
 		if (isset($argument['mapper'])) {
 			$this->mapper = $argument['mapper'];
 		} else {
@@ -369,14 +361,7 @@ class Sync extends TimedJob {
 		if (isset($argument['accessFactory'])) {
 			$this->accessFactory = $argument['accessFactory'];
 		} else {
-			$this->accessFactory = new AccessFactory(
-				$this->ldap,
-				$this->userManager,
-				$this->ldapHelper,
-				$this->config,
-				$this->ncUserManager,
-				$this->logger
-			);
+			$this->accessFactory = \OCP\Server::get(AccessFactory::class);
 		}
 	}
 }

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -43,7 +43,6 @@ use OCP\Notification\IManager;
 use Test\TestCase;
 
 class SyncTest extends TestCase {
-
 	/** @var  array */
 	protected $arguments;
 	/** @var  Helper|\PHPUnit\Framework\MockObject\MockObject */
@@ -99,7 +98,7 @@ class SyncTest extends TestCase {
 			'accessFactory' => $this->accessFactory,
 		];
 
-		$this->sync = new Sync($this->userManager, $this->createMock(ITimeFactory::class));
+		$this->sync = new Sync($this->createMock(ITimeFactory::class));
 	}
 
 	public function intervalDataProvider() {


### PR DESCRIPTION
* Resolves: #37454 

## Summary

PR #34772 broke the fix from PR #35070 because AccessFactory was reusing the same Manager instance for all access instances.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
