### PR TITLE
Allow stdClass in XML responses

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -143,6 +143,10 @@ abstract class BaseResponse extends Response {
 				$k = 'element';
 			}
 
+			if ($v instanceof \stdClass) {
+				$v = [];
+			}
+
 			if (\is_array($v)) {
 				$writer->startElement($k);
 				$this->toXML($v, $writer);

--- a/tests/lib/AppFramework/OCS/BaseResponseTest.php
+++ b/tests/lib/AppFramework/OCS/BaseResponseTest.php
@@ -45,13 +45,14 @@ class BaseResponseTest extends \Test\TestCase {
 				'someElement' => 'withAttribute',
 			],
 			'value without key',
+			'object' => new \stdClass(),
 		];
 
 		$this->invokePrivate($response, 'toXml', [$data, $writer]);
 		$writer->endDocument();
 
 		$this->assertEquals(
-			"<?xml version=\"1.0\"?>\n<hello>hello</hello><information test=\"some data\"><someElement>withAttribute</someElement></information><element>value without key</element>\n",
+			"<?xml version=\"1.0\"?>\n<hello>hello</hello><information test=\"some data\"><someElement>withAttribute</someElement></information><element>value without key</element><object/>\n",
 			$writer->outputMemory(true)
 		);
 	}


### PR DESCRIPTION
## Summary

Allows returning `\stdClass()` in DataResponse that are encoded to XML.
JSON can already to it and converts it to `{}`, but for XML special handling is required.

This change is required in order to properly describe APIs using empty JSON objects (`[]` gets converted to `[]` in JSON instead of `{}`). XML just also needs to support it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
