### PR TITLE
fix(carddav): Make SystemAddressBook::__construct $groupManager argument nullable

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -64,7 +64,7 @@ class SystemAddressbook extends AddressBook {
 		IUserSession $userSession,
 		?IRequest $request = null,
 		?TrustedServers $trustedServers = null,
-		?IGroupManager $groupManager) {
+		?IGroupManager $groupManager = null) {
 		parent::__construct($carddavBackend, $addressBookInfo, $l10n);
 		$this->config = $config;
 		$this->userSession = $userSession;


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/38772

## Summary

Make PHP happy.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
