### PR TITLE
fix(previews): Don't crash on animated WEBP images

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -691,9 +691,56 @@ class OC_Image implements \OCP\IImage {
 					if (!$this->checkImageSize($imagePath)) {
 						return false;
 					}
-					$this->resource = @imagecreatefromwebp($imagePath);
+
+					// Check for animated header before generating preview since libgd does not handle them well
+					// Adapted from here: https://stackoverflow.com/a/68491679/4085517 (stripped to only to check for animations + added additional error checking)
+					// Header format details here: https://developers.google.com/speed/webp/docs/riff_container
+
+					// Load up the header data, if any
+					$fp = fopen($imagePath, 'rb');
+					if (!$fp) {
+						return false;
+					}
+					$data = fread($fp, 90);
+					if (!$data) {
+						return false;
+					}
+					fclose($fp);
+					unset($fp);
+
+					$headerFormat = 'A4Riff/' . // get n string
+						'I1Filesize/' . // get integer (file size but not actual size)
+						'A4Webp/' . // get n string
+						'A4Vp/' . // get n string
+						'A74Chunk';
+
+					$header = unpack($headerFormat, $data);
+					unset($data, $headerFormat);
+					if (!$header) {
+						return false;
+					}
+
+					// Check if we're really dealing with a valid WEBP header rather than just one suffixed ".webp"
+					if (!isset($header['Riff']) || strtoupper($header['Riff']) !== 'RIFF') {
+						return false;
+					}
+					if (!isset($header['Webp']) || strtoupper($header['Webp']) !== 'WEBP') {
+						return false;
+					}
+					if (!isset($header['Vp']) || strpos(strtoupper($header['Vp']), 'VP8') === false) {
+						return false;
+					}
+
+					// Check for animation indicators
+					if (strpos(strtoupper($header['Chunk']), 'ANIM') !== false || strpos(strtoupper($header['Chunk']), 'ANMF') !== false) {
+						// Animated so don't let it reach libgd
+						$this->logger->debug('OC_Image->loadFromFile, animated WEBP images not supported: ' . $imagePath, ['app' => 'core']);
+					} else {
+						// We're safe so give it to libgd
+						$this->resource = @imagecreatefromwebp($imagePath);
+					}
 				} else {
-					$this->logger->debug('OC_Image->loadFromFile, webp images not supported: ' . $imagePath, ['app' => 'core']);
+					$this->logger->debug('OC_Image->loadFromFile, WEBP images not supported: ' . $imagePath, ['app' => 'core']);
 				}
 				break;
 				/*


### PR DESCRIPTION
* Resolves: #30029 and #37263 <!-- related github issue -->

## Summary

libgd handles animated WEBP images poorly (fatal error and generates a meaningless/misleading error message). As a result we were returning a 500 error for these `/preview` requests (web) and a fatal error at the command-line (`occ`). Now we bypass libgd if we detect an animated WEBP image and simply don't generate the preview. No more 500 error. Should fix `occ` too.

The prospect of incorporating animation handling is an upstream matter:

libgd/libgd#648
https://bugs.php.net/bug.php?id=79809
https://www.php.net/manual/en/function.imagecreatefromwebp.php

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
