### PR TITLE
fix(carddav): Mark system address book as read-only

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -45,6 +45,7 @@ use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Reader;
+use function array_filter;
 use function array_unique;
 
 class SystemAddressbook extends AddressBook {
@@ -295,5 +296,14 @@ class SystemAddressbook extends AddressBook {
 			parent::delete();
 		}
 		throw new Forbidden();
+	}
+
+	public function getACL() {
+		return array_filter(parent::getACL(), function($acl) {
+			if (in_array($acl['privilege'], ['{DAV:}write', '{DAV:}all'], true)) {
+				return false;
+			}
+			return true;
+		});
 	}
 }


### PR DESCRIPTION
Mark the SAB read-only for https://github.com/nextcloud/server/issues/19575 / https://github.com/nextcloud/server/issues/37797 and https://github.com/nextcloud/contacts/issues/3383

## Summary

Sets appropriate ACLs for the system address book. Only the dav backend writes to it. This allows clients to hide actions that are forbidden.

## TODO

- [x] Adjust ACLs

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
