### PR TITLE
chore: Adjust editorconfig for package.json and package-lock.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,10 @@ trim_trailing_whitespace = false
 [*.svg]
 insert_final_newline = false
 
+[package*.json]
+indent_size = 2
+indent_style = space
+
 [build/psalm-baseline.xml]
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
- Defactor standard in the npm universe and across half the apps and server
- but the other half was following the initial rule of 4space tabs
