### PR TITLE
Add css variables for info colors (`--color-info`)

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -26,6 +26,9 @@
   --color-success: #46ba61;
   --color-success-rgb: 70,186,97;
   --color-success-hover: #6ac780;
+  --color-info: #006aa3;
+  --color-info-rgb: 0,106,163;
+  --color-info-hover: #3287b5;
   --color-loading-light: #cccccc;
   --color-loading-dark: #444444;
   --color-box-shadow-rgb: 77,77,77;

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -147,6 +147,9 @@ class DefaultTheme implements ITheme {
 			'--color-success' => '#46ba61',
 			'--color-success-rgb' => join(',', $this->util->hexToRGB('#46ba61')),
 			'--color-success-hover' => $this->util->mix('#46ba61', $colorMainBackground, 60),
+			'--color-info' => '#006aa3',
+			'--color-info-rgb' => join(',', $this->util->hexToRGB('#006aa3')),
+			'--color-info-hover' => $this->util->mix('#006aa3', $colorMainBackground, 60),
 
 			// used for the icon loading animation
 			'--color-loading-light' => '#cccccc',


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/nextcloud-vue/pull/4063#discussion_r1187741514

## Summary
Introduce a new css variable to style the color of information text / boxes in a consistent color across Nextcloud apps.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required (see: https://github.com/nextcloud/documentation/pull/10374 )
