### PR TITLE
Fix text color on header menu when light primary color is used

### DIFF
--- a/core/src/components/AppMenu.vue
+++ b/core/src/components/AppMenu.vue
@@ -146,7 +146,6 @@ $header-icon-size: 20px;
 		height: 50px;
 		position: relative;
 		display: flex;
-		filter: var(--background-image-invert-if-bright);
 
 		&.app-menu-entry__active {
 			opacity: 1;
@@ -187,6 +186,7 @@ $header-icon-size: 20px;
 			height: $header-icon-size;
 			padding: calc((100% - $header-icon-size) / 2);
 			box-sizing: content-box;
+			filter: var(--background-image-invert-if-bright);
 		}
 
 		.app-menu-entry--label {


### PR DESCRIPTION

* Resolves: Not opened

## Summary

Actually if color is setted in a "light" color (like #ffffff or #f2f2f2) text on menu will be inverted due to filter setted on li tag, instead on img tag.

Example:
![image](https://github.com/nextcloud/server/assets/35271287/5a4de89b-b1ec-4efc-b557-cad69dbcdd0e)


After this PR, result will be:

![image](https://github.com/nextcloud/server/assets/35271287/968437e5-21c2-437c-8674-74e2cd21a08c)

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
