### PR TITLE
Implement file action trriger as button

### DIFF
--- a/apps/files/js/templates/file_action_trigger.handlebars
+++ b/apps/files/js/templates/file_action_trigger.handlebars
@@ -1,4 +1,4 @@
-<a class="action action-{{nameLowerCase}}" href="#" data-action="{{name}}">
+<button class="action action-{{nameLowerCase}}" data-action="{{name}}">
 	{{#if icon}}
 		<img class="svg" alt="{{altText}}" src="{{icon}}" />
 	{{else}}
@@ -10,4 +10,4 @@
 		{{/unless}}
 	{{/if}}
 	{{#if displayName}}<span> {{displayName}}</span>{{/if}}
-</a>
+</button>


### PR DESCRIPTION


Resolves : https://github.com/nextcloud/server/issues/37103

## Summary

Actions on file table would now use button element instead of link.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
