### PR TITLE
Switch to IDateTimeFormatter::formatTimeSpan()

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -629,20 +629,26 @@ class Storage {
 		$diff = time() - $timestamp;
 
 		if ($diff < 60) { // first minute
-			return  $diff . " seconds ago";
-		} elseif ($diff < 3600) { //first hour
-			return round($diff / 60) . " minutes ago";
-		} elseif ($diff < 86400) { // first day
-			return round($diff / 3600) . " hours ago";
-		} elseif ($diff < 604800) { //first week
-			return round($diff / 86400) . " days ago";
-		} elseif ($diff < 2419200) { //first month
-			return round($diff / 604800) . " weeks ago";
-		} elseif ($diff < 29030400) { // first year
-			return round($diff / 2419200) . " months ago";
-		} else {
-			return round($diff / 29030400) . " years ago";
+			return $diff . " seconds ago";
 		}
+
+		$intervals = [
+			['interval' => 60, 'unit' => 'minute'],
+			['interval' => 3600, 'unit' => 'hour'],
+			['interval' => 86400, 'unit' => 'day'],
+			['interval' => 604800, 'unit' => 'week'],
+			['interval' => 2419200, 'unit' => 'month'],
+			['interval' => 29030400, 'unit' => 'year'],
+		];
+
+		foreach ($intervals as $interval) {
+			if ($diff < $interval['interval']) {
+				$value = round($diff / ($interval['interval'] / 60));
+				return $value . ' ' . $interval['unit'] . ($value > 1 ? 's' : '') . ' ago';
+			}
+		}
+
+		return round($diff / 29030400) . " years ago";
 	}
 
 	/**

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -58,6 +58,7 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Command\IBus;
+use OCP\IDateTimeFormatter;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\NotFoundException;
@@ -516,7 +517,7 @@ class Storage {
 						$filename = $pathparts['filename'];
 						$key = $timestamp . '#' . $filename;
 						$versions[$key]['version'] = $timestamp;
-						$versions[$key]['humanReadableTimestamp'] = self::getHumanReadableTimestamp((int)$timestamp);
+						$versions[$key]['humanReadableTimestamp'] = IDateTimeFormatter::formatTimeSpan($timestamp);
 						if (empty($userFullPath)) {
 							$versions[$key]['preview'] = '';
 						} else {
@@ -617,38 +618,6 @@ class Storage {
 			$version->delete();
 			\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
 		}
-	}
-
-	/**
-	 * translate a timestamp into a string like "5 days ago"
-	 *
-	 * @param int $timestamp
-	 * @return string for example "5 days ago"
-	 */
-	private static function getHumanReadableTimestamp(int $timestamp): string {
-		$diff = time() - $timestamp;
-
-		if ($diff < 60) { // first minute
-			return $diff . " seconds ago";
-		}
-
-		$intervals = [
-			['interval' => 60, 'unit' => 'minute'],
-			['interval' => 3600, 'unit' => 'hour'],
-			['interval' => 86400, 'unit' => 'day'],
-			['interval' => 604800, 'unit' => 'week'],
-			['interval' => 2419200, 'unit' => 'month'],
-			['interval' => 29030400, 'unit' => 'year'],
-		];
-
-		foreach ($intervals as $interval) {
-			if ($diff < $interval['interval']) {
-				$value = round($diff / ($interval['interval'] / 60));
-				return $value . ' ' . $interval['unit'] . ($value > 1 ? 's' : '') . ' ago';
-			}
-		}
-
-		return round($diff / 29030400) . " years ago";
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Switch to `/OCP/IDateTimeFormatter::formatTimeSpan`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
