### PR TITLE
fix(caldav): Ignore invalid events for reminder generation

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -793,6 +793,10 @@ class ReminderService {
 			if ($child->name !== 'VEVENT') {
 				continue;
 			}
+			// Ignore invalid events with no DTSTART
+			if ($child->DTSTART === null) {
+				continue;
+			}
 
 			$vevents[] = $child;
 		}

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -342,6 +342,53 @@ ICS;
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}
 
+	/**
+	 * RFC5545 says DTSTART is REQUIRED, but we have seen event without the prop
+	 */
+	public function testOnCalendarObjectCreateNoDtstart(): void {
+		$calendarData = <<<EOD
+BEGIN:VCALENDAR
+PRODID:-//Nextcloud calendar v1.6.4
+BEGIN:VEVENT
+CREATED:20160602T133732
+DTSTAMP:20160602T133732
+LAST-MODIFIED:20160602T133732
+UID:wej2z68l9h
+SUMMARY:Test Event
+BEGIN:VALARM
+ACTION:EMAIL
+TRIGGER:-PT15M
+END:VALARM
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;VALUE=DATE-TIME:20160608T000000Z
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOD;
+		$objectData = [
+			'calendardata' => $calendarData,
+			'id' => '42',
+			'calendarid' => '1337',
+			'component' => 'vevent',
+		];
+
+		$this->backend->expects($this->exactly(2))
+			->method('insertReminder')
+			->withConsecutive(
+				[1337, 42, 'wej2z68l9h', false, null, false, '5c70531aab15c92b52518ae10a2f78a4', 'de919af7429d3b5c11e8b9d289b411a6', 'EMAIL', true, 1465429500, false],
+				[1337, 42, 'wej2z68l9h', false, null, false, '5c70531aab15c92b52518ae10a2f78a4', '35b3eae8e792aa2209f0b4e1a302f105', 'DISPLAY', false, 1465344000, false]
+			)
+			->willReturn(1);
+
+		$this->timeFactory->expects($this->once())
+			->method('getDateTime')
+			->with()
+			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
+
+		$this->reminderService->onCalendarObjectCreate($objectData);
+	}
+
 	public function testOnCalendarObjectCreateSingleEntryWithRepeat(): void {
 		$objectData = [
 			'calendardata' => self::CALENDAR_DATA_REPEAT,

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -373,18 +373,13 @@ EOD;
 			'component' => 'vevent',
 		];
 
-		$this->backend->expects($this->exactly(2))
+		$this->backend->expects($this->never())
 			->method('insertReminder')
 			->withConsecutive(
 				[1337, 42, 'wej2z68l9h', false, null, false, '5c70531aab15c92b52518ae10a2f78a4', 'de919af7429d3b5c11e8b9d289b411a6', 'EMAIL', true, 1465429500, false],
 				[1337, 42, 'wej2z68l9h', false, null, false, '5c70531aab15c92b52518ae10a2f78a4', '35b3eae8e792aa2209f0b4e1a302f105', 'DISPLAY', false, 1465344000, false]
 			)
 			->willReturn(1);
-
-		$this->timeFactory->expects($this->once())
-			->method('getDateTime')
-			->with()
-			->willReturn(DateTime::createFromFormat(DateTime::ATOM, '2016-06-08T00:00:00+00:00'));
 
 		$this->reminderService->onCalendarObjectCreate($objectData);
 	}


### PR DESCRIPTION
## Summary

Fixes ``Call to a member function serialize() on null at apps/dav/lib/CalDAV/Reminder/ReminderService.php:261`` with 25.0.4.

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
