### PR TITLE
Update bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -103,6 +103,7 @@ body:
         Select PHP engine version serving Nextcloud Server.
         _Describe in the "Additional info" section if you chose "Other"._
       options:
+        - "PHP 7.4"
         - "PHP 8.0"
         - "PHP 8.1"
         - "PHP 8.2"

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -17,7 +17,7 @@ body:
       options:
         - label: This is a **bug**, not a question or a configuration/webserver/proxy issue.
           required: true
-        - label: This issue is **not** already reported on Github _(I've searched it)_.
+        - label: This issue is **not** already reported on Github OR Nextcloud Community Forum _(I've searched it)_.
           required: true
         - label: Nextcloud Server **is** up to date. See [Maintenance and Release Schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule) for supported versions.
           required: true
@@ -78,9 +78,9 @@ body:
         Select Nextcloud Server version.
         _Versions not listed here are not maintained and not supported anymore_
       options:
-        - "24"
         - "25"
         - "26"
+        - "27"
         - "master"
     validations:
       required: true
@@ -103,10 +103,9 @@ body:
         Select PHP engine version serving Nextcloud Server.
         _Describe in the "Additional info" section if you chose "Other"._
       options:
-        - "PHP 7.3"
-        - "PHP 7.4"
         - "PHP 8.0"
         - "PHP 8.1"
+        - "PHP 8.2"
         - "Other"
   - type: dropdown
     id: webserver
@@ -118,7 +117,6 @@ body:
       options:
         - "Apache (supported)"
         - "Nginx"
-        - "Lighttpd"
         - "Other"
   - type: dropdown
     id: database
@@ -141,8 +139,8 @@ body:
       description: |
         Select if bug is present after an update or on a fresh install.
       options:
-        - "Updated from a minor version (ex. 22.2.3 to 22.2.4)"
-        - "Updated to a major version (ex. 22.2.3 to 23.0.1)"
+        - "Updated from a MINOR version (ex. 22.1 to 22.2)"
+        - "Upgraded to a MAJOR version (ex. 22 to 23)"
         - "Fresh Nextcloud Server install"
   - type: dropdown
     id: encryption
@@ -192,8 +190,6 @@ body:
         ```
         > NOTE: This will be automatically formatted into code for better readability.
       render: shell
-    validations:
-      required: true
   - type: textarea
     id: nextcloud-signingstatus
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -21,8 +21,6 @@ body:
           required: true
         - label: Nextcloud Server **is** up to date. See [Maintenance and Release Schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule) for supported versions.
           required: true
-        - label: Nextcloud Server **is** running on 64bit capable CPU, PHP and OS.
-          required: true
         - label: I agree to follow Nextcloud's [Code of Conduct](https://nextcloud.com/contribute/code-of-conduct/).
           required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -17,7 +17,7 @@ body:
       options:
         - label: This is a **bug**, not a question or a configuration/webserver/proxy issue.
           required: true
-        - label: This issue is **not** already reported on Github OR Nextcloud Community Forum _(I've searched it)_.
+        - label: This issue is **not** already reported on [Github](https://github.com/nextcloud/server/pulls?q=is%3Aopen+is%3Apr+label%3Abug) OR [Nextcloud Community Forum](https://help.nextcloud.com/) _(I've searched it)_.
           required: true
         - label: Nextcloud Server **is** up to date. See [Maintenance and Release Schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule) for supported versions.
           required: true


### PR DESCRIPTION
- Remove v24 / add v27 (already at RC state, so `master` choice will be v28)
- Add PHP 8.2, removes 7.3
- Lighttpd dropdown choice removed as this webserver is not supported and not documented
- Activated apps not being required (remaining as optional) as all other sections are also optional (including Nextcloud logs)