### PR TITLE
fix(carddav): Don't show system address book cards to guests

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -92,7 +92,7 @@ class SystemAddressbook extends AddressBook {
 			// Should never happen because we don't allow anonymous access
 			return [];
 		}
-		if (!$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
+		if ($user->getBackendClassName() === 'Guests' || !$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
 			$name = SyncService::getCardUri($user);
 			try {
 				return [parent::getChild($name)];
@@ -135,8 +135,8 @@ class SystemAddressbook extends AddressBook {
 		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$shareEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$shareEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
-		if (!$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
-			$user = $this->userSession->getUser();
+		$user = $this->userSession->getUser();
+		if (($user !== null && $user->getBackendClassName() === 'Guests') || !$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
 			// No user or cards with no access
 			if ($user === null || !in_array(SyncService::getCardUri($user), $paths, true)) {
 				return [];
@@ -149,7 +149,6 @@ class SystemAddressbook extends AddressBook {
 			}
 		}
 		if ($shareEnumerationGroup) {
-			$user = $this->userSession->getUser();
 			if ($this->groupManager === null || $user === null) {
 				// Group manager or user is not available, so we can't determine which data is safe
 				return [];
@@ -196,19 +195,18 @@ class SystemAddressbook extends AddressBook {
 	 * @throws Forbidden
 	 */
 	public function getChild($name): Card {
+		$user = $this->userSession->getUser();
 		$shareEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$shareEnumerationGroup = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$shareEnumerationPhone = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_phone', 'no') === 'yes';
-		if (!$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
-			$currentUser = $this->userSession->getUser();
-			$ownName = $currentUser !== null ? SyncService::getCardUri($currentUser) : null;
+		if (($user !== null && $user->getBackendClassName() === 'Guests') || !$shareEnumeration || (!$shareEnumerationGroup && $shareEnumerationPhone)) {
+			$ownName = $user !== null ? SyncService::getCardUri($user) : null;
 			if ($ownName === $name) {
 				return parent::getChild($name);
 			}
 			throw new Forbidden();
 		}
 		if ($shareEnumerationGroup) {
-			$user = $this->userSession->getUser();
 			if ($user === null || $this->groupManager === null) {
 				// Group manager is not available, so we can't determine which data is safe
 				throw new Forbidden();


### PR DESCRIPTION
## Summary

Guests should not see other users in the system address book

## TODO

- [x] Requires https://github.com/nextcloud/server/pull/38423
- [x] Fix contact search (via contacts menu)
- [x] Tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
