### PR TITLE
[stable21] Increase from 100000 to 600000 iterations for hash_pbkdf2

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -105,7 +105,7 @@ class Crypt {
 		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser()->getUID() : '"no user given"';
 		$this->config = $config;
 		$this->l = $l;
-		$this->supportedKeyFormats = ['hash', 'password'];
+		$this->supportedKeyFormats = ['hash2', 'hash', 'password'];
 
 		$this->supportLegacy = $this->config->getSystemValueBool('encryption.legacy_format_support', false);
 	}
@@ -207,11 +207,11 @@ class Crypt {
 	/**
 	 * generate header for encrypted file
 	 *
-	 * @param string $keyFormat (can be 'hash' or 'password')
+	 * @param string $keyFormat (can be 'hash2', 'hash' or 'password')
 	 * @return string
 	 * @throws \InvalidArgumentException
 	 */
-	public function generateHeader($keyFormat = 'hash') {
+	public function generateHeader($keyFormat = 'hash2') {
 		if (in_array($keyFormat, $this->supportedKeyFormats, true) === false) {
 			throw new \InvalidArgumentException('key format "' . $keyFormat . '" is not supported');
 		}
@@ -351,22 +351,20 @@ class Crypt {
 	 * @param string $uid only used for user keys
 	 * @return string
 	 */
-	protected function generatePasswordHash($password, $cipher, $uid = '') {
+	protected function generatePasswordHash(string $password, string $cipher, string $uid = '', int $iterations = 600000): string {
 		$instanceId = $this->config->getSystemValue('instanceid');
 		$instanceSecret = $this->config->getSystemValue('secret');
 		$salt = hash('sha256', $uid . $instanceId . $instanceSecret, true);
 		$keySize = $this->getKeySize($cipher);
 
-		$hash = hash_pbkdf2(
+		return hash_pbkdf2(
 			'sha256',
 			$password,
 			$salt,
-			100000,
+			$iterations,
 			$keySize,
 			true
 		);
-
-		return $hash;
 	}
 
 	/**
@@ -412,7 +410,9 @@ class Crypt {
 		}
 
 		if ($keyFormat === 'hash') {
-			$password = $this->generatePasswordHash($password, $cipher, $uid);
+			$password = $this->generatePasswordHash($password, $cipher, $uid, 100000);
+		} elseif ($keyFormat === 'hash2') {
+			$password = $this->generatePasswordHash($password, $cipher, $uid, 600000);
 		}
 
 		// If we found a header we need to remove it from the key we want to decrypt

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -140,7 +140,7 @@ class CryptTest extends TestCase {
 	 */
 	public function dataTestGenerateHeader() {
 		return [
-			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:HEND'],
+			[null, 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash2:HEND'],
 			['password', 'HBEGIN:cipher:AES-128-CFB:keyFormat:password:HEND'],
 			['hash', 'HBEGIN:cipher:AES-128-CFB:keyFormat:hash:HEND']
 		];


### PR DESCRIPTION
Backport #38584

[stable24] Increase from 100000 to 600000 iterations for hash_pbkdf2

(cherry picked from commit a7dc41fb5efed25dca8a48be0ed80818be850921)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
