### PR TITLE
 Uses PHP8's constructor property promotion core/Command/App,/Background, and /Broadcast 

### DIFF
--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -33,12 +33,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Command implements CompletionAwareInterface {
-	protected IAppManager $appManager;
 	protected int $exitCode = 0;
 
-	public function __construct(IAppManager $appManager) {
+	public function __construct(protected IAppManager $appManager) {
 		parent::__construct();
-		$this->appManager = $appManager;
 	}
 
 	protected function configure(): void {

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -35,7 +35,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Disable extends Command implements CompletionAwareInterface {
 	protected int $exitCode = 0;
 
-	public function __construct(protected IAppManager $appManager) {
+	public function __construct(
+		protected IAppManager $appManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -39,14 +39,13 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Command implements CompletionAwareInterface {
-	protected IAppManager $appManager;
-	protected IGroupManager $groupManager;
 	protected int $exitCode = 0;
 
-	public function __construct(IAppManager $appManager, IGroupManager $groupManager) {
+	public function __construct(
+		protected IAppManager $appManager,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct();
-		$this->appManager = $appManager;
-		$this->groupManager = $groupManager;
 	}
 
 	protected function configure(): void {

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -33,7 +33,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListApps extends Base {
-	public function __construct(protected IAppManager $manager) {
+	public function __construct(
+		protected IAppManager $manager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -33,11 +33,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListApps extends Base {
-	protected IAppManager $manager;
-
-	public function __construct(IAppManager $manager) {
+	public function __construct(protected IAppManager $manager) {
 		parent::__construct();
-		$this->manager = $manager;
 	}
 
 	protected function configure() {

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -39,15 +39,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
 class Remove extends Command implements CompletionAwareInterface {
-	protected IAppManager $manager;
-	private Installer $installer;
-	private LoggerInterface $logger;
-
-	public function __construct(IAppManager $manager, Installer $installer, LoggerInterface $logger) {
+	public function __construct(
+		protected IAppManager $manager,
+		private Installer $installer,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-		$this->manager = $manager;
-		$this->installer = $installer;
-		$this->logger = $logger;
 	}
 
 	protected function configure() {

--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -37,15 +37,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Update extends Command {
-	protected IAppManager $manager;
-	private Installer $installer;
-	private LoggerInterface $logger;
-
-	public function __construct(IAppManager $manager, Installer $installer, LoggerInterface $logger) {
+	public function __construct(
+		protected IAppManager $manager,
+		private Installer $installer,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-		$this->manager = $manager;
-		$this->installer = $installer;
-		$this->logger = $logger;
 	}
 
 	protected function configure() {

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -39,7 +39,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class Base extends Command {
 	abstract protected function getMode();
 
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -38,11 +38,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class Base extends Command {
 	abstract protected function getMode();
-	protected IConfig $config;
 
-	public function __construct(IConfig $config) {
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Background/Job.php
+++ b/core/Command/Background/Job.php
@@ -35,14 +35,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Job extends Command {
-	protected IJobList $jobList;
-	protected ILogger $logger;
-
-	public function __construct(IJobList $jobList,
-								ILogger $logger) {
+	public function __construct(
+		protected IJobList $jobList,
+		protected ILogger $logger,
+	) {
 		parent::__construct();
-		$this->jobList = $jobList;
-		$this->logger = $logger;
 	}
 
 	protected function configure(): void {

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	public function __construct(protected IJobList $jobList) {
+	public function __construct(
+		protected IJobList $jobList,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -32,11 +32,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	protected IJobList $jobList;
-
-	public function __construct(IJobList $jobList) {
+	public function __construct(protected IJobList $jobList) {
 		parent::__construct();
-		$this->jobList = $jobList;
 	}
 
 	protected function configure(): void {

--- a/core/Command/Broadcast/Test.php
+++ b/core/Command/Broadcast/Test.php
@@ -34,11 +34,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Test extends Command {
-	private IEventDispatcher $eventDispatcher;
-
-	public function __construct(IEventDispatcher $eventDispatcher) {
+	public function __construct(private IEventDispatcher $eventDispatcher) {
 		parent::__construct();
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	protected function configure(): void {

--- a/core/Command/Broadcast/Test.php
+++ b/core/Command/Broadcast/Test.php
@@ -34,7 +34,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Test extends Command {
-	public function __construct(private IEventDispatcher $eventDispatcher) {
+	public function __construct(
+		private IEventDispatcher $eventDispatcher,
+	) {
 		parent::__construct();
 	}
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/App`, `/core/Command/Background`, and `/core/Command/Broadcast` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.