### PR TITLE
fix(dispatcher): Migrate to OCP event dispatcher before symfony/event…

### DIFF
--- a/.github/workflows/lint-eslint-when-unrelated.yml
+++ b/.github/workflows/lint-eslint-when-unrelated.yml
@@ -1,0 +1,39 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# Use lint-eslint together with lint-eslint-when-unrelated to make eslint a required check for GitHub actions
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: Lint eslint
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'apps/**/appinfo/info.xml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.eslintrc.*'
+      - '.eslintignore'
+      - '**.js'
+      - '**.ts'
+      - '**.vue'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    permissions:
+      contents: none
+
+    runs-on: ubuntu-latest
+
+    name: eslint
+
+    steps:
+      - run: 'echo "No eslint required"'

--- a/.github/workflows/node-when-unrelated.yml
+++ b/.github/workflows/node-when-unrelated.yml
@@ -1,0 +1,43 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# Use node together with node-when-unrelated to make eslint a required check for GitHub actions
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: Node
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'src/**'
+      - 'apps/**/appinfo/info.xml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '**.js'
+      - '**.ts'
+      - '**.vue'
+  push:
+    branches:
+      - main
+      - master
+      - stable*
+
+concurrency:
+  group: node-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    permissions:
+      contents: none
+
+    runs-on: ubuntu-latest
+
+    name: node
+    steps:
+      - name: Skip
+        run: 'echo "No JS/TS files changed, skipped Node"'

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -34,9 +34,9 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\AppFramework\IAppContainer;
 use OCP\IUser;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Application extends App implements IBootstrap {
@@ -56,8 +56,8 @@ class Application extends App implements IBootstrap {
 	/**
 	 * @todo move the OCP events and then move the registration to `register`
 	 */
-	private function registerEventListeners(EventDispatcher $dispatcher,
-											IAppContainer $appContainer): void {
+	private function registerEventListeners(EventDispatcherInterface $dispatcher,
+											ContainerInterface $appContainer): void {
 		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) use ($appContainer) {
 			/** @var IUser $user */
 			$user = $event->getSubject();

--- a/apps/systemtags/lib/AppInfo/Application.php
+++ b/apps/systemtags/lib/AppInfo/Application.php
@@ -31,9 +31,9 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\SystemTag\ManagerEvent;
 use OCP\SystemTag\MapperEvent;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'systemtags';
@@ -47,7 +47,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (EventDispatcher $dispatcher) use ($context) {
+		$context->injectFn(function (IEventDispatcher $dispatcher) use ($context) {
 			/*
 			 * @todo move the OCP events and then move the registration to `register`
 			 */

--- a/lib/private/EventDispatcher/SymfonyAdapter.php
+++ b/lib/private/EventDispatcher/SymfonyAdapter.php
@@ -113,8 +113,7 @@ class SymfonyAdapter implements EventDispatcherInterface {
 
 		// Event with no payload (object) need special handling
 		if ($newEvent === null) {
-			$this->eventDispatcher->getSymfonyDispatcher()->dispatch($eventName);
-			return new Event();
+			$newEvent = new Event();
 		}
 
 		// Flip the argument order for Symfony to prevent a trigger_error

--- a/tests/lib/EventDispatcher/SymfonyAdapterTest.php
+++ b/tests/lib/EventDispatcher/SymfonyAdapterTest.php
@@ -179,6 +179,7 @@ class SymfonyAdapterTest extends TestCase {
 		$symfonyDispatcher->expects(self::once())
 			->method('dispatch')
 			->with(
+				$this->anything(),
 				$eventName
 			)
 			->willReturnArgument(0);

--- a/tests/lib/Share20/LegacyHooksTest.php
+++ b/tests/lib/Share20/LegacyHooksTest.php
@@ -23,12 +23,15 @@
 
 namespace Test\Share20;
 
+use OC\EventDispatcher\SymfonyAdapter;
 use OC\Share20\LegacyHooks;
 use OC\Share20\Manager;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\File;
+use OCP\IServerContainer;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
@@ -46,7 +49,10 @@ class LegacyHooksTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->eventDispatcher = new EventDispatcher();
+		$symfonyDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+		$logger = $this->createMock(LoggerInterface::class);
+		$eventDispatcher = new \OC\EventDispatcher\EventDispatcher($symfonyDispatcher, \OC::$server->get(IServerContainer::class), $logger);
+		$this->eventDispatcher = new SymfonyAdapter($eventDispatcher, $logger);
 		$this->hooks = new LegacyHooks($this->eventDispatcher);
 		$this->manager = \OC::$server->getShareManager();
 	}


### PR DESCRIPTION
…-dispatcher upgrade

## Summary

Required for the upcoming symfony/event-dispatcher upgrade which breaks their API.
Also raised in apps:
- https://github.com/nextcloud/circles/issues/1317
- https://github.com/nextcloud/groupfolders/issues/2409
- https://github.com/nextcloud/collectives/issues/710

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
