### PR TITLE
generate user themed favicon and touchicon

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -120,14 +120,15 @@ class IconController extends Controller {
 		} catch (NotFoundException $e) {
 		}
 		if ($iconFile === null && $this->imageManager->shouldReplaceIcons()) {
+			$color = $this->themingDefaults->getColorPrimary();
 			try {
-				$iconFile = $this->imageManager->getCachedImage('favIcon-' . $app);
+				$iconFile = $this->imageManager->getCachedImage('favIcon-' . $app . $color);
 			} catch (NotFoundException $exception) {
 				$icon = $this->iconBuilder->getFavicon($app);
 				if ($icon === false || $icon === '') {
 					return new NotFoundResponse();
 				}
-				$iconFile = $this->imageManager->setCachedImage('favIcon-' . $app, $icon);
+				$iconFile = $this->imageManager->setCachedImage('favIcon-' . $app . $color, $icon);
 			}
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/x-icon']);
 		}
@@ -157,14 +158,15 @@ class IconController extends Controller {
 		} catch (NotFoundException $e) {
 		}
 		if ($this->imageManager->shouldReplaceIcons()) {
+			$color = $this->themingDefaults->getColorPrimary();
 			try {
-				$iconFile = $this->imageManager->getCachedImage('touchIcon-' . $app);
+				$iconFile = $this->imageManager->getCachedImage('touchIcon-' . $app . $color);
 			} catch (NotFoundException $exception) {
 				$icon = $this->iconBuilder->getTouchIcon($app);
 				if ($icon === false || $icon === '') {
 					return new NotFoundResponse();
 				}
-				$iconFile = $this->imageManager->setCachedImage('touchIcon-' . $app, $icon);
+				$iconFile = $this->imageManager->setCachedImage('touchIcon-' . $app . $color, $icon);
 			}
 			$response = new FileDisplayResponse($iconFile, Http::STATUS_OK, ['Content-Type' => 'image/png']);
 		}


### PR DESCRIPTION
The problem was that the color was not taken into account by the logic. So as soon as the icon is created and put into place in the theming directory, it gets never re-created by changing the color. My PR now takes the color of the icon into account by putting it into the file name. The same logic is alreaddy applied and funcitoning here: https://github.com/nextcloud/server/blob/7afcc44827333683dc104cc9701963151d22946a/apps/theming/lib/Controller/IconController.php#L89-L97