### PR TITLE
bug-report-template - move `Official All-in-One appliance` to the bottom

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -62,7 +62,6 @@ body:
         Select installation method you've used.
         _Describe the method in the "Additional info" section if you chose "Other"._
       options:
-        - "Official All-in-One appliance"
         - "Community Web installer on a VPS or web space"
         - "Community Manual installation with Archive"
         - "Community Docker image"
@@ -70,6 +69,7 @@ body:
         - "Community SNAP package"
         - "Community VM appliance"
         - "Other Community project"
+        - "Official All-in-One appliance"
   - type: dropdown
     id: nextcloud-version
     attributes:


### PR DESCRIPTION
Motivation: Most people seem to just use the top one which is incorrect in most cases since most reports come up on different systems than AIO.