### PR TITLE
fix(caldav): Only track interactions of event organizers

### DIFF
--- a/apps/dav/lib/Listener/CalendarContactInteractionListener.php
+++ b/apps/dav/lib/Listener/CalendarContactInteractionListener.php
@@ -142,8 +142,28 @@ class CalendarContactInteractionListener implements IEventListener {
 	}
 
 	private function emitFromObject(VEvent $vevent, IUser $user): void {
-		if (!$vevent->ATTENDEE) {
+		$userEmail = $user->getPrimaryEMailAddress();
+		if ($userEmail === null) {
+			// This user can't be organizer
+			return;
+		}
+
+		if (!$vevent->ORGANIZER || !$vevent->ATTENDEE) {
 			// Nothing left to do
+			return;
+		}
+		$organizer = $vevent->ORGANIZER;
+		if (!($organizer instanceof Property)) {
+			return;
+		}
+		$organizerMailTo = $organizer->getValue();
+		if (strpos($organizerMailTo, 'mailto:') !== 0) {
+			// Doesn't look like an email
+			return;
+		}
+		$organizerEmail = substr($organizerMailTo, strlen('mailto:'));
+		$userEmail = $user->getPrimaryEMailAddress();
+		if ($organizerEmail !== $userEmail) {
 			return;
 		}
 

--- a/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
+++ b/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
@@ -135,7 +135,7 @@ UID:b74a0c8e-93b0-447f-aed5-b679b19e874a
 DTSTART;TZID=Europe/Vienna:20210202T103000
 DTEND;TZID=Europe/Vienna:20210202T133000
 SUMMARY:tes
-ORGANIZER;CN=admin:mailto:christoph.wurst@nextcloud.com
+ORGANIZER;CN=admin:mailto:user@domain.tld
 ATTENDEE;CN=somethingbutnotanemail;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;
  ROLE=REQ-PARTICIPANT;RSVP=FALSE:mailto:somethingbutnotanemail
 DESCRIPTION:test
@@ -143,6 +143,55 @@ END:VEVENT
 END:VCALENDAR
 EVENT]);
 		$user = $this->createMock(IUser::class);
+		$user->method('getPrimaryEMailAddress')->willReturn('user@domain.tld');
+		$this->userSession->expects(self::once())->method('getUser')->willReturn($user);
+		$this->eventDispatcher->expects(self::never())->method('dispatchTyped');
+		$this->logger->expects(self::never())->method('warning');
+
+		$this->listener->handle($event);
+	}
+
+	public function testParseImportedEventWithUnknownOrganizer(): void {
+		$event = new CalendarObjectCreatedEvent(123, [], [], ['calendardata' => <<<EVENT
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//IDN nextcloud.com//Calendar app 2.1.3//EN
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20210202T091151Z
+DTSTAMP:20210203T130231Z
+LAST-MODIFIED:20210203T130231Z
+SEQUENCE:9
+UID:b74a0c8e-93b0-447f-aed5-b679b19e874a
+DTSTART;TZID=Europe/Vienna:20210202T103000
+DTEND;TZID=Europe/Vienna:20210202T133000
+SUMMARY:tes
+ORGANIZER;CN=admin:mailto:someoneelse@email.tld
+ATTENDEE;CN=somethingbutnotanemail;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;
+ ROLE=REQ-PARTICIPANT;RSVP=FALSE:mailto:somethingbutnotanemail
+DESCRIPTION:test
+END:VEVENT
+END:VCALENDAR
+EVENT]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getPrimaryEMailAddress')->willReturn('user@domain.tld');
 		$this->userSession->expects(self::once())->method('getUser')->willReturn($user);
 		$this->eventDispatcher->expects(self::never())->method('dispatchTyped');
 		$this->logger->expects(self::never())->method('warning');
@@ -182,7 +231,7 @@ UID:b74a0c8e-93b0-447f-aed5-b679b19e874a
 DTSTART;TZID=Europe/Vienna:20210202T103000
 DTEND;TZID=Europe/Vienna:20210202T133000
 SUMMARY:tes
-ORGANIZER;CN=admin:mailto:christoph.wurst@nextcloud.com
+ORGANIZER;CN=admin:mailto:user@domain.tld
 ATTENDEE;CN=user@domain.tld;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;
  ROLE=REQ-PARTICIPANT;RSVP=FALSE:mailto:user@domain.tld
 DESCRIPTION:test
@@ -190,6 +239,7 @@ END:VEVENT
 END:VCALENDAR
 EVENT]);
 		$user = $this->createMock(IUser::class);
+		$user->method('getPrimaryEMailAddress')->willReturn('user@domain.tld');
 		$this->userSession->expects(self::once())->method('getUser')->willReturn($user);
 		$this->mailer->expects(self::once())->method('validateMailAddress')->willReturn(true);
 		$this->eventDispatcher->expects(self::once())


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/38390

## Summary

Imported events can have attendees to and we wrongly capture them as interactions. Only if the owner of the event is organizer it is their interaction. Anything else can be ignored.

## TODO

- [x] Fix event contacts interaction

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
