### PR TITLE
explicitly handle /files_ecryption/... paths when setting up mounts

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -365,7 +365,7 @@ class SetupManager {
 	 * @return IUser|null
 	 */
 	private function getUserForPath(string $path) {
-		if (strpos($path, '/__groupfolders') === 0) {
+		if (str_starts_with($path, '/__groupfolders') || str_starts_with($path, '/files_encryption')) {
 			return null;
 		} elseif (substr_count($path, '/') < 2) {
 			if ($user = $this->userSession->getUser()) {


### PR DESCRIPTION
Always setup the root storages instead of checking if it's a valid user path