### PR TITLE
redis: Do not try to authenticate with non-string password/user

### DIFF
--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -72,8 +72,8 @@ class RedisFactory {
 		}
 
 		$auth = null;
-		if (isset($config['password']) && $config['password'] !== '') {
-			if (isset($config['user']) && $config['user'] !== '') {
+		if (isset($config['password']) && (string)$config['password'] !== '') {
+			if (isset($config['user']) && (string)$config['user'] !== '') {
 				$auth = [$config['user'], $config['password']];
 			} else {
 				$auth = $config['password'];


### PR DESCRIPTION
* Resolves: The never ending `ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?` errors users encounter (usually when upgrading).

## Summary

If the configuration for Redis in Nextcloud has a password that is false (e.g. `'password' => false` or `'password' => getenv('REDIS_HOST_PASSWORD')` with no environment variable set), `RedisFactory.php`'s test `if (isset($config['password']) && $config['password'] !== '')` will evaluate to true, and due to that Nextcloud will try to *authenticate* with Redis even though there is no password actually set.

Example config from an old (v19) installation that was updated where the problem triggers:
~~~
<?php
if (getenv('REDIS_HOST')) {    // <-- Set.
  $CONFIG = array (
    'memcache.distributed' => '\OC\Memcache\Redis',
    'memcache.locking' => '\OC\Memcache\Redis',
    'redis' => array(
      'host' => getenv('REDIS_HOST'),
      'password' => getenv('REDIS_HOST_PASSWORD'),    // <-- Not set.
    ),
  );

  if (getenv('REDIS_HOST_PORT') !== false) {
    $CONFIG['redis']['port'] = (int) getenv('REDIS_HOST_PORT');
  } elseif (getenv('REDIS_HOST')[0] != '/') {
    $CONFIG['redis']['port'] = 6379;
  }
}  
~~~

This in turn has caused the so many times encountered `ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?` error when using Nextcloud with Redis. Many users have encountered this over many years, and the usual "solution" to that is to set a password for Redis directly or using an environment variable. However, that is not an actual fix for the actual cause of this error. In particular for environments where the Redis instance is only reachable by Nextcloud alone - encouraging people to use passwords with Redis is something that should be done by other means than having code that does not work as it should when a password is not set.

So, if there is no password set in such a way that it evaluates to false in the Redis config in Nextcloud, then Nextcloud should not attempt to authenticate when contacting Redis. This PR fixes that, it only tries to authenticate if there is any content in the password. The same logic is also applied to the `user` setting in the configuration for Redis in Nextcloud.

## TODO

- Merge it :-) I've tested this PR with the latest release of NC which is v26.0.2.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)