### PR TITLE
fix(caldav): Close DB cursor in reminder index background job

### DIFF
--- a/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
+++ b/apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php
@@ -105,8 +105,8 @@ class BuildReminderIndexBackgroundJob extends QueuedJob {
 			->andWhere($query->expr()->gt('id', $query->createNamedParameter($offset)))
 			->orderBy('id', 'ASC');
 
-		$stmt = $query->execute();
-		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+		$result = $query->executeQuery();
+		while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
 			$offset = $row['id'];
 			if (is_resource($row['calendardata'])) {
 				$row['calendardata'] = stream_get_contents($row['calendardata']);
@@ -120,10 +120,12 @@ class BuildReminderIndexBackgroundJob extends QueuedJob {
 			}
 
 			if (($this->timeFactory->getTime() - $startTime) > 15) {
+				$result->closeCursor();
 				return $offset;
 			}
 		}
 
+		$result->closeCursor();
 		return $stopAt;
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Discovered working on https://github.com/nextcloud/server/pull/38648. The DB cursor hasn't been closed.

## TODO

- [x] Fix

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
