### PR TITLE
fix: Removed invalid user from CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /apps/dav/lib/CardDAV                         @ChristophWurst @miaulalala @tcitworld
 /apps/encryption/appinfo/info.xml             @come-nc @icewind1991
 /apps/federatedfilesharing/appinfo/info.xml   @icewind1991 @danxuliu
-/apps/federation/appinfo/info.xml             @vitormattos @datenangebot
+/apps/federation/appinfo/info.xml             @datenangebot
 /apps/files/appinfo/info.xml                  @skjnldsv @Pytal @ArtificialOwl @come-nc @artonge @icewind1991 @szaimen @susnux @Fenn-CS
 /apps/files_external/appinfo/info.xml         @icewind1991 @artonge
 /apps/files_sharing/appinfo/info.xml          @skjnldsv @come-nc


### PR DESCRIPTION
* Resolves

![image](https://github.com/nextcloud/server/assets/1374172/02020400-a33e-4208-9bb3-5b95c2f033ec)


## Summary

The user was removed from the repo/orga. There is no replacement for the maintainer role yet.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
