### PR TITLE
fix: Throw early when a service cannot be found in the app container

### DIFF
--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -154,8 +154,10 @@ class ServerContainer extends SimpleContainer {
 			try {
 				return $appContainer->queryNoFallback($name);
 			} catch (QueryException $e) {
-				// Didn't find the service or the respective app container,
-				// ignore it and fall back to the core container.
+				// Didn't find the service or the respective app container
+				// In this case the service won't be part of the core container,
+				// so we can throw directly
+				throw $e;
 			}
 		} elseif (strpos($name, 'OC\\Settings\\') === 0 && substr_count($name, '\\') >= 3) {
 			$segments = explode('\\', $name);


### PR DESCRIPTION
## Summary

I noticed that when an app has a wrongly named file for the matching class name like a class TestService being in a file CoreService.php and then being used through dependency injection the error message was not very useful. This PR aims to make error messages more useful in case loading a class within an app fails.

The reason for that is that afterwards the server container is queried which might fail due to other missing dependencies anyways. Since we already check and only run this code path for getting services within the OCA\ namespace we can probably just throw directly as I'm not aware of any OCA classes that could land in the server container.

Would merge for 28 only as it has a bit of a risk of breaking things.

fix https://github.com/nextcloud/server/issues/10263

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
