### PR TITLE
perf: skip request without write permission

### DIFF
--- a/apps/dav/lib/Connector/Sabre/DavAclPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/DavAclPlugin.php
@@ -94,8 +94,19 @@ class DavAclPlugin extends \Sabre\DAVACL\Plugin {
 		$path = $request->getPath();
 
 		// prevent the plugin from causing an unneeded overhead for file requests
-		if (strpos($path, 'files/') !== 0) {
-			parent::beforeMethod($request, $response);
+		if (str_starts_with($path, 'files/')) {
+			return;
+		}
+
+		parent::beforeMethod($request, $response);
+
+		$createAddressbookOrCalendarRequest = ($request->getMethod() === 'MKCALENDAR' || $request->getMethod() === 'MKCOL')
+			&& (str_starts_with($path, 'addressbooks/') || str_starts_with($path, 'calendars/'));
+
+		if ($createAddressbookOrCalendarRequest) {
+			[$parentName] = \Sabre\Uri\split($path);
+			// is calendars/users/bob or addressbooks/users/bob writeable?
+			$this->checkPrivileges($parentName, '{DAV:}write');
 		}
 	}
 }

--- a/build/integration/features/bootstrap/CalDavContext.php
+++ b/build/integration/features/bootstrap/CalDavContext.php
@@ -27,6 +27,7 @@
 require __DIR__ . '/../../vendor/autoload.php';
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 
 class CalDavContext implements \Behat\Behat\Context\Context {
@@ -231,6 +232,30 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 					$actual
 				)
 			);
+		}
+	}
+
+	/**
+	 * @When :user sends a create calendar request to :calendar on the endpoint :endpoint
+	 */
+	public function sendsCreateCalendarRequest(string $user, string $calendar, string $endpoint) {
+		$davUrl = $this->baseUrl . $endpoint . $calendar;
+		$password = ($user === 'admin') ? 'admin' : '123456';
+
+		try {
+			$this->response = $this->client->request(
+				'MKCALENDAR',
+				$davUrl,
+				[
+					'body' => '<c:mkcalendar xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns"><d:set><d:prop><d:displayname>test</d:displayname><o:calendar-enabled>1</o:calendar-enabled><a:calendar-color>#21213D</a:calendar-color><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop></d:set></c:mkcalendar>',
+					'auth' => [
+						$user,
+						$password,
+					],
+				]
+			);
+		} catch (GuzzleException $e) {
+			$this->response = $e->getResponse();
 		}
 	}
 }

--- a/build/integration/features/caldav.feature
+++ b/build/integration/features/caldav.feature
@@ -59,3 +59,19 @@ Feature: caldav
     When "admin" requests calendar "/" on the endpoint "/remote.php/dav/public-calendars"
     Then The CalDAV HTTP status code should be "207"
     Then There should be "0" calendars in the response body
+
+  Scenario: Create calendar request for non-existing calendar of another user
+    Given user "user0" exists
+    When "user0" sends a create calendar request to "admin/MyCalendar2" on the endpoint "/remote.php/dav/calendars/"
+    Then The CalDAV HTTP status code should be "404"
+    And The exception is "Sabre\DAV\Exception\NotFound"
+    And The error message is "Node with name 'admin' could not be found"
+
+  Scenario: Create calendar request for existing calendar of another user
+    Given user "user0" exists
+    When "admin" creates a calendar named "MyCalendar2"
+    Then The CalDAV HTTP status code should be "201"
+    When "user0" sends a create calendar request to "admin/MyCalendar2" on the endpoint "/remote.php/dav/calendars/"
+    Then The CalDAV HTTP status code should be "404"
+    And The exception is "Sabre\DAV\Exception\NotFound"
+    And The error message is "Node with name 'admin' could not be found"

--- a/build/integration/features/carddav.feature
+++ b/build/integration/features/carddav.feature
@@ -62,3 +62,18 @@ Feature: carddav
       |X-Permitted-Cross-Domain-Policies|none|
       |X-Robots-Tag|noindex, nofollow|
       |X-XSS-Protection|1; mode=block|
+
+  Scenario: Create addressbook request for non-existing addressbook of another user
+    Given user "user0" exists
+    When "user0" sends a create addressbook request to "admin/MyAddressbook2" on the endpoint "/remote.php/dav/addressbooks/"
+    Then The CardDAV HTTP status code should be "404"
+    And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
+    And The CardDAV error message is "File not found: admin in 'addressbooks'"
+
+  Scenario: Create addressbook request for existing addressbook of another user
+    Given user "user0" exists
+    When "admin" creates an addressbook named "MyAddressbook2" with statuscode "201"
+    When "user0" sends a create addressbook request to "admin/MyAddressbook2" on the endpoint "/remote.php/dav/addressbooks/"
+    Then The CardDAV HTTP status code should be "404"
+    And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
+    And The CardDAV error message is "File not found: admin in 'addressbooks'"


### PR DESCRIPTION
## Summary

Without write permission for the parent, no calendar or address book can be created.

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
