### PR TITLE
[3/3] Refactors /core controllers using constructor property promotion.

### DIFF
--- a/core/Controller/SearchController.php
+++ b/core/Controller/SearchController.php
@@ -34,10 +34,12 @@ use OCP\Search\Result;
 use Psr\Log\LoggerInterface;
 
 class SearchController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private ISearch $searcher,
-								private LoggerInterface $logger) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ISearch $searcher,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/SearchController.php
+++ b/core/Controller/SearchController.php
@@ -34,19 +34,11 @@ use OCP\Search\Result;
 use Psr\Log\LoggerInterface;
 
 class SearchController extends Controller {
-	private ISearch $searcher;
-	private LoggerInterface $logger;
-
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		ISearch $search,
-		LoggerInterface $logger
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private ISearch $searcher,
+								private LoggerInterface $logger) {
 		parent::__construct($appName, $request);
-
-		$this->searcher = $search;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -37,7 +37,9 @@ use OCP\ILogger;
 class SetupController {
 	private string $autoConfigFile;
 
-	public function __construct(protected Setup $setupHelper) {
+	public function __construct(
+		protected Setup $setupHelper,
+	) {
 		$this->autoConfigFile = \OC::$configDir.'autoconfig.php';
 	}
 

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -35,15 +35,10 @@ use OC\Setup;
 use OCP\ILogger;
 
 class SetupController {
-	protected Setup $setupHelper;
 	private string $autoConfigFile;
 
-	/**
-	 * @param Setup $setupHelper
-	 */
-	public function __construct(Setup $setupHelper) {
+	public function __construct(protected Setup $setupHelper) {
 		$this->autoConfigFile = \OC::$configDir.'autoconfig.php';
-		$this->setupHelper = $setupHelper;
 	}
 
 	public function run(array $post): void {

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -36,19 +36,11 @@ use OCP\Translation\CouldNotTranslateException;
 use OCP\Translation\ITranslationManager;
 
 class TranslationApiController extends \OCP\AppFramework\OCSController {
-	private ITranslationManager $translationManager;
-	private IL10N $l;
-
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		ITranslationManager $translationManager,
-		IL10N $l,
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private ITranslationManager $translationManager,
+								private IL10N $l10n) {
 		parent::__construct($appName, $request);
-
-		$this->translationManager = $translationManager;
-		$this->l = $l;
 	}
 
 	/**
@@ -76,11 +68,11 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 
 			]);
 		} catch (PreConditionNotMetException) {
-			return new DataResponse(['message' => $this->l->t('No translation provider available')], Http::STATUS_PRECONDITION_FAILED);
+			return new DataResponse(['message' => $this->l10n->t('No translation provider available')], Http::STATUS_PRECONDITION_FAILED);
 		} catch (InvalidArgumentException) {
-			return new DataResponse(['message' => $this->l->t('Could not detect language')], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['message' => $this->l10n->t('Could not detect language')], Http::STATUS_BAD_REQUEST);
 		} catch (CouldNotTranslateException $e) {
-			return new DataResponse(['message' => $this->l->t('Unable to translate'), 'from' => $e->getFrom()], Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['message' => $this->l10n->t('Unable to translate'), 'from' => $e->getFrom()], Http::STATUS_BAD_REQUEST);
 		}
 	}
 }

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -36,10 +36,12 @@ use OCP\Translation\CouldNotTranslateException;
 use OCP\Translation\ITranslationManager;
 
 class TranslationApiController extends \OCP\AppFramework\OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								private ITranslationManager $translationManager,
-								private IL10N $l10n) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ITranslationManager $translationManager,
+		private IL10N $l10n,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -42,20 +42,14 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class TwoFactorChallengeController extends Controller {
-	private Manager $twoFactorManager;
-	private IUserSession $userSession;
-	private ISession $session;
-	private LoggerInterface $logger;
-	private IURLGenerator $urlGenerator;
-
-	public function __construct($appName, IRequest $request, Manager $twoFactorManager, IUserSession $userSession,
-		ISession $session, IURLGenerator $urlGenerator, LoggerInterface $logger) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private Manager $twoFactorManager,
+								private IUserSession $userSession,
+								private ISession $session,
+								private IURLGenerator $urlGenerator,
+								private LoggerInterface $logger) {
 		parent::__construct($appName, $request);
-		$this->twoFactorManager = $twoFactorManager;
-		$this->userSession = $userSession;
-		$this->session = $session;
-		$this->urlGenerator = $urlGenerator;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -42,13 +42,15 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class TwoFactorChallengeController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private Manager $twoFactorManager,
-								private IUserSession $userSession,
-								private ISession $session,
-								private IURLGenerator $urlGenerator,
-								private LoggerInterface $logger) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private Manager $twoFactorManager,
+		private IUserSession $userSession,
+		private ISession $session,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -40,22 +40,12 @@ use OCP\Search\ISearchQuery;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 class UnifiedSearchController extends OCSController {
-	private SearchComposer $composer;
-	private IUserSession $userSession;
-	private IRouter $router;
-	private IURLGenerator $urlGenerator;
-
 	public function __construct(IRequest $request,
-								IUserSession $userSession,
-								SearchComposer $composer,
-								IRouter $router,
-								IURLGenerator $urlGenerator) {
+								private IUserSession $userSession,
+								private SearchComposer $composer,
+								private IRouter $router,
+								private IURLGenerator $urlGenerator) {
 		parent::__construct('core', $request);
-
-		$this->composer = $composer;
-		$this->userSession = $userSession;
-		$this->router = $router;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -40,11 +40,13 @@ use OCP\Search\ISearchQuery;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 class UnifiedSearchController extends OCSController {
-	public function __construct(IRequest $request,
-								private IUserSession $userSession,
-								private SearchComposer $composer,
-								private IRouter $router,
-								private IURLGenerator $urlGenerator) {
+	public function __construct(
+		IRequest $request,
+		private IUserSession $userSession,
+		private SearchComposer $composer,
+		private IRouter $router,
+		private IURLGenerator $urlGenerator,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/UserController.php
+++ b/core/Controller/UserController.php
@@ -30,14 +30,10 @@ use OCP\IRequest;
 use OCP\IUserManager;
 
 class UserController extends Controller {
-	protected IUserManager $userManager;
-
-	public function __construct($appName,
+	public function __construct(string $appName,
 								IRequest $request,
-								IUserManager $userManager
-	) {
+								protected IUserManager $userManager) {
 		parent::__construct($appName, $request);
-		$this->userManager = $userManager;
 	}
 
 	/**

--- a/core/Controller/UserController.php
+++ b/core/Controller/UserController.php
@@ -30,9 +30,11 @@ use OCP\IRequest;
 use OCP\IUserManager;
 
 class UserController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								protected IUserManager $userManager) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/WebAuthnController.php
+++ b/core/Controller/WebAuthnController.php
@@ -45,20 +45,14 @@ class WebAuthnController extends Controller {
 	private const WEBAUTHN_LOGIN = 'webauthn_login';
 	private const WEBAUTHN_LOGIN_UID = 'webauthn_login_uid';
 
-	private Manager $webAuthnManger;
-	private ISession $session;
-	private LoggerInterface $logger;
-	private WebAuthnChain $webAuthnChain;
-	private UrlGenerator $urlGenerator;
-
-	public function __construct($appName, IRequest $request, Manager $webAuthnManger, ISession $session, LoggerInterface $logger, WebAuthnChain $webAuthnChain, URLGenerator $urlGenerator) {
+	public function __construct(string $appName,
+								IRequest $request,
+								private Manager $webAuthnManger,
+								private ISession $session,
+								private LoggerInterface $logger,
+								private WebAuthnChain $webAuthnChain,
+								private URLGenerator $urlGenerator) {
 		parent::__construct($appName, $request);
-
-		$this->webAuthnManger = $webAuthnManger;
-		$this->session = $session;
-		$this->logger = $logger;
-		$this->webAuthnChain = $webAuthnChain;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**

--- a/core/Controller/WebAuthnController.php
+++ b/core/Controller/WebAuthnController.php
@@ -45,13 +45,15 @@ class WebAuthnController extends Controller {
 	private const WEBAUTHN_LOGIN = 'webauthn_login';
 	private const WEBAUTHN_LOGIN_UID = 'webauthn_login_uid';
 
-	public function __construct(string $appName,
-								IRequest $request,
-								private Manager $webAuthnManger,
-								private ISession $session,
-								private LoggerInterface $logger,
-								private WebAuthnChain $webAuthnChain,
-								private URLGenerator $urlGenerator) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private Manager $webAuthnManger,
+		private ISession $session,
+		private LoggerInterface $logger,
+		private WebAuthnChain $webAuthnChain,
+		private URLGenerator $urlGenerator,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/WellKnownController.php
+++ b/core/Controller/WellKnownController.php
@@ -33,8 +33,10 @@ use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 
 class WellKnownController extends Controller {
-	public function __construct(IRequest $request,
-								private RequestManager $requestManager) {
+	public function __construct(
+		IRequest $request,
+		private RequestManager $requestManager,
+	) {
 		parent::__construct('core', $request);
 	}
 

--- a/core/Controller/WellKnownController.php
+++ b/core/Controller/WellKnownController.php
@@ -33,13 +33,9 @@ use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 
 class WellKnownController extends Controller {
-	/** @var RequestManager */
-	private $requestManager;
-
 	public function __construct(IRequest $request,
-								RequestManager $wellKnownManager) {
+								private RequestManager $requestManager) {
 		parent::__construct('core', $request);
-		$this->requestManager = $wellKnownManager;
 	}
 
 	/**

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -37,35 +37,17 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 
 class WhatsNewController extends OCSController {
-	/** @var IConfig */
-	protected $config;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var ChangesCheck */
-	private $whatsNewService;
-	/** @var IFactory */
-	private $langFactory;
-	/** @var Defaults */
-	private $defaults;
-
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		CapabilitiesManager $capabilitiesManager,
-		IUserSession $userSession,
-		IUserManager $userManager,
-		Manager $keyManager,
-		IConfig $config,
-		ChangesCheck $whatsNewService,
-		IFactory $langFactory,
-		Defaults $defaults
-	) {
+	public function __construct(string $appName,
+								IRequest $request,
+								CapabilitiesManager $capabilitiesManager,
+								private IUserSession $userSession,
+								IUserManager $userManager,
+								Manager $keyManager,
+								private IConfig $config,
+								private ChangesCheck $whatsNewService,
+								private IFactory $langFactory,
+								private Defaults $defaults) {
 		parent::__construct($appName, $request, $capabilitiesManager, $userSession, $userManager, $keyManager);
-		$this->config = $config;
-		$this->userSession = $userSession;
-		$this->whatsNewService = $whatsNewService;
-		$this->langFactory = $langFactory;
-		$this->defaults = $defaults;
 	}
 
 	/**

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -37,16 +37,18 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 
 class WhatsNewController extends OCSController {
-	public function __construct(string $appName,
-								IRequest $request,
-								CapabilitiesManager $capabilitiesManager,
-								private IUserSession $userSession,
-								IUserManager $userManager,
-								Manager $keyManager,
-								private IConfig $config,
-								private ChangesCheck $whatsNewService,
-								private IFactory $langFactory,
-								private Defaults $defaults) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		CapabilitiesManager $capabilitiesManager,
+		private IUserSession $userSession,
+		IUserManager $userManager,
+		Manager $keyManager,
+		private IConfig $config,
+		private ChangesCheck $whatsNewService,
+		private IFactory $langFactory,
+		private Defaults $defaults,
+	) {
 		parent::__construct($appName, $request, $capabilitiesManager, $userSession, $userManager, $keyManager);
 	}
 

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -33,9 +33,11 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class WipeController extends Controller {
-	public function __construct(string $appName,
-								IRequest $request,
-								private RemoteWipe $remoteWipe) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private RemoteWipe $remoteWipe,
+	) {
 		parent::__construct($appName, $request);
 	}
 

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -33,15 +33,10 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class WipeController extends Controller {
-	/** @var RemoteWipe */
-	private $remoteWipe;
-
 	public function __construct(string $appName,
 								IRequest $request,
-								RemoteWipe $remoteWipe) {
+								private RemoteWipe $remoteWipe) {
 		parent::__construct($appName, $request);
-
-		$this->remoteWipe = $remoteWipe;
 	}
 
 	/**


### PR DESCRIPTION
This PR is the third part of the three-part refactoring of the `/core` controllers by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.

I figured I should split the changes into three parts to make reviewing the changes easier.