### PR TITLE
Reduce exif provider errors during file scan

### DIFF
--- a/lib/private/Metadata/FileMetadataMapper.php
+++ b/lib/private/Metadata/FileMetadataMapper.php
@@ -60,7 +60,7 @@ class FileMetadataMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT_ARRAY)))
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('group_name', $qb->createNamedParameter($groupName, IQueryBuilder::PARAM_STR)));
 
 		return $this->findEntity($qb);
@@ -111,7 +111,7 @@ class FileMetadataMapper extends QBMapper {
 	/**
 	 * Updates an entry in the db from an entity
 	 *
-	 * @param Entity $entity the entity that should be created
+	 * @param FileMetadata $entity the entity that should be created
 	 * @return FileMetadata the saved entity with the set id
 	 * @throws Exception
 	 * @throws \InvalidArgumentException if entity has no id
@@ -147,5 +147,31 @@ class FileMetadataMapper extends QBMapper {
 			->executeStatement();
 
 		return $entity;
+	}
+
+	/**
+	 * Override the insertOrUpdate as we could be in a transaction in which case we can not afford on error.
+	 *
+	 * @param FileMetadata $entity the entity that should be created/updated
+	 * @return FileMetadata the saved entity with the (new) id
+	 * @throws Exception
+	 * @throws \InvalidArgumentException if entity has no id
+	 */
+	public function insertOrUpdate(Entity $entity): FileMetadata {
+		try {
+			$existingEntity = $this->findForGroupForFile($entity->getId(), $entity->getGroupName());
+		} catch (\Throwable) {
+			$existingEntity = null;
+		}
+
+		if ($existingEntity !== null) {
+			if ($entity->getValue() !== $existingEntity->getValue()) {
+				return $this->update($entity);
+			} else {
+				return $existingEntity;
+			}
+		} else {
+			return parent::insertOrUpdate($entity);
+		}
 	}
 }

--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -44,10 +44,14 @@ class ExifProvider implements IMetadataProvider {
 		return extension_loaded('exif');
 	}
 
-	/** @return array{'gps': FileMetadata, 'size': FileMetadata} */
+	/** @return array{'gps'?: FileMetadata, 'size'?: FileMetadata} */
 	public function execute(File $file): array {
 		$exifData = [];
 		$fileDescriptor = $file->fopen('rb');
+
+		if ($fileDescriptor === false) {
+			return [];
+		}
 
 		$data = null;
 		try {
@@ -107,7 +111,7 @@ class ExifProvider implements IMetadataProvider {
 	}
 
 	public static function getMimetypesSupported(): string {
-		return '/image\/.*/';
+		return '/image\/(png|jpeg|heif|webp|tiff)/';
 	}
 
 	/**


### PR DESCRIPTION
Update metadata logic a bit to limits errors during file scan.

1. Prevent inserting when a metadata already exists to not create error in the middle of a transaction. This causes issue on Postgres.
2. Reduce EXIF data extraction to a subset of image file formats. This will reduce the amount of `exif_read_data(): File not supported` error.
