### PR TITLE
fix: Avoid extra stream copy to memory/temp if we can determine the size

### DIFF
--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -219,6 +219,7 @@ class SeekableHttpStream implements File {
 	public function stream_stat() {
 		if ($this->getCurrent()) {
 			$stat = fstat($this->getCurrent());
+			$stat = $stat ? $stat : [];
 			$stat['size'] = $this->totalSize;
 			return $stat;
 		} else {


### PR DESCRIPTION
On my local setup the stream was seekable and reported the proper size, so I think we can actually avoid the extra effort to copy the stream beginning to memory to determin which upload mechanism to use for cases where a size is reported. The fallback is still in place if the stream reports 0 or null as the size.

Introduced with https://github.com/nextcloud/server/pull/27877/files#diff-030e38a9e621019981acf91654c1d8d3a12ab3150dbd9fcc4c280479b8c853dbR144-R148

Test case needed adjustment since the implementation of a NonSeekableStream falsely reported to be seekable on its metadata.