### PR TITLE
fix(caldav): Cast calendar objects id to int when building index

### DIFF
--- a/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
@@ -107,7 +107,7 @@ class BuildReminderIndexBackgroundJob extends QueuedJob {
 
 		$result = $query->executeQuery();
 		while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
-			$offset = $row['id'];
+			$offset = (int) $row['id'];
 			if (is_resource($row['calendardata'])) {
 				$row['calendardata'] = stream_get_contents($row['calendardata']);
 			}


### PR DESCRIPTION
## Summary

Fixes

```
TypeError: Return value of OCA\DAV\BackgroundJob\BuildReminderIndexBackgroundJob::buildIndex() must be of the type int, string returned in /var/www/html/nextcloud/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php:123
Stack trace:
#0 /var/www/html/nextcloud/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php(80): OCA\DAV\BackgroundJob\BuildReminderIndexBackgroundJob->buildIndex()
#1 /var/www/html/nextcloud/lib/public/BackgroundJob/Job.php(78): OCA\DAV\BackgroundJob\BuildReminderIndexBackgroundJob->run()
#2 /var/www/html/nextcloud/lib/public/BackgroundJob/QueuedJob.php(58): OCP\BackgroundJob\Job->start()
#3 /var/www/html/nextcloud/lib/public/BackgroundJob/QueuedJob.php(48): OCP\BackgroundJob\QueuedJob->start()
#4 /var/www/html/nextcloud/cron.php(152): OCP\BackgroundJob\QueuedJob->execute()
#5 {main}
```

My guess is that the database driver sometimes returns an int, other times it gives a string (sqlite?).

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
