### PR TITLE
make Node::getParent lazy

### DIFF
--- a/apps/files_trashbin/lib/Trash/TrashItem.php
+++ b/apps/files_trashbin/lib/Trash/TrashItem.php
@@ -186,4 +186,8 @@ class TrashItem implements ITrashItem {
 	public function getUploadTime(): int {
 		return $this->fileInfo->getUploadTime();
 	}
+
+	public function getParentId(): int {
+		return $this->fileInfo->getParentId();
+	}
 }

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -412,4 +412,8 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	public function getUploadTime(): int {
 		return (int) $this->data['upload_time'];
 	}
+
+	public function getParentId(): int {
+		return $this->data['parent'] ?? -1;
+	}
 }

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -207,6 +207,9 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getId() {
+		if (isset($this->data['fileid'])) {
+			return $this->data['fileid'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -221,6 +224,9 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getMTime() {
+		if (isset($this->data['mtime'])) {
+			return $this->data['mtime'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -228,6 +234,9 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getSize($includeMounts = true): int|float {
+		if (isset($this->data['size'])) {
+			return $this->data['size'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -235,6 +244,9 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getEtag() {
+		if (isset($this->data['etag'])) {
+			return $this->data['etag'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
@@ -299,6 +311,12 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getName() {
+		if (isset($this->data['path'])) {
+			return basename($this->data['path']);
+		}
+		if (isset($this->data['name'])) {
+			return $this->data['name'];
+		}
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -551,4 +551,11 @@ class LazyFolder implements Folder {
 	public function getRelativePath($path) {
 		return PathHelper::getRelativePath($this->getPath(), $path);
 	}
+
+	public function getParentId(): int {
+		if (isset($this->data['parent'])) {
+			return $this->data['parent'];
+		}
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
 }

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OC\Files\Node;
 
+use OC\Files\Filesystem;
 use OC\Files\Utils\PathHelper;
 use OCP\Files\Folder;
 use OCP\Constants;
@@ -418,19 +419,12 @@ class LazyFolder implements Folder {
 	public function getFullPath($path) {
 		if (isset($this->data['path'])) {
 			$path = PathHelper::normalizePath($path);
-			if (!$this->isValidPath($path)) {
+			if (!Filesystem::isValidPath($path)) {
 				throw new NotPermittedException('Invalid path "' . $path . '"');
 			}
 			return $this->data['path'] . $path;
 		}
 		return $this->__call(__FUNCTION__, func_get_args());
-	}
-
-	public function isValidPath($path) {
-		if (!str_starts_with($path, '/')) {
-			$path = '/' . $path;
-		}
-		return !(str_contains($path, '/../') || strrchr($path, '/') === '/..');
 	}
 
 	/**

--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -33,9 +33,18 @@ use OCP\Files\IRootFolder;
  * @package OC\Files\Node
  */
 class LazyRoot extends LazyFolder implements IRootFolder {
-	/**
-	 * @inheritDoc
-	 */
+	public function __construct(\Closure $folderClosure, array $data = []) {
+		parent::__construct($this, $folderClosure, $data);
+	}
+
+	protected function getRootFolder(): IRootFolder {
+		$folder = $this->getRealFolder();
+		if (!$folder instanceof IRootFolder) {
+			throw new \Exception('Lazy root folder closure didn\'t return a root folder');
+		}
+		return $folder;
+	}
+
 	public function getUserFolder($userId) {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}

--- a/lib/private/Files/Node/LazyUserFolder.php
+++ b/lib/private/Files/Node/LazyUserFolder.php
@@ -34,19 +34,17 @@ use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class LazyUserFolder extends LazyFolder {
-	private IRootFolder $root;
 	private IUser $user;
 	private string $path;
 	private IMountManager $mountManager;
 
 	public function __construct(IRootFolder $rootFolder, IUser $user, IMountManager $mountManager) {
-		$this->root = $rootFolder;
 		$this->user = $user;
 		$this->mountManager = $mountManager;
 		$this->path = '/' . $user->getUID() . '/files';
-		parent::__construct(function () use ($user): Folder {
+		parent::__construct($rootFolder, function () use ($user): Folder {
 			try {
-				$node = $this->root->get($this->path);
+				$node = $this->getRootFolder()->get($this->path);
 				if ($node instanceof File) {
 					$e = new \RuntimeException();
 					\OCP\Server::get(LoggerInterface::class)->error('User root storage is not a folder: ' . $this->path, [
@@ -56,10 +54,10 @@ class LazyUserFolder extends LazyFolder {
 				}
 				return $node;
 			} catch (NotFoundException $e) {
-				if (!$this->root->nodeExists('/' . $user->getUID())) {
-					$this->root->newFolder('/' . $user->getUID());
+				if (!$this->getRootFolder()->nodeExists('/' . $user->getUID())) {
+					$this->getRootFolder()->newFolder('/' . $user->getUID());
 				}
-				return $this->root->newFolder($this->path);
+				return $this->getRootFolder()->newFolder($this->path);
 			}
 		}, [
 			'path' => $this->path,
@@ -71,7 +69,7 @@ class LazyUserFolder extends LazyFolder {
 	}
 
 	public function get($path) {
-		return $this->root->get('/' . $this->user->getUID() . '/files/' . ltrim($path, '/'));
+		return $this->getRootFolder()->get('/' . $this->user->getUID() . '/files/' . ltrim($path, '/'));
 	}
 
 	/**
@@ -79,7 +77,7 @@ class LazyUserFolder extends LazyFolder {
 	 * @return \OCP\Files\Node[]
 	 */
 	public function getById($id) {
-		return $this->root->getByIdInPath((int)$id, $this->getPath());
+		return $this->getRootFolder()->getByIdInPath((int)$id, $this->getPath());
 	}
 
 	public function getMountPoint() {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -334,13 +334,7 @@ class Node implements INode {
 	 * @return bool
 	 */
 	public function isValidPath($path) {
-		if (!$path || $path[0] !== '/') {
-			$path = '/' . $path;
-		}
-		if (strstr($path, '/../') || strrchr($path, '/') === '/..') {
-			return false;
-		}
-		return true;
+		return Filesystem::isValidPath($path);
 	}
 
 	public function isMounted() {

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -59,10 +59,7 @@ class Node implements INode {
 
 	protected ?FileInfo $fileInfo;
 
-	/**
-	 * @var Node|null
-	 */
-	protected $parent;
+	protected ?INode $parent;
 
 	private bool $infoHasSubMountsIncluded;
 
@@ -300,13 +297,13 @@ class Node implements INode {
 				return $this->root;
 			}
 
+			// gather the metadata we already know about our parent
 			$parentData = [
 				'path' => $newPath,
+				'fileid' => $this->getFileInfo()->getParentId(),
 			];
-			if ($this->fileInfo instanceof \OC\Files\FileInfo && isset($this->fileInfo['parent'])) {
-				$parentData['fileid'] = $this->fileInfo['parent'];
-			}
 
+			// and create lazy folder with it instead of always querying
 			$this->parent = new LazyFolder(function () use ($newPath) {
 				return $this->root->get($newPath);
 			}, $parentData);
@@ -485,5 +482,9 @@ class Node implements INode {
 
 	public function getUploadTime(): int {
 		return $this->getFileInfo()->getUploadTime();
+	}
+
+	public function getParentId(): int {
+		return $this->fileInfo->getParentId();
 	}
 }

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -300,7 +300,16 @@ class Node implements INode {
 				return $this->root;
 			}
 
-			$this->parent = $this->root->get($newPath);
+			$parentData = [
+				'path' => $newPath,
+			];
+			if ($this->fileInfo instanceof \OC\Files\FileInfo && isset($this->fileInfo['parent'])) {
+				$parentData['fileid'] = $this->fileInfo['parent'];
+			}
+
+			$this->parent = new LazyFolder(function () use ($newPath) {
+				return $this->root->get($newPath);
+			}, $parentData);
 		}
 
 		return $this->parent;

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -304,7 +304,7 @@ class Node implements INode {
 			];
 
 			// and create lazy folder with it instead of always querying
-			$this->parent = new LazyFolder(function () use ($newPath) {
+			$this->parent = new LazyFolder($this->root, function () use ($newPath) {
 				return $this->root->get($newPath);
 			}, $parentData);
 		}

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -299,4 +299,13 @@ interface FileInfo {
 	 * @since 18.0.0
 	 */
 	public function getUploadTime(): int;
+
+	/**
+	 * Get the fileid or the parent folder
+	 * or -1 if this item has no parent folder (because it is the root)
+	 *
+	 * @return int
+	 * @since 28.0.0
+	 */
+	public function getParentId(): int;
 }


### PR DESCRIPTION
Since we know the parent exists and we have some basic metadata already, a lazy folder can be enough is some cases.

Main motivation is allow getting the parent it without extra db queries using `$node->getParent()->getId()`.