### PR TITLE
Do not show Tags action when systemtag is disabled

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -108,12 +108,14 @@
 							iconClass: 'icon-delete',
 							order: 99,
 						},
-						{
-							name: 'tags',
-							displayName:  t('files', 'Tags'),
-							iconClass: 'icon-tag',
-							order: 100,
-						},
+						...(
+							OCA?.SystemTags === undefined ? [] : ([{
+								name: 'tags',
+								displayName:  t('files', 'Tags'),
+								iconClass: 'icon-tag',
+								order: 100,
+							}])
+						),
 					],
 					sorting: {
 						mode: $('#defaultFileSorting').val() === 'basename'


### PR DESCRIPTION
Follow up of https://github.com/nextcloud/server/pull/28133

Same as in the Sidebar: https://github.com/nextcloud/server/blob/f9c427ce635ca5a4c57a15093c7a97dc6ccdf9eb/apps/files/src/views/Sidebar.vue#L293-L295

Before | After
-- | --
![Screenshot from 2023-04-27 13-55-23](https://user-images.githubusercontent.com/6653109/234854676-deafcd65-dbce-4c48-9476-6cd0e53350be.png) | ![Screenshot from 2023-04-27 13-56-21](https://user-images.githubusercontent.com/6653109/234854667-5ed0961b-f99c-473b-81ac-994f895445ce.png)
