### PR TITLE
fix: better error message on missing user files dir

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -487,7 +487,7 @@ class OC_Helper {
 			$rootInfo = \OC\Files\Filesystem::getFileInfo($path, $includeExtStorage ? 'ext' : false);
 		}
 		if (!$rootInfo instanceof \OCP\Files\FileInfo) {
-			throw new \OCP\Files\NotFoundException();
+			throw new \OCP\Files\NotFoundException('The root directory of the user\'s files is missing');
 		}
 		$used = $rootInfo->getSize($includeMountPoints);
 		if ($used < 0) {


### PR DESCRIPTION
When the user directory is missing,t he error thrown is very cryptic. 
Now it's a bit better and we know the error.

I hesitated to to have a real error page, but I figured this is more like an admin info to have.

![image](https://github.com/nextcloud/server/assets/14975046/ee7a1f78-2893-442f-91d5-6124740ce2fb)