### PR TITLE
Add a method to get all users with access to a file in OCP

### DIFF
--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -40,7 +40,9 @@ class Listener {
 		$users = [];
 		$filesPerUser = $cache->getReadableNodesByUserForFileId((int)$event->getComment()->getObjectId());
 		foreach ($filesPerUser as $user => $files) {
-			$users[$user] = reset($files)?->getPath();
+			/* Remove /user/files prefix */
+			$sections = explode('/', reset($files)?->getPath() ?? '', 4);
+			$users[$user] = '/'.($sections[3] ?? '');
 		}
 
 		$actor = $this->session->getUser();

--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -37,10 +37,9 @@ class Listener {
 
 		$cache = $this->mountCollection->getMountCache();
 
-		$users = [];
-		$filesPerUser = $cache->getReadableNodesByUserForFileId((int)$event->getComment()->getObjectId());
-		foreach ($filesPerUser as $user => $files) {
-			$users[$user] = $this->rootFolder->getUserFolder($user)->getRelativePath(reset($files)?->getPath() ?? '');
+		$users = $cache->getReadablePathByUserForFileId((int)$event->getComment()->getObjectId());
+		if (empty($users)) {
+			return;
 		}
 
 		$actor = $this->session->getUser();

--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -40,9 +40,7 @@ class Listener {
 		$users = [];
 		$filesPerUser = $cache->getReadableNodesByUserForFileId((int)$event->getComment()->getObjectId());
 		foreach ($filesPerUser as $user => $files) {
-			/* Remove /user/files prefix */
-			$sections = explode('/', reset($files)?->getPath() ?? '', 4);
-			$users[$user] = '/'.($sections[3] ?? '');
+			$users[$user] = $this->rootFolder->getUserFolder($user)->getRelativePath(reset($files)?->getPath() ?? '');
 		}
 
 		$actor = $this->session->getUser();

--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -12,7 +12,6 @@ use OCP\App\IAppManager;
 use OCP\Comments\CommentsEvent;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IShareHelper;
@@ -36,24 +35,12 @@ class Listener {
 			return;
 		}
 
-		// Get all mount point owners
 		$cache = $this->mountCollection->getMountCache();
-		$mounts = $cache->getMountsForFileId((int)$event->getComment()->getObjectId());
-		if (empty($mounts)) {
-			return;
-		}
 
 		$users = [];
-		foreach ($mounts as $mount) {
-			$owner = $mount->getUser()->getUID();
-			$ownerFolder = $this->rootFolder->getUserFolder($owner);
-			$nodes = $ownerFolder->getById((int)$event->getComment()->getObjectId());
-			if (!empty($nodes)) {
-				/** @var Node $node */
-				$node = array_shift($nodes);
-				$al = $this->shareHelper->getPathsForAccessList($node);
-				$users += $al['users'];
-			}
+		$filesPerUser = $cache->getReadableNodesByUserForFileId((int)$event->getComment()->getObjectId());
+		foreach ($filesPerUser as $user => $files) {
+			$users[$user] = reset($files)?->getPath();
 		}
 
 		$actor = $this->session->getUser();

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -153,13 +153,9 @@ class Listener {
 		// Get all mount point owners
 		$cache = $this->mountCollection->getMountCache();
 
-		$users = [];
-		$filesPerUser = $cache->getReadableNodesByUserForFileId((int)$event->getObjectId());
-		if (empty($filesPerUser)) {
+		$users = $cache->getReadablePathByUserForFileId((int)$event->getObjectId());
+		if (empty($users)) {
 			return;
-		}
-		foreach ($filesPerUser as $user => $files) {
-			$users[$user] = $this->rootFolder->getUserFolder($user)->getRelativePath(reset($files)?->getPath() ?? '');
 		}
 
 		$actor = $this->session->getUser();

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -159,9 +159,7 @@ class Listener {
 			return;
 		}
 		foreach ($filesPerUser as $user => $files) {
-			/* Remove /user/files prefix */
-			$sections = explode('/', reset($files)?->getPath() ?? '', 4);
-			$users[$user] = '/'.($sections[3] ?? '');
+			$users[$user] = $this->rootFolder->getUserFolder($user)->getRelativePath(reset($files)?->getPath() ?? '');
 		}
 
 		$actor = $this->session->getUser();

--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -44,18 +44,7 @@ class FileUtils {
 			return [];
 		}
 
-		$mounts = $this->userMountCache->getMountsForFileId($id);
-		$result = [];
-		foreach ($mounts as $mount) {
-			if (isset($result[$mount->getUser()->getUID()])) {
-				continue;
-			}
-
-			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
-			$result[$mount->getUser()->getUID()] = $userFolder->getById($id);
-		}
-
-		return $result;
+		return $this->userMountCache->getReadableNodesByUserForFileId($id);
 	}
 
 	/**

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -395,12 +395,45 @@ class UserMountCache implements IUserMountCache {
 		$rootFolder = Server::get(IRootFolder::class);
 		$result = [];
 		foreach ($mounts as $mount) {
-			if (isset($result[$mount->getUser()->getUID()])) {
+			$uid = $mount->getUser()->getUID();
+			if (!isset($result[$uid])) {
+				$result[$uid] = [];
+			}
+
+			$userFolder = $rootFolder->getUserFolder($uid);
+			$result[$uid] = array_merge($result[$uid], $userFolder->getById($fileId));
+		}
+
+		return array_filter($result);
+	}
+
+	/**
+	 * Get all users having read access to a file, with a path they see it as.
+	 * They may see the same file under other paths,
+	 *  to get this information use the exhaustive getReadableNodesByUserForFileId
+	 *
+	 * @return array<string,string> Paths giving access to the given fileId, indexed by user ID
+	 * @since 28.0.0
+	 */
+	public function getReadablePathByUserForFileId(int $fileId): array {
+		$mounts = $this->getMountsForFileId($fileId);
+		$rootFolder = Server::get(IRootFolder::class);
+		$result = [];
+		foreach ($mounts as $mount) {
+			$uid = $mount->getUser()->getUID();
+			if (isset($result[$uid])) {
 				continue;
 			}
 
-			$userFolder = $rootFolder->getUserFolder($mount->getUser()->getUID());
-			$result[$mount->getUser()->getUID()] = $userFolder->getById($fileId);
+			$userFolder = $rootFolder->getUserFolder($uid);
+			$nodes = $userFolder->getById($fileId);
+			$node = reset($nodes);
+			if ($node) {
+				$path = $userFolder->getRelativePath($node->getPath());
+				if ($path !== null) {
+					$result[$uid] = $path;
+				}
+			}
 		}
 
 		return $result;

--- a/lib/public/Files/Config/IUserMountCache.php
+++ b/lib/public/Files/Config/IUserMountCache.php
@@ -8,6 +8,7 @@
 namespace OCP\Files\Config;
 
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
 
@@ -64,6 +65,14 @@ interface IUserMountCache {
 	 * @since 9.0.0
 	 */
 	public function getMountsForFileId($fileId, $user = null);
+
+	/**
+	 * Get all cached nodes that give access to a file
+	 *
+	 * @return array<string, Node[]> Nodes giving access to the given fileId, indexed by user ID
+	 * @since 28.0.0
+	 */
+	public function getReadableNodesByUserForFileId(int $fileId): array;
 
 	/**
 	 * Remove all cached mounts for a user

--- a/lib/public/Files/Config/IUserMountCache.php
+++ b/lib/public/Files/Config/IUserMountCache.php
@@ -75,6 +75,15 @@ interface IUserMountCache {
 	public function getReadableNodesByUserForFileId(int $fileId): array;
 
 	/**
+	 * Get all users having read access to a file, with a path they see it as.
+	 * They may see the same file under other paths, to get this information use exhaustive getReadableNodesByUserForFileId
+	 *
+	 * @return array<string, string> Paths giving access to the given fileId, indexed by user ID
+	 * @since 28.0.0
+	 */
+	public function getReadablePathByUserForFileId(int $fileId): array;
+
+	/**
 	 * Remove all cached mounts for a user
 	 *
 	 * @param IUser $user


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

In a lot of places we need the list of users having access to a file, this is especially often the case in activity providers in applications, to notify all users of an event.
Currently the implementation is done differently each time, this is an attempt to bring a method in OCP that allows to get the list of users having access to a file and under which path.
For comments for example, this fixes showing the activity event to users having access to the file through a groupfolder.

## TODO

- [ ] See if this is the right implementation
- [ ] Use it in all places that needs this feature
- [ ] Use it in applications where it makes sense, especially activity
- [ ] See how groupfolder ACLs could be integrated in there to avoid returning users which actually do not have access to the file

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
