### PR TITLE
Remove some dead code in files app

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -139,9 +139,6 @@
 
 			this._setupEvents();
 
-			this._debouncedPersistShowHiddenFilesState = _.debounce(this._persistShowHiddenFilesState, 1200);
-			this._debouncedPersistCropImagePreviewsState = _.debounce(this._persistCropImagePreviewsState, 1200);
-
 			if (sessionStorage.getItem('WhatsNewServerCheck') < (Date.now() - 3600*1000)) {
 				OCP.WhatsNew.query(); // for Nextcloud server
 				sessionStorage.setItem('WhatsNewServerCheck', Date.now());


### PR DESCRIPTION
No clue what this is doing, but it's never used anywhere (the debounced function doesn't exist to begin with)
Pl close if I'm wrong and this is actually useful.