### PR TITLE
Wrap doctrine exceptions on IQueryBuilder::execute

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -277,7 +277,12 @@ class QueryBuilder implements IQueryBuilder {
 			]);
 		}
 
-		$result = $this->queryBuilder->execute();
+		try {
+			$result = $this->queryBuilder->execute();
+		} catch (\Doctrine\DBAL\Exception $e) {
+			throw \OC\DB\Exceptions\DbalException::wrap($e);
+		}
+
 		if (is_int($result)) {
 			return $result;
 		}


### PR DESCRIPTION
While the method is deprecated it is still used in tons of places especially in server, and the annotation for throwing a `OCP\DB\Exception` was wrong for a long time. This PR aims to wrap the `\Doctrine\DBAL\Exception` that is actually thrown in a `OCP\DB\Exception` as it is already done for executeQuery and executeStatement.

Since this is bringing the implementation up to date with the alerady existing php doc comments I wouldn't consider this breaking but I could imagine all kind of issues showing up, therefore I opened as a backport fix for 27 and below https://github.com/nextcloud/server/pull/38440

Let's see what CI thinks about this