### PR TITLE
Uses PHP8's constructor property promotion in core/Command/Db classes.

### DIFF
--- a/core/Command/Db/AddMissingColumns.php
+++ b/core/Command/Db/AddMissingColumns.php
@@ -45,14 +45,11 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package OC\Core\Command\Db
  */
 class AddMissingColumns extends Command {
-	private Connection $connection;
-	private EventDispatcherInterface $dispatcher;
-
-	public function __construct(Connection $connection, EventDispatcherInterface $dispatcher) {
+	public function __construct(
+		private Connection $connection,
+		private EventDispatcherInterface $dispatcher,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
-		$this->dispatcher = $dispatcher;
 	}
 
 	protected function configure() {

--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -53,14 +53,11 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package OC\Core\Command\Db
  */
 class AddMissingIndices extends Command {
-	private Connection $connection;
-	private EventDispatcherInterface $dispatcher;
-
-	public function __construct(Connection $connection, EventDispatcherInterface $dispatcher) {
+	public function __construct(
+		private Connection $connection,
+		private EventDispatcherInterface $dispatcher,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
-		$this->dispatcher = $dispatcher;
 	}
 
 	protected function configure() {

--- a/core/Command/Db/AddMissingPrimaryKeys.php
+++ b/core/Command/Db/AddMissingPrimaryKeys.php
@@ -45,14 +45,11 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package OC\Core\Command\Db
  */
 class AddMissingPrimaryKeys extends Command {
-	private Connection $connection;
-	private EventDispatcherInterface $dispatcher;
-
-	public function __construct(Connection $connection, EventDispatcherInterface $dispatcher) {
+	public function __construct(
+		private Connection $connection,
+		private EventDispatcherInterface $dispatcher,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
-		$this->dispatcher = $dispatcher;
 	}
 
 	protected function configure() {

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -42,7 +42,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ConvertFilecacheBigInt extends Command {
-	public function __construct(private Connection $connection) {
+	public function __construct(
+		private Connection $connection,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -42,10 +42,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ConvertFilecacheBigInt extends Command {
-	private Connection $connection;
-
-	public function __construct(Connection $connection) {
-		$this->connection = $connection;
+	public function __construct(private Connection $connection) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/ConvertMysqlToMB4.php
+++ b/core/Command/Db/ConvertMysqlToMB4.php
@@ -37,21 +37,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConvertMysqlToMB4 extends Command {
-	private IConfig $config;
-	private IDBConnection $connection;
-	private IURLGenerator $urlGenerator;
-	private LoggerInterface $logger;
-
 	public function __construct(
-		IConfig $config,
-		IDBConnection $connection,
-		IURLGenerator $urlGenerator,
-		LoggerInterface $logger
+		private IConfig $config,
+		private IDBConnection $connection,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
 	) {
-		$this->config = $config;
-		$this->connection = $connection;
-		$this->urlGenerator = $urlGenerator;
-		$this->logger = $logger;
 		parent::__construct();
 	}
 

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -56,13 +56,12 @@ use function preg_match;
 use function preg_quote;
 
 class ConvertType extends Command implements CompletionAwareInterface {
-	protected IConfig $config;
-	protected ConnectionFactory $connectionFactory;
 	protected array $columnTypes;
 
-	public function __construct(IConfig $config, ConnectionFactory $connectionFactory) {
-		$this->config = $config;
-		$this->connectionFactory = $connectionFactory;
+	public function __construct(
+		protected IConfig $config,
+		protected ConnectionFactory $connectionFactory,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -56,7 +56,7 @@ use function preg_match;
 use function preg_quote;
 
 class ConvertType extends Command implements CompletionAwareInterface {
-	protected array $columnTypes;
+	protected array $columnTypes = [];
 
 	public function __construct(
 		protected IConfig $config,

--- a/core/Command/Db/Migrations/ExecuteCommand.php
+++ b/core/Command/Db/Migrations/ExecuteCommand.php
@@ -35,13 +35,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ExecuteCommand extends Command implements CompletionAwareInterface {
-	private Connection $connection;
-	private IConfig $config;
-
-	public function __construct(Connection $connection, IConfig $config) {
-		$this->connection = $connection;
-		$this->config = $config;
-
+	public function __construct(
+		private Connection $connection,
+		private IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -33,10 +33,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MigrateCommand extends Command implements CompletionAwareInterface {
-	private Connection $connection;
-
-	public function __construct(Connection $connection) {
-		$this->connection = $connection;
+	public function __construct(private Connection $connection) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -33,7 +33,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MigrateCommand extends Command implements CompletionAwareInterface {
-	public function __construct(private Connection $connection) {
+	public function __construct(
+		private Connection $connection,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -34,7 +34,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class StatusCommand extends Command implements CompletionAwareInterface {
-	public function __construct(private Connection $connection) {
+	public function __construct(
+		private Connection $connection,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -34,10 +34,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class StatusCommand extends Command implements CompletionAwareInterface {
-	private Connection $connection;
-
-	public function __construct(Connection $connection) {
-		$this->connection = $connection;
+	public function __construct(private Connection $connection) {
 		parent::__construct();
 	}
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors /core/Command/Db classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.