### PR TITLE
fix: remove cpu core detection for preview semaphore

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1161,7 +1161,7 @@ $CONFIG = [
  * been generated.
  *
  * This should be greater than 'preview_concurrency_new'.
- * If unspecified, defaults to twice the value of 'preview_concurrency_new'.
+ * Defaults to 8
  */
 'preview_concurrency_all' => 8,
 
@@ -1170,9 +1170,9 @@ $CONFIG = [
  *
  * Depending on the max preview size set by 'preview_max_x' and 'preview_max_y',
  * the generation process can consume considerable CPU and memory resources.
+ *
  * It's recommended to limit this to be no greater than the number of CPU cores.
- * If unspecified, defaults to the number of CPU cores, or 4 if that cannot
- * be determined.
+ * Defaults to 4
  */
 'preview_concurrency_new' => 4,
 

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -186,7 +186,7 @@ class PreviewManager implements IPreview {
 	 * @since 11.0.0 - \InvalidArgumentException was added in 12.0.0
 	 */
 	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null) {
-		$previewConcurrency = $this->getGenerator()->getNumConcurrentPreviews('preview_concurrency_all');
+		$previewConcurrency = $this->config->getSystemValueInt('preview_concurrency_all', 8);
 		$sem = Generator::guardWithSemaphore(Generator::SEMAPHORE_ID_ALL, $previewConcurrency);
 		try {
 			$preview = $this->getGenerator()->getPreview($file, $width, $height, $crop, $mode, $mimeType);


### PR DESCRIPTION
* Resolves: #37921

## Summary

The idea of automatically limiting the number of concurrent preview requests to the number of CPU cores is nice. Unfortunately it's difficult to determinate the number of CPU cores (e.g. open_basedir, freebsd, etc.).

This patch removes the detection and set the default for requests (existing + new) to 8 and generation to 4.

## TODO

- [ ] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
