### PR TITLE
[2/3] Refactors /core controllers using constructor property promotion.

### DIFF
--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -45,13 +45,14 @@ use OCP\IRequest;
 
 class JsController extends Controller {
 	protected IAppData $appData;
-	protected ITimeFactory $timeFactory;
 
-	public function __construct($appName, IRequest $request, Factory $appDataFactory, ITimeFactory $timeFactory) {
+	public function __construct(string $appName,
+								IRequest $request,
+								Factory $appDataFactory,
+								protected ITimeFactory $timeFactory) {
 		parent::__construct($appName, $request);
 
 		$this->appData = $appDataFactory->get('js');
-		$this->timeFactory = $timeFactory;
 	}
 
 	/**

--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -46,10 +46,12 @@ use OCP\IRequest;
 class JsController extends Controller {
 	protected IAppData $appData;
 
-	public function __construct(string $appName,
-								IRequest $request,
-								Factory $appDataFactory,
-								protected ITimeFactory $timeFactory) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		Factory $appDataFactory,
+		protected ITimeFactory $timeFactory,
+	) {
 		parent::__construct($appName, $request);
 
 		$this->appData = $appDataFactory->get('js');

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -62,19 +62,21 @@ class LoginController extends Controller {
 	public const LOGIN_MSG_INVALIDPASSWORD = 'invalidpassword';
 	public const LOGIN_MSG_USERDISABLED = 'userdisabled';
 
-	public function __construct(?string $appName,
-								IRequest $request,
-								private IUserManager $userManager,
-								private IConfig $config,
-								private ISession $session,
-								private Session $userSession,
-								private IURLGenerator $urlGenerator,
-								private Defaults $defaults,
-								private Throttler $throttler,
-								private IInitialStateService $initialStateService,
-								private WebAuthnManager $webAuthnManager,
-								private IManager $manager,
-								private IL10N $l10n) {
+	public function __construct(
+		?string $appName,
+		IRequest $request,
+		private IUserManager $userManager,
+		private IConfig $config,
+		private ISession $session,
+		private Session $userSession,
+		private IURLGenerator $urlGenerator,
+		private Defaults $defaults,
+		private Throttler $throttler,
+		private IInitialStateService $initialStateService,
+		private WebAuthnManager $webAuthnManager,
+		private IManager $manager,
+		private IL10N $l10n,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -38,6 +38,7 @@ use OC\Authentication\Login\Chain;
 use OC\Authentication\Login\LoginData;
 use OC\Authentication\WebAuthn\Manager as WebAuthnManager;
 use OC\Security\Bruteforce\Throttler;
+use OC\User\Session;
 use OC_App;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -54,7 +55,6 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Notification\IManager;
 use OCP\Util;
 
@@ -67,7 +67,7 @@ class LoginController extends Controller {
 								private IUserManager $userManager,
 								private IConfig $config,
 								private ISession $session,
-								private IUserSession $userSession,
+								private Session $userSession,
 								private IURLGenerator $urlGenerator,
 								private Defaults $defaults,
 								private Throttler $throttler,

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -38,7 +38,6 @@ use OC\Authentication\Login\Chain;
 use OC\Authentication\Login\LoginData;
 use OC\Authentication\WebAuthn\Manager as WebAuthnManager;
 use OC\Security\Bruteforce\Throttler;
-use OC\User\Session;
 use OC_App;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -63,44 +63,20 @@ class LoginController extends Controller {
 	public const LOGIN_MSG_INVALIDPASSWORD = 'invalidpassword';
 	public const LOGIN_MSG_USERDISABLED = 'userdisabled';
 
-	private IUserManager $userManager;
-	private IConfig $config;
-	private ISession $session;
-	/** @var Session */
-	private $userSession;
-	private IURLGenerator $urlGenerator;
-	private Defaults $defaults;
-	private Throttler $throttler;
-	private IInitialStateService $initialStateService;
-	private WebAuthnManager $webAuthnManager;
-	private IManager $manager;
-	private IL10N $l10n;
-
 	public function __construct(?string $appName,
 								IRequest $request,
-								IUserManager $userManager,
-								IConfig $config,
-								ISession $session,
-								IUserSession $userSession,
-								IURLGenerator $urlGenerator,
-								Defaults $defaults,
-								Throttler $throttler,
-								IInitialStateService $initialStateService,
-								WebAuthnManager $webAuthnManager,
-								IManager $manager,
-								IL10N $l10n) {
+								private IUserManager $userManager,
+								private IConfig $config,
+								private ISession $session,
+								private IUserSession $userSession,
+								private IURLGenerator $urlGenerator,
+								private Defaults $defaults,
+								private Throttler $throttler,
+								private IInitialStateService $initialStateService,
+								private WebAuthnManager $webAuthnManager,
+								private IManager $manager,
+								private IL10N $l10n) {
 		parent::__construct($appName, $request);
-		$this->userManager = $userManager;
-		$this->config = $config;
-		$this->session = $session;
-		$this->userSession = $userSession;
-		$this->urlGenerator = $urlGenerator;
-		$this->defaults = $defaults;
-		$this->throttler = $throttler;
-		$this->initialStateService = $initialStateService;
-		$this->webAuthnManager = $webAuthnManager;
-		$this->manager = $manager;
-		$this->l10n = $l10n;
 	}
 
 	/**

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -73,54 +73,26 @@ use function reset;
  * @package OC\Core\Controller
  */
 class LostController extends Controller {
-	protected IURLGenerator $urlGenerator;
-	protected IUserManager $userManager;
-	protected Defaults $defaults;
-	protected IL10N $l10n;
 	protected string $from;
-	protected IManager $encryptionManager;
-	protected IConfig $config;
-	protected IMailer $mailer;
-	private LoggerInterface $logger;
-	private Manager $twoFactorManager;
-	private IInitialState $initialState;
-	private IVerificationToken $verificationToken;
-	private IEventDispatcher $eventDispatcher;
-	private Limiter $limiter;
 
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		IURLGenerator $urlGenerator,
-		IUserManager $userManager,
-		Defaults $defaults,
-		IL10N $l10n,
-		IConfig $config,
-		string $defaultMailAddress,
-		IManager $encryptionManager,
-		IMailer $mailer,
-		LoggerInterface $logger,
-		Manager $twoFactorManager,
-		IInitialState $initialState,
-		IVerificationToken $verificationToken,
-		IEventDispatcher $eventDispatcher,
-		Limiter $limiter
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private IURLGenerator $urlGenerator,
+								private IUserManager $userManager,
+								private Defaults $defaults,
+								private IL10N $l10n,
+								private IConfig $config,
+								string $defaultMailAddress,
+								private IManager $encryptionManager,
+								private IMailer $mailer,
+								private LoggerInterface $logger,
+								private Manager $twoFactorManager,
+								private IInitialState $initialState,
+								private IVerificationToken $verificationToken,
+								private IEventDispatcher $eventDispatcher,
+								private Limiter $limiter) {
 		parent::__construct($appName, $request);
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
-		$this->defaults = $defaults;
-		$this->l10n = $l10n;
 		$this->from = $defaultMailAddress;
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
-		$this->mailer = $mailer;
-		$this->logger = $logger;
-		$this->twoFactorManager = $twoFactorManager;
-		$this->initialState = $initialState;
-		$this->verificationToken = $verificationToken;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->limiter = $limiter;
 	}
 
 	/**

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -75,22 +75,24 @@ use function reset;
 class LostController extends Controller {
 	protected string $from;
 
-	public function __construct(string $appName,
-								IRequest $request,
-								private IURLGenerator $urlGenerator,
-								private IUserManager $userManager,
-								private Defaults $defaults,
-								private IL10N $l10n,
-								private IConfig $config,
-								string $defaultMailAddress,
-								private IManager $encryptionManager,
-								private IMailer $mailer,
-								private LoggerInterface $logger,
-								private Manager $twoFactorManager,
-								private IInitialState $initialState,
-								private IVerificationToken $verificationToken,
-								private IEventDispatcher $eventDispatcher,
-								private Limiter $limiter) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+		private Defaults $defaults,
+		private IL10N $l10n,
+		private IConfig $config,
+		string $defaultMailAddress,
+		private IManager $encryptionManager,
+		private IMailer $mailer,
+		private LoggerInterface $logger,
+		private Manager $twoFactorManager,
+		private IInitialState $initialState,
+		private IVerificationToken $verificationToken,
+		private IEventDispatcher $eventDispatcher,
+		private Limiter $limiter,
+	) {
 		parent::__construct($appName, $request);
 		$this->from = $defaultMailAddress;
 	}

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -30,10 +30,12 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class NavigationController extends OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private INavigationManager $navigationManager,
-								private IURLGenerator $urlGenerator) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private INavigationManager $navigationManager,
+		private IURLGenerator $urlGenerator,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -30,13 +30,11 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class NavigationController extends OCSController {
-	private INavigationManager $navigationManager;
-	private IURLGenerator $urlGenerator;
-
-	public function __construct(string $appName, IRequest $request, INavigationManager $navigationManager, IURLGenerator $urlGenerator) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private INavigationManager $navigationManager,
+								private IURLGenerator $urlGenerator) {
 		parent::__construct($appName, $request);
-		$this->navigationManager = $navigationManager;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/core/Controller/OCJSController.php
+++ b/core/Controller/OCJSController.php
@@ -47,19 +47,21 @@ use OCP\L10N\IFactory;
 class OCJSController extends Controller {
 	private JSConfigHelper $helper;
 
-	public function __construct(string $appName,
-								IRequest $request,
-								IFactory $l10nFactory,
-								Defaults $defaults,
-								IAppManager $appManager,
-								ISession $session,
-								IUserSession $userSession,
-								IConfig $config,
-								IGroupManager $groupManager,
-								IniGetWrapper $iniWrapper,
-								IURLGenerator $urlGenerator,
-								CapabilitiesManager $capabilitiesManager,
-								IInitialStateService $initialStateService) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IFactory $l10nFactory,
+		Defaults $defaults,
+		IAppManager $appManager,
+		ISession $session,
+		IUserSession $userSession,
+		IConfig $config,
+		IGroupManager $groupManager,
+		IniGetWrapper $iniWrapper,
+		IURLGenerator $urlGenerator,
+		CapabilitiesManager $capabilitiesManager,
+		IInitialStateService $initialStateService,
+	) {
 		parent::__construct($appName, $request);
 
 		$this->helper = new JSConfigHelper(

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -35,22 +35,13 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 
 class OCSController extends \OCP\AppFramework\OCSController {
-	private CapabilitiesManager $capabilitiesManager;
-	private IUserSession $userSession;
-	private IUserManager $userManager;
-	private Manager $keyManager;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								CapabilitiesManager $capabilitiesManager,
-								IUserSession $userSession,
-								IUserManager $userManager,
-								Manager $keyManager) {
+								private CapabilitiesManager $capabilitiesManager,
+								private IUserSession $userSession,
+								private IUserManager $userManager,
+								private Manager $keyManager) {
 		parent::__construct($appName, $request);
-		$this->capabilitiesManager = $capabilitiesManager;
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
-		$this->keyManager = $keyManager;
 	}
 
 	/**

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -35,12 +35,14 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 
 class OCSController extends \OCP\AppFramework\OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private CapabilitiesManager $capabilitiesManager,
-								private IUserSession $userSession,
-								private IUserManager $userManager,
-								private Manager $keyManager) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private CapabilitiesManager $capabilitiesManager,
+		private IUserSession $userSession,
+		private IUserManager $userManager,
+		private Manager $keyManager,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -40,21 +40,12 @@ use OCP\IPreview;
 use OCP\IRequest;
 
 class PreviewController extends Controller {
-	private ?string $userId;
-	private IRootFolder $root;
-	private IPreview $preview;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								IPreview $preview,
-								IRootFolder $root,
-								?string $userId
-	) {
+								private IPreview $preview,
+								private IRootFolder $root,
+								private ?string $userId) {
 		parent::__construct($appName, $request);
-
-		$this->preview = $preview;
-		$this->root = $root;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -40,11 +40,13 @@ use OCP\IPreview;
 use OCP\IRequest;
 
 class PreviewController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private IPreview $preview,
-								private IRootFolder $root,
-								private ?string $userId) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IPreview $preview,
+		private IRootFolder $root,
+		private ?string $userId,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/ProfileApiController.php
+++ b/core/Controller/ProfileApiController.php
@@ -38,11 +38,13 @@ use OCP\IUserSession;
 use OC\Profile\ProfileManager;
 
 class ProfileApiController extends OCSController {
-	public function __construct(IRequest $request,
-								private ProfileConfigMapper $configMapper,
-								private ProfileManager $profileManager,
-								private IUserManager $userManager,
-								private IUserSession $userSession) {
+	public function __construct(
+		IRequest $request,
+		private ProfileConfigMapper $configMapper,
+		private ProfileManager $profileManager,
+		private IUserManager $userManager,
+		private IUserSession $userSession,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/ProfileApiController.php
+++ b/core/Controller/ProfileApiController.php
@@ -38,23 +38,12 @@ use OCP\IUserSession;
 use OC\Profile\ProfileManager;
 
 class ProfileApiController extends OCSController {
-	private ProfileConfigMapper $configMapper;
-	private ProfileManager $profileManager;
-	private IUserManager $userManager;
-	private IUserSession $userSession;
-
-	public function __construct(
-		IRequest $request,
-		ProfileConfigMapper $configMapper,
-		ProfileManager $profileManager,
-		IUserManager $userManager,
-		IUserSession $userSession
-	) {
+	public function __construct(IRequest $request,
+								private ProfileConfigMapper $configMapper,
+								private ProfileManager $profileManager,
+								private IUserManager $userManager,
+								private IUserSession $userSession) {
 		parent::__construct('core', $request);
-		$this->configMapper = $configMapper;
-		$this->profileManager = $profileManager;
-		$this->userManager = $userManager;
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/core/Controller/ProfilePageController.php
+++ b/core/Controller/ProfilePageController.php
@@ -40,33 +40,16 @@ use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\EventDispatcher\IEventDispatcher;
 
 class ProfilePageController extends Controller {
-	private IInitialState $initialStateService;
-	private ProfileManager $profileManager;
-	private IShareManager $shareManager;
-	private IUserManager $userManager;
-	private IUserSession $userSession;
-	private IUserStatusManager $userStatusManager;
-	private IEventDispatcher $eventDispatcher;
-
-	public function __construct(
-		$appName,
-		IRequest $request,
-		IInitialState $initialStateService,
-		ProfileManager $profileManager,
-		IShareManager $shareManager,
-		IUserManager $userManager,
-		IUserSession $userSession,
-		IUserStatusManager $userStatusManager,
-		IEventDispatcher $eventDispatcher
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private IInitialState $initialStateService,
+								private ProfileManager $profileManager,
+								private IShareManager $shareManager,
+								private IUserManager $userManager,
+								private IUserSession $userSession,
+								private IUserStatusManager $userStatusManager,
+								private IEventDispatcher $eventDispatcher) {
 		parent::__construct($appName, $request);
-		$this->initialStateService = $initialStateService;
-		$this->profileManager = $profileManager;
-		$this->shareManager = $shareManager;
-		$this->userManager = $userManager;
-		$this->userSession = $userSession;
-		$this->userStatusManager = $userStatusManager;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**

--- a/core/Controller/ProfilePageController.php
+++ b/core/Controller/ProfilePageController.php
@@ -40,15 +40,17 @@ use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\EventDispatcher\IEventDispatcher;
 
 class ProfilePageController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private IInitialState $initialStateService,
-								private ProfileManager $profileManager,
-								private IShareManager $shareManager,
-								private IUserManager $userManager,
-								private IUserSession $userSession,
-								private IUserStatusManager $userStatusManager,
-								private IEventDispatcher $eventDispatcher) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IInitialState $initialStateService,
+		private ProfileManager $profileManager,
+		private IShareManager $shareManager,
+		private IUserManager $userManager,
+		private IUserSession $userSession,
+		private IUserStatusManager $userStatusManager,
+		private IEventDispatcher $eventDispatcher,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/RecommendedAppsController.php
+++ b/core/Controller/RecommendedAppsController.php
@@ -33,15 +33,10 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class RecommendedAppsController extends Controller {
-	public IURLGenerator $urlGenerator;
-	private IInitialStateService $initialStateService;
-
 	public function __construct(IRequest $request,
-								IURLGenerator $urlGenerator,
-								IInitialStateService $initialStateService) {
+								public IURLGenerator $urlGenerator,
+								private IInitialStateService $initialStateService) {
 		parent::__construct('core', $request);
-		$this->urlGenerator = $urlGenerator;
-		$this->initialStateService = $initialStateService;
 	}
 
 	/**

--- a/core/Controller/RecommendedAppsController.php
+++ b/core/Controller/RecommendedAppsController.php
@@ -33,9 +33,11 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class RecommendedAppsController extends Controller {
-	public function __construct(IRequest $request,
-								public IURLGenerator $urlGenerator,
-								private IInitialStateService $initialStateService) {
+	public function __construct(
+		IRequest $request,
+		public IURLGenerator $urlGenerator,
+		private IInitialStateService $initialStateService,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -30,10 +30,12 @@ use OCP\Collaboration\Reference\IReferenceManager;
 use OCP\IRequest;
 
 class ReferenceApiController extends \OCP\AppFramework\OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private IReferenceManager $referenceManager,
-								private ?string $userId) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IReferenceManager $referenceManager,
+		private ?string $userId,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -30,16 +30,11 @@ use OCP\Collaboration\Reference\IReferenceManager;
 use OCP\IRequest;
 
 class ReferenceApiController extends \OCP\AppFramework\OCSController {
-	private IReferenceManager $referenceManager;
-	private ?string $userId;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								IReferenceManager $referenceManager,
-								?string $userId) {
+								private IReferenceManager $referenceManager,
+								private ?string $userId) {
 		parent::__construct($appName, $request);
-		$this->referenceManager = $referenceManager;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/core/Controller/ReferenceController.php
+++ b/core/Controller/ReferenceController.php
@@ -36,13 +36,11 @@ use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 
 class ReferenceController extends Controller {
-	private IReferenceManager $referenceManager;
-	private IAppDataFactory $appDataFactory;
-
-	public function __construct(string $appName, IRequest $request, IReferenceManager $referenceManager, IAppDataFactory $appDataFactory) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private IReferenceManager $referenceManager,
+								private IAppDataFactory $appDataFactory) {
 		parent::__construct($appName, $request);
-		$this->referenceManager = $referenceManager;
-		$this->appDataFactory = $appDataFactory;
 	}
 
 	/**

--- a/core/Controller/ReferenceController.php
+++ b/core/Controller/ReferenceController.php
@@ -36,10 +36,12 @@ use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 
 class ReferenceController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private IReferenceManager $referenceManager,
-								private IAppDataFactory $appDataFactory) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IReferenceManager $referenceManager,
+		private IAppDataFactory $appDataFactory,
+	) {
 		parent::__construct($appName, $request);
 	}
 


### PR DESCRIPTION
This PR is the second part of the three-part refactoring of the `/core` controllers by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.

I figured I should split the changes into three parts to make reviewing the changes easier.