### PR TITLE
Fix: ContactManager search with fullmatch

### DIFF
--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -58,15 +58,18 @@ class ContactsManager implements IManager {
 			$strictSearch = array_key_exists('strict_search', $options) && $options['strict_search'] === true;
 
 			if ($addressBook->isSystemAddressBook()) {
+				$enumeration = !\array_key_exists('enumeration', $options) || $options['enumeration'] !== false;
 				$fullMatch = !\array_key_exists('fullmatch', $options) || $options['fullmatch'] !== false;
-				if (!$fullMatch) {
-					// Neither full match is allowed, so skip the system address book
+
+				if (!$enumeration && !$fullMatch) {
+					// No access to system address book AND no full match allowed
 					continue;
 				}
+
 				if ($strictSearch) {
 					$searchOptions['wildcard'] = false;
 				} else {
-					$searchOptions['wildcard'] = !\array_key_exists('enumeration', $options) || $options['enumeration'] !== false;
+					$searchOptions['wildcard'] = $enumeration;
 				}
 			} else {
 				$searchOptions['wildcard'] = !$strictSearch;


### PR DESCRIPTION
* Contributes to: https://github.com/nextcloud/mail/pull/8551

## Summary

If I understand the sharing options in the admin settings right, the following should lead to the suggestion of a SAB user in the same group, and don't show other SAB users even if there is a full match (name, email).

![image](https://github.com/nextcloud/server/assets/74607597/e3968806-be36-42cb-89dd-d570e95b6ac5)

Currently, because of the 'fullmatch' option, I pass as false in mail, the if condition is triggered and no SAB user is suggested at all. To work correctly I think there should be the check for the access to the SAB as well.

Maybe I am wrong here, correct me if that's the case :)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
