### PR TITLE
feat(UserMigration)!: 32-bit support

### DIFF
--- a/apps/dav/lib/UserMigration/CalendarMigrator.php
+++ b/apps/dav/lib/UserMigration/CalendarMigrator.php
@@ -211,7 +211,7 @@ class CalendarMigrator implements IMigrator, ISizeEstimationMigrator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getEstimatedExportSize(IUser $user): int {
+	public function getEstimatedExportSize(IUser $user): int|float {
 		$calendarExports = $this->getCalendarExports($user, new NullOutput());
 		$calendarCount = count($calendarExports);
 
@@ -230,7 +230,7 @@ class CalendarMigrator implements IMigrator, ISizeEstimationMigrator {
 		// 450B for each component (events, todos, alarms, etc.)
 		$size += ($componentCount * 450) / 1024;
 
-		return (int)ceil($size);
+		return ceil($size);
 	}
 
 	/**

--- a/apps/dav/lib/UserMigration/ContactsMigrator.php
+++ b/apps/dav/lib/UserMigration/ContactsMigrator.php
@@ -202,7 +202,7 @@ class ContactsMigrator implements IMigrator, ISizeEstimationMigrator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getEstimatedExportSize(IUser $user): int {
+	public function getEstimatedExportSize(IUser $user): int|float {
 		$addressBookExports = $this->getAddressBookExports($user, new NullOutput());
 		$addressBookCount = count($addressBookExports);
 
@@ -217,7 +217,7 @@ class ContactsMigrator implements IMigrator, ISizeEstimationMigrator {
 		// 350B for each contact
 		$size += ($contactsCount * 350) / 1024;
 
-		return (int)ceil($size);
+		return ceil($size);
 	}
 
 	/**

--- a/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
+++ b/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
@@ -67,7 +67,7 @@ class TrashbinMigrator implements IMigrator, ISizeEstimationMigrator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getEstimatedExportSize(IUser $user): int {
+	public function getEstimatedExportSize(IUser $user): int|float {
 		$uid = $user->getUID();
 
 		try {
@@ -75,7 +75,7 @@ class TrashbinMigrator implements IMigrator, ISizeEstimationMigrator {
 			if (!$trashbinFolder instanceof Folder) {
 				return 0;
 			}
-			return (int)ceil($trashbinFolder->getSize() / 1024);
+			return ceil($trashbinFolder->getSize() / 1024);
 		} catch (\Throwable $e) {
 			return 0;
 		}

--- a/apps/settings/lib/UserMigration/AccountMigrator.php
+++ b/apps/settings/lib/UserMigration/AccountMigrator.php
@@ -84,7 +84,7 @@ class AccountMigrator implements IMigrator, ISizeEstimationMigrator {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getEstimatedExportSize(IUser $user): int {
+	public function getEstimatedExportSize(IUser $user): int|float {
 		$size = 100; // 100KiB for account JSON
 
 		try {
@@ -97,7 +97,7 @@ class AccountMigrator implements IMigrator, ISizeEstimationMigrator {
 			// Skip avatar in size estimate on failure
 		}
 
-		return (int)ceil($size);
+		return ceil($size);
 	}
 
 	/**

--- a/lib/public/UserMigration/ISizeEstimationMigrator.php
+++ b/lib/public/UserMigration/ISizeEstimationMigrator.php
@@ -38,6 +38,7 @@ interface ISizeEstimationMigrator {
 	 * Should be fast, favor performance over accuracy.
 	 *
 	 * @since 25.0.0
+	 * @since 27.0.0 return value may overflow from int to float
 	 */
-	public function getEstimatedExportSize(IUser $user): int;
+	public function getEstimatedExportSize(IUser $user): int|float;
 }


### PR DESCRIPTION
## Summary

32-bit support for `\OCP\UserMigration`

## TODO

- [x] https://github.com/nextcloud/documentation/pull/10484

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)