### PR TITLE
Imaginary WebP support

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -651,6 +651,8 @@ class Generator {
 				return 'png';
 			case 'image/jpeg':
 				return 'jpg';
+			case 'image/webp':
+				return 'webp';
 			case 'image/gif':
 				return 'gif';
 			default:

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -106,6 +106,15 @@ class Imaginary extends ProviderV2 {
 				$mimeType = 'jpeg';
 		}
 
+		$preview_format = $this->config->getSystemValueString('preview_format', 'jpeg');
+
+		switch ($preview_format) { // Change the format to the correct one
+			case 'webp':
+				$mimeType = 'webp';
+				break;
+			default:
+		}
+
 		$operations = [];
 
 		if ($convert) {
@@ -121,7 +130,16 @@ class Imaginary extends ProviderV2 {
 			];
 		}
 
-		$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
+		switch ($mimeType) {
+			case 'jpeg':
+				$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
+				break;
+			case 'webp':
+				$quality = $this->config->getAppValue('preview', 'webp_quality', '80');
+				break;
+			default:
+				$quality = $this->config->getAppValue('preview', 'jpeg_quality', '80');
+		}
 
 		$operations[] = [
 			'operation' => ($crop ? 'smartcrop' : 'fit'),


### PR DESCRIPTION
* Resolves: # https://github.com/nextcloud/server/issues/37993)

## Summary
Hello, is my first pull, it was suggested to me in a comment and I must admit I don't really know how to do something like this.
Anyway, this code adds Imaginary WebP support and allows to add an API key.

In theory you could also extend this with e.g. Imaginary_query in the config, where you could just add something like that in the config itself.

However, until now I only wanted to add these two options.

```
  'preview_format' => 'webp',
  occ config:app:set preview webp_quality --value="30"
```

If preview_format or webp_quality doesn't exist the default will be used again.

So far WebP works exclusively for Imaginary, if it should work for the other generations I might need some help to find my way around the code.

As a small warning, I am not a skilled application developer only a hobby developer, because it has bothered that WebP does not work.

But I wanted to contribute something to the project and make it work faster.

Hope I did this right.

## TODO

- [x] for image/png application/illustrator you could use lossless or close to lossless WebP, because i don't know now how to do that lossless with imaginary. image/heic you could actually add in WebP support.

## Checklist

- Code is properly formatted
- [x] Tested
On web server, android
