### PR TITLE
Allow "wasm-unsafe-eval" in CSP

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicy.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicy.php
@@ -64,6 +64,14 @@ class ContentSecurityPolicy extends \OCP\AppFramework\Http\ContentSecurityPolicy
 		$this->evalScriptAllowed = $evalScriptAllowed;
 	}
 
+	public function isEvalWasmAllowed(): ?bool {
+		return $this->evalWasmAllowed;
+	}
+
+	public function setEvalWasmAllowed(bool $evalWasmAllowed): void {
+		$this->evalWasmAllowed = $evalWasmAllowed;
+	}
+
 	/**
 	 * @return array
 	 */

--- a/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/ContentSecurityPolicy.php
@@ -44,6 +44,8 @@ class ContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	protected $inlineScriptAllowed = false;
 	/** @var bool Whether eval in JS scripts is allowed */
 	protected $evalScriptAllowed = false;
+	/** @var bool Whether WebAssembly compilation is allowed */
+	protected ?bool $evalWasmAllowed = false;
 	/** @var bool Whether strict-dynamic should be set */
 	protected $strictDynamicAllowed = false;
 	/** @var array Domains from which scripts can get loaded */

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -47,6 +47,8 @@ class EmptyContentSecurityPolicy {
 	 * @link https://github.com/owncloud/core/issues/11925
 	 */
 	protected $evalScriptAllowed = null;
+	/** @var bool Whether WebAssembly compilation is allowed */
+	protected ?bool $evalWasmAllowed = null;
 	/** @var array Domains from which scripts can get loaded */
 	protected $allowedScriptDomains = null;
 	/**
@@ -113,6 +115,17 @@ class EmptyContentSecurityPolicy {
 	 */
 	public function allowEvalScript($state = true) {
 		$this->evalScriptAllowed = $state;
+		return $this;
+	}
+
+	/**
+	 * Whether WebAssembly compilation is allowed or forbidden
+	 * @param bool $state
+	 * @return $this
+	 * @since 28.0.0
+	 */
+	public function allowEvalWasm(bool $state = true) {
+		$this->evalWasmAllowed = $state;
 		return $this;
 	}
 
@@ -433,7 +446,7 @@ class EmptyContentSecurityPolicy {
 		$policy .= "base-uri 'none';";
 		$policy .= "manifest-src 'self';";
 
-		if (!empty($this->allowedScriptDomains) || $this->evalScriptAllowed) {
+		if (!empty($this->allowedScriptDomains) || $this->evalScriptAllowed || $this->evalWasmAllowed) {
 			$policy .= 'script-src ';
 			if (is_string($this->useJsNonce)) {
 				if ($this->strictDynamicAllowed) {
@@ -452,6 +465,9 @@ class EmptyContentSecurityPolicy {
 			}
 			if ($this->evalScriptAllowed) {
 				$policy .= ' \'unsafe-eval\'';
+			}
+			if ($this->evalWasmAllowed) {
+				$policy .= ' \'wasm-unsafe-eval\'';
 			}
 			$policy .= ';';
 		}

--- a/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
@@ -46,6 +46,8 @@ class StrictContentSecurityPolicy extends EmptyContentSecurityPolicy {
 	protected $inlineScriptAllowed = false;
 	/** @var bool Whether eval in JS scripts is allowed */
 	protected $evalScriptAllowed = false;
+	/** @var bool Whether WebAssembly compilation is allowed */
+	protected ?bool $evalWasmAllowed = false;
 	/** @var array Domains from which scripts can get loaded */
 	protected $allowedScriptDomains = [
 		'\'self\'',

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -456,6 +456,13 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
+	public function testGetPolicyUnsafeWasmEval() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' 'wasm-unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+
+		$this->contentSecurityPolicy->allowEvalWasm(true);
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
 	public function testGetPolicyNonce() {
 		$nonce = 'my-nonce';
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -75,6 +75,13 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
+	public function testGetPolicyScriptAllowWasmEval() {
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src  'wasm-unsafe-eval';frame-ancestors 'none'";
+
+		$this->contentSecurityPolicy->allowEvalWasm(true);
+		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
+	}
+
 	public function testGetPolicyStyleDomainValid() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
 


### PR DESCRIPTION
If a page has a Content Security Policy header and [the `script-src` (or `default-src`) directive does not contain neither `wasm-unsafe-eval` nor `unsafe-eval` loading and executing WebAssembly is blocked](https://w3c.github.io/webappsec-csp/#can-compile-wasm-bytes) in the page (although it is still possible to load and execute WebAssembly in a worker thread).

Although the Nextcloud classes to manage the CSP already supported allowing `unsafe-eval` this affects not only WebAssembly, but [also the `eval` operation in JavaScript](https://w3c.github.io/webappsec-csp/#can-compile-strings).

To make possible to allow WebAssembly execution without allowing JavaScript `eval` this commit adds support for allowing `wasm-unsafe-eval` (which [is supported since some versions already by browsers](https://caniuse.com/mdn-http_headers_content-security-policy_script-src_wasm-unsafe-eval)).

Nevertheless, please keep in mind that running heavy WebAssembly code in the main thread can lead to unresponsiveness in the rest of the UI; it might be better to run WebAssembly code in a worker thread and do it in the main thread only for light (so it does not block the rest of the code) real time (which could lead to issues if run in a worker thread due to the synchronization of the data between the threads) calculations.
