### PR TITLE
docs: add dbtableprefix to sample config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -136,7 +136,7 @@ $CONFIG = [
  *
  * Default to ``oc_``
  */
-'dbtableprefix' => '',
+'dbtableprefix' => 'oc_',
 
 /**
  *  Enable persistent connexions to the database.


### PR DESCRIPTION
Unfortunately (and naturally), people copy values from the sample config and end up with databases with no prefix. This causes issues for Doctrine in certain corner cases (related https://github.com/pulsejet/memories/issues/648).

So this is a simple proposal to set the sample config value to the default value.