### PR TITLE
Uses PHP8's constructor property promotion in core/Command and /

### DIFF
--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -29,11 +29,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Check extends Base {
-	private SystemConfig $config;
-
-	public function __construct(SystemConfig $config) {
+	public function __construct(private SystemConfig $config) {
 		parent::__construct();
-		$this->config = $config;
 	}
 
 	protected function configure() {

--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -29,7 +29,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Check extends Base {
-	public function __construct(private SystemConfig $config) {
+	public function __construct(
+		private SystemConfig $config,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -33,14 +33,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Status extends Base {
-	private IConfig $config;
-	private Defaults $themingDefaults;
-
-	public function __construct(IConfig $config, Defaults $themingDefaults) {
+	public function __construct(
+		private IConfig $config,
+		private Defaults $themingDefaults,
+	) {
 		parent::__construct('status');
-
-		$this->config = $config;
-		$this->themingDefaults = $themingDefaults;
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Base.php
+++ b/core/Command/TwoFactorAuth/Base.php
@@ -30,7 +30,12 @@ use OCP\IUserManager;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 
 class Base extends \OC\Core\Command\Base {
-	protected IUserManager $userManager;
+	public function __construct(
+		?string $name,
+		protected IUserManager $userManager,
+	) {
+		parent::__construct($name);
+	}
 
 	/**
 	 * Return possible values for the named option

--- a/core/Command/TwoFactorAuth/Cleanup.php
+++ b/core/Command/TwoFactorAuth/Cleanup.php
@@ -32,12 +32,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Cleanup extends Base {
-	private IRegistry $registry;
-
-	public function __construct(IRegistry $registry) {
+	public function __construct(private IRegistry $registry) {
 		parent::__construct();
-
-		$this->registry = $registry;
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Cleanup.php
+++ b/core/Command/TwoFactorAuth/Cleanup.php
@@ -35,7 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Cleanup extends Base {
 	public function __construct(
 		private IRegistry $registry,
-		protected IUserManager $userManager,
+		IUserManager $userManager,
 	) {
 		parent::__construct(
 			null,

--- a/core/Command/TwoFactorAuth/Cleanup.php
+++ b/core/Command/TwoFactorAuth/Cleanup.php
@@ -27,13 +27,20 @@ declare(strict_types=1);
 namespace OC\Core\Command\TwoFactorAuth;
 
 use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Cleanup extends Base {
-	public function __construct(private IRegistry $registry) {
-		parent::__construct();
+	public function __construct(
+		private IRegistry $registry,
+		protected IUserManager $userManager,
+	) {
+		parent::__construct(
+			null,
+			$userManager,
+		);
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Disable extends Base {
 	public function __construct(
 		private ProviderManager $manager,
-		protected IUserManager $userManager,
+		IUserManager $userManager,
 	) {
 		parent::__construct(
 			'twofactorauth:disable',

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -29,12 +29,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Disable extends Base {
-	private ProviderManager $manager;
-
-	public function __construct(ProviderManager $manager, IUserManager $userManager) {
+	public function __construct(
+		private ProviderManager $manager,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct('twofactorauth:disable');
-		$this->manager = $manager;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -33,7 +33,10 @@ class Disable extends Base {
 		private ProviderManager $manager,
 		protected IUserManager $userManager,
 	) {
-		parent::__construct('twofactorauth:disable');
+		parent::__construct(
+			'twofactorauth:disable',
+			$userManager,
+		);
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -29,12 +29,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enable extends Base {
-	private ProviderManager $manager;
-
-	public function __construct(ProviderManager $manager, IUserManager $userManager) {
+	public function __construct(
+		private ProviderManager $manager,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct('twofactorauth:enable');
-		$this->manager = $manager;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -33,7 +33,10 @@ class Enable extends Base {
 		private ProviderManager $manager,
 		protected IUserManager $userManager,
 	) {
-		parent::__construct('twofactorauth:enable');
+		parent::__construct(
+			'twofactorauth:enable',
+			$userManager,
+		);
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Enable extends Base {
 	public function __construct(
 		private ProviderManager $manager,
-		protected IUserManager $userManager,
+		IUserManager $userManager,
 	) {
 		parent::__construct(
 			'twofactorauth:enable',

--- a/core/Command/TwoFactorAuth/Enforce.php
+++ b/core/Command/TwoFactorAuth/Enforce.php
@@ -35,7 +35,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enforce extends Command {
-	public function __construct(private MandatoryTwoFactor $mandatoryTwoFactor) {
+	public function __construct(
+		private MandatoryTwoFactor $mandatoryTwoFactor,
+	) {
 		parent::__construct();
 	}
 

--- a/core/Command/TwoFactorAuth/Enforce.php
+++ b/core/Command/TwoFactorAuth/Enforce.php
@@ -35,12 +35,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Enforce extends Command {
-	private MandatoryTwoFactor $mandatoryTwoFactor;
-
-	public function __construct(MandatoryTwoFactor $mandatoryTwoFactor) {
+	public function __construct(private MandatoryTwoFactor $mandatoryTwoFactor) {
 		parent::__construct();
-
-		$this->mandatoryTwoFactor = $mandatoryTwoFactor;
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/State.php
+++ b/core/Command/TwoFactorAuth/State.php
@@ -35,7 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class State extends Base {
 	public function __construct(
 		private IRegistry $registry,
-		protected IUserManager $userManager,
+		IUserManager $userManager,
 	) {
 		parent::__construct(
 			'twofactorauth:state',

--- a/core/Command/TwoFactorAuth/State.php
+++ b/core/Command/TwoFactorAuth/State.php
@@ -37,7 +37,10 @@ class State extends Base {
 		private IRegistry $registry,
 		protected IUserManager $userManager,
 	) {
-		parent::__construct('twofactorauth:state');
+		parent::__construct(
+			'twofactorauth:state',
+			$userManager,
+		);
 	}
 
 	protected function configure() {

--- a/core/Command/TwoFactorAuth/State.php
+++ b/core/Command/TwoFactorAuth/State.php
@@ -33,13 +33,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class State extends Base {
-	private IRegistry $registry;
-
-	public function __construct(IRegistry $registry, IUserManager $userManager) {
+	public function __construct(
+		private IRegistry $registry,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct('twofactorauth:state');
-
-		$this->registry = $registry;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure() {

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -62,15 +62,12 @@ class Upgrade extends Command {
 	public const ERROR_INVALID_ARGUMENTS = 4;
 	public const ERROR_FAILURE = 5;
 
-	private IConfig $config;
-	private LoggerInterface $logger;
-	private Installer $installer;
-
-	public function __construct(IConfig $config, LoggerInterface $logger, Installer $installer) {
+	public function __construct(
+		private IConfig $config,
+		private LoggerInterface $logger,
+		private Installer $installer,
+	) {
 		parent::__construct();
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->installer = $installer;
 	}
 
 	protected function configure() {

--- a/tests/Core/Command/TwoFactorAuth/CleanupTest.php
+++ b/tests/Core/Command/TwoFactorAuth/CleanupTest.php
@@ -28,6 +28,7 @@ namespace Core\Command\TwoFactorAuth;
 
 use OC\Core\Command\TwoFactorAuth\Cleanup;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
@@ -36,6 +37,9 @@ class CleanupTest extends TestCase {
 	/** @var IRegistry|MockObject */
 	private $registry;
 
+	/** @var IUserManager|MockObject */
+	private $userManager;
+
 	/** @var CommandTester */
 	private $cmd;
 
@@ -43,8 +47,9 @@ class CleanupTest extends TestCase {
 		parent::setUp();
 
 		$this->registry = $this->createMock(IRegistry::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 
-		$cmd = new Cleanup($this->registry);
+		$cmd = new Cleanup($this->registry, $this->userManager);
 		$this->cmd = new CommandTester($cmd);
 	}
 


### PR DESCRIPTION
Following https://github.com/nextcloud/server/pull/38636, https://github.com/nextcloud/server/pull/38637, and https://github.com/nextcloud/server/pull/38638 PRs, I have made the required adjustments to the `/core/Command/` namespace as well.

I figured I should split the changes into multiple PRs to make reviewing the changes easier.

This PR refactors `/core/Command` and `/core/Command/TwoFactorAuth` classes by using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.