### PR TITLE
fix(translation): Don't use translation providers when from and to ar…

### DIFF
--- a/lib/private/Translation/TranslationManager.php
+++ b/lib/private/Translation/TranslationManager.php
@@ -80,6 +80,10 @@ class TranslationManager implements ITranslationManager {
 			}
 		}
 
+		if ($fromLanguage === $toLanguage) {
+			return $text;
+		}
+
 		foreach ($this->getProviders() as $provider) {
 			try {
 				return $provider->translate($fromLanguage, $toLanguage, $text);


### PR DESCRIPTION
…e the same


* Resolves: #38087 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
