### PR TITLE
chore(ocp)!: Drop \OCP\Util::writeLog

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -32,7 +32,7 @@
 namespace OC\Core\Controller;
 
 use OC\Setup;
-use OCP\ILogger;
+use function OCP\Log\logger;
 
 class SetupController {
 	private string $autoConfigFile;
@@ -114,7 +114,7 @@ class SetupController {
 
 	public function loadAutoConfig(array $post): array {
 		if (file_exists($this->autoConfigFile)) {
-			\OCP\Util::writeLog('core', 'Autoconfig file found, setting up Nextcloud…', ILogger::INFO);
+			logger('core')->info('Autoconfig file found, setting up Nextcloud…');
 			$AUTOCONFIG = [];
 			include $this->autoConfigFile;
 			$post = array_merge($post, $AUTOCONFIG);

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -37,8 +37,8 @@ declare(strict_types=1);
 namespace OC;
 
 use \OCP\AutoloadNotAllowedException;
-use OCP\ILogger;
 use OCP\ICache;
+use function OCP\Log\logger;
 
 class Autoloader {
 	/** @var bool */
@@ -105,7 +105,7 @@ class Autoloader {
 			 * Remove "apps/" from inclusion path for smooth migration to multi app dir
 			 */
 			if (strpos(\OC::$CLASSPATH[$class], 'apps/') === 0) {
-				\OCP\Util::writeLog('core', 'include path for class "' . $class . '" starts with "apps/"', ILogger::DEBUG);
+				logger('core')->debug('Include path for class "' . $class . '" starts with "apps/"');
 				$paths[] = str_replace('apps/', '', \OC::$CLASSPATH[$class]);
 			}
 		} elseif (strpos($class, 'OC_') === 0) {

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -75,6 +75,7 @@ use OCP\IUserSession;
 use OCP\Security\Bruteforce\IThrottler;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use function OCP\Log\logger;
 
 /**
  * @deprecated 20.0.0
@@ -404,7 +405,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	}
 
 	/**
-	 * @deprecated use the ILogger instead
+	 * @deprecated use the LoggerInterface instead
 	 * @param string $message
 	 * @param string $level
 	 * @return mixed
@@ -427,7 +428,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$level = ILogger::ERROR;
 				break;
 		}
-		\OCP\Util::writeLog($this->getAppName(), $message, $level);
+		logger($this->getAppName())->log($level, $message);
 	}
 
 	/**

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -75,7 +75,6 @@ use OCP\IUserSession;
 use OCP\Security\Bruteforce\IThrottler;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use function OCP\Log\logger;
 
 /**
  * @deprecated 20.0.0
@@ -402,33 +401,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 	private function getUserId() {
 		return $this->getServer()->getSession()->get('user_id');
-	}
-
-	/**
-	 * @deprecated use the LoggerInterface instead
-	 * @param string $message
-	 * @param string $level
-	 * @return mixed
-	 */
-	public function log($message, $level) {
-		switch ($level) {
-			case 'debug':
-				$level = ILogger::DEBUG;
-				break;
-			case 'info':
-				$level = ILogger::INFO;
-				break;
-			case 'warn':
-				$level = ILogger::WARN;
-				break;
-			case 'fatal':
-				$level = ILogger::FATAL;
-				break;
-			default:
-				$level = ILogger::ERROR;
-				break;
-		}
-		logger($this->getAppName())->log($level, $message);
 	}
 
 	/**

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -39,6 +39,7 @@ use OCP\ILogger;
 use OCP\ITags;
 use OCP\Share_Backend;
 use Psr\Log\LoggerInterface;
+use function OCP\Log\logger;
 
 class Tags implements ITags {
 	/**
@@ -529,7 +530,7 @@ class Tags implements ITags {
 		if (is_string($tag) && !is_numeric($tag)) {
 			$tag = trim($tag);
 			if ($tag === '') {
-				\OCP\Util::writeLog('core', __METHOD__.', Cannot add an empty tag', ILogger::DEBUG);
+				logger('core')->debug(__METHOD__.', Cannot add an empty tag');
 				return false;
 			}
 			if (!$this->hasTag($tag)) {
@@ -569,7 +570,7 @@ class Tags implements ITags {
 		if (is_string($tag) && !is_numeric($tag)) {
 			$tag = trim($tag);
 			if ($tag === '') {
-				\OCP\Util::writeLog('core', __METHOD__.', Tag name is empty', ILogger::DEBUG);
+				logger('core')->debug(__METHOD__.', Tag name is empty');
 				return false;
 			}
 			$tagId = $this->getTagId($tag);
@@ -609,8 +610,8 @@ class Tags implements ITags {
 		$names = array_map('trim', $names);
 		array_filter($names);
 
-		\OCP\Util::writeLog('core', __METHOD__ . ', before: '
-			. print_r($this->tags, true), ILogger::DEBUG);
+		logger('core')->debug(__METHOD__ . ', before: '
+			. print_r($this->tags, true));
 		foreach ($names as $name) {
 			$id = null;
 
@@ -625,8 +626,8 @@ class Tags implements ITags {
 				unset($this->tags[$key]);
 				$this->mapper->delete($tag);
 			} else {
-				\OCP\Util::writeLog('core', __METHOD__ . 'Cannot delete tag ' . $name
-					. ': not found.', ILogger::ERROR);
+				logger('core')->error(__METHOD__ . 'Cannot delete tag ' . $name
+					. ': not found.');
 			}
 			if (!is_null($id) && $id !== false) {
 				try {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -56,7 +56,6 @@ use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\ILogger;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -66,6 +65,7 @@ use OC\Repair;
 use OC\Repair\Events\RepairErrorEvent;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
+use function OCP\Log\logger;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
@@ -292,7 +292,7 @@ class OC_App {
 			}
 		}
 
-		\OCP\Util::writeLog('core', 'No application directories are marked as writable.', ILogger::ERROR);
+		logger('core')->error('No application directories are marked as writable.');
 		return null;
 	}
 
@@ -517,7 +517,7 @@ class OC_App {
 
 		foreach (OC::$APPSROOTS as $apps_dir) {
 			if (!is_readable($apps_dir['path'])) {
-				\OCP\Util::writeLog('core', 'unable to read app folder : ' . $apps_dir['path'], ILogger::WARN);
+				logger('core')->warning('Unable to read app folder: ' . $apps_dir['path']);
 				continue;
 			}
 			$dh = opendir($apps_dir['path']);
@@ -568,12 +568,12 @@ class OC_App {
 			if (array_search($app, $blacklist) === false) {
 				$info = $appManager->getAppInfo($app, false, $langCode);
 				if (!is_array($info)) {
-					\OCP\Util::writeLog('core', 'Could not read app info file for app "' . $app . '"', ILogger::ERROR);
+					logger('core')->error('Could not read app info file for app "' . $app . '"');
 					continue;
 				}
 
 				if (!isset($info['name'])) {
-					\OCP\Util::writeLog('core', 'App id "' . $app . '" has no name in appinfo', ILogger::ERROR);
+					logger('core')->error('App id "' . $app . '" has no name in appinfo');
 					continue;
 				}
 
@@ -870,11 +870,11 @@ class OC_App {
 				}
 				return new \OC\Files\View('/' . OC_User::getUser() . '/' . $appId);
 			} else {
-				\OCP\Util::writeLog('core', 'Can\'t get app storage, app ' . $appId . ', user not logged in', ILogger::ERROR);
+				logger('core')->error('Can\'t get app storage, app ' . $appId . ', user not logged in');
 				return false;
 			}
 		} else {
-			\OCP\Util::writeLog('core', 'Can\'t get app storage, app ' . $appId . ' not enabled', ILogger::ERROR);
+			logger('core')->error('Can\'t get app storage, app ' . $appId . ' not enabled');
 			return false;
 		}
 	}

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -38,10 +38,10 @@
 
 use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\UserLoggedInEvent;
+use function OCP\Log\logger;
 
 /**
  * This class provides wrapper methods for user management. Multiple backends are
@@ -93,7 +93,7 @@ class OC_User {
 				case 'database':
 				case 'mysql':
 				case 'sqlite':
-					\OCP\Util::writeLog('core', 'Adding user backend ' . $backend . '.', ILogger::DEBUG);
+					logger('core')->debug('Adding user backend ' . $backend . '.');
 					self::$_usedBackends[$backend] = new \OC\User\Database();
 					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
@@ -102,7 +102,7 @@ class OC_User {
 					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				default:
-					\OCP\Util::writeLog('core', 'Adding default user backend ' . $backend . '.', ILogger::DEBUG);
+					logger('core')->debug('Adding default user backend ' . $backend . '.');
 					$className = 'OC_USER_' . strtoupper($backend);
 					self::$_usedBackends[$backend] = new $className();
 					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
@@ -147,10 +147,10 @@ class OC_User {
 					self::useBackend($backend);
 					self::$_setupedBackends[] = $i;
 				} else {
-					\OCP\Util::writeLog('core', 'User backend ' . $class . ' already initialized.', ILogger::DEBUG);
+					logger('core')->debug('User backend ' . $class . ' already initialized.');
 				}
 			} else {
-				\OCP\Util::writeLog('core', 'User backend ' . $class . ' not found.', ILogger::ERROR);
+				logger('core')->error('User backend ' . $class . ' not found.');
 			}
 		}
 	}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -105,19 +105,6 @@ class Util {
 	}
 
 	/**
-	 * write a message in the log
-	 * @param string $app
-	 * @param string $message
-	 * @param int $level
-	 * @since 4.0.0
-	 * @deprecated 13.0.0 use log of \OCP\ILogger
-	 */
-	public static function writeLog($app, $message, $level) {
-		$context = ['app' => $app];
-		\OC::$server->getLogger()->log($level, $message, $context);
-	}
-
-	/**
 	 * check if sharing is disabled for the current user
 	 *
 	 * @return boolean


### PR DESCRIPTION
## Summary

The method was deprecated in Nextcloud 13, released 2018-02-06.

## TODO

- [x] Migrate remaining usages to `logger(...)` https://docs.nextcloud.com/server/27/developer_manual/basics/logging.html#logging
- [x] Drop the method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [ ] https://github.com/nextcloud/documentation/pull/10540
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
