### PR TITLE
(base) Give a hint in web interface if SimpleXML (php-xml) is missing

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -652,6 +652,13 @@ class OC {
 		$bootstrapCoordinator->runInitialRegistration();
 
 		$eventLogger->start('init_session', 'Initialize session');
+
+		// Check for PHP SimpleXML extension earlier since we need it before our other checks and want to provide a useful hint for web users
+		// see https://github.com/nextcloud/server/pull/2619
+		if (!function_exists('simplexml_load_file')) {
+			throw new \OCP\HintException('The PHP SimpleXML/PHP-XML extension is not installed.', 'Install the extension or make sure it is enabled.');
+		}
+		
 		OC_App::loadApps(['session']);
 		if (!self::$CLI) {
 			self::initSession();


### PR DESCRIPTION
* Resolves: #2180  <!-- related github issue -->
* And prevents similar reports: 
  - #31473
  - #23970
  - #18610
  - #15708

## Summary

Avoids a 500 error and also gives a useful error message on the web interface if this module isn't installed, gets overlooked during a PHP upgrade, etc.

* While we check for it later, it's too late for session.
* Inspired by #17163
* Related to #2619 (which was never merged and seemed intended to silence things rather than give the user a useful hint for self-resolution)

## TODO

- [ ] Maybe some field testing?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
