### PR TITLE
fix(carddav): Check if SERVER variables are set before accessing them

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -35,14 +35,12 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\IUser;
 use OCP\IUserSession;
 use Sabre\CardDAV\Backend\SyncSupport;
 use Sabre\CardDAV\Backend\BackendInterface;
 use Sabre\CardDAV\Card;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
-use Sabre\DAV\ICollection;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Reader;
 use function array_filter;
@@ -234,12 +232,13 @@ class SystemAddressbook extends AddressBook {
 		}
 
 		/** @psalm-suppress NoInterfaceProperties */
-		if ($this->request->server['PHP_AUTH_USER'] !== 'system') {
+		$server = $this->request->server;
+		if (!isset($server['PHP_AUTH_USER']) || $server['PHP_AUTH_USER'] !== 'system') {
 			return false;
 		}
 
 		/** @psalm-suppress NoInterfaceProperties */
-		$sharedSecret = $this->request->server['PHP_AUTH_PW'];
+		$sharedSecret = $server['PHP_AUTH_PW'] ?? null;
 		if ($sharedSecret === null) {
 			return false;
 		}
@@ -299,7 +298,7 @@ class SystemAddressbook extends AddressBook {
 	}
 
 	public function getACL() {
-		return array_filter(parent::getACL(), function($acl) {
+		return array_filter(parent::getACL(), function ($acl) {
 			if (in_array($acl['privilege'], ['{DAV:}write', '{DAV:}all'], true)) {
 				return false;
 			}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/38411

## Summary

Server variables can not be set, check if they are.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
