### PR TITLE
Implement actions menu items as buttons

### DIFF
--- a/apps/files/js/templates/fileactionsmenu.handlebars
+++ b/apps/files/js/templates/fileactionsmenu.handlebars
@@ -1,7 +1,7 @@
 <ul>
 	{{#each items}}
 		<li class="{{#if inline}}hidden{{/if}} action-{{nameLowerCase}}-container">
-			<a href="#" class="menuitem action action-{{nameLowerCase}} permanent" data-action="{{name}}">
+			<button class="menuitem action action-{{nameLowerCase}} permanent" data-action="{{name}}">
 				{{#if icon}}<img class="icon" src="{{icon}}"/>
 				{{else}}
 					{{#if iconClass}}
@@ -11,7 +11,7 @@
 					{{/if}}
 				{{/if}}
 				<span>{{displayName}}</span>
-			</a>
+			</button>
 		</li>
 	{{/each}}
 </ul>


### PR DESCRIPTION
Resolves : https://github.com/nextcloud/server/issues/37104

## Summary
Actions menu items on file list table are implemented now correctly implemented as buttons not links.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
