### PR TITLE
Make oauth2 client secret column larger

### DIFF
--- a/apps/oauth2/appinfo/info.xml
+++ b/apps/oauth2/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>OAuth 2.0</name>
 	<summary>Allows OAuth2 compatible authentication from other web applications.</summary>
 	<description>The OAuth2 app allows administrators to configure the built-in authentication workflow to also allow OAuth2 compatible authentication from other web applications.</description>
-	<version>1.16.1</version>
+	<version>1.16.2</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>OAuth2</namespace>

--- a/apps/oauth2/composer/composer/autoload_classmap.php
+++ b/apps/oauth2/composer/composer/autoload_classmap.php
@@ -20,5 +20,6 @@ return array(
     'OCA\\OAuth2\\Migration\\Version010401Date20181207190718' => $baseDir . '/../lib/Migration/Version010401Date20181207190718.php',
     'OCA\\OAuth2\\Migration\\Version010402Date20190107124745' => $baseDir . '/../lib/Migration/Version010402Date20190107124745.php',
     'OCA\\OAuth2\\Migration\\Version011601Date20230522143227' => $baseDir . '/../lib/Migration/Version011601Date20230522143227.php',
+    'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => $baseDir . '/../lib/Migration/Version011602Date20230613160650.php',
     'OCA\\OAuth2\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
 );

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -35,6 +35,7 @@ class ComposerStaticInitOAuth2
         'OCA\\OAuth2\\Migration\\Version010401Date20181207190718' => __DIR__ . '/..' . '/../lib/Migration/Version010401Date20181207190718.php',
         'OCA\\OAuth2\\Migration\\Version010402Date20190107124745' => __DIR__ . '/..' . '/../lib/Migration/Version010402Date20190107124745.php',
         'OCA\\OAuth2\\Migration\\Version011601Date20230522143227' => __DIR__ . '/..' . '/../lib/Migration/Version011601Date20230522143227.php',
+        'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => __DIR__ . '/..' . '/../lib/Migration/Version011602Date20230613160650.php',
         'OCA\\OAuth2\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
     );
 

--- a/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
+++ b/apps/oauth2/lib/Migration/Version011601Date20230522143227.php
@@ -49,7 +49,7 @@ class Version011601Date20230522143227 extends SimpleMigrationStep {
 			$table = $schema->getTable('oauth2_clients');
 			if ($table->hasColumn('secret')) {
 				$column = $table->getColumn('secret');
-				$column->setLength(256);
+				$column->setLength(512);
 				return $schema;
 			}
 		}

--- a/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
+++ b/apps/oauth2/lib/Migration/Version011602Date20230613160650.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright 2023, Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\OAuth2\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version011602Date20230613160650 extends SimpleMigrationStep {
+
+	public function __construct(
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('oauth2_clients')) {
+			$table = $schema->getTable('oauth2_clients');
+			if ($table->hasColumn('secret')) {
+				$column = $table->getColumn('secret');
+				// we still change the column length in case Version011601Date20230522143227
+				// has run before it was changed to set the length to 512
+				$column->setLength(512);
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -84,4 +84,14 @@ class ClientMapperTest extends TestCase {
 	public function testGetClients() {
 		$this->assertSame('array', gettype($this->clientMapper->getClients()));
 	}
+
+	public function testInsertLongEncryptedSecret(): void {
+		$client = new Client();
+		$client->setClientIdentifier('MyNewClient');
+		$client->setName('Client Name');
+		$client->setRedirectUri('https://example.com/');
+		$client->setSecret('b81dc8e2dc178817bf28ca7b37265aa96559ca02e6dcdeb74b42221d096ed5ef63681e836ae0ba1077b5fb5e6c2fa7748c78463f66fe0110c8dcb8dd7eb0305b16d0cd993e2ae275879994a2abf88c68|e466d9befa6b0102341458e45ecd551a|013af9e277374483123437f180a3b0371a411ad4f34c451547909769181a7d7cc191f0f5c2de78376d124dd7751b8c9660aabdd913f5e071fc6b819ba2e3d919|3');
+		$this->clientMapper->insert($client);
+		$this->assertTrue(true);
+	}
 }


### PR DESCRIPTION
refs https://github.com/nextcloud/server/pull/38398#discussion_r1226617872

This also adds a simple test inserting a client with a long secret.

@kesselb Any idea how much chars we can expect at most by giving a 64 chars to https://github.com/nextcloud/server/blob/master/lib/private/Security/Crypto.php#L93 ?