### PR TITLE
feat: Add occ user:user:sync-account-data for updating oc_accounts information from user backends

### DIFF
--- a/core/Command/User/SyncAccountDataCommand.php
+++ b/core/Command/User/SyncAccountDataCommand.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Julius Härrtl <jus@bitgrid.net>
+ *
+ * @author Julius Härrtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\User\Backend\IGetDisplayNameBackend;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncAccountDataCommand extends Base {
+	protected IUserManager $userManager;
+	protected IAccountManager $accountManager;
+
+	public function __construct(
+		IUserManager $userManager,
+		IAccountManager $accountManager
+	) {
+		$this->userManager = $userManager;
+		$this->accountManager = $accountManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('user:sync-account-data')
+			->setDescription('sync user backend data to accounts table for configured users')
+			->addOption(
+				'limit',
+				'l',
+				InputOption::VALUE_OPTIONAL,
+				'Number of users to retrieve',
+				'500'
+			)->addOption(
+				'offset',
+				'o',
+				InputOption::VALUE_OPTIONAL,
+				'Offset for retrieving users',
+				'0'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$users = $this->userManager->searchDisplayName('', (int) $input->getOption('limit'), (int) $input->getOption('offset'));
+
+		foreach ($users as $user) {
+			$this->updateUserAccount($user, $output);
+		}
+		return 0;
+	}
+
+	private function updateUserAccount(IUser $user, OutputInterface $output): void {
+		$changed = false;
+		$account = $this->accountManager->getAccount($user);
+		if ($user->getBackend() instanceof IGetDisplayNameBackend) {
+			try {
+				$displayNameProperty = $account->getProperty(IAccountManager::PROPERTY_DISPLAYNAME);
+			} catch (PropertyDoesNotExistException) {
+				$displayNameProperty = null;
+			}
+			if (!$displayNameProperty || $displayNameProperty->getValue() !== $user->getDisplayName()) {
+				$output->writeln($user->getUID() . ' - updating changed display name');
+				$account->setProperty(
+					IAccountManager::PROPERTY_DISPLAYNAME,
+					$user->getDisplayName(),
+					$displayNameProperty ? $displayNameProperty->getScope() : IAccountManager::SCOPE_PRIVATE,
+					$displayNameProperty ? $displayNameProperty->getVerified() : IAccountManager::NOT_VERIFIED,
+					$displayNameProperty ? $displayNameProperty->getVerificationData() : ''
+				);
+				$changed = true;
+			}
+		}
+
+		if ($changed) {
+			$this->accountManager->updateAccount($account);
+			$output->writeln($user->getUID() . ' - account data updated');
+		} else {
+			$output->writeln($user->getUID() . ' - nothing to update');
+		}
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -192,6 +192,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->getUserManager(), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));
 	$application->add(new OC\Core\Command\User\AddAppPassword(\OC::$server->get(\OCP\IUserManager::class), \OC::$server->get(\OC\Authentication\Token\IProvider::class), \OC::$server->get(\OCP\Security\ISecureRandom::class), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class)));
 
 	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1012,6 +1012,7 @@ return array(
     'OC\\Core\\Command\\User\\Report' => $baseDir . '/core/Command/User/Report.php',
     'OC\\Core\\Command\\User\\ResetPassword' => $baseDir . '/core/Command/User/ResetPassword.php',
     'OC\\Core\\Command\\User\\Setting' => $baseDir . '/core/Command/User/Setting.php',
+    'OC\\Core\\Command\\User\\SyncAccountDataCommand' => $baseDir . '/core/Command/User/SyncAccountDataCommand.php',
     'OC\\Core\\Controller\\AppPasswordController' => $baseDir . '/core/Controller/AppPasswordController.php',
     'OC\\Core\\Controller\\AutoCompleteController' => $baseDir . '/core/Controller/AutoCompleteController.php',
     'OC\\Core\\Controller\\AvatarController' => $baseDir . '/core/Controller/AvatarController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1045,6 +1045,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\Report' => __DIR__ . '/../../..' . '/core/Command/User/Report.php',
         'OC\\Core\\Command\\User\\ResetPassword' => __DIR__ . '/../../..' . '/core/Command/User/ResetPassword.php',
         'OC\\Core\\Command\\User\\Setting' => __DIR__ . '/../../..' . '/core/Command/User/Setting.php',
+        'OC\\Core\\Command\\User\\SyncAccountDataCommand' => __DIR__ . '/../../..' . '/core/Command/User/SyncAccountDataCommand.php',
         'OC\\Core\\Controller\\AppPasswordController' => __DIR__ . '/../../..' . '/core/Controller/AppPasswordController.php',
         'OC\\Core\\Controller\\AutoCompleteController' => __DIR__ . '/../../..' . '/core/Controller/AutoCompleteController.php',
         'OC\\Core\\Controller\\AvatarController' => __DIR__ . '/../../..' . '/core/Controller/AvatarController.php',


### PR DESCRIPTION
## Summary

This can be useful in cases where the state between user backend and oc_accounts has become inconsistent.

Usually the account data is updated once the change on the user backend is detected. Potential leftovers from older bugs
(https://github.com/nextcloud/user_saml/pull/582) might though never get updated. This could lead to the contacts menu never showing the correct display name. The contacts menu is read from the system address book, which is only updated from oc_accounts.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
