### PR TITLE
feat: add width, height, crop and mode to BeforePreviewFetchedEvent

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -91,7 +91,7 @@ class Generator {
 	 * @param int $height
 	 * @param bool $crop
 	 * @param string $mode
-	 * @param string $mimeType
+	 * @param string|null $mimeType
 	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @throws \InvalidArgumentException if the preview would be invalid (in case the original image is invalid)
@@ -109,7 +109,11 @@ class Generator {
 			new GenericEvent($file, $specification)
 		);
 		$this->eventDispatcher->dispatchTyped(new BeforePreviewFetchedEvent(
-			$file
+			$file,
+			$width,
+			$height,
+			$crop,
+			$mode,
 		));
 
 		// since we only ask for one preview, and the generate method return the last one it created, it returns the one we want

--- a/lib/public/Preview/BeforePreviewFetchedEvent.php
+++ b/lib/public/Preview/BeforePreviewFetchedEvent.php
@@ -27,19 +27,27 @@ declare(strict_types=1);
 namespace OCP\Preview;
 
 use OCP\Files\Node;
+use OCP\IPreview;
 
 /**
  * @since 25.0.1
  */
 class BeforePreviewFetchedEvent extends \OCP\EventDispatcher\Event {
-	private Node $node;
-
 	/**
 	 * @since 25.0.1
 	 */
-	public function __construct(Node $node) {
+	public function __construct(
+		private Node $node,
+		/** @deprecated 28.0.0 null deprecated **/
+		private ?int $width = null,
+		/** @deprecated 28.0.0 null deprecated **/
+		private ?int $height = null,
+		/** @deprecated 28.0.0 null deprecated **/
+		private ?bool $crop = null,
+		/** @deprecated 28.0.0 null deprecated **/
+		private ?string $mode = null,
+	) {
 		parent::__construct();
-		$this->node = $node;
 	}
 
 	/**
@@ -47,5 +55,34 @@ class BeforePreviewFetchedEvent extends \OCP\EventDispatcher\Event {
 	 */
 	public function getNode(): Node {
 		return $this->node;
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getWidth(): ?int {
+		return $this->width;
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getHeight(): ?int {
+		return $this->height;
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function isCrop(): ?bool {
+		return $this->crop;
+	}
+
+	/**
+	 * @since 28.0.0
+	 * @return null|IPreview::MODE_FILL|IPreview::MODE_COVER
+	 */
+	public function getMode(): ?string {
+		return $this->mode;
 	}
 }

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -125,7 +125,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, 100, 100, false, IPreview::MODE_FILL));
 
 		$result = $this->generator->getPreview($file, 100, 100);
 		$this->assertSame($previewFile, $result);
@@ -264,7 +264,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, 100, 100, false, IPreview::MODE_FILL));
 
 		$result = $this->generator->getPreview($file, 100, 100);
 		$this->assertSame($previewFile, $result);
@@ -316,7 +316,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, 1024, 512, true, IPreview::MODE_COVER));
 
 		$this->generator->getPreview($file, 1024, 512, true, IPreview::MODE_COVER, 'invalidType');
 	}
@@ -366,7 +366,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, 1024, 512, true, IPreview::MODE_COVER));
 
 		$result = $this->generator->getPreview($file, 1024, 512, true, IPreview::MODE_COVER, 'invalidType');
 		$this->assertSame($preview, $result);
@@ -405,7 +405,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, 100, 100, false, IPreview::MODE_FILL));
 
 		$this->expectException(NotFoundException::class);
 		$this->generator->getPreview($file, 100, 100);
@@ -543,7 +543,7 @@ class GeneratorTest extends \Test\TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->with(new BeforePreviewFetchedEvent($file));
+			->with(new BeforePreviewFetchedEvent($file, $reqX, $reqY, $crop, $mode));
 
 		$result = $this->generator->getPreview($file, $reqX, $reqY, $crop, $mode);
 		if ($expectedX === $maxX && $expectedY === $maxY) {


### PR DESCRIPTION
## Summary

user_usage_report keeps a counter for files read.[^1]

The app uses

- OC_Filesystem::read hook
- Event listener (the legacy one) for IPreview::EVENT

Request for previews do not trigger the hook, hence the additional event listener. 
The thumbnails for a list or grid view should not count, so we need the width and height.

[^1]: https://github.com/nextcloud/user_usage_report/blob/c12e97d84033818af27ae5cf659c88f743137be7/lib/AppInfo/Application.php#L51

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
