### PR TITLE
[stable25] fix(theming): fix header primary invert if background disabled

### DIFF
--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -87,13 +87,15 @@ trait CommonThemeTrait {
 		$hasCustomLogoHeader = $this->util->isLogoThemed();
 
 		$variables = [];
+		$defaultColorPrimary = $this->themingDefaults->getDefaultColorPrimary();
 
 		// If primary as background has been request or if we have a custom primary colour
 		// let's not define the background image
 		if ($backgroundDeleted) {
-			$variables['--color-background-plain'] = $this->themingDefaults->getColorPrimary();
+			$variables['--color-background-plain'] = $defaultColorPrimary;
 			if ($this->themingDefaults->isUserThemingDisabled() || $user === null) {
 				$variables['--image-background-plain'] = 'true';
+				$variables['--background-image-invert-if-bright'] = $this->util->invertTextColor($defaultColorPrimary) ? 'invert(100%)' : 'no';
 			}
 		}
 
@@ -164,6 +166,7 @@ trait CommonThemeTrait {
 			if ($globalBackgroundDeleted) {
 				return [
 					'--image-background-plain' => 'true',
+					'--background-image-invert-if-bright' => $this->util->invertTextColor($this->primaryColor) ? 'invert(100%)' : 'no',
 				];
 			}
 		}


### PR DESCRIPTION
stable26 is already fixed (and above)

## Conditions
- Have global background disabled
- Have `#FFFFFF` as global primary colour

## Results
| Before | After |
|:---------:|:------:|
|![image](https://github.com/nextcloud/server/assets/14975046/3bc68f4e-c619-46e5-87f5-6fda721c52cc)|![image](https://github.com/nextcloud/server/assets/14975046/b0cdc37f-c44a-49b0-bf8c-f51f2811d894)|
