### PR TITLE
Add config variable for curl timeout

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -290,6 +290,11 @@ $CONFIG = [
 'session_lifetime' => 60 * 60 * 24,
 
 /**
+ * The timeout for requests to remote servers (e.g., needed for federated shares).
+ */
+'remote_curl_timeout' => 30,
+
+/**
  * `true` enabled a relaxed session timeout, where the session timeout would no longer be
  * handled by Nextcloud but by either the PHP garbage collection or the expiration of
  * potential other session backends like redis.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -290,9 +290,9 @@ $CONFIG = [
 'session_lifetime' => 60 * 60 * 24,
 
 /**
- * The timeout for requests to remote servers (e.g., needed for federated shares).
+ * The timeout in seconds for requests to servers made by the DAV component (e.g., needed for federated shares).
  */
-'remote_curl_timeout' => 30,
+'davstorage.request_timeout' => 30,
 
 /**
  * `true` enabled a relaxed session timeout, where the session timeout would no longer be

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -373,7 +373,9 @@ class DAV extends Common {
 						->newClient()
 						->get($this->createBaseUri() . $this->encodePath($path), [
 							'auth' => [$this->user, $this->password],
-							'stream' => true
+							'stream' => true,
+							// set download timeout for users with slow connections or large files
+							'timeout' => \OC::$server->getConfig()->getSystemValueInt('remote_curl_timeout', 30)
 						]);
 				} catch (\GuzzleHttp\Exception\ClientException $e) {
 					if ($e->getResponse() instanceof ResponseInterface
@@ -530,7 +532,9 @@ class DAV extends Common {
 			->newClient()
 			->put($this->createBaseUri() . $this->encodePath($target), [
 				'body' => $source,
-				'auth' => [$this->user, $this->password]
+				'auth' => [$this->user, $this->password],
+				// set upload timeout for users with slow connections or large files
+				'timeout' => \OC::$server->getConfig()->getSystemValueInt('remote_curl_timeout', 30)
 			]);
 
 		$this->removeCachedFile($target);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -93,6 +93,9 @@ class DAV extends Common {
 	protected LoggerInterface $logger;
 	protected IEventLogger $eventLogger;
 
+	/** @var int */
+	private $timeout;
+
 	/**
 	 * @param array $params
 	 * @throws \Exception
@@ -135,6 +138,8 @@ class DAV extends Common {
 		}
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 		$this->eventLogger = \OC::$server->get(IEventLogger::class);
+		// This timeout value will be used for the download and upload of files
+		$this->timeout = \OC::$server->getConfig()->getSystemValueInt('davstorage.request_timeout', 30);
 	}
 
 	protected function init() {
@@ -375,7 +380,7 @@ class DAV extends Common {
 							'auth' => [$this->user, $this->password],
 							'stream' => true,
 							// set download timeout for users with slow connections or large files
-							'timeout' => \OC::$server->getConfig()->getSystemValueInt('remote_curl_timeout', 30)
+							'timeout' => $this->timeout
 						]);
 				} catch (\GuzzleHttp\Exception\ClientException $e) {
 					if ($e->getResponse() instanceof ResponseInterface
@@ -534,7 +539,7 @@ class DAV extends Common {
 				'body' => $source,
 				'auth' => [$this->user, $this->password],
 				// set upload timeout for users with slow connections or large files
-				'timeout' => \OC::$server->getConfig()->getSystemValueInt('remote_curl_timeout', 30)
+				'timeout' => $this->timeout
 			]);
 
 		$this->removeCachedFile($target);

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -51,6 +51,7 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\IConfig;
 use OCP\Util;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV\Client;
@@ -139,7 +140,7 @@ class DAV extends Common {
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 		$this->eventLogger = \OC::$server->get(IEventLogger::class);
 		// This timeout value will be used for the download and upload of files
-		$this->timeout = \OC::$server->getConfig()->getSystemValueInt('davstorage.request_timeout', 30);
+		$this->timeout = \OC::$server->get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', 30);
 	}
 
 	protected function init() {


### PR DESCRIPTION
* Resolves: #26071

## Summary

Add the config variable for `davstorage.request_timeout` in order to define remote timeouts.
Needed for nextcloud federation with large files.


## Details on errors:
Basically, you encounter two types of errors when dealing with large files in federated shares (see below).
In both cases you get a timeout because the put / get command is not finished in 30s (hard coded in the defaults; see lib/private/Http/Client/Client.php). This PR introduces the configuration variable `davstorage.request_timeout` which replaces this default timeout in the get/put command of the DAV module. The DAV module is used by the federated share to transfer data between two cloud instances.

### Download from Federated Share:

```
[webdav] Error: Sabre\DAV\Exception: cURL error 28: Operation timed out after 30000 milliseconds with 315250376 out of 1478242034 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://REMOTE_CLOUD/public.php/webdav/SOME_FILE_Cut_copy.mp4 at <<closure>>

0. /var/www/cloud-html/apps/dav/lib/Connector/Sabre/File.php line 492
   OCA\DAV\Connector\Sabre\File->convertToSabreException()
1. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php line 85
   OCA\DAV\Connector\Sabre\File->get()
2. /var/www/cloud-html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
   Sabre\DAV\CorePlugin->httpGet()
3. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 472
   Sabre\DAV\Server->emit()
4. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 253
   Sabre\DAV\Server->invokeMethod()
5. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 321
   Sabre\DAV\Server->start()
6. /var/www/cloud-html/apps/dav/lib/Server.php line 366
   Sabre\DAV\Server->exec()
7. /var/www/cloud-html/apps/dav/appinfo/v2/remote.php line 35
   OCA\DAV\Server->exec()
8. /var/www/cloud-html/remote.php line 172
   require_once("/var/www/cloud- ... p")

Caused by:

GuzzleHttp\Exception\ConnectException: cURL error 28: Operation timed out after 30000 milliseconds with 315250376 out of 1478242034 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://REMOTE_CLOUD/public.php/webdav/SOME_FILE_Cut_copy.mp4 at <<closure>>

 0. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php line 158
    GuzzleHttp\Handler\CurlFactory::createRejection("*** sensitive parameters replaced ***")
 1. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php line 110
    GuzzleHttp\Handler\CurlFactory::finishError()
 2. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlHandler.php line 47
    GuzzleHttp\Handler\CurlFactory::finish()
 3. /var/www/cloud-html/lib/private/Http/Client/DnsPinMiddleware.php line 150
    GuzzleHttp\Handler\CurlHandler->__invoke()
 4. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php line 35
    OC\Http\Client\DnsPinMiddleware->OC\Http\Client\{closure}("*** sensitive parameters replaced ***")
 5. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Middleware.php line 31
    GuzzleHttp\PrepareBodyMiddleware->__invoke()
 6. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/RedirectMiddleware.php line 71
    GuzzleHttp\Middleware::GuzzleHttp\{closure}("*** sensitive parameters replaced ***")
 7. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Middleware.php line 63
    GuzzleHttp\RedirectMiddleware->__invoke()
 8. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/HandlerStack.php line 75
    GuzzleHttp\Middleware::GuzzleHttp\{closure}("*** sensitive parameters replaced ***")
 9. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 331
    GuzzleHttp\HandlerStack->__invoke()
10. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 168
    GuzzleHttp\Client->transfer()
11. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 187
    GuzzleHttp\Client->requestAsync("*** sensitive parameters replaced ***")
12. /var/www/cloud-html/lib/private/Http/Client/Client.php line 226
    GuzzleHttp\Client->request()
13. /var/www/cloud-html/lib/private/Files/Storage/DAV.php line 358
    OC\Http\Client\Client->get()
14. /var/www/cloud-html/lib/private/Files/Storage/Wrapper/Wrapper.php line 298
    OC\Files\Storage\DAV->fopen()
15. /var/www/cloud-html/lib/private/Files/Storage/Wrapper/Availability.php line 314
    OC\Files\Storage\Wrapper\Wrapper->fopen()
16. /var/www/cloud-html/apps/files_antivirus/lib/AvirWrapper.php line 77
    OC\Files\Storage\Wrapper\Availability->fopen()
17. /var/www/cloud-html/lib/private/Files/View.php line 1180
    OCA\Files_Antivirus\AvirWrapper->fopen()
18. /var/www/cloud-html/lib/private/Files/View.php line 1006
    OC\Files\View->basicOperation()
19. /var/www/cloud-html/apps/dav/lib/Connector/Sabre/File.php line 490
    OC\Files\View->fopen()
20. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php line 85
    OCA\DAV\Connector\Sabre\File->get()
21. /var/www/cloud-html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
    Sabre\DAV\CorePlugin->httpGet()
22. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 472
    Sabre\DAV\Server->emit()
23. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 253
    Sabre\DAV\Server->invokeMethod()
24. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 321
    Sabre\DAV\Server->start()
25. /var/www/cloud-html/apps/dav/lib/Server.php line 366
    Sabre\DAV\Server->exec()
26. /var/www/cloud-html/apps/dav/appinfo/v2/remote.php line 35
    OCA\DAV\Server->exec()
27. /var/www/cloud-html/remote.php line 172
    require_once("/var/www/cloud- ... p")
```

## Upload to Federated Share:

```
[no app in context] Error: GuzzleHttp\Exception\ConnectException: cURL error 28: Operation timed out after 30000 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://REMOTE_CLOUD/public.php/webdav/SOME_FILE_Cut.mp4 at <<closure>>

 0. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php line 158
    GuzzleHttp\Handler\CurlFactory::createRejection("*** sensitive parameters replaced ***")
 1. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlFactory.php line 110
    GuzzleHttp\Handler\CurlFactory::finishError()
 2. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Handler/CurlHandler.php line 47
    GuzzleHttp\Handler\CurlFactory::finish()
 3. /var/www/cloud-html/lib/private/Http/Client/DnsPinMiddleware.php line 150
    GuzzleHttp\Handler\CurlHandler->__invoke()
 4. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php line 64
    OC\Http\Client\DnsPinMiddleware->OC\Http\Client\{closure}("*** sensitive parameters replaced ***")
 5. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Middleware.php line 31
    GuzzleHttp\PrepareBodyMiddleware->__invoke()
 6. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/RedirectMiddleware.php line 71
    GuzzleHttp\Middleware::GuzzleHttp\{closure}("*** sensitive parameters replaced ***")
 7. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Middleware.php line 63
    GuzzleHttp\RedirectMiddleware->__invoke()
 8. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/HandlerStack.php line 75
    GuzzleHttp\Middleware::GuzzleHttp\{closure}("*** sensitive parameters replaced ***")
 9. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 331
    GuzzleHttp\HandlerStack->__invoke()
10. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 168
    GuzzleHttp\Client->transfer()
11. /var/www/cloud-html/3rdparty/guzzlehttp/guzzle/src/Client.php line 187
    GuzzleHttp\Client->requestAsync("*** sensitive parameters replaced ***")
12. /var/www/cloud-html/lib/private/Http/Client/Client.php line 333
    GuzzleHttp\Client->request()
13. /var/www/cloud-html/lib/private/Files/Storage/DAV.php line 514
    OC\Http\Client\Client->put()
14. /var/www/cloud-html/lib/private/Files/Storage/DAV.php line 422
    OC\Files\Storage\DAV->uploadFile()
15. /var/www/cloud-html/lib/private/Files/Storage/DAV.php line 413
    OC\Files\Storage\DAV->writeBack()
16. <<closure>>
    OC\Files\Storage\DAV->OC\Files\Storage\{closure}("*** sensitive parameters replaced ***")
17. /var/www/cloud-html/3rdparty/icewind/streams/src/CallbackWrapper.php line 119
    call_user_func()
18. <<closure>>
    Icewind\Streams\CallbackWrapper->stream_close("*** sensitive parameters replaced ***")
19. /var/www/cloud-html/lib/private/Files/Storage/Common.php line 883
    fclose("*** sensitive parameters replaced ***")
20. /var/www/cloud-html/lib/private/Files/Storage/Wrapper/Wrapper.php line 644
    OC\Files\Storage\Common->writeStream()
21. /var/www/cloud-html/lib/private/Files/Storage/Wrapper/Wrapper.php line 644
    OC\Files\Storage\Wrapper\Wrapper->writeStream()
22. /var/www/cloud-html/apps/files_antivirus/lib/AvirWrapper.php line 96
    OC\Files\Storage\Wrapper\Wrapper->writeStream()
23. /var/www/cloud-html/apps/dav/lib/Connector/Sabre/File.php line 248
    OCA\Files_Antivirus\AvirWrapper->writeStream()
24. /var/www/cloud-html/apps/dav/lib/Connector/Sabre/Directory.php line 149
    OCA\DAV\Connector\Sabre\File->put()
25. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Tree.php line 307
    OCA\DAV\Connector\Sabre\Directory->createFile("*** sensitive parameters replaced ***")
26. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Tree.php line 133
    Sabre\DAV\Tree->copyNode()
27. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Tree.php line 163
    Sabre\DAV\Tree->copy()
28. /var/www/cloud-html/apps/dav/lib/Upload/ChunkingPlugin.php line 94
    Sabre\DAV\Tree->move()
29. /var/www/cloud-html/apps/dav/lib/Upload/ChunkingPlugin.php line 76
    OCA\DAV\Upload\ChunkingPlugin->performMove()
30. /var/www/cloud-html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
    OCA\DAV\Upload\ChunkingPlugin->beforeMove()
31. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php line 603
    Sabre\DAV\Server->emit()
32. /var/www/cloud-html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
    Sabre\DAV\CorePlugin->httpMove()
33. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 472
    Sabre\DAV\Server->emit()
34. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 253
    Sabre\DAV\Server->invokeMethod()
35. /var/www/cloud-html/3rdparty/sabre/dav/lib/DAV/Server.php line 321
    Sabre\DAV\Server->start()
36. /var/www/cloud-html/apps/dav/lib/Server.php line 366
    Sabre\DAV\Server->exec()
37. /var/www/cloud-html/apps/dav/appinfo/v2/remote.php line 35
    OCA\DAV\Server->exec()
38. /var/www/cloud-html/remote.php line 172
    require_once("/var/www/cloud- ... p")
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
