### PR TITLE
add imaginary_key

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1228,6 +1228,11 @@ $CONFIG = [
 'preview_imaginary_url' => 'http://previews_hpb:8088/',
 
 /**
+ * If you want set a api key for imaginary.
+ */
+'preview_imaginary_key' => 'secret',
+
+/**
  * Only register providers that have been explicitly enabled
  *
  * The following providers are disabled by default due to performance or privacy

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -136,9 +136,10 @@ class Imaginary extends ProviderV2 {
 		];
 
 		try {
+			$imaginaryKey = $this->config->getSystemValueString('preview_imaginary_key', '');
 			$response = $httpClient->post(
 				$imaginaryUrl . '/pipeline', [
-					'query' => ['operations' => json_encode($operations)],
+					'query' => ['operations' => json_encode($operations), 'key' => $imaginaryKey],
 					'stream' => true,
 					'content-type' => $file->getMimeType(),
 					'body' => $stream,


### PR DESCRIPTION
* Resolves: part of https://github.com/nextcloud/server/issues/37993

## Summary
To hedge, in case the imaginary is used on another serer, so that no iptables are necessary, but only optional.
I have seen that imaginary hardly gets updates, but Nextcloud has taken over the maintenance, so I think it is still safe.

I have converted it to its own PR at the request of @szaimen to make it easier to migrate.
https://github.com/nextcloud/server/pull/38032#issuecomment-1554204370
