### PR TITLE
chore: Update AUTHORS for Nextcloud 27

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,33 +1,40 @@
 Nextcloud is written by:
  - AW-UC <git@a-wesemann.de>
+ - Aaron Ball <nullspoon@oper.io>
  - Aaron Wood <aaronjwood@gmail.com>
  - Abijeet <abijeetpatro@gmail.com>
- - Achim Königs <garfonso@tratschtante.de>
  - Adam Williamson <awilliam@redhat.com>
  - Administrator "Administrator@WINDOWS-2012"
  - Adrian Brzezinski <adrian.brzezinski@eo.pl>
+ - Akhil <akhil.potukuchi@gmail.com>
+ - Akhil <akhil@e.email>
+ - Akhil Potukuchi <akhil.potukuchi@gmail.com>
+ - Alan Meeson <alan@carefullycalculated.co.uk>
  - Aldo "xoen" Giambelluca <xoen@xoen.org>
  - Alecks Gates <alecks.g@gmail.com>
  - Alejandro Varela <epma01@gmail.com>
+ - Alex Harpin <development@landsofshadow.co.uk>
  - Alex Weirig <alex.weirig@technolink.lu>
- - Alexander A. Klimov <grandmaster@al2klimov.de>
  - Alexander Bergolth <leo@strike.wu.ac.at>
- - Alexey Pyltsyn <lex61rus@gmail.com>
+ - Alexander F <32201363+alx-tuilmenau@users.noreply.github.com>
  - Allan Nordhøy <epost@anotheragency.no>
+ - Anderson Luiz Alves <alacn1@gmail.com>
  - Andreas Fischer <bantu@owncloud.com>
  - Andreas Pflug <dev@admin4.org>
  - Andrew Brown <andrew@casabrown.com>
- - André Gaul <gaul@web-yard.de>
+ - Andy Xheli <axheli@axtsolutions.com>
  - Anna Larch <anna@nextcloud.com>
+ - ArcticFall <23174635+ArcticFall@users.noreply.github.com>
  - Ardinis <Ardinis@users.noreply.github.com>
  - Ari Selseng <ari@selseng.net>
  - Arne Hamann <kontakt+github@arne.email>
  - Artem Kochnev <MrJeos@gmail.com>
  - Artem Sidorenko <artem@posteo.de>
  - Arthur Schiwon <blizzz@arthur-schiwon.de>
+ - Artur Neumann <artur@jankaritech.com>
  - Artur Neumann <info@individual-it.net>
  - Ashod Nakashian <ashod.nakashian@collabora.co.uk>
- - Avior <florian.bouillon@delta-wings.net>
+ - Asier Iturralde Sarasola <asier.iturralde@gmail.com>
  - Axel Helmert <axel.helmert@luka.de>
  - Azul <azul@riseup.net>
  - Bart Visscher <bartv@thisnet.nl>
@@ -36,13 +43,19 @@ Nextcloud is written by:
  - Bastien Ho <bastienho@urbancube.fr>
  - Benjamin Diele <benjamin@diele.be>
  - Benjamin Liles <benliles@arch.tamu.edu>
+ - Bennet Becker <bbecker@pks.mpg.de>
+ - Bennet Becker <dev@bennet.cc>
+ - Bernard Spil <Sp1l@users.noreply.github.com>
+ - Bernd Rederlechner <Bernd.Rederlechner@t-systems.com>
  - Bernd Stellwag <burned@zerties.org>
  - Bernhard Ostertag <bernieo.code@gmx.de>
  - Bernhard Posselt <dev@bernhard-posselt.com>
  - Bernhard Reiter <ockham@raz.or.at>
+ - Bill McGonigle <bill-github.com@bfccomputing.com>
  - Birk Borkason <daniel.niccoli@gmail.com>
  - Bjoern Schiessle <bjoern@schiessle.org>
  - Björn Schießle <bjoern@schiessle.org>
+ - Bjørn Forsman <bjorn.forsman@gmail.com>
  - Blaok <i@blaok.me>
  - Boris Rybalkin <ribalkin@gmail.com>
  - Borjan Tchakaloff <borjan@tchakaloff.fr>
@@ -50,7 +63,9 @@ Nextcloud is written by:
  - Brandon Kirsch <brandonkirsch@github.com>
  - Branko Kokanovic <branko@kokanovic.org>
  - Brice Maron <brice@bmaron.net>
- - Byron Marohn <combustible@live.com>
+ - CRA Yoshihito Nakatani <yoshihito.nakatani@craftsman-software.com>
+ - Carl Csaposs <carl@csaposs.com>
+ - Carl Schwan <carl@carlschwan.eu>
  - Carla Schroder <carla@owncloud.com>
  - Carlos Cerrillo <ccerrillo@gmail.com>
  - Carlos Ferreira <carlos@reendex.com>
@@ -60,37 +75,47 @@ Nextcloud is written by:
  - Christian Berendt <berendt@b1-systems.de>
  - Christian Jürges <christian@eqipe.ch>
  - Christian Kampka <christian@kampka.net>
- - Christian Oliff <christianoliff@yahoo.com>
  - Christian Weiske <cweiske@cweiske.de>
  - Christoph Schaefer "christophł@wolkesicher.de"
  - Christoph Seitz <christoph.seitz@posteo.de>
  - Christoph Wickert <cwickert@suse.de>
  - Christoph Wurst <christoph@winzerhof-wurst.at>
  - Christopher Bartz <bartz@dkrz.de>
+ - Christopher Ng <chrng8@gmail.com>
  - Christopher Schäpers <kondou@ts.unde.re>
  - Christopher T. Johnson <ctjctj@gmail.com>
- - Claas Augner <github@caugner.de>
  - Clark Tomlinson <fallen013@gmail.com>
+ - Claus-Justus Heine <himself@claus-justus-heine.de>
  - Clement Wong <git@clement.hk>
  - Cornelius Kölbel <cornelius.koelbel@netknights.it>
- - Cthulhux <git@tuxproject.de>
+ - Cyrille Bollu <cyrpub@bollu.be>
+ - Cédric Neukom <github@webguy.ch>
+ - Côme Chilliet <91878298+come-nc@users.noreply.github.com>
+ - Côme Chilliet <come.chilliet@nextcloud.com>
  - Damjan Georgievski <gdamjan@gmail.com>
  - Dan Callahan <dan.callahan@gmail.com>
+ - Daniel <mail@danielkesselberg.de>
  - Daniel Calviño Sánchez <danxuliu@gmail.com>
  - Daniel Hansson <daniel@techandme.se>
  - Daniel Jagszent <daniel@jagszent.de>
  - Daniel Kesselberg <mail@danielkesselberg.de>
  - Daniel Rudolf <github.com@daniel-rudolf.de>
  - Daniel Schneider <daniel@schneidoa.de>
+ - Daniel Teichmann <daniel.teichmann@das-netzwerkteam.de>
  - Dariusz Olszewski <starypatyk@users.noreply.github.com>
+ - David <37280718+yeyulantu@users.noreply.github.com>
  - David Prévot <taffit@debian.org>
  - David Toledo <dtoledo@solidgear.es>
  - Denis Mosolov <denismosolov@gmail.com>
  - Derek <derek.kelly27@gmail.com>
  - Dominik Schmidt <dev@dominik-schmidt.de>
  - Donquixote <marjunebatac@gmail.com>
+ - Dries Mys <dries.mys@my-dreams.be>
+ - EWouters <6179932+EWouters@users.noreply.github.com>
  - Elijah Martin-Merrill <elijah@nyp-itsours.com>
+ - Ember 'n0emis' Keske <git@n0emis.eu>
  - Eric Masseran <rico.masseran@gmail.com>
+ - Erik van Velzen <erik@evanv.nl>
  - Evgeny Golyshev <eugulixes@gmail.com>
  - Fabrizio Steiner <fabrizio.steiner@gmail.com>
  - Felix Epp <work@felixepp.de>
@@ -99,29 +124,38 @@ Nextcloud is written by:
  - Felix Nieuwenhuizen <felix@tdlrali.com>
  - Felix Nüsse <Felix.nuesse@t-online.de>
  - Felix Rupp <github@felixrupp.com>
+ - Ferdinand Thiessen <opensource@fthiessen.de>
+ - Ferdinand Thiessen <rpm@fthiessen.de>
  - Filis Futsarov <filisko@users.noreply.github.com>
  - Florent <florent@coppint.com>
  - Florian Schunk <florian.schunk@rwth-aachen.de>
  - Florin Peter <github@florin-peter.de>
- - Flávio Gomes da Silva Lisboa <flavio.lisboa@serpro.gov.br>
- - Frank Isemann <frank@isemann.name>
  - Frank Karlitschek <frank@karlitschek.de>
  - François Freitag <mail@franek.fr>
  - François Kubler <francois@kubler.org>
+ - François Ménabé <francois.menabe@gmail.com>
  - Frederic Werner <frederic-github@werner-net.work>
  - Frédéric Fortier <frederic.fortier@oronospolytechnique.com>
  - Gary Kim <gary@garykim.dev>
  - Georg Ehrke <oc.list@georgehrke.com>
+ - Git'Fellow <12234510+solracsf@users.noreply.github.com>
+ - Git'Fellow <carlos@reendex.com>
+ - Glandos <bugs-github@antipoul.fr>
  - GrayFix <grayfix@gmail.com>
  - Greta Doci <gretadoci@gmail.com>
  - GretaD <gretadoci@gmail.com>
  - Guillaume COMPAGNON <gcompagnon@outlook.com>
+ - Guillaume Colson <guillaume.colson@univ-lorraine.fr>
  - Guillaume Virlet <github@virlet.org>
  - Hasso Tepper <hasso@zone.ee>
  - Hemanth Kumar Veeranki <hems.india1997@gmail.com>
  - Hendrik Leppelsack <hendrik@leppelsack.de>
+ - Hinrich Mahler <22366557+Bibo-Joshi@users.noreply.github.com>
  - Holger Hees <holger.hees@gmail.com>
+ - HouraisanNEET <HouraisanNEET@users.noreply.github.com>
  - Ilja Neumann <ineumann@owncloud.com>
+ - Ilya Apasov <apasov@users.noreply.github.com>
+ - Immanuel Pasanec <immanuel.pasanec@compaso.de>
  - Individual IT Services <info@individual-it.net>
  - Iscle <albertiscle9@gmail.com>
  - J0WI <J0WI@users.noreply.github.com>
@@ -129,13 +163,15 @@ Nextcloud is written by:
  - Jacob Neplokh <me@jacobneplokh.com>
  - Jakob Sack <mail@jakobsack.de>
  - Jakub Onderka <ahoj@jakubonderka.cz>
- - James Letendre <James.Letendre@gmail.com>
+ - James Guo <i@ze3kr.com>
  - Jan C. Borchardt <hey@jancborchardt.net>
+ - Jan Messer <jan@mtec-studios.ch>
  - Jan-Christoph Borchardt <hey@jancborchardt.net>
+ - Jan-Philipp Litza <jpl@plutex.de>
  - Jan-Philipp Litza <jplitza@users.noreply.github.com>
- - Janis Köhr <janis.koehr@novatec-gmbh.de>
- - Jared Boone <jared.boone@gmail.com>
+ - JanBartels <j.bartels@arcor.de>
  - Jarkko Lehtoranta <devel@jlranta.com>
+ - Jasper Weyne <jasperweyne@gmail.com>
  - Jean-Louis Dupond <jean-louis@dupond.be>
  - Jens-Christian Fischer <jens-christian.fischer@switch.ch>
  - Jesús Macias <jmacias@solidgear.es>
@@ -150,25 +186,31 @@ Nextcloud is written by:
  - Johannes Schlichenmaier <johannes@schlichenmaier.info>
  - Johannes Willnecker <johannes@willnecker.com>
  - John Molakvoæ <skjnldsv@protonmail.com>
+ - Jonas <jonas@freesources.org>
+ - Jonas Heinrich <heinrich@synyx.de>
+ - Jonas Meurer <jonas@freesources.org>
  - Jonas Rittershofer <jotoeri@users.noreply.github.com>
- - Jonas Sulzer <jonas@violoncello.ch>
  - Jonny007-MKD <1-23-4-5@web.de>
  - Jos Poortvliet <jos@opensuse.org>
  - Jose Quinteiro <github@quinteiro.org>
+ - Josh Richards <josh.t.richards@gmail.com>
  - Juan Pablo Villafañez <jvillafanez@solidgear.es>
  - Juan Pablo Villafáñez <jvillafanez@solidgear.es>
  - Julien Lutran <julien.lutran@corp.ovh.com>
  - Julien Veyssier <eneiluj@posteo.net>
+ - Julien Veyssier <julien-nc@posteo.net>
  - Julius Haertl <jus@bitgrid.net>
  - Julius Härtl <jus@bitgrid.net>
+ - Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>
  - Jörn Friedrich Dreyer <jfd@butonic.de>
  - KB7777 <k.burkowski@gmail.com>
  - Kamil Domanski <kdomanski@kdemail.net>
+ - Karel Hink <info@karelhink.cz>
  - Kawohl <john@owncloud.com>
  - Kenneth Newwood <kenneth@newwood.name>
- - Kevin Lanni <therealklanni@gmail.com>
  - Kevin Ndung'u <kevgathuku@gmail.com>
- - Kim Brose <kim.brose@rwth-aachen.de>
+ - Kevin Niehage <k.niehage@syseleven.de>
+ - Kirill Popov <kirill.s.popov@gmail.com>
  - Klaas Freitag <freitag@owncloud.com>
  - Knut Ahlers <knut@ahlers.me>
  - Ko- <k.stoffelen@cs.ru.nl>
@@ -179,7 +221,7 @@ Nextcloud is written by:
  - Lars Knickrehm <mail@lars-sh.de>
  - Laurens Post <Crote@users.noreply.github.com>
  - Laurens Post <lkpost@scept.re>
- - Lauris Binde <laurisb@users.noreply.github.com>
+ - Lee Garrett <lgarrett@rocketjump.eu>
  - Lennart Rosam <hello@takuto.de>
  - Lennart Rosam <lennart.rosam@medien-systempartner.de>
  - Leon Klingele <git@leonklingele.de>
@@ -189,13 +231,22 @@ Nextcloud is written by:
  - Lionel Elie Mamane <lionel@mamane.lu>
  - Loki3000 <github@labcms.ru>
  - Lorenzo M. Catucci <lorenzo@sancho.ccd.uniroma2.it>
+ - Lorenzo Tanganelli <35271287+tanganellilore@users.noreply.github.com>
+ - Louis <6653109+artonge@users.noreply.github.com>
+ - Louis Chemineau <louis@chmn.me>
  - Loïc Hermann <loic.hermann@sciam.fr>
+ - Luka Trovic <luka@nextcloud.com>
  - Lukas Reschke <lukas@statuscode.ch>
  - Lukas Stabe <lukas@stabe.de>
  - Luke Policinski <lpolicinski@gmail.com>
  - Magnus Walbeck <mw@mwalbeck.org>
+ - Maksim Sukharev <antreesy.web@gmail.com>
+ - Marc Hefter <marchefter@gmail.com>
+ - Marc Hefter <marchefter@march42.net>
  - Marcel Klehr <mklehr@gmx.net>
+ - Marcel Müller <marcel-mueller@gmx.de>
  - Marcel Waldvogel <marcel.waldvogel@uni-konstanz.de>
+ - Marco Ambrosini <marcoambrosini@pm.me>
  - Marco Ziech <marco@ziech.net>
  - Marin Treselj <marin@pixelipo.com>
  - Mario Danic <mario@lovelyhq.com>
@@ -204,19 +255,25 @@ Nextcloud is written by:
  - Marius David Wieschollek <git.public@mdns.eu>
  - Markus Goetz <markus@woboq.com>
  - Markus Staab <markus.staab@redaxo.de>
+ - Markus Zeller <git@markuszeller.com>
  - MartB <mart.b@outlook.de>
- - Martin <github@diemattels.at>
+ - Martin Brugnara <martin@0x6d62.eu>
  - Martin Konrad <info@martin-konrad.net>
  - Martin Konrad <konrad@frib.msu.edu>
  - Martin Mattel <martin.mattel@diemattels.at>
- - Marvin Thomas Rabe <mrabe@marvinrabe.de>
  - Masaki Kawabata Neto <masaki.kawabata@gmail.com>
  - MasterOfDeath <rinat.gumirov@mail.ru>
  - Matthew Setter <matthew@matthewsetter.com>
+ - Matthieu Gallien <matthieu.gallien@nextcloud.com>
+ - Mattia Narducci <mattianarducci1@gmail.com>
+ - Max <max@nextcloud.com>
  - Max Kovalenko <mxss1998@yandex.ru>
+ - Max Kunzelmann <maxdev@posteo.de>
  - Maxence Lange <maxence@artificial-owl.com>
  - Maxence Lange <maxence@nextcloud.com>
  - Maxence Lange <maxence@pontapreta.net>
+ - Maxime Besson <maxime.besson@worteks.com>
+ - Maximilian Martin <maximilian_martin@gmx.de>
  - Maxopoly <max@dermax.org>
  - MichaIng <28480705+MichaIng@users.noreply.github.com>
  - MichaIng <micha@dietpi.com>
@@ -224,40 +281,51 @@ Nextcloud is written by:
  - Michael Göhler <somebody.here@gmx.de>
  - Michael Jobst <mjobst+github@tecratech.de>
  - Michael Jobst <mjobst@necls.com>
+ - Michael Kuhn <github@ikkoku.de>
  - Michael Kuhn <michael@ikkoku.de>
  - Michael Letzgus <www@chronos.michael-letzgus.de>
  - Michael Roitzsch <reactorcontrol@icloud.com>
  - Michael Weimann <mail@michael-weimann.eu>
  - Michael Zamot <michael@zamot.io>
  - Michał Węgrzynek <michal.wegrzynek@malloc.com.pl>
+ - Michiel de Jong <michiel@unhosted.org>
+ - Micke Nordin <kano@sunet.se>
+ - Mickey Knox <mickey@netfreaks.org>
  - Miguel Prokop <miguel.prokop@vtu.com>
  - Mikael Hammarin <mikael@try2.se>
+ - Mikael Nordin <mickenordin@users.noreply.github.com>
+ - Mikael Saarinen <mikaels@iki.fi>
+ - Mikhail Sazanov <m@sazanof.ru>
  - Mitar <mitar.git@tnode.com>
  - Mohammed Abdellatif <m.latief@gmail.com>
  - Morris Jobke <hey@morrisjobke.de>
+ - Mátyás Jani <jzombi@gmail.com>
+ - Naoto Kobayashi <naoto.kobayashi4c@gmail.com>
  - Nazar Mokrynskyi <nazar@mokrynskyi.com>
- - Nick Sweeting <git@sweeting.me>
  - Nicolai Ehemann <en@enlightened.de>
  - Nicolas Grekas <nicolas.grekas@gmail.com>
  - Nicolas SIMIDE <2083596+dems54@users.noreply.github.com>
  - Nils <git@to.nilsschnabel.de>
  - Nils Wittenbrink <nilswittenbrink@web.de>
  - Nina Pypchenko <22447785+nina-py@users.noreply.github.com>
- - Nmz <nemesiz@nmz.lt>
+ - NoSleep82 <52562874+NoSleep82@users.noreply.github.com>
  - Noveen Sachdeva <noveen.sachdeva@research.iiit.ac.in>
  - Ole Ostergaard <ole.c.ostergaard@gmail.com>
  - Ole Ostergaard <ole.ostergaard@knime.com>
  - Oliver Kohl D.Sc. <oliver@kohl.bz>
  - Oliver Wegner <void1976@gmail.com>
  - Olivier Paroz <github@oparoz.com>
+ - Orzu Ionut <orzu.ionut@gmail.com>
  - Owen Winkler <a_github@midnightcircus.com>
  - Pascal de Bruijn <pmjdebruijn@pcode.nl>
  - Patrick Paysant <patrick.paysant@linagora.com>
  - Patrik Kernstock <info@pkern.at>
  - Pauli Järvinen <pauli.jarvinen@gmail.com>
  - Pavel Krasikov <klonishe@gmail.com>
+ - Pawel Boguslawski <pawel.boguslawski@ib.pl>
  - Pellaeon Lin <nfsmwlin@gmail.com>
  - Peter Kubica <peter@kubica.ch>
+ - Petre T <petre.tudor@dorkfarm.com>
  - Phil Davis <phil.davis@inf.org>
  - Philipp Kapfer <philipp.kapfer@gmx.at>
  - Philipp Schaffrath <github@philipp.schaffrath.email>
@@ -269,6 +337,7 @@ Nextcloud is written by:
  - Piotr M <mrow4a@yahoo.com>
  - Piotr Mrowczynski <mrow4a@yahoo.com>
  - Piotr Mrówczyński <mrow4a@yahoo.com>
+ - Pytal <24800714+Pytal@users.noreply.github.com>
  - Qingping Hou <dave2008713@gmail.com>
  - Raghu Nayyar <hey@raghunayyar.com>
  - Ralph Krimmel <rkrimme1@gwdg.de>
@@ -279,7 +348,10 @@ Nextcloud is written by:
  - RealRancor <fisch.666@gmx.de>
  - Rello <Rello@users.noreply.github.com>
  - Remco Brenninkmeijer <requist1@starmail.nl>
+ - Retidurc Silvernight <retidurc@silvernight.social>
  - Richard Steinmetz <richard@steinmetz.cloud>
+ - Richard de Boer <github@tubul.net>
+ - Rid <rid@cylo.io>
  - Rinat Gumirov <rinat.gumirov@mail.ru>
  - Robert Dailey <rcdailey@gmail.com>
  - Robin Appelman <robin@icewind.nl>
@@ -291,6 +363,7 @@ Nextcloud is written by:
  - Romain Rivière <lecoyote@lecoyote.org>
  - Roman Kreisel <mail@romankreisel.de>
  - Ross Nicoll <jrn@jrn.me.uk>
+ - Rsplwe <i@rsplwe.com>
  - Ruben Homs <ruben@homs.codes>
  - RussellAult <RussellAult@users.noreply.github.com>
  - Rémy Jacquin <remy@remyj.fr>
@@ -303,11 +376,10 @@ Nextcloud is written by:
  - Sander Ruitenbeek <s.ruitenbeek@getgoing.nl>
  - Sander Ruitenbeek <sander@grids.be>
  - Sandro Lutz <sandro.lutz@temparus.ch>
- - Sascha Sambale <mastixmc@gmail.com>
+ - Sanpi <sanpi@homecomputing.fr>
  - Sascha Wiswedel <sascha.wiswedel@nextcloud.com>
  - Scott Dutton <exussum12@users.noreply.github.com>
  - Scott Dutton <scott@exussum.co.uk>
- - Scott Shambarger <devel@shambarger.net>
  - Sean Comeau <sean@ftlnetworks.ca>
  - Sean Molenaar <sean@seanmolenaar.eu>
  - Sebastian Döll <sebastian.doell@libasys.de>
@@ -322,10 +394,16 @@ Nextcloud is written by:
  - Sergey Shliakhov <husband.sergey@gmail.com>
  - Sergio Bertolin <sbertolin@solidgear.es>
  - Sergio Bertolín <sbertolin@solidgear.es>
+ - Sijmen Schoon <me@sijmenschoon.nl>
  - Simon Könnecke <simonkoennecke@gmail.com>
+ - Simon L <szaimen@e.mail.de>
+ - Simon Leiner <simon@leiner.me>
  - Simon Spannagel <simonspa@kth.se>
  - Simounet <contact@simounet.net>
  - Sjors van der Pluijm <sjors@desjors.nl>
+ - Stanimir Bozhilov <stanimir.bozhilov.1998@gmail.com>
+ - Stanimir Bozhilov <stanimir@audriga.com>
+ - Stefan <Stefan.Schilling@EXXETA.com>
  - Stefan Rado <owncloud@sradonia.net>
  - Stefan Schneider <stefan.schneider@squareweave.com.au>
  - Stefan Weiberg <sweiberg@suse.com>
@@ -339,6 +417,7 @@ Nextcloud is written by:
  - Sujith Haridasan <Sujith_Haridasan@mentor.com>
  - Sujith Haridasan <sujith.h@gmail.com>
  - Sven Strickroth <email@cs-ware.de>
+ - Sylvain <git@sylvain.dev>
  - Sylvia van Os <sylvia@hackerchick.me>
  - Tekhnee <info@tekhnee.org>
  - Temtaime <temtaime@gmail.com>
@@ -357,6 +436,7 @@ Nextcloud is written by:
  - Timo Förster <tfoerster@webfoersterei.de>
  - Tobia De Koninck <LEDfan@users.noreply.github.com>
  - Tobia De Koninck <tobia@ledfan.be>
+ - Tobias Assmann <tobias.assmann@ecsec.de>
  - Tobias Kaminsky <tobias@kaminsky.me>
  - Tobias Perschon <tobias@perschon.at>
  - Tom Grant <TomG736@users.noreply.github.com>
@@ -364,30 +444,42 @@ Nextcloud is written by:
  - Tomasz Grobelny <tomasz@grobelny.net>
  - Tomasz Paluszkiewicz <tomasz.paluszkiewicz@gmail.com>
  - Tor Lillqvist <tml@collabora.com>
+ - UmbrellaCodr <umbrella@biohazard.cc>
  - Unknown <anpz.asutp@gmail.com>
+ - Unpublished <unpublished@gmx.net>
  - Valdnet <47037905+Valdnet@users.noreply.github.com>
+ - Vanessa Pertsch <vanessa.pertsch@nextcloud.com>
+ - Varun Patil <radialapps@gmail.com>
+ - Varun Patil <varunpatil@ucla.edu>
  - Victor Dubiniuk <dubiniuk@owncloud.com>
  - Viktor Szépe <viktor@szepe.net>
  - Vincent Chan <plus.vincchan@gmail.com>
  - Vincent Petry <vincent@nextcloud.com>
+ - Vincent Van Houtte <vvh@aplusv.be>
  - Vinicius Cubas Brand <vinicius@eita.org.br>
  - Vitor Mattos <vitor@php.rio>
  - Vlastimil Pecinka <pecinka@email.cz>
  - Volkan Gezer <volkangezer@gmail.com>
  - Volker <skydiablo@gmx.net>
+ - William <william.hak57@gmail.com>
  - William Pain <pain.william@gmail.com>
  - Xheni Myrtaj <myrtajxheni@gmail.com>
  - Xuanwo <xuanwo@yunify.com>
+ - ZitronePlus <tobiasscharf92@gmail.com>
+ - acsfer <12234510+acsfer@users.noreply.github.com>
  - acsfer <carlos@reendex.com>
  - adrien <adrien.waksberg@believedigital.com>
+ - alanmeeson <alan@carefullycalculated.co.uk>
  - aler9 <46489434+aler9@users.noreply.github.com>
  - alexweirig <alex.weirig@technolink.lu>
  - b108@volgograd "b108@volgograd"
+ - bbx-github <53237674+bbx-github@users.noreply.github.com>
  - bladewing <lukas@ifflaender-family.de>
  - bline <scottbeck@gmail.com>
  - blizzz <blizzz@arthur-schiwon.de>
  - brad2014 <brad2014@users.noreply.github.com>
  - brumsel <brumsel@losecatcher.de>
+ - cahogan <caitlin.hogan@swiftsolar.com>
  - call-me-matt <nextcloud@matthiasheinisch.de>
  - castillo92 <37965565+castillo92@users.noreply.github.com>
  - cetra3 <peter@parashift.com.au>
@@ -400,27 +492,32 @@ Nextcloud is written by:
  - duritong <peter.meier+github@immerda.ch>
  - eduardo <eduardo@vnexu.net>
  - eleith <online+github@eleith.com>
- - enoch <lanxenet@hotmail.com>
  - essys <essys@users.noreply.github.com>
  - exner104 <59639860+exner104@users.noreply.github.com>
  - fabian <fabian@web2.0-apps.de>
  - felixboehm <felix@webhippie.de>
+ - fenn-cs <fenn25.fn@gmail.com>
  - fnuesse <felix.nuesse@t-online.de>
  - fnuesse <fnuesse@techfak.uni-bielefeld.de>
- - helix84 <helix84@centrum.sk>
+ - greta <gretadoci@gmail.com>
  - hkjolhede <hkjolhede@gmail.com>
  - hoellen <dev@hoellen.eu>
+ - howardZa <33491519+howardZa@users.noreply.github.com>
  - ideaship <ideaship@users.noreply.github.com>
  - j-ed <juergen@eisfair.org>
  - j3l11234 <297259024@qq.com>
  - jaltek <jaltek@mailbox.org>
  - jknockaert <jasper@knockaert.nl>
+ - jld3103 <jld3103yt@gmail.com>
  - josh4trunks <joshruehlig@gmail.com>
+ - julia.kirschenheuter <julia.kirschenheuter@nextcloud.com>
  - karakayasemi <karakayasemi@itu.edu.tr>
  - kevin147147 <kevintamool@gmail.com>
  - korelstar <korelstar@users.noreply.github.com>
  - leith abdulla <online-nextcloud@eleith.com>
  - lui87kw <lukas.ifflaender@uni-wuerzburg.de>
+ - luz paz <luzpaz@github.com>
+ - luz paz <luzpaz@pm.me>
  - lynn-stephenson <lynn.stephenson@protonmail.com>
  - macjohnny <estebanmarin@gmx.ch>
  - marco44 <cousinmarc@gmail.com>
@@ -431,7 +528,6 @@ Nextcloud is written by:
  - michaelletzgus <michaelletzgus@users.noreply.github.com>
  - michag86 <micha_g@arcor.de>
  - mmccarn <mmccarn-github@mmsionline.us>
- - nacho <nacho@ownyourbits.com>
  - nhirokinet <nhirokinet@nhiroki.net>
  - nik gaffney <nik@fo.am>
  - nishiki <nishiki@yaegashi.fr>
@@ -439,9 +535,12 @@ Nextcloud is written by:
  - noveens <noveen.sachdeva@research.iiit.ac.in>
  - npmbuildbot[bot] "npmbuildbot[bot]@users.noreply.github.com"
  - onehappycat <one.happy.cat@gmx.com>
- - oparoz <owncloud@interfasys.ch>
  - phisch <git@philippschaffrath.de>
+ - pjft <pjft@users.noreply.github.com>
+ - plumbeo <plumbeo@users.noreply.github.com>
+ - rakekniven <2069590+rakekniven@users.noreply.github.com>
  - rakekniven <mark.ziegler@rakekniven.de>
+ - raul <raul@nextcloud.com>
  - robottod <83244577+robottod@users.noreply.github.com>
  - root "root@oc.(none)"
  - root <root@localhost.localdomain>
@@ -451,6 +550,8 @@ Nextcloud is written by:
  - scolebrook <scolebrook@mac.com>
  - shkdee <louis.traynard@m4x.org>
  - simonspa <1677436+simonspa@users.noreply.github.com>
+ - smichel17 <git@smichel.me>
+ - sodimel <corentin@244466666.xyz>
  - ste101 <stephan_bauer@gmx.de>
  - sualko <klaus@jsxc.org>
  - szaimen <szaimen@e.mail.de>
@@ -462,6 +563,7 @@ Nextcloud is written by:
  - v1r0x <vinzenz.rosenkranz@gmail.com>
  - voxsim "Simon Vocella"
  - waleczny <michal@walczak.xyz>
+ - zorn-v <zorn7@yandex.ru>
  - zulan <git@zulan.net>
  - Łukasz Buśko <busko.lukasz@pm.me>
 


### PR DESCRIPTION
## Summary

Minimal version of https://github.com/nextcloud/server/pull/38216.

* No header updates
* No email deduplication if anyone has a new email

