### PR TITLE
 Uses PHP8's constructor property promotion core/Command/Info, /Integrity, and /Preview

### DIFF
--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -23,11 +23,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class File extends Command {
 	private IL10N $l10n;
-	private FileUtils $fileUtils;
 
-	public function __construct(IFactory $l10nFactory, FileUtils $fileUtils) {
+	public function __construct(
+		IFactory $l10nFactory,
+		private FileUtils $fileUtils,
+	) {
 		$this->l10n = $l10nFactory->get("core");
-		$this->fileUtils = $fileUtils;
 		parent::__construct();
 	}
 

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Info;
 
-use OC\Files\SetupManager;
 use OCA\Circles\MountManager\CircleMount;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_Sharing\SharedMount;
@@ -33,7 +32,6 @@ use OCP\Files\Config\IUserMountCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
-use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
@@ -43,21 +41,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use OCP\Files\Folder;
 
 class FileUtils {
-	private IRootFolder $rootFolder;
-	private IUserMountCache $userMountCache;
-	private IMountManager $mountManager;
-	private SetupManager $setupManager;
-
 	public function __construct(
-		IRootFolder $rootFolder,
-		IUserMountCache $userMountCache,
-		IMountManager $mountManager,
-		SetupManager $setupManager
+		private IRootFolder $rootFolder,
+		private IUserMountCache $userMountCache,
 	) {
-		$this->rootFolder = $rootFolder;
-		$this->userMountCache = $userMountCache;
-		$this->mountManager = $mountManager;
-		$this->setupManager = $setupManager;
 	}
 
 	/**

--- a/core/Command/Info/Space.php
+++ b/core/Command/Info/Space.php
@@ -32,7 +32,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Space extends Command {
-	public function __construct(private FileUtils $fileUtils) {
+	public function __construct(
+		private FileUtils $fileUtils,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Info/Space.php
+++ b/core/Command/Info/Space.php
@@ -32,10 +32,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Space extends Command {
-	private FileUtils $fileUtils;
-
-	public function __construct(FileUtils $fileUtils) {
-		$this->fileUtils = $fileUtils;
+	public function __construct(private FileUtils $fileUtils) {
 		parent::__construct();
 	}
 

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -40,11 +40,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class CheckApp extends Base {
-	private Checker $checker;
-
-	public function __construct(Checker $checker) {
+	public function __construct(private Checker $checker) {
 		parent::__construct();
-		$this->checker = $checker;
 	}
 
 	/**

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -40,7 +40,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class CheckApp extends Base {
-	public function __construct(private Checker $checker) {
+	public function __construct(
+		private Checker $checker,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -36,7 +36,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class CheckCore extends Base {
-	public function __construct(private Checker $checker) {
+	public function __construct(
+		private Checker $checker,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -36,11 +36,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class CheckCore extends Base {
-	private Checker $checker;
-
-	public function __construct(Checker $checker) {
+	public function __construct(private Checker $checker) {
 		parent::__construct();
-		$this->checker = $checker;
 	}
 
 	/**

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -40,17 +40,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class SignApp extends Command {
-	private Checker $checker;
-	private FileAccessHelper $fileAccessHelper;
-	private IURLGenerator $urlGenerator;
-
-	public function __construct(Checker $checker,
-								FileAccessHelper $fileAccessHelper,
-								IURLGenerator $urlGenerator) {
+	public function __construct(
+		private Checker $checker,
+		private FileAccessHelper $fileAccessHelper,
+		private IURLGenerator $urlGenerator,
+	) {
 		parent::__construct(null);
-		$this->checker = $checker;
-		$this->fileAccessHelper = $fileAccessHelper;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	protected function configure() {

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -39,14 +39,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Core\Command\Integrity
  */
 class SignCore extends Command {
-	private Checker $checker;
-	private FileAccessHelper $fileAccessHelper;
-
-	public function __construct(Checker $checker,
-								FileAccessHelper $fileAccessHelper) {
+	public function __construct(
+		private Checker $checker,
+		private FileAccessHelper $fileAccessHelper,
+	) {
 		parent::__construct(null);
-		$this->checker = $checker;
-		$this->fileAccessHelper = $fileAccessHelper;
 	}
 
 	protected function configure() {

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -36,15 +36,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Generate extends Command {
-	private IRootFolder $rootFolder;
-	private IUserMountCache $userMountCache;
-	private IPreview $previewManager;
-
-	public function __construct(IRootFolder $rootFolder, IUserMountCache $userMountCache, IPreview $previewManager) {
-		$this->rootFolder = $rootFolder;
-		$this->userMountCache = $userMountCache;
-		$this->previewManager = $previewManager;
-
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private IUserMountCache $userMountCache,
+		private IPreview $previewManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Preview/Repair.php
+++ b/core/Command/Preview/Repair.php
@@ -45,20 +45,17 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use function pcntl_signal;
 
 class Repair extends Command {
-	protected IConfig $config;
-	private IRootFolder $rootFolder;
-	private LoggerInterface $logger;
 	private bool $stopSignalReceived = false;
 	private int $memoryLimit;
 	private int $memoryTreshold;
-	private ILockingProvider $lockingProvider;
 
-	public function __construct(IConfig $config, IRootFolder $rootFolder, LoggerInterface $logger, IniGetWrapper $phpIni, ILockingProvider $lockingProvider) {
-		$this->config = $config;
-		$this->rootFolder = $rootFolder;
-		$this->logger = $logger;
-		$this->lockingProvider = $lockingProvider;
-
+	public function __construct(
+		protected IConfig $config,
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
+		IniGetWrapper $phpIni,
+		private ILockingProvider $lockingProvider,
+	) {
 		$this->memoryLimit = (int)$phpIni->getBytes('memory_limit');
 		$this->memoryTreshold = $this->memoryLimit - 25 * 1024 * 1024;
 

--- a/core/Command/Preview/ResetRenderedTexts.php
+++ b/core/Command/Preview/ResetRenderedTexts.php
@@ -39,24 +39,14 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ResetRenderedTexts extends Command {
-	protected IDBConnection $connection;
-	protected IUserManager $userManager;
-	protected IAvatarManager $avatarManager;
-	private Root $previewFolder;
-	private IMimeTypeLoader $mimeTypeLoader;
-
-	public function __construct(IDBConnection $connection,
-								IUserManager $userManager,
-								IAvatarManager $avatarManager,
-								Root $previewFolder,
-								IMimeTypeLoader $mimeTypeLoader) {
+	public function __construct(
+		protected IDBConnection $connection,
+		protected IUserManager $userManager,
+		protected IAvatarManager $avatarManager,
+		private Root $previewFolder,
+		private IMimeTypeLoader $mimeTypeLoader,
+	) {
 		parent::__construct();
-
-		$this->connection = $connection;
-		$this->userManager = $userManager;
-		$this->avatarManager = $avatarManager;
-		$this->previewFolder = $previewFolder;
-		$this->mimeTypeLoader = $mimeTypeLoader;
 	}
 
 	protected function configure() {


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/Info`, `/core/Command/Integrity`, and `/core/Command/Preview` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.