### PR TITLE
fix(storage): fallback to copy and unlink when rename fails

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -335,7 +335,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$srcParent = dirname($source);
 		$dstParent = dirname($target);
 
@@ -361,21 +361,14 @@ class Local extends \OC\Files\Storage\Common {
 		}
 
 		if ($this->is_dir($source)) {
-			// we can't move folders across devices, use copy instead
-			$stat1 = stat(dirname($this->getSourcePath($source)));
-			$stat2 = stat(dirname($this->getSourcePath($target)));
-			if ($stat1['dev'] !== $stat2['dev']) {
-				$result = $this->copy($source, $target);
-				if ($result) {
-					$result &= $this->rmdir($source);
-				}
-				return $result;
-			}
-
 			$this->checkTreeForForbiddenItems($this->getSourcePath($source));
 		}
 
-		return rename($this->getSourcePath($source), $this->getSourcePath($target));
+		if (@rename($this->getSourcePath($source), $this->getSourcePath($target))) {
+			return true;
+		}
+
+		return $this->copy($source, $target) && $this->rmdir($source);
 	}
 
 	public function copy($source, $target) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/14743
* Resolves: https://github.com/nextcloud/server/issues/38569

## Summary

Alternative approach to https://github.com/nextcloud/server/pull/19289 

If you use docker's OverlayFS and mount two folders into your container from the same disk it's also not possible to rename, but `$stat['dev']` is equal.[^1]

Many thanks again to @kubatek94 for the initial pull request.

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)


[^1]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
