### PR TITLE
feat: add detected mime type to exception

### DIFF
--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -240,7 +240,7 @@ class ImageManager {
 		$supportedFormats = $this->getSupportedUploadImageFormats($key);
 		$detectedMimeType = mime_content_type($tmpFile);
 		if (!in_array($detectedMimeType, $supportedFormats, true)) {
-			throw new \Exception('Unsupported image type');
+			throw new \Exception('Unsupported image type: ' . $detectedMimeType);
 		}
 
 		if ($key === 'background' && $this->shouldOptimizeBackgroundImage($detectedMimeType, filesize($tmpFile))) {

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -390,4 +390,30 @@ class ImageManagerTest extends TestCase {
 
 		$this->imageManager->updateImage($key, $tmpFile);
 	}
+
+	public function testUnsupportedImageType(): void {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Unsupported image type: text/plain');
+
+		$file = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$oldFile = $this->createMock(ISimpleFile::class);
+
+		$folder->expects($this->any())
+			->method('getFile')
+			->willReturn($oldFile);
+
+		$this->rootFolder
+			->expects($this->any())
+			->method('getFolder')
+			->with('images')
+			->willReturn($folder);
+
+		$folder->expects($this->once())
+			->method('newFile')
+			->with('favicon')
+			->willReturn($file);
+
+		$this->imageManager->updateImage('favicon', __DIR__ . '/../../../tests/data/lorem.txt');
+	}
 }


### PR DESCRIPTION
* Resolves: #38842

## Summary

The mimetype may not match the file extension.
Helps the user to find out why a provided image is not accepted.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
