### PR TITLE
use more efficient tag retrieval on DAV report request

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -219,6 +219,10 @@ class FilesReportPlugin extends ServerPlugin {
 		// gather all file ids matching filter
 		try {
 			$resultFileIds = $this->processFilterRulesForFileIDs($filterRules);
+			// no logic in circles and favorites for paging, we always have all results, and slice later on
+			$resultFileIds = array_slice($resultFileIds, $offset ?? 0, $limit ?? null);
+			// fetching nodes has paging on DB level – therefore we cannot mix and slice the results, similar
+			// to user backends. I.e. the final result may return more results than requested.
 			$resultNodes = $this->processFilterRulesForFileNodes($filterRules, $limit ?? null, $offset ?? null);
 		} catch (TagNotFoundException $e) {
 			throw new PreconditionFailed('Cannot filter by non-existing tag', 0, $e);

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -30,6 +30,7 @@ namespace OCA\DAV\Connector\Sabre;
 use OC\Files\View;
 use OCP\App\IAppManager;
 use OCP\Files\Folder;
+use OCP\Files\Node as INode;
 use OCP\IGroupManager;
 use OCP\ITagManager;
 use OCP\IUserSession;
@@ -238,7 +239,9 @@ class FilesReportPlugin extends ServerPlugin {
 		// find sabre nodes by file id, restricted to the root node path
 		$additionalNodes = $this->findNodesByFileIds($reportTargetNode, $resultFileIds);
 		if ($additionalNodes && $results) {
-			$results = array_intersect($results, $additionalNodes);
+			$results = array_uintersect($results, $additionalNodes, function (Node $a, Node $b): int {
+				return $a->getId() - $b->getId();
+			});
 		} elseif (!$results && $additionalNodes) {
 			$results = $additionalNodes;
 		}
@@ -344,7 +347,7 @@ class FilesReportPlugin extends ServerPlugin {
 				if (count($nodes) === 0) {
 					$nodes = $tmpNodes;
 				} else {
-					$nodes = array_uintersect($nodes, $tmpNodes, function (\OCP\Files\Node $a, \OCP\Files\Node $b): int {
+					$nodes = array_uintersect($nodes, $tmpNodes, function (INode $a, INode $b): int {
 						return $a->getId() - $b->getId();
 					});
 				}

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -341,49 +341,6 @@ class FilesReportPlugin extends ServerPlugin {
 		return $nodes;
 	}
 
-	private function getSystemTagFileIds($systemTagIds) {
-		$resultFileIds = null;
-
-		// check user permissions, if applicable
-		if (!$this->isAdmin()) {
-			// check visibility/permission
-			$tags = $this->tagManager->getTagsByIds($systemTagIds);
-			$unknownTagIds = [];
-			foreach ($tags as $tag) {
-				if (!$tag->isUserVisible()) {
-					$unknownTagIds[] = $tag->getId();
-				}
-			}
-
-			if (!empty($unknownTagIds)) {
-				throw new TagNotFoundException('Tag with ids ' . implode(', ', $unknownTagIds) . ' not found');
-			}
-		}
-
-		// fetch all file ids and intersect them
-		foreach ($systemTagIds as $systemTagId) {
-			$fileIds = $this->tagMapper->getObjectIdsForTags($systemTagId, 'files');
-
-			if (empty($fileIds)) {
-				// This tag has no files, nothing can ever show up
-				return [];
-			}
-
-			// first run ?
-			if ($resultFileIds === null) {
-				$resultFileIds = $fileIds;
-			} else {
-				$resultFileIds = array_intersect($resultFileIds, $fileIds);
-			}
-
-			if (empty($resultFileIds)) {
-				// Empty intersection, nothing can show up anymore
-				return [];
-			}
-		}
-		return $resultFileIds;
-	}
-
 	/**
 	 * @suppress PhanUndeclaredClassMethod
 	 * @param array $circlesIds

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -330,7 +330,9 @@ class FilesReportPlugin extends ServerPlugin {
 
 		$nodes = [];
 
-		if (!empty($systemTagIds)) {
+		// type check to ensure searchBySystemTag is available, it is not
+		// exposed in API yet
+		if (!empty($systemTagIds) && $this->userFolder instanceof \OC\Files\Node\Folder) {
 			$tags = $this->tagManager->getTagsByIds($systemTagIds);
 			$tagName = (current($tags))->getName();
 			$nodes = $this->userFolder->searchBySystemTag($tagName, $this->userSession->getUser()->getUID(), $limit ?? 0, $offset ?? 0);

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -284,9 +284,9 @@ class FilesReportPlugin extends ServerPlugin {
 	 * @param array $filterRules
 	 * @return array array of unique file id results
 	 */
-	protected function processFilterRulesForFileIDs($filterRules) {
+	protected function processFilterRulesForFileIDs(array $filterRules): array {
 		$ns = '{' . $this::NS_OWNCLOUD . '}';
-		$resultFileIds = null;
+		$resultFileIds = [];
 		$circlesIds = [];
 		$favoriteFilter = null;
 		foreach ($filterRules as $filterRule) {
@@ -407,7 +407,7 @@ class FilesReportPlugin extends ServerPlugin {
 	 * @param array $fileIds file ids
 	 * @return Node[] array of Sabre nodes
 	 */
-	public function findNodesByFileIds($rootNode, $fileIds): array {
+	public function findNodesByFileIds(Node $rootNode, array $fileIds): array {
 		if (empty($fileIds)) {
 			return [];
 		}

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -283,8 +283,6 @@ class FilesReportPlugin extends ServerPlugin {
 	 *
 	 * @param array $filterRules
 	 * @return array array of unique file id results
-	 *
-	 * @throws TagNotFoundException whenever a tag was not found
 	 */
 	protected function processFilterRulesForFileIDs($filterRules) {
 		$ns = '{' . $this::NS_OWNCLOUD . '}';
@@ -335,12 +333,8 @@ class FilesReportPlugin extends ServerPlugin {
 			!empty($systemTagIds)
 			&& (method_exists($this->userFolder, 'searchBySystemTag'))
 		) {
-			$tags = $this->tagManager->getTagsByIds($systemTagIds);
+			$tags = $this->tagManager->getTagsByIds($systemTagIds, $this->userSession->getUser());
 			foreach ($tags as $tag) {
-				if (!$tag->isUserVisible()) {
-					// searchBySystemTag() also has the criteria to include only user visible tags. They can be skipped early nevertheless.
-					continue;
-				}
 				$tagName = $tag->getName();
 				$tmpNodes = $this->userFolder->searchBySystemTag($tagName, $this->userSession->getUser()->getUID(), $limit ?? 0, $offset ?? 0);
 				if (count($nodes) === 0) {

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -336,10 +336,7 @@ class FilesReportPlugin extends ServerPlugin {
 
 		// type check to ensure searchBySystemTag is available, it is not
 		// exposed in API yet
-		if (
-			!empty($systemTagIds)
-			&& (method_exists($this->userFolder, 'searchBySystemTag'))
-		) {
+		if (!empty($systemTagIds)) {
 			$tags = $this->tagManager->getTagsByIds($systemTagIds, $this->userSession->getUser());
 			foreach ($tags as $tag) {
 				$tagName = $tag->getName();

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -27,6 +27,7 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
+use OC\Files\Node\LazyFolder;
 use OC\Files\View;
 use OCP\App\IAppManager;
 use OCP\Files\Folder;
@@ -332,7 +333,11 @@ class FilesReportPlugin extends ServerPlugin {
 
 		// type check to ensure searchBySystemTag is available, it is not
 		// exposed in API yet
-		if (!empty($systemTagIds) && $this->userFolder instanceof \OC\Files\Node\Folder) {
+		if (
+			!empty($systemTagIds)
+			&& ($this->userFolder instanceof \OC\Files\Node\Folder
+				|| $this->userFolder instanceof LazyFolder)
+		) {
 			$tags = $this->tagManager->getTagsByIds($systemTagIds);
 			$tagName = (current($tags))->getName();
 			$nodes = $this->userFolder->searchBySystemTag($tagName, $this->userSession->getUser()->getUID(), $limit ?? 0, $offset ?? 0);

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -234,8 +234,10 @@ class FilesReportPlugin extends ServerPlugin {
 
 		// find sabre nodes by file id, restricted to the root node path
 		$additionalNodes = $this->findNodesByFileIds($reportTargetNode, $resultFileIds);
-		if (!empty($additionalNodes)) {
+		if ($additionalNodes && $results) {
 			$results = array_intersect($results, $additionalNodes);
+		} elseif (!$results && $additionalNodes) {
+			$results = $additionalNodes;
 		}
 
 		$filesUri = $this->getFilesBaseUri($uri, $reportTargetNode->getPath());

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -44,25 +44,28 @@ use OCP\IUserSession;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\INode;
 use Sabre\DAV\Tree;
 use Sabre\HTTP\ResponseInterface;
 
 class FilesReportPluginTest extends \Test\TestCase {
-	/** @var \Sabre\DAV\Server|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var \Sabre\DAV\Server|MockObject */
 	private $server;
 
-	/** @var \Sabre\DAV\Tree|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var \Sabre\DAV\Tree|MockObject */
 	private $tree;
 
-	/** @var ISystemTagObjectMapper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ISystemTagObjectMapper|MockObject */
 	private $tagMapper;
 
-	/** @var ISystemTagManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ISystemTagManager|MockObject */
 	private $tagManager;
 
-	/** @var ITags|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITags|MockObject */
 	private $privateTags;
+
+	private ITagManager|MockObject $privateTagManager;
 
 	/** @var  \OCP\IUserSession */
 	private $userSession;
@@ -70,19 +73,19 @@ class FilesReportPluginTest extends \Test\TestCase {
 	/** @var FilesReportPluginImplementation */
 	private $plugin;
 
-	/** @var View|\PHPUnit\Framework\MockObject\MockObject **/
+	/** @var View|MockObject **/
 	private $view;
 
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject **/
+	/** @var IGroupManager|MockObject **/
 	private $groupManager;
 
-	/** @var Folder|\PHPUnit\Framework\MockObject\MockObject **/
+	/** @var Folder|MockObject **/
 	private $userFolder;
 
-	/** @var IPreview|\PHPUnit\Framework\MockObject\MockObject * */
+	/** @var IPreview|MockObject * */
 	private $previewManager;
 
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject * */
+	/** @var IAppManager|MockObject * */
 	private $appManager;
 
 	protected function setUp(): void {
@@ -124,8 +127,8 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$this->tagMapper = $this->createMock(ISystemTagObjectMapper::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->privateTags = $this->createMock(ITags::class);
-		$privateTagManager = $this->createMock(ITagManager::class);
-		$privateTagManager->expects($this->any())
+		$this->privateTagManager = $this->createMock(ITagManager::class);
+		$this->privateTagManager->expects($this->any())
 			->method('load')
 			->with('files')
 			->willReturn($this->privateTags);
@@ -145,7 +148,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			$this->view,
 			$this->tagManager,
 			$this->tagMapper,
-			$privateTagManager,
+			$this->privateTagManager,
 			$this->userSession,
 			$this->groupManager,
 			$this->userFolder,
@@ -217,17 +220,6 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(2))
-			->method('getObjectIdsForTags')
-			->withConsecutive(
-				['123', 'files'],
-				['456', 'files'],
-			)
-			->willReturnOnConsecutiveCalls(
-				['111', '222'],
-				['111', '222', '333'],
-			);
-
 		$reportTargetNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -255,20 +247,40 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('/' . $path)
 			->willReturn($reportTargetNode);
 
-		$filesNode1 = $this->getMockBuilder(Folder::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$filesNode2 = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$filesNode2->method('getSize')
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
 			->willReturn(10);
 
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag456 = $this->createMock(ISystemTag::class);
+		$tag456->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
+		$tag456->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456'])
+			->willReturn([$tag123, $tag456]);
+
 		$this->userFolder->expects($this->exactly(2))
-			->method('getById')
+			->method('searchBySystemTag')
 			->withConsecutive(
-				['111'],
-				['222'],
+				['OneTwoThree'],
+				['FourFiveSix'],
 			)
 			->willReturnOnConsecutiveCalls(
 				[$filesNode1],
@@ -317,7 +329,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 				[$filesNode2],
 			);
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
+		/** @var \OCA\DAV\Connector\Sabre\Directory|MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
@@ -370,7 +382,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 				[$filesNode2],
 			);
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $reportTargetNode */
+		/** @var \OCA\DAV\Connector\Sabre\Directory|MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
@@ -454,20 +466,38 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(1))
-			->method('getObjectIdsForTags')
-			->withConsecutive(
-				['123', 'files']
-			)
-			->willReturnMap([
-				['123', 'files', 0, '', ['111', '222']],
-			]);
-
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 		];
 
-		$this->assertEquals(['111', '222'], $this->invokePrivate($this->plugin, 'processFilterRules', [$rules]));
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123'])
+			->willReturn([$tag123]);
+
+		$this->userFolder->expects($this->once())
+			->method('searchBySystemTag')
+			->with('OneTwoThree')
+			->willReturn([$filesNode1, $filesNode2]);
+
+		$this->assertEquals([$filesNode1, $filesNode2], $this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, 0, 0]));
 	}
 
 	public function testProcessFilterRulesAndCondition(): void {
@@ -475,23 +505,65 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(2))
-			->method('getObjectIdsForTags')
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+		$filesNode3 = $this->createMock(File::class);
+		$filesNode3->expects($this->any())
+			->method('getSize')
+			->willReturn(14);
+		$filesNode3->expects($this->any())
+			->method('getId')
+			->willReturn(333);
+
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag456 = $this->createMock(ISystemTag::class);
+		$tag456->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
+		$tag456->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456'])
+			->willReturn([$tag123, $tag456]);
+
+		$this->userFolder->expects($this->exactly(2))
+			->method('searchBySystemTag')
 			->withConsecutive(
-				['123', 'files'],
-				['456', 'files']
+				['OneTwoThree'],
+				['FourFiveSix'],
 			)
-			->willReturnMap([
-				['123', 'files', 0, '', ['111', '222']],
-				['456', 'files', 0, '', ['222', '333']],
-			]);
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1, $filesNode2],
+				[$filesNode2, $filesNode3],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals([$filesNode2], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null])));
 	}
 
 	public function testProcessFilterRulesAndConditionWithOneEmptyResult(): void {
@@ -499,23 +571,58 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(2))
-			->method('getObjectIdsForTags')
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag456 = $this->createMock(ISystemTag::class);
+		$tag456->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
+		$tag456->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456'])
+			->willReturn([$tag123, $tag456]);
+
+		$this->userFolder->expects($this->exactly(2))
+			->method('searchBySystemTag')
 			->withConsecutive(
-				['123', 'files'],
-				['456', 'files']
+				['OneTwoThree'],
+				['FourFiveSix'],
 			)
-			->willReturnMap([
-				['123', 'files', 0, '', ['111', '222']],
-				['456', 'files', 0, '', []],
-			]);
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1, $filesNode2],
+				[],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals([], $this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]));
 	}
 
 	public function testProcessFilterRulesAndConditionWithFirstEmptyResult(): void {
@@ -523,23 +630,55 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(1))
-			->method('getObjectIdsForTags')
-			->withConsecutive(
-				['123', 'files'],
-				['456', 'files']
-			)
-			->willReturnMap([
-				['123', 'files', 0, '', []],
-				['456', 'files', 0, '', ['111', '222']],
-			]);
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag456 = $this->createMock(ISystemTag::class);
+		$tag456->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
+		$tag456->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456'])
+			->willReturn([$tag123, $tag456]);
+
+		$this->userFolder->expects($this->once())
+			->method('searchBySystemTag')
+			->with('OneTwoThree')
+			->willReturnOnConsecutiveCalls(
+				[],
+				[$filesNode1, $filesNode2],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals([], $this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]));
 	}
 
 	public function testProcessFilterRulesAndConditionWithEmptyMidResult(): void {
@@ -547,18 +686,63 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(true);
 
-		$this->tagMapper->expects($this->exactly(2))
-			->method('getObjectIdsForTags')
-			->withConsecutive(
-				['123', 'files'],
-				['456', 'files'],
-				['789', 'files']
-			)
-			->willReturnMap([
-				['123', 'files', 0, '', ['111', '222']],
-				['456', 'files', 0, '', ['333']],
-				['789', 'files', 0, '', ['111', '222']],
-			]);
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+		$filesNode3 = $this->createMock(Folder::class);
+		$filesNode3->expects($this->any())
+			->method('getSize')
+			->willReturn(13);
+		$filesNode3->expects($this->any())
+			->method('getId')
+			->willReturn(333);
+
+		$tag123 = $this->createMock(ISystemTag::class);
+		$tag123->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
+		$tag123->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag456 = $this->createMock(ISystemTag::class);
+		$tag456->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
+		$tag456->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+		$tag789 = $this->createMock(ISystemTag::class);
+		$tag789->expects($this->any())
+			->method('getName')
+			->willReturn('SevenEightNein');
+		$tag789->expects($this->any())
+			->method('isUserVisible')
+			->willReturn(true);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456', '789'])
+			->willReturn([$tag123, $tag456, $tag789]);
+		
+		$this->userFolder->expects($this->exactly(2))
+			->method('searchBySystemTag')
+			->withConsecutive(['OneTwoThree'], ['FourFiveSix'], ['SevenEightNein'])
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1, $filesNode2],
+				[$filesNode3],
+				[$filesNode1, $filesNode2],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
@@ -566,7 +750,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '789'],
 		];
 
-		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals([], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null])));
 	}
 
 	public function testProcessFilterRulesInvisibleTagAsAdmin(): void {
@@ -614,7 +798,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null])));
 	}
 
 
@@ -655,7 +839,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->invokePrivate($this->plugin, 'processFilterRules', [$rules]);
+		$this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]);
 	}
 
 	public function testProcessFilterRulesVisibleTagAsUser(): void {
@@ -663,48 +847,58 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('isAdmin')
 			->willReturn(false);
 
-		$tag1 = $this->getMockBuilder(ISystemTag::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$tag1 = $this->createMock(ISystemTag::class);
 		$tag1->expects($this->any())
 			->method('getId')
 			->willReturn('123');
 		$tag1->expects($this->any())
 			->method('isUserVisible')
 			->willReturn(true);
+		$tag1->expects($this->any())
+			->method('getName')
+			->willReturn('OneTwoThree');
 
-		$tag2 = $this->getMockBuilder(ISystemTag::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$tag2 = $this->createMock(ISystemTag::class);
 		$tag2->expects($this->any())
 			->method('getId')
 			->willReturn('123');
 		$tag2->expects($this->any())
 			->method('isUserVisible')
 			->willReturn(true);
+		$tag2->expects($this->any())
+			->method('getName')
+			->willReturn('FourFiveSix');
 
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['123', '456'])
 			->willReturn([$tag1, $tag2]);
 
-		$this->tagMapper->expects($this->exactly(2))
-			->method('getObjectIdsForTags')
-			->withConsecutive(
-				['123'],
-				['456'],
-			)
-			->willReturnOnConsecutiveCalls(
-				['111', '222'],
-				['222', '333'],
-			);
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getSize')
+			->willReturn(12);
+		$filesNode2 = $this->createMock(Folder::class);
+		$filesNode2->expects($this->any())
+			->method('getSize')
+			->willReturn(10);
+
+		$this->tagManager->expects($this->once())
+			->method('getTagsByIds')
+			->with(['123', '456'])
+			->willReturn([$tag1, $tag2]);
+
+		// main assertion: only user visible tags are being passed through.
+		$this->userFolder->expects($this->exactly(1))
+			->method('searchBySystemTag')
+			->with('FourFiveSix', $this->anything(), $this->anything(), $this->anything());
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->assertEquals(['222'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]);
 	}
 
 	public function testProcessFavoriteFilter(): void {
@@ -716,7 +910,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->method('getFavorites')
 			->willReturn(['456', '789']);
 
-		$this->assertEquals(['456', '789'], array_values($this->invokePrivate($this->plugin, 'processFilterRules', [$rules])));
+		$this->assertEquals(['456', '789'], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileIDs', [$rules])));
 	}
 
 	public function filesBaseUriProvider() {

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -890,12 +890,25 @@ class FilesReportPluginTest extends \Test\TestCase {
 
 		$filesNode1 = $this->createMock(File::class);
 		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
+		$filesNode1->expects($this->any())
 			->method('getSize')
 			->willReturn(12);
 		$filesNode2 = $this->createMock(Folder::class);
 		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+		$filesNode2->expects($this->any())
 			->method('getSize')
 			->willReturn(10);
+		$filesNode3 = $this->createMock(Folder::class);
+		$filesNode3->expects($this->any())
+			->method('getId')
+			->willReturn(333);
+		$filesNode3->expects($this->any())
+			->method('getSize')
+			->willReturn(33);
 
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
@@ -903,16 +916,20 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->willReturn([$tag1, $tag2]);
 
 		// main assertion: only user visible tags are being passed through.
-		$this->userFolder->expects($this->exactly(1))
+		$this->userFolder->expects($this->exactly(2))
 			->method('searchBySystemTag')
-			->with('FourFiveSix', $this->anything(), $this->anything(), $this->anything());
+			->withConsecutive(['OneTwoThree'], ['FourFiveSix'])
+			->willReturnOnConsecutiveCalls(
+				[$filesNode1, $filesNode2],
+				[$filesNode2, $filesNode3],
+			);
 
 		$rules = [
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '123'],
 			['name' => '{http://owncloud.org/ns}systemtag', 'value' => '456'],
 		];
 
-		$this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]);
+		$this->assertEquals([$filesNode2], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null])));
 	}
 
 	public function testProcessFavoriteFilter(): void {

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -37,6 +37,7 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
+use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -152,22 +153,26 @@ class QuerySearchHelper {
 			if ($user === null) {
 				throw new \InvalidArgumentException("Searching by tag requires the user to be set in the query");
 			}
-			$query
-				->leftJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
-				->leftJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
-					$builder->expr()->eq('tagmap.type', 'tag.type'),
-					$builder->expr()->eq('tagmap.categoryid', 'tag.id'),
-					$builder->expr()->eq('tag.type', $builder->createNamedParameter('files')),
-					$builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID()))
-				))
-				->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $builder->expr()->andX(
-					$builder->expr()->eq('file.fileid', $builder->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
-					$builder->expr()->eq('systemtagmap.objecttype', $builder->createNamedParameter('files'))
-				))
-				->leftJoin('systemtagmap', 'systemtag', 'systemtag', $builder->expr()->andX(
-					$builder->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
-					$builder->expr()->eq('systemtag.visibility', $builder->createNamedParameter(true))
-				));
+			if ($searchQuery->getSearchOperation() instanceof ISearchComparison && $searchQuery->getSearchOperation()->getField() === 'systemtag') {
+				$query
+					->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $builder->expr()->andX(
+						$builder->expr()->eq('file.fileid', $builder->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
+						$builder->expr()->eq('systemtagmap.objecttype', $builder->createNamedParameter('files'))
+					))
+					->leftJoin('systemtagmap', 'systemtag', 'systemtag', $builder->expr()->andX(
+						$builder->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
+						$builder->expr()->eq('systemtag.visibility', $builder->createNamedParameter(true))
+					));
+			} else {
+				$query
+					->leftJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
+					->leftJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
+						$builder->expr()->eq('tagmap.type', 'tag.type'),
+						$builder->expr()->eq('tagmap.categoryid', 'tag.id'),
+						$builder->expr()->eq('tag.type', $builder->createNamedParameter('files')),
+						$builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID()))
+					));
+			}
 		}
 
 		$this->applySearchConstraints($query, $searchQuery, $caches);

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -153,25 +153,30 @@ class QuerySearchHelper {
 			if ($user === null) {
 				throw new \InvalidArgumentException("Searching by tag requires the user to be set in the query");
 			}
-			if ($searchQuery->getSearchOperation() instanceof ISearchComparison && $searchQuery->getSearchOperation()->getField() === 'systemtag') {
-				$query
-					->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $builder->expr()->andX(
-						$builder->expr()->eq('file.fileid', $builder->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
-						$builder->expr()->eq('systemtagmap.objecttype', $builder->createNamedParameter('files'))
-					))
-					->leftJoin('systemtagmap', 'systemtag', 'systemtag', $builder->expr()->andX(
-						$builder->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
-						$builder->expr()->eq('systemtag.visibility', $builder->createNamedParameter(true))
-					));
-			} else {
-				$query
-					->leftJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
-					->leftJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
-						$builder->expr()->eq('tagmap.type', 'tag.type'),
-						$builder->expr()->eq('tagmap.categoryid', 'tag.id'),
-						$builder->expr()->eq('tag.type', $builder->createNamedParameter('files')),
-						$builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID()))
-					));
+			if ($searchQuery->getSearchOperation() instanceof ISearchComparison) {
+				switch ($searchQuery->getSearchOperation()->getField()) {
+					case 'systemtag':
+						$query
+							->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $builder->expr()->andX(
+								$builder->expr()->eq('file.fileid', $builder->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
+								$builder->expr()->eq('systemtagmap.objecttype', $builder->createNamedParameter('files'))
+							))
+							->leftJoin('systemtagmap', 'systemtag', 'systemtag', $builder->expr()->andX(
+								$builder->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
+								$builder->expr()->eq('systemtag.visibility', $builder->createNamedParameter(true))
+							));
+						break;
+					case 'tagname':
+						$query
+							->leftJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
+							->leftJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
+								$builder->expr()->eq('tagmap.type', 'tag.type'),
+								$builder->expr()->eq('tagmap.categoryid', 'tag.id'),
+								$builder->expr()->eq('tag.type', $builder->createNamedParameter('files')),
+								$builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID()))
+							));
+						break;
+				}
 			}
 		}
 

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -40,6 +40,7 @@ use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchQuery;
 use OCP\IDBConnection;
+use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class QuerySearchHelper {
@@ -118,6 +119,29 @@ class QuerySearchHelper {
 		return $tags;
 	}
 
+	protected function equipQueryForSystemTags(CacheQueryBuilder $query): void {
+		$query
+			->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $query->expr()->andX(
+				$query->expr()->eq('file.fileid', $query->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
+				$query->expr()->eq('systemtagmap.objecttype', $query->createNamedParameter('files'))
+			))
+			->leftJoin('systemtagmap', 'systemtag', 'systemtag', $query->expr()->andX(
+				$query->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
+				$query->expr()->eq('systemtag.visibility', $query->createNamedParameter(true))
+			));
+	}
+
+	protected function equipQueryForDavTags(CacheQueryBuilder $query, IUser $user): void {
+		$query
+			->leftJoin('file', 'vcategory_to_object', 'tagmap', $query->expr()->eq('file.fileid', 'tagmap.objid'))
+			->leftJoin('tagmap', 'vcategory', 'tag', $query->expr()->andX(
+				$query->expr()->eq('tagmap.type', 'tag.type'),
+				$query->expr()->eq('tagmap.categoryid', 'tag.id'),
+				$query->expr()->eq('tag.type', $query->createNamedParameter('files')),
+				$query->expr()->eq('tag.uid', $query->createNamedParameter($user->getUID()))
+			));
+	}
+
 	/**
 	 * Perform a file system search in multiple caches
 	 *
@@ -156,27 +180,16 @@ class QuerySearchHelper {
 			if ($searchQuery->getSearchOperation() instanceof ISearchComparison) {
 				switch ($searchQuery->getSearchOperation()->getField()) {
 					case 'systemtag':
-						$query
-							->leftJoin('file', 'systemtag_object_mapping', 'systemtagmap', $builder->expr()->andX(
-								$builder->expr()->eq('file.fileid', $builder->expr()->castColumn('systemtagmap.objectid', IQueryBuilder::PARAM_INT)),
-								$builder->expr()->eq('systemtagmap.objecttype', $builder->createNamedParameter('files'))
-							))
-							->leftJoin('systemtagmap', 'systemtag', 'systemtag', $builder->expr()->andX(
-								$builder->expr()->eq('systemtag.id', 'systemtagmap.systemtagid'),
-								$builder->expr()->eq('systemtag.visibility', $builder->createNamedParameter(true))
-							));
+						$this->equipQueryForSystemTags($query);
 						break;
 					case 'tagname':
-						$query
-							->leftJoin('file', 'vcategory_to_object', 'tagmap', $builder->expr()->eq('file.fileid', 'tagmap.objid'))
-							->leftJoin('tagmap', 'vcategory', 'tag', $builder->expr()->andX(
-								$builder->expr()->eq('tagmap.type', 'tag.type'),
-								$builder->expr()->eq('tagmap.categoryid', 'tag.id'),
-								$builder->expr()->eq('tag.type', $builder->createNamedParameter('files')),
-								$builder->expr()->eq('tag.uid', $builder->createNamedParameter($user->getUID()))
-							));
+					case 'favorite':
+						$this->equipQueryForDavTags($query, $user);
 						break;
 				}
+			} elseif ($searchQuery->getSearchOperation() instanceof SearchBinaryOperator) {
+				$this->equipQueryForSystemTags($query);
+				$this->equipQueryForDavTags($query, $user);
 			}
 		}
 

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -69,20 +69,17 @@ class SearchBuilder {
 	}
 
 	/**
-	 * Whether or not the tag tables should be joined to complete the search
-	 *
-	 * @param ISearchOperator $operator
-	 * @return boolean
+	 * @return string[]
 	 */
-	public function shouldJoinTags(ISearchOperator $operator) {
+	public function extractRequestedFields(ISearchOperator $operator): array {
 		if ($operator instanceof ISearchBinaryOperator) {
-			return array_reduce($operator->getArguments(), function ($shouldJoin, ISearchOperator $operator) {
-				return $shouldJoin || $this->shouldJoinTags($operator);
-			}, false);
+			return array_reduce($operator->getArguments(), function (array $fields, ISearchOperator $operator) {
+				return array_unique(array_merge($fields, $this->extractRequestedFields($operator)));
+			}, []);
 		} elseif ($operator instanceof ISearchComparison) {
-			return $operator->getField() === 'tagname' || $operator->getField() === 'favorite' || $operator->getField() === 'systemtag';
+			return [$operator->getField()];
 		}
-		return false;
+		return [];
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -304,8 +304,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 		return $this->search($query);
 	}
 
-	public function searchBySystemTag(string $tag, string $userId, int $limit = 0, int $offset = 0): array {
-		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'systemtag', $tag), $userId, $limit, $offset);
+	public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0): array {
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'systemtag', $tagName), $userId, $limit, $offset);
 		return $this->search($query);
 	}
 

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -300,7 +300,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return Node[]
 	 */
 	public function searchByTag($tag, $userId) {
-		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tagname', $tag), $userId);
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tag', $tag), $userId);
+		return $this->search($query);
+	}
+
+	public function searchBySystemTag(string $tag, string $userId, int $limit = 0, int $offset = 0): array {
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'systemtag', $tag), $userId, $limit, $offset);
 		return $this->search($query);
 	}
 

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -300,7 +300,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return Node[]
 	 */
 	public function searchByTag($tag, $userId) {
-		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tag', $tag), $userId);
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tagname', $tag), $userId);
 		return $this->search($query);
 	}
 

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -448,6 +448,10 @@ class LazyFolder implements Folder {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
+	public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
 	/**
 	 * @inheritDoc
 	 */

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -91,7 +91,7 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getTagsByIds($tagIds): array {
+	public function getTagsByIds($tagIds, ?IUser $user = null): array {
 		if (!\is_array($tagIds)) {
 			$tagIds = [$tagIds];
 		}
@@ -116,7 +116,12 @@ class SystemTagManager implements ISystemTagManager {
 
 		$result = $query->execute();
 		while ($row = $result->fetch()) {
-			$tags[$row['id']] = $this->createSystemTagFromRow($row);
+			$tag = $this->createSystemTagFromRow($row);
+			if ($user && !$this->canUserSeeTag($tag, $user)) {
+				// if a user is given, hide invisible tags
+				continue;
+			}
+			$tags[$row['id']] = $tag;
 		}
 
 		$result->closeCursor();

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -135,6 +135,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		while ($row = $result->fetch()) {
 			$objectIds[] = $row['objectid'];
 		}
+		$result->closeCursor();
 
 		return $objectIds;
 	}

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -142,6 +142,16 @@ interface Folder extends Node {
 	public function searchByTag($tag, $userId);
 
 	/**
+	 * search for files by system tag
+	 *
+	 * @param string|int $tag tag name
+	 * @param string $userId user id to ensure access on returned nodes
+	 * @return \OCP\Files\Node[]
+	 * @since 28.0.0
+	 */
+	public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0);
+
+	/**
 	 * get a file or folder inside the folder by it's internal id
 	 *
 	 * This method could return multiple entries. For example once the file/folder

--- a/lib/public/SystemTag/ISystemTagManager.php
+++ b/lib/public/SystemTag/ISystemTagManager.php
@@ -38,6 +38,7 @@ interface ISystemTagManager {
 	 * Returns the tag objects matching the given tag ids.
 	 *
 	 * @param array|string $tagIds id or array of unique ids of the tag to retrieve
+	 * @param ?IUser $user optional user to run a visibility check against for each tag
 	 *
 	 * @return ISystemTag[] array of system tags with tag id as key
 	 *
@@ -45,9 +46,9 @@ interface ISystemTagManager {
 	 * @throws TagNotFoundException if at least one given tag ids did no exist
 	 * 			The message contains a json_encoded array of the ids that could not be found
 	 *
-	 * @since 9.0.0
+	 * @since 9.0.0, optional parameter $user added in 28.0.0
 	 */
-	public function getTagsByIds($tagIds): array;
+	public function getTagsByIds($tagIds, ?IUser $user = null): array;
 
 	/**
 	 * Returns the tag object matching the given attributes.


### PR DESCRIPTION
## Summary

- uses DAV search approach against valid files joined by systemtag selector
- reduced table join for tag/systemtag search
- supports pagination
- no changes to the output formats or similar

Example request body:

```xml
<?xml version="1.0"?>
<oc:filter-files xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns" xmlns:ocs="http://open-collaboration-services.org/ns">
  <d:prop>
    <d:getcontentlength/>
    <d:getcontenttype/>
    <d:getetag/>
    <d:getlastmodified/>
    <d:resourcetype/>
    <nc:face-detections/>
    <nc:file-metadata-size/>
    <nc:has-preview/>
    <nc:realpath/>
    <oc:favorite/>
    <oc:fileid/>
    <oc:permissions/>
    <nc:nbItems/>
  </d:prop>
  <oc:filter-rules>
    <oc:systemtag>32</oc:systemtag>
  </oc:filter-rules>
  <d:limit>
    <d:nresults>50</d:nresults>
    <nc:firstresult>0</nc:firstresult>
  </d:limit>
</oc:filter-files>
```

Example call:
 
```bash
curl -s -u 'user:password' 'https://my.nxt.cld/remote.php/dav/files/user/' -X REPORT  -H 'Accept: text/plain'  -H 'Content-Type: text/plain;charset=UTF-8' --data @/home/nextcloud/report-people-tag.xml
```


:information_source: the base branch is #37961 This PR is an addition to it, but I keep it seperated for smaller changesets.


## TODO

- [ ] Performance testing with a serious data set
- [ ] Reconsider pragmatic architectual choices (quick PoC)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
