### PR TITLE
Fix error on delete in ChunkingV2Plugin

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -255,17 +255,15 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	public function beforeDelete(RequestInterface $request, ResponseInterface $response) {
 		try {
-			$this->prepareUpload($request->getPath());
-			if (!$this->uploadFolder instanceof UploadFolder) {
-				return true;
-			}
-
-			[$storage, $storagePath] = $this->getUploadStorage($this->uploadPath);
-			$storage->cancelChunkedWrite($storagePath, $this->uploadId);
-			return true;
-		} catch (NotFound $e) {
+			$this->prepareUpload(dirname($request->getPath()));
+			$this->checkPrerequisites();
+		} catch (StorageInvalidException|BadRequest|NotFound $e) {
 			return true;
 		}
+
+		[$storage, $storagePath] = $this->getUploadStorage($this->uploadPath);
+		$storage->cancelChunkedWrite($storagePath, $this->uploadId);
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #37578 

## Summary
This PR fix the error on "delete" call when is used and storage class that is not IChunkedFileWrite::class.
Implementation is the same of other "before" method

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
