### PR TITLE
fix(eventdispatcher): Don't use all evaluating "or"

### DIFF
--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -58,7 +58,7 @@ class EventDispatcher implements IEventDispatcher {
 
 		// inject the event dispatcher into the logger
 		// this is done here because there is a cyclic dependency between the event dispatcher and logger
-		if ($this->logger instanceof Log or $this->logger instanceof Log\PsrLoggerAdapter) {
+		if ($this->logger instanceof Log || $this->logger instanceof Log\PsrLoggerAdapter) {
 			$this->logger->setEventDispatcher($this);
 		}
 	}


### PR DESCRIPTION
## Summary

`or` is always evaluating all expressions. There is no need to do this here, so in order to emphasize best practises it should be replaced with `||`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
