### PR TITLE
feat(ocp): Allow sending emails with subject and body

### DIFF
--- a/lib/private/Mail/Message.php
+++ b/lib/private/Mail/Message.php
@@ -207,11 +207,6 @@ class Message implements IMessage {
 		return $this->bcc;
 	}
 
-	/**
-	 * Set the subject of this message.
-	 *
-	 * @return $this
-	 */
 	public function setSubject(string $subject): IMessage {
 		$this->symfonyEmail->subject($subject);
 		return $this;
@@ -224,10 +219,6 @@ class Message implements IMessage {
 		return $this->symfonyEmail->getSubject() ?? '';
 	}
 
-	/**
-	 * Set the plain-text body of this message.
-	 * @return $this
-	 */
 	public function setPlainBody(string $body): IMessage {
 		$this->symfonyEmail->text($body);
 		return $this;
@@ -242,10 +233,6 @@ class Message implements IMessage {
 		return $body;
 	}
 
-	/**
-	 * Set the HTML body of this message. Consider also sending a plain-text body instead of only an HTML one.
-	 * @return $this
-	 */
 	public function setHtmlBody(string $body): IMessage {
 		if (!$this->plainTextOnly) {
 			$this->symfonyEmail->html($body);

--- a/lib/public/Mail/IMessage.php
+++ b/lib/public/Mail/IMessage.php
@@ -33,6 +33,36 @@ namespace OCP\Mail;
  */
 interface IMessage {
 	/**
+	 * Set the subject of this message
+	 *
+	 * @param string $subject
+	 *
+	 * @return self
+	 * @since 28.0.0
+	 */
+	public function setSubject(string $subject): IMessage;
+
+	/**
+	 * Set the plain-text body of this message
+	 *
+	 * @param string $body
+	 *
+	 * @return self
+	 * @since 28.0.0
+	 */
+	public function setPlainBody(string $body): IMessage;
+
+	/**
+	 * Set the HTML body of this message. Consider also sending a plain-text body instead of only an HTML one.
+	 *
+	 * @param string $body
+	 *
+	 * @return self
+	 * @since 28.0.0
+	 */
+	public function setHtmlBody(string $body): IMessage;
+
+	/**
 	 * @param IAttachment $attachment
 	 * @return IMessage
 	 * @since 13.0.0


### PR DESCRIPTION
## Summary

Allows consumers of OCP to set subject and body of emails. 

API flaw discovered while writing https://github.com/nextcloud/documentation/pull/10554.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [x] https://github.com/nextcloud/documentation/pull/10557
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
