### PR TITLE
Fix a TypeError on OC\Files\Cache\QuerySearchHelper::getCachesAndMoun…

### DIFF
--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -35,6 +35,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchQuery;
@@ -198,7 +199,7 @@ class QuerySearchHelper {
 	/**
 	 * @return array{array<string, ICache>, array<string, IMountPoint>}
 	 */
-	public function getCachesAndMountPointsForSearch(Root $root, string $path, bool $limitToHome = false): array {
+	public function getCachesAndMountPointsForSearch(IRootFolder $root, string $path, bool $limitToHome = false): array {
 		$rootLength = strlen($path);
 		$mount = $root->getMount($path);
 		$storage = $mount->getStorage();

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -55,4 +55,40 @@ interface IRootFolder extends Folder, Emitter {
 	 * @since 24.0.0
 	 */
 	public function getByIdInPath(int $id, string $path);
+
+	/**
+	 * @param \OC\Files\Storage\Storage $storage
+	 * @param string $mountPoint
+	 * @param array $arguments
+	 */
+	public function mount($storage, $mountPoint, $arguments = []);
+
+	/**
+	 * @param string $mountPoint
+	 * @return \OC\Files\Mount\MountPoint
+	 */
+	public function getMount($mountPoint);
+
+	/**
+	 * @param string $mountPoint
+	 * @return \OC\Files\Mount\MountPoint[]
+	 */
+	public function getMountsIn($mountPoint);
+
+	/**
+	 * @param string $storageId
+	 * @return \OC\Files\Mount\MountPoint[]
+	 */
+	public function getMountByStorageId($storageId);
+
+	/**
+	 * @param int $numericId
+	 * @return MountPoint[]
+	 */
+	public function getMountByNumericStorageId($numericId);
+
+	/**
+	 * @param \OC\Files\Mount\MountPoint $mount
+	 */
+	public function unMount($mount);
 }


### PR DESCRIPTION
* Resolves: a bug that comes SOOOOOOO many times on my server.

## Summary

Just an error by using `LazyRootFolder` :)

I added to `OCP\Files\IRootFolder` the signature of `*mount` and `getMount*` method and make `OC\Files\Cache\QuerySearchHelper::getCachesAndMountPointsForSearch()` requiering an `OCP\Files\IRootFolder` instead of a `OC\Files\Node\Root`.

Formated log of the error which occurs SOOOOOOOOO many times (deployed via NextCloud-AIO):
```
[webdav] Error: TypeError: OC\Files\Cache\QuerySearchHelper::getCachesAndMountPointsForSearch(): Argument https://github.com/nextcloud/server/issues/1 ($root) must be of type OC\Files\Node\Root, OC\Files\Node\LazyRoot given, called in /var/www/html/lib/private/Files/Node/Folder.php on line 237 at <<closure>>

 0. /var/www/html/lib/private/Files/Node/Folder.php line 237
    OC\Files\Cache\QuerySearchHelper->getCachesAndMountPointsForSearch(["OC\\Files\\Node\\LazyRoot"], "/XXX/files/Being uploaded", false)
 1. /var/www/html/lib/private/Files/Node/Folder.php line 291
    OC\Files\Node\Folder->search(["OC\\Files\\Search\\SearchQuery"])
 2. /var/www/html/custom_apps/music/lib/Utility/Scanner.php line 383
    OC\Files\Node\Folder->searchByMime("audio")
 3. /var/www/html/custom_apps/music/lib/Hooks/FileHooks.php line 42
    OCA\Music\Utility\Scanner->deleteFolder(["OC\\Files\\Node\\Folder"])
 4. <<closure>>
    OCA\Music\Hooks\FileHooks::deleted(["OC\\Files\\Node\\Folder"])
 5. /var/www/html/lib/private/Hooks/EmitterTrait.php line 105
    call_user_func_array(["OCA\\Music\\Ho ... "], [["OC\\Files\\Node\\Folder"]])
 6. /var/www/html/lib/private/Hooks/PublicEmitter.php line 40
    OC\Hooks\BasicEmitter->emit("\\OC\\Files", "preDelete", [["OC\\Files\\Node\\Folder"]])
 7. /var/www/html/lib/private/Files/Node/Root.php line 143
    OC\Hooks\PublicEmitter->emit("\\OC\\Files", "preDelete", [["OC\\Files\\Node\\Folder"]])
 8. <<closure>>
    OC\Files\Node\Root->emit("\\OC\\Files", "preDelete", [["OC\\Files\\Node\\Folder"]])
 9. /var/www/html/lib/private/Files/Node/LazyFolder.php line 72
    call_user_func_array([["OC\\Files\\Node\\Root"],"emit"], ["\\OC\\Files"," ... ]])
10. /var/www/html/lib/private/Files/Node/LazyFolder.php line 100
    OC\Files\Node\LazyFolder->__call("emit", ["\\OC\\Files"," ... ]])
11. /var/www/html/lib/private/Files/Node/HookConnector.php line 145
    OC\Files\Node\LazyFolder->emit("\\OC\\Files", "preDelete", [["OC\\Files\\Node\\Folder"]])
12. /var/www/html/lib/private/legacy/OC_Hook.php line 105
    OC\Files\Node\HookConnector->delete([true,"/Being uploaded"])
13. /var/www/html/lib/private/Files/View.php line 1295
    OC_Hook::emit("OC_Filesystem", "delete", [true,"/Being uploaded"])
14. /var/www/html/lib/private/Files/View.php line 1165
    OC\Files\View->runHooks(["delete"], "/Being uploaded")
15. /var/www/html/lib/private/Files/View.php line 351
    OC\Files\View->basicOperation("rmdir", "/Being uploaded", ["delete"])
16. /var/www/html/apps/dav/lib/Connector/Sabre/Directory.php line 307
    OC\Files\View->rmdir("/Being uploaded")
17. /var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php line 179
    OCA\DAV\Connector\Sabre\Directory->delete()
18. /var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php line 281
    Sabre\DAV\Tree->delete("files/XXX/Being uploaded")
19. /var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
    Sabre\DAV\CorePlugin->httpDelete(["Sabre\\HTTP\\Request"], ["Sabre\\HTTP\\Response"])
20. /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php line 472
    Sabre\DAV\Server->emit("method:DELETE", [["Sabre\\HTTP\\ ... ]])
21. /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php line 253
    Sabre\DAV\Server->invokeMethod(["Sabre\\HTTP\\Request"], ["Sabre\\HTTP\\Response"])
22. /var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php line 321
    Sabre\DAV\Server->start()
23. /var/www/html/apps/dav/lib/Server.php line 366
    Sabre\DAV\Server->exec()
24. /var/www/html/apps/dav/appinfo/v2/remote.php line 35
    OCA\DAV\Server->exec()
25. /var/www/html/remote.php line 172
    require_once("/var/www/html/a ... p")

DELETE /remote.php/dav/files/XXX/Being%20uploaded
from XXX.XXX.XXX.XXX by XXX at 2023-06-14T16:22:40+00:00
```


## Checklist

- Code should be [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) (linted using `php -l` and tested in prod on my server)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are not included. I am currently testing it on my server, and it seems that does not break. I also have doubt about the presence of unit testing on this topic, else, the TypeError should never become in prod.
- No screenshots before/after for front-end changes: not a UI change.
- No Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) is required: not a new feature.
- No [Backports requested](https://github.com/nextcloud/backportbot/#usage), but feel free to request it.