### PR TITLE
Uses PHP8's constructor property promotion in core/Command/Config and Group

### DIFF
--- a/core/Command/Config/App/DeleteConfig.php
+++ b/core/Command/Config/App/DeleteConfig.php
@@ -28,7 +28,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DeleteConfig extends Base {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Config/App/DeleteConfig.php
+++ b/core/Command/Config/App/DeleteConfig.php
@@ -28,14 +28,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DeleteConfig extends Base {
-	protected IConfig $config;
-
-	/**
-	 * @param IConfig $config
-	 */
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -28,11 +28,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GetConfig extends Base {
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -28,7 +28,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GetConfig extends Base {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -28,7 +28,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetConfig extends Base {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -28,11 +28,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetConfig extends Base {
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -35,11 +35,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Import extends Command implements CompletionAwareInterface {
 	protected array $validRootKeys = ['system', 'apps'];
-	protected IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -36,7 +36,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Import extends Command implements CompletionAwareInterface {
 	protected array $validRootKeys = ['system', 'apps'];
 
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -33,13 +33,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListConfigs extends Base {
 	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_JSON_PRETTY;
-	protected SystemConfig $systemConfig;
-	protected IAppConfig $appConfig;
 
-	public function __construct(SystemConfig $systemConfig, IAppConfig $appConfig) {
+	public function __construct(
+		protected SystemConfig $systemConfig,
+		protected IAppConfig $appConfig,
+	) {
 		parent::__construct();
-		$this->systemConfig = $systemConfig;
-		$this->appConfig = $appConfig;
 	}
 
 	protected function configure() {

--- a/core/Command/Config/System/Base.php
+++ b/core/Command/Config/System/Base.php
@@ -26,11 +26,8 @@ use OC\SystemConfig;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 
 abstract class Base extends \OC\Core\Command\Base {
-	protected SystemConfig $systemConfig;
-
-	public function __construct(SystemConfig $systemConfig) {
+	public function __construct(protected SystemConfig $systemConfig) {
 		parent::__construct();
-		$this->systemConfig = $systemConfig;
 	}
 
 	/**

--- a/core/Command/Config/System/Base.php
+++ b/core/Command/Config/System/Base.php
@@ -26,7 +26,9 @@ use OC\SystemConfig;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 
 abstract class Base extends \OC\Core\Command\Base {
-	public function __construct(protected SystemConfig $systemConfig) {
+	public function __construct(
+		protected SystemConfig $systemConfig,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Config/System/DeleteConfig.php
+++ b/core/Command/Config/System/DeleteConfig.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DeleteConfig extends Base {
-	public function __construct(SystemConfig $systemConfig) {
+	public function __construct(
+		SystemConfig $systemConfig,
+	) {
 		parent::__construct($systemConfig);
 	}
 

--- a/core/Command/Config/System/GetConfig.php
+++ b/core/Command/Config/System/GetConfig.php
@@ -29,7 +29,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GetConfig extends Base {
-	public function __construct(SystemConfig $systemConfig) {
+	public function __construct(
+		SystemConfig $systemConfig,
+	) {
 		parent::__construct($systemConfig);
 	}
 

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SetConfig extends Base {
-	public function __construct(SystemConfig $systemConfig) {
+	public function __construct(
+		SystemConfig $systemConfig,
+	) {
 		parent::__construct($systemConfig);
 	}
 

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -36,10 +36,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	protected IGroupManager $groupManager;
-
-	public function __construct(IGroupManager $groupManager) {
-		$this->groupManager = $groupManager;
+	public function __construct(protected IGroupManager $groupManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -36,7 +36,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	public function __construct(protected IGroupManager $groupManager) {
+	public function __construct(
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/AddUser.php
+++ b/core/Command/Group/AddUser.php
@@ -34,12 +34,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class AddUser extends Base {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-
-	public function __construct(IUserManager $userManager, IGroupManager $groupManager) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -35,10 +35,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	protected IGroupManager $groupManager;
-
-	public function __construct(IGroupManager $groupManager) {
-		$this->groupManager = $groupManager;
+	public function __construct(protected IGroupManager $groupManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -35,7 +35,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	public function __construct(protected IGroupManager $groupManager) {
+	public function __construct(
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/Info.php
+++ b/core/Command/Group/Info.php
@@ -35,10 +35,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Info extends Base {
-	protected IGroupManager $groupManager;
-
-	public function __construct(IGroupManager $groupManager) {
-		$this->groupManager = $groupManager;
+	public function __construct(protected IGroupManager $groupManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/Info.php
+++ b/core/Command/Group/Info.php
@@ -35,7 +35,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Info extends Base {
-	public function __construct(protected IGroupManager $groupManager) {
+	public function __construct(
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	public function __construct(protected IGroupManager $groupManager) {
+	public function __construct(
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -32,10 +32,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	protected IGroupManager $groupManager;
-
-	public function __construct(IGroupManager $groupManager) {
-		$this->groupManager = $groupManager;
+	public function __construct(protected IGroupManager $groupManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Group/RemoveUser.php
+++ b/core/Command/Group/RemoveUser.php
@@ -34,12 +34,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveUser extends Base {
-	protected IUserManager $userManager;
-	protected IGroupManager $groupManager;
-
-	public function __construct(IUserManager $userManager, IGroupManager $groupManager) {
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
+	public function __construct(
+		protected IUserManager $userManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
 	}
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/Config` and `/core/Command/Group` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.