### PR TITLE
[1/3] Refactors /core controllers using constructor property promotion.

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -45,11 +45,12 @@ class AppPasswordController extends \OCP\AppFramework\OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-								private ISession $session,
-								private ISecureRandom $random,
-								private IProvider $tokenProvider,
-								private IStore $credentialStore,
-								private IEventDispatcher $eventDispatcher) {
+		private ISession $session,
+		private ISecureRandom $random,
+		private IProvider $tokenProvider,
+		private IStore $credentialStore,
+		private IEventDispatcher $eventDispatcher,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -42,8 +42,9 @@ use OCP\ISession;
 use OCP\Security\ISecureRandom;
 
 class AppPasswordController extends \OCP\AppFramework\OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
+	public function __construct(
+		string $appName,
+		IRequest $request,
 								private ISession $session,
 								private ISecureRandom $random,
 								private IProvider $tokenProvider,

--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -42,26 +42,14 @@ use OCP\ISession;
 use OCP\Security\ISecureRandom;
 
 class AppPasswordController extends \OCP\AppFramework\OCSController {
-	private ISession $session;
-	private ISecureRandom $random;
-	private IProvider $tokenProvider;
-	private IStore $credentialStore;
-	private IEventDispatcher $eventDispatcher;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								ISession $session,
-								ISecureRandom $random,
-								IProvider $tokenProvider,
-								IStore $credentialStore,
-								IEventDispatcher $eventDispatcher) {
+								private ISession $session,
+								private ISecureRandom $random,
+								private IProvider $tokenProvider,
+								private IStore $credentialStore,
+								private IEventDispatcher $eventDispatcher) {
 		parent::__construct($appName, $request);
-
-		$this->session = $session;
-		$this->random = $random;
-		$this->tokenProvider = $tokenProvider;
-		$this->credentialStore = $credentialStore;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**

--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -40,11 +40,13 @@ use OCP\IRequest;
 use OCP\Share\IShare;
 
 class AutoCompleteController extends OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private ISearch $collaboratorSearch,
-								private IManager $autoCompleteManager,
-								private IEventDispatcher $dispatcher) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ISearch $collaboratorSearch,
+		private IManager $autoCompleteManager,
+		private IEventDispatcher $dispatcher,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -40,20 +40,12 @@ use OCP\IRequest;
 use OCP\Share\IShare;
 
 class AutoCompleteController extends OCSController {
-	private ISearch $collaboratorSearch;
-	private IManager $autoCompleteManager;
-	private IEventDispatcher $dispatcher;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								ISearch $collaboratorSearch,
-								IManager $autoCompleteManager,
-								IEventDispatcher $dispatcher) {
+								private ISearch $collaboratorSearch,
+								private IManager $autoCompleteManager,
+								private IEventDispatcher $dispatcher) {
 		parent::__construct($appName, $request);
-
-		$this->collaboratorSearch = $collaboratorSearch;
-		$this->autoCompleteManager = $autoCompleteManager;
-		$this->dispatcher = $dispatcher;
 	}
 
 	/**

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -51,16 +51,18 @@ use Psr\Log\LoggerInterface;
  * @package OC\Core\Controller
  */
 class AvatarController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								protected IAvatarManager $avatarManager,
-								protected ICache $cache,
-								protected IL10N $l10n,
-								protected IUserManager $userManager,
-								protected IRootFolder $rootFolder,
-								protected LoggerInterface $logger,
-								protected ?string $userId,
-								protected TimeFactory $timeFactory) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		protected IAvatarManager $avatarManager,
+		protected ICache $cache,
+		protected IL10N $l10n,
+		protected IUserManager $userManager,
+		protected IRootFolder $rootFolder,
+		protected LoggerInterface $logger,
+		protected ?string $userId,
+		protected TimeFactory $timeFactory,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -43,7 +43,6 @@ use OCP\ICache;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserManager;
-use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -52,36 +51,17 @@ use Psr\Log\LoggerInterface;
  * @package OC\Core\Controller
  */
 class AvatarController extends Controller {
-	protected IAvatarManager $avatarManager;
-	protected ICache $cache;
-	protected IL10N $l;
-	protected IUserManager $userManager;
-	protected IUserSession $userSession;
-	protected IRootFolder $rootFolder;
-	protected LoggerInterface $logger;
-	protected ?string $userId;
-	protected TimeFactory $timeFactory;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								IAvatarManager $avatarManager,
-								ICache $cache,
-								IL10N $l10n,
-								IUserManager $userManager,
-								IRootFolder $rootFolder,
-								LoggerInterface $logger,
-								?string $userId,
-								TimeFactory $timeFactory) {
+								protected IAvatarManager $avatarManager,
+								protected ICache $cache,
+								protected IL10N $l10n,
+								protected IUserManager $userManager,
+								protected IRootFolder $rootFolder,
+								protected LoggerInterface $logger,
+								protected ?string $userId,
+								protected TimeFactory $timeFactory) {
 		parent::__construct($appName, $request);
-
-		$this->avatarManager = $avatarManager;
-		$this->cache = $cache;
-		$this->l = $l10n;
-		$this->userManager = $userManager;
-		$this->rootFolder = $rootFolder;
-		$this->logger = $logger;
-		$this->userId = $userId;
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**
@@ -173,18 +153,18 @@ class AvatarController extends Controller {
 			/** @var File $node */
 			$node = $userFolder->get($path);
 			if (!($node instanceof File)) {
-				return new JSONResponse(['data' => ['message' => $this->l->t('Please select a file.')]]);
+				return new JSONResponse(['data' => ['message' => $this->l10n->t('Please select a file.')]]);
 			}
 			if ($node->getSize() > 20 * 1024 * 1024) {
 				return new JSONResponse(
-					['data' => ['message' => $this->l->t('File is too big')]],
+					['data' => ['message' => $this->l10n->t('File is too big')]],
 					Http::STATUS_BAD_REQUEST
 				);
 			}
 
 			if ($node->getMimeType() !== 'image/jpeg' && $node->getMimeType() !== 'image/png') {
 				return new JSONResponse(
-					['data' => ['message' => $this->l->t('The selected file is not an image.')]],
+					['data' => ['message' => $this->l10n->t('The selected file is not an image.')]],
 					Http::STATUS_BAD_REQUEST
 				);
 			}
@@ -193,7 +173,7 @@ class AvatarController extends Controller {
 				$content = $node->getContent();
 			} catch (\OCP\Files\NotPermittedException $e) {
 				return new JSONResponse(
-					['data' => ['message' => $this->l->t('The selected file cannot be read.')]],
+					['data' => ['message' => $this->l10n->t('The selected file cannot be read.')]],
 					Http::STATUS_BAD_REQUEST
 				);
 			}
@@ -205,7 +185,7 @@ class AvatarController extends Controller {
 			) {
 				if ($files['size'][0] > 20 * 1024 * 1024) {
 					return new JSONResponse(
-						['data' => ['message' => $this->l->t('File is too big')]],
+						['data' => ['message' => $this->l10n->t('File is too big')]],
 						Http::STATUS_BAD_REQUEST
 					);
 				}
@@ -214,16 +194,16 @@ class AvatarController extends Controller {
 				unlink($files['tmp_name'][0]);
 			} else {
 				$phpFileUploadErrors = [
-					UPLOAD_ERR_OK => $this->l->t('The file was uploaded'),
-					UPLOAD_ERR_INI_SIZE => $this->l->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
-					UPLOAD_ERR_FORM_SIZE => $this->l->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
-					UPLOAD_ERR_PARTIAL => $this->l->t('The file was only partially uploaded'),
-					UPLOAD_ERR_NO_FILE => $this->l->t('No file was uploaded'),
-					UPLOAD_ERR_NO_TMP_DIR => $this->l->t('Missing a temporary folder'),
-					UPLOAD_ERR_CANT_WRITE => $this->l->t('Could not write file to disk'),
-					UPLOAD_ERR_EXTENSION => $this->l->t('A PHP extension stopped the file upload'),
+					UPLOAD_ERR_OK => $this->l10n->t('The file was uploaded'),
+					UPLOAD_ERR_INI_SIZE => $this->l10n->t('The uploaded file exceeds the upload_max_filesize directive in php.ini'),
+					UPLOAD_ERR_FORM_SIZE => $this->l10n->t('The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form'),
+					UPLOAD_ERR_PARTIAL => $this->l10n->t('The file was only partially uploaded'),
+					UPLOAD_ERR_NO_FILE => $this->l10n->t('No file was uploaded'),
+					UPLOAD_ERR_NO_TMP_DIR => $this->l10n->t('Missing a temporary folder'),
+					UPLOAD_ERR_CANT_WRITE => $this->l10n->t('Could not write file to disk'),
+					UPLOAD_ERR_EXTENSION => $this->l10n->t('A PHP extension stopped the file upload'),
 				];
-				$message = $phpFileUploadErrors[$files['error'][0]] ?? $this->l->t('Invalid file provided');
+				$message = $phpFileUploadErrors[$files['error'][0]] ?? $this->l10n->t('Invalid file provided');
 				$this->logger->warning($message, ['app' => 'core']);
 				return new JSONResponse(
 					['data' => ['message' => $message]],
@@ -233,7 +213,7 @@ class AvatarController extends Controller {
 		} else {
 			//Add imgfile
 			return new JSONResponse(
-				['data' => ['message' => $this->l->t('No image or file provided')]],
+				['data' => ['message' => $this->l10n->t('No image or file provided')]],
 				Http::STATUS_BAD_REQUEST
 			);
 		}
@@ -248,7 +228,7 @@ class AvatarController extends Controller {
 				$mimeType = $image->mimeType();
 				if ($mimeType !== 'image/jpeg' && $mimeType !== 'image/png') {
 					return new JSONResponse(
-						['data' => ['message' => $this->l->t('Unknown filetype')]],
+						['data' => ['message' => $this->l10n->t('Unknown filetype')]],
 						Http::STATUS_OK
 					);
 				}
@@ -262,7 +242,7 @@ class AvatarController extends Controller {
 						return new JSONResponse(['status' => 'success']);
 					} catch (\Throwable $e) {
 						$this->logger->error($e->getMessage(), ['exception' => $e, 'app' => 'core']);
-						return new JSONResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
+						return new JSONResponse(['data' => ['message' => $this->l10n->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
 					}
 				}
 
@@ -273,13 +253,13 @@ class AvatarController extends Controller {
 				);
 			} else {
 				return new JSONResponse(
-					['data' => ['message' => $this->l->t('Invalid image')]],
+					['data' => ['message' => $this->l10n->t('Invalid image')]],
 					Http::STATUS_OK
 				);
 			}
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e, 'app' => 'core']);
-			return new JSONResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_OK);
+			return new JSONResponse(['data' => ['message' => $this->l10n->t('An error occurred. Please contact your admin.')]], Http::STATUS_OK);
 		}
 	}
 
@@ -293,7 +273,7 @@ class AvatarController extends Controller {
 			return new JSONResponse();
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e, 'app' => 'core']);
-			return new JSONResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
+			return new JSONResponse(['data' => ['message' => $this->l10n->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
 		}
 	}
 
@@ -306,7 +286,7 @@ class AvatarController extends Controller {
 		$tmpAvatar = $this->cache->get('tmpAvatar');
 		if (is_null($tmpAvatar)) {
 			return new JSONResponse(['data' => [
-				'message' => $this->l->t("No temporary profile picture available, try again")
+				'message' => $this->l10n->t("No temporary profile picture available, try again")
 			]],
 				Http::STATUS_NOT_FOUND);
 		}
@@ -330,19 +310,19 @@ class AvatarController extends Controller {
 	 */
 	public function postCroppedAvatar(?array $crop = null): JSONResponse {
 		if (is_null($crop)) {
-			return new JSONResponse(['data' => ['message' => $this->l->t("No crop data provided")]],
+			return new JSONResponse(['data' => ['message' => $this->l10n->t("No crop data provided")]],
 				Http::STATUS_BAD_REQUEST);
 		}
 
 		if (!isset($crop['x'], $crop['y'], $crop['w'], $crop['h'])) {
-			return new JSONResponse(['data' => ['message' => $this->l->t("No valid crop data provided")]],
+			return new JSONResponse(['data' => ['message' => $this->l10n->t("No valid crop data provided")]],
 				Http::STATUS_BAD_REQUEST);
 		}
 
 		$tmpAvatar = $this->cache->get('tmpAvatar');
 		if (is_null($tmpAvatar)) {
 			return new JSONResponse(['data' => [
-				'message' => $this->l->t("No temporary profile picture available, try again")
+				'message' => $this->l10n->t("No temporary profile picture available, try again")
 			]],
 				Http::STATUS_BAD_REQUEST);
 		}
@@ -357,11 +337,11 @@ class AvatarController extends Controller {
 			$this->cache->remove('tmpAvatar');
 			return new JSONResponse(['status' => 'success']);
 		} catch (\OC\NotSquareException $e) {
-			return new JSONResponse(['data' => ['message' => $this->l->t('Crop is not square')]],
+			return new JSONResponse(['data' => ['message' => $this->l10n->t('Crop is not square')]],
 				Http::STATUS_BAD_REQUEST);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e, 'app' => 'core']);
-			return new JSONResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
+			return new JSONResponse(['data' => ['message' => $this->l10n->t('An error occurred. Please contact your admin.')]], Http::STATUS_BAD_REQUEST);
 		}
 	}
 }

--- a/core/Controller/CSRFTokenController.php
+++ b/core/Controller/CSRFTokenController.php
@@ -33,9 +33,11 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class CSRFTokenController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private CsrfTokenManager $tokenManager) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private CsrfTokenManager $tokenManager,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/CSRFTokenController.php
+++ b/core/Controller/CSRFTokenController.php
@@ -33,12 +33,10 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class CSRFTokenController extends Controller {
-	private CsrfTokenManager $tokenManager;
-
-	public function __construct(string $appName, IRequest $request,
-		CsrfTokenManager $tokenManager) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private CsrfTokenManager $tokenManager) {
 		parent::__construct($appName, $request);
-		$this->tokenManager = $tokenManager;
 	}
 
 	/**

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -57,45 +57,22 @@ use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
 class ClientFlowLoginController extends Controller {
-	private IUserSession $userSession;
-	private IL10N $l10n;
-	private Defaults $defaults;
-	private ISession $session;
-	private IProvider $tokenProvider;
-	private ISecureRandom $random;
-	private IURLGenerator $urlGenerator;
-	private ClientMapper $clientMapper;
-	private AccessTokenMapper $accessTokenMapper;
-	private ICrypto $crypto;
-	private IEventDispatcher $eventDispatcher;
-
 	public const STATE_NAME = 'client.flow.state.token';
 
 	public function __construct(string $appName,
 								IRequest $request,
-								IUserSession $userSession,
-								IL10N $l10n,
-								Defaults $defaults,
-								ISession $session,
-								IProvider $tokenProvider,
-								ISecureRandom $random,
-								IURLGenerator $urlGenerator,
-								ClientMapper $clientMapper,
-								AccessTokenMapper $accessTokenMapper,
-								ICrypto $crypto,
-								IEventDispatcher $eventDispatcher) {
+								private IUserSession $userSession,
+								private IL10N $l10n,
+								private Defaults $defaults,
+								private ISession $session,
+								private IProvider $tokenProvider,
+								private ISecureRandom $random,
+								private IURLGenerator $urlGenerator,
+								private ClientMapper $clientMapper,
+								private AccessTokenMapper $accessTokenMapper,
+								private ICrypto $crypto,
+								private IEventDispatcher $eventDispatcher) {
 		parent::__construct($appName, $request);
-		$this->userSession = $userSession;
-		$this->l10n = $l10n;
-		$this->defaults = $defaults;
-		$this->session = $session;
-		$this->tokenProvider = $tokenProvider;
-		$this->random = $random;
-		$this->urlGenerator = $urlGenerator;
-		$this->clientMapper = $clientMapper;
-		$this->accessTokenMapper = $accessTokenMapper;
-		$this->crypto = $crypto;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	private function getClientName(): string {

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -59,19 +59,21 @@ use OCP\Session\Exceptions\SessionNotAvailableException;
 class ClientFlowLoginController extends Controller {
 	public const STATE_NAME = 'client.flow.state.token';
 
-	public function __construct(string $appName,
-								IRequest $request,
-								private IUserSession $userSession,
-								private IL10N $l10n,
-								private Defaults $defaults,
-								private ISession $session,
-								private IProvider $tokenProvider,
-								private ISecureRandom $random,
-								private IURLGenerator $urlGenerator,
-								private ClientMapper $clientMapper,
-								private AccessTokenMapper $accessTokenMapper,
-								private ICrypto $crypto,
-								private IEventDispatcher $eventDispatcher) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IUserSession $userSession,
+		private IL10N $l10n,
+		private Defaults $defaults,
+		private ISession $session,
+		private IProvider $tokenProvider,
+		private ISecureRandom $random,
+		private IURLGenerator $urlGenerator,
+		private ClientMapper $clientMapper,
+		private AccessTokenMapper $accessTokenMapper,
+		private ICrypto $crypto,
+		private IEventDispatcher $eventDispatcher,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -51,16 +51,18 @@ class ClientFlowLoginV2Controller extends Controller {
 	public const TOKEN_NAME = 'client.flow.v2.login.token';
 	public const STATE_NAME = 'client.flow.v2.state.token';
 
-	public function __construct(string $appName,
-								IRequest $request,
-								private LoginFlowV2Service $loginFlowV2Service,
-								private IURLGenerator $urlGenerator,
-								private ISession $session,
-								private IUserSession $userSession,
-								private ISecureRandom $random,
-								private Defaults $defaults,
-								private ?string $userId,
-								private IL10N $l10n) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private LoginFlowV2Service $loginFlowV2Service,
+		private IURLGenerator $urlGenerator,
+		private ISession $session,
+		private IUserSession $userSession,
+		private ISecureRandom $random,
+		private Defaults $defaults,
+		private ?string $userId,
+		private IL10N $l10n,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -51,34 +51,17 @@ class ClientFlowLoginV2Controller extends Controller {
 	public const TOKEN_NAME = 'client.flow.v2.login.token';
 	public const STATE_NAME = 'client.flow.v2.state.token';
 
-	private LoginFlowV2Service $loginFlowV2Service;
-	private IURLGenerator $urlGenerator;
-	private IUserSession $userSession;
-	private ISession $session;
-	private ISecureRandom $random;
-	private Defaults $defaults;
-	private ?string $userId;
-	private IL10N $l10n;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								LoginFlowV2Service $loginFlowV2Service,
-								IURLGenerator $urlGenerator,
-								ISession $session,
-								IUserSession $userSession,
-								ISecureRandom $random,
-								Defaults $defaults,
-								?string $userId,
-								IL10N $l10n) {
+								private LoginFlowV2Service $loginFlowV2Service,
+								private IURLGenerator $urlGenerator,
+								private ISession $session,
+								private IUserSession $userSession,
+								private ISecureRandom $random,
+								private Defaults $defaults,
+								private ?string $userId,
+								private IL10N $l10n) {
 		parent::__construct($appName, $request);
-		$this->loginFlowV2Service = $loginFlowV2Service;
-		$this->urlGenerator = $urlGenerator;
-		$this->session = $session;
-		$this->userSession = $userSession;
-		$this->random = $random;
-		$this->defaults = $defaults;
-		$this->userId = $userId;
-		$this->l10n = $l10n;
 	}
 
 	/**

--- a/core/Controller/CollaborationResourcesController.php
+++ b/core/Controller/CollaborationResourcesController.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OC\Core\Controller;
 
 use Exception;
@@ -41,22 +42,12 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class CollaborationResourcesController extends OCSController {
-	private IManager $manager;
-	private IUserSession $userSession;
-	private LoggerInterface $logger;
-
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		IManager $manager,
-		IUserSession $userSession,
-		LoggerInterface $logger
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private IManager $manager,
+								private IUserSession $userSession,
+								private LoggerInterface $logger) {
 		parent::__construct($appName, $request);
-
-		$this->manager = $manager;
-		$this->userSession = $userSession;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/core/Controller/CollaborationResourcesController.php
+++ b/core/Controller/CollaborationResourcesController.php
@@ -42,11 +42,13 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class CollaborationResourcesController extends OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private IManager $manager,
-								private IUserSession $userSession,
-								private LoggerInterface $logger) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IManager $manager,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/ContactsMenuController.php
+++ b/core/Controller/ContactsMenuController.php
@@ -33,13 +33,10 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 class ContactsMenuController extends Controller {
-	private Manager $manager;
-	private IUserSession $userSession;
-
-	public function __construct(IRequest $request, IUserSession $userSession, Manager $manager) {
+	public function __construct(IRequest $request,
+								private IUserSession $userSession,
+								private Manager $manager) {
 		parent::__construct('core', $request);
-		$this->userSession = $userSession;
-		$this->manager = $manager;
 	}
 
 	/**

--- a/core/Controller/ContactsMenuController.php
+++ b/core/Controller/ContactsMenuController.php
@@ -33,9 +33,11 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 class ContactsMenuController extends Controller {
-	public function __construct(IRequest $request,
-								private IUserSession $userSession,
-								private Manager $manager) {
+	public function __construct(
+		IRequest $request,
+		private IUserSession $userSession,
+		private Manager $manager,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -46,10 +46,12 @@ use OCP\IRequest;
 class CssController extends Controller {
 	protected IAppData $appData;
 
-	public function __construct(string $appName,
-								IRequest $request,
-								Factory $appDataFactory,
-								protected ITimeFactory $timeFactory) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		Factory $appDataFactory,
+		protected ITimeFactory $timeFactory,
+	) {
 		parent::__construct($appName, $request);
 
 		$this->appData = $appDataFactory->get('css');

--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -45,16 +45,14 @@ use OCP\IRequest;
 
 class CssController extends Controller {
 	protected IAppData $appData;
-	protected ITimeFactory $timeFactory;
 
 	public function __construct(string $appName,
 								IRequest $request,
 								Factory $appDataFactory,
-								ITimeFactory $timeFactory) {
+								protected ITimeFactory $timeFactory) {
 		parent::__construct($appName, $request);
 
 		$this->appData = $appDataFactory->get('css');
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/core/Controller/GuestAvatarController.php
+++ b/core/Controller/GuestAvatarController.php
@@ -36,10 +36,12 @@ class GuestAvatarController extends Controller {
 	/**
 	 * GuestAvatarController constructor.
 	 */
-	public function __construct(string $appName,
-								IRequest $request,
-								private IAvatarManager $avatarManager,
-								private LoggerInterface $logger) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IAvatarManager $avatarManager,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/GuestAvatarController.php
+++ b/core/Controller/GuestAvatarController.php
@@ -33,21 +33,14 @@ use Psr\Log\LoggerInterface;
  * This controller handles guest avatar requests.
  */
 class GuestAvatarController extends Controller {
-	private LoggerInterface $logger;
-	private IAvatarManager $avatarManager;
-
 	/**
 	 * GuestAvatarController constructor.
 	 */
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		IAvatarManager $avatarManager,
-		LoggerInterface $logger
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private IAvatarManager $avatarManager,
+								private LoggerInterface $logger) {
 		parent::__construct($appName, $request);
-		$this->avatarManager = $avatarManager;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/core/Controller/HoverCardController.php
+++ b/core/Controller/HoverCardController.php
@@ -33,9 +33,11 @@ use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class HoverCardController extends \OCP\AppFramework\OCSController {
-	public function __construct(IRequest $request,
-								private IUserSession $userSession,
-								private Manager $manager) {
+	public function __construct(
+		IRequest $request,
+		private IUserSession $userSession,
+		private Manager $manager,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/HoverCardController.php
+++ b/core/Controller/HoverCardController.php
@@ -33,13 +33,10 @@ use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class HoverCardController extends \OCP\AppFramework\OCSController {
-	private Manager $manager;
-	private IUserSession $userSession;
-
-	public function __construct(IRequest $request, IUserSession $userSession, Manager $manager) {
+	public function __construct(IRequest $request,
+								private IUserSession $userSession,
+								private Manager $manager) {
 		parent::__construct('core', $request);
-		$this->userSession = $userSession;
-		$this->manager = $manager;
 	}
 
 	/**


### PR DESCRIPTION
This PR is the first part of the three-part refactoring of the `/core` controllers by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.

I figured I should split the changes into three parts to make reviewing the changes easier.