### PR TITLE
[stable27] fix: Catch Deadlock properly as execute throws Doctrine exceptions not our wrapped ones

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -27,7 +27,7 @@
  */
 namespace OC\Files\Cache;
 
-use OC\DB\Exceptions\DbalException;
+use Doctrine\DBAL\Exception\DeadlockException;
 use OC\Files\FileInfo;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IUpdater;
@@ -260,7 +260,7 @@ class Updater implements IUpdater {
 			if ($mtime !== false) {
 				try {
 					$this->cache->update($parentId, ['storage_mtime' => $mtime]);
-				} catch (DbalException $e) {
+				} catch (DeadlockException $e) {
 					// ignore the failure.
 					// with failures concurrent updates, someone else would have already done it.
 					// in the worst case the `storage_mtime` isn't updated, which should at most only trigger an extra rescan


### PR DESCRIPTION
Followup fix to https://github.com/nextcloud/server/pull/37820 since the Cache update method uses IQueryBuilder::execute which does not wrap the Doctrine exception as the phpdoc annotation wrongly defines.

Fix only against stable27 as for master i think we should fix the wrapping instead: https://github.com/nextcloud/server/pull/38439