### PR TITLE
Improve translations api with detecting languages

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -614,6 +614,7 @@ return array(
     'OCP\\Talk\\IConversationOptions' => $baseDir . '/lib/public/Talk/IConversationOptions.php',
     'OCP\\Talk\\ITalkBackend' => $baseDir . '/lib/public/Talk/ITalkBackend.php',
     'OCP\\Template' => $baseDir . '/lib/public/Template.php',
+    'OCP\\Translation\\CouldNotTranslateException' => $baseDir . '/lib/public/Translation/CouldNotTranslateException.php',
     'OCP\\Translation\\IDetectLanguageProvider' => $baseDir . '/lib/public/Translation/IDetectLanguageProvider.php',
     'OCP\\Translation\\ITranslationManager' => $baseDir . '/lib/public/Translation/ITranslationManager.php',
     'OCP\\Translation\\ITranslationProvider' => $baseDir . '/lib/public/Translation/ITranslationProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -647,6 +647,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Talk\\IConversationOptions' => __DIR__ . '/../../..' . '/lib/public/Talk/IConversationOptions.php',
         'OCP\\Talk\\ITalkBackend' => __DIR__ . '/../../..' . '/lib/public/Talk/ITalkBackend.php',
         'OCP\\Template' => __DIR__ . '/../../..' . '/lib/public/Template.php',
+        'OCP\\Translation\\CouldNotTranslateException' => __DIR__ . '/../../..' . '/lib/public/Translation/CouldNotTranslateException.php',
         'OCP\\Translation\\IDetectLanguageProvider' => __DIR__ . '/../../..' . '/lib/public/Translation/IDetectLanguageProvider.php',
         'OCP\\Translation\\ITranslationManager' => __DIR__ . '/../../..' . '/lib/public/Translation/ITranslationManager.php',
         'OCP\\Translation\\ITranslationProvider' => __DIR__ . '/../../..' . '/lib/public/Translation/ITranslationProvider.php',

--- a/lib/private/Translation/TranslationManager.php
+++ b/lib/private/Translation/TranslationManager.php
@@ -30,6 +30,7 @@ use InvalidArgumentException;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\IServerContainer;
 use OCP\PreConditionNotMetException;
+use OCP\Translation\CouldNotTranslateException;
 use OCP\Translation\IDetectLanguageProvider;
 use OCP\Translation\ITranslationManager;
 use OCP\Translation\ITranslationProvider;
@@ -58,7 +59,7 @@ class TranslationManager implements ITranslationManager {
 		return $languages;
 	}
 
-	public function translate(string $text, ?string $fromLanguage, string $toLanguage): string {
+	public function translate(string $text, ?string &$fromLanguage, string $toLanguage): string {
 		if (!$this->hasProviders()) {
 			throw new PreConditionNotMetException('No translation providers available');
 		}
@@ -87,7 +88,7 @@ class TranslationManager implements ITranslationManager {
 			}
 		}
 
-		throw new RuntimeException('Could not translate text');
+		throw new CouldNotTranslateException($fromLanguage);
 	}
 
 	public function getProviders(): array {

--- a/lib/private/Translation/TranslationManager.php
+++ b/lib/private/Translation/TranslationManager.php
@@ -63,15 +63,23 @@ class TranslationManager implements ITranslationManager {
 			throw new PreConditionNotMetException('No translation providers available');
 		}
 
-		foreach ($this->getProviders() as $provider) {
-			if ($fromLanguage === null && $provider instanceof IDetectLanguageProvider) {
-				$fromLanguage = $provider->detectLanguage($text);
+		if ($fromLanguage === null) {
+			foreach ($this->getProviders() as $provider) {
+				if ($provider instanceof IDetectLanguageProvider) {
+					$fromLanguage = $provider->detectLanguage($text);
+				}
+
+				if ($fromLanguage !== null) {
+					break;
+				}
 			}
 
 			if ($fromLanguage === null) {
 				throw new InvalidArgumentException('Could not detect language');
 			}
+		}
 
+		foreach ($this->getProviders() as $provider) {
 			try {
 				return $provider->translate($fromLanguage, $toLanguage, $text);
 			} catch (RuntimeException $e) {

--- a/lib/public/Translation/CouldNotTranslateException.php
+++ b/lib/public/Translation/CouldNotTranslateException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\Translation;
+
+/**
+ * @since 27.0.0
+ */
+class CouldNotTranslateException extends \RuntimeException {
+	/**
+	 * @since 27.0.0
+	 */
+	public function __construct(
+		protected ?string $from,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @since 27.0.0
+	 */
+	public function getFrom(): ?string {
+		return $this->from;
+	}
+}

--- a/lib/public/Translation/ITranslationManager.php
+++ b/lib/public/Translation/ITranslationManager.php
@@ -28,7 +28,6 @@ namespace OCP\Translation;
 
 use InvalidArgumentException;
 use OCP\PreConditionNotMetException;
-use RuntimeException;
 
 /**
  * @since 26.0.0
@@ -54,7 +53,7 @@ interface ITranslationManager {
 	 * @since 26.0.0
 	 * @throws PreConditionNotMetException If no provider was registered but this method was still called
 	 * @throws InvalidArgumentException If no matching provider was found that can detect a language
-	 * @throws RuntimeException If the translation failed for other reasons
+	 * @throws CouldNotTranslateException If the translation failed for other reasons
 	 */
-	public function translate(string $text, ?string $fromLanguage, string $toLanguage): string;
+	public function translate(string $text, ?string &$fromLanguage, string $toLanguage): string;
 }


### PR DESCRIPTION
## Summary

1. Fix a bug that when the first translation provider was unable to detect a language translations would not work
2. Return the from language (on success and error) so that clients can select the proper option and/or give hints to the user how they can get closer to a translation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
