### PR TITLE
Uses PHP8's constructor property promotion in core/Command/User classes.

### DIFF
--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -39,13 +39,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 class Add extends Command {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-
-	public function __construct(IUserManager $userManager, IGroupManager $groupManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
 	}
 
 	protected function configure() {

--- a/core/Command/User/AddAppPassword.php
+++ b/core/Command/User/AddAppPassword.php
@@ -41,19 +41,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 class AddAppPassword extends Command {
-	protected IUserManager $userManager;
-	protected IProvider $tokenProvider;
-	private ISecureRandom $random;
-	private IEventDispatcher $eventDispatcher;
-
-	public function __construct(IUserManager $userManager,
-								IProvider $tokenProvider,
-								ISecureRandom $random,
-								IEventDispatcher $eventDispatcher) {
-		$this->tokenProvider = $tokenProvider;
-		$this->userManager = $userManager;
-		$this->random = $random;
-		$this->eventDispatcher = $eventDispatcher;
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IProvider $tokenProvider,
+		private ISecureRandom $random,
+		private IEventDispatcher $eventDispatcher,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -33,7 +33,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	public function __construct(protected IUserManager $userManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -33,14 +33,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	/** @var IUserManager */
-	protected $userManager;
-
-	/**
-	 * @param IUserManager $userManager
-	 */
-	public function __construct(IUserManager $userManager) {
-		$this->userManager = $userManager;
+	public function __construct(protected IUserManager $userManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Base {
-	public function __construct(protected IUserManager $userManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -32,10 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Base {
-	protected IUserManager $userManager;
-
-	public function __construct(IUserManager $userManager) {
-		$this->userManager = $userManager;
+	public function __construct(protected IUserManager $userManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -32,10 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Base {
-	protected IUserManager $userManager;
-
-	public function __construct(IUserManager $userManager) {
-		$this->userManager = $userManager;
+	public function __construct(protected IUserManager $userManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Base {
-	public function __construct(protected IUserManager $userManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -35,12 +35,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Info extends Base {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-
-	public function __construct(IUserManager $userManager, IGroupManager $groupManager) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -34,10 +34,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class LastSeen extends Base {
-	protected IUserManager $userManager;
-
-	public function __construct(IUserManager $userManager) {
-		$this->userManager = $userManager;
+	public function __construct(protected IUserManager $userManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -34,7 +34,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class LastSeen extends Base {
-	public function __construct(protected IUserManager $userManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -33,13 +33,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-
-	public function __construct(IUserManager $userManager,
-								IGroupManager $groupManager) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -41,13 +41,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Report extends Command {
 	public const DEFAULT_COUNT_DIRS_MAX_USERS = 500;
 
-	protected IUserManager $userManager;
-	private IConfig $config;
-
-	public function __construct(IUserManager $userManager,
-								IConfig $config) {
-		$this->userManager = $userManager;
-		$this->config = $config;
+	public function __construct(
+		protected IUserManager $userManager,
+		private IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -41,13 +41,11 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
 class ResetPassword extends Base {
-	protected IUserManager $userManager;
-	private IAppManager $appManager;
-
-	public function __construct(IUserManager $userManager, IAppManager $appManager) {
+	public function __construct(
+		protected IUserManager $userManager,
+		private IAppManager $appManager,
+	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->appManager = $appManager;
 	}
 
 	protected function configure() {

--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -36,13 +36,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Setting extends Base {
-	protected IUserManager $userManager;
-	protected IConfig $config;
-
-	public function __construct(IUserManager $userManager, IConfig $config) {
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IConfig $config,
+	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->config = $config;
 	}
 
 	protected function configure() {


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/User` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.