### PR TITLE
fix: Do not attempt to use l10n files as sources for combined js files

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -100,7 +100,7 @@ class JSResourceLocator extends ResourceLocator {
 			$app_path = realpath($app_path);
 
 			// check combined files
-			if ($this->cacheAndAppendCombineJsonIfExist($app_path, $script.'.json', $app)) {
+			if (!str_starts_with($script, 'l10n/') && $this->cacheAndAppendCombineJsonIfExist($app_path, $script.'.json', $app)) {
 				return;
 			}
 


### PR DESCRIPTION
My personal instance turned out an empty page after upgrading to 27.0.0-beta.2 and the log showed the trace below.

It seems that https://github.com/nextcloud/server/pull/38207 caused that translation json files were considered sources for the js combiner and its structure of course doesn't match the expected one as no file path is listed in there.

Iirc we don't use the combiner if debug mode is enabled so this might be the reason why this hasn't shown during development.


```
{
  "reqId": "pJgZ85GSItQ361CMiuVs",
  "level": 3,
  "time": "2023-05-13T07:48:53+00:00",
  "remoteAddr": "92.225.64.107",
  "user": "jus",
  "app": "index",
  "method": "GET",
  "url": "/apps/dashboard/",
  "message": "Object of class stdClass could not be converted to string",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0",
  "version": "27.0.0.3",
  "exception": {
    "Exception": "Error",
    "Message": "Object of class stdClass could not be converted to string",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/Template/JSCombiner.php",
        "line": 96,
        "function": "cache",
        "class": "OC\\Template\\JSCombiner",
        "type": "->",
        "args": [
          "/var/www/nextcloud/apps-extra/richdocuments/l10n",
          "de.json",
          [
            "OC\\Files\\SimpleFS\\SimpleFolder"
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Template/JSResourceLocator.php",
        "line": 145,
        "function": "process",
        "class": "OC\\Template\\JSCombiner",
        "type": "->",
        "args": [
          "/var/www/nextcloud/apps-extra/richdocuments",
          "l10n/de.json",
          "richdocuments"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Template/JSResourceLocator.php",
        "line": 103,
        "function": "cacheAndAppendCombineJsonIfExist",
        "class": "OC\\Template\\JSResourceLocator",
        "type": "->",
        "args": [
          "/var/www/nextcloud/apps-extra/richdocuments",
          "l10n/de.json",
          "richdocuments"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Template/ResourceLocator.php",
        "line": 73,
        "function": "doFind",
        "class": "OC\\Template\\JSResourceLocator",
        "type": "->",
        "args": [
          "l10n/de"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/TemplateLayout.php",
        "line": 377,
        "function": "find",
        "class": "OC\\Template\\ResourceLocator",
        "type": "->",
        "args": [
          [
            "core/js/common",
            "core/js/main",
            "core/js/unsupported-browser-redirect",
            "core/l10n/de",
            "core/js/files_fileinfo",
            "And 58 more entries, set log level to debug to see all entries"
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/TemplateLayout.php",
        "line": 222,
        "function": "findJavascriptFiles",
        "class": "OC\\TemplateLayout",
        "type": "::",
        "args": [
          [
            "core/js/common",
            "core/js/main",
            "core/js/unsupported-browser-redirect",
            "core/l10n/de",
            "core/js/files_fileinfo",
            "And 58 more entries, set log level to debug to see all entries"
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Template.php",
        "line": 182,
        "function": "__construct",
        "class": "OC\\TemplateLayout",
        "type": "->",
        "args": [
          "user",
          "dashboard"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Http/TemplateResponse.php",
        "line": 213,
        "function": "fetchPage",
        "class": "OC_Template",
        "type": "->",
        "args": [
          [
            "#app-dashboard",
            null
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 182,
        "function": "render",
        "class": "OCP\\AppFramework\\Http\\TemplateResponse",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 183,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          [
            "OCA\\Dashboard\\Controller\\DashboardController"
          ],
          "index"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 315,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Dashboard\\Controller\\DashboardController",
          "index",
          [
            "OC\\AppFramework\\DependencyInjection\\DIContainer"
          ],
          [
            "dashboard.dashboard.index"
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1061,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/dashboard/"
        ]
      },
      {
        "file": "/var/www/nextcloud/index.php",
        "line": 36,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/var/www/nextcloud/lib/private/Template/JSCombiner.php",
    "Line": 163,
    "CustomMessage": "--"
  }
}
```
