### PR TITLE
Allow inserting HTML fragments in email templates

### DIFF
--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -598,6 +598,25 @@ EOF;
 	}
 
 	/**
+	 * Adds a HTML fragment to the body of the email. Use only for basic HTML fragments and make sure the given HTML is valid, as this can affect the whole email HTML body
+	 *
+	 * @param string $html The HTML fragment to add to the body of the email
+	 * @param string $plainText The plain text alternative version for the HTML fragment
+	 * @since 27.0.0
+	 */
+	public function addHTMLFragment(string $html, string $plainText): void {
+		if ($this->footerAdded) {
+			return;
+		}
+
+		$this->ensureBodyListClosed();
+		$this->ensureBodyIsOpened();
+
+		$this->htmlBody .= $html;
+		$this->plainBody .= $plainText . PHP_EOL . PHP_EOL;
+	}
+
+	/**
 	 * Close the HTML body when it is open
 	 */
 	protected function ensureBodyIsClosed() {

--- a/lib/public/Mail/IEMailTemplate.php
+++ b/lib/public/Mail/IEMailTemplate.php
@@ -137,6 +137,15 @@ interface IEMailTemplate {
 	public function addBodyButton(string $text, string $url, $plainText = '');
 
 	/**
+	 * Adds a HTML fragment to the body of the email. Use only for basic HTML fragments and make sure the given HTML is valid, as this can affect the whole email HTML body
+	 *
+	 * @param string $html The HTML fragment to add to the body of the email
+	 * @param string $plainText The plain text alternative version for the HTML fragment
+	 * @since 27.0.0
+	 */
+	public function addHTMLFragment(string $html, string $plainText): void;
+
+	/**
 	 * Adds a logo and a text to the footer. <br> in the text will be replaced by new lines in the plain text email
 	 *
 	 * @param string $text If the text is empty the default "Name - Slogan<br>This is an automatically sent email" will be used


### PR DESCRIPTION
**This is a proposal, this PR is here for discussions.**

Email templates currently only allow to add text bodies, lists and buttons. It's not possible to add formatting or other elements. Also, text bodies are always centered, which can be hard to read when there a lot of text. This provides a way to inject arbitrary HTML in emails, which can be useful in some cases.

One of these cases I have is https://github.com/nextcloud/announcementcenter/issues/644, which would be achieved otherwise by creating an `IMessage` from scratch, but that prevents consistency and theming.

Right now the HTML fragment is really just injected in the HTML body, but we could validate (very basically, at a XML level) and sanitize it (using [SF's HTML Sanitizer](https://symfony.com/doc/current/html_sanitizer.html)).

Another option is to allow for Markdown fragments directly, and do the rendering here (brings another specific dependency though).

## TODO

- [ ] Add tests to `tests/lib/Mail/EMailTemplateTest.php`
- [ ] Add docs for the new feature

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
