### PR TITLE
Do not stop at the first PHP error/warning in files:scan

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -204,7 +204,7 @@ class Scan extends Base {
 			return 1;
 		}
 
-		$this->initTools();
+		$this->initTools($output);
 
 		$user_count = 0;
 		foreach ($users as $user) {
@@ -236,15 +236,19 @@ class Scan extends Base {
 	/**
 	 * Initialises some useful tools for the Command
 	 */
-	protected function initTools() {
+	protected function initTools(OutputInterface $output) {
 		// Start the timer
 		$this->execTime = -microtime(true);
 		// Convert PHP errors to exceptions
-		set_error_handler([$this, 'exceptionErrorHandler'], E_ALL);
+		set_error_handler(
+			fn (int $severity, string $message, string $file, int $line): bool =>
+				$this->exceptionErrorHandler($output, $severity, $message, $file, $line),
+			E_ALL
+		);
 	}
 
 	/**
-	 * Processes PHP errors as exceptions in order to be able to keep track of problems
+	 * Processes PHP errors in order to be able to show them in the output
 	 *
 	 * @see https://www.php.net/manual/en/function.set-error-handler.php
 	 *
@@ -252,15 +256,15 @@ class Scan extends Base {
 	 * @param string $message
 	 * @param string $file the filename that the error was raised in
 	 * @param int $line the line number the error was raised
-	 *
-	 * @throws \ErrorException
 	 */
-	public function exceptionErrorHandler($severity, $message, $file, $line) {
-		if (!(error_reporting() & $severity)) {
-			// This error code is not included in error_reporting
-			return;
+	public function exceptionErrorHandler(OutputInterface $output, int $severity, string $message, string $file, int $line): bool {
+		if (($severity === E_DEPRECATED) || ($severity === E_USER_DEPRECATED)) {
+			// Do not show deprecation warnings
+			return false;
 		}
-		throw new \ErrorException($message, 0, $severity, $file, $line);
+		$e = new \ErrorException($message, 0, $severity, $file, $line);
+		$output->writeln("\t<error>$e</error>");
+		return true;
 	}
 
 	/**

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -192,11 +192,6 @@ class Scan extends Base {
 			$users = $input->getArgument('user_id');
 		}
 
-		# restrict the verbosity level to VERBOSITY_VERBOSE
-		if ($output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-			$output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-		}
-
 		# check quantity of users to be process and show it on the command line
 		$users_total = count($users);
 		if ($users_total === 0) {
@@ -263,7 +258,8 @@ class Scan extends Base {
 			return false;
 		}
 		$e = new \ErrorException($message, 0, $severity, $file, $line);
-		$output->writeln("\t<error>$e</error>");
+		$output->writeln('<error>Error during scan: ' . $e->getMessage() . '</error>');
+		$output->writeln('<error>' . $e->getTraceAsString() . '</error>', OutputInterface::VERBOSITY_VERY_VERBOSE);
 		return true;
 	}
 

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -58,6 +58,7 @@ class Scan extends Base {
 	protected float $execTime = 0;
 	protected int $foldersCounter = 0;
 	protected int $filesCounter = 0;
+	protected int $errorsCounter = 0;
 	private IRootFolder $root;
 	private MetadataManager $metadataManager;
 
@@ -148,10 +149,12 @@ class Scan extends Base {
 
 		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
 			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
+			++$this->errorsCounter;
 		});
 
 		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
 			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
+			++$this->errorsCounter;
 		});
 
 		try {
@@ -164,14 +167,17 @@ class Scan extends Base {
 			$output->writeln("<error>Home storage for user $user not writable or 'files' subdirectory missing</error>");
 			$output->writeln('  ' . $e->getMessage());
 			$output->writeln('Make sure you\'re running the scan command only as the user the web server runs as');
+			++$this->errorsCounter;
 		} catch (InterruptedException $e) {
 			# exit the function if ctrl-c has been pressed
 			$output->writeln('Interrupted by user');
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Path not found: ' . $e->getMessage() . '</error>');
+			++$this->errorsCounter;
 		} catch (\Exception $e) {
 			$output->writeln('<error>Exception during scan: ' . $e->getMessage() . '</error>');
 			$output->writeln('<error>' . $e->getTraceAsString() . '</error>');
+			++$this->errorsCounter;
 		}
 	}
 
@@ -260,6 +266,7 @@ class Scan extends Base {
 		$e = new \ErrorException($message, 0, $severity, $file, $line);
 		$output->writeln('<error>Error during scan: ' . $e->getMessage() . '</error>');
 		$output->writeln('<error>' . $e->getTraceAsString() . '</error>', OutputInterface::VERBOSITY_VERY_VERBOSE);
+		++$this->errorsCounter;
 		return true;
 	}
 
@@ -271,28 +278,18 @@ class Scan extends Base {
 		$this->execTime += microtime(true);
 
 		$headers = [
-			'Folders', 'Files', 'Elapsed time'
+			'Folders',
+			'Files',
+			'Errors',
+			'Elapsed time',
 		];
-
-		$this->showSummary($headers, null, $output);
-	}
-
-	/**
-	 * Shows a summary of operations
-	 *
-	 * @param string[] $headers
-	 * @param string[] $rows
-	 * @param OutputInterface $output
-	 */
-	protected function showSummary($headers, $rows, OutputInterface $output) {
 		$niceDate = $this->formatExecTime();
-		if (!$rows) {
-			$rows = [
-				$this->foldersCounter,
-				$this->filesCounter,
-				$niceDate,
-			];
-		}
+		$rows = [
+			$this->foldersCounter,
+			$this->filesCounter,
+			$this->errorsCounter,
+			$niceDate,
+		];
 		$table = new Table($output);
 		$table
 			->setHeaders($headers)


### PR DESCRIPTION
* Resolves: #35931 

## Summary

The files:scan command sets a custom error handler to show PHP errors. But it stops at the first one, failing the whole scan for one malformed PNG file.
This PR changes that to instead show errors but continue.

Output:
![Screenshot_20230427_104813](https://user-images.githubusercontent.com/91878298/234810800-54c7dd46-9501-4ce4-a3da-5877add160e6.png)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
