### PR TITLE
Fix file_get_content signatures to make it clear it can return false

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -554,7 +554,7 @@ class Filesystem {
 	}
 
 	/**
-	 * @return string
+	 * @return string|false
 	 */
 	public static function file_get_contents($path) {
 		return self::$defaultInstance->file_get_contents($path);

--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -46,14 +46,16 @@ class File extends Node implements \OCP\Files\File {
 	/**
 	 * @return string
 	 * @throws NotPermittedException
+	 * @throws GenericFileException
 	 * @throws LockedException
 	 */
 	public function getContent() {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_READ)) {
-			/**
-			 * @var \OC\Files\Storage\Storage $storage;
-			 */
-			return $this->view->file_get_contents($this->path);
+			$content = $this->view->file_get_contents($this->path);
+			if ($content === false) {
+				throw new GenericFileException();
+			}
+			return $content;
 		} else {
 			throw new NotPermittedException();
 		}
@@ -62,7 +64,7 @@ class File extends Node implements \OCP\Files\File {
 	/**
 	 * @param string|resource $data
 	 * @throws NotPermittedException
-	 * @throws \OCP\Files\GenericFileException
+	 * @throws GenericFileException
 	 * @throws LockedException
 	 */
 	public function putContent($data) {

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -300,7 +300,7 @@ class Encoding extends Wrapper {
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 */
 	public function file_get_contents($path) {
 		return $this->storage->file_get_contents($this->findPathToUse($path));

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -217,7 +217,7 @@ class Encryption extends Wrapper {
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function file_get_contents($path) {
 		$encryptionModule = $this->getEncryptionModule($path);

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -248,7 +248,7 @@ class Jail extends Wrapper {
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 */
 	public function file_get_contents($path) {
 		return $this->getWrapperStorage()->file_get_contents($this->getUnjailedPath($path));

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -238,7 +238,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 */
 	public function file_get_contents($path) {
 		return $this->getWrapperStorage()->file_get_contents($path);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -564,7 +564,7 @@ class View {
 
 	/**
 	 * @param string $path
-	 * @return mixed
+	 * @return string|false
 	 * @throws LockedException
 	 */
 	public function file_get_contents($path) {

--- a/lib/public/Files/File.php
+++ b/lib/public/Files/File.php
@@ -40,6 +40,7 @@ interface File extends Node {
 	 *
 	 * @return string
 	 * @throws NotPermittedException
+	 * @throws GenericFileException
 	 * @throws LockedException
 	 * @since 6.0.0
 	 */

--- a/lib/public/Files/Storage.php
+++ b/lib/public/Files/Storage.php
@@ -217,7 +217,7 @@ interface Storage extends IStorage {
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 * @since 6.0.0
 	 */
 	public function file_get_contents($path);

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -214,7 +214,7 @@ interface IStorage {
 	 * see https://www.php.net/manual/en/function.file_get_contents.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 * @since 9.0.0
 	 */
 	public function file_get_contents($path);


### PR DESCRIPTION
## Summary

In File::getContent, which must return a string, throw an Exception instead of returning false.

This avoids some TypeError that I’ve seen reported recently, either through SimpleFile which has a strong return type, or through a call to getimagesizefromstring which expects a string.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
