### PR TITLE
Refactors lib/private/Contacts.

### DIFF
--- a/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
+++ b/lib/private/Contacts/ContactsMenu/ActionProviderStore.php
@@ -39,18 +39,14 @@ use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class ActionProviderStore {
-	private IServerContainer $serverContainer;
-	private AppManager $appManager;
-	private LoggerInterface $logger;
-
-	public function __construct(IServerContainer $serverContainer, AppManager $appManager, LoggerInterface $logger) {
-		$this->serverContainer = $serverContainer;
-		$this->appManager = $appManager;
-		$this->logger = $logger;
+	public function __construct(
+		private IServerContainer $serverContainer,
+		private AppManager $appManager,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**
-	 * @param IUser $user
 	 * @return IProvider[]
 	 * @throws Exception
 	 */
@@ -90,7 +86,6 @@ class ActionProviderStore {
 	}
 
 	/**
-	 * @param IUser $user
 	 * @return string[]
 	 */
 	private function getAppProviderClasses(IUser $user): array {

--- a/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
+++ b/lib/private/Contacts/ContactsMenu/Actions/LinkAction.php
@@ -34,11 +34,11 @@ class LinkAction implements ILinkAction {
 	/**
 	 * @param string $icon absolute URI to an icon
 	 */
-	public function setIcon(string $icon) {
+	public function setIcon(string $icon): void {
 		$this->icon = $icon;
 	}
 
-	public function setName(string $name) {
+	public function setName(string $name): void {
 		$this->name = $name;
 	}
 
@@ -46,7 +46,7 @@ class LinkAction implements ILinkAction {
 		return $this->name;
 	}
 
-	public function setPriority(int $priority) {
+	public function setPriority(int $priority): void {
 		$this->priority = $priority;
 	}
 
@@ -54,7 +54,7 @@ class LinkAction implements ILinkAction {
 		return $this->priority;
 	}
 
-	public function setHref(string $href) {
+	public function setHref(string $href): void {
 		$this->href = $href;
 	}
 
@@ -65,7 +65,7 @@ class LinkAction implements ILinkAction {
 	/**
 	 * @since 23.0.0
 	 */
-	public function setAppId(string $appId) {
+	public function setAppId(string $appId): void {
 		$this->appId = $appId;
 	}
 

--- a/lib/private/Contacts/ContactsMenu/ContactsStore.php
+++ b/lib/private/Contacts/ContactsMenu/ContactsStore.php
@@ -44,33 +44,16 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 
 class ContactsStore implements IContactsStore {
-	private IManager $contactsManager;
-	private IConfig $config;
-	private ProfileManager $profileManager;
-	private IUserManager $userManager;
-	private IURLGenerator $urlGenerator;
-	private IGroupManager $groupManager;
-	private KnownUserService $knownUserService;
-	private IL10NFactory $l10nFactory;
-
 	public function __construct(
-		IManager $contactsManager,
-		IConfig $config,
-		ProfileManager $profileManager,
-		IUserManager $userManager,
-		IURLGenerator $urlGenerator,
-		IGroupManager $groupManager,
-		KnownUserService $knownUserService,
-		IL10NFactory $l10nFactory
+		private IManager $contactsManager,
+		private IConfig $config,
+		private ProfileManager $profileManager,
+		private IUserManager $userManager,
+		private IURLGenerator $urlGenerator,
+		private IGroupManager $groupManager,
+		private KnownUserService $knownUserService,
+		private IL10NFactory $l10nFactory,
 	) {
-		$this->contactsManager = $contactsManager;
-		$this->config = $config;
-		$this->profileManager = $profileManager;
-		$this->userManager = $userManager;
-		$this->urlGenerator = $urlGenerator;
-		$this->groupManager = $groupManager;
-		$this->knownUserService = $knownUserService;
-		$this->l10nFactory = $l10nFactory;
 	}
 
 	/**
@@ -126,9 +109,7 @@ class ContactsStore implements IContactsStore {
 	 * enabled it will filter all users which doesn't have a common group
 	 * with the current user.
 	 *
-	 * @param IUser $self
 	 * @param Entry[] $entries
-	 * @param string|null $filter
 	 * @return Entry[] the filtered contacts
 	 */
 	private function filterContacts(

--- a/lib/private/Contacts/ContactsMenu/Entry.php
+++ b/lib/private/Contacts/ContactsMenu/Entry.php
@@ -134,20 +134,13 @@ class Entry implements IEntry {
 		$this->properties = $contact;
 	}
 
-	/**
-	 * @param string $key
-	 * @return mixed
-	 */
-	public function getProperty(string $key) {
+	public function getProperty(string $key): mixed {
 		if (!isset($this->properties[$key])) {
 			return null;
 		}
 		return $this->properties[$key];
 	}
 
-	/**
-	 * @return array
-	 */
 	public function jsonSerialize(): array {
 		$topAction = !empty($this->actions) ? $this->actions[0]->jsonSerialize() : null;
 		$otherActions = array_map(function (IAction $action) {

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -33,22 +33,15 @@ use OCP\IConfig;
 use OCP\IUser;
 
 class Manager {
-	private ContactsStore $store;
-	private ActionProviderStore $actionProviderStore;
-	private IAppManager $appManager;
-	private IConfig $config;
-
-	public function __construct(ContactsStore $store, ActionProviderStore $actionProviderStore, IAppManager $appManager, IConfig $config) {
-		$this->store = $store;
-		$this->actionProviderStore = $actionProviderStore;
-		$this->appManager = $appManager;
-		$this->config = $config;
+	public function __construct(
+		private ContactsStore $store,
+		private ActionProviderStore $actionProviderStore,
+		private IAppManager $appManager,
+		private IConfig $config,
+	) {
 	}
 
 	/**
-	 * @param IUser $user
-	 * @param string|null $filter
-	 * @return array
 	 * @throws Exception
 	 */
 	public function getEntries(IUser $user, ?string $filter): array {
@@ -95,10 +88,9 @@ class Manager {
 
 	/**
 	 * @param IEntry[] $entries
-	 * @param IUser $user
 	 * @throws Exception
 	 */
-	private function processEntries(array $entries, IUser $user) {
+	private function processEntries(array $entries, IUser $user): void {
 		$providers = $this->actionProviderStore->getProviders($user);
 		foreach ($entries as $entry) {
 			foreach ($providers as $provider) {

--- a/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php
@@ -28,18 +28,13 @@ use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IURLGenerator;
 
 class EMailProvider implements IProvider {
-	private IActionFactory $actionFactory;
-	private IURLGenerator $urlGenerator;
-
-	public function __construct(IActionFactory $actionFactory, IURLGenerator $urlGenerator) {
-		$this->actionFactory = $actionFactory;
-		$this->urlGenerator = $urlGenerator;
+	public function __construct(
+		private IActionFactory $actionFactory,
+		private IURLGenerator $urlGenerator,
+	) {
 	}
 
-	/**
-	 * @param IEntry $entry
-	 */
-	public function process(IEntry $entry) {
+	public function process(IEntry $entry): void {
 		$iconUrl = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'actions/mail.svg'));
 		foreach ($entry->getEMailAddresses() as $address) {
 			if (empty($address)) {

--- a/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php
@@ -37,36 +37,18 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 
 class LocalTimeProvider implements IProvider {
-	private IActionFactory $actionFactory;
-	private IL10NFactory $l10nFactory;
-	private IURLGenerator $urlGenerator;
-	private IUserManager $userManager;
-	private ITimeFactory $timeFactory;
-	private IDateTimeFormatter $dateTimeFormatter;
-	private IConfig $config;
-
 	public function __construct(
-		IActionFactory $actionFactory,
-		IL10NFactory $l10nFactory,
-		IURLGenerator $urlGenerator,
-		IUserManager $userManager,
-		ITimeFactory $timeFactory,
-		IDateTimeFormatter $dateTimeFormatter,
-		IConfig $config
+		private IActionFactory $actionFactory,
+		private IL10NFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+		private ITimeFactory $timeFactory,
+		private IDateTimeFormatter $dateTimeFormatter,
+		private IConfig $config,
 	) {
-		$this->actionFactory = $actionFactory;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
-		$this->timeFactory = $timeFactory;
-		$this->dateTimeFormatter = $dateTimeFormatter;
-		$this->config = $config;
 	}
 
-	/**
-	 * @param IEntry $entry
-	 */
-	public function process(IEntry $entry) {
+	public function process(IEntry $entry): void {
 		$targetUserId = $entry->getProperty('UID');
 		$targetUser = $this->userManager->get($targetUserId);
 		if (!empty($targetUser)) {

--- a/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php
@@ -33,30 +33,16 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory as IL10NFactory;
 
 class ProfileProvider implements IProvider {
-	private IActionFactory $actionFactory;
-	private ProfileManager $profileManager;
-	private IL10NFactory $l10nFactory;
-	private IURLGenerator $urlGenerator;
-	private IUserManager $userManager;
-
 	public function __construct(
-		IActionFactory $actionFactory,
-		ProfileManager $profileManager,
-		IL10NFactory $l10nFactory,
-		IURLGenerator $urlGenerator,
-		IUserManager $userManager
+		private IActionFactory $actionFactory,
+		private ProfileManager $profileManager,
+		private IL10NFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
 	) {
-		$this->actionFactory = $actionFactory;
-		$this->profileManager = $profileManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
-		$this->userManager = $userManager;
 	}
 
-	/**
-	 * @param IEntry $entry
-	 */
-	public function process(IEntry $entry) {
+	public function process(IEntry $entry): void {
 		$targetUserId = $entry->getProperty('UID');
 		$targetUser = $this->userManager->get($targetUserId);
 		if (!empty($targetUser)) {


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Contacts` namespace.

The improvements in this PRs include:

- Using PHP8's constructor property promotion
- Adding return types
- Removing redundant docblocks