### PR TITLE
 Uses PHP8's constructor property promotion in remaining /core classes

### DIFF
--- a/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
+++ b/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
@@ -32,13 +32,12 @@ use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
-	protected IConfig $config;
-	protected LoggerInterface $log;
-
-	public function __construct(IConfig $config, LoggerInterface $log, ITimeFactory $time) {
+	public function __construct(
+		protected IConfig $config,
+		protected LoggerInterface $log,
+		ITimeFactory $time,
+	) {
 		parent::__construct($time);
-		$this->config = $config;
-		$this->log = $log;
 	}
 
 	/**

--- a/core/BackgroundJobs/CheckForUserCertificates.php
+++ b/core/BackgroundJobs/CheckForUserCertificates.php
@@ -36,15 +36,13 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class CheckForUserCertificates extends QueuedJob {
-	protected IConfig $config;
-	private IUserManager $userManager;
-	private IRootFolder $rootFolder;
-
-	public function __construct(IConfig $config, IUserManager $userManager, IRootFolder $rootFolder, ITimeFactory $time) {
+	public function __construct(
+		protected IConfig $config,
+		private IUserManager $userManager,
+		private IRootFolder $rootFolder,
+		ITimeFactory $time,
+	) {
 		parent::__construct($time);
-		$this->config = $config;
-		$this->userManager = $userManager;
-		$this->rootFolder = $rootFolder;
 	}
 
 	/**

--- a/core/BackgroundJobs/CleanupLoginFlowV2.php
+++ b/core/BackgroundJobs/CleanupLoginFlowV2.php
@@ -31,11 +31,11 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 
 class CleanupLoginFlowV2 extends TimedJob {
-	private LoginFlowV2Mapper $loginFlowV2Mapper;
-
-	public function __construct(ITimeFactory $time, LoginFlowV2Mapper $loginFlowV2Mapper) {
+	public function __construct(
+		ITimeFactory $time,
+		private LoginFlowV2Mapper $loginFlowV2Mapper,
+	) {
 		parent::__construct($time);
-		$this->loginFlowV2Mapper = $loginFlowV2Mapper;
 
 		$this->setInterval(3600);
 	}

--- a/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php
+++ b/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php
@@ -32,13 +32,12 @@ use OCP\IUser;
 use OCP\IUserManager;
 
 class LookupServerSendCheckBackgroundJob extends QueuedJob {
-	protected IConfig $config;
-	private IUserManager $userManager;
-
-	public function __construct(IConfig $config, IUserManager $userManager, ITimeFactory $time) {
+	public function __construct(
+		protected IConfig $config,
+		private IUserManager $userManager,
+		ITimeFactory $time,
+	) {
 		parent::__construct($time);
-		$this->config = $config;
-		$this->userManager = $userManager;
 	}
 
 	public function run($arguments) {

--- a/core/Data/LoginFlowV2Credentials.php
+++ b/core/Data/LoginFlowV2Credentials.php
@@ -26,17 +26,11 @@ declare(strict_types=1);
 namespace OC\Core\Data;
 
 class LoginFlowV2Credentials implements \JsonSerializable {
-	/** @var string */
-	private $server;
-	/** @var string */
-	private $loginName;
-	/** @var string */
-	private $appPassword;
-
-	public function __construct(string $server, string $loginName, string $appPassword) {
-		$this->server = $server;
-		$this->loginName = $loginName;
-		$this->appPassword = $appPassword;
+	public function __construct(
+		private string $server,
+		private string $loginName,
+		private string $appPassword,
+	) {
 	}
 
 	/**

--- a/core/Data/LoginFlowV2Tokens.php
+++ b/core/Data/LoginFlowV2Tokens.php
@@ -26,14 +26,10 @@ declare(strict_types=1);
 namespace OC\Core\Data;
 
 class LoginFlowV2Tokens {
-	/** @var string */
-	private $loginToken;
-	/** @var string */
-	private $pollToken;
-
-	public function __construct(string $loginToken, string $pollToken) {
-		$this->loginToken = $loginToken;
-		$this->pollToken = $pollToken;
+	public function __construct(
+		private string $loginToken,
+		private string $pollToken,
+	) {
 	}
 
 	public function getPollToken(): string {

--- a/core/Db/LoginFlowV2Mapper.php
+++ b/core/Db/LoginFlowV2Mapper.php
@@ -36,12 +36,15 @@ use OCP\IDBConnection;
 class LoginFlowV2Mapper extends QBMapper {
 	private const lifetime = 1200;
 
-	/** @var ITimeFactory */
-	private $timeFactory;
-
-	public function __construct(IDBConnection $db, ITimeFactory $timeFactory) {
-		parent::__construct($db, 'login_flow_v2', LoginFlowV2::class);
-		$this->timeFactory = $timeFactory;
+	public function __construct(
+		IDBConnection $db,
+		private ITimeFactory $timeFactory,
+	) {
+		parent::__construct(
+			$db,
+			'login_flow_v2',
+			LoginFlowV2::class,
+		);
 	}
 
 	/**

--- a/core/Events/BeforePasswordResetEvent.php
+++ b/core/Events/BeforePasswordResetEvent.php
@@ -35,16 +35,14 @@ use OCP\IUser;
  * @since 25.0.0
  */
 class BeforePasswordResetEvent extends Event {
-	private IUser $user;
-	private string $password;
-
 	/**
 	 * @since 25.0.0
 	 */
-	public function __construct(IUser $user, string $password) {
+	public function __construct(
+		private IUser $user,
+		private string $password,
+	) {
 		parent::__construct();
-		$this->user = $user;
-		$this->password = $password;
 	}
 
 	/**

--- a/core/Events/PasswordResetEvent.php
+++ b/core/Events/PasswordResetEvent.php
@@ -35,16 +35,14 @@ use OCP\IUser;
  * @since 25.0.0
  */
 class PasswordResetEvent extends Event {
-	private IUser $user;
-	private string $password;
-
 	/**
 	 * @since 25.0.0
 	 */
-	public function __construct(IUser $user, string $password) {
+	public function __construct(
+		private IUser $user,
+		private string $password,
+	) {
 		parent::__construct();
-		$this->user = $user;
-		$this->password = $password;
 	}
 
 	/**

--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -46,38 +46,14 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 
 class TwoFactorMiddleware extends Middleware {
-	/** @var Manager */
-	private $twoFactorManager;
-
-	/** @var Session */
-	private $userSession;
-
-	/** @var ISession */
-	private $session;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var IControllerMethodReflector */
-	private $reflector;
-
-	/** @var IRequest */
-	private $request;
-
-	/**
-	 * @param Manager $twoFactorManager
-	 * @param Session $userSession
-	 * @param ISession $session
-	 * @param IURLGenerator $urlGenerator
-	 */
-	public function __construct(Manager $twoFactorManager, Session $userSession, ISession $session,
-		IURLGenerator $urlGenerator, IControllerMethodReflector $reflector, IRequest $request) {
-		$this->twoFactorManager = $twoFactorManager;
-		$this->userSession = $userSession;
-		$this->session = $session;
-		$this->urlGenerator = $urlGenerator;
-		$this->reflector = $reflector;
-		$this->request = $request;
+	public function __construct(
+		private Manager $twoFactorManager,
+		private Session $userSession,
+		private ISession $session,
+		private IURLGenerator $urlGenerator,
+		private IControllerMethodReflector $reflector,
+		private IRequest $request,
+	) {
 	}
 
 	/**

--- a/core/Notification/CoreNotifier.php
+++ b/core/Notification/CoreNotifier.php
@@ -36,17 +36,11 @@ use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
 class CoreNotifier implements INotifier {
-	/** @var IConfig */
-	private $config;
-	/** @var IFactory */
-	private $l10nFactory;
-	/** @var IURLGenerator */
-	private $url;
-
-	public function __construct(IConfig $config, IFactory $factory, IURLGenerator $url) {
-		$this->config = $config;
-		$this->l10nFactory = $factory;
-		$this->url = $url;
+	public function __construct(
+		private IConfig $config,
+		private IFactory $factory,
+		private IURLGenerator $url,
+	) {
 	}
 
 	/**
@@ -66,14 +60,14 @@ class CoreNotifier implements INotifier {
 	 * @since 17.0.0
 	 */
 	public function getName(): string {
-		return $this->l10nFactory->get('core')->t('Nextcloud Server');
+		return $this->factory->get('core')->t('Nextcloud Server');
 	}
 
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'core') {
 			throw new \InvalidArgumentException();
 		}
-		$l = $this->l10nFactory->get('core', $languageCode);
+		$l = $this->factory->get('core', $languageCode);
 
 		if ($notification->getSubject() === 'repair_exposing_links') {
 			$notification->setParsedSubject($l->t('Some of your link shares have been removed'));

--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -43,28 +43,15 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class LoginFlowV2Service {
-	private LoginFlowV2Mapper $mapper;
-	private ISecureRandom $random;
-	private ITimeFactory $time;
-	private IConfig $config;
-	private ICrypto $crypto;
-	private LoggerInterface $logger;
-	private IProvider $tokenProvider;
-
-	public function __construct(LoginFlowV2Mapper $mapper,
-								ISecureRandom $random,
-								ITimeFactory $time,
-								IConfig $config,
-								ICrypto $crypto,
-								LoggerInterface $logger,
-								IProvider $tokenProvider) {
-		$this->mapper = $mapper;
-		$this->random = $random;
-		$this->time = $time;
-		$this->config = $config;
-		$this->crypto = $crypto;
-		$this->logger = $logger;
-		$this->tokenProvider = $tokenProvider;
+	public function __construct(
+		private LoginFlowV2Mapper $mapper,
+		private ISecureRandom $random,
+		private ITimeFactory $time,
+		private IConfig $config,
+		private ICrypto $crypto,
+		private LoggerInterface $logger,
+		private IProvider $tokenProvider,
+	) {
 	}
 
 	/**

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -65,12 +65,11 @@ class FeedBackHandler {
 	private int $progressStateMax = 100;
 	private int $progressStateStep = 0;
 	private string $currentStep = '';
-	private IEventSource $eventSource;
-	private IL10N $l10n;
 
-	public function __construct(IEventSource $eventSource, IL10N $l10n) {
-		$this->eventSource = $eventSource;
-		$this->l10n = $l10n;
+	public function __construct(
+		private IEventSource $eventSource,
+		private IL10N $l10n,
+	) {
 	}
 
 	public function handleRepairFeedback(Event $event): void {


### PR DESCRIPTION
Following previously merged PRs, I have also made the required adjustments to the remaining classes in `/core/` namespace.

This PR refactors the remaining classes in `/core/` namespace using PHP8's constructor property promotion to remove redundant lines and make the code cleaner.
