### PR TITLE
Rename `numericStorageId` to `numericExternalStorageId` in PersonalMount.php

### DIFF
--- a/apps/files_external/lib/Lib/PersonalMount.php
+++ b/apps/files_external/lib/Lib/PersonalMount.php
@@ -36,8 +36,8 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	/** @var UserStoragesService */
 	protected $storagesService;
 
-	/** @var int */
-	protected $numericStorageId;
+	/** @var int id of the external storage (mount) (not the numeric id of the resulting storage!) */
+	protected $numericExternalStorageId;
 
 	/**
 	 * @param UserStoragesService $storagesService
@@ -51,7 +51,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	public function __construct(
 		UserStoragesService $storagesService,
 		StorageConfig $storageConfig,
-		$storageId,
+		$externalStorageId,
 		$storage,
 		$mountpoint,
 		$arguments = null,
@@ -61,7 +61,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	) {
 		parent::__construct($storageConfig, $storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId);
 		$this->storagesService = $storagesService;
-		$this->numericStorageId = $storageId;
+		$this->numericExternalStorageId = $externalStorageId;
 	}
 
 	/**
@@ -71,7 +71,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	 * @return bool
 	 */
 	public function moveMount($target) {
-		$storage = $this->storagesService->getStorage($this->numericStorageId);
+		$storage = $this->storagesService->getStorage($this->numericExternalStorageId);
 		// remove "/$user/files" prefix
 		$targetParts = explode('/', trim($target, '/'), 3);
 		$storage->setMountPoint($targetParts[2]);
@@ -86,7 +86,7 @@ class PersonalMount extends ExternalMountPoint implements MoveableMount {
 	 * @return bool
 	 */
 	public function removeMount() {
-		$this->storagesService->removeStorage($this->numericStorageId);
+		$this->storagesService->removeStorage($this->numericExternalStorageId);
 		return true;
 	}
 }


### PR DESCRIPTION
so that it doesn't override `numericStorageId` in the `MountPoint` baseclass

* Fixes https://github.com/nextcloud/server/issues/37473
  (see this one for a detailed explanation of the bug)
* Fixes https://github.com/nextcloud/server/issues/37414

## TODO

- [ ] Discuss: This fixes this issue in the least intrusive way, but there might be other, preferred ways of doing this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
