### PR TITLE
Refactors lib/private/SystemTag

### DIFF
--- a/lib/private/SystemTag/ManagerFactory.php
+++ b/lib/private/SystemTag/ManagerFactory.php
@@ -40,25 +40,16 @@ use OCP\SystemTag\ISystemTagObjectMapper;
  */
 class ManagerFactory implements ISystemTagManagerFactory {
 	/**
-	 * Server container
-	 *
-	 * @var IServerContainer
-	 */
-	private $serverContainer;
-
-	/**
 	 * Constructor for the system tag manager factory
-	 *
-	 * @param IServerContainer $serverContainer server container
 	 */
-	public function __construct(IServerContainer $serverContainer) {
-		$this->serverContainer = $serverContainer;
+	public function __construct(
+		private IServerContainer $serverContainer,
+	) {
 	}
 
 	/**
 	 * Creates and returns an instance of the system tag manager
 	 *
-	 * @return ISystemTagManager
 	 * @since 9.0.0
 	 */
 	public function getManager(): ISystemTagManager {
@@ -73,7 +64,6 @@ class ManagerFactory implements ISystemTagManagerFactory {
 	 * Creates and returns an instance of the system tag object
 	 * mapper
 	 *
-	 * @return ISystemTagObjectMapper
 	 * @since 9.0.0
 	 */
 	public function getObjectMapper(): ISystemTagObjectMapper {

--- a/lib/private/SystemTag/SystemTag.php
+++ b/lib/private/SystemTag/SystemTag.php
@@ -30,39 +30,12 @@ namespace OC\SystemTag;
 use OCP\SystemTag\ISystemTag;
 
 class SystemTag implements ISystemTag {
-	/**
-	 * @var string
-	 */
-	private $id;
-
-	/**
-	 * @var string
-	 */
-	private $name;
-
-	/**
-	 * @var bool
-	 */
-	private $userVisible;
-
-	/**
-	 * @var bool
-	 */
-	private $userAssignable;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string $id tag id
-	 * @param string $name tag name
-	 * @param bool $userVisible whether the tag is user visible
-	 * @param bool $userAssignable whether the tag is user assignable
-	 */
-	public function __construct(string $id, string $name, bool $userVisible, bool $userAssignable) {
-		$this->id = $id;
-		$this->name = $name;
-		$this->userVisible = $userVisible;
-		$this->userAssignable = $userAssignable;
+	public function __construct(
+		private string $id,
+		private string $name,
+		private bool $userVisible,
+		private bool $userAssignable,
+	) {
 	}
 
 	/**
@@ -97,14 +70,14 @@ class SystemTag implements ISystemTag {
 	 * {@inheritdoc}
 	 */
 	public function getAccessLevel(): int {
-		if ($this->userVisible) {
-			if ($this->userAssignable) {
-				return self::ACCESS_LEVEL_PUBLIC;
-			} else {
-				return self::ACCESS_LEVEL_RESTRICTED;
-			}
-		} else {
+		if (!$this->userVisible) {
 			return self::ACCESS_LEVEL_INVISIBLE;
 		}
+
+		if (!$this->userAssignable) {
+			return self::ACCESS_LEVEL_RESTRICTED;
+		}
+
+		return self::ACCESS_LEVEL_PUBLIC;
 	}
 }

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -50,10 +50,8 @@ class SystemTagManager implements ISystemTagManager {
 
 	/**
 	 * Prepared query for selecting tags directly
-	 *
-	 * @var \OCP\DB\QueryBuilder\IQueryBuilder
 	 */
-	private $selectTagQuery;
+	private IQueryBuilder $selectTagQuery;
 
 	public function __construct(
 		protected IDBConnection $connection,
@@ -219,7 +217,12 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function updateTag(string $tagId, string $newName, bool $userVisible, bool $userAssignable) {
+	public function updateTag(
+		string $tagId,
+		string $newName,
+		bool $userVisible,
+		bool $userAssignable,
+	): void {
 		try {
 			$tags = $this->getTagsByIds($tagId);
 		} catch (TagNotFoundException $e) {
@@ -271,7 +274,7 @@ class SystemTagManager implements ISystemTagManager {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function deleteTags($tagIds) {
+	public function deleteTags($tagIds): void {
 		if (!\is_array($tagIds)) {
 			$tagIds = [$tagIds];
 		}
@@ -363,14 +366,14 @@ class SystemTagManager implements ISystemTagManager {
 		return false;
 	}
 
-	private function createSystemTagFromRow($row) {
+	private function createSystemTagFromRow($row): SystemTag {
 		return new SystemTag((string)$row['id'], $row['name'], (bool)$row['visibility'], (bool)$row['editable']);
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function setTagGroups(ISystemTag $tag, array $groupIds) {
+	public function setTagGroups(ISystemTag $tag, array $groupIds): void {
 		// delete relationships first
 		$this->connection->beginTransaction();
 		try {

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -81,7 +81,6 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			$result->closeCursor();
 		}
 
-
 		return $mapping;
 	}
 
@@ -128,7 +127,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function assignTags(string $objId, string $objectType, $tagIds) {
+	public function assignTags(string $objId, string $objectType, $tagIds): void {
 		if (!\is_array($tagIds)) {
 			$tagIds = [$tagIds];
 		}
@@ -169,7 +168,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function unassignTags(string $objId, string $objectType, $tagIds) {
+	public function unassignTags(string $objId, string $objectType, $tagIds): void {
 		if (!\is_array($tagIds)) {
 			$tagIds = [$tagIds];
 		}
@@ -241,7 +240,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	 *
 	 * @throws \OCP\SystemTag\TagNotFoundException if at least one tag did not exist
 	 */
-	private function assertTagsExist($tagIds) {
+	private function assertTagsExist(array $tagIds): void {
 		$tags = $this->tagManager->getTagsByIds($tagIds);
 		if (\count($tags) !== \count($tagIds)) {
 			// at least one tag missing, bail out

--- a/lib/private/SystemTag/SystemTagsInFilesDetector.php
+++ b/lib/private/SystemTag/SystemTagsInFilesDetector.php
@@ -36,7 +36,9 @@ use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 
 class SystemTagsInFilesDetector {
-	public function __construct(protected QuerySearchHelper $searchHelper) {
+	public function __construct(
+		protected QuerySearchHelper $searchHelper,
+	) {
 	}
 
 	public function detectAssignedSystemTagsIn(


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/SystemTag` namespace.

The improvements in this PRs include:

- Using PHP8's constructor property promotion
- Using early returns
- Adding return types
- Adding types to properties
- Removing redundant docblocks