### PR TITLE
chore: Drop dead private methods in /lib

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -564,19 +564,6 @@ class Cache implements ICache {
 	}
 
 	/**
-	 * Get all sub folders of a folder
-	 *
-	 * @param ICacheEntry $entry the cache entry of the folder to get the subfolders for
-	 * @return ICacheEntry[] the cache entries for the subfolders
-	 */
-	private function getSubFolders(ICacheEntry $entry) {
-		$children = $this->getFolderContentsById($entry->getId());
-		return array_filter($children, function ($child) {
-			return $child->getMimeType() == FileInfo::MIMETYPE_FOLDER;
-		});
-	}
-
-	/**
 	 * Remove all children of a folder
 	 *
 	 * @param ICacheEntry $entry the cache entry of the folder to remove the children of

--- a/lib/private/Repair/NC22/LookupServerSendCheck.php
+++ b/lib/private/Repair/NC22/LookupServerSendCheck.php
@@ -45,15 +45,6 @@ class LookupServerSendCheck implements IRepairStep {
 		return 'Add background job to set the lookup server share state for users';
 	}
 
-	private function shouldRun(): bool {
-		$versionFromBeforeUpdate = $this->config->getSystemValueString('version', '0.0.0.0');
-
-		// was added to 22.0.0.3
-		return (version_compare($versionFromBeforeUpdate, '22.0.0.3', '<') && version_compare($versionFromBeforeUpdate, '22.0.0.0', '>='))
-			||
-			(version_compare($versionFromBeforeUpdate, '21.0.1.2', '<') && version_compare($versionFromBeforeUpdate, '21.0.0.0', '>'));
-	}
-
 	public function run(IOutput $output): void {
 		$this->jobList->add(LookupServerSendCheckBackgroundJob::class);
 	}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -199,15 +199,6 @@ class Internal extends Session {
 	}
 
 	/**
-	 * @throws \Exception
-	 */
-	private function validateSession() {
-		if ($this->sessionClosed) {
-			throw new SessionNotAvailableException('Session has been closed - no further changes to the session are allowed');
-		}
-	}
-
-	/**
 	 * @param string $functionName the full session_* function name
 	 * @param array $parameters
 	 * @param bool $silence whether to suppress warnings

--- a/lib/private/Session/Memory.php
+++ b/lib/private/Session/Memory.php
@@ -30,7 +30,6 @@ declare(strict_types=1);
  */
 namespace OC\Session;
 
-use Exception;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
 /**
@@ -112,16 +111,5 @@ class Memory extends Session {
 		$reopened = $this->sessionClosed;
 		$this->sessionClosed = false;
 		return $reopened;
-	}
-
-	/**
-	 * In case the session has already been locked an exception will be thrown
-	 *
-	 * @throws Exception
-	 */
-	private function validateSession() {
-		if ($this->sessionClosed) {
-			throw new Exception('Session has been closed - no further changes to the session are allowed');
-		}
 	}
 }


### PR DESCRIPTION
## Summary

Automated refactoring.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
