### PR TITLE
chore(app): Do not clear unused cache key

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -673,8 +673,6 @@ class AppManager implements IAppManager {
 	 * Clear the cached list of apps when enabling/disabling an app
 	 */
 	public function clearAppsCache() {
-		$settingsMemCache = $this->memCacheFactory->createDistributed('settings');
-		$settingsMemCache->clear('listApps');
 		$this->appInfos = [];
 	}
 

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -133,14 +133,7 @@ class AppManagerTest extends TestCase {
 		);
 	}
 
-	protected function expectClearCache() {
-		$this->cache->expects($this->once())
-			->method('clear')
-			->with('listApps');
-	}
-
 	public function testEnableApp() {
-		$this->expectClearCache();
 		// making sure "files_trashbin" is disabled
 		if ($this->manager->isEnabledForUser('files_trashbin')) {
 			$this->manager->disableApp('files_trashbin');
@@ -151,7 +144,6 @@ class AppManagerTest extends TestCase {
 	}
 
 	public function testDisableApp() {
-		$this->expectClearCache();
 		$this->eventDispatcher->expects($this->once())->method('dispatchTyped')->with(new AppDisableEvent('files_trashbin'));
 		$this->manager->disableApp('files_trashbin');
 		$this->assertEquals('no', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
@@ -180,7 +172,6 @@ class AppManagerTest extends TestCase {
 			->willReturn('group2');
 
 		$groups = [$group1, $group2];
-		$this->expectClearCache();
 
 		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)
@@ -229,7 +220,6 @@ class AppManagerTest extends TestCase {
 			->willReturn('group2');
 
 		$groups = [$group1, $group2];
-		$this->expectClearCache();
 
 		/** @var AppManager|MockObject $manager */
 		$manager = $this->getMockBuilder(AppManager::class)


### PR DESCRIPTION
## Summary

Drive-by fix while reading some code. I am not able to find any usage of that cache key.

https://github.com/nextcloud/server/commit/d01cfde98229c6d1bd14feefd889205027920d14 added the code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
