### PR TITLE
Drop meta robots header

### DIFF
--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -203,7 +203,6 @@ class TemplateResponse extends Response {
 			$renderAs = $this->renderAs;
 		}
 
-		\OCP\Util::addHeader('meta', ['name' => 'robots', 'content' => 'noindex, nofollow']);
 		$template = new \OCP\Template($this->appName, $this->templateName, $renderAs);
 
 		foreach ($this->params as $key => $value) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36688

## Summary
`X-Robots-Tag` is already set everywhere where possible ([here](https://github.com/nextcloud/server/blob/76d4487f63fc01c061a6a2be66d5cc51a7e11965/.htaccess#L34) and [here](https://github.com/nextcloud/server/blob/76d4487f63fc01c061a6a2be66d5cc51a7e11965/lib/private/legacy/OC_Response.php#L102) and [here](https://github.com/nextcloud/server/blob/76d4487f63fc01c061a6a2be66d5cc51a7e11965/lib/public/AppFramework/Http/Response.php#L260) and also [here](https://github.com/nextcloud/server/blob/76d4487f63fc01c061a6a2be66d5cc51a7e11965/robots.txt#L2)) and fully supported by all major crawlers (Google, Yahoo, Bing, Yandex...) so it should be fully safe to avoid inject this meta header.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
