### PR TITLE
chore(404): Extend 404 error message to mention possibly missing permissions

### DIFF
--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -18,7 +18,7 @@ if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 	<div class="body-login-container update">
 		<div class="icon-big icon-search"></div>
 		<h2><?php p($l->t('Page not found')); ?></h2>
-		<p class="infogroup"><?php p($l->t('The page could not be found on the server.')); ?></p>
+		<p class="infogroup"><?php p($l->t('The page could not be found on the server or you may not be allowed to view it.')); ?></p>
 		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
 			<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 		</a></p>


### PR DESCRIPTION
## Summary
We sometimes return a 404 when the user doesn't have permission to view a file, to avoid leaking the information that the file exists. To avoid confusing users, let's add that information to the message. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
