### PR TITLE
chore(ocp)!: Drop \OCP\Util::linkToPublic

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -278,21 +278,6 @@ class Util {
 	}
 
 	/**
-	 * Creates an absolute url for public use
-	 * @param string $service id
-	 * @return string the url
-	 * @since 4.5.0
-	 * @deprecated 15.0.0 - use OCP\IURLGenerator
-	 */
-	public static function linkToPublic($service) {
-		$urlGenerator = \OC::$server->getURLGenerator();
-		if ($service === 'files') {
-			return $urlGenerator->getAbsoluteURL('/s');
-		}
-		return $urlGenerator->getAbsoluteURL($urlGenerator->linkTo('', 'public.php').'?service='.$service);
-	}
-
-	/**
 	 * Returns the server host name without an eventual port number
 	 * @return string the server hostname
 	 * @since 5.0.0


### PR DESCRIPTION
## Summary

Drop unused method deprecated in Nextcloud 15, 2018-12-10.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [x] https://github.com/nextcloud/documentation/pull/10558
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
