### PR TITLE
chore: Fine-tune editorconfig for build/psalm-baseline.xml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,7 @@ trim_trailing_whitespace = false
 
 [*.svg]
 insert_final_newline = false
+
+[build/psalm-baseline.xml]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
## Summary

We use tabs and four spaces of indent. Psalm uses spaces and two spaces of indent.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
