### PR TITLE
fix(JSResourceLocator): Handle missing translations silently

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -99,21 +99,28 @@ class JSResourceLocator extends ResourceLocator {
 			// gets turned into cwd.
 			$app_path = realpath($app_path);
 
-			// missing translations files will be ignored
-			if (strpos($script, 'l10n/') === 0) {
-				$this->appendScriptIfExist($app_path, $script, $app_url);
+			// check combined files
+			if ($this->cacheAndAppendCombineJsonIfExist($app_path, $script.'.json', $app)) {
 				return;
 			}
 
-			if (!$this->cacheAndAppendCombineJsonIfExist($app_path, $script.'.json', $app)) {
-				$this->appendScriptIfExist($app_path, $script, $app_url);
+			// fallback to plain file location
+			if ($this->appendScriptIfExist($app_path, $script, $app_url)) {
+				return;
 			}
 		} catch (AppPathNotFoundException) {
-			$this->logger->error('Could not find resource {resource} to load', [
-				'resource' => $app . '/' . $script . '.js',
-				'app' => 'jsresourceloader',
-			]);
+			// pass (general error handling happens below)
 		}
+
+		// missing translations files will be ignored
+		if (strpos($script, 'l10n/') === 0) {
+			return;
+		}
+
+		$this->logger->error('Could not find resource {resource} to load', [
+			'resource' => $app . '/' . $script . '.js',
+			'app' => 'jsresourceloader',
+		]);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #38119

## Summary
Ensure that even if no app path could be loaded, missing translations are handled silently and no error is logged in that case.
I have also added a test case for the linked issue.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
