### PR TITLE
chore!: Drop \OC_Defaults::getLogoClaim

### DIFF
--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -245,15 +245,6 @@ class OC_Defaults {
 	}
 
 	/**
-	 * Returns logo claim
-	 * @return string logo claim
-	 * @deprecated 13.0.0
-	 */
-	public function getLogoClaim() {
-		return '';
-	}
-
-	/**
 	 * Returns short version of the footer
 	 * @return string short footer
 	 */


### PR DESCRIPTION
## Summary

The method was deprecated in Nextcloud 13, released 2018-02-06.

Strictly peaking the method is not public API. I'll write docs nevertheless.

## TODO

- [x] Remove deprecated and unused code

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
