### PR TITLE
enh(theming): RGBY contrast

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -20,6 +20,7 @@
   --color-error: #e9322d;
   --color-error-rgb: 233,50,45;
   --color-error-hover: #ed5a56;
+  --color-error-text: #e7201b;
   --color-warning: #eca700;
   --color-warning-rgb: 236,167,0;
   --color-warning-hover: #efb832;

--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -25,9 +25,10 @@
   --color-warning-rgb: 194,137,0;
   --color-warning-hover: #cea032;
   --color-warning-text: #996c00;
-  --color-success: #46ba61;
-  --color-success-rgb: 70,186,97;
-  --color-success-hover: #6ac780;
+  --color-success: #3fa857;
+  --color-success-rgb: 63,168,87;
+  --color-success-hover: #65b978;
+  --color-success-text: #318344;
   --color-info: #006aa3;
   --color-info-rgb: 0,106,163;
   --color-info-hover: #3287b5;

--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -21,9 +21,10 @@
   --color-error-rgb: 233,50,45;
   --color-error-hover: #ed5a56;
   --color-error-text: #e7201b;
-  --color-warning: #eca700;
-  --color-warning-rgb: 236,167,0;
-  --color-warning-hover: #efb832;
+  --color-warning: #c28900;
+  --color-warning-rgb: 194,137,0;
+  --color-warning-hover: #cea032;
+  --color-warning-text: #996c00;
   --color-success: #46ba61;
   --color-success-rgb: 70,186,97;
   --color-success-hover: #6ac780;

--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -32,6 +32,7 @@
   --color-info: #006aa3;
   --color-info-rgb: 0,106,163;
   --color-info-hover: #3287b5;
+  --color-info-text: #006aa3;
   --color-loading-light: #cccccc;
   --color-loading-dark: #444444;
   --color-box-shadow-rgb: 77,77,77;

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -59,6 +59,8 @@ class DarkTheme extends DefaultTheme implements ITheme {
 		$colorBoxShadow = $this->util->darken($colorMainBackground, 70);
 		$colorBoxShadowRGB = join(',', $this->util->hexToRGB($colorBoxShadow));
 
+		$colorError = '#e9322d';
+
 		return array_merge(
 			$defaultVariables,
 			$this->generatePrimaryVariables($colorMainBackground, $colorMainText),
@@ -81,6 +83,11 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-text-maxcontrast-background-blur' => $this->util->lighten($colorTextMaxcontrast, 2),
 				'--color-text-light' => $this->util->darken($colorMainText, 10),
 				'--color-text-lighter' => $this->util->darken($colorMainText, 20),
+
+				'--color-error' => $colorError,
+				'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),
+				'--color-error-hover' => $this->util->mix($colorError, $colorMainBackground, 60),
+				'--color-error-text' => $this->util->lighten($colorError, 3),
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#777',

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -61,6 +61,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 
 		$colorError = '#e9322d';
 		$colorWarning = '#c28900';
+		$colorSuccess = '#3fa857';
 
 		return array_merge(
 			$defaultVariables,
@@ -93,6 +94,10 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-warning-rgb' => join(',', $this->util->hexToRGB($colorWarning)),
 				'--color-warning-hover' => $this->util->mix($colorWarning, $colorMainBackground, 60),
 				'--color-warning-text' => $colorWarning,
+				'--color-success' => $colorSuccess,
+				'--color-success-rgb' => join(',', $this->util->hexToRGB($colorSuccess)),
+				'--color-success-hover' => $this->util->mix($colorSuccess, $colorMainBackground, 60),
+				'--color-success-text' => $colorSuccess,
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#777',

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -62,6 +62,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 		$colorError = '#e9322d';
 		$colorWarning = '#c28900';
 		$colorSuccess = '#3fa857';
+		$colorInfo = '#006aa3';
 
 		return array_merge(
 			$defaultVariables,
@@ -98,6 +99,10 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-success-rgb' => join(',', $this->util->hexToRGB($colorSuccess)),
 				'--color-success-hover' => $this->util->mix($colorSuccess, $colorMainBackground, 60),
 				'--color-success-text' => $colorSuccess,
+				'--color-info' => $colorInfo,
+				'--color-info-rgb' => join(',', $this->util->hexToRGB($colorInfo)),
+				'--color-info-hover' => $this->util->mix($colorInfo, $colorMainBackground, 60),
+				'--color-info-text' => $this->util->lighten($colorInfo, 9),
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#777',

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -60,6 +60,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 		$colorBoxShadowRGB = join(',', $this->util->hexToRGB($colorBoxShadow));
 
 		$colorError = '#e9322d';
+		$colorWarning = '#c28900';
 
 		return array_merge(
 			$defaultVariables,
@@ -88,6 +89,10 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),
 				'--color-error-hover' => $this->util->mix($colorError, $colorMainBackground, 60),
 				'--color-error-text' => $this->util->lighten($colorError, 3),
+				'--color-warning' => $colorWarning,
+				'--color-warning-rgb' => join(',', $this->util->hexToRGB($colorWarning)),
+				'--color-warning-hover' => $this->util->mix($colorWarning, $colorMainBackground, 60),
+				'--color-warning-text' => $colorWarning,
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#777',

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -110,6 +110,7 @@ class DefaultTheme implements ITheme {
 		$colorBoxShadowRGB = join(',', $this->util->hexToRGB($colorBoxShadow));
 
 		$colorError = '#e9322d';
+		$colorWarning = '#c28900';
 
 		$variables = [
 			'--color-main-background' => $colorMainBackground,
@@ -144,9 +145,10 @@ class DefaultTheme implements ITheme {
 			'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),
 			'--color-error-hover' => $this->util->mix($colorError, $colorMainBackground, 60),
 			'--color-error-text' => $this->util->darken($colorError, 4),
-			'--color-warning' => '#eca700',
-			'--color-warning-rgb' => join(',', $this->util->hexToRGB('#eca700')),
-			'--color-warning-hover' => $this->util->mix('#eca700', $colorMainBackground, 60),
+			'--color-warning' => $colorWarning,
+			'--color-warning-rgb' => join(',', $this->util->hexToRGB($colorWarning)),
+			'--color-warning-hover' => $this->util->mix($colorWarning, $colorMainBackground, 60),
+			'--color-warning-text' => $this->util->darken($colorWarning, 8),
 			'--color-success' => '#46ba61',
 			'--color-success-rgb' => join(',', $this->util->hexToRGB('#46ba61')),
 			'--color-success-hover' => $this->util->mix('#46ba61', $colorMainBackground, 60),

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -111,6 +111,7 @@ class DefaultTheme implements ITheme {
 
 		$colorError = '#e9322d';
 		$colorWarning = '#c28900';
+		$colorSuccess = '#3fa857';
 
 		$variables = [
 			'--color-main-background' => $colorMainBackground,
@@ -149,9 +150,10 @@ class DefaultTheme implements ITheme {
 			'--color-warning-rgb' => join(',', $this->util->hexToRGB($colorWarning)),
 			'--color-warning-hover' => $this->util->mix($colorWarning, $colorMainBackground, 60),
 			'--color-warning-text' => $this->util->darken($colorWarning, 8),
-			'--color-success' => '#46ba61',
-			'--color-success-rgb' => join(',', $this->util->hexToRGB('#46ba61')),
-			'--color-success-hover' => $this->util->mix('#46ba61', $colorMainBackground, 60),
+			'--color-success' => $colorSuccess,
+			'--color-success-rgb' => join(',', $this->util->hexToRGB($colorSuccess)),
+			'--color-success-hover' => $this->util->mix($colorSuccess, $colorMainBackground, 60),
+			'--color-success-text' => $this->util->darken($colorSuccess, 10),
 			'--color-info' => '#006aa3',
 			'--color-info-rgb' => join(',', $this->util->hexToRGB('#006aa3')),
 			'--color-info-hover' => $this->util->mix('#006aa3', $colorMainBackground, 60),

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -112,6 +112,7 @@ class DefaultTheme implements ITheme {
 		$colorError = '#e9322d';
 		$colorWarning = '#c28900';
 		$colorSuccess = '#3fa857';
+		$colorInfo = '#006aa3';
 
 		$variables = [
 			'--color-main-background' => $colorMainBackground,
@@ -154,9 +155,10 @@ class DefaultTheme implements ITheme {
 			'--color-success-rgb' => join(',', $this->util->hexToRGB($colorSuccess)),
 			'--color-success-hover' => $this->util->mix($colorSuccess, $colorMainBackground, 60),
 			'--color-success-text' => $this->util->darken($colorSuccess, 10),
-			'--color-info' => '#006aa3',
-			'--color-info-rgb' => join(',', $this->util->hexToRGB('#006aa3')),
-			'--color-info-hover' => $this->util->mix('#006aa3', $colorMainBackground, 60),
+			'--color-info' => $colorInfo,
+			'--color-info-rgb' => join(',', $this->util->hexToRGB($colorInfo)),
+			'--color-info-hover' => $this->util->mix($colorInfo, $colorMainBackground, 60),
+			'--color-info-text' => $colorInfo,
 
 			// used for the icon loading animation
 			'--color-loading-light' => '#cccccc',

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -109,6 +109,8 @@ class DefaultTheme implements ITheme {
 		$colorBoxShadow = $this->util->darken($colorMainBackground, 70);
 		$colorBoxShadowRGB = join(',', $this->util->hexToRGB($colorBoxShadow));
 
+		$colorError = '#e9322d';
+
 		$variables = [
 			'--color-main-background' => $colorMainBackground,
 			'--color-main-background-rgb' => $colorMainBackgroundRGB,
@@ -137,10 +139,11 @@ class DefaultTheme implements ITheme {
 
 			'--color-scrollbar' => 'rgba(' . $colorMainTextRgb . ', .15)',
 
-			// info/warning/success feedback colours
-			'--color-error' => '#e9322d',
-			'--color-error-rgb' => join(',', $this->util->hexToRGB('#e9322d')),
-			'--color-error-hover' => $this->util->mix('#e9322d', $colorMainBackground, 60),
+			// error/warning/success/info feedback colours
+			'--color-error' => $colorError,
+			'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),
+			'--color-error-hover' => $this->util->mix($colorError, $colorMainBackground, 60),
+			'--color-error-text' => $this->util->darken($colorError, 4),
 			'--color-warning' => '#eca700',
 			'--color-warning-rgb' => join(',', $this->util->hexToRGB('#eca700')),
 			'--color-warning-hover' => $this->util->mix('#eca700', $colorMainBackground, 60),


### PR DESCRIPTION
- For https://github.com/nextcloud/server/issues/36949

## Summary

Existing `--color-[error|warning|success|info]` variables are currently used for various borders, icons, and text

They have been adjusted to meet the minimum 3:1 contrast ratio for “Graphical Objects and User Interface Components”, see https://webaim.org/resources/contrastchecker/

New variables `--color-[error|warning|success|info]-text` are added for text which meet the minimum 4.5:1 contrast ratio on light `#ffffff` and dark `#171717` backgrounds

### Contrast
```css
/* contrast ratio on light background #ffffff */
:root {
  --color-error: #e9322d;        /* 4.23 */
  --color-error-text: #e7201b;   /* 4.55 */
  --color-warning: #c28900;      /* 3.06 */
  --color-warning-text: #996c00; /* 4.67 */
  --color-success: #3fa857;      /* 3.02 */
  --color-success-text: #318344; /* 4.71 */
  --color-info: #006aa3;         /* 5.85 */
  --color-info-text: #006aa3;    /* 5.85 */
}

/* contrast ratio on dark background #171717 */
:root {
  --color-error: #e9322d;        /* 4.23 */
  --color-error-text: #ea403b;   /* 4.52 */
  --color-warning: #c28900;      /* 5.87 */
  --color-warning-text: #c28900; /* 5.87 */
  --color-success: #3fa857;      /* 5.93 */
  --color-success-text: #3fa857; /* 5.93 */
  --color-info: #006aa3;         /* 3.07 */
  --color-info-text: #0088d1;    /* 4.65 */
}
```

### Screenshots

| | Screenshot |
--- | ---
Before | ![image](https://github.com/nextcloud/server/assets/24800714/39322c13-72dc-43be-aa90-0fcd60bc8685)
After | ![image](https://github.com/nextcloud/server/assets/24800714/4f3d7e98-aaa9-4ba6-9a25-a237b7870502)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)