### PR TITLE
use source cache when listing folder during recursive copy

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -38,6 +38,7 @@ use Icewind\Streams\IteratorDirectory;
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\PolyFill\CopyDirectory;
+use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
@@ -593,7 +594,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 				if (is_array($sourceEntryData) && array_key_exists('scan_permissions', $sourceEntryData)) {
 					$sourceEntry['permissions'] = $sourceEntryData['scan_permissions'];
 				}
-				$this->copyInner($sourceEntry, $targetInternalPath);
+				$this->copyInner($sourceStorage->getCache(), $sourceEntry, $targetInternalPath);
 				return true;
 			}
 		}
@@ -611,12 +612,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			throw new NotFoundException('Source object not found');
 		}
 
-		$this->copyInner($sourceEntry, $target);
+		$this->copyInner($cache, $sourceEntry, $target);
 
 		return true;
 	}
 
-	private function copyInner(ICacheEntry $sourceEntry, string $to) {
+	private function copyInner(ICache $sourceCache, ICacheEntry $sourceEntry, string $to) {
 		$cache = $this->getCache();
 
 		if ($sourceEntry->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
@@ -625,8 +626,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			}
 			$this->mkdir($to);
 
-			foreach ($cache->getFolderContentsById($sourceEntry->getId()) as $child) {
-				$this->copyInner($child, $to . '/' . $child->getName());
+			foreach ($sourceCache->getFolderContentsById($sourceEntry->getId()) as $child) {
+				$this->copyInner($sourceCache, $child, $to . '/' . $child->getName());
 			}
 		} else {
 			$this->copyFile($sourceEntry, $to);


### PR DESCRIPTION
- use source cache when listing folder during recursive copy

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] Manual backports
