### PR TITLE
Replace id3parser with mp3info

### DIFF
--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -28,11 +28,10 @@
  */
 namespace OC\Preview;
 
-use ID3Parser\ID3Parser;
-
 use OCP\Files\File;
 use OCP\IImage;
 use Psr\Log\LoggerInterface;
+use wapmorgan\Mp3Info\Mp3Info;
 
 class MP3 extends ProviderV2 {
 	/**
@@ -46,11 +45,12 @@ class MP3 extends ProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
-		$getID3 = new ID3Parser();
-
 		$tmpPath = $this->getLocalFile($file);
+
 		try {
-			$tags = $getID3->analyze($tmpPath);
+			$audio = new Mp3Info($tmpPath, true);
+			/** @var string|null|false $picture */
+			$picture = $audio->getCover();
 		} catch (\Throwable $e) {
 			\OC::$server->get(LoggerInterface::class)->info($e->getMessage(), [
 				'exception' => $e,
@@ -61,12 +61,7 @@ class MP3 extends ProviderV2 {
 			$this->cleanTmpFiles();
 		}
 
-		$picture = isset($tags['id3v2']['APIC'][0]['data']) ? $tags['id3v2']['APIC'][0]['data'] : null;
-		if (is_null($picture) && isset($tags['id3v2']['PIC'][0]['data'])) {
-			$picture = $tags['id3v2']['PIC'][0]['data'];
-		}
-
-		if (!is_null($picture)) {
+		if (is_string($picture)) {
 			$image = new \OCP\Image();
 			$image->loadFromData($picture);
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/pull/38496

## Summary

We forked getID3 to provide a library to only read MP3 files but nothing else.
Our primary use case is to use an embedded image as a preview.

[Mp3Info](https://github.com/wapmorgan/Mp3Info) seems like a nice and lightweight replacement for getID3.

## TODO

- [x] CI
- [x] Merge & Backport https://github.com/nextcloud/server/pull/38496
- [x] Merge & Rebase https://github.com/nextcloud/3rdparty/pull/1420

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
