### PR TITLE
 Uses PHP8's constructor property promotion in core/Command/Log, /Security, and /SystemTag

### DIFF
--- a/core/Command/Log/File.php
+++ b/core/Command/Log/File.php
@@ -36,10 +36,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class File extends Command implements Completion\CompletionAwareInterface {
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
 	}
 

--- a/core/Command/Log/File.php
+++ b/core/Command/Log/File.php
@@ -36,7 +36,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class File extends Command implements Completion\CompletionAwareInterface {
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -39,10 +39,7 @@ class Manage extends Command implements CompletionAwareInterface {
 	public const DEFAULT_LOG_LEVEL = 2;
 	public const DEFAULT_TIMEZONE = 'UTC';
 
-	protected IConfig $config;
-
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(protected IConfig $config) {
 		parent::__construct();
 	}
 

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -39,7 +39,9 @@ class Manage extends Command implements CompletionAwareInterface {
 	public const DEFAULT_LOG_LEVEL = 2;
 	public const DEFAULT_TIMEZONE = 'UTC';
 
-	public function __construct(protected IConfig $config) {
+	public function __construct(
+		protected IConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ImportCertificate extends Base {
-	public function __construct(protected ICertificateManager $certificateManager) {
+	public function __construct(
+		protected ICertificateManager $certificateManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -30,10 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ImportCertificate extends Base {
-	protected ICertificateManager $certificateManager;
-
-	public function __construct(ICertificateManager $certificateManager) {
-		$this->certificateManager = $certificateManager;
+	public function __construct(protected ICertificateManager $certificateManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -31,12 +31,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCertificates extends Base {
-	protected ICertificateManager $certificateManager;
-	protected IL10N $l;
-
-	public function __construct(ICertificateManager $certificateManager, IL10N $l) {
-		$this->certificateManager = $certificateManager;
-		$this->l = $l;
+	public function __construct(
+		protected ICertificateManager $certificateManager,
+		protected IL10N $l,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveCertificate extends Base {
-	public function __construct(protected ICertificateManager $certificateManager) {
+	public function __construct(
+		protected ICertificateManager $certificateManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -30,10 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveCertificate extends Base {
-	protected ICertificateManager $certificateManager;
-
-	public function __construct(ICertificateManager $certificateManager) {
-		$this->certificateManager = $certificateManager;
+	public function __construct(protected ICertificateManager $certificateManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/ResetBruteforceAttempts.php
+++ b/core/Command/Security/ResetBruteforceAttempts.php
@@ -30,10 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ResetBruteforceAttempts extends Base {
-	protected Throttler $throttler;
-
-	public function __construct(Throttler $throttler) {
-		$this->throttler = $throttler;
+	public function __construct(protected Throttler $throttler) {
 		parent::__construct();
 	}
 

--- a/core/Command/Security/ResetBruteforceAttempts.php
+++ b/core/Command/Security/ResetBruteforceAttempts.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ResetBruteforceAttempts extends Base {
-	public function __construct(protected Throttler $throttler) {
+	public function __construct(
+		protected Throttler $throttler,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Add.php
+++ b/core/Command/SystemTag/Add.php
@@ -31,7 +31,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	public function __construct(protected ISystemTagManager $systemTagManager) {
+	public function __construct(
+		protected ISystemTagManager $systemTagManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Add.php
+++ b/core/Command/SystemTag/Add.php
@@ -31,10 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Add extends Base {
-	protected ISystemTagManager $systemTagManager;
-
-	public function __construct(ISystemTagManager $systemTagManager) {
-		$this->systemTagManager = $systemTagManager;
+	public function __construct(protected ISystemTagManager $systemTagManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Delete.php
+++ b/core/Command/SystemTag/Delete.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	public function __construct(protected ISystemTagManager $systemTagManager) {
+	public function __construct(
+		protected ISystemTagManager $systemTagManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Delete.php
+++ b/core/Command/SystemTag/Delete.php
@@ -30,10 +30,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Delete extends Base {
-	protected ISystemTagManager $systemTagManager;
-
-	public function __construct(ISystemTagManager $systemTagManager) {
-		$this->systemTagManager = $systemTagManager;
+	public function __construct(protected ISystemTagManager $systemTagManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Edit.php
+++ b/core/Command/SystemTag/Edit.php
@@ -31,7 +31,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Edit extends Base {
-	public function __construct(protected ISystemTagManager $systemTagManager) {
+	public function __construct(
+		protected ISystemTagManager $systemTagManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/Edit.php
+++ b/core/Command/SystemTag/Edit.php
@@ -31,10 +31,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Edit extends Base {
-	protected ISystemTagManager $systemTagManager;
-
-	public function __construct(ISystemTagManager $systemTagManager) {
-		$this->systemTagManager = $systemTagManager;
+	public function __construct(protected ISystemTagManager $systemTagManager) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/ListCommand.php
+++ b/core/Command/SystemTag/ListCommand.php
@@ -30,7 +30,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	public function __construct(protected ISystemTagManager $systemTagManager) {
+	public function __construct(
+		protected ISystemTagManager $systemTagManager,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/SystemTag/ListCommand.php
+++ b/core/Command/SystemTag/ListCommand.php
@@ -30,10 +30,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	protected ISystemTagManager $systemTagManager;
-
-	public function __construct(ISystemTagManager $systemTagManager) {
-		$this->systemTagManager = $systemTagManager;
+	public function __construct(protected ISystemTagManager $systemTagManager) {
 		parent::__construct();
 	}
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command/Log`, `/core/Command/Security`, and `/core/Command/SystemTag` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.