### PR TITLE
fix(caching): Avoid checking existence before fetching

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -126,9 +126,10 @@ class Swift extends \OC\Files\Storage\Common {
 	 * @throws \OCP\Files\StorageNotAvailableException
 	 */
 	private function fetchObject(string $path) {
-		if ($this->objectCache->hasKey($path)) {
+		$cached = $this->objectCache->get($path);
+		if ($cached !== null) {
 			// might be "false" if object did not exist from last check
-			return $this->objectCache->get($path);
+			return $cached;
 		}
 		try {
 			$object = $this->getContainer()->getObject($path);

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -265,8 +265,9 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 
 	private function testRemoteUrl(string $url): bool {
 		$cache = $this->memcacheFactory->createDistributed('files_sharing_remote_url');
-		if ($cache->hasKey($url)) {
-			return (bool)$cache->get($url);
+		$cached = $cache->get($url);
+		if ($cached !== null) {
+			return (bool)$cached;
 		}
 
 		$client = $this->httpClient->newClient();

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -117,8 +117,9 @@ class SharedMount extends MountPoint implements MoveableMount {
 		$this->eventDispatcher->dispatchTyped($event);
 		$parent = $event->getParent();
 
-		if ($folderExistCache->hasKey($parent)) {
-			$parentExists = $folderExistCache->get($parent);
+		$cached = $folderExistCache->get($parent);
+		if ($cached) {
+			$parentExists = $cached;
 		} else {
 			$parentExists = $this->recipientView->is_dir($parent);
 			$folderExistCache->set($parent, $parentExists);

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -795,8 +795,9 @@ class AccountManager implements IAccountManager {
 	}
 
 	public function getAccount(IUser $user): IAccount {
-		if ($this->internalCache->hasKey($user->getUID())) {
-			return $this->internalCache->get($user->getUID());
+		$cached = $this->internalCache->get($user->getUID());
+		if ($cached !== null) {
+			return $cached;
 		}
 		$account = $this->parseAccountData($user, $this->getUser($user));
 		$this->internalCache->set($user->getUID(), $account);


### PR DESCRIPTION
## Summary

Following https://github.com/nextcloud/server/blob/ff661045edd3a796d2a555e5a8d9762eb8ea30fb/lib/public/ICache.php#L59.

The cache might expire between checking for key existence and fetching the value. In this rare case the code continues with a null value when it doesn't expect one.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
