### PR TITLE
chore: Set code owners for OCP changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,10 @@
 */TwoFactorAuth/*                   @ChristophWurst @miaulalala @nickvergessen
 /core/templates/twofactor*          @ChristophWurst @miaulalala @nickvergessen
 
+# Nextcloud GmbH engineering team leads to ensure stability of the platform and documentation of critical changes
+# https://docs.nextcloud.com/server/latest/developer_manual/prologue/compatibility_app_ecosystem.html#documentation-procedures-of-changes-that-affect-app-developers
+/lib/public                         @AndyScherzinger @ChristophWurst @DaphneMuller @juliushaertl @nickvergessen
+
 # Personal interest
 */Activity/*                        @nickvergessen
 */Notifications/*                   @nickvergessen


### PR DESCRIPTION
## Summary

We have to ensure the platform stays as stable as possible and document critical changes. This has been written down and communicated a few times: https://docs.nextcloud.com/server/27/developer_manual/prologue/compatibility_app_ecosystem.html#documentation-procedures-of-changes-that-affect-app-developers.

With this change, Nextcloud GmbH engineering team leads (Files, Integration, Groupware, Office, Talk) get assigned as owners. Github will request our reviews for changes in that path.

More info about code ownders can be found at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
