### PR TITLE
fix(trashbin): Truncate long filenames

### DIFF
--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -146,7 +146,7 @@ class RestoreAllFiles extends Base {
 			$timestamp = $trashFile->getMtime();
 			$humanTime = $this->l10n->l('datetime', $timestamp);
 			$output->write("File <info>$filename</info> originally deleted at <info>$humanTime</info> ");
-			$file = $filename . '.d' . $timestamp;
+			$file = Trashbin::getTrashFilename($filename, $timestamp);
 			$location = Trashbin::getLocation($uid, $filename, (string) $timestamp);
 			if ($location === '.') {
 				$location = '';

--- a/apps/files_trashbin/lib/Sabre/TrashFile.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFile.php
@@ -26,12 +26,14 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Trashbin\Sabre;
 
+use OCA\Files_Trashbin\Trashbin;
+
 class TrashFile extends AbstractTrashFile {
 	public function get() {
-		return $this->data->getStorage()->fopen($this->data->getInternalPath() . '.d' . $this->getLastModified(), 'rb');
+		return $this->data->getStorage()->fopen(Trashbin::getTrashFilename($this->data->getInternalPath(), $this->getLastModified()), 'rb');
 	}
 
 	public function getName(): string {
-		return $this->data->getName() . '.d' . $this->getLastModified();
+		return Trashbin::getTrashFilename($this->data->getName(), $this->getLastModified());
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolder.php
@@ -26,8 +26,10 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Trashbin\Sabre;
 
+use OCA\Files_Trashbin\Trashbin;
+
 class TrashFolder extends AbstractTrashFolder {
 	public function getName(): string {
-		return $this->data->getName() . '.d' . $this->getLastModified();
+		return Trashbin::getTrashFilename($this->data->getName(), $this->getLastModified());
 	}
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -58,11 +58,12 @@ class LegacyTrashBackend implements ITrashBackend {
 			if (!$originalLocation) {
 				$originalLocation = $file->getName();
 			}
+			$trashFilename = Trashbin::getTrashFilename($file->getName(), $file->getMtime());
 			return new TrashItem(
 				$this,
 				$originalLocation,
 				$file->getMTime(),
-				$parentTrashPath . '/' . $file->getName() . ($isRoot ? '.d' . $file->getMtime() : ''),
+				$parentTrashPath . '/' . ($isRoot ? $trashFilename : $file->getName()),
 				$file,
 				$user
 			);

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -88,6 +88,11 @@ class StorageTest extends \Test\TestCase {
 	 */
 	private $userView;
 
+	// 239 chars so appended timestamp of 12 chars will exceed max length of 250 chars
+	private const LONG_FILENAME = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt';
+	// 250 chars
+	private const MAX_FILENAME = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt';
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -109,6 +114,8 @@ class StorageTest extends \Test\TestCase {
 		$this->rootView = new \OC\Files\View('/');
 		$this->userView = new \OC\Files\View('/' . $this->user . '/files/');
 		$this->userView->file_put_contents('test.txt', 'foo');
+		$this->userView->file_put_contents(static::LONG_FILENAME, 'foo');
+		$this->userView->file_put_contents(static::MAX_FILENAME, 'foo');
 
 		$this->userView->mkdir('folder');
 		$this->userView->file_put_contents('folder/inside.txt', 'bar');
@@ -162,6 +169,44 @@ class StorageTest extends \Test\TestCase {
 		$this->assertEquals(1, count($results));
 		$name = $results[0]->getName();
 		$this->assertEquals('inside.txt', $name);
+	}
+
+	/**
+	 * Test that deleting a file with a long filename puts it into the trashbin.
+	 */
+	public function testSingleStorageDeleteLongFilename() {
+		$truncatedFilename = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt';
+
+		$this->assertTrue($this->userView->file_exists(static::LONG_FILENAME));
+		$this->userView->unlink(static::LONG_FILENAME);
+		[$storage,] = $this->userView->resolvePath(static::LONG_FILENAME);
+		$storage->getScanner()->scan(''); // make sure we check the storage
+		$this->assertFalse($this->userView->getFileInfo(static::LONG_FILENAME));
+
+		// check if file is in trashbin
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files/');
+		$this->assertEquals(1, count($results));
+		$name = $results[0]->getName();
+		$this->assertEquals($truncatedFilename, substr($name, 0, strrpos($name, '.')));
+	}
+
+	/**
+	 * Test that deleting a file with the max filename length puts it into the trashbin.
+	 */
+	public function testSingleStorageDeleteMaxLengthFilename() {
+		$truncatedFilename = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt';
+
+		$this->assertTrue($this->userView->file_exists(static::MAX_FILENAME));
+		$this->userView->unlink(static::MAX_FILENAME);
+		[$storage,] = $this->userView->resolvePath(static::MAX_FILENAME);
+		$storage->getScanner()->scan(''); // make sure we check the storage
+		$this->assertFalse($this->userView->getFileInfo(static::MAX_FILENAME));
+
+		// check if file is in trashbin
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files/');
+		$this->assertEquals(1, count($results));
+		$name = $results[0]->getName();
+		$this->assertEquals($truncatedFilename, substr($name, 0, strrpos($name, '.')));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Truncate filenames longer than the 250 char limit of the oc_filecache `name` column to fix deletion of files with names that would exceed 250 chars when appended with the 12 char timestamp suffix

Characters are removed from the middle of the string rather than the end due to dependencies on the embedded timestamp string which if truncated would throw trashbin errors

## TODO

- [x] Tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)