### PR TITLE
fix(dav): Catch SAB sync errors during upgrade

### DIFF
--- a/apps/dav/lib/Migration/Version1027Date20230504122946.php
+++ b/apps/dav/lib/Migration/Version1027Date20230504122946.php
@@ -34,6 +34,7 @@ use OCP\Migration\SimpleMigrationStep;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class Version1027Date20230504122946 extends SimpleMigrationStep {
 	private SyncService $syncService;
@@ -49,6 +50,13 @@ class Version1027Date20230504122946 extends SimpleMigrationStep {
 	 * @param array $options
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		$this->syncService->syncInstance();
+		try {
+			$this->syncService->syncInstance();
+		} catch (Throwable $e) {
+			$this->logger->error('Could not sync system address books during update', [
+				'exception' => $e,
+			]);
+			$output->warning('System address book sync failed. See logs for details');
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Allow completion of the upgrade from 26 to 27 even if the instance runs into https://github.com/nextcloud/server/issues/38902 or https://github.com/nextcloud/server/issues/38873.

## TODO

- [x] Improve code
- [x] Feedback from an affected instance

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
