### PR TITLE
Refactors lib/private/Avatar.

### DIFF
--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -55,59 +55,26 @@ use Psr\Log\LoggerInterface;
  * This class implements methods to access Avatar functionality
  */
 class AvatarManager implements IAvatarManager {
-	/** @var IUserSession */
-	private $userSession;
-
-	/** @var Manager */
-	private $userManager;
-
-	/** @var IAppData */
-	private $appData;
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var IAccountManager */
-	private $accountManager;
-
-	/** @var KnownUserService */
-	private $knownUserService;
-
 	public function __construct(
-			IUserSession $userSession,
-			Manager $userManager,
-			IAppData $appData,
-			IL10N $l,
-			LoggerInterface $logger,
-			IConfig $config,
-			IAccountManager $accountManager,
-			KnownUserService $knownUserService
+		private IUserSession $userSession,
+		private Manager $userManager,
+		private IAppData $appData,
+		private IL10N $l,
+		private LoggerInterface $logger,
+		private IConfig $config,
+		private IAccountManager $accountManager,
+		private KnownUserService $knownUserService,
 	) {
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
-		$this->appData = $appData;
-		$this->l = $l;
-		$this->logger = $logger;
-		$this->config = $config;
-		$this->accountManager = $accountManager;
-		$this->knownUserService = $knownUserService;
 	}
 
 	/**
 	 * return a user specific instance of \OCP\IAvatar
 	 * @see \OCP\IAvatar
 	 * @param string $userId the ownCloud user id
-	 * @return \OCP\IAvatar
 	 * @throws \Exception In case the username is potentially dangerous
 	 * @throws NotFoundException In case there is no user folder yet
 	 */
-	public function getAvatar(string $userId) : IAvatar {
+	public function getAvatar(string $userId): IAvatar {
 		$user = $this->userManager->get($userId);
 		if ($user === null) {
 			throw new \Exception('user does not exist');
@@ -116,10 +83,7 @@ class AvatarManager implements IAvatarManager {
 		// sanitize userID - fixes casing issue (needed for the filesystem stuff that is done below)
 		$userId = $user->getUID();
 
-		$requestingUser = null;
-		if ($this->userSession !== null) {
-			$requestingUser = $this->userSession->getUser();
-		}
+		$requestingUser = $this->userSession?->getUser();
 
 		try {
 			$folder = $this->appData->getFolder($userId);
@@ -157,7 +121,7 @@ class AvatarManager implements IAvatarManager {
 	/**
 	 * Clear generated avatars
 	 */
-	public function clearCachedAvatars() {
+	public function clearCachedAvatars(): void {
 		$users = $this->config->getUsersForUserValue('avatar', 'generated', 'true');
 		foreach ($users as $userId) {
 			// This also bumps the avatar version leading to cache invalidation in browsers
@@ -183,7 +147,6 @@ class AvatarManager implements IAvatarManager {
 	 * Returns a GuestAvatar.
 	 *
 	 * @param string $name The guest name, e.g. "Albert".
-	 * @return IAvatar
 	 */
 	public function getGuestAvatar(string $name): IAvatar {
 		return new GuestAvatar($name, $this->logger);

--- a/lib/private/Avatar/AvatarManager.php
+++ b/lib/private/Avatar/AvatarManager.php
@@ -83,7 +83,7 @@ class AvatarManager implements IAvatarManager {
 		// sanitize userID - fixes casing issue (needed for the filesystem stuff that is done below)
 		$userId = $user->getUID();
 
-		$requestingUser = $this->userSession?->getUser();
+		$requestingUser = $this->userSession->getUser();
 
 		try {
 			$folder = $this->appData->getFolder($userId);

--- a/lib/private/Avatar/GuestAvatar.php
+++ b/lib/private/Avatar/GuestAvatar.php
@@ -35,18 +35,15 @@ use Psr\Log\LoggerInterface;
  */
 class GuestAvatar extends Avatar {
 	/**
-	 * Holds the guest user display name.
-	 */
-	private string $userDisplayName;
-
-	/**
 	 * GuestAvatar constructor.
 	 *
 	 * @param string $userDisplayName The guest user display name
 	 */
-	public function __construct(string $userDisplayName, LoggerInterface $logger) {
+	public function __construct(
+		private string $userDisplayName,
+		LoggerInterface $logger,
+	) {
 		parent::__construct($logger);
-		$this->userDisplayName = $userDisplayName;
 	}
 
 	/**
@@ -68,7 +65,6 @@ class GuestAvatar extends Avatar {
 	 * Setting avatars isn't implemented for guests.
 	 *
 	 * @param \OCP\IImage|resource|string $data
-	 * @return void
 	 */
 	public function set($data): void {
 		// unimplemented for guest user avatars

--- a/lib/private/Avatar/PlaceholderAvatar.php
+++ b/lib/private/Avatar/PlaceholderAvatar.php
@@ -32,9 +32,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
-use OCP\IConfig;
 use OCP\IImage;
-use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -44,26 +42,12 @@ use Psr\Log\LoggerInterface;
  * for faster retrieval, unlike the GuestAvatar.
  */
 class PlaceholderAvatar extends Avatar {
-	private ISimpleFolder $folder;
-	private User $user;
-
-	/**
-	 * UserAvatar constructor.
-	 *
-	 * @param IConfig $config The configuration
-	 * @param ISimpleFolder $folder The avatar files folder
-	 * @param IL10N $l The localization helper
-	 * @param User $user The user this class manages the avatar for
-	 * @param LoggerInterface $logger The logger
-	 */
 	public function __construct(
-		ISimpleFolder $folder,
-		$user,
-		LoggerInterface $logger) {
+		private ISimpleFolder $folder,
+		private User $user,
+		LoggerInterface $logger,
+	) {
 		parent::__construct($logger);
-
-		$this->folder = $folder;
-		$this->user = $user;
 	}
 
 	/**
@@ -80,7 +64,6 @@ class PlaceholderAvatar extends Avatar {
 	 * @throws \Exception if the provided file is not a jpg or png image
 	 * @throws \Exception if the provided image is not valid
 	 * @throws NotSquareException if the image is not square
-	 * @return void
 	 */
 	public function set($data): void {
 		// unimplemented for placeholder avatars
@@ -102,8 +85,6 @@ class PlaceholderAvatar extends Avatar {
 	 *
 	 * If there is no avatar file yet, one is generated.
 	 *
-	 * @param int $size
-	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\PreConditionNotMetException

--- a/lib/private/Avatar/UserAvatar.php
+++ b/lib/private/Avatar/UserAvatar.php
@@ -44,31 +44,14 @@ use Psr\Log\LoggerInterface;
  * This class represents a registered user's avatar.
  */
 class UserAvatar extends Avatar {
-	private IConfig $config;
-	private ISimpleFolder $folder;
-	private IL10N $l;
-	private User $user;
-
-	/**
-	 * UserAvatar constructor.
-	 *
-	 * @param IConfig $config The configuration
-	 * @param ISimpleFolder $folder The avatar files folder
-	 * @param IL10N $l The localization helper
-	 * @param User $user The user this class manages the avatar for
-	 * @param LoggerInterface $logger The logger
-	 */
 	public function __construct(
-		ISimpleFolder $folder,
-		IL10N $l,
-		User $user,
+		private ISimpleFolder $folder,
+		private IL10N $l,
+		private User $user,
 		LoggerInterface $logger,
-		IConfig $config) {
+		private IConfig $config,
+	) {
 		parent::__construct($logger);
-		$this->folder = $folder;
-		$this->l = $l;
-		$this->user = $user;
-		$this->config = $config;
 	}
 
 	/**
@@ -85,7 +68,6 @@ class UserAvatar extends Avatar {
 	 * @throws \Exception if the provided file is not a jpg or png image
 	 * @throws \Exception if the provided image is not valid
 	 * @throws NotSquareException if the image is not square
-	 * @return void
 	 */
 	public function set($data): void {
 		$img = $this->getAvatarImage($data);
@@ -113,7 +95,6 @@ class UserAvatar extends Avatar {
 	 * Returns an image from several sources.
 	 *
 	 * @param IImage|resource|string|\GdImage $data An image object, imagedata or path to the avatar
-	 * @return IImage
 	 */
 	private function getAvatarImage($data): IImage {
 		if ($data instanceof IImage) {
@@ -229,8 +210,6 @@ class UserAvatar extends Avatar {
 	 *
 	 * If there is no avatar file yet, one is generated.
 	 *
-	 * @param int $size
-	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @throws \OCP\Files\NotPermittedException
 	 * @throws \OCP\PreConditionNotMetException


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Avatar` namespace.

The improvements in this PRs include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Removing redundant docblocks