### PR TITLE
fix(dav): Fix avatar size in system address book

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -151,7 +151,7 @@ class Converter {
 
 	private function getAvatarImage(IUser $user): ?IImage {
 		try {
-			return $user->getAvatarImage(-1);
+			return $user->getAvatarImage(512);
 		} catch (Exception $ex) {
 			return null;
 		}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -571,7 +571,7 @@ class User implements IUser {
 		}
 
 		$avatar = $this->avatarManager->getAvatar($this->uid);
-		$image = $avatar->get(-1);
+		$image = $avatar->get($size);
 		if ($image) {
 			return $image;
 		}


### PR DESCRIPTION

## Summary

Before our server went away on a 14MB avatar:
```
In Connection.php line 123:
                                                                   
  SQLSTATE[HY000]: General error: 2006 MySQL server has gone away  
                                                                   
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
