### PR TITLE
Fix issues where unencrypted_size was being falsely used for non-encrypted home folders

### DIFF
--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -134,7 +134,7 @@ class CacheEntry implements ICacheEntry {
 	}
 
 	public function getUnencryptedSize(): int {
-		if (isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
+		if ($this->data['encrypted'] && isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
 			return $this->data['unencrypted_size'];
 		} else {
 			return $this->data['size'] ?? 0;

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -207,7 +207,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		if ($includeMounts) {
 			$this->updateEntryfromSubMounts();
 
-			if (isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
+			if ($this->isEncrypted() && isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
 				return $this->data['unencrypted_size'];
 			} else {
 				return isset($this->data['size']) ? 0 + $this->data['size'] : 0;
@@ -229,7 +229,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return bool
 	 */
 	public function isEncrypted() {
-		return $this->data['encrypted'];
+		return $this->data['encrypted'] ?? false;
 	}
 
 	/**

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -559,6 +559,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 
 		if ($exists) {
+			// Always update the unencrypted size, for encryption the Encryption wrapper will update this afterwards anyways
+			$stat['unencrypted_size'] = $stat['size'];
 			$this->getCache()->update($fileId, $stat);
 		} else {
 			if (!$this->validateWrites || $this->objectStore->objectExists($urn)) {

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1071,7 +1071,7 @@ class Encryption extends Wrapper {
 
 		// object store, stores the size after write and doesn't update this during scan
 		// manually store the unencrypted size
-		if ($result && $this->getWrapperStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
+		if ($result && $this->getWrapperStorage()->instanceOfStorage(ObjectStoreStorage::class) && $this->shouldEncrypt($path)) {
 			$this->getCache()->put($path, ['unencrypted_size' => $count]);
 		}
 


### PR DESCRIPTION
This fixes issues that occur when encryption is enabled but the encryption of home folders is disabled on object storage. 

Before this change the unencrypted_size might have been set but not always updated (e.g. when writing to a file through fopen). This lead to issues later on when trying to download the file but the size returned from the filecache didn't match with what the storage returns. 

#34232 didn't help here since the scan command it uses is not available for object storage.

Steps to reproduce
- Enable encryption
- Disable home folder encryption
- Upload a docx file
- Open the docx file in Collabora, change something and save (this uses fopen)

Before:
- The unencrypted_size column wasn't updated and the file was no longer downloadable

After:
- The file is downloadable even if the unencrypted size has a wrong data, since the file isn't encrypted we should just stick to the regular size column
- The unencrypted_size column will be properly updated by the ObjectStoreStorage already, for cases when encryption is enabled the Encryption Wrapper will anyways update the value afterwards

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
