### PR TITLE
Check for open_basedir before reading /proc

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -258,8 +258,20 @@ class Generator {
 	public static function getHardwareConcurrency(): int {
 		static $width;
 		if (!isset($width)) {
-			if (is_file("/proc/cpuinfo")) {
-				$width = substr_count(file_get_contents("/proc/cpuinfo"), "processor");
+			if (function_exists('ini_get')) {
+				$openBasedir = ini_get('open_basedir');
+				if ($openBasedir == '') {
+					$width = is_readable('/proc/cpuinfo') ? substr_count(file_get_contents('/proc/cpuinfo'), 'processor') : 0;
+				} else {
+					$openBasedirPaths = explode(':', $openBasedir);
+					foreach ($openBasedirPaths as $path) {
+						if (strpos($path, '/proc') === 0 || $path === '/proc/cpuinfo') {
+							$width = is_readable('/proc/cpuinfo') ? substr_count(file_get_contents('/proc/cpuinfo'), 'processor') : 0;
+						} else {
+							$width = 0;
+						}
+					}
+				}
 			} else {
 				$width = 0;
 			}

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -257,20 +257,14 @@ class Generator {
 	 */
 	public static function getHardwareConcurrency(): int {
 		static $width;
+
 		if (!isset($width)) {
 			if (function_exists('ini_get')) {
 				$openBasedir = ini_get('open_basedir');
-				if ($openBasedir == '') {
+				if (empty($openBasedir) || strpos($openBasedir, '/proc/cpuinfo') !== false) {
 					$width = is_readable('/proc/cpuinfo') ? substr_count(file_get_contents('/proc/cpuinfo'), 'processor') : 0;
 				} else {
-					$openBasedirPaths = explode(':', $openBasedir);
-					foreach ($openBasedirPaths as $path) {
-						if (strpos($path, '/proc') === 0 || $path === '/proc/cpuinfo') {
-							$width = is_readable('/proc/cpuinfo') ? substr_count(file_get_contents('/proc/cpuinfo'), 'processor') : 0;
-						} else {
-							$width = 0;
-						}
-					}
+					$width = 0;
 				}
 			} else {
 				$width = 0;


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/37921

## Summary

Check if `open_basedir` is set. If yes and is restrictive, or if can't be determined, set it to `0`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
