### PR TITLE
Add a Dependabot configuration to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -171,3 +171,12 @@ updates:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+
+# GitHub Actions
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "03:00"
+    timezone: Europe/Paris


### PR DESCRIPTION
* Resolves: No issue filed

## Summary

GitHub workflow logs show that some of the actions are running on Node 12, which is deprecated and will be removed soon. [[example from a recent run](https://github.com/nextcloud/server/actions/runs/5231339838)]

This can be addressed by adding a Dependabot configuration for GitHub action versions. Therefore this PR targets a Dependabot configuration for ongoing updates, rather than updating the action versions as a one-off.

I've added sign-off signatures to my git commits. Please let me know if I overlooked anything that needs to be addressed.

Thanks for your work on NextCloud!

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
