### PR TITLE
fix: change maintenance mode info wording

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -178,17 +178,13 @@ class Application {
 	 * for writing outputs.
 	 * @return void
 	 */
-	private function writeMaintenanceModeInfo(
-		InputInterface $input, ConsoleOutputInterface $output
-	) {
+	private function writeMaintenanceModeInfo(InputInterface $input, ConsoleOutputInterface $output): void {
 		if ($input->getArgument('command') !== '_completion'
 			&& $input->getArgument('command') !== 'maintenance:mode'
 			&& $input->getArgument('command') !== 'status') {
 			$errOutput = $output->getErrorOutput();
-			$errOutput->writeln(
-				'<comment>Nextcloud is in maintenance mode, hence the database isn\'t accessible.' . PHP_EOL .
-				'Cannot perform any command except \'maintenance:mode --off\'</comment>' . PHP_EOL
-			);
+			$errOutput->writeln('<comment>Nextcloud is in maintenance mode, no apps are loaded.</comment>');
+			$errOutput->writeln('<comment>Commands provided by apps are unavailable.</comment>');
 		}
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

```
Nextcloud is in maintenance mode, hence the database isn't accessible.
Cannot perform any command except 'maintenance:mode --off'
```

A customer brought to our attention that the message is misleading.

In maintenance mode the database is accessible and it's possible to execute other commands then maintenance:mode

![image](https://user-images.githubusercontent.com/3902676/234364392-a3c56065-8b8d-481e-8815-279cdf488e60.png)

The reason we changed the message was https://github.com/nextcloud/server/issues/20515. 
I restored the old wording and added another line to make clear that some commands are unavailable.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
