### PR TITLE
Fix generated avatars cache

### DIFF
--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -160,13 +160,8 @@ class AvatarManager implements IAvatarManager {
 	public function clearCachedAvatars() {
 		$users = $this->config->getUsersForUserValue('avatar', 'generated', 'true');
 		foreach ($users as $userId) {
-			try {
-				$folder = $this->appData->getFolder($userId);
-				$folder->delete();
-			} catch (NotFoundException $e) {
-				$this->logger->debug("No cache for the user $userId. Ignoring...");
-			}
-			$this->config->setUserValue($userId, 'avatar', 'generated', 'false');
+			// This also bumps the avatar version leading to cache invalidation in browsers
+			$this->getAvatar($userId)->remove();
 		}
 	}
 

--- a/lib/private/Repair/ClearGeneratedAvatarCache.php
+++ b/lib/private/Repair/ClearGeneratedAvatarCache.php
@@ -42,7 +42,7 @@ class ClearGeneratedAvatarCache implements IRepairStep {
 	}
 
 	public function getName(): string {
-		return 'Clear every generated avatar on major updates';
+		return 'Clear every generated avatar';
 	}
 
 	/**
@@ -51,8 +51,9 @@ class ClearGeneratedAvatarCache implements IRepairStep {
 	private function shouldRun(): bool {
 		$versionFromBeforeUpdate = $this->config->getSystemValueString('version', '0.0.0.0');
 
-		// was added to 25.0.0.10
-		return version_compare($versionFromBeforeUpdate, '25.0.0.10', '<=');
+		// This job only runs if the server was on a version lower than or equal to 27.0.0 before the upgrade.
+		// To clear the avatar cache again, bump the version to the currently released version (and change the operator to <= if it's not the master branch) and wait for the next release.
+		return version_compare($versionFromBeforeUpdate, '27.0.0', '<');
 	}
 
 	public function run(IOutput $output): void {

--- a/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
+++ b/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
@@ -61,7 +61,7 @@ class ClearGeneratedAvatarCacheTest extends \Test\TestCase {
 			['15.0.0.3', true],
 			['13.0.5.2', true],
 			['12.0.0.0', true],
-			['26.0.0.1', false],
+			['26.0.0.1', true],
 			['15.0.0.2', true],
 			['13.0.0.0', true],
 			['27.0.0.5', false]


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/34755

## Summary

Patch needs to be backported to 25 & 26 and have their respective latest released versions set in the comparison

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
