### PR TITLE
add summary of detected changes to files:scan output

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -37,6 +37,9 @@ use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OCP\Files\Events\FileCacheUpdated;
+use OCP\Files\Events\NodeAddedToCache;
+use OCP\Files\Events\NodeRemovedFromCache;
 use OCP\Files\File;
 use OC\ForbiddenException;
 use OC\Metadata\MetadataManager;
@@ -59,18 +62,27 @@ class Scan extends Base {
 	protected int $foldersCounter = 0;
 	protected int $filesCounter = 0;
 	protected int $errorsCounter = 0;
+	protected int $newCounter = 0;
+	protected int $updatedCounter = 0;
+	protected int $removedCounter = 0;
 	private IRootFolder $root;
 	private MetadataManager $metadataManager;
+	private IEventDispatcher $eventDispatcher;
+	private LoggerInterface $logger;
 
 	public function __construct(
 		IUserManager $userManager,
 		IRootFolder $rootFolder,
-		MetadataManager $metadataManager
+		MetadataManager $metadataManager,
+		IEventDispatcher $eventDispatcher,
+		LoggerInterface $logger
 	) {
 		$this->userManager = $userManager;
 		parent::__construct();
 		$this->root = $rootFolder;
 		$this->metadataManager = $metadataManager;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->logger = $logger;
 	}
 
 	protected function configure() {
@@ -155,6 +167,16 @@ class Scan extends Base {
 		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
 			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
 			++$this->errorsCounter;
+		});
+
+		$this->eventDispatcher->addListener(NodeAddedToCache::class, function() {
+			++$this->newCounter;
+		});
+		$this->eventDispatcher->addListener(FileCacheUpdated::class, function() {
+			++$this->updatedCounter;
+		});
+		$this->eventDispatcher->addListener(NodeRemovedFromCache::class, function() {
+			++$this->removedCounter;
 		});
 
 		try {
@@ -277,9 +299,14 @@ class Scan extends Base {
 		// Stop the timer
 		$this->execTime += microtime(true);
 
+		$this->logger->info("Completed scan of {$this->filesCounter} files in {$this->foldersCounter} folder. Found {$this->newCounter} new, {$this->updatedCounter} updated and {$this->removedCounter} removed items");
+
 		$headers = [
 			'Folders',
 			'Files',
+			'New',
+			'Updated',
+			'Removed',
 			'Errors',
 			'Elapsed time',
 		];
@@ -287,6 +314,9 @@ class Scan extends Base {
 		$rows = [
 			$this->foldersCounter,
 			$this->filesCounter,
+			$this->newCounter,
+			$this->updatedCounter,
+			$this->removedCounter,
 			$this->errorsCounter,
 			$niceDate,
 		];

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -291,7 +291,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			$data['permissions'] = $data['scan_permissions'];
 		}
 		\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data]);
-		$this->emit('\OC\Files\Cache\Scanner', 'addToCache', [$path, $this->storageId, $data]);
+		$this->emit('\OC\Files\Cache\Scanner', 'addToCache', [$path, $this->storageId, $data, $fileId]);
 		if ($this->cacheActive) {
 			if ($fileId !== -1) {
 				$this->cache->update($fileId, $data);

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -251,9 +251,13 @@ class Scanner extends PublicEmitter {
 				$this->postProcessEntry($storage, $path);
 				$this->dispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
 			});
-			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path) use ($storage) {
+			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path, $storageId, $data, $fileId) use ($storage) {
 				$this->postProcessEntry($storage, $path);
-				$this->dispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));
+				if ($fileId) {
+					$this->dispatcher->dispatchTyped(new FileCacheUpdated($storage, $path));
+				} else {
+					$this->dispatcher->dispatchTyped(new NodeAddedToCache($storage, $path));
+				}
 			});
 
 			if (!$storage->file_exists($relativePath)) {


### PR DESCRIPTION
Add number of updated, added and removed items to the `files:scan` summary.

Also write a summary to the log so the data can be retrieved if the `files:scan` is ran in the background