### PR TITLE
SystemTags endpoint to return tags used by a user with meta data

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -310,6 +310,7 @@ return array(
     'OCA\\DAV\\SystemTag\\SystemTagNode' => $baseDir . '/../lib/SystemTag/SystemTagNode.php',
     'OCA\\DAV\\SystemTag\\SystemTagPlugin' => $baseDir . '/../lib/SystemTag/SystemTagPlugin.php',
     'OCA\\DAV\\SystemTag\\SystemTagsByIdCollection' => $baseDir . '/../lib/SystemTag/SystemTagsByIdCollection.php',
+    'OCA\\DAV\\SystemTag\\SystemTagsInUseCollection' => $baseDir . '/../lib/SystemTag/SystemTagsInUseCollection.php',
     'OCA\\DAV\\SystemTag\\SystemTagsObjectMappingCollection' => $baseDir . '/../lib/SystemTag/SystemTagsObjectMappingCollection.php',
     'OCA\\DAV\\SystemTag\\SystemTagsObjectTypeCollection' => $baseDir . '/../lib/SystemTag/SystemTagsObjectTypeCollection.php',
     'OCA\\DAV\\SystemTag\\SystemTagsRelationsCollection' => $baseDir . '/../lib/SystemTag/SystemTagsRelationsCollection.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -325,6 +325,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\SystemTag\\SystemTagNode' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagNode.php',
         'OCA\\DAV\\SystemTag\\SystemTagPlugin' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagPlugin.php',
         'OCA\\DAV\\SystemTag\\SystemTagsByIdCollection' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagsByIdCollection.php',
+        'OCA\\DAV\\SystemTag\\SystemTagsInUseCollection' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagsInUseCollection.php',
         'OCA\\DAV\\SystemTag\\SystemTagsObjectMappingCollection' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagsObjectMappingCollection.php',
         'OCA\\DAV\\SystemTag\\SystemTagsObjectTypeCollection' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagsObjectTypeCollection.php',
         'OCA\\DAV\\SystemTag\\SystemTagsRelationsCollection' => __DIR__ . '/..' . '/../lib/SystemTag/SystemTagsRelationsCollection.php',

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -133,10 +133,7 @@ class RootCollection extends SimpleCollection {
 			$groupManager,
 			\OC::$server->getEventDispatcher()
 		);
-		$systemTagInUseCollection = new SystemTag\SystemTagsInUseCollection(
-			$userSession,
-			$rootFolder
-		);
+		$systemTagInUseCollection = \OCP\Server::get(SystemTag\SystemTagsInUseCollection::class);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),
 			$userManager,

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -48,6 +48,7 @@ use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\SimpleCollection;
@@ -65,6 +66,7 @@ class RootCollection extends SimpleCollection {
 		$dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$config = \OC::$server->get(IConfig::class);
 		$proxyMapper = \OC::$server->query(ProxyMapper::class);
+		$rootFolder = \OCP\Server::get(IRootFolder::class);
 
 		$userPrincipalBackend = new Principal(
 			$userManager,
@@ -131,6 +133,10 @@ class RootCollection extends SimpleCollection {
 			$groupManager,
 			\OC::$server->getEventDispatcher()
 		);
+		$systemTagInUseCollection = new SystemTag\SystemTagsInUseCollection(
+			$userSession,
+			$rootFolder
+		);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),
 			$userManager,
@@ -179,6 +185,7 @@ class RootCollection extends SimpleCollection {
 				$systemAddressBookRoot]),
 			$systemTagCollection,
 			$systemTagRelationsCollection,
+			$systemTagInUseCollection,
 			$commentsCollection,
 			$uploadCollection,
 			$avatarCollection,

--- a/apps/dav/lib/SystemTag/SystemTagNode.php
+++ b/apps/dav/lib/SystemTag/SystemTagNode.php
@@ -64,6 +64,9 @@ class SystemTagNode implements \Sabre\DAV\INode {
 	 */
 	protected $isAdmin;
 
+	protected int $numberOfFiles = -1;
+	protected int $referenceFileId = -1;
+
 	/**
 	 * Sets up the node, expects a full path name
 	 *
@@ -178,5 +181,21 @@ class SystemTagNode implements \Sabre\DAV\INode {
 			// can happen if concurrent deletion occurred
 			throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found', 0, $e);
 		}
+	}
+
+	public function getNumberOfFiles(): int {
+		return $this->numberOfFiles;
+	}
+
+	public function setNumberOfFiles(int $numberOfFiles): void {
+		$this->numberOfFiles = $numberOfFiles;
+	}
+
+	public function getReferenceFileId(): int {
+		return $this->referenceFileId;
+	}
+
+	public function setReferenceFileId(int $referenceFileId): void {
+		$this->referenceFileId = $referenceFileId;
 	}
 }

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -244,9 +244,9 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			return;
 		}
 
-		// child nodes from systemtags-current should point to normal tag endpoint
-		if (preg_match('/^systemtags-current\/[0-9]+/', $propFind->getPath())) {
-			$propFind->setPath(str_replace('systemtags-current/', 'systemtags/', $propFind->getPath()));
+		// child nodes from systemtags-assigned should point to normal tag endpoint
+		if (preg_match('/^systemtags-assigned\/[0-9]+/', $propFind->getPath())) {
+			$propFind->setPath(str_replace('systemtags-assigned/', 'systemtags/', $propFind->getPath()));
 		}
 
 		$propFind->handle(self::ID_PROPERTYNAME, function () use ($node) {

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -61,6 +61,8 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 	public const GROUPS_PROPERTYNAME = '{http://owncloud.org/ns}groups';
 	public const CANASSIGN_PROPERTYNAME = '{http://owncloud.org/ns}can-assign';
 	public const SYSTEM_TAGS_PROPERTYNAME = '{http://nextcloud.org/ns}system-tags';
+	public const NUM_FILES_PROPERTYNAME = '{http://nextcloud.org/ns}files-assigned';
+	public const FILEID_PROPERTYNAME = '{http://nextcloud.org/ns}reference-fileid';
 
 	/**
 	 * @var \Sabre\DAV\Server $server
@@ -242,6 +244,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			return;
 		}
 
+		// child nodes from systemtags-current should point to normal tag endpoint
+		if (preg_match('/^systemtags-current\/[0-9]+/', $propFind->getPath())) {
+			$propFind->setPath(str_replace('systemtags-current/', 'systemtags/', $propFind->getPath()));
+		}
+
 		$propFind->handle(self::ID_PROPERTYNAME, function () use ($node) {
 			return $node->getSystemTag()->getId();
 		});
@@ -276,6 +283,16 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 			return implode('|', $groups);
 		});
+
+		if ($node instanceof SystemTagNode) {
+			$propFind->handle(self::NUM_FILES_PROPERTYNAME, function () use ($node): int {
+				return $node->getNumberOfFiles();
+			});
+
+			$propFind->handle(self::FILEID_PROPERTYNAME, function () use ($node): int {
+				return $node->getReferenceFileId();
+			});
+		}
 	}
 
 	private function propfindForFile(PropFind $propFind, Node $node): void {
@@ -370,6 +387,8 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			self::USERVISIBLE_PROPERTYNAME,
 			self::USERASSIGNABLE_PROPERTYNAME,
 			self::GROUPS_PROPERTYNAME,
+			self::NUM_FILES_PROPERTYNAME,
+			self::FILEID_PROPERTYNAME,
 		], function ($props) use ($node) {
 			$tag = $node->getSystemTag();
 			$name = $tag->getName();
@@ -404,6 +423,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 				$propValue = $props[self::GROUPS_PROPERTYNAME];
 				$groupIds = explode('|', $propValue);
 				$this->tagManager->setTagGroups($tag, $groupIds);
+			}
+
+			if (isset($props[self::NUM_FILES_PROPERTYNAME]) || isset($props[self::FILEID_PROPERTYNAME])) {
+				// read-only properties
+				throw new Forbidden();
 			}
 
 			if ($updateTag) {

--- a/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DAV\SystemTag;
+
+use OC\SystemTag\SystemTag;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use OCP\SystemTag\ISystemTagManager;
+use Sabre\DAV\Exception\Forbidden;
+
+class SystemTagsInUseCollection extends \Sabre\DAV\SimpleCollection {
+	protected IUserSession $userSession;
+	protected IRootFolder $rootFolder;
+
+	public function __construct(IUserSession $userSession, IRootFolder $rootFolder) {
+		$this->userSession = $userSession;
+		$this->rootFolder = $rootFolder;
+		$this->name = 'systemtags-current';
+	}
+
+	public function setName($name): void {
+		throw new Forbidden('Permission denied to rename this collection');
+	}
+
+	public function getChildren() {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new Forbidden('Permission denied to read this collection');
+		}
+
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$result = $userFolder->getSystemTags('image');
+		$children = [];
+		foreach ($result as $tagData) {
+			$tag = new SystemTag((string)$tagData['id'], $tagData['name'], (bool)$tagData['visibility'], (bool)$tagData['editable']);
+			$node = new SystemTagNode($tag, $user, false, \OCP\Server::get(ISystemTagManager::class));
+			$node->setNumberOfFiles($tagData['number_files']);
+			$node->setReferenceFileId($tagData['ref_file_id']);
+			$children[] = $node;
+		}
+		return $children;
+	}
+}

--- a/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
@@ -42,7 +42,7 @@ class SystemTagsInUseCollection extends \Sabre\DAV\SimpleCollection {
 		$this->userSession = $userSession;
 		$this->rootFolder = $rootFolder;
 		$this->mediaType = $mediaType;
-		$this->name = 'systemtags-current';
+		$this->name = 'systemtags-assigned';
 		if ($this->mediaType != '') {
 			$this->name .= '/' . $this->mediaType;
 		}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1620,6 +1620,7 @@ return array(
     'OC\\SystemTag\\SystemTag' => $baseDir . '/lib/private/SystemTag/SystemTag.php',
     'OC\\SystemTag\\SystemTagManager' => $baseDir . '/lib/private/SystemTag/SystemTagManager.php',
     'OC\\SystemTag\\SystemTagObjectMapper' => $baseDir . '/lib/private/SystemTag/SystemTagObjectMapper.php',
+    'OC\\SystemTag\\SystemTagsInFilesDetector' => $baseDir . '/lib/private/SystemTag/SystemTagsInFilesDetector.php',
     'OC\\TagManager' => $baseDir . '/lib/private/TagManager.php',
     'OC\\Tagging\\Tag' => $baseDir . '/lib/private/Tagging/Tag.php',
     'OC\\Tagging\\TagMapper' => $baseDir . '/lib/private/Tagging/TagMapper.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1653,6 +1653,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\SystemTag\\SystemTag' => __DIR__ . '/../../..' . '/lib/private/SystemTag/SystemTag.php',
         'OC\\SystemTag\\SystemTagManager' => __DIR__ . '/../../..' . '/lib/private/SystemTag/SystemTagManager.php',
         'OC\\SystemTag\\SystemTagObjectMapper' => __DIR__ . '/../../..' . '/lib/private/SystemTag/SystemTagObjectMapper.php',
+        'OC\\SystemTag\\SystemTagsInFilesDetector' => __DIR__ . '/../../..' . '/lib/private/SystemTag/SystemTagsInFilesDetector.php',
         'OC\\TagManager' => __DIR__ . '/../../..' . '/lib/private/TagManager.php',
         'OC\\Tagging\\Tag' => __DIR__ . '/../../..' . '/lib/private/Tagging/Tag.php',
         'OC\\Tagging\\TagMapper' => __DIR__ . '/../../..' . '/lib/private/Tagging/TagMapper.php',

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -41,8 +41,28 @@ class CacheQueryBuilder extends QueryBuilder {
 		parent::__construct($connection, $systemConfig, $logger);
 	}
 
+	public function selectTagUsage(): self {
+		$this
+			->select('systemtag.name', 'systemtag.id', 'systemtag.visibility', 'systemtag.editable')
+			->selectAlias($this->createFunction('COUNT(filecache.fileid)'), 'number_files')
+			->selectAlias($this->createFunction('MAX(filecache.fileid)'), 'ref_file_id')
+			->from('filecache', 'filecache')
+			->leftJoin('filecache', 'systemtag_object_mapping', 'systemtagmap', $this->expr()->andX(
+				$this->expr()->eq('filecache.fileid', $this->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
+				$this->expr()->eq('systemtagmap.objecttype', $this->createNamedParameter('files'))
+			))
+			->leftJoin('systemtagmap', 'systemtag', 'systemtag', $this->expr()->andX(
+				$this->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
+				$this->expr()->eq('systemtag.visibility', $this->createNamedParameter(true))
+			))
+			->where($this->expr()->like('systemtag.name', $this->createNamedParameter('_%')))
+			->groupBy('systemtag.name', 'systemtag.id', 'systemtag.visibility', 'systemtag.editable');
+
+		return $this;
+	}
+
 	public function selectFileCache(string $alias = null, bool $joinExtendedCache = true) {
-		$name = $alias ? $alias : 'filecache';
+		$name = $alias ?: 'filecache';
 		$this->select("$name.fileid", 'storage', 'path', 'path_hash', "$name.parent", "$name.name", 'mimetype', 'mimepart', 'size', 'mtime',
 			'storage_mtime', 'encrypted', 'etag', 'permissions', 'checksum', 'unencrypted_size')
 			->from('filecache', $name);

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -55,7 +55,6 @@ class CacheQueryBuilder extends QueryBuilder {
 				$this->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
 				$this->expr()->eq('systemtag.visibility', $this->createNamedParameter(true))
 			))
-			->where($this->expr()->like('systemtag.name', $this->createNamedParameter('_%')))
 			->groupBy('systemtag.name', 'systemtag.id', 'systemtag.visibility', 'systemtag.editable');
 
 		return $this;

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -74,6 +74,41 @@ class QuerySearchHelper {
 		);
 	}
 
+	protected function applySearchConstraints(CacheQueryBuilder $query, ISearchQuery $searchQuery, array $caches): void {
+		$storageFilters = array_values(array_map(function (ICache $cache) {
+			return $cache->getQueryFilterForStorage();
+		}, $caches));
+		$storageFilter = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, $storageFilters);
+		$filter = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [$searchQuery->getSearchOperation(), $storageFilter]);
+		$this->queryOptimizer->processOperator($filter);
+
+		$searchExpr = $this->searchBuilder->searchOperatorToDBExpr($query, $filter);
+		if ($searchExpr) {
+			$query->andWhere($searchExpr);
+		}
+
+		$this->searchBuilder->addSearchOrdersToQuery($query, $searchQuery->getOrder());
+
+		if ($searchQuery->getLimit()) {
+			$query->setMaxResults($searchQuery->getLimit());
+		}
+		if ($searchQuery->getOffset()) {
+			$query->setFirstResult($searchQuery->getOffset());
+		}
+	}
+
+	public function findUsedTagsInCaches(ISearchQuery $searchQuery, array $caches): array {
+		$query = $this->getQueryBuilder();
+		$query->selectTagUsage();
+
+		$this->applySearchConstraints($query, $searchQuery, $caches);
+
+		$result = $query->execute();
+		$tags = $result->fetchAll();
+		$result->closeCursor();
+		return $tags;
+	}
+
 	/**
 	 * Perform a file system search in multiple caches
 	 *
@@ -127,26 +162,7 @@ class QuerySearchHelper {
 				));
 		}
 
-		$storageFilters = array_values(array_map(function (ICache $cache) {
-			return $cache->getQueryFilterForStorage();
-		}, $caches));
-		$storageFilter = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, $storageFilters);
-		$filter = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [$searchQuery->getSearchOperation(), $storageFilter]);
-		$this->queryOptimizer->processOperator($filter);
-
-		$searchExpr = $this->searchBuilder->searchOperatorToDBExpr($builder, $filter);
-		if ($searchExpr) {
-			$query->andWhere($searchExpr);
-		}
-
-		$this->searchBuilder->addSearchOrdersToQuery($query, $searchQuery->getOrder());
-
-		if ($searchQuery->getLimit()) {
-			$query->setMaxResults($searchQuery->getLimit());
-		}
-		if ($searchQuery->getOffset()) {
-			$query->setFirstResult($searchQuery->getOffset());
-		}
+		$this->applySearchConstraints($query, $searchQuery, $caches);
 
 		$result = $query->execute();
 		$files = $result->fetchAll();
@@ -158,7 +174,7 @@ class QuerySearchHelper {
 		$result->closeCursor();
 
 		// loop through all caches for each result to see if the result matches that storage
-		// results are grouped by the same array keys as the caches argument to allow the caller to distringuish the source of the results
+		// results are grouped by the same array keys as the caches argument to allow the caller to distinguish the source of the results
 		$results = array_fill_keys(array_keys($caches), []);
 		foreach ($rawEntries as $rawEntry) {
 			foreach ($caches as $cacheKey => $cache) {

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -35,7 +35,6 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
-use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchQuery;
@@ -228,5 +227,4 @@ class QuerySearchHelper {
 
 		return [$caches, $mountByMountPoint];
 	}
-
 }

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -97,6 +97,10 @@ class QuerySearchHelper {
 		}
 	}
 
+
+	/**
+	 * @return array<array-key, array{id: int, name: string, visibility: int, editable: int, ref_file_id: int, number_files: int}>
+	 */
 	public function findUsedTagsInCaches(ISearchQuery $searchQuery, array $caches): array {
 		$query = $this->getQueryBuilder();
 		$query->selectTagUsage();

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -25,13 +25,18 @@
  */
 namespace OC\Files\Cache;
 
+use OC\Files\Cache\Wrapper\CacheJail;
+use OC\Files\Node\Root;
 use OC\Files\Search\QueryOptimizer\QueryOptimizer;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IDBConnection;
@@ -190,4 +195,38 @@ class QuerySearchHelper {
 		}
 		return $results;
 	}
+
+	/**
+	 * @return array{array<string, ICache>, array<string, IMountPoint>}
+	 */
+	public function getCachesAndMountPointsForSearch(Root $root, string $path, bool $limitToHome = false): array {
+		$rootLength = strlen($path);
+		$mount = $root->getMount($path);
+		$storage = $mount->getStorage();
+		$internalPath = $mount->getInternalPath($path);
+
+		if ($internalPath !== '') {
+			// a temporary CacheJail is used to handle filtering down the results to within this folder
+			$caches = ['' => new CacheJail($storage->getCache(''), $internalPath)];
+		} else {
+			$caches = ['' => $storage->getCache('')];
+		}
+		$mountByMountPoint = ['' => $mount];
+
+		if (!$limitToHome) {
+			/** @var IMountPoint[] $mounts */
+			$mounts = $root->getMountsIn($path);
+			foreach ($mounts as $mount) {
+				$storage = $mount->getStorage();
+				if ($storage) {
+					$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
+					$caches[$relativeMountPoint] = $storage->getCache('');
+					$mountByMountPoint[$relativeMountPoint] = $mount;
+				}
+			}
+		}
+
+		return [$caches, $mountByMountPoint];
+	}
+
 }

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -204,7 +204,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		throw new NotPermittedException('No create permission for path "' . $path . '"');
 	}
 
-	private function queryFromOperator(ISearchOperator $operator, string $uid = null): ISearchQuery {
+	private function queryFromOperator(ISearchOperator $operator, string $uid = null, int $limit = 0, int $offset = 0): ISearchQuery {
 		if ($uid === null) {
 			$user = null;
 		} else {
@@ -212,7 +212,38 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$userManager = \OC::$server->query(IUserManager::class);
 			$user = $userManager->get($uid);
 		}
-		return new SearchQuery($operator, 0, 0, [], $user);
+		return new SearchQuery($operator, $limit, $offset, [], $user);
+	}
+
+	/**
+	 * @psalm-return list{0: array<string, \OCP\Files\Cache\ICache>, 1: array<string, \OCP\Files\Mount\IMountPoint>}
+	 */
+	protected function getCachesAndMountpointsForSearch(bool $limitToHome = false): array {
+		$rootLength = strlen($this->path);
+		$mount = $this->root->getMount($this->path);
+		$storage = $mount->getStorage();
+		$internalPath = $mount->getInternalPath($this->path);
+		if ($internalPath !== '') {
+			// a temporary CacheJail is used to handle filtering down the results to within this folder
+			$caches = ['' => new CacheJail($storage->getCache(''), $internalPath)];
+		} else {
+			$caches = ['' => $storage->getCache('')];
+		}
+		$mountByMountPoint = ['' => $mount];
+
+		if (!$limitToHome) {
+			$mounts = $this->root->getMountsIn($this->path);
+			foreach ($mounts as $mount) {
+				$storage = $mount->getStorage();
+				if ($storage) {
+					$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
+					$caches[$relativeMountPoint] = $storage->getCache('');
+					$mountByMountPoint[$relativeMountPoint] = $mount;
+				}
+			}
+		}
+
+		return [$caches, $mountByMountPoint];
 	}
 
 	/**
@@ -234,40 +265,14 @@ class Folder extends Node implements \OCP\Files\Folder {
 			throw new \InvalidArgumentException('searching by owner is only allowed in the users home folder');
 		}
 
-		$rootLength = strlen($this->path);
-		$mount = $this->root->getMount($this->path);
-		$storage = $mount->getStorage();
-		$internalPath = $mount->getInternalPath($this->path);
-
-		// collect all caches for this folder, indexed by their mountpoint relative to this folder
-		// and save the mount which is needed later to construct the FileInfo objects
-
-		if ($internalPath !== '') {
-			// a temporary CacheJail is used to handle filtering down the results to within this folder
-			$caches = ['' => new CacheJail($storage->getCache(''), $internalPath)];
-		} else {
-			$caches = ['' => $storage->getCache('')];
-		}
-		$mountByMountPoint = ['' => $mount];
-
-		if (!$limitToHome) {
-			$mounts = $this->root->getMountsIn($this->path);
-			foreach ($mounts as $mount) {
-				$storage = $mount->getStorage();
-				if ($storage) {
-					$relativeMountPoint = ltrim(substr($mount->getMountPoint(), $rootLength), '/');
-					$caches[$relativeMountPoint] = $storage->getCache('');
-					$mountByMountPoint[$relativeMountPoint] = $mount;
-				}
-			}
-		}
+		[$caches, $mountByMountPoint] = $this->getCachesAndMountpointsForSearch($limitToHome);
 
 		/** @var QuerySearchHelper $searchHelper */
 		$searchHelper = \OC::$server->get(QuerySearchHelper::class);
 		$resultsPerCache = $searchHelper->searchInCaches($query, $caches);
 
 		// loop through all results per-cache, constructing the FileInfo object from the CacheEntry and merge them all
-		$files = array_merge(...array_map(function (array $results, $relativeMountPoint) use ($mountByMountPoint) {
+		$files = array_merge(...array_map(function (array $results, string $relativeMountPoint) use ($mountByMountPoint) {
 			$mount = $mountByMountPoint[$relativeMountPoint];
 			return array_map(function (ICacheEntry $result) use ($relativeMountPoint, $mount) {
 				return $this->cacheEntryToFileInfo($mount, $relativeMountPoint, $result);
@@ -330,6 +335,17 @@ class Folder extends Node implements \OCP\Files\Folder {
 	public function searchByTag($tag, $userId) {
 		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tagname', $tag), $userId);
 		return $this->search($query);
+	}
+
+	/**
+	 * @return Node[]
+	 */
+	public function getSystemTags(string $mediaType, int $limit = 0, int $offset = 0): array {
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', $mediaType . '/%'), null, $limit, $offset);
+		[$caches, ] = $this->getCachesAndMountpointsForSearch();
+		/** @var QuerySearchHelper $searchHelper */
+		$searchHelper = \OCP\Server::get(QuerySearchHelper::class);
+		return $searchHelper->findUsedTagsInCaches($query, $caches);
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -338,10 +338,17 @@ class Folder extends Node implements \OCP\Files\Folder {
 	}
 
 	/**
-	 * @return Node[]
+	 *
+	 * @return array<array-key, array{id: int, name: string, visibility: int, editable: int, ref_file_id: int, number_files: int}>
 	 */
 	public function getSystemTags(string $mediaType, int $limit = 0, int $offset = 0): array {
-		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', $mediaType . '/%'), null, $limit, $offset);
+		// Currently query has to have exactly one search condition. If no media type is provided,
+		// we fall back to the presence of a systemtag.
+		if (empty($mediaType)) {
+			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'systemtag', '%'), null, $limit, $offset);
+		} else {
+			$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', $mediaType . '/%'), null, $limit, $offset);
+		}
 		[$caches, ] = $this->getCachesAndMountpointsForSearch();
 		/** @var QuerySearchHelper $searchHelper */
 		$searchHelper = \OCP\Server::get(QuerySearchHelper::class);

--- a/lib/private/SystemTag/SystemTagsInFilesDetector.php
+++ b/lib/private/SystemTag/SystemTagsInFilesDetector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\SystemTag;
+
+use OC\Files\Cache\QuerySearchHelper;
+use OC\Files\Node\Root;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchQuery;
+use OCP\Files\Folder;
+use OCP\Files\Search\ISearchComparison;
+
+class SystemTagsInFilesDetector {
+	public function __construct(protected QuerySearchHelper $searchHelper) {
+	}
+
+	public function detectAssignedSystemTagsIn(
+		Folder $folder,
+		string $filteredMediaType = '',
+		int $limit = 0,
+		int $offset = 0
+	): array {
+		// Currently query has to have exactly one search condition. If no media type is provided,
+		// we fall back to the presence of a system tag.
+		if (empty($filteredMediaType)) {
+			$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'systemtag', '%'), $limit, $offset, []);
+		} else {
+			$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', $filteredMediaType . '/%'), $limit, $offset, []);
+		}
+		[$caches, ] = $this->searchHelper->getCachesAndMountPointsForSearch(
+			$this->getRootFolder($folder),
+			$folder->getPath(),
+		);
+		return $this->searchHelper->findUsedTagsInCaches($query, $caches);
+	}
+
+	protected function getRootFolder(?Folder $folder): Root {
+		if ($folder instanceof Root) {
+			return $folder;
+		} elseif ($folder === null) {
+			throw new \LogicException('Could not climb up to root folder');
+		}
+		return $this->getRootFolder($folder->getParent());
+	}
+}


### PR DESCRIPTION
## Summary

Target case is photos app: when visiting the tags category, all systemtags of the whole cloud are retrieved. In subsequent steps the next tag is requested until the browser view is filled with tag tiles (i.e. previews are requested just as well).

With this approach, we incorporate the dav search and look for user related tags that are used by them, and already returns the statistics (number of files tagged with the respective tag) as well as a file id for the purpose to load the preview. This defaults to the file with the highest id.

Call:
```bash
curl -s -u 'user:password' \
  'https://my.nc.srv/remote.php/dav/systemtags-assigned' \
  -X PROPFIND -H 'Accept: text/plain' \
  -H 'Accept-Language: en-US,en;q=0.5'  -H 'Depth: 1' \
  -H 'Content-Type: text/plain;charset=UTF-8' \
  --data @/home/doe/request-systemtag-props.xml
```

With request-systemtag-props.xml:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<d:propfind xmlns:d="DAV:">
        <d:prop xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
                <oc:id/>
                <oc:display-name/>
                <oc:user-visible/>
                <oc:user-assignable/>
                <oc:can-assign/>
                <nc:files-assigned/>
                <nc:reference-fileid/>
        </d:prop>
</d:propfind>
```

Example output:
```xml
  …
  <d:response>
    <d:href>/master/remote.php/dav/systemtags/84</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>84</oc:id>
        <oc:display-name>Computer</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-assignable>true</oc:user-assignable>
        <oc:can-assign>true</oc:can-assign>
        <nc:files-assigned>42</nc:files-assigned>
        <nc:reference-fileid>924022</nc:reference-fileid>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/systemtags/97</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>97</oc:id>
        <oc:display-name>Bear</oc:display-name>
        <oc:user-visible>true</oc:user-visible>
        <oc:user-assignable>true</oc:user-assignable>
        <oc:can-assign>true</oc:can-assign>
        <nc:files-assigned>1</nc:files-assigned>
        <nc:reference-fileid>923422</nc:reference-fileid>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
  </d:response>
  …
```

**Update 23/05/04**

Added was support to retrieve tags for a specific media type. This works with the URI. So, while the `systemtags-current` root provides tag information across all files, querying `/remote.php/dav/systemtags-current/image` will return tag information only for all image-typed files. 

In the first commit, the image-type condition was hard coded.

**/Update**

**Update 23/05/04**

The endpoint was renamed from `systemtags-current` to `systemtags-assigned`. The information at the top (before the updates) are adjusted.

**/Update**

## TODO

- [ ] Performance testing with a serious data set 
- [ ] Reconsider pragmatic architectual choices (quick PoC)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
