### PR TITLE
Add uploadsdirectory param

### DIFF
--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -105,7 +105,7 @@ class UploadHome implements ICollection {
 		$user_path = '/' . $user->getUID() . '/uploads';
         $absoluteUserPath = $rootView->getLocalFile($user_path);
 
-		if ($allowSymlinks && $uploadsDirectory != '' && $absoluteUserPath) {
+		if ($allowSymlinks && $uploadsDirectory !== '' && $absoluteUserPath) {
 			$upload_user_path = $uploadsDirectory . $user_path;
 
 			if (!$rootView->file_exists($user_path) || !is_link($absoluteUserPath) || ($upload_user_path != realpath($absoluteUserPath)) ) {

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -98,35 +98,35 @@ class UploadHome implements ICollection {
 		$user = \OC::$server->getUserSession()->getUser();
 		Filesystem::initMountPoints($user->getUID());
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(IConfig::class);
 
 		$allowSymlinks = $config->getSystemValueBool('localstorage.allowsymlinks', false);
-		$uploadsDirectory = $config->getSystemValue('uploadsdirectory', '');
+		$uploadsDirectory = $config->getSystemValueString('uploadsdirectory', '');
 		$user_path = '/' . $user->getUID() . '/uploads';
-        $absolute_user_path = $rootView->getLocalFile($user_path);
+        $absoluteUserPath = $rootView->getLocalFile($user_path);
 
-		if ($allowSymlinks && $uploadsDirectory != '' && $absolute_user_path) {
+		if ($allowSymlinks && $uploadsDirectory != '' && $absoluteUserPath) {
 			$upload_user_path = $uploadsDirectory . $user_path;
 
-			if (!$rootView->file_exists($user_path) || !is_link($absolute_user_path) || ($upload_user_path != realpath($absolute_user_path)) ) {
+			if (!$rootView->file_exists($user_path) || !is_link($absoluteUserPath) || ($upload_user_path != realpath($absoluteUserPath)) ) {
 
                 if (!is_dir($upload_user_path)) {
                     mkdir($upload_user_path, 0750, true);
                 }
 
 				// useful if link is broken due to $upload_user_path changes
-                if (is_link($absolute_user_path)) {
-                    unlink($absolute_user_path);
-                } else if (is_dir($absolute_user_path)) {
+                if (is_link($absoluteUserPath)) {
+                    unlink($absoluteUserPath);
+                } elseif (is_dir($absoluteUserPath)) {
                     $rootView->rmdir($user_path);
                 }
-                symlink($upload_user_path, $absolute_user_path);
+                symlink($upload_user_path, $absoluteUserPath);
 
 			}
 
 		} else {
-            if ($absolute_user_path && is_link($absolute_user_path)) {
-                unlink($absolute_user_path);
+            if ($absoluteUserPath && is_link($absoluteUserPath)) {
+                unlink($absoluteUserPath);
             }
 			if (!$rootView->file_exists($user_path)) {
 				$rootView->mkdir($user_path);

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -28,6 +28,7 @@ namespace OCA\DAV\Upload;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCP\IConfig;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\ICollection;
 

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -105,10 +105,10 @@ class UploadHome implements ICollection {
 		$user_path = '/' . $user->getUID() . '/uploads';
         $absolute_user_path = $rootView->getLocalFile($user_path);
 
-		if ($allowSymlinks && $uploadsDirectory != '') {
+		if ($allowSymlinks && $uploadsDirectory != '' && $absolute_user_path) {
 			$upload_user_path = $uploadsDirectory . $user_path;
 
-			if (!$rootView->file_exists($user_path) || !is_link($link_user_path) || ($upload_user_path != readlink($absolute_user_path)) ) {
+			if (!$rootView->file_exists($user_path) || !is_link($absolute_user_path) || ($upload_user_path != realpath($absolute_user_path)) ) {
 
                 if (!is_dir($upload_user_path)) {
                     mkdir($upload_user_path, 0750, true);
@@ -125,7 +125,7 @@ class UploadHome implements ICollection {
 			}
 
 		} else {
-            if (is_link($absolute_user_path)) {
+            if ($absolute_user_path && is_link($absolute_user_path)) {
                 unlink($absolute_user_path);
             }
 			if (!$rootView->file_exists($user_path)) {

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -102,26 +102,26 @@ class UploadHome implements ICollection {
 		$config = \OC::$server->get(IConfig::class);
 
 		$allowSymlinks = $config->getSystemValueBool('localstorage.allowsymlinks', false);
-		$uploadsDirectory = $config->getSystemValueString('uploadsdirectory', '');
-		$user_path = '/' . $user->getUID() . '/uploads';
-        $absoluteUserPath = $rootView->getLocalFile($user_path);
+		$uploadsPath = $config->getSystemValueString('uploads_path', '');
+		$userPath = '/' . $user->getUID() . '/uploads';
+        $absoluteUserPath = $rootView->getLocalFile($userPath);
 
-		if ($allowSymlinks && $uploadsDirectory !== '' && $absoluteUserPath) {
-			$upload_user_path = $uploadsDirectory . $user_path;
+		if ($allowSymlinks && $uploadsPath !== '' && $absoluteUserPath) {
+			$uploadUserPath = $uploadsPath . $userPath;
 
-			if (!$rootView->file_exists($user_path) || !is_link($absoluteUserPath) || ($upload_user_path != realpath($absoluteUserPath)) ) {
+			if (!$rootView->file_exists($userPath) || !is_link($absoluteUserPath) || ($uploadUserPath != realpath($absoluteUserPath)) ) {
 
-                if (!is_dir($upload_user_path)) {
-                    mkdir($upload_user_path, 0750, true);
+                if (!is_dir($uploadUserPath)) {
+                    mkdir($uploadUserPath, 0750, true);
                 }
 
-				// useful if link is broken due to $upload_user_path changes
+				// useful if link is broken due to $uploadUserPath changes
                 if (is_link($absoluteUserPath)) {
                     unlink($absoluteUserPath);
                 } elseif (is_dir($absoluteUserPath)) {
-                    $rootView->rmdir($user_path);
+                    $rootView->rmdir($userPath);
                 }
-                symlink($upload_user_path, $absoluteUserPath);
+                symlink($uploadUserPath, $absoluteUserPath);
 
 			}
 
@@ -129,12 +129,12 @@ class UploadHome implements ICollection {
             if ($absoluteUserPath && is_link($absoluteUserPath)) {
                 unlink($absoluteUserPath);
             }
-			if (!$rootView->file_exists($user_path)) {
-				$rootView->mkdir($user_path);
+			if (!$rootView->file_exists($userPath)) {
+				$rootView->mkdir($userPath);
 			}
 		}
 		
-		return new View($user_path);
+		return new View($userPath);
 	}
 
 	private function getStorage() {

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -120,7 +120,7 @@ class UploadHome implements ICollection {
                 } else if (is_dir($absolute_user_path)) {
                     $rootView->rmdir($user_path);
                 }
-                symlink($upload_user_path, $link_user_path);
+                symlink($upload_user_path, $absolute_user_path);
 
 			}
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1898,12 +1898,12 @@ $CONFIG = [
 'updatedirectory' => '',
 
 /**
- * Override where Nextcloud stores uploads user files while uploading (chunks). Useful in situations
+ * Override where Nextcloud stores uploaded  user files while uploading (chunks). Useful in situations
  * where the default `<user_id>/uploads` is on network disk like NFS.
- * Defaults to the value of `` if unset. Require `localstorage.allowsymlinks` set to `true` because
+ * Defaults to the value of '' if unset. Require `localstorage.allowsymlinks` set to `true` because
  * impementation require symlink to works.
  */
-'uploadsdirectory' => '',
+'uploads_path' => '',
 
 /**
  * Blacklist a specific file or files and disallow the upload of files

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1898,6 +1898,14 @@ $CONFIG = [
 'updatedirectory' => '',
 
 /**
+ * Override where Nextcloud stores uploads user files while uploading (chunks). Useful in situations
+ * where the default `<user_id>/uploads` is on network disk like NFS.
+ * Defaults to the value of `` if unset. Require `localstorage.allowsymlinks` set to `true` because
+ * impementation require symlink to works.
+ */
+'uploadsdirectory' => '',
+
+/**
  * Blacklist a specific file or files and disallow the upload of files
  * with this name. ``.htaccess`` is blocked by default.
  * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.


### PR DESCRIPTION
* Resolves: #38505
* 
## Summary
This PR will address the feature above, adding new config parameter and manage it.

The "smart" solution adopted is to use the conjunction of param that already exists `localstorage.allowsymlinks` and new config param `uploadsdirectory`.
The idea is to use a symlink to avoid the rework in all files/functions where `<user_id>/uploads` it's used. 

The only piece of code that require changes is `apps/dav/lib/Upload/UploadHome.php` that check if `localstorage.allowsymlinks` is true and `uploadsdirectory` is setted, if yes we create symlink (if not already exists), if not, we continue to use the current implementation.

In case of user changes `localstorage.allowsymlinks` or `uploadsdirectory`, we will delete current link (or directory) and recreate it (link or dir based on settings).


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
