### PR TITLE
emit an event when a message is logged

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -489,6 +489,7 @@ return array(
     'OCP\\Lock\\ManuallyLockedException' => $baseDir . '/lib/public/Lock/ManuallyLockedException.php',
     'OCP\\Lockdown\\ILockdownManager' => $baseDir . '/lib/public/Lockdown/ILockdownManager.php',
     'OCP\\Log\\Audit\\CriticalActionPerformedEvent' => $baseDir . '/lib/public/Log/Audit/CriticalActionPerformedEvent.php',
+    'OCP\\Log\\BeforeMessageLoggedEvent' => $baseDir . '/lib/public/Log/BeforeMessageLoggedEvent.php',
     'OCP\\Log\\IDataLogger' => $baseDir . '/lib/public/Log/IDataLogger.php',
     'OCP\\Log\\IFileBased' => $baseDir . '/lib/public/Log/IFileBased.php',
     'OCP\\Log\\ILogFactory' => $baseDir . '/lib/public/Log/ILogFactory.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -522,6 +522,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Lock\\ManuallyLockedException' => __DIR__ . '/../../..' . '/lib/public/Lock/ManuallyLockedException.php',
         'OCP\\Lockdown\\ILockdownManager' => __DIR__ . '/../../..' . '/lib/public/Lockdown/ILockdownManager.php',
         'OCP\\Log\\Audit\\CriticalActionPerformedEvent' => __DIR__ . '/../../..' . '/lib/public/Log/Audit/CriticalActionPerformedEvent.php',
+        'OCP\\Log\\BeforeMessageLoggedEvent' => __DIR__ . '/../../..' . '/lib/public/Log/BeforeMessageLoggedEvent.php',
         'OCP\\Log\\IDataLogger' => __DIR__ . '/../../..' . '/lib/public/Log/IDataLogger.php',
         'OCP\\Log\\IFileBased' => __DIR__ . '/../../..' . '/lib/public/Log/IFileBased.php',
         'OCP\\Log\\ILogFactory' => __DIR__ . '/../../..' . '/lib/public/Log/ILogFactory.php',

--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
  */
 namespace OC\EventDispatcher;
 
+use OC\Log;
 use Psr\Log\LoggerInterface;
 use function get_class;
 use OC\Broadcast\Events\BroadcastEvent;
@@ -54,6 +55,12 @@ class EventDispatcher implements IEventDispatcher {
 		$this->dispatcher = $dispatcher;
 		$this->container = $container;
 		$this->logger = $logger;
+
+		// inject the event dispatcher into the logger
+		// this is done here because there is a cyclic dependency between the event dispatcher and logger
+		if ($this->logger instanceof Log or $this->logger instanceof Log\PsrLoggerAdapter) {
+			$this->logger->setEventDispatcher($this);
+		}
 	}
 
 	public function addListener(string $eventName,

--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OC\Log;
 
 use OC\Log;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\Log\IDataLogger;
 use Psr\Log\InvalidArgumentException;
@@ -40,6 +41,10 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 
 	public function __construct(Log $logger) {
 		$this->logger = $logger;
+	}
+
+	public function setEventDispatcher(IEventDispatcher $eventDispatcher) {
+		$this->logger->setEventDispatcher($eventDispatcher);
 	}
 
 	private function containsThrowable(array $context): bool {

--- a/lib/public/Log/BeforeMessageLoggedEvent.php
+++ b/lib/public/Log/BeforeMessageLoggedEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\Log;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Even for when a log item is being logged
+ *
+ * @since 28.0.0
+ */
+class BeforeMessageLoggedEvent extends Event {
+	private int $level;
+	private string $app;
+	private $message;
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function __construct(string $app, int $level, $message) {
+		$this->level = $level;
+		$this->app = $app;
+		$this->message = $message;
+	}
+
+	/**
+	 * Get the level of the log item
+	 *
+	 * @return int
+	 * @since 28.0.0
+	 */
+	public function getLevel(): int {
+		return $this->level;
+	}
+
+
+	/**
+	 * Get the app context of the log item
+	 *
+	 * @return string
+	 * @since 28.0.0
+	 */
+	public function getApp(): string {
+		return $this->app;
+	}
+
+
+	/**
+	 * Get the message of the log item
+	 *
+	 * @return string
+	 * @since 28.0.0
+	 */
+	public function getMessage(): string {
+		return $this->message;
+	}
+}


### PR DESCRIPTION
Allow apps to do their own handling, notably this is emitted even if it would be normally filtered by log level

Needed for https://github.com/nextcloud/logreader/pull/873