### PR TITLE
clean failed upload chunks

### DIFF
--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -47,7 +47,15 @@ class UploadFolder implements ICollection {
 
 	public function createFile($name, $data = null) {
 		// TODO: verify name - should be a simple number
-		$this->node->createFile($name, $data);
+		try {
+			$this->node->createFile($name, $data);
+		} catch (\Exception $e) {
+			if ($this->node->childExists($name)) {
+				$child = $this->node->getChild($name);
+				$child->delete();
+			}
+			throw $e;
+		}
 	}
 
 	public function createDirectory($name) {


### PR DESCRIPTION
When an exception is throw during the uploading of a part, make sure the part is cleaned up so it doesn't cause issues during assembly later on.

Note that storages using "part files" already [have this behavior](https://github.com/nextcloud/server/blob/6034cc6893eba6e294970966ad9a6389488948d1/apps/dav/lib/Connector/Sabre/File.php#L315-L317).