### PR TITLE
Bugfix/36644 pruneOutdatedSyncTokens deletes all entries

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3134,10 +3134,19 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		if ($keep < 0) {
 			throw new \InvalidArgumentException();
 		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->select($query->func()->max('id'))
+			->from('calendarchanges');
+
+		$maxId =  $query->executeQuery()->fetchOne();
+		if (!$maxId || $maxId < $keep) {
+		    return 0;
+		}
+
 		$query = $this->db->getQueryBuilder();
 		$query->delete('calendarchanges')
-			->orderBy('id', 'DESC')
-			->setFirstResult($keep);
+			->where($query->expr()->lte('id', $query->createNamedParameter($maxId - $keep, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
 		return $query->executeStatement();
 	}
 

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1399,10 +1399,19 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		if ($keep < 0) {
 			throw new \InvalidArgumentException();
 		}
+
+		$query = $this->db->getQueryBuilder();
+		$query->select($query->func()->max('id'))
+			->from('addressbookchanges');
+
+		$maxId =  $query->executeQuery()->fetchOne();
+		if (!$maxId || $maxId < $keep) {
+		    return 0;
+		}
+
 		$query = $this->db->getQueryBuilder();
 		$query->delete('addressbookchanges')
-			->orderBy('id', 'DESC')
-			->setFirstResult($keep);
+			->where($query->expr()->lte('id', $query->createNamedParameter($maxId - $keep, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
 		return $query->executeStatement();
 	}
 


### PR DESCRIPTION
* Resolves: #36644

## Summary

With Nextcloud 26, CalDAV / CardDAV Clients which are using SyncToken (for example Thunderbird) don't receive calendar / contact updates which happened before the last run of `pruneOutdatedSyncTokens`. During collaborative research we found out that `pruneOutdatedSyncTokens` does delete all entries of calendarchanges / addressbookchanges by accident.

This pull request changes the `pruneOutdatedSyncTokens` functions to first select the highest ID in the `*changes` table and use it in a WHERE clause during deletion of the tokens.

Sine calendar on Thunderbird / maybe other clients are regularly missing events I would say this is a quite high impact bug. For me and others, calendar syncing is currently practically unusable.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) (I hope)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests
