### PR TITLE
Rely on getconf() instead of /proc/cpuinfo

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -297,7 +297,7 @@ class Generator {
 		static $width;
 		if (!isset($width)) {
 			if (function_exists('getconf')) {
-				$width = is_int(getconf('_NPROCESSORS_ONLN')) ?? is_int(getconf('NPROCESSORS_ONLN')) ?? 0;
+				$width = getconf('_NPROCESSORS_ONLN');
 			} else {
 				$width = 0;
 			}

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -296,8 +296,8 @@ class Generator {
 	public static function getHardwareConcurrency(): int {
 		static $width;
 		if (!isset($width)) {
-			if (is_file("/proc/cpuinfo")) {
-				$width = substr_count(file_get_contents("/proc/cpuinfo"), "processor");
+			if (function_exists('getconf')) {
+				$width = is_int(getconf('_NPROCESSORS_ONLN')) ?? is_int(getconf('NPROCESSORS_ONLN')) ?? 0;
 			} else {
 				$width = 0;
 			}


### PR DESCRIPTION
## Summary

`getconf()` is more compatible and less `open_basedir()` error prone.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
