### PR TITLE
chore: remove check for suhosin.executor.func.blacklist

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -596,11 +596,6 @@ class Util {
 		if (in_array($functionName, $disabled)) {
 			return false;
 		}
-		$disabled = explode(',', $ini->get('suhosin.executor.func.blacklist') ?: '');
-		$disabled = array_map('trim', $disabled);
-		if (in_array($functionName, $disabled)) {
-			return false;
-		}
 		return true;
 	}
 }


### PR DESCRIPTION
## Summary

Suhosin is/was a PHP extension.
The last release was 2015-05-21.
Suhosin does not support PHP 8.

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
