### PR TITLE
Fix deletion of User when system link are used in him user folder

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -136,10 +136,10 @@ class Local extends \OC\Files\Storage\Common {
 				if (in_array($file->getBasename(), ['.', '..'])) {
 					$it->next();
 					continue;
-				} elseif ($file->isDir()) {
-					rmdir($file->getPathname());
 				} elseif ($file->isFile() || $file->isLink()) {
 					unlink($file->getPathname());
+				} elseif ($file->isDir()) {
+					rmdir($file->getPathname());
 				}
 				$it->next();
 			}


### PR DESCRIPTION
Signed-off-by: Lorenzo Tanganelli <lorenzo.tanganelli@hotmail.it>


* Resolves: # <!-- related github issue -->

## Summary
In a localstorage with `localstorage.allowsymlinks` enabled, if we add a symlink in a folder under `<user_id>` data and then we try to delete this `<user_id>`, we receive a delete error and user is not deleted completly because these folder are recognized as a dir and not symlink.

This beacase in the `lib/private/Files/Storage/Local.php` at line 140 it's used the function `isDir()` that , as per php documentation, `->isDir()` return TRUE for symlinks of directories. Better use `getType()` method instead, which returns 'link' for symlinks.`

To easy fix it, without rewrite function with getType(), we can simply invert `elseif` in that function, checking dir after the check of `isFile` or `isLink`.

In that way we check if is file or link before and unlink it.


## TODO

N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
