### PR TITLE
fix(contactsinteraction): Read, update or insert in DB transaction

### DIFF
--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -28,10 +28,12 @@ namespace OCA\ContactsInteraction\Listeners;
 use OCA\ContactsInteraction\Db\CardSearchDao;
 use OCA\ContactsInteraction\Db\RecentContact;
 use OCA\ContactsInteraction\Db\RecentContactMapper;
+use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Contacts\Events\ContactInteractedWithEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -41,9 +43,13 @@ use Sabre\VObject\UUIDUtil;
 use Throwable;
 
 class ContactInteractionListener implements IEventListener {
+
+	use TTransactional;
+
 	private RecentContactMapper $mapper;
 	private CardSearchDao $cardSearchDao;
 	private IUserManager $userManager;
+	private IDBConnection $dbConnection;
 	private ITimeFactory $timeFactory;
 	private IL10N $l10n;
 	private LoggerInterface $logger;
@@ -51,12 +57,14 @@ class ContactInteractionListener implements IEventListener {
 	public function __construct(RecentContactMapper $mapper,
 								CardSearchDao $cardSearchDao,
 								IUserManager $userManager,
+								IDBConnection $connection,
 								ITimeFactory $timeFactory,
 								IL10N $l10nFactory,
 								LoggerInterface $logger) {
 		$this->mapper = $mapper;
 		$this->cardSearchDao = $cardSearchDao;
 		$this->userManager = $userManager;
+		$this->dbConnection = $connection;
 		$this->timeFactory = $timeFactory;
 		$this->l10n = $l10nFactory;
 		$this->logger = $logger;
@@ -77,58 +85,60 @@ class ContactInteractionListener implements IEventListener {
 			return;
 		}
 
-		$existing = $this->mapper->findMatch(
-			$event->getActor(),
-			$event->getUid(),
-			$event->getEmail(),
-			$event->getFederatedCloudId()
-		);
-		if (!empty($existing)) {
-			$now = $this->timeFactory->getTime();
-			foreach ($existing as $c) {
-				$c->setLastContact($now);
-				$this->mapper->update($c);
+		$this->atomic(function () use ($event) {
+			$existing = $this->mapper->findMatch(
+				$event->getActor(),
+				$event->getUid(),
+				$event->getEmail(),
+				$event->getFederatedCloudId()
+			);
+			if (!empty($existing)) {
+				$now = $this->timeFactory->getTime();
+				foreach ($existing as $c) {
+					$c->setLastContact($now);
+					$this->mapper->update($c);
+				}
+
+				return;
 			}
 
-			return;
-		}
-
-		$contact = new RecentContact();
-		$contact->setActorUid($event->getActor()->getUID());
-		if ($event->getUid() !== null) {
-			$contact->setUid($event->getUid());
-		}
-		if ($event->getEmail() !== null) {
-			$contact->setEmail($event->getEmail());
-		}
-		if ($event->getFederatedCloudId() !== null) {
-			$contact->setFederatedCloudId($event->getFederatedCloudId());
-		}
-		$contact->setLastContact($this->timeFactory->getTime());
-
-		$copy = $this->cardSearchDao->findExisting(
-			$event->getActor(),
-			$event->getUid(),
-			$event->getEmail(),
-			$event->getFederatedCloudId()
-		);
-		if ($copy !== null) {
-			try {
-				$parsed = Reader::read($copy, Reader::OPTION_FORGIVING);
-				$parsed->CATEGORIES = $this->l10n->t('Recently contacted');
-				$contact->setCard($parsed->serialize());
-			} catch (Throwable $e) {
-				$this->logger->warning(
-					'Could not parse card to add recent category: ' . $e->getMessage(),
-					[
-						'exception' => $e,
-					]);
-				$contact->setCard($copy);
+			$contact = new RecentContact();
+			$contact->setActorUid($event->getActor()->getUID());
+			if ($event->getUid() !== null) {
+				$contact->setUid($event->getUid());
 			}
-		} else {
-			$contact->setCard($this->generateCard($contact));
-		}
-		$this->mapper->insert($contact);
+			if ($event->getEmail() !== null) {
+				$contact->setEmail($event->getEmail());
+			}
+			if ($event->getFederatedCloudId() !== null) {
+				$contact->setFederatedCloudId($event->getFederatedCloudId());
+			}
+			$contact->setLastContact($this->timeFactory->getTime());
+
+			$copy = $this->cardSearchDao->findExisting(
+				$event->getActor(),
+				$event->getUid(),
+				$event->getEmail(),
+				$event->getFederatedCloudId()
+			);
+			if ($copy !== null) {
+				try {
+					$parsed = Reader::read($copy, Reader::OPTION_FORGIVING);
+					$parsed->CATEGORIES = $this->l10n->t('Recently contacted');
+					$contact->setCard($parsed->serialize());
+				} catch (Throwable $e) {
+					$this->logger->warning(
+						'Could not parse card to add recent category: ' . $e->getMessage(),
+						[
+							'exception' => $e,
+						]);
+					$contact->setCard($copy);
+				}
+			} else {
+				$contact->setCard($this->generateCard($contact));
+			}
+			$this->mapper->insert($contact);
+		}, $this->dbConnection);
 	}
 
 	private function getDisplayName(?string $uid): ?string {

--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -86,11 +86,14 @@ class ContactInteractionListener implements IEventListener {
 		}
 
 		$this->atomic(function () use ($event) {
+			$uid = $event->getUid();
+			$email = $event->getEmail();
+			$federatedCloudId = $event->getFederatedCloudId();
 			$existing = $this->mapper->findMatch(
 				$event->getActor(),
-				$event->getUid(),
-				$event->getEmail(),
-				$event->getFederatedCloudId()
+				$uid,
+				$email,
+				$federatedCloudId
 			);
 			if (!empty($existing)) {
 				$now = $this->timeFactory->getTime();
@@ -104,22 +107,22 @@ class ContactInteractionListener implements IEventListener {
 
 			$contact = new RecentContact();
 			$contact->setActorUid($event->getActor()->getUID());
-			if ($event->getUid() !== null) {
-				$contact->setUid($event->getUid());
+			if ($uid !== null) {
+				$contact->setUid($uid);
 			}
-			if ($event->getEmail() !== null) {
-				$contact->setEmail($event->getEmail());
+			if ($email !== null) {
+				$contact->setEmail($email);
 			}
-			if ($event->getFederatedCloudId() !== null) {
-				$contact->setFederatedCloudId($event->getFederatedCloudId());
+			if ($federatedCloudId !== null) {
+				$contact->setFederatedCloudId($federatedCloudId);
 			}
 			$contact->setLastContact($this->timeFactory->getTime());
 
 			$copy = $this->cardSearchDao->findExisting(
 				$event->getActor(),
-				$event->getUid(),
-				$event->getEmail(),
-				$event->getFederatedCloudId()
+				$uid,
+				$email,
+				$federatedCloudId
 			);
 			if ($copy !== null) {
 				try {


### PR DESCRIPTION
## Summary

The transaction guarantees there are no two concurrent inserts for the same interaction.

I have not seen a conflict in production. I just noticed that this code is prone to fail in rare cases.

This is best reviewed as https://github.com/nextcloud/server/pull/37933/files?w=1

## TODO

- [x] Span DB transaction for the read-write operation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
