### PR TITLE
Add cancel button for when user entry is being edited

### DIFF
--- a/apps/settings/src/components/Users/UserRow.vue
+++ b/apps/settings/src/components/Users/UserRow.vue
@@ -221,12 +221,10 @@
 		</div>
 
 		<div class="userActions">
-<<<<<<< HEAD
 			<UserRowActions v-if="!loading.all"
 				:actions="userActions"
 				:edit="true"
 				@update:edit="toggleEdit" />
-=======
 			<div v-if="!loading.all"
 				class="toggleUserActions">
 				<NcActions>
@@ -250,7 +248,6 @@
 				<div class="icon-checkmark" />
 				{{ feedbackMessage }}
 			</div>
->>>>>>> 7a2938b01f3 (Add cancel button for when user entry is being edited)
 		</div>
 	</div>
 </template>

--- a/apps/settings/src/components/Users/UserRow.vue
+++ b/apps/settings/src/components/Users/UserRow.vue
@@ -230,10 +230,6 @@
 			<div v-if="!loading.all"
 				class="toggleUserActions">
 				<NcActions :inline="2">
-					<NcActionButton icon="icon-checkmark"
-						:title="t('settings', 'Done')"
-						:aria-label="t('settings', 'Done')"
-						@click="editing = false" />
 					<NcActionButton icon="icon-close"
 						:title="t('settings', 'Cancel')"
 						:aria-label="t('settings', 'Cancel')"

--- a/apps/settings/src/components/Users/UserRow.vue
+++ b/apps/settings/src/components/Users/UserRow.vue
@@ -221,10 +221,40 @@
 		</div>
 
 		<div class="userActions">
+<<<<<<< HEAD
 			<UserRowActions v-if="!loading.all"
 				:actions="userActions"
 				:edit="true"
 				@update:edit="toggleEdit" />
+=======
+			<div v-if="!loading.all"
+				class="toggleUserActions">
+				<NcActions :inline="2">
+					<NcActionButton icon="icon-checkmark"
+						:title="t('settings', 'Done')"
+						:aria-label="t('settings', 'Done')"
+						@click="editing = false" />
+					<NcActionButton icon="icon-close"
+						:title="t('settings', 'Cancel')"
+						:aria-label="t('settings', 'Cancel')"
+						@click="editing = false" />
+				</NcActions>
+				<div v-click-outside="hideMenu" class="userPopoverMenuWrapper">
+					<button class="icon-more"
+						:aria-expanded="openedMenu"
+						:aria-label="t('settings', 'Toggle user actions menu')"
+						@click.prevent="toggleMenu" />
+					<div :class="{ 'open': openedMenu }" class="popovermenu">
+						<NcPopoverMenu :menu="userActions" />
+					</div>
+				</div>
+			</div>
+			<div :style="{opacity: feedbackMessage !== '' ? 1 : 0}"
+				class="feedback">
+				<div class="icon-checkmark" />
+				{{ feedbackMessage }}
+			</div>
+>>>>>>> 7a2938b01f3 (Add cancel button for when user entry is being edited)
 		</div>
 	</div>
 </template>

--- a/apps/settings/src/components/Users/UserRow.vue
+++ b/apps/settings/src/components/Users/UserRow.vue
@@ -229,7 +229,7 @@
 =======
 			<div v-if="!loading.all"
 				class="toggleUserActions">
-				<NcActions :inline="2">
+				<NcActions>
 					<NcActionButton icon="icon-close"
 						:title="t('settings', 'Cancel')"
 						:aria-label="t('settings', 'Cancel')"


### PR DESCRIPTION
* Resolves: #22608

## Summary
Add a cancel button between checkmark button and three-dot button for when user entry is being edited.
### Before
![Screen Shot 2023-06-22 at 8 02 07 PM](https://github.com/nextcloud/server/assets/35510082/fddd8aa8-0fdf-4d52-993f-58f1023b9948)

### After
![Screen Shot 2023-06-21 at 10 40 21 PM](https://github.com/nextcloud/server/assets/35510082/e56dc22e-7e4c-4b9b-8a56-d43ef91fcab4)


## Potential next steps
[This comment](https://github.com/nextcloud/server/issues/22608#issuecomment-751663701) may be the next fix to make user experience more intuitive and straightforward. I personally would think that the user editing process would be like this if I were a new user to the app. I can certainly implement a way to make this happen, either in the same PR or in the next PR after this one's completed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included or are not applicable
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
