### PR TITLE
[stable26] Increase from 100000 to 600000 iterations for hash_pbkdf2

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -70,9 +70,9 @@ class Crypt {
 	// default cipher from old Nextcloud versions
 	public const LEGACY_CIPHER = 'AES-128-CFB';
 
-	public const SUPPORTED_KEY_FORMATS = ['hash', 'password'];
+	public const SUPPORTED_KEY_FORMATS = ['hash2', 'hash', 'password'];
 	// one out of SUPPORTED_KEY_FORMATS
-	public const DEFAULT_KEY_FORMAT = 'hash';
+	public const DEFAULT_KEY_FORMAT = 'hash2';
 	// default key format, old Nextcloud version encrypted the private key directly
 	// with the user password
 	public const LEGACY_KEY_FORMAT = 'password';
@@ -376,22 +376,20 @@ class Crypt {
 	 * @param string $uid only used for user keys
 	 * @return string
 	 */
-	protected function generatePasswordHash($password, $cipher, $uid = '') {
+	protected function generatePasswordHash(string $password, string $cipher, string $uid = '', int $iterations = 600000): string {
 		$instanceId = $this->config->getSystemValue('instanceid');
 		$instanceSecret = $this->config->getSystemValue('secret');
 		$salt = hash('sha256', $uid . $instanceId . $instanceSecret, true);
 		$keySize = $this->getKeySize($cipher);
 
-		$hash = hash_pbkdf2(
+		return hash_pbkdf2(
 			'sha256',
 			$password,
 			$salt,
-			100000,
+			$iterations,
 			$keySize,
 			true
 		);
-
-		return $hash;
 	}
 
 	/**
@@ -436,8 +434,10 @@ class Crypt {
 			$keyFormat = self::LEGACY_KEY_FORMAT;
 		}
 
-		if ($keyFormat === self::DEFAULT_KEY_FORMAT) {
-			$password = $this->generatePasswordHash($password, $cipher, $uid);
+		if ($keyFormat === 'hash') {
+			$password = $this->generatePasswordHash($password, $cipher, $uid, 100000);
+		} elseif ($keyFormat === 'hash2') {
+			$password = $this->generatePasswordHash($password, $cipher, $uid, 600000);
 		}
 
 		$binaryEncoding = isset($header['encoding']) && $header['encoding'] === self::BINARY_ENCODING_FORMAT;

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -139,7 +139,7 @@ class CryptTest extends TestCase {
 	 */
 	public function dataTestGenerateHeader() {
 		return [
-			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:encoding:binary:HEND'],
+			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash2:encoding:binary:HEND'],
 			['password', 'HBEGIN:cipher:AES-128-CFB:keyFormat:password:encoding:binary:HEND'],
 			['hash', 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:encoding:binary:HEND']
 		];


### PR DESCRIPTION
Backport of #38206

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
