### PR TITLE
fix(l10n): Fix plural issue with different locale and language

### DIFF
--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -215,7 +215,12 @@ class L10N implements IL10N {
 	public function getIdentityTranslator(): IdentityTranslator {
 		if (\is_null($this->identityTranslator)) {
 			$this->identityTranslator = new IdentityTranslator();
-			$this->identityTranslator->setLocale($this->getLocaleCode());
+			// We need to use the language code here instead of the locale,
+			// because Symfony does not distinguish between the two and would
+			// otherwise e.g. with locale "Czech" and language "German" try to
+			// pick a non-existing plural rule, because Czech has 4 plural forms
+			// and German only 2.
+			$this->identityTranslator->setLocale($this->getLanguageCode());
 		}
 
 		return $this->identityTranslator;

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -85,6 +85,15 @@ class L10nTest extends TestCase {
 		$this->assertEquals('5 oken', (string)$l->n('%n window', '%n windows', 5));
 	}
 
+	public function testGermanPluralWithCzechLocaleTranslations() {
+		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/de.json';
+		$l = new L10N($this->getFactory(), 'test', 'de', 'cs_CZ', [$transFile]);
+
+		$this->assertEquals('1 Datei', (string) $l->n('%n file', '%n files', 1));
+		$this->assertEquals('2 Dateien', (string) $l->n('%n file', '%n files', 2));
+		$this->assertEquals('5 Dateien', (string) $l->n('%n file', '%n files', 5));
+	}
+
 	public function dataPlaceholders(): array {
 		return [
 			['Ordered placeholders one %s two %s', 'Placeholder one 1 two 2'],


### PR DESCRIPTION
We need to use the language code here instead of the locale, because Symfony does not distinguish between the two and would otherwise e.g. with locale "Czech" and language "German" try to pick a non-existing plural rule, because Czech has 4 plural forms and German only 2.

* Resolves: https://github.com/nextcloud/spreed/issues/9558

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
