### PR TITLE
[stable25] fix: BMP image without color info causes array access on `false`

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -931,6 +931,11 @@ class OC_Image implements \OCP\IImage {
 						break;
 					case 8:
 						$color = @unpack('n', $vide . ($data[$p] ?? ''));
+						if ($color === false) {
+							fclose($fh);
+							$this->logger->warning('Invalid 8bit bmp without color', ['app' => 'core']);
+							return false;
+						}
 						$color[1] = isset($palette[$color[1] + 1]) ? $palette[$color[1] + 1] : $palette[1];
 						break;
 					case 4:


### PR DESCRIPTION
* Resolves: ``Trying to access array offset on value of type bool at lib/private/legacy/OC_Image.php#934``

## Summary

Invalid BMPs can cause PHP errors to be logged again and again.

26+ don't have this problem because the OC_Image method was replaced with a call to GD in https://github.com/nextcloud/server/pull/35560

## TODO

- [x] Fix array access
- [x] Manual tests to verify the error is gone

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
