### PR TITLE
[26] check the username when doing external storage session auth

### DIFF
--- a/apps/files_external/lib/Lib/Auth/Password/SessionCredentials.php
+++ b/apps/files_external/lib/Lib/Auth/Password/SessionCredentials.php
@@ -30,6 +30,7 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore as CredentialsStore;
 use OCP\Files\Storage;
+use OCP\Files\StorageAuthException;
 use OCP\IL10N;
 use OCP\IUser;
 
@@ -55,6 +56,10 @@ class SessionCredentials extends AuthMechanism {
 			$credentials = $this->credentialsStore->getLoginCredentials();
 		} catch (CredentialsUnavailableException $e) {
 			throw new InsufficientDataForMeaningfulAnswerException('No session credentials saved');
+		}
+
+		if ($credentials->getUID() !== $user->getUID()) {
+			throw new StorageAuthException('Session credentials for storage owner not available');
 		}
 
 		$storage->setBackendOption('user', $credentials->getLoginName());


### PR DESCRIPTION
Backport of #38265