### PR TITLE
Use default page size for jumping to desired offset

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1994,8 +1994,14 @@ class Access extends LDAPUtility {
 				// to start from 0 to come to the desired page. cookie value
 				// of '0' is valid, because 389ds
 				$defaultPageSize = (int)$this->connection->ldapPagingSize;
-				$reOffset = ($offset - $defaultPageSize) < 0 ? 0 : $offset - $defaultPageSize;
-				$this->search($filter, $base, $attr, $defaultPageSize, $reOffset, true);
+				if ($offset < $defaultPageSize) {
+					/* Make a search with offset as page size and dismiss the result, to init the cookie */
+					$this->search($filter, $base, $attr, $offset, 0, true);
+				} else {
+					/* Make a search for previous page and dismiss the result, to init the cookie */
+					$reOffset = $offset - $defaultPageSize;
+					$this->search($filter, $base, $attr, $defaultPageSize, $reOffset, true);
+				}
 				if (!$this->hasMoreResults()) {
 					// when the cookie is reset with != 0 offset, there are no further
 					// results, so stop.

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1993,8 +1993,9 @@ class Access extends LDAPUtility {
 				// no cookie known from a potential previous search. We need
 				// to start from 0 to come to the desired page. cookie value
 				// of '0' is valid, because 389ds
-				$reOffset = ($offset - $pageSize) < 0 ? 0 : $offset - $pageSize;
-				$this->search($filter, $base, $attr, $pageSize, $reOffset, true);
+				$defaultPageSize = (int)$this->connection->ldapPagingSize;
+				$reOffset = ($offset - $defaultPageSize) < 0 ? 0 : $offset - $defaultPageSize;
+				$this->search($filter, $base, $attr, $defaultPageSize, $reOffset, true);
 				if (!$this->hasMoreResults()) {
 					// when the cookie is reset with != 0 offset, there are no further
 					// results, so stop.


### PR DESCRIPTION
* Resolves: #38417 

## Summary

Instead of using the final limit as page size, use the default one, which may be higher.
For instance `occ ldap:search --limit=2 --offset=100 ""` will now do 2 requests instead of 50.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
