### PR TITLE
adjust admin setup check to increase warning to configure https

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -741,10 +741,10 @@
 					}
 				} else if (!/(?:^(?:localhost|127\.0\.0\.1|::1)|\.onion)$/.exec(window.location.hostname)) {
 					messages.push({
-						msg: t('core', 'Accessing site insecurely via HTTP. You are strongly advised to set up your server to require HTTPS instead, as described in the {linkstart}security tips ↗{linkend}.')
+						msg: t('core', 'Accessing site insecurely via HTTP. You are strongly advised to set up your server to require HTTPS instead, as described in the {linkstart}security tips ↗{linkend}. Without it some important web functionality like "copy to clipboard" or "service workers" will not work!')
 							.replace('{linkstart}', '<a target="_blank" rel="noreferrer noopener" class="external" href="' + tipsUrl + '">')
 							.replace('{linkend}', '</a>'),
-						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
 					});
 				}
 			} else {


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/36582

Reason: Without https some important web functionality like "copy to clipboard" or "service workers" does not work!