### PR TITLE
Fix files API route names

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -62,74 +62,74 @@ $application->registerRoutes(
 				'root' => '',
 			],
 			[
-				'name' => 'API#getThumbnail',
+				'name' => 'Api#getThumbnail',
 				'url' => '/api/v1/thumbnail/{x}/{y}/{file}',
 				'verb' => 'GET',
 				'requirements' => ['file' => '.+']
 			],
 			[
-				'name' => 'API#updateFileTags',
+				'name' => 'Api#updateFileTags',
 				'url' => '/api/v1/files/{path}',
 				'verb' => 'POST',
 				'requirements' => ['path' => '.+'],
 			],
 			[
-				'name' => 'API#getRecentFiles',
+				'name' => 'Api#getRecentFiles',
 				'url' => '/api/v1/recent/',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#getStorageStats',
+				'name' => 'Api#getStorageStats',
 				'url' => '/api/v1/stats',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#setViewConfig',
+				'name' => 'Api#setViewConfig',
 				'url' => '/api/v1/views/{view}/{key}',
 				'verb' => 'PUT'
 			],
 			[
-				'name' => 'API#getViewConfigs',
+				'name' => 'Api#getViewConfigs',
 				'url' => '/api/v1/views',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#getViewConfig',
+				'name' => 'Api#getViewConfig',
 				'url' => '/api/v1/views/{view}',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#setConfig',
+				'name' => 'Api#setConfig',
 				'url' => '/api/v1/config/{key}',
 				'verb' => 'PUT'
 			],
 			[
-				'name' => 'API#getConfigs',
+				'name' => 'Api#getConfigs',
 				'url' => '/api/v1/configs',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#showHiddenFiles',
+				'name' => 'Api#showHiddenFiles',
 				'url' => '/api/v1/showhidden',
 				'verb' => 'POST'
 			],
 			[
-				'name' => 'API#cropImagePreviews',
+				'name' => 'Api#cropImagePreviews',
 				'url' => '/api/v1/cropimagepreviews',
 				'verb' => 'POST'
 			],
 			[
-				'name' => 'API#showGridView',
+				'name' => 'Api#showGridView',
 				'url' => '/api/v1/showgridview',
 				'verb' => 'POST'
 			],
 			[
-				'name' => 'API#getGridView',
+				'name' => 'Api#getGridView',
 				'url' => '/api/v1/showgridview',
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'API#getNodeType',
+				'name' => 'Api#getNodeType',
 				'url' => '/api/v1/quickaccess/get/NodeType',
 				'verb' => 'GET',
 			],
@@ -139,7 +139,7 @@ $application->registerRoutes(
 				'verb' => 'GET'
 			],
 			[
-				'name' => 'api#serviceWorker',
+				'name' => 'Api#serviceWorker',
 				'url' => '/preview-service-worker.js',
 				'verb' => 'GET'
 			],


### PR DESCRIPTION
## Summary

The route names should have the correct controller names. It only worked before this change because the class matching is case-insensitive.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
