### PR TITLE
Refactor lib/private/Calendar

### DIFF
--- a/lib/private/Calendar/CalendarQuery.php
+++ b/lib/private/Calendar/CalendarQuery.php
@@ -28,33 +28,24 @@ namespace OC\Calendar;
 use OCP\Calendar\ICalendarQuery;
 
 class CalendarQuery implements ICalendarQuery {
-	/** @var string */
-	private $principalUri;
+	public array $searchProperties = [];
 
-	/** @var array */
-	public $searchProperties;
+	private ?string $searchPattern;
 
-	/** @var string|null */
-	private $searchPattern;
+	private array $options = [
+		'types' => [],
+	];
 
-	/** @var array */
-	private $options;
+	private ?int $offset;
 
-	/** @var int|null */
-	private $offset;
-
-	/** @var int|null */
-	private $limit;
+	private ?int $limit;
 
 	/** @var string[] */
-	private $calendarUris = [];
+	private array $calendarUris = [];
 
-	public function __construct(string $principalUri) {
-		$this->principalUri = $principalUri;
-		$this->searchProperties = [];
-		$this->options = [
-			'types' => [],
-		];
+	public function __construct(
+		private string $principalUri,
+	) {
 	}
 
 	public function getPrincipalUri(): string {

--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -50,33 +50,19 @@ class Manager implements IManager {
 	/**
 	 * @var ICalendar[] holds all registered calendars
 	 */
-	private $calendars = [];
+	private array $calendars = [];
 
 	/**
 	 * @var \Closure[] to call to load/register calendar providers
 	 */
-	private $calendarLoaders = [];
+	private array $calendarLoaders = [];
 
-	/** @var Coordinator */
-	private $coordinator;
-
-	/** @var ContainerInterface */
-	private $container;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	private ITimeFactory $timeFactory;
-
-
-	public function __construct(Coordinator $coordinator,
-								ContainerInterface $container,
-								LoggerInterface $logger,
-								ITimeFactory $timeFactory) {
-		$this->coordinator = $coordinator;
-		$this->container = $container;
-		$this->logger = $logger;
-		$this->timeFactory = $timeFactory;
+	public function __construct(
+		private Coordinator $coordinator,
+		private ContainerInterface $container,
+		private LoggerInterface $logger,
+		private ITimeFactory $timeFactory,
+	) {
 	}
 
 	/**
@@ -92,7 +78,13 @@ class Manager implements IManager {
 	 * @return array an array of events/journals/todos which are arrays of arrays of key-value-pairs
 	 * @since 13.0.0
 	 */
-	public function search($pattern, array $searchProperties = [], array $options = [], $limit = null, $offset = null) {
+	public function search(
+		$pattern,
+		array $searchProperties = [],
+		array $options = [],
+		$limit = null,
+		$offset = null,
+	): array {
 		$this->loadCalendars();
 		$result = [];
 		foreach ($this->calendars as $calendar) {
@@ -112,29 +104,25 @@ class Manager implements IManager {
 	 * @return bool true if enabled, false if not
 	 * @since 13.0.0
 	 */
-	public function isEnabled() {
+	public function isEnabled(): bool {
 		return !empty($this->calendars) || !empty($this->calendarLoaders);
 	}
 
 	/**
 	 * Registers a calendar
 	 *
-	 * @param ICalendar $calendar
-	 * @return void
 	 * @since 13.0.0
 	 */
-	public function registerCalendar(ICalendar $calendar) {
+	public function registerCalendar(ICalendar $calendar): void {
 		$this->calendars[$calendar->getKey()] = $calendar;
 	}
 
 	/**
 	 * Unregisters a calendar
 	 *
-	 * @param ICalendar $calendar
-	 * @return void
 	 * @since 13.0.0
 	 */
-	public function unregisterCalendar(ICalendar $calendar) {
+	public function unregisterCalendar(ICalendar $calendar): void {
 		unset($this->calendars[$calendar->getKey()]);
 	}
 
@@ -142,19 +130,18 @@ class Manager implements IManager {
 	 * In order to improve lazy loading a closure can be registered which will be called in case
 	 * calendars are actually requested
 	 *
-	 * @param \Closure $callable
-	 * @return void
 	 * @since 13.0.0
 	 */
-	public function register(\Closure $callable) {
+	public function register(\Closure $callable): void {
 		$this->calendarLoaders[] = $callable;
 	}
 
 	/**
 	 * @return ICalendar[]
+	 *
 	 * @since 13.0.0
 	 */
-	public function getCalendars() {
+	public function getCalendars(): array {
 		$this->loadCalendars();
 
 		return array_values($this->calendars);
@@ -162,10 +149,10 @@ class Manager implements IManager {
 
 	/**
 	 * removes all registered calendar instances
-	 * @return void
+	 *
 	 * @since 13.0.0
 	 */
-	public function clear() {
+	public function clear(): void {
 		$this->calendars = [];
 		$this->calendarLoaders = [];
 	}
@@ -173,7 +160,7 @@ class Manager implements IManager {
 	/**
 	 * loads all calendars
 	 */
-	private function loadCalendars() {
+	private function loadCalendars(): void {
 		foreach ($this->calendarLoaders as $callable) {
 			$callable($this);
 		}
@@ -181,8 +168,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $principalUri
-	 * @param array $calendarUris
 	 * @return ICreateFromString[]
 	 */
 	public function getCalendarsForPrincipal(string $principalUri, array $calendarUris = []): array {
@@ -240,7 +225,12 @@ class Manager implements IManager {
 	/**
 	 * @throws \OCP\DB\Exception
 	 */
-	public function handleIMipReply(string $principalUri, string $sender, string $recipient, string $calendarData): bool {
+	public function handleIMipReply(
+		string $principalUri,
+		string $sender,
+		string $recipient,
+		string $calendarData,
+	): bool {
 		/** @var VCalendar $vObject */
 		$vObject = Reader::read($calendarData);
 		/** @var VEvent $vEvent */
@@ -309,7 +299,13 @@ class Manager implements IManager {
 	 * @since 25.0.0
 	 * @throws \OCP\DB\Exception
 	 */
-	public function handleIMipCancel(string $principalUri, string $sender, ?string $replyTo, string $recipient, string $calendarData): bool {
+	public function handleIMipCancel(
+		string $principalUri,
+		string $sender,
+		?string $replyTo,
+		string $recipient,
+		string $calendarData,
+	): bool {
 		$vObject = Reader::read($calendarData);
 		/** @var VEvent $vEvent */
 		$vEvent = $vObject->{'VEVENT'};

--- a/lib/private/Calendar/Resource/Manager.php
+++ b/lib/private/Calendar/Resource/Manager.php
@@ -33,46 +33,38 @@ use OCP\Calendar\Resource\IManager;
 use OCP\IServerContainer;
 
 class Manager implements IManager {
-	private Coordinator $bootstrapCoordinator;
-
-	private IServerContainer $server;
-
 	private bool $bootstrapBackendsLoaded = false;
 
 	/**
 	 * @var string[] holds all registered resource backends
 	 * @psalm-var class-string<IBackend>[]
 	 */
-	private $backends = [];
+	private array $backends = [];
 
 	/** @var IBackend[] holds all backends that have been initialized already */
-	private $initializedBackends = [];
+	private array $initializedBackends = [];
 
-	public function __construct(Coordinator $bootstrapCoordinator,
-								IServerContainer $server) {
-		$this->bootstrapCoordinator = $bootstrapCoordinator;
-		$this->server = $server;
+	public function __construct(
+		private Coordinator $bootstrapCoordinator,
+		private IServerContainer $server,
+	) {
 	}
 
 	/**
 	 * Registers a resource backend
 	 *
-	 * @param string $backendClass
-	 * @return void
 	 * @since 14.0.0
 	 */
-	public function registerBackend(string $backendClass) {
+	public function registerBackend(string $backendClass): void {
 		$this->backends[$backendClass] = $backendClass;
 	}
 
 	/**
 	 * Unregisters a resource backend
 	 *
-	 * @param string $backendClass
-	 * @return void
 	 * @since 14.0.0
 	 */
-	public function unregisterBackend(string $backendClass) {
+	public function unregisterBackend(string $backendClass): void {
 		unset($this->backends[$backendClass], $this->initializedBackends[$backendClass]);
 	}
 
@@ -114,9 +106,8 @@ class Manager implements IManager {
 	/**
 	 * @param string $backendId
 	 * @throws \OCP\AppFramework\QueryException
-	 * @return IBackend|null
 	 */
-	public function getBackend($backendId) {
+	public function getBackend($backendId): ?IBackend {
 		$backends = $this->getBackends();
 		foreach ($backends as $backend) {
 			if ($backend->getBackendIdentifier() === $backendId) {
@@ -129,10 +120,10 @@ class Manager implements IManager {
 
 	/**
 	 * removes all registered backend instances
-	 * @return void
+	 *
 	 * @since 14.0.0
 	 */
-	public function clear() {
+	public function clear(): void {
 		$this->backends = [];
 		$this->initializedBackends = [];
 	}

--- a/lib/private/Calendar/Room/Manager.php
+++ b/lib/private/Calendar/Room/Manager.php
@@ -33,10 +33,6 @@ use OCP\Calendar\Room\IManager;
 use OCP\IServerContainer;
 
 class Manager implements IManager {
-	private Coordinator $bootstrapCoordinator;
-
-	private IServerContainer $server;
-
 	private bool $bootstrapBackendsLoaded = false;
 
 	/**
@@ -48,20 +44,18 @@ class Manager implements IManager {
 	/** @var IBackend[] holds all backends that have been initialized already */
 	private array $initializedBackends = [];
 
-	public function __construct(Coordinator $bootstrapCoordinator,
-								IServerContainer $server) {
-		$this->bootstrapCoordinator = $bootstrapCoordinator;
-		$this->server = $server;
+	public function __construct(
+		private Coordinator $bootstrapCoordinator,
+		private IServerContainer $server,
+	) {
 	}
 
 	/**
 	 * Registers a resource backend
 	 *
-	 * @param string $backendClass
-	 * @return void
 	 * @since 14.0.0
 	 */
-	public function registerBackend(string $backendClass) {
+	public function registerBackend(string $backendClass): void {
 		$this->backends[$backendClass] = $backendClass;
 	}
 
@@ -69,10 +63,9 @@ class Manager implements IManager {
 	 * Unregisters a resource backend
 	 *
 	 * @param string $backendClass
-	 * @return void
 	 * @since 14.0.0
 	 */
-	public function unregisterBackend(string $backendClass) {
+	public function unregisterBackend(string $backendClass): void {
 		unset($this->backends[$backendClass], $this->initializedBackends[$backendClass]);
 	}
 
@@ -120,9 +113,8 @@ class Manager implements IManager {
 	/**
 	 * @param string $backendId
 	 * @throws \OCP\AppFramework\QueryException
-	 * @return IBackend|null
 	 */
-	public function getBackend($backendId) {
+	public function getBackend($backendId): ?IBackend {
 		$backends = $this->getBackends();
 		foreach ($backends as $backend) {
 			if ($backend->getBackendIdentifier() === $backendId) {
@@ -135,10 +127,10 @@ class Manager implements IManager {
 
 	/**
 	 * removes all registered backend instances
-	 * @return void
+	 *
 	 * @since 14.0.0
 	 */
-	public function clear() {
+	public function clear(): void {
 		$this->backends = [];
 		$this->initializedBackends = [];
 	}


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Calendar` namespace.

The improvements in this PRs include:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks