### PR TITLE
Uses PHP8's constructor property promotion in core/Command/Maintenance

### DIFF
--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -29,13 +29,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DataFingerprint extends Command {
-	protected IConfig $config;
-	protected ITimeFactory $timeFactory;
-
-	public function __construct(IConfig $config,
-								ITimeFactory $timeFactory) {
-		$this->config = $config;
-		$this->timeFactory = $timeFactory;
+	public function __construct(
+		protected IConfig $config,
+		protected ITimeFactory $timeFactory,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -47,13 +47,11 @@ use Throwable;
 use function get_class;
 
 class Install extends Command {
-	private SystemConfig $config;
-	private IniGetWrapper $iniGetWrapper;
-
-	public function __construct(SystemConfig $config, IniGetWrapper $iniGetWrapper) {
+	public function __construct(
+		private SystemConfig $config,
+		private IniGetWrapper $iniGetWrapper,
+	) {
 		parent::__construct();
-		$this->config = $config;
-		$this->iniGetWrapper = $iniGetWrapper;
 	}
 
 	protected function configure() {

--- a/core/Command/Maintenance/Mimetype/UpdateDB.php
+++ b/core/Command/Maintenance/Mimetype/UpdateDB.php
@@ -35,16 +35,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class UpdateDB extends Command {
 	public const DEFAULT_MIMETYPE = 'application/octet-stream';
 
-	protected IMimeTypeDetector $mimetypeDetector;
-	protected IMimeTypeLoader $mimetypeLoader;
-
 	public function __construct(
-		IMimeTypeDetector $mimetypeDetector,
-		IMimeTypeLoader $mimetypeLoader
+		protected IMimeTypeDetector $mimetypeDetector,
+		protected IMimeTypeLoader $mimetypeLoader,
 	) {
 		parent::__construct();
-		$this->mimetypeDetector = $mimetypeDetector;
-		$this->mimetypeLoader = $mimetypeLoader;
 	}
 
 	protected function configure() {

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -31,13 +31,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateJS extends Command {
-	protected IMimeTypeDetector $mimetypeDetector;
-
-	public function __construct(
-		IMimeTypeDetector $mimetypeDetector
-	) {
+	public function __construct(protected IMimeTypeDetector $mimetypeDetector) {
 		parent::__construct();
-		$this->mimetypeDetector = $mimetypeDetector;
 	}
 
 	protected function configure() {

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -31,7 +31,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateJS extends Command {
-	public function __construct(protected IMimeTypeDetector $mimetypeDetector) {
+	public function __construct(
+		protected IMimeTypeDetector $mimetypeDetector,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -33,10 +33,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Mode extends Command {
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -33,7 +33,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Mode extends Command {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -47,19 +47,16 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Repair extends Command {
-	protected \OC\Repair $repair;
-	protected IConfig $config;
-	private IEventDispatcher $dispatcher;
 	private ProgressBar $progress;
 	private OutputInterface $output;
-	private IAppManager $appManager;
 	protected bool $errored = false;
 
-	public function __construct(\OC\Repair $repair, IConfig $config, IEventDispatcher $dispatcher, IAppManager $appManager) {
-		$this->repair = $repair;
-		$this->config = $config;
-		$this->dispatcher = $dispatcher;
-		$this->appManager = $appManager;
+	public function __construct(
+		protected \OC\Repair $repair,
+		protected IConfig $config,
+		private IEventDispatcher $dispatcher,
+		private IAppManager $appManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/RepairShareOwnership.php
+++ b/core/Command/Maintenance/RepairShareOwnership.php
@@ -38,15 +38,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class RepairShareOwnership extends Command {
-	private IDBConnection $dbConnection;
-	private IUserManager $userManager;
-
 	public function __construct(
-		IDBConnection $dbConnection,
-		IUserManager $userManager
+		private IDBConnection $dbConnection,
+		private IUserManager $userManager,
 	) {
-		$this->dbConnection = $dbConnection;
-		$this->userManager = $userManager;
 		parent::__construct();
 	}
 

--- a/core/Command/Maintenance/UpdateTheme.php
+++ b/core/Command/Maintenance/UpdateTheme.php
@@ -33,15 +33,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateTheme extends UpdateJS {
-	protected IMimeTypeDetector $mimetypeDetector;
-	protected ICacheFactory $cacheFactory;
-
 	public function __construct(
 		IMimeTypeDetector $mimetypeDetector,
-		ICacheFactory $cacheFactory
+		protected ICacheFactory $cacheFactory,
 	) {
 		parent::__construct($mimetypeDetector);
-		$this->cacheFactory = $cacheFactory;
 	}
 
 	protected function configure() {


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/Maintenance` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.