### PR TITLE
feat: set background = backgroundColor via occ

### DIFF
--- a/apps/theming/lib/Command/UpdateConfig.php
+++ b/apps/theming/lib/Command/UpdateConfig.php
@@ -111,6 +111,11 @@ class UpdateConfig extends Command {
 			return 0;
 		}
 
+		if ($key === 'background' && $value === 'backgroundColor') {
+			$this->themingDefaults->undo($key);
+			$key = $key . 'Mime';
+		}
+
 		if (in_array($key, ImageManager::SUPPORTED_IMAGE_KEYS, true)) {
 			if (strpos($value, '/') !== 0) {
 				$output->writeln('<error>The image file needs to be provided as an absolute path: ' . $value . '.</error>');


### PR DESCRIPTION
## Summary

Before:

```shell
$ occ theming:config background backgroundColor
The image file needs to be provided as an absolute path: backgroundColor.
```

After:

```shell
$ occ theming:config background backgroundColor       
Updated backgroundMime to backgroundColor

```

## TODO

- [ ] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
