### PR TITLE
Refactors lib/private/Accounts classes

### DIFF
--- a/lib/private/Accounts/Account.php
+++ b/lib/private/Accounts/Account.php
@@ -39,13 +39,11 @@ class Account implements IAccount {
 	use TAccountsHelper;
 
 	/** @var IAccountPropertyCollection[]|IAccountProperty[] */
-	private $properties = [];
+	private array $properties = [];
 
-	/** @var IUser */
-	private $user;
-
-	public function __construct(IUser $user) {
-		$this->user = $user;
+	public function __construct(
+		private IUser $user,
+	) {
 	}
 
 	public function setProperty(string $property, string $value, string $scope, string $verified, string $verificationData = ''): IAccount {

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -85,7 +85,7 @@ class AccountManager implements IAccountManager {
 
 	private string $table = 'accounts';
 	private string $dataTable = 'accounts_data';
-	private IL10N $l10n;
+	private ?IL10N $l10n = null;
 	private CappedMemoryCache $internalCache;
 
 	/**
@@ -120,7 +120,6 @@ class AccountManager implements IAccountManager {
 		private ICrypto $crypto,
 	) {
 		$this->internalCache = new CappedMemoryCache();
-		$this->l10n = $factory->get('core');
 	}
 
 	/**
@@ -348,12 +347,10 @@ class AccountManager implements IAccountManager {
 	}
 
 	protected function searchUsersForRelatedCollection(string $property, array $values): array {
-		switch ($property) {
-			case IAccountManager::PROPERTY_EMAIL:
-				return array_flip($this->searchUsers(IAccountManager::COLLECTION_EMAIL, $values));
-			default:
-				return [];
-		}
+		return match ($property) {
+			IAccountManager::PROPERTY_EMAIL => array_flip($this->searchUsers(IAccountManager::COLLECTION_EMAIL, $values)),
+			default => [],
+		};
 	}
 
 	/**
@@ -415,6 +412,10 @@ class AccountManager implements IAccountManager {
 		$emailTemplate = $this->mailer->createEMailTemplate('core.EmailVerification', [
 			'link' => $link,
 		]);
+
+		if (!$this->l10n) {
+			$this->l10n = $this->factory->get('core');
+		}
 
 		$emailTemplate->setSubject($this->l10n->t('%s email verification', [$this->defaults->getName()]));
 		$emailTemplate->addHeader();

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -120,6 +120,7 @@ class AccountManager implements IAccountManager {
 		private ICrypto $crypto,
 	) {
 		$this->internalCache = new CappedMemoryCache();
+		$this->l10n = $factory->get('core');
 	}
 
 	/**
@@ -414,10 +415,6 @@ class AccountManager implements IAccountManager {
 		$emailTemplate = $this->mailer->createEMailTemplate('core.EmailVerification', [
 			'link' => $link,
 		]);
-
-		if (!$this->l10n) {
-			$this->l10n = $this->factory->get('core');
-		}
 
 		$emailTemplate->setSubject($this->l10n->t('%s email verification', [$this->defaults->getName()]));
 		$emailTemplate->addHeader();

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -83,40 +83,9 @@ class AccountManager implements IAccountManager {
 
 	use TProfileHelper;
 
-	/** @var  IDBConnection database connection */
-	private $connection;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var string table name */
-	private $table = 'accounts';
-
-	/** @var string table name */
-	private $dataTable = 'accounts_data';
-
-	/** @var EventDispatcherInterface */
-	private $eventDispatcher;
-
-	/** @var IJobList */
-	private $jobList;
-
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var IVerificationToken */
-	private $verificationToken;
-	/** @var IMailer */
-	private $mailer;
-	/** @var Defaults */
-	private $defaults;
-	/** @var IL10N */
-	private $l10n;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var ICrypto */
-	private $crypto;
-	/** @var IFactory */
-	private $l10nfactory;
+	private string $table = 'accounts';
+	private string $dataTable = 'accounts_data';
+	private IL10N $l10n;
 	private CappedMemoryCache $internalCache;
 
 	/**
@@ -138,35 +107,22 @@ class AccountManager implements IAccountManager {
 	];
 
 	public function __construct(
-		IDBConnection            $connection,
-		IConfig                  $config,
-		EventDispatcherInterface $eventDispatcher,
-		IJobList                 $jobList,
-		LoggerInterface          $logger,
-		IVerificationToken       $verificationToken,
-		IMailer                  $mailer,
-		Defaults                 $defaults,
-		IFactory                 $factory,
-		IURLGenerator            $urlGenerator,
-		ICrypto                  $crypto
+		private IDBConnection $connection,
+		private IConfig $config,
+		private EventDispatcherInterface $eventDispatcher,
+		private IJobList $jobList,
+		private LoggerInterface $logger,
+		private IVerificationToken $verificationToken,
+		private IMailer $mailer,
+		private Defaults $defaults,
+		private IFactory $factory,
+		private IURLGenerator $urlGenerator,
+		private ICrypto $crypto,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->jobList = $jobList;
-		$this->logger = $logger;
-		$this->verificationToken = $verificationToken;
-		$this->mailer = $mailer;
-		$this->defaults = $defaults;
-		$this->urlGenerator = $urlGenerator;
-		$this->crypto = $crypto;
-		// DIing IL10N results in a dependency loop
-		$this->l10nfactory = $factory;
 		$this->internalCache = new CappedMemoryCache();
 	}
 
 	/**
-	 * @param string $input
 	 * @return string Provided phone number in E.164 format when it was a valid number
 	 * @throws InvalidArgumentException When the phone number was invalid or no default region is set and the number doesn't start with a country code
 	 */
@@ -195,9 +151,6 @@ class AccountManager implements IAccountManager {
 	}
 
 	/**
-	 *
-	 * @param string $input
-	 * @return string
 	 * @throws InvalidArgumentException When the website did not have http(s) as protocol or the host name was empty
 	 */
 	protected function parseWebsite(string $input): string {
@@ -251,7 +204,7 @@ class AccountManager implements IAccountManager {
 		}
 	}
 
-	protected function sanitizePhoneNumberValue(IAccountProperty $property, bool $throwOnData = false) {
+	protected function sanitizePhoneNumberValue(IAccountProperty $property, bool $throwOnData = false): void {
 		if ($property->getName() !== self::PROPERTY_PHONE) {
 			if ($throwOnData) {
 				throw new InvalidArgumentException(sprintf('sanitizePhoneNumberValue can only sanitize phone numbers, %s given', $property->getName()));
@@ -271,7 +224,7 @@ class AccountManager implements IAccountManager {
 		}
 	}
 
-	protected function sanitizeWebsite(IAccountProperty $property, bool $throwOnData = false) {
+	protected function sanitizeWebsite(IAccountProperty $property, bool $throwOnData = false): void {
 		if ($property->getName() !== self::PROPERTY_WEBSITE) {
 			if ($throwOnData) {
 				throw new InvalidArgumentException(sprintf('sanitizeWebsite can only sanitize web domains, %s given', $property->getName()));
@@ -313,10 +266,8 @@ class AccountManager implements IAccountManager {
 
 	/**
 	 * delete user from accounts table
-	 *
-	 * @param IUser $user
 	 */
-	public function deleteUser(IUser $user) {
+	public function deleteUser(IUser $user): void {
 		$uid = $user->getUID();
 		$query = $this->connection->getQueryBuilder();
 		$query->delete($this->table)
@@ -328,8 +279,6 @@ class AccountManager implements IAccountManager {
 
 	/**
 	 * delete user from accounts table
-	 *
-	 * @param IUser $user
 	 */
 	public function deleteUserData(IUser $user): void {
 		$uid = $user->getUID();
@@ -467,7 +416,7 @@ class AccountManager implements IAccountManager {
 		]);
 
 		if (!$this->l10n) {
-			$this->l10n = $this->l10nfactory->get('core');
+			$this->l10n = $this->factory->get('core');
 		}
 
 		$emailTemplate->setSubject($this->l10n->t('%s email verification', [$this->defaults->getName()]));
@@ -552,9 +501,6 @@ class AccountManager implements IAccountManager {
 
 	/**
 	 * add new user to accounts table
-	 *
-	 * @param IUser $user
-	 * @param array $data
 	 */
 	protected function insertNewUser(IUser $user, array $data): void {
 		$uid = $user->getUID();

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -115,7 +115,7 @@ class AccountManager implements IAccountManager {
 		private IVerificationToken $verificationToken,
 		private IMailer $mailer,
 		private Defaults $defaults,
-		private IFactory $factory,
+		private IFactory $l10nFactory,
 		private IURLGenerator $urlGenerator,
 		private ICrypto $crypto,
 	) {
@@ -414,7 +414,7 @@ class AccountManager implements IAccountManager {
 		]);
 
 		if (!$this->l10n) {
-			$this->l10n = $this->factory->get('core');
+			$this->l10n = $this->l10nFactory->get('core');
 		}
 
 		$emailTemplate->setSubject($this->l10n->t('%s email verification', [$this->defaults->getName()]));

--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -32,25 +32,17 @@ use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
 
 class AccountProperty implements IAccountProperty {
-	/** @var string */
-	private $name;
-	/** @var string */
-	private $value;
-	/** @var string */
-	private $scope;
-	/** @var string */
-	private $verified;
-	/** @var string */
-	private $verificationData;
-	/** @var string */
-	private $locallyVerified = IAccountManager::NOT_VERIFIED;
+	private string $scope;
+	private string $locallyVerified = IAccountManager::NOT_VERIFIED;
 
-	public function __construct(string $name, string $value, string $scope, string $verified, string $verificationData) {
-		$this->name = $name;
-		$this->value = $value;
+	public function __construct(
+		private string $name,
+		private string $value,
+		string $scope,
+		private string $verified,
+		private string $verificationData,
+	) {
 		$this->setScope($scope);
-		$this->verified = $verified;
-		$this->verificationData = $verificationData;
 	}
 
 	public function jsonSerialize(): array {
@@ -67,9 +59,6 @@ class AccountProperty implements IAccountProperty {
 	 * Set the value of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @param string $value
-	 * @return IAccountProperty
 	 */
 	public function setValue(string $value): IAccountProperty {
 		$this->value = $value;
@@ -80,9 +69,6 @@ class AccountProperty implements IAccountProperty {
 	 * Set the scope of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @param string $scope
-	 * @return IAccountProperty
 	 */
 	public function setScope(string $scope): IAccountProperty {
 		$newScope = $this->mapScopeToV2($scope);
@@ -102,9 +88,6 @@ class AccountProperty implements IAccountProperty {
 	 * Set the verification status of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @param string $verified
-	 * @return IAccountProperty
 	 */
 	public function setVerified(string $verified): IAccountProperty {
 		$this->verified = $verified;
@@ -115,8 +98,6 @@ class AccountProperty implements IAccountProperty {
 	 * Get the name of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @return string
 	 */
 	public function getName(): string {
 		return $this->name;
@@ -126,8 +107,6 @@ class AccountProperty implements IAccountProperty {
 	 * Get the value of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @return string
 	 */
 	public function getValue(): string {
 		return $this->value;
@@ -137,8 +116,6 @@ class AccountProperty implements IAccountProperty {
 	 * Get the scope of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @return string
 	 */
 	public function getScope(): string {
 		return $this->scope;
@@ -149,25 +126,18 @@ class AccountProperty implements IAccountProperty {
 			return $scope;
 		}
 
-		switch ($scope) {
-			case IAccountManager::VISIBILITY_PRIVATE:
-			case '':
-				return IAccountManager::SCOPE_LOCAL;
-			case IAccountManager::VISIBILITY_CONTACTS_ONLY:
-				return IAccountManager::SCOPE_FEDERATED;
-			case IAccountManager::VISIBILITY_PUBLIC:
-				return IAccountManager::SCOPE_PUBLISHED;
-			default:
-				return $scope;
-		}
+		return match ($scope) {
+			IAccountManager::VISIBILITY_PRIVATE, '' => IAccountManager::SCOPE_LOCAL,
+			IAccountManager::VISIBILITY_CONTACTS_ONLY => IAccountManager::SCOPE_FEDERATED,
+			IAccountManager::VISIBILITY_PUBLIC => IAccountManager::SCOPE_PUBLISHED,
+			default => $scope,
+		};
 	}
 
 	/**
 	 * Get the verification status of a property
 	 *
 	 * @since 15.0.0
-	 *
-	 * @return string
 	 */
 	public function getVerified(): string {
 		return $this->verified;

--- a/lib/private/Accounts/AccountPropertyCollection.php
+++ b/lib/private/Accounts/AccountPropertyCollection.php
@@ -32,14 +32,12 @@ use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\IAccountPropertyCollection;
 
 class AccountPropertyCollection implements IAccountPropertyCollection {
-	/** @var string */
-	protected $collectionName = '';
-
 	/** @var IAccountProperty[] */
-	protected $properties = [];
+	protected array $properties = [];
 
-	public function __construct(string $collectionName) {
-		$this->collectionName = $collectionName;
+	public function __construct(
+		protected string $collectionName,
+	) {
 	}
 
 	public function setProperties(array $properties): IAccountPropertyCollection {

--- a/lib/private/Accounts/Hooks.php
+++ b/lib/private/Accounts/Hooks.php
@@ -36,14 +36,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<UserChangedEvent>
  */
 class Hooks implements IEventListener {
-	/** @var IAccountManager */
-	private $accountManager;
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(LoggerInterface $logger, IAccountManager $accountManager) {
-		$this->logger = $logger;
-		$this->accountManager = $accountManager;
+	public function __construct(
+		private LoggerInterface $logger,
+		private IAccountManager $accountManager,
+	) {
 	}
 
 	/**


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Accounts` namespace.

The improvements in this PRs include but are not limited to:
- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks