### PR TITLE
Get rid of more int casts in file size manipulations

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -60,6 +60,7 @@ use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -191,8 +192,8 @@ class Cache implements ICache {
 		$data['path'] = (string)$data['path'];
 		$data['fileid'] = (int)$data['fileid'];
 		$data['parent'] = (int)$data['parent'];
-		$data['size'] = 0 + $data['size'];
-		$data['unencrypted_size'] = 0 + ($data['unencrypted_size'] ?? 0);
+		$data['size'] = Util::numericToNumber($data['size']);
+		$data['unencrypted_size'] = Util::numericToNumber($data['unencrypted_size'] ?? 0);
 		$data['mtime'] = (int)$data['mtime'];
 		$data['storage_mtime'] = (int)$data['storage_mtime'];
 		$data['encryptedVersion'] = (int)$data['encrypted'];
@@ -913,7 +914,7 @@ class Cache implements ICache {
 	 * @param string $path
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @param bool $ignoreUnknown don't mark the folder size as unknown if any of it's children are unknown
-	 * @return int
+	 * @return int|float
 	 */
 	protected function calculateFolderSizeInner(string $path, $entry = null, bool $ignoreUnknown = false) {
 		$totalSize = 0;
@@ -937,13 +938,13 @@ class Cache implements ICache {
 
 			if ($rows) {
 				$sizes = array_map(function (array $row) {
-					return (int)$row['size'];
+					return Util::numericToNumber($row['size']);
 				}, $rows);
 				$unencryptedOnlySizes = array_map(function (array $row) {
-					return (int)$row['unencrypted_size'];
+					return Util::numericToNumber($row['unencrypted_size']);
 				}, $rows);
 				$unencryptedSizes = array_map(function (array $row) {
-					return (int)(($row['unencrypted_size'] > 0) ? $row['unencrypted_size'] : $row['size']);
+					return Util::numericToNumber(($row['unencrypted_size'] > 0) ? $row['unencrypted_size'] : $row['size']);
 				}, $rows);
 
 				$sum = array_sum($sizes);

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -901,7 +901,7 @@ class Cache implements ICache {
 	 *
 	 * @param string $path
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
-	 * @return int
+	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null) {
 		return $this->calculateFolderSizeInner($path, $entry);

--- a/lib/private/Files/Cache/HomeCache.php
+++ b/lib/private/Files/Cache/HomeCache.php
@@ -36,7 +36,7 @@ class HomeCache extends Cache {
 	 *
 	 * @param string $path
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
-	 * @return int
+	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null) {
 		if ($path !== '/' and $path !== '' and $path !== 'files' and $path !== 'files_trashbin' and $path !== 'files_versions') {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -386,7 +386,7 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param int $folderId id for the folder to be scanned
 	 * @param bool $lock set to false to disable getting an additional read lock during scanning
 	 * @param array $data the data of the folder before (re)scanning the children
-	 * @return int the size of the scanned folder or -1 if the size is unknown at this stage
+	 * @return int|float the size of the scanned folder or -1 if the size is unknown at this stage
 	 */
 	protected function scanChildren($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $folderId = null, $lock = true, array $data = []) {
 		if ($reuse === -1) {

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -240,7 +240,7 @@ class CacheJail extends CacheWrapper {
 	 *
 	 * @param string $path
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
-	 * @return int
+	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null) {
 		if ($this->getCache() instanceof Cache) {

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -250,7 +250,7 @@ class CacheWrapper extends Cache {
 	 *
 	 * @param string $path
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
-	 * @return int
+	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null) {
 		if ($this->getCache() instanceof Cache) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -51,6 +51,7 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\Util;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV\Client;
 use Sabre\DAV\Xml\Property\ResourceType;
@@ -451,7 +452,7 @@ class DAV extends Common {
 				return FileInfo::SPACE_UNKNOWN;
 			}
 			if (isset($response['{DAV:}quota-available-bytes'])) {
-				return (int)$response['{DAV:}quota-available-bytes'];
+				return Util::numericToNumber($response['{DAV:}quota-available-bytes']);
 			} else {
 				return FileInfo::SPACE_UNKNOWN;
 			}
@@ -605,7 +606,7 @@ class DAV extends Common {
 			}
 			return [
 				'mtime' => isset($response['{DAV:}getlastmodified']) ? strtotime($response['{DAV:}getlastmodified']) : null,
-				'size' => (int)($response['{DAV:}getcontentlength'] ?? 0),
+				'size' => Util::numericToNumber($response['{DAV:}getcontentlength'] ?? 0),
 			];
 		} catch (\Exception $e) {
 			$this->convertException($e, $path);

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -52,6 +52,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Storage\IStorage;
 use OCP\IConfig;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -422,7 +423,7 @@ class Local extends \OC\Files\Storage\Common {
 		if ($space === false || is_null($space)) {
 			return \OCP\Files\FileInfo::SPACE_UNKNOWN;
 		}
-		return (int)$space;
+		return Util::numericToNumber($space);
 	}
 
 	public function search($query) {


### PR DESCRIPTION
* Resolves: #37940

## Summary

On 32bits sizes may be floats. There were a few places where this was still not taken into account.

I did not fix the following:
```
lib/private/Files/ObjectStore/S3.php:           return (int)$stat->get('ContentLength');
lib/private/Files/ObjectStore/ObjectStoreStorage.php:           $stat['size'] = (int)$size;
```
Because it would bubble up to the interface `IObjectStoreMultiPartUpload` in OCP, and I’m not sure if it is possible/easy to support floats there.

Also did not fix:
```
lib/private/Files/Stream/Encryption.php:                        $positionInFile = (int)floor($this->position / $this->unencryptedBlockSize) *
lib/private/Files/Stream/Encryption.php:                $newFilePosition = (int)floor($newPosition / $this->unencryptedBlockSize)
lib/private/Files/Stream/Encryption.php:                $position = (int)floor($this->position / $this->unencryptedBlockSize);
lib/private/Files/Stream/Encryption.php:                        $position = (int)floor($this->position / $this->unencryptedBlockSize);
lib/private/Files/Stream/Encryption.php:                        $completeBlocksInFile = (int)floor($this->unencryptedSize / $this->unencryptedBlockSize);
lib/private/Files/Stream/Encryption.php:                        if ($completeBlocksInFile === (int)floor($this->position / $this->unencryptedBlockSize)) {
lib/private/Files/Stream/Encryption.php:                        $position = (int)floor($this->position / $this->unencryptedBlockSize);
lib/private/Files/Stream/Encryption.php:                        $numberOfChunks = (int)($this->unencryptedSize / $this->unencryptedBlockSize);
```
It’s not clear if those can overflow or not.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
