### PR TITLE
fix(ocp): Mark IMessage::attachInline as @since 27

### DIFF
--- a/lib/public/Mail/IMessage.php
+++ b/lib/public/Mail/IMessage.php
@@ -47,7 +47,7 @@ interface IMessage {
 	 * @param string|null $contentType MIME Content-Type (e.g. text/plain or text/calendar)
 	 *
 	 * @return IMessage
-	 * @since 26.0.0
+	 * @since 27.0.0
 	 */
 	public function attachInline(string $body, string $name, string $contentType = null): IMessage;
 


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/pull/36118#discussion_r1193077583

## Summary

The PR was merged for 27, not 26.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
