### PR TITLE
(htaccess) Permit admin-deployed phpinfo.php access

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -532,7 +532,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff2?|ico|jpg|jpeg|map|webm|mp4|mp3|ogg|wav|wasm|tflite)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/ajax/update\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/img/(favicon\\.ico|manifest\\.json)$";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(cron|public|remote|status)\\.php";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(cron|public|remote|status|phpinfo)\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v(1|2)\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/robots\\.txt";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(ocm-provider|ocs-provider|updater)/";


### PR DESCRIPTION
## Summary

Even though some PHP info is exposed in NC under Admin->System, accessing `phpinfo()` via the web server is still routinely needed by admins to troubleshoot an installation. 

One common case would be if the NC installation is completely broken - in which case Admin->System would also be inaccessible.

Executing PHP from the command-line is not a useful substitute - even though it's often mistakenly used instead while troubleshooting - since it may or may not have the same settings or even be the same version of PHP active in the web server.

Unfortunately our current .htaccess mod_rewrite rules prevent admins from accessing their own self-created `phpinfo.php`. This fixes that.

While the admin will still needs to provide their own `phpinfo.php` file, this enables it to be accessible as expected (and as I believe was possible several NC versions ago IIRC anyhow). 

If the `phpinfo.php` file does not exist (the default state), things still fall through to the NC 404 handler so there's no change in behavior under normal operation.

(Thanks to the poster PSN for the idea: https://help.nextcloud.com/t/how-to-get-phpinfo-to-display-info/133180/8)

## TODO

- [ ] A separate PR for adding similar functionality to the NGINX example configurations in the Documentation repo

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
