### PR TITLE
Remove unreachable UserStatus#clearStatus route

### DIFF
--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -169,16 +169,6 @@ class UserStatusController extends OCSController {
 	 *
 	 * @return DataResponse
 	 */
-	public function clearStatus(): DataResponse {
-		$this->service->clearStatus($this->userId);
-		return new DataResponse([]);
-	}
-
-	/**
-	 * @NoAdminRequired
-	 *
-	 * @return DataResponse
-	 */
 	public function clearMessage(): DataResponse {
 		$this->service->clearMessage($this->userId);
 		return new DataResponse([]);

--- a/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
+++ b/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
@@ -326,15 +326,6 @@ class UserStatusControllerTest extends TestCase {
 		];
 	}
 
-	public function testClearStatus(): void {
-		$this->service->expects($this->once())
-			->method('clearStatus')
-			->with('john.doe');
-
-		$response = $this->controller->clearStatus();
-		$this->assertEquals([], $response->getData());
-	}
-
 	public function testClearMessage(): void {
 		$this->service->expects($this->once())
 			->method('clearMessage')


### PR DESCRIPTION
## Summary

I noticed the endpoint at https://github.com/nextcloud/server/blob/263a6910c41c07614e2a40349f2ae23e2fca0cb9/apps/user_status/lib/Controller/UserStatusController.php#L172 doesn't have a route and therefore is unreachable.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
