### PR TITLE
fix: expect interface, not a specific implementation

### DIFF
--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -26,15 +26,14 @@
 namespace OC\Files\Cache;
 
 use OC\Files\Cache\Wrapper\CacheJail;
-use OC\Files\Node\Root;
 use OC\Files\Search\QueryOptimizer\QueryOptimizer;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
-use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchQuery;
@@ -198,7 +197,7 @@ class QuerySearchHelper {
 	/**
 	 * @return array{array<string, ICache>, array<string, IMountPoint>}
 	 */
-	public function getCachesAndMountPointsForSearch(Root $root, string $path, bool $limitToHome = false): array {
+	public function getCachesAndMountPointsForSearch(IRootFolder $root, string $path, bool $limitToHome = false): array {
 		$rootLength = strlen($path);
 		$mount = $root->getMount($path);
 		$storage = $mount->getStorage();

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -199,12 +199,8 @@ class QuerySearchHelper {
 	 */
 	public function getCachesAndMountPointsForSearch(IRootFolder $root, string $path, bool $limitToHome = false): array {
 		$rootLength = strlen($path);
-		$storage = null;
-		if (method_exists($root, 'getMount')) {
-			/** @var IMountPoint $mount */
-			$mount = $root->getMount($path);
-			$storage = $mount->getStorage();
-		}
+		$mount = $root->getMount($path);
+		$storage = $mount->getStorage();
 		if ($storage === null) {
 			return [];
 		}
@@ -221,8 +217,7 @@ class QuerySearchHelper {
 		/** @var IMountPoint[] $mountByMountPoint */
 		$mountByMountPoint = ['' => $mount];
 
-		if (!$limitToHome && method_exists($root, 'getMountsIn')) {
-			/** @var IMountPoint[] $mounts */
+		if (!$limitToHome) {
 			$mounts = $root->getMountsIn($path);
 			foreach ($mounts as $mount) {
 				$storage = $mount->getStorage();

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -143,9 +143,6 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		return $this->path;
 	}
 
-	/**
-	 * @return \OCP\Files\Storage
-	 */
 	public function getStorage() {
 		return $this->storage;
 	}

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -40,6 +40,7 @@ use OC\Files\Utils\PathHelper;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node as INode;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Search\ISearchBinaryOperator;
@@ -109,12 +110,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		}, $folderContent);
 	}
 
-	/**
-	 * @param string $path
-	 * @param FileInfo $info
-	 * @return File|Folder
-	 */
-	protected function createNode($path, FileInfo $info = null, bool $infoHasSubMountsIncluded = true) {
+	protected function createNode(string $path, ?FileInfo $info = null, bool $infoHasSubMountsIncluded = true): INode {
 		if (is_null($info)) {
 			$isDir = $this->view->is_dir($path);
 		} else {
@@ -330,6 +326,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return array
 	 */
 	protected function getByIdInRootMount(int $id): array {
+		if (!method_exists($this->root, 'createNode')) {
+			// Always expected to be false. Being a method of Folder, this is
+			// always implemented. For it is an internal method and should not
+			// be exposed and made public, it is not part of an interface.
+			return [];
+		}
 		$mount = $this->root->getMount('');
 		$storage = $mount->getStorage();
 		$cacheEntry = $storage?->getCache($this->path)->get($id);
@@ -385,7 +387,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	/**
 	 * @param int $limit
 	 * @param int $offset
-	 * @return \OCP\Files\Node[]
+	 * @return INode[]
 	 */
 	public function getRecent($limit, $offset = 0) {
 		$filterOutNonEmptyFolder = new SearchBinaryOperator(

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -330,12 +330,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return array
 	 */
 	protected function getByIdInRootMount(int $id): array {
-		$storage = null;
-		if (\method_exists($this->root, 'getMount')) {
-			/** @var IMountPoint $mount */
-			$mount = $this->root->getMount('');
-			$storage = $mount->getStorage();
-		}
+		$mount = $this->root->getMount('');
+		$storage = $mount->getStorage();
 		$cacheEntry = $storage?->getCache($this->path)->get($id);
 		if (!$cacheEntry) {
 			return [];

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -330,8 +330,13 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @return array
 	 */
 	protected function getByIdInRootMount(int $id): array {
-		$mount = $this->root->getMount('');
-		$cacheEntry = $mount->getStorage()->getCache($this->path)->get($id);
+		$storage = null;
+		if (\method_exists($this->root, 'getMount')) {
+			/** @var IMountPoint $mount */
+			$mount = $this->root->getMount('');
+			$storage = $mount->getStorage();
+		}
+		$cacheEntry = $storage?->getCache($this->path)->get($id);
 		if (!$cacheEntry) {
 			return [];
 		}
@@ -346,7 +351,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		return [$this->root->createNode(
 			$absolutePath, new \OC\Files\FileInfo(
 				$absolutePath,
-				$mount->getStorage(),
+				$storage,
 				$cacheEntry->getPath(),
 				$cacheEntry,
 				$mount

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -29,6 +29,7 @@ namespace OC\Files\Node;
 use OC\Files\Utils\PathHelper;
 use OCP\Files\Folder;
 use OCP\Constants;
+use OCP\Files\Mount\IMountPoint;
 
 /**
  * Class LazyFolder
@@ -111,14 +112,14 @@ class LazyFolder implements Folder {
 	/**
 	 * @inheritDoc
 	 */
-	public function getMount($mountPoint) {
+	public function getMount(string $mountPoint): IMountPoint {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
 	/**
-	 * @inheritDoc
+	 * @return IMountPoint[]
 	 */
-	public function getMountsIn($mountPoint) {
+	public function getMountsIn(string $mountPoint): array {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -34,6 +34,7 @@ use OC\Files\Mount\MoveableMount;
 use OC\Files\Utils\PathHelper;
 use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
+use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Lock\LockedException;
@@ -47,10 +48,7 @@ class Node implements \OCP\Files\Node {
 	 */
 	protected $view;
 
-	/**
-	 * @var \OC\Files\Node\Root $root
-	 */
-	protected $root;
+	protected IRootFolder $root;
 
 	/**
 	 * @var string $path Absolute path to the node (e.g. /admin/files/folder/file)
@@ -72,7 +70,7 @@ class Node implements \OCP\Files\Node {
 	 * @param string $path
 	 * @param FileInfo $fileInfo
 	 */
-	public function __construct($root, $view, $path, $fileInfo = null, ?Node $parent = null, bool $infoHasSubMountsIncluded = true) {
+	public function __construct(IRootFolder $root, $view, $path, $fileInfo = null, ?Node $parent = null, bool $infoHasSubMountsIncluded = true) {
 		if (Filesystem::normalizePath($view->getRoot()) !== '/') {
 			throw new PreConditionNotMetException('The view passed to the node should not have any fake root set');
 		}
@@ -402,7 +400,7 @@ class Node implements \OCP\Files\Node {
 
 	/**
 	 * @param string $targetPath
-	 * @return \OC\Files\Node\Node
+	 * @return \OCP\Files\Node
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException if copy not allowed or failed
@@ -428,7 +426,7 @@ class Node implements \OCP\Files\Node {
 
 	/**
 	 * @param string $targetPath
-	 * @return \OC\Files\Node\Node
+	 * @return \OCP\Files\Node
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException if move not allowed or failed

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -45,6 +45,7 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node as INode;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IUser;
@@ -339,10 +340,9 @@ class Root extends Folder implements IRootFolder {
 	}
 
 	/**
-	 * @return Node
 	 * @throws \OCP\Files\NotFoundException
 	 */
-	public function getParent() {
+	public function getParent(): INode|IRootFolder {
 		throw new NotFoundException();
 	}
 

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -154,11 +154,7 @@ class Root extends Folder implements IRootFolder {
 		$this->mountManager->addMount($mount);
 	}
 
-	/**
-	 * @param string $mountPoint
-	 * @return \OC\Files\Mount\MountPoint
-	 */
-	public function getMount($mountPoint) {
+	public function getMount(string $mountPoint): IMountPoint {
 		return $this->mountManager->find($mountPoint);
 	}
 
@@ -166,7 +162,7 @@ class Root extends Folder implements IRootFolder {
 	 * @param string $mountPoint
 	 * @return \OC\Files\Mount\MountPoint[]
 	 */
-	public function getMountsIn($mountPoint) {
+	public function getMountsIn(string $mountPoint): array {
 		return $this->mountManager->findIn($mountPoint);
 	}
 

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -26,6 +26,7 @@ namespace OCP\Files;
 
 use OC\Hooks\Emitter;
 use OC\User\NoUserException;
+use OCP\Files\Mount\IMountPoint;
 
 /**
  * Interface IRootFolder
@@ -55,4 +56,16 @@ interface IRootFolder extends Folder, Emitter {
 	 * @since 24.0.0
 	 */
 	public function getByIdInPath(int $id, string $path);
+
+	/**
+	 * @return IMountPoint[]
+	 *
+	 * @since 28.0.0
+	 */
+	public function getMountsIn(string $mountPoint): array;
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getMount(string $mountPoint): IMountPoint;
 }

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -24,6 +24,7 @@ use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Jail;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\Search\ISearchComparison;
@@ -462,12 +463,13 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testIsSubNode() {
-		$file = new Node(null, $this->view, '/foo/bar');
-		$folder = new Folder(null, $this->view, '/foo');
+		$rootFolderMock = $this->createMock(IRootFolder::class);
+		$file = new Node($rootFolderMock, $this->view, '/foo/bar');
+		$folder = new Folder($rootFolderMock, $this->view, '/foo');
 		$this->assertTrue($folder->isSubNode($file));
 		$this->assertFalse($folder->isSubNode($folder));
 
-		$file = new Node(null, $this->view, '/foobar');
+		$file = new Node($rootFolderMock, $this->view, '/foobar');
 		$this->assertFalse($folder->isSubNode($file));
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/owncloud/music/issues/1068

## Summary

- fixes a regression when deleting folders while music app was enabled, for a LazyRoot was passed to this method.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
