### PR TITLE
Enable version features again with S3 versioning

### DIFF
--- a/apps/files_versions/lib/Capabilities.php
+++ b/apps/files_versions/lib/Capabilities.php
@@ -46,13 +46,13 @@ class Capabilities implements ICapability {
 	 * @return array
 	 */
 	public function getCapabilities() {
-		$groupFolderOrS3VersioningInstalled = $this->appManager->isInstalled('groupfolders') || $this->appManager->isInstalled('files_versions_s3');
+		$groupFolderInstalled = $this->appManager->isInstalled('groupfolders');
 
 		return [
 			'files' => [
 				'versioning' => true,
-				'version_labeling' => !$groupFolderOrS3VersioningInstalled && $this->config->getSystemValueBool('enable_version_labeling', true),
-				'version_deletion' => !$groupFolderOrS3VersioningInstalled && $this->config->getSystemValueBool('enable_version_deletion', true),
+				'version_labeling' => !$groupFolderInstalled && $this->config->getSystemValueBool('enable_version_labeling', true),
+				'version_deletion' => !$groupFolderInstalled && $this->config->getSystemValueBool('enable_version_deletion', true),
 			]
 		];
 	}


### PR DESCRIPTION
## Summary

After nextcloud/files_versions_s3#28 is merged, we can enable version features with the S3 versioning backend again.