### PR TITLE
chore: update HowToApplyALicense.md

### DIFF
--- a/contribute/HowToApplyALicense.md
+++ b/contribute/HowToApplyALicense.md
@@ -9,16 +9,60 @@ Additionally Nextcloud doesn't require a CLA (Contributor License
 Agreement). The copyright belongs to all the individual
 contributors.
 
-If you modify an existing file, please keep the existing license header as
-it is and just add your copyright notice:
+## Apply a license to a new file
 
-````
-@copyright Copyright (c) <year>, <your name> (<your email address>)
+If you create a new file please use a license header
+
+#### Frontend source (`.js`, `.ts`, `.css` and etc)
+
+```js
+/**
+ * @copyright Copyright (c) <year>, <your name> (<your email address>)
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 ````
 
-If you create a new file please use this license header:
+or `.vue` files
 
-````
+```html
+<!--
+  - @copyright Copyright (c) <year>, <your name> (<your email address>)
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+```
+
+#### Backend source (`.php`)
+
+```php
 /**
  * @copyright Copyright (c) <year>, <your name> (<your email address>)
  *
@@ -38,7 +82,38 @@ If you create a new file please use this license header:
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+```
+
+## Apply a licence to an existing file
+
+If you modify an existing file, please keep the existing license header as
+it is and just add your copyright notice, for example:
+
+````diff
+/**
+ * @copyright Copyright (c) 2022, Alice (alice@nextcloud.local)
+ * @copyright Copyright (c) 2023, Bob (bob@nextcloud.local)
++* @copyright Copyright (c) <year>, <your name> (<your email address>) 
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 ````
+
+## DCO
 
 Additionally we require a Developer Certificate of Origin (DCO), look
 at [CONTRIBUTING.md][contributing] to learn more how to sign your commits.


### PR DESCRIPTION
## Summary

I'd like to improve `HowToApplyALicense.md`

1. Update **applying to an existing file** with a diff
2. Add different files for different file types (add html-like for `.vue`)
3. Add different samples for different types of source:

The current example doesn't work on frontend. It is blocked by [@nextcloud/eslint-config](https://github.com/nextcloud/eslint-config/). Which inherits `eslint-plugin-jsdoc` and checks the license by [spdx-expression-parse](https://github.com/jslicense/spdx-expression-parse.js). So all JS files have `AGPL-3.0-or-later` instead of recommended by this doc `GNU AGPL version 3 or any later version`. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
