### PR TITLE
fix(docs): Fix language and copy-paste class name in docs of CSP

### DIFF
--- a/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictContentSecurityPolicy.php
@@ -32,7 +32,7 @@ namespace OCP\AppFramework\Http;
  * ('self') are allowed.
  *
  * Even if a value gets modified above defaults will still get appended. Please
- * notice that Nextcloud ships already with sensible defaults and those policies
+ * note that Nextcloud ships already with sensible defaults and those policies
  * should require no modification at all for most use-cases.
  *
  * This class represents out strictest defaults. They may get change from release

--- a/lib/public/AppFramework/Http/StrictEvalContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictEvalContentSecurityPolicy.php
@@ -26,13 +26,13 @@ declare(strict_types=1);
 namespace OCP\AppFramework\Http;
 
 /**
- * Class StrictInlineContentSecurityPolicy is a simple helper which allows applications to
+ * Class StrictEvalContentSecurityPolicy is a simple helper which allows applications to
  * modify the Content-Security-Policy sent by Nextcloud. Per default only JavaScript,
  * stylesheets, images, fonts, media and connections from the same domain
  * ('self') are allowed.
  *
  * Even if a value gets modified above defaults will still get appended. Please
- * notice that Nextcloud ships already with sensible defaults and those policies
+ * note that Nextcloud ships already with sensible defaults and those policies
  * should require no modification at all for most use-cases.
  *
  * This is a temp helper class from the default ContentSecurityPolicy to allow slow

--- a/lib/public/AppFramework/Http/StrictInlineContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/StrictInlineContentSecurityPolicy.php
@@ -32,7 +32,7 @@ namespace OCP\AppFramework\Http;
  * ('self') are allowed.
  *
  * Even if a value gets modified above defaults will still get appended. Please
- * notice that Nextcloud ships already with sensible defaults and those policies
+ * note that Nextcloud ships already with sensible defaults and those policies
  * should require no modification at all for most use-cases.
  *
  * This is a temp helper class from the default ContentSecurityPolicy to allow slow


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
