### PR TITLE
also log stream size when reporting unexpected chunk size

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -153,10 +153,14 @@ class AssemblyStream implements \Icewind\Streams\File {
 			$this->currentNodeRead += $read;
 
 			if (feof($this->currentStream)) {
+				$streamStat = fstat($this->currentStream);
 				fclose($this->currentStream);
 				$currentNodeSize = $this->nodes[$this->currentNode]->getSize();
 				if ($this->currentNodeRead < $currentNodeSize) {
-					throw new \Exception('Stream from assembly node shorter than expected, got ' . $this->currentNodeRead . ' bytes, expected ' . $currentNodeSize);
+					throw new \Exception('Stream from assembly node shorter than expected, got ' .
+						$this->currentNodeRead . ' bytes, node size is reported as ' .
+						$currentNodeSize . 'B, stream is reported as ' . $streamStat['size'] . 'B'
+					);
 				}
 				$this->currentNode++;
 				$this->currentNodeRead = 0;


### PR DESCRIPTION
The stream size should give a more accurate view of how large the node is on the storage, which might be different from how big that filecache thinks the node is in error cases.

This should help distinguishing issues with writing the chunk from issues with reading the node.