### PR TITLE
fix: install vfsStream to run testMimeTypeIcon again

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -228,6 +228,7 @@ steps:
   image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
   commands:
     - bash tests/drone-run-php-tests.sh || exit 0
+    - composer install --working-dir=build/integration
     - NOCOVERAGE=true TEST_SELECTION=NODB ./autotest.sh sqlite
 
 services:

--- a/build/integration/composer.json
+++ b/build/integration/composer.json
@@ -6,6 +6,7 @@
     "guzzlehttp/guzzle": "7.6.1",
     "jarnaiz/behat-junit-formatter": "^1.3",
     "sabre/dav": "4.4.0",
-    "symfony/event-dispatcher": "~5.3"
+    "symfony/event-dispatcher": "~5.3",
+    "mikey179/vfsstream": "^1.6"
   }
 }

--- a/build/integration/composer.lock
+++ b/build/integration/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f70730fd3a96421a6eb98ceded7ce71",
+    "content-hash": "fc14ec29883127d72d5151bb492db619",
     "packages": [],
     "packages-dev": [
         {
@@ -688,6 +688,57 @@
                 "source": "https://github.com/j-arnaiz/behat-junit-formatter/tree/master"
             },
             "time": "2016-01-26T17:05:07+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2022-02-23T02:02:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -135,6 +135,7 @@ class DetectionTest extends \Test\TestCase {
 		if (!class_exists('org\\bovigo\\vfs\\vfsStream')) {
 			$this->markTestSkipped('Package vfsStream not installed');
 		}
+
 		$confDir = \org\bovigo\vfs\vfsStream::setup();
 		$mimetypealiases_dist = \org\bovigo\vfs\vfsStream::newFile('mimetypealiases.dist.json')->at($confDir);
 
@@ -157,7 +158,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder.svg'))
 			->willReturn('folder.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());
@@ -176,7 +177,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-shared.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-shared.svg'))
 			->willReturn('folder-shared.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());
@@ -196,7 +197,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-external.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/folder-external.svg'))
 			->willReturn('folder-external.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());
@@ -216,7 +217,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/my-type.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/my-type.svg'))
 			->willReturn('my-type.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());
@@ -237,12 +238,12 @@ class DetectionTest extends \Test\TestCase {
 		$urlGenerator->expects($this->exactly(2))
 			->method('imagePath')
 			->withConsecutive(
-				[$this->equalTo('core'), $this->equalTo('filetypes/my-type.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/my.png')]
+				[$this->equalTo('core'), $this->equalTo('filetypes/my-type.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/my.svg')]
 			)
 			->willReturnCallback(
 				function ($appName, $file) {
-					if ($file === 'filetypes/my.png') {
+					if ($file === 'filetypes/my.svg') {
 						return 'my.svg';
 					}
 					throw new \RuntimeException();
@@ -267,13 +268,13 @@ class DetectionTest extends \Test\TestCase {
 		$urlGenerator->expects($this->exactly(3))
 			->method('imagePath')
 			->withConsecutive(
-				[$this->equalTo('core'), $this->equalTo('filetypes/foo-bar.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/foo.png')],
-				[$this->equalTo('core'), $this->equalTo('filetypes/file.png')]
+				[$this->equalTo('core'), $this->equalTo('filetypes/foo-bar.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/foo.svg')],
+				[$this->equalTo('core'), $this->equalTo('filetypes/file.svg')]
 			)
 			->willReturnCallback(
 				function ($appName, $file) {
-					if ($file === 'filetypes/file.png') {
+					if ($file === 'filetypes/file.svg') {
 						return 'file.svg';
 					}
 					throw new \RuntimeException();
@@ -296,7 +297,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/foo-bar.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/foo-bar.svg'))
 			->willReturn('foo-bar.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());
@@ -322,7 +323,7 @@ class DetectionTest extends \Test\TestCase {
 		//Only call the url generator once
 		$urlGenerator->expects($this->once())
 			->method('imagePath')
-			->with($this->equalTo('core'), $this->equalTo('filetypes/foobar-baz.png'))
+			->with($this->equalTo('core'), $this->equalTo('filetypes/foobar-baz.svg'))
 			->willReturn('foobar-baz.svg');
 
 		$detection = new Detection($urlGenerator, $logger, $confDir->url(), $confDir->url());


### PR DESCRIPTION
## Summary

I had in mind to use vfsStream to write a unit test for CacheMountProvider. 

DetectionTest.testMimeTypeIcon is using vfsStream.
https://github.com/nextcloud/server/commit/11be3d6276b7d54ccb166c9ea418e4e54c5eef57#diff-3502da4abe2721c4106a1bd15f035a4d0a9197e27899a0d73f9cac18adb323c8 broke the test.

I cannot say if we need the test. It did not run for at least 7 years :see_no_evil: 



## TODO

- [ ] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
