### PR TITLE
fix(SAB): Save avatar to SAB

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -60,7 +60,7 @@ class Converter {
 		$publish = false;
 
 		foreach ($userProperties as $property) {
-			if (empty($property->getValue())) {
+			if ($property->getName() !== IAccountManager::PROPERTY_AVATAR && empty($property->getValue())) {
 				continue;
 			}
 


### PR DESCRIPTION
* Resolves: #38412 <!-- related github issue -->

## Summary

Changes to the avatar in the profile settings are saved in the SAB now.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
