### PR TITLE
Improve delay in accessing WebDAV folders on external storage

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -262,14 +262,14 @@ class DAV extends Common {
 				$this->statCache->set($path, true);
 			}
 			foreach ($files as $file) {
+				$fileDetail = $response[$file];
 				$file = urldecode($file);
 				// do not store the real entry, we might not have all properties
 				if (!$this->statCache->hasKey($path)) {
 					$this->statCache->set($file, true);
 				}
-				$fileDetail = $response[$file];
 				$file = basename($file);
-				$this->propfindCache->set($file, $fileDetail);
+				$this->propfindCache->set($this->encodePath($file), $fileDetail);
 				$content[] = $file;
 			}
 			return IteratorDirectory::wrap($content);
@@ -293,7 +293,7 @@ class DAV extends Common {
 	 */
 	protected function propfind($path) {
 		$path = $this->cleanPath($path);
-		$propfindCacheResponse = $this->propfindCache->get($path);
+		$propfindCacheResponse = $this->propfindCache->get($this->encodePath($path));
 		if (!is_null($propfindCacheResponse)) {
 			return $propfindCacheResponse;
 		}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary
**Issue**: loading time while open an external directory increases with the number of children (files, folders).
**Root cause**: profind function has been called for each child to fetch metadata/permissions and it seem unneccessary.
**Update**: 
- Caching the profind response of children while calling function opendir. Then, we don't need to call profind function for each child anymore.
- Optimize propfind caching to prevent duplicate call

**Before**: calling of profind function for each child increases loading time; propfind duplicate call for parent dir
![image](https://github.com/nextcloud/server/assets/89908051/e6e53e5d-87b4-4373-950b-9e1c82a23d74)

**After**: calling profind function reduced since profind response has been cached while calling opendir; no duplicate propfind call
![image](https://github.com/nextcloud/server/assets/89908051/4719aa19-f898-4d47-96d6-4790edb32e2d)


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
