### PR TITLE
Don't required since tag in OCP for inherited docs

### DIFF
--- a/build/psalm/OcpSinceChecker.php
+++ b/build/psalm/OcpSinceChecker.php
@@ -68,7 +68,7 @@ class OcpSinceChecker implements Psalm\Plugin\EventHandler\AfterClassLikeVisitIn
 			return;
 		}
 
-		if (!isset($parsedDocblock->tags['since'])) {
+		if (!isset($parsedDocblock->tags['since']) && !isset($parsedDocblock->tags['inheritdoc']) && !isset($parsedDocblock->tags['inheritDoc'])) {
 			IssueBuffer::maybeAdd(
 				new InvalidDocblock(
 					'@since is required for classes/interfaces in OCP.',
@@ -103,7 +103,7 @@ class OcpSinceChecker implements Psalm\Plugin\EventHandler\AfterClassLikeVisitIn
 			return;
 		}
 
-		if (!isset($parsedDocblock->tags['since'])) {
+		if (!isset($parsedDocblock->tags['since']) && !isset($parsedDocblock->tags['inheritdoc']) && !isset($parsedDocblock->tags['inheritDoc'])) {
 			IssueBuffer::maybeAdd(
 				new InvalidDocblock(
 					'@since is required for methods in OCP.',


### PR DESCRIPTION
## Summary

This allows to override methods and classes without having to specify the since tag again. It will be inherited from the parent method or class because the whole doc is inherited. The parent method or class doesn't need to be checked when the inherited doc is encountered, because it will already get checked by the same checker.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
