### PR TITLE
fix: Avoid failing to update the current version entry if there is none

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -40,6 +40,7 @@ use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
 use OCA\Files_Versions\Storage;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\Exception;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\BeforeNodeCopiedEvent;
@@ -57,6 +58,7 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use Psr\Log\LoggerInterface;
 
 class FileEventsListener implements IEventListener {
 	private IRootFolder $rootFolder;
@@ -74,15 +76,18 @@ class FileEventsListener implements IEventListener {
 	 */
 	private array $versionsDeleted = [];
 	private IMimeTypeLoader $mimeTypeLoader;
+	private LoggerInterface $logger;
 
 	public function __construct(
 		IRootFolder $rootFolder,
 		VersionsMapper $versionsMapper,
-		IMimeTypeLoader $mimeTypeLoader
+		IMimeTypeLoader $mimeTypeLoader,
+		LoggerInterface $logger,
 	) {
 		$this->rootFolder = $rootFolder;
 		$this->versionsMapper = $versionsMapper;
 		$this->mimeTypeLoader = $mimeTypeLoader;
+		$this->logger = $logger;
 	}
 
 	public function handle(Event $event): void {
@@ -234,13 +239,29 @@ class FileEventsListener implements IEventListener {
 			// Unless both versions have the same mtime.
 			$this->created($node);
 		} else {
-			// If no new version was stored in the FS, no new version should be added in the DB.
-			// So we simply update the associated version.
-			$currentVersionEntity = $this->versionsMapper->findVersionForFileId($node->getId(), $writeHookInfo['previousNode']->getMtime());
-			$currentVersionEntity->setTimestamp($node->getMTime());
-			$currentVersionEntity->setSize($node->getSize());
-			$currentVersionEntity->setMimetype($this->mimeTypeLoader->getId($node->getMimetype()));
-			$this->versionsMapper->update($currentVersionEntity);
+			try {
+				// If no new version was stored in the FS, no new version should be added in the DB.
+				// So we simply update the associated version.
+				$currentVersionEntity = $this->versionsMapper->findVersionForFileId($node->getId(), $writeHookInfo['previousNode']->getMtime());
+				$currentVersionEntity->setTimestamp($node->getMTime());
+				$currentVersionEntity->setSize($node->getSize());
+				$currentVersionEntity->setMimetype($this->mimeTypeLoader->getId($node->getMimetype()));
+				$this->versionsMapper->update($currentVersionEntity);
+			} catch (Exception $e) {
+				$this->logger->error('Failed to update existing version for ' . $node->getPath(), [
+					'exception' => $e,
+					'versionCreated' => $writeHookInfo['versionCreated'],
+					'previousNode' => [
+						'size' => $writeHookInfo['previousNode']->getSize(),
+						'mtime' => $writeHookInfo['previousNode']->getMTime(),
+					],
+					'node' => [
+						'size' => $node->getSize(),
+						'mtime' => $node->getMTime(),
+					]
+				]);
+				throw $e;
+			}
 		}
 
 		unset($this->writeHookInfo[$node->getId()]);

--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -232,8 +232,8 @@ class FileEventsListener implements IEventListener {
 		}
 
 		if (
-			($writeHookInfo['versionCreated'] && $node->getMTime() !== $writeHookInfo['previousNode']->getMTime()) ||
-			$writeHookInfo['previousNode']->getSize() === 0
+			($writeHookInfo['versionCreated'] || $writeHookInfo['previousNode']->getSize() === 0) &&
+			$node->getMTime() !== $writeHookInfo['previousNode']->getMTime()
 		) {
 			// If a new version was created, insert a version in the DB for the current content.
 			// Unless both versions have the same mtime.


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>


* Resolves: https://github.com/nextcloud/server/issues/41174

## Summary

I managed to reproduce the error by having a file without a versions entry as it would be the case for files from before the upgrade to 25.

Steps to reproduce on latest master:
- Create a new text file
- Let it open but don't type
- Drop the created entry in oc_files_versions to simulate an older file
- Type something and save in the text app

The first attempt to save will not create a version as the size is 0 and https://github.com/nextcloud/server/blob/c3475f4dbbb9f5562218f058c3c53c38d084ad1b/apps/files_versions/lib/Storage.php#L227-L228 will not write a version in this case. However the logic in the FileEventsListener then would hit the case of the error message where there is no current version stored in the table.

It seemed reasonable to me to just create it in this case.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
