### PR TITLE
do not fail if size metadata for an image fail

### DIFF
--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -68,7 +68,12 @@ class ExifProvider implements IMetadataProvider {
 		$size->setArrayAsValue([]);
 
 		if (!$data) {
-			$sizeResult = getimagesizefromstring($file->getContent());
+			try {
+				$sizeResult = getimagesizefromstring($file->getContent());
+			} catch (\Exception $ex) {
+				$this->logger->info("Couldn't extract metadata for ".$file->getId(), ['exception' => $ex]);
+				$sizeResult = false;
+			}
 			if ($sizeResult !== false) {
 				$size->setArrayAsValue([
 					'width' => $sizeResult[0],


### PR DESCRIPTION
some images may trigger an exception when trying to get their size

Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

fix for a blocking exception when running `occ files:scan --generate-metadata` for some images

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
