### PR TITLE
doc(config): Rearrange sample config into appropriate sections

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -55,6 +55,12 @@ $CONFIG = [
 'passwordsalt' => '',
 
 /**
+ * Secret used by Nextcloud for various purposes, e.g. to encrypt data. If you
+ * lose this string there will be data corruption.
+ */
+'secret' => '',
+
+/**
  * Your list of trusted domains that users can log into. Specifying trusted
  * domains prevents host header poisoning. Do not remove this, as it performs
  * necessary security checks.
@@ -223,17 +229,6 @@ $CONFIG = [
 'force_locale' => 'en_US',
 
 /**
- * Set the default app to open on login. Use the app names as they appear in the
- * URL after clicking them in the Apps menu, such as documents, calendar, and
- * gallery. You can use a comma-separated list of app names, so if the first
- * app is not enabled for a user then Nextcloud will try the second one, and so
- * on. If no enabled apps are found it defaults to the dashboard app.
- *
- * Defaults to ``dashboard,files``
- */
-'defaultapp' => 'dashboard,files',
-
-/**
  * ``true`` enables the Help menu item in the user menu (top right of the
  * Nextcloud Web interface). ``false`` removes the Help item.
  */
@@ -244,6 +239,37 @@ $CONFIG = [
  * pages), and ``false`` prevents them from changing their display names.
  */
 'allow_user_to_change_display_name' => true,
+
+/**
+ * The directory where the skeleton files are located. These files will be
+ * copied to the data directory of new users. Leave empty to not copy any
+ * skeleton files.
+ * ``{lang}`` can be used as a placeholder for the language of the user.
+ * If the directory does not exist, it falls back to non dialect (from ``de_DE``
+ * to ``de``). If that does not exist either, it falls back to ``default``
+ *
+ * Defaults to ``core/skeleton`` in the Nextcloud directory.
+ */
+'skeletondirectory' => '/path/to/nextcloud/core/skeleton',
+
+
+/**
+ * The directory where the template files are located. These files will be
+ * copied to the template directory of new users. Leave empty to not copy any
+ * template files.
+ * ``{lang}`` can be used as a placeholder for the language of the user.
+ * If the directory does not exist, it falls back to non dialect (from ``de_DE``
+ * to ``de``). If that does not exist either, it falls back to ``default``
+ *
+ * If this is not set creating a template directory will only happen if no custom
+ * ``skeletondirectory`` is defined, otherwise the shipped templates will be used
+ * to create a template directory for the user.
+ */
+'templatedirectory' => '/path/to/nextcloud/templates',
+
+/**
+ * User session
+ */
 
 /**
  * Lifetime of the remember login cookie. This should be larger than the
@@ -362,33 +388,6 @@ $CONFIG = [
  * This will show an error. But the direct login still works with adding ?direct=1
  */
 'hide_login_form' => false,
-
-/**
- * The directory where the skeleton files are located. These files will be
- * copied to the data directory of new users. Leave empty to not copy any
- * skeleton files.
- * ``{lang}`` can be used as a placeholder for the language of the user.
- * If the directory does not exist, it falls back to non dialect (from ``de_DE``
- * to ``de``). If that does not exist either, it falls back to ``default``
- *
- * Defaults to ``core/skeleton`` in the Nextcloud directory.
- */
-'skeletondirectory' => '/path/to/nextcloud/core/skeleton',
-
-
-/**
- * The directory where the template files are located. These files will be
- * copied to the template directory of new users. Leave empty to not copy any
- * template files.
- * ``{lang}`` can be used as a placeholder for the language of the user.
- * If the directory does not exist, it falls back to non dialect (from ``de_DE``
- * to ``de``). If that does not exist either, it falls back to ``default``
- *
- * If this is not set creating a template directory will only happen if no custom
- * ``skeletondirectory`` is defined, otherwise the shipped templates will be used
- * to create a template directory for the user.
- */
-'templatedirectory' => '/path/to/nextcloud/templates',
 
 /**
  * If your user backend does not allow password resets (e.g. when it's a
@@ -1068,6 +1067,17 @@ $CONFIG = [
  */
 
 /**
+ * Set the default app to open on login. Use the app names as they appear in the
+ * URL after clicking them in the Apps menu, such as documents, calendar, and
+ * gallery. You can use a comma-separated list of app names, so if the first
+ * app is not enabled for a user then Nextcloud will try the second one, and so
+ * on. If no enabled apps are found it defaults to the dashboard app.
+ *
+ * Defaults to ``dashboard,files``
+ */
+'defaultapp' => 'dashboard,files',
+
+/**
  * When enabled, admins may install apps from the Nextcloud app store.
  *
  * Defaults to ``true``
@@ -1344,6 +1354,14 @@ $CONFIG = [
  */
 'maintenance_window_start' => 1,
 
+/**
+ * Log all LDAP requests into a file
+ *
+ * Warning: This heavily decreases the performance of the server and is only
+ * meant to debug/profile the LDAP interaction manually.
+ * Also, it might log sensitive data into a plain text file.
+ */
+'ldap_log_file' => '',
 
 /**
  * SSL
@@ -2036,12 +2054,6 @@ $CONFIG = [
 'filesystem_cache_readonly' => false,
 
 /**
- * Secret used by Nextcloud for various purposes, e.g. to encrypt data. If you
- * lose this string there will be data corruption.
- */
-'secret' => '',
-
-/**
  * List of trusted proxy servers
  *
  * You may set this to an array containing a combination of
@@ -2255,15 +2267,6 @@ $CONFIG = [
  * Also, it might log sensitive data into a plain text file.
  */
 'redis_log_file' => '',
-
-/**
- * Log all LDAP requests into a file
- *
- * Warning: This heavily decreases the performance of the server and is only
- * meant to debug/profile the LDAP interaction manually.
- * Also, it might log sensitive data into a plain text file.
- */
-'ldap_log_file' => '',
 
 /**
  * Enable diagnostics event logging


### PR DESCRIPTION
## Summary

Organize the https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html page.

* `secret` into *Default parameters*
* `defaultapp` into *Apps*
* `skeletondirectory` and `templatedirectory` into *User experience*
* `ldaplogfile` into *LDAP*

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
