### PR TITLE
fix loading custom logo image

### DIFF
--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -190,7 +190,7 @@ class Util {
 		if ($this->config->getAppValue('theming', 'logoMime', '') !== '') {
 			$logoFile = null;
 			try {
-				$folder = $this->appData->getFolder('images');
+				$folder = $this->appData->getFolder('global/images');
 				return $folder->getFile('logo');
 			} catch (NotFoundException $e) {
 			}

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -103,7 +103,7 @@ class IconBuilderTest extends TestCase {
 			->willReturn($color);
 		$this->appData->expects($this->once())
 			->method('getFolder')
-			->with('images')
+			->with('global/images')
 			->willThrowException(new NotFoundException());
 
 		$expectedIcon = new \Imagick(realpath(dirname(__FILE__)). "/data/" . $file);
@@ -132,7 +132,7 @@ class IconBuilderTest extends TestCase {
 			->willReturn($color);
 		$this->appData->expects($this->once())
 			->method('getFolder')
-			->with('images')
+			->with('global/images')
 			->willThrowException(new NotFoundException());
 
 		$expectedIcon = new \Imagick(realpath(dirname(__FILE__)). "/data/" . $file);
@@ -165,7 +165,7 @@ class IconBuilderTest extends TestCase {
 			->willReturn($color);
 		$this->appData->expects($this->once())
 			->method('getFolder')
-			->with('images')
+			->with('global/images')
 			->willThrowException(new NotFoundException());
 
 		$expectedIcon = new \Imagick(realpath(dirname(__FILE__)). "/data/" . $file);

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -153,7 +153,7 @@ class UtilTest extends TestCase {
 	public function testGetAppIcon($app, $expected) {
 		$this->appData->expects($this->any())
 			->method('getFolder')
-			->with('images')
+			->with('global/images')
 			->willThrowException(new NotFoundException());
 		$this->appManager->expects($this->once())
 			->method('getAppPath')
@@ -180,7 +180,7 @@ class UtilTest extends TestCase {
 			->willReturn($file);
 		$this->appData->expects($this->once())
 			->method('getFolder')
-			->with('images')
+			->with('global/images')
 			->willReturn($folder);
 		$icon = $this->util->getAppIcon('noapplikethis');
 		$this->assertEquals($file, $icon);


### PR DESCRIPTION
Seems to be a leftover from https://github.com/nextcloud/server/pull/34599

To test:

- upload a custom logo image in theming
- open `/index.php/apps/theming/icon`

Note that you might need to mess with the [caching](https://github.com/nextcloud/server/blob/04b236e32061ddc0b236728363cdaeb189fc3c6a/apps/theming/lib/Controller/IconController.php#L160-L168) or re-upload the icon to get the change to show.