### PR TITLE
fix(weather_status): Pass address as param to OSM API

### DIFF
--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author Julien Veyssier <eneiluj@posteo.net>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  *
- * @license GNU AGPL version 3 or any later version
+ * @license AGPL-3.0-or-later
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -310,13 +310,14 @@ class WeatherStatusService {
 	 */
 	private function searchForAddress(string $address): array {
 		$params = [
+			'q' => $address,
 			'format' => 'json',
 			'addressdetails' => '1',
 			'extratags' => '1',
 			'namedetails' => '1',
 			'limit' => '1',
 		];
-		$url = 'https://nominatim.openstreetmap.org/search/' . $address;
+		$url = 'https://nominatim.openstreetmap.org/search';
 		$results = $this->requestJSON($url, $params);
 		if (count($results) > 0) {
 			return $results[0];


### PR DESCRIPTION
## Summary
For some addresses the location can not be fetched although the address is correct.
For example `Bruxelles` will fetch the forecast initially but when adding it as a favorite and selecting it, it does not work because the address is saved as `Ville de Bruxelles - Stad Brussel, België / Belgique / Belgien` which contains the `/` character.

This is simply solved by passing the address as the query parameter (as the OSM documentation states).

### Screenshots (screen cast gifs)
before | after
---|---
![before](https://github.com/nextcloud/server/assets/1855448/51ff6951-2bd9-4822-a7a1-d00c921588c3)|![after](https://github.com/nextcloud/server/assets/1855448/0e27ec9b-d048-4dfc-a703-e09588dd8708)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Screenshots before/after for front-end changes
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
