### PR TITLE
feat: Add setup check warning if instance is in debug mode

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -521,6 +521,12 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						})
 					}
+					if (window.oc_debug) {
+						messages.push({
+							msg: t('core', 'This instance is running in debug mode. Only enable this for local development and not in production environments.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						})
+					}
 
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpDefaultCharset', messages)
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\PhpOutputBuffering', messages)


### PR DESCRIPTION
I've seen a couple of instances running in debug mode in production recently and thought it might be a good idea to add a setup check for this since we only recommend it for development purposes as it may widen security measurements and also could introduce unexpected behaviour for regular users where the js assets are not automatically invalidated in the browser cache.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
