### PR TITLE
ci: Use conventional commits for CA bundle updates

### DIFF
--- a/.github/workflows/update-cacert-bundle.yml
+++ b/.github/workflows/update-cacert-bundle.yml
@@ -29,12 +29,12 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
-          commit-message: Update CA certificate bundle
+          commit-message: "fix(security): Update CA certificate bundle"
           committer: GitHub <noreply@github.com>
           author: nextcloud-command <nextcloud-command@users.noreply.github.com>
           signoff: true
           branch: automated/noid/${{ matrix.branches }}-update-ca-cert-bundle
-          title: "[${{ matrix.branches }}] Update ca-cert bundle"
+          title: "[${{ matrix.branches }}] fix(security): Update CA certificate bundle"
           body: |
             Auto-generated update of CA certificate bundle from [https://curl.se/docs/caextract.html](https://curl.se/docs/caextract.html)
           labels: |


### PR DESCRIPTION
## Summary

Use conventional commits for the automated bundle update PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
