### PR TITLE
Download files via post request

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1051,7 +1051,7 @@
 			};
 
 			if(this.getSelectedFiles().length > 1) {
-				OCA.Files.Files.handleDownload(this.getDownloadUrl(files, dir, true), disableLoadingState);
+				OCA.Files.Files.handleDownload(this.getDownloadUrl(files, dir, true), disableLoadingState, files, dir);
 			}
 			else {
 				var first = this.getSelectedFiles()[0];

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -364,7 +364,7 @@
 		 * @param {string} url download URL
 		 * @param {Function} callback function to call once the download has started
 		 */
-		handleDownload: function(url, callback) {
+		handleDownload: function(url, callback, files = null, dir = null)  {
 			var randomToken = Math.random().toString(36).substring(2),
 				checkForDownloadCookie = function() {
 					if (!OC.Util.isCookieSetToValue('ocDownloadStarted', randomToken)){
@@ -380,6 +380,10 @@
 			} else {
 				url += '?';
 			}
+			filesClient = OC.Files.getClient();
+			filesClient = filesClient.getClient();
+			// Method signature : request: function (method, url, headers, body, responseType, options) 
+			filesClient.request('POST', url, [], []);
 			OC.redirect(url + 'downloadStartSecret=' + randomToken);
 			OC.Util.waitFor(checkForDownloadCookie, 500);
 		}


### PR DESCRIPTION
## Summary

Currently, download requests are handled via a get request which can break in various ways.

For example, if the GET URL is too long and the servers MAX_URL_LENGTH (size) is reached a 404 is thrown as reported in #7935

Resolves: https://github.com/nextcloud/server/issues/7935

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
