### PR TITLE
allow to specify upgrade.cli-upgrade-link in order to link to the correct documentation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2155,6 +2155,11 @@ $CONFIG = [
 'upgrade.disable-web' => false,
 
 /**
+ * Allows to modify the cli-upgrade link in order to link to a different documentation
+ */
+'upgrade.cli-upgrade-link' => '',
+
+/**
  * Set this Nextcloud instance to debugging mode
  *
  * Only enable this for local development and not in production environments

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -103,7 +103,7 @@ class FeedBackHandler {
 if (\OCP\Util::needUpgrade()) {
 	$config = \OC::$server->getSystemConfig();
 	if ($config->getValue('upgrade.disable-web', false)) {
-		$eventSource->send('failure', $l->t('Please use the command line updater because updating via the browser is disabled in your config.php.'));
+		$eventSource->send('failure', $l->t('Please use the command line updater because updating via browser is disabled in your config.php.'));
 		$eventSource->close();
 		exit();
 	}

--- a/core/templates/update.use-cli.php
+++ b/core/templates/update.use-cli.php
@@ -5,10 +5,14 @@
 			<?php if ($_['tooBig']) {
 				p($l->t('Please use the command line updater because you have a big instance with more than 50 users.'));
 			} else {
-				p($l->t('Please use the command line updater because automatic updating is disabled in the config.php.'));
+				p($l->t('Please use the command line updater because updating via browser is disabled in your config.php.'));
 			} ?><br><br>
-			<?php
-						print_unescaped($l->t('For help, see the  <a target="_blank" rel="noreferrer noopener" href="%s">documentation</a>.', [link_to_docs('admin-cli-upgrade')])); ?>
+			<?php if (is_string($_['cliUpgradeLink']) && $_['cliUpgradeLink'] !== '') {
+				$cliUpgradeLink = $_['cliUpgradeLink'];
+			} else {
+				$cliUpgradeLink = link_to_docs('admin-cli-upgrade');
+			}
+			print_unescaped($l->t('For help, see the  <a target="_blank" rel="noreferrer noopener" href="%s">documentation</a>.', [$cliUpgradeLink])); ?>
 		</div>
 	</div>
 

--- a/lib/base.php
+++ b/lib/base.php
@@ -312,6 +312,7 @@ class OC {
 	 * Prints the upgrade page
 	 */
 	private static function printUpgradePage(\OC\SystemConfig $systemConfig): void {
+		$cliUpgradeLink = $systemConfig->getValue('upgrade.cli-upgrade-link', '');
 		$disableWebUpdater = $systemConfig->getValue('upgrade.disable-web', false);
 		$tooBig = false;
 		if (!$disableWebUpdater) {
@@ -358,6 +359,7 @@ class OC {
 			$template->assign('productName', 'nextcloud'); // for now
 			$template->assign('version', OC_Util::getVersionString());
 			$template->assign('tooBig', $tooBig);
+			$template->assign('cliUpgradeLink', $cliUpgradeLink);
 
 			$template->printPage();
 			die();


### PR DESCRIPTION
After the calendar app caused this due to app updates, this became necessary in order being able to show the correct docs in AIO in case this screen is shown.