### PR TITLE
Mutualize expireDate handling when creating and updating a share

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -627,16 +627,6 @@ class ShareAPIController extends OCSController {
 
 				$share->setSendPasswordByTalk(true);
 			}
-
-			//Expire date
-			if ($expireDate !== '') {
-				try {
-					$expireDate = $this->parseDate($expireDate);
-					$share->setExpirationDate($expireDate);
-				} catch (\Exception $e) {
-					throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
-				}
-			}
 		} elseif ($shareType === IShare::TYPE_REMOTE) {
 			if (!$this->shareManager->outgoingServer2ServerSharesAllowed()) {
 				throw new OCSForbiddenException($this->l->t('Sharing %1$s failed because the back end does not allow shares from type %2$s', [$node->getPath(), $shareType]));
@@ -708,6 +698,16 @@ class ShareAPIController extends OCSController {
 			}
 		} else {
 			throw new OCSBadRequestException($this->l->t('Unknown share type'));
+		}
+
+		//Expire date
+		if ($expireDate !== '') {
+			try {
+				$expireDate = $this->parseDate($expireDate);
+				$share->setExpirationDate($expireDate);
+			} catch (\Exception $e) {
+				throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
+			}
 		}
 
 		$share->setShareType($shareType);
@@ -1216,17 +1216,6 @@ class ShareAPIController extends OCSController {
 				$permissions = $newPermissions;
 			}
 
-			if ($expireDate === '') {
-				$share->setExpirationDate(null);
-			} elseif ($expireDate !== null) {
-				try {
-					$expireDate = $this->parseDate($expireDate);
-				} catch (\Exception $e) {
-					throw new OCSBadRequestException($e->getMessage(), $e);
-				}
-				$share->setExpirationDate($expireDate);
-			}
-
 			if ($password === '') {
 				$share->setPassword(null);
 			} elseif ($password !== null) {
@@ -1256,17 +1245,17 @@ class ShareAPIController extends OCSController {
 			if ($permissions !== null) {
 				$share->setPermissions($permissions);
 			}
+		}
 
-			if ($expireDate === '') {
-				$share->setExpirationDate(null);
-			} elseif ($expireDate !== null) {
-				try {
-					$expireDate = $this->parseDate($expireDate);
-				} catch (\Exception $e) {
-					throw new OCSBadRequestException($e->getMessage(), $e);
-				}
-				$share->setExpirationDate($expireDate);
+		if ($expireDate === '') {
+			$share->setExpirationDate(null);
+		} elseif ($expireDate !== null) {
+			try {
+				$expireDate = $this->parseDate($expireDate);
+			} catch (\Exception $e) {
+				throw new OCSBadRequestException($e->getMessage(), $e);
 			}
+			$share->setExpirationDate($expireDate);
 		}
 
 		try {


### PR DESCRIPTION
The code was the same when updating a share, so I moved it out of the `if/else` statement.
I assume that the handling of `expireDate` should be the same when creating a share, so I moved it out of the`if/elseif/.../else` statement too.

Not modification was made to the code, I only moved it.