### PR TITLE
Remove job from oc_jobs when the file is not findable

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -307,7 +307,8 @@ class JobList implements IJobList {
 					$class = $row['class'];
 					$job = new $class();
 				} else {
-					// job from disabled app or old version of an app, no need to do anything
+					// Remove job from disabled app or old version of an app
+					$this->removeById($row['id']);
 					return null;
 				}
 			}


### PR DESCRIPTION
When an application is disabled, or when a background jobs is removed by the app developer, then the job won't be found at execution time.
In those cases, we return null, but it makes sense to remove those jobs from oc_job.

If the app was disabled, the job will be re-added if the app is enabled again.