### PR TITLE
fix: Remove duplicate memory session creation on cron jobs

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -54,14 +54,6 @@ try {
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 
-	\OC::$server->getSession()->close();
-
-	// initialize a dummy memory session
-	$session = new \OC\Session\Memory('');
-	$cryptoWrapper = \OC::$server->getSessionCryptoWrapper();
-	$session = $cryptoWrapper->wrapSession($session);
-	\OC::$server->setSession($session);
-
 	$logger = \OC::$server->getLogger();
 	$config = \OC::$server->getConfig();
 	$tempManager = \OC::$server->getTempManager();


### PR DESCRIPTION
## Summary

There might be scenarios (especially on previous versions where session writes do not reopen) where application code lie the encryption KeyManager still holds the previously initialized Memory session which they obtained through DI. There should be no need to close the existing one and create a new one and crypto wrappers should also be unneeded as we are storing in memory only anyways.

There is already a memory session by default which is available if no session is set manually through `OC::initSession` or the calls removed in ths PR.

https://github.com/nextcloud/server/blob/a2afc7b6a9b42598cadcc3d3e9dde80e0a8a9ce4/lib/private/Server.php#L561

## TODO

- [x] Waiting for CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
