### PR TITLE
Fix 32bits ci

### DIFF
--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -1,6 +1,10 @@
 name: PHPUnit 32bits
 
 on:
+  pull_request:
+    paths:
+      - 'version.php'
+      - '.github/workflows/phpunit-32bits.yml'
   workflow_dispatch:
   schedule:
     - cron: "15 1 * * 1-6"

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -135,7 +135,6 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		$this->assertEquals($expectedWebRoot, $webRoot);
 		$this->assertEquals($expectedFile, $file);
 
-		array_pop(\OC::$APPSROOTS);
 		//unlink($new_apps_path_symlink);
 		//$this->rrmdir($new_apps_path);
 	}
@@ -173,8 +172,7 @@ class JSResourceLocatorTest extends \Test\TestCase {
 			$this->assertEquals($expectedWebRoot, $resources[$idx][1]);
 			$this->assertEquals($expectedFiles[$idx], $resources[$idx][2]);
 		}
-		
-		array_pop(\OC::$APPSROOTS);
+
 		$this->rrmdir($new_apps_path);
 	}
 }

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -135,8 +135,8 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		$this->assertEquals($expectedWebRoot, $webRoot);
 		$this->assertEquals($expectedFile, $file);
 
-		//unlink($new_apps_path_symlink);
-		//$this->rrmdir($new_apps_path);
+		unlink($new_apps_path_symlink);
+		$this->rrmdir($new_apps_path);
 	}
 
 	public function testFindModuleJSWithFallback() {
@@ -164,7 +164,6 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		$resources = $locator->getResources();
 		$this->assertCount(3, $resources);
 
-		$expectedRoot = $new_apps_path . '/test-js-app';
 		$expectedWebRoot = \OC::$WEBROOT . '/js-apps-test/test-js-app';
 		$expectedFiles = ['module.mjs', 'both.mjs', 'plain.js'];
 


### PR DESCRIPTION
## Summary

Fix 32bit CI which was failing with:
```
There was 1 error:

1) OCA\Files_Sharing\Tests\UpdaterTest::testDeleteParentFolder
Exception: Could not download app files_trashbin

/__w/server/server/lib/private/Installer.php:387
/__w/server/server/lib/private/legacy/OC_App.php:275
/__w/server/server/apps/files_sharing/tests/UpdaterTest.php:79
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
