### PR TITLE
Add getDocBaseUrl on theming app

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -71,6 +71,7 @@ class ThemingDefaults extends \OC_Defaults {
 	private string $productName;
 	private string $url;
 	private string $color;
+	private string $docBaseUrl;
 
 	private string $iTunesAppId;
 	private string $iOSClientUrl;
@@ -120,6 +121,7 @@ class ThemingDefaults extends \OC_Defaults {
 		$this->iOSClientUrl = parent::getiOSClientUrl();
 		$this->AndroidClientUrl = parent::getAndroidClientUrl();
 		$this->FDroidClientUrl = parent::getFDroidClientUrl();
+		$this->docBaseUrl = parent::getDocBaseUrl();
 	}
 
 	public function getName() {
@@ -161,6 +163,10 @@ class ThemingDefaults extends \OC_Defaults {
 
 	public function getPrivacyUrl() {
 		return (string)$this->config->getAppValue('theming', 'privacyUrl', '');
+	}
+
+	public function getDocBaseUrl() {
+		return (string)$this->config->getAppValue('theming', 'docBaseUrl', $this->docBaseUrl);
 	}
 
 	public function getShortFooter() {


### PR DESCRIPTION
* Resolves: not opened for this type of PR

## Summary
With new theming introduced on nextcloud >25, we can customize DocBaseUrl only if we use "old fashion way", adding `defaults.php` under `/themes/<custom_theme>/ `.

With this PR I simply added a `getDocBaseUrl()` function, that will get theming `docBaseUrl` config and will use for doc base url.
It will fallback on the defaullt one if not found, in the same way as other function.

## TODO

N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
