### PR TITLE
fix: do not fetch LDAP display name all the time

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -461,7 +461,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	/**
 	 * get display name of the user
 	 * @param string $uid user ID of the user
-	 * @return string|false display name
+	 * @return ?string|false display name
 	 */
 	public function getDisplayName($uid) {
 		if ($this->userPluginManager->implementsActions(Backend::GET_DISPLAYNAME)) {
@@ -472,44 +472,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 			return false;
 		}
 
-		$cacheKey = 'getDisplayName'.$uid;
-		if (!is_null($displayName = $this->access->connection->getFromCache($cacheKey))) {
-			return $displayName;
-		}
-
-		//Check whether the display name is configured to have a 2nd feature
-		$additionalAttribute = $this->access->connection->ldapUserDisplayName2;
-		$displayName2 = '';
-		if ($additionalAttribute !== '') {
-			$displayName2 = $this->access->readAttribute(
-				$this->access->username2dn($uid),
-				$additionalAttribute);
-		}
-
-		$displayName = $this->access->readAttribute(
-			$this->access->username2dn($uid),
-			$this->access->connection->ldapUserDisplayName);
-
-		if ($displayName && (count($displayName) > 0)) {
-			$displayName = $displayName[0];
-
-			if (is_array($displayName2)) {
-				$displayName2 = count($displayName2) > 0 ? $displayName2[0] : '';
-			}
-
-			$user = $this->access->userManager->get($uid);
-			if ($user instanceof User) {
-				$displayName = $user->composeAndStoreDisplayName($displayName, $displayName2);
-				$this->access->connection->writeToCache($cacheKey, $displayName);
-			}
-			if ($user instanceof OfflineUser) {
-				/** @var OfflineUser $user*/
-				$displayName = $user->getDisplayName();
-			}
-			return $displayName;
-		}
-
-		return null;
+		return $this->ocConfig->getUserValue($uid, 'user_ldap', 'displayName', null);
 	}
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -145,7 +145,7 @@ class User implements IUser {
 			if (!empty($displayName)) {
 				$this->displayName = $displayName;
 			} else {
-				$this->displayName = $this->uid;
+				return $this->uid;
 			}
 		}
 		return $this->displayName;


### PR DESCRIPTION
## Summary

- use cache and rely on background update mechanism
- with ajax cron it will still run
- core User must not cache uid as displayname to address edge case (early announcement with displayname not ready). Also, the 98% case is that a displayname is set, I think.

One one hand this targets a theoretical/rare edge case, where the Accounts Manager would attempt to insert a row, and in the process fetches the display name, upon with a change would also insert the same row, ending in a database exception.

On the other hand, this removes a lot of LDAP requests only looking for the displayname. Like with the email address, this value would be only updated twice a day in the background and upon login (unless ajax is used as background job, then updates will happen always, which is slowing doing responsiveness).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
