### PR TITLE
Drop \OC_App methods deprecated in Nextcloud 14

### DIFF
--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
  */
 namespace OCA\UpdateNotification\Notification;
 
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -200,6 +201,6 @@ class Notifier implements INotifier {
 	}
 
 	protected function getAppInfo($appId, $languageCode) {
-		return \OC_App::getAppInfo($appId, false, $languageCode);
+		return \OCP\Server::get(IAppManager::class)->getAppInfo($appId, false, $languageCode);
 	}
 }

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -70,7 +70,7 @@ class Disable extends Command implements CompletionAwareInterface {
 
 		try {
 			$this->appManager->disableApp($appId);
-			$appVersion = \OC_App::getAppVersion($appId);
+			$appVersion = $this->appManager->getAppVersion($appId);
 			$output->writeln($appId . ' ' . $appVersion . ' disabled');
 		} catch (\Exception $e) {
 			$output->writeln($e->getMessage());

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -109,7 +109,7 @@ class Enable extends Command implements CompletionAwareInterface {
 			}
 
 			$installer->installApp($appId, $forceEnable);
-			$appVersion = \OC_App::getAppVersion($appId);
+			$appVersion = $this->appManager->getAppVersion($appId);
 
 			if ($groupIds === []) {
 				$this->appManager->enableApp($appId, $forceEnable);

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -28,6 +28,7 @@
 namespace OC\Core\Command\App;
 
 use OC\Installer;
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -89,7 +90,7 @@ class Install extends Command {
 			return 1;
 		}
 
-		$appVersion = \OC_App::getAppVersion($appId);
+		$appVersion = \OCP\Server::get(IAppManager::class)->getAppVersion($appId);
 		$output->writeln($appId . ' ' . $appVersion . ' installed');
 
 		if (!$input->getOption('keep-disabled')) {

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -116,7 +116,7 @@ class Remove extends Command implements CompletionAwareInterface {
 			return 1;
 		}
 
-		$appVersion = \OC_App::getAppVersion($appId);
+		$appVersion = $this->manager->getAppVersion($appId);
 		$output->writeln($appId . ' ' . $appVersion . ' removed');
 
 		return 0;

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -34,6 +34,7 @@ namespace OC\AppFramework;
 use OC\AppFramework\DependencyInjection\DIContainer;
 use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Http\Request;
+use OCP\App\IAppManager;
 use OCP\Profiler\IProfiler;
 use OC\Profiler\RoutingDataCollector;
 use OCP\AppFramework\QueryException;
@@ -68,7 +69,7 @@ class App {
 			return $topNamespace . self::$nameSpaceCache[$appId];
 		}
 
-		$appInfo = \OC_App::getAppInfo($appId);
+		$appInfo = \OCP\Server::get(IAppManager::class)->getAppInfo($appId);
 		if (isset($appInfo['namespace'])) {
 			self::$nameSpaceCache[$appId] = trim($appInfo['namespace']);
 		} else {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -48,6 +48,7 @@ use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OC_App;
 use OC_Helper;
+use OCP\App\IAppManager;
 use OCP\HintException;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
@@ -164,7 +165,7 @@ class Installer {
 		OC_App::executeRepairSteps($appId, $info['repair-steps']['install']);
 
 		//set the installed version
-		\OC::$server->getConfig()->setAppValue($info['id'], 'installed_version', OC_App::getAppVersion($info['id'], false));
+		\OC::$server->getConfig()->setAppValue($info['id'], 'installed_version', \OCP\Server::get(IAppManager::class)->getAppVersion($info['id'], false));
 		\OC::$server->getConfig()->setAppValue($info['id'], 'enabled', 'no');
 
 		//set remote/public handlers
@@ -349,7 +350,7 @@ class Installer {
 					}
 
 					// Check if the version is lower than before
-					$currentVersion = OC_App::getAppVersion($appId);
+					$currentVersion = \OCP\Server::get(IAppManager::class)->getAppVersion($appId, true);
 					$newVersion = (string)$xml->version;
 					if (version_compare($currentVersion, $newVersion) === 1) {
 						throw new \Exception(
@@ -423,7 +424,7 @@ class Installer {
 
 		foreach ($this->apps as $app) {
 			if ($app['id'] === $appId) {
-				$currentVersion = OC_App::getAppVersion($appId);
+				$currentVersion = \OCP\Server::get(IAppManager::class)->getAppVersion($appId, true);
 
 				if (!isset($app['releases'][0]['version'])) {
 					return false;
@@ -601,7 +602,7 @@ class Installer {
 
 		OC_App::executeRepairSteps($app, $info['repair-steps']['install']);
 
-		$config->setAppValue($app, 'installed_version', OC_App::getAppVersion($app));
+		$config->setAppValue($app, 'installed_version', \OCP\Server::get(IAppManager::class)->getAppVersion($app));
 		if (array_key_exists('ocsid', $info)) {
 			$config->setAppValue($app, 'ocsid', $info['ocsid']);
 		}

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -114,7 +114,7 @@ class Installer {
 		}
 
 		$l = \OC::$server->getL10N('core');
-		$info = OC_App::getAppInfo($basedir.'/appinfo/info.xml', true, $l->getLanguageCode());
+		$info = \OCP\Server::get(IAppManager::class)->getAppInfo($basedir . '/appinfo/info.xml', true, $l->getLanguageCode());
 
 		if (!is_array($info)) {
 			throw new \Exception(
@@ -594,7 +594,7 @@ class Installer {
 		//run appinfo/install.php
 		self::includeAppScript("$appPath/appinfo/install.php");
 
-		$info = OC_App::getAppInfo($app);
+		$info = \OCP\Server::get(IAppManager::class)->getAppInfo($app);
 		if (is_null($info)) {
 			return false;
 		}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -40,6 +40,7 @@ declare(strict_types=1);
  */
 namespace OC;
 
+use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
@@ -355,9 +356,9 @@ class Updater extends BasicEmitter {
 			$stack = $stacks[$type];
 			foreach ($stack as $appId) {
 				if (\OC_App::shouldUpgrade($appId)) {
-					$this->emit('\OC\Updater', 'appUpgradeStarted', [$appId, \OC_App::getAppVersion($appId)]);
+					$this->emit('\OC\Updater', 'appUpgradeStarted', [$appId, \OCP\Server::get(IAppManager::class)->getAppVersion($appId)]);
 					\OC_App::updateApp($appId);
-					$this->emit('\OC\Updater', 'appUpgrade', [$appId, \OC_App::getAppVersion($appId)]);
+					$this->emit('\OC\Updater', 'appUpgrade', [$appId, \OCP\Server::get(IAppManager::class)->getAppVersion($appId)]);
 				}
 				if ($type !== $pseudoOtherType) {
 					// load authentication, filesystem and logging apps after

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -394,21 +394,6 @@ class OC_App {
 		return isset($appData['version']) ? $appData['version'] : '';
 	}
 
-
-	/**
-	 * Read all app metadata from the info.xml file
-	 *
-	 * @param string $appId id of the app or the path of the info.xml file
-	 * @param bool $path
-	 * @param string $lang
-	 * @return array|null
-	 * @note all data is read from info.xml, not just pre-defined fields
-	 * @deprecated 14.0.0 use \OC::$server->getAppManager()->getAppInfo()
-	 */
-	public static function getAppInfo(string $appId, bool $path = false, string $lang = null) {
-		return \OC::$server->getAppManager()->getAppInfo($appId, $path, $lang);
-	}
-
 	/**
 	 * Returns the navigation
 	 *
@@ -609,7 +594,7 @@ class OC_App {
 
 		foreach ($installedApps as $app) {
 			if (array_search($app, $blacklist) === false) {
-				$info = OC_App::getAppInfo($app, false, $langCode);
+				$info = $appManager->getAppInfo($app, false, $langCode);
 				if (!is_array($info)) {
 					\OCP\Util::writeLog('core', 'Could not read app info file for app "' . $app . '"', ILogger::ERROR);
 					continue;
@@ -801,7 +786,7 @@ class OC_App {
 
 		\OC::$server->getAppManager()->clearAppsCache();
 		$l = \OC::$server->getL10N('core');
-		$appData = self::getAppInfo($appId, false, $l->getLanguageCode());
+		$appData = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppInfo($appId, false, $l->getLanguageCode());
 
 		$ignoreMaxApps = \OC::$server->getConfig()->getSystemValue('app_install_overwrite', []);
 		$ignoreMax = in_array($appId, $ignoreMaxApps, true);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -395,19 +395,6 @@ class OC_App {
 	}
 
 	/**
-	 * Returns the Settings Navigation
-	 *
-	 * @return string[]
-	 * @deprecated 14.0.0 use \OC::$server->getNavigationManager()->getAll('settings')
-	 *
-	 * This function returns an array containing all settings pages added. The
-	 * entries are sorted by the key 'order' ascending.
-	 */
-	public static function getSettingsNavigation(): array {
-		return OC::$server->getNavigationManager()->getAll('settings');
-	}
-
-	/**
 	 * get the id of loaded app
 	 *
 	 * @return string

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -383,18 +383,6 @@ class OC_App {
 	}
 
 	/**
-	 * get the last version of the app from appinfo/info.xml
-	 *
-	 * @param string $appId
-	 * @param bool $useCache
-	 * @return string
-	 * @deprecated 14.0.0 use \OC::$server->getAppManager()->getAppVersion()
-	 */
-	public static function getAppVersion(string $appId, bool $useCache = true): string {
-		return \OC::$server->getAppManager()->getAppVersion($appId, $useCache);
-	}
-
-	/**
 	 * get app's version based on it's path
 	 *
 	 * @param string $path
@@ -685,7 +673,7 @@ class OC_App {
 					}
 				}
 
-				$info['version'] = OC_App::getAppVersion($app);
+				$info['version'] = $appManager->getAppVersion($app);
 				$appList[] = $info;
 			}
 		}
@@ -695,7 +683,7 @@ class OC_App {
 
 	public static function shouldUpgrade(string $app): bool {
 		$versions = self::getAppVersions();
-		$currentVersion = OC_App::getAppVersion($app);
+		$currentVersion = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($app);
 		if ($currentVersion && isset($versions[$app])) {
 			$installedVersion = $versions[$app];
 			if (!version_compare($currentVersion, $installedVersion, '=')) {
@@ -853,7 +841,7 @@ class OC_App {
 
 		self::setAppTypes($appId);
 
-		$version = \OC_App::getAppVersion($appId);
+		$version = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
 		\OC::$server->getConfig()->setAppValue($appId, 'installed_version', $version);
 
 		\OC::$server->get(IEventDispatcher::class)->dispatchTyped(new AppUpdateEvent($appId));

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -395,21 +395,6 @@ class OC_App {
 	}
 
 	/**
-	 * Returns the navigation
-	 *
-	 * @return array
-	 * @deprecated 14.0.0 use \OC::$server->getNavigationManager()->getAll()
-	 *
-	 * This function returns an array containing all entries added. The
-	 * entries are sorted by the key 'order' ascending. Additional to the keys
-	 * given for each app the following keys exist:
-	 *   - active: boolean, signals if the user is on this navigation entry
-	 */
-	public static function getNavigation(): array {
-		return OC::$server->getNavigationManager()->getAll();
-	}
-
-	/**
 	 * Returns the Settings Navigation
 	 *
 	 * @return string[]

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -21,6 +21,8 @@
 
 namespace Test;
 
+use OCP\App\IAppManager;
+
 /**
  * Class InfoXmlTest
  *
@@ -58,7 +60,7 @@ class InfoXmlTest extends TestCase {
 	 * @param string $app
 	 */
 	public function testClasses($app) {
-		$appInfo = \OC_App::getAppInfo($app);
+		$appInfo = \OCP\Server::get(IAppManager::class)->getAppInfo($app);
 		$appPath = \OC_App::getAppPath($app);
 		\OC_App::registerAutoloading($app, $appPath);
 

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -11,6 +11,7 @@ namespace Test;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Archive\ZIP;
 use OC\Installer;
+use OCP\App\IAppManager;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
@@ -88,7 +89,7 @@ class InstallerTest extends TestCase {
 
 	public function testInstallApp() {
 		// Read the current version of the app to check for bug #2572
-		\OC_App::getAppVersion('testapp');
+		\OCP\Server::get(IAppManager::class)->getAppVersion('testapp', true);
 
 		// Extract app
 		$pathOfTestApp = __DIR__ . '/../data/testapp.zip';


### PR DESCRIPTION
## Summary

The methods were deprecated in Nextcloud 14, released 2018-09-10.

## TODO

- [x] Inline remaining usages
- [x] Drop the methods

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [ ] https://github.com/nextcloud/documentation/pull/10545
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
