### PR TITLE
Use a Generator for users in searchInGroups, type it as iterable

### DIFF
--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -335,7 +335,7 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGet
 		return 'LDAP';
 	}
 
-	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array {
+	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): iterable {
 		return $this->handleRequest($gid, 'searchInGroup', [$gid, $search, $limit, $offset]);
 	}
 }

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -336,10 +336,15 @@ class Database extends ABackend implements
 	 * @return array<int,string> an array of user ids
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0): array {
-		return array_values(array_map(fn ($user) => $user->getUid(), $this->searchInGroup($gid, $search, $limit, $offset)));
+		$userIds = [];
+		$users = $this->searchInGroup($gid, $search, $limit, $offset);
+		foreach ($users as $userId => $user) {
+			$userIds[] = $userId;
+		}
+		return $userIds;
 	}
 
-	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array {
+	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): iterable {
 		$this->fixDI();
 
 		$query = $this->dbConn->getQueryBuilder();
@@ -380,11 +385,9 @@ class Database extends ABackend implements
 		$users = [];
 		$userManager = \OCP\Server::get(IUserManager::class);
 		while ($row = $result->fetch()) {
-			$users[$row['uid']] = new LazyUser($row['uid'], $userManager, $row['displayname'] ?? null);
+			yield $row['uid'] => new LazyUser($row['uid'], $userManager, $row['displayname'] ?? null);
 		}
 		$result->closeCursor();
-
-		return $users;
 	}
 
 	/**

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -251,7 +251,12 @@ class Group implements IGroup {
 		$users = [];
 		foreach ($this->backends as $backend) {
 			if ($backend instanceof ISearchableGroupBackend) {
-				$users += $backend->searchInGroup($this->gid, $search, $limit ?? -1, $offset ?? 0);
+				$backendUsers = $backend->searchInGroup($this->gid, $search, $limit ?? -1, $offset ?? 0);
+				foreach ($backendUsers as $userId => $user) {
+					if (!isset($users[$userId])) {
+						$users[$userId] = $user;
+					}
+				}
 			} else {
 				$userIds = $backend->usersInGroup($this->gid, $search, $limit ?? -1, $offset ?? 0);
 				$userManager = \OCP\Server::get(IUserManager::class);

--- a/lib/public/Group/Backend/ISearchableGroupBackend.php
+++ b/lib/public/Group/Backend/ISearchableGroupBackend.php
@@ -44,8 +44,8 @@ interface ISearchableGroupBackend {
 	 *                       want to search. This can be empty to get all the users.
 	 * @param int $limit     The limit of results
 	 * @param int $offset    The offset of the results
-	 * @return array<string,IUser> Users indexed by uid
+	 * @return iterable<string,IUser> Users indexed by uid
 	 * @since 27.0.0
 	 */
-	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array;
+	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): iterable;
 }


### PR DESCRIPTION
## Summary

Since this is a new method in 27 it’s the occasion to make use of a generator instead of an array

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
