### PR TITLE
fix: Empty fallback for template creator action label

### DIFF
--- a/lib/public/Files/Template/TemplateFileCreator.php
+++ b/lib/public/Files/Template/TemplateFileCreator.php
@@ -40,7 +40,7 @@ final class TemplateFileCreator implements \JsonSerializable {
 	/**
 	 * @since 27.0.0
 	 */
-	protected string $actionLabel;
+	protected string $actionLabel = '';
 
 	/**
 	 * @since 21.0.0


### PR DESCRIPTION
Make #37929 a non-breaking change to have a default empty value for apps that do not set the new action label yet.

https://github.com/nextcloud/server/pull/37929#issuecomment-1525696903