### PR TITLE
Uses PHP8's constructor property promotion in core/Migrations

### DIFF
--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -39,11 +39,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version13000Date20170718121200 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	private $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		private IDBConnection $connection,
+	) {
 	}
 
 	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {

--- a/core/Migrations/Version14000Date20180404140050.php
+++ b/core/Migrations/Version14000Date20180404140050.php
@@ -35,11 +35,9 @@ use OCP\Migration\SimpleMigrationStep;
  * Auto-generated migration step: Please modify to your needs!
  */
 class Version14000Date20180404140050 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	private $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		private IDBConnection $connection,
+	) {
 	}
 
 	public function name(): string {

--- a/core/Migrations/Version16000Date20190427105638.php
+++ b/core/Migrations/Version16000Date20190427105638.php
@@ -33,11 +33,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version16000Date20190427105638 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	private $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		private IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version18000Date20190920085628.php
+++ b/core/Migrations/Version18000Date20190920085628.php
@@ -36,11 +36,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version18000Date20190920085628 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version18000Date20191014105105.php
+++ b/core/Migrations/Version18000Date20191014105105.php
@@ -36,11 +36,9 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version18000Date20191014105105 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version18000Date20191204114856.php
+++ b/core/Migrations/Version18000Date20191204114856.php
@@ -32,11 +32,9 @@ use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
 class Version18000Date20191204114856 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version20000Date20201109081918.php
+++ b/core/Migrations/Version20000Date20201109081918.php
@@ -35,11 +35,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version20000Date20201109081918 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version24000Date20211210141942.php
+++ b/core/Migrations/Version24000Date20211210141942.php
@@ -37,11 +37,9 @@ use OCP\Migration\SimpleMigrationStep;
  *
  */
 class Version24000Date20211210141942 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version24000Date20211230140012.php
+++ b/core/Migrations/Version24000Date20211230140012.php
@@ -33,11 +33,9 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version24000Date20211230140012 extends SimpleMigrationStep {
-	/** @var IDBConnection */
-	protected $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {

--- a/core/Migrations/Version25000Date20221007010957.php
+++ b/core/Migrations/Version25000Date20221007010957.php
@@ -38,10 +38,9 @@ use OCP\Migration\SimpleMigrationStep;
  *
  */
 class Version25000Date20221007010957 extends SimpleMigrationStep {
-	protected IDBConnection $connection;
-
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
 	}
 
 	/**

--- a/core/Migrations/Version27000Date20230309104325.php
+++ b/core/Migrations/Version27000Date20230309104325.php
@@ -39,7 +39,7 @@ use OCP\Migration\SimpleMigrationStep;
  */
 class Version27000Date20230309104325 extends SimpleMigrationStep {
 	public function __construct(
-		private IDBConnection $connection
+		private IDBConnection $connection,
 	) {
 	}
 


### PR DESCRIPTION
Following previously merged PRs, I have also made the required adjustments to the `/core/Migrations/` namespace.

This PR refactors `/core/Migrations/` classes using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.