### PR TITLE
Refactors "strpos" calls in /apps/comments

### DIFF
--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -182,7 +182,7 @@ class Provider implements IProvider {
 				}
 
 				$message = str_replace('@"' . $mention['id'] . '"', '{mention' . $mentionCount . '}', $message);
-				if (strpos($mention['id'], ' ') === false && strpos($mention['id'], 'guest/') !== 0) {
+				if (!str_contains($mention['id'], ' ') && !str_starts_with($mention['id'], 'guest/')) {
 					$message = str_replace('@' . $mention['id'], '{mention' . $mentionCount . '}', $message);
 				}
 

--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -118,7 +118,7 @@ class Notifier implements INotifier {
 				$node = $nodes[0];
 
 				$path = rtrim($node->getPath(), '/');
-				if (strpos($path, '/' . $notification->getUser() . '/files/') === 0) {
+				if (str_starts_with($path, '/' . $notification->getUser() . '/files/')) {
 					// Remove /user/files/...
 					$fullPath = $path;
 					[,,, $path] = explode('/', $fullPath, 4);
@@ -182,7 +182,7 @@ class Notifier implements INotifier {
 			// index of the mentions of that type.
 			$mentionParameterId = 'mention-' . $mention['type'] . $mentionTypeCount[$mention['type']];
 			$message = str_replace('@"' . $mention['id'] . '"', '{' . $mentionParameterId . '}', $message);
-			if (strpos($mention['id'], ' ') === false && strpos($mention['id'], 'guest/') !== 0) {
+			if (!str_contains($mention['id'], ' ') && !str_starts_with($mention['id'], 'guest/')) {
 				$message = str_replace('@' . $mention['id'], '{' . $mentionParameterId . '}', $message);
 			}
 


### PR DESCRIPTION
## Summary
Following https://github.com/nextcloud/server/pull/38261 and https://github.com/nextcloud/server/pull/38260, I have replaced `strpos` calls in `/apps/comments` namespace as well to improve code readability.