### PR TITLE
Refactors "strpos" calls in /core to improve code readability.

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -368,9 +368,9 @@ class ClientFlowLoginController extends Controller {
 	private function getServerPath(): string {
 		$serverPostfix = '';
 
-		if (strpos($this->request->getRequestUri(), '/index.php') !== false) {
+		if (str_contains($this->request->getRequestUri(), '/index.php')) {
 			$serverPostfix = substr($this->request->getRequestUri(), 0, strpos($this->request->getRequestUri(), '/index.php'));
-		} elseif (strpos($this->request->getRequestUri(), '/login/flow') !== false) {
+		} elseif (str_contains($this->request->getRequestUri(), '/login/flow')) {
 			$serverPostfix = substr($this->request->getRequestUri(), 0, strpos($this->request->getRequestUri(), '/login/flow'));
 		}
 

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -363,9 +363,9 @@ class ClientFlowLoginV2Controller extends Controller {
 	private function getServerPath(): string {
 		$serverPostfix = '';
 
-		if (strpos($this->request->getRequestUri(), '/index.php') !== false) {
+		if (str_contains($this->request->getRequestUri(), '/index.php')) {
 			$serverPostfix = substr($this->request->getRequestUri(), 0, strpos($this->request->getRequestUri(), '/index.php'));
-		} elseif (strpos($this->request->getRequestUri(), '/login/v2') !== false) {
+		} elseif (str_contains($this->request->getRequestUri(), '/login/v2')) {
 			$serverPostfix = substr($this->request->getRequestUri(), 0, strpos($this->request->getRequestUri(), '/login/v2'));
 		}
 

--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -101,7 +101,7 @@ class CssController extends Controller {
 	private function getFile(ISimpleFolder $folder, string $fileName, bool &$gzip): ISimpleFile {
 		$encoding = $this->request->getHeader('Accept-Encoding');
 
-		if (strpos($encoding, 'gzip') !== false) {
+		if (str_contains($encoding, 'gzip')) {
 			try {
 				$gzip = true;
 				return $folder->getFile($fileName . '.gzip'); # Safari doesn't like .gz

--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -99,7 +99,7 @@ class JsController extends Controller {
 	private function getFile(ISimpleFolder $folder, string $fileName, bool &$gzip): ISimpleFile {
 		$encoding = $this->request->getHeader('Accept-Encoding');
 
-		if (strpos($encoding, 'gzip') !== false) {
+		if (str_contains($encoding, 'gzip')) {
 			try {
 				$gzip = true;
 				return $folder->getFile($fileName . '.gzip'); # Safari doesn't like .gz

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -275,7 +275,7 @@ class LoginController extends Controller {
 			$location = $this->urlGenerator->getAbsoluteURL($redirectUrl);
 			// Deny the redirect if the URL contains a @
 			// This prevents unvalidated redirects like ?redirect_url=:user@domain.com
-			if (strpos($location, '@') === false) {
+			if (!str_contains($location, '@')) {
 				return new RedirectResponse($location);
 			}
 		}

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -94,10 +94,10 @@ class NavigationController extends OCSController {
 	 */
 	private function rewriteToAbsoluteUrls(array $navigation): array {
 		foreach ($navigation as &$entry) {
-			if (0 !== strpos($entry['href'], $this->urlGenerator->getBaseUrl())) {
+			if (!str_starts_with($entry['href'], $this->urlGenerator->getBaseUrl())) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
-			if (0 !== strpos($entry['icon'], $this->urlGenerator->getBaseUrl())) {
+			if (!str_starts_with($entry['icon'], $this->urlGenerator->getBaseUrl())) {
 				$entry['icon'] = $this->urlGenerator->getAbsoluteURL($entry['icon']);
 			}
 		}

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -44,7 +44,7 @@ use OC\Repair\Events\RepairStartEvent;
 use OC\Repair\Events\RepairStepEvent;
 use OC\Repair\Events\RepairWarningEvent;
 
-if (strpos(@ini_get('disable_functions'), 'set_time_limit') === false) {
+if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
 	@set_time_limit(0);
 }
 


### PR DESCRIPTION
## Summary
Following #38261 and #38260, I have replaced `strpos` calls in `/core` namespace as well.
