### PR TITLE
Uses PHP8's constructor property promotion in core/Command/Encryption

### DIFF
--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -40,19 +40,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ChangeKeyStorageRoot extends Command {
-	protected View $rootView;
-	protected IUserManager $userManager;
-	protected IConfig $config;
-	protected Util $util;
-	protected QuestionHelper $questionHelper;
-
-	public function __construct(View $view, IUserManager $userManager, IConfig $config, Util $util, QuestionHelper $questionHelper) {
+	public function __construct(
+		protected View $rootView,
+		protected IUserManager $userManager,
+		protected IConfig $config,
+		protected Util $util,
+		protected QuestionHelper $questionHelper,
+	) {
 		parent::__construct();
-		$this->rootView = $view;
-		$this->userManager = $userManager;
-		$this->config = $config;
-		$this->util = $util;
-		$this->questionHelper = $questionHelper;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -41,8 +41,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class DecryptAll extends Command {
-	protected bool $wasTrashbinEnabled;
-	protected bool $wasMaintenanceModeEnabled;
+	protected bool $wasTrashbinEnabled = false;
+	protected bool $wasMaintenanceModeEnabled = false;
 
 	public function __construct(
 		protected IManager $encryptionManager,

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -41,28 +41,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class DecryptAll extends Command {
-	protected IManager $encryptionManager;
-	protected IAppManager $appManager;
-	protected IConfig $config;
-	protected QuestionHelper $questionHelper;
 	protected bool $wasTrashbinEnabled;
 	protected bool $wasMaintenanceModeEnabled;
-	protected \OC\Encryption\DecryptAll $decryptAll;
 
 	public function __construct(
-		IManager $encryptionManager,
-		IAppManager $appManager,
-		IConfig $config,
-		\OC\Encryption\DecryptAll $decryptAll,
-		QuestionHelper $questionHelper
+		protected IManager $encryptionManager,
+		protected IAppManager $appManager,
+		protected IConfig $config,
+		protected \OC\Encryption\DecryptAll $decryptAll,
+		protected QuestionHelper $questionHelper,
 	) {
 		parent::__construct();
-
-		$this->appManager = $appManager;
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
-		$this->decryptAll = $decryptAll;
-		$this->questionHelper = $questionHelper;
 	}
 
 	/**

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -27,11 +27,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Command {
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -27,7 +27,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Command {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -29,14 +29,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Command {
-	protected IConfig $config;
-	protected IManager $encryptionManager;
-
-	public function __construct(IConfig $config, IManager $encryptionManager) {
+	public function __construct(
+		protected IConfig $config,
+		protected IManager $encryptionManager,
+	) {
 		parent::__construct();
-
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
 	}
 
 	protected function configure() {
@@ -70,7 +67,7 @@ class Enable extends Command {
 			return 1;
 		}
 		$output->writeln('Default module: ' . $defaultModule);
-		
+
 		return 0;
 	}
 }

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class EncryptAll extends Command {
 	protected bool $wasTrashbinEnabled = false;
-	protected bool $wasMaintenanceModeEnabled;
+	protected bool $wasMaintenanceModeEnabled = false;
 
 	public function __construct(
 		protected IManager $encryptionManager,

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -36,24 +36,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class EncryptAll extends Command {
-	protected IManager $encryptionManager;
-	protected IAppManager $appManager;
-	protected IConfig $config;
-	protected QuestionHelper $questionHelper;
 	protected bool $wasTrashbinEnabled = false;
 	protected bool $wasMaintenanceModeEnabled;
 
 	public function __construct(
-		IManager $encryptionManager,
-		IAppManager $appManager,
-		IConfig $config,
-		QuestionHelper $questionHelper
+		protected IManager $encryptionManager,
+		protected IAppManager $appManager,
+		protected IConfig $config,
+		protected QuestionHelper $questionHelper,
 	) {
 		parent::__construct();
-		$this->appManager = $appManager;
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
-		$this->questionHelper = $questionHelper;
 	}
 
 	/**

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -30,16 +30,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListModules extends Base {
-	protected IManager $encryptionManager;
-	protected IConfig $config;
-
 	public function __construct(
-		IManager $encryptionManager,
-		IConfig $config
+		protected IManager $encryptionManager,
+		protected IConfig $config,
 	) {
 		parent::__construct();
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/MigrateKeyStorage.php
+++ b/core/Command/Encryption/MigrateKeyStorage.php
@@ -33,7 +33,6 @@ use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/core/Command/Encryption/MigrateKeyStorage.php
+++ b/core/Command/Encryption/MigrateKeyStorage.php
@@ -38,20 +38,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MigrateKeyStorage extends Command {
-	protected View $rootView;
-	protected IUserManager $userManager;
-	protected IConfig $config;
-	protected Util $util;
-	protected QuestionHelper $questionHelper;
-	private ICrypto $crypto;
-
-	public function __construct(View $view, IUserManager $userManager, IConfig $config, Util $util, ICrypto $crypto) {
+	public function __construct(
+		protected View $rootView,
+		protected IUserManager $userManager,
+		protected IConfig $config,
+		protected Util $util,
+		private ICrypto $crypto,
+	) {
 		parent::__construct();
-		$this->rootView = $view;
-		$this->userManager = $userManager;
-		$this->config = $config;
-		$this->util = $util;
-		$this->crypto = $crypto;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/SetDefaultModule.php
+++ b/core/Command/Encryption/SetDefaultModule.php
@@ -31,16 +31,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetDefaultModule extends Command {
-	protected IManager $encryptionManager;
-	protected IConfig $config;
-
 	public function __construct(
-		IManager $encryptionManager,
-		IConfig $config
+		protected IManager $encryptionManager,
+		protected IConfig $config,
 	) {
 		parent::__construct();
-		$this->encryptionManager = $encryptionManager;
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -29,11 +29,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowKeyStorageRoot extends Command {
-	protected Util $util;
-
-	public function __construct(Util $util) {
+	public function __construct(protected Util $util) {
 		parent::__construct();
-		$this->util = $util;
 	}
 
 	protected function configure() {

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -29,7 +29,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowKeyStorageRoot extends Command {
-	public function __construct(protected Util $util) {
+	public function __construct(
+		protected Util $util,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -27,7 +27,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends Base {
-	public function __construct(protected IManager $encryptionManager) {
+	public function __construct(
+		protected IManager $encryptionManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -27,11 +27,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends Base {
-	protected IManager $encryptionManager;
-
-	public function __construct(IManager $encryptionManager) {
+	public function __construct(protected IManager $encryptionManager) {
 		parent::__construct();
-		$this->encryptionManager = $encryptionManager;
 	}
 
 	protected function configure() {


### PR DESCRIPTION
Following #38636, #38637, and #38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/Encryption` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.
