### PR TITLE
feat: remove orphaned entries from filecache_extended

### DIFF
--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -24,9 +24,11 @@
  */
 namespace OCA\Files\Command;
 
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -44,7 +46,8 @@ class DeleteOrphanedFiles extends Command {
 	protected function configure(): void {
 		$this
 			->setName('files:cleanup')
-			->setDescription('cleanup filecache');
+			->setDescription('cleanup filecache')
+			->addOption('filecache-extended', null, InputOption::VALUE_NONE, 'remove orphaned entries from filecache_extended');
 	}
 
 	public function execute(InputInterface $input, OutputInterface $output): int {
@@ -75,9 +78,42 @@ class DeleteOrphanedFiles extends Command {
 
 		$output->writeln("$deletedEntries orphaned file cache entries deleted");
 
+		if ($input->getOption('filecache-extended')) {
+			$deletedFileCacheExtended = $this->cleanupOrphanedFileCacheExtended();
+			$output->writeln("$deletedFileCacheExtended orphaned file cache extended entries deleted");
+		}
+
+
 		$deletedMounts = $this->cleanupOrphanedMounts();
 		$output->writeln("$deletedMounts orphaned mount entries deleted");
 		return self::SUCCESS;
+	}
+
+	private function cleanupOrphanedFileCacheExtended(): int {
+		$deletedEntries = 0;
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('fce.fileid')
+			->from('filecache_extended', 'fce')
+			->leftJoin('fce', 'filecache', 'fc', $query->expr()->eq('fce.fileid', 'fc.fileid'))
+			->where($query->expr()->isNull('fc.fileid'))
+			->setMaxResults(self::CHUNK_SIZE);
+
+		$deleteQuery = $this->connection->getQueryBuilder();
+		$deleteQuery->delete('filecache_extended')
+			->where($deleteQuery->expr()->in('fileid', $deleteQuery->createParameter('idsToDelete')));
+
+		$result = $query->executeQuery();
+		while ($result->rowCount() > 0) {
+			$idsToDelete = $result->fetchAll(\PDO::FETCH_COLUMN);
+
+			$deleteQuery->setParameter('idsToDelete', $idsToDelete, IQueryBuilder::PARAM_INT_ARRAY);
+			$deletedEntries += $deleteQuery->executeStatement();
+
+			$result = $query->executeQuery();
+		}
+
+		return $deletedEntries;
 	}
 
 	private function cleanupOrphanedMounts(): int {

--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -47,7 +47,7 @@ class DeleteOrphanedFiles extends Command {
 		$this
 			->setName('files:cleanup')
 			->setDescription('cleanup filecache')
-			->addOption('filecache-extended', null, InputOption::VALUE_NONE, 'remove orphaned entries from filecache_extended');
+			->addOption('skip-filecache-extended', null, InputOption::VALUE_NONE, 'don\'t remove orphaned entries from filecache_extended');
 	}
 
 	public function execute(InputInterface $input, OutputInterface $output): int {
@@ -78,7 +78,7 @@ class DeleteOrphanedFiles extends Command {
 
 		$output->writeln("$deletedEntries orphaned file cache entries deleted");
 
-		if ($input->getOption('filecache-extended')) {
+		if (!$input->getOption('skip-filecache-extended')) {
 			$deletedFileCacheExtended = $this->cleanupOrphanedFileCacheExtended();
 			$output->writeln("$deletedFileCacheExtended orphaned file cache extended entries deleted");
 		}

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -132,10 +132,11 @@ class DeleteOrphanedFilesTest extends TestCase {
 
 		// parent folder, `files`, ´test` and `welcome.txt` => 4 elements
 		$output
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('writeln')
 			->withConsecutive(
 				['3 orphaned file cache entries deleted'],
+				['0 orphaned file cache extended entries deleted'],
 				['1 orphaned mount entries deleted'],
 			);
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Test scenario:

- Run sql: `select * from oc_filecache_extended left join oc_filecache on oc_filecache_extended.fileid = oc_filecache.fileid where oc_filecache.fileid is null;`
- Mount an external storage (e.g. local)
- Upload some files to the external storage
- Delete external storage
- Run sql: `select * from oc_filecache_extended left join oc_filecache on oc_filecache_extended.fileid = oc_filecache.fileid where oc_filecache.fileid is null;`
- See files without a matching record in filecache 

https://github.com/nextcloud/server/blob/e69c7c4d26731acd91cc683fbe118da1e423c460/lib/private/Files/Cache/Storage.php#L222

Best would be to clear filecache_extended when deleting the storage. 


## TODO

- [ ] OCI
- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
