### PR TITLE
adjust light color variables to have a bit more contrast

### DIFF
--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -40,8 +40,8 @@ trait CommonThemeTrait {
 	protected function generatePrimaryVariables(string $colorMainBackground, string $colorMainText): array {
 		$isBrightColor = $this->util->isBrightColor($colorMainBackground);
 		$colorPrimaryElement = $this->util->elementColor($this->primaryColor, $isBrightColor);
-		$colorPrimaryLight = $this->util->mix($colorPrimaryElement, $colorMainBackground, -80);
-		$colorPrimaryElementLight = $this->util->mix($colorPrimaryElement, $colorMainBackground, -80);
+		$colorPrimaryLight = $this->util->mix($this->primaryColor, $colorMainBackground, -30);
+		$colorPrimaryElementLight = $this->util->mix($colorPrimaryElement, $colorMainBackground, -30);
 
 		// primary related colours
 		return [
@@ -60,7 +60,7 @@ trait CommonThemeTrait {
 			'--color-primary-hover' => $this->util->mix($this->primaryColor, $colorMainBackground, 60),
 			'--color-primary-light' => $colorPrimaryLight,
 			'--color-primary-light-text' => $this->util->mix($this->primaryColor, $this->util->invertTextColor($colorPrimaryLight) ? '#000000' : '#ffffff', -20),
-			'--color-primary-light-hover' => $this->util->mix($colorPrimaryLight, $colorMainText, 90),
+			'--color-primary-light-hover' => $this->util->mix($colorPrimaryLight, $colorMainText, 70),
 
 			// used for buttons, inputs...
 			'--color-primary-element' => $colorPrimaryElement,
@@ -69,10 +69,10 @@ trait CommonThemeTrait {
 
 			// used for hover/focus states
 			'--color-primary-element-light' => $colorPrimaryElementLight,
-			'--color-primary-element-light-hover' => $this->util->mix($colorPrimaryElementLight, $colorMainText, 90),
+			'--color-primary-element-light-hover' => $this->util->mix($colorPrimaryElementLight, $colorMainText, 70),
 			'--color-primary-element-light-text' => $this->util->mix($colorPrimaryElement, $this->util->invertTextColor($colorPrimaryElementLight) ? '#000000' : '#ffffff', -20),
 			// mostly used for disabled states
-			'--color-primary-element-text-dark' => $this->util->darken($this->util->invertTextColor($colorPrimaryElement) ? '#000000' : '#ffffff', 7),
+			'--color-primary-element-text-dark' => $this->util->darken($this->util->invertTextColor($colorPrimaryElement) ? '#000000' : '#ffffff', 10),
 
 			// to use like this: background-image: var(--gradient-primary-background);
 			'--gradient-primary-background' => 'linear-gradient(40deg, var(--color-primary) 0%, var(--color-primary-hover) 100%)',

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -69,7 +69,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 
 				'--color-scrollbar' => $this->util->lighten($colorMainBackground, 15),
 
-				'--color-background-hover' => $this->util->lighten($colorMainBackground, 4),
+				'--color-background-hover' => $this->util->lighten($colorMainBackground, 14),
 				'--color-background-dark' => $this->util->lighten($colorMainBackground, 7),
 				'--color-background-darker' => $this->util->lighten($colorMainBackground, 14),
 

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -120,7 +120,7 @@ class DefaultTheme implements ITheme {
 			'--gradient-main-background' => 'var(--color-main-background) 0%, var(--color-main-background-translucent) 85%, transparent 100%',
 
 			// used for different active/hover/focus/disabled states
-			'--color-background-hover' => $this->util->darken($colorMainBackground, 4),
+			'--color-background-hover' => $this->util->darken($colorMainBackground, 14),
 			'--color-background-dark' => $this->util->darken($colorMainBackground, 7),
 			'--color-background-darker' => $this->util->darken($colorMainBackground, 14),
 


### PR DESCRIPTION
<details>
<summary>Screenshots</summary>





### sidebar active entry:
before:
![image](https://github.com/nextcloud/server/assets/42591237/33d6e711-faca-4ac4-8743-f07971ce5c24)
after:
![image](https://github.com/nextcloud/server/assets/42591237/cb006c3b-a32f-4f4d-a8e1-e229c4cea00c)

### secondary button:
before:
![image](https://github.com/nextcloud/server/assets/42591237/73964f20-a973-40bc-92ae-d12e78c181be)
after:
![image](https://github.com/nextcloud/server/assets/42591237/69478340-5eea-40ee-8c0b-bd12fe30257d)

### secondary button hover:
before:
![image](https://github.com/nextcloud/server/assets/42591237/2eabdd6a-2647-4c64-82c0-86331d0223b9)
after:
![image](https://github.com/nextcloud/server/assets/42591237/644a7b6b-8eb1-4c18-9543-365090b8b233)


### sidebar hover:
before:
![image](https://github.com/nextcloud/server/assets/42591237/e9a972b0-2fdb-41ea-8956-8438331bc23b)
after:
![image](https://github.com/nextcloud/server/assets/42591237/ba9a1b35-922b-4a3f-bcf6-999d3ec57e83)

dropdown active:
before:
![image](https://github.com/nextcloud/server/assets/42591237/74a3001d-4688-4bd6-bfdc-fb24b65086a2)
after:
![image](https://github.com/nextcloud/server/assets/42591237/4e613b10-e416-452b-9abc-edfa6d30f667)

dropdown hover:
before:
![image](https://github.com/nextcloud/server/assets/42591237/375c76dd-6b40-447e-9938-920b50832daf)
after:
![image](https://github.com/nextcloud/server/assets/42591237/db6899a4-3452-46b1-9b5e-33498af7eea3)

</details>