### PR TITLE
file scanner performance improvements

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreScanner.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreScanner.php
@@ -39,7 +39,7 @@ class ObjectStoreScanner extends Scanner {
 		return [];
 	}
 
-	protected function scanChildren($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $folderId = null, $lock = true, array $data = []) {
+	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int $oldSize) {
 		return 0;
 	}
 


### PR DESCRIPTION
- Fixes some invalid logic around re-using known folder ids that was causing an extra `select` for every folder scanned
- Properly forward known folder sizes during recursive scan, saving a `select` and an `update` for every folder scanned
- Make `scanChildren` parameters non-option to simplify reasoning

[Comparison](https://blackfire.io/profiles/compare/2fb96003-37be-41d9-82f0-a34052fac59b/graph) scanning 23239 files over 466 folders