### PR TITLE
fix(files): Only render the menu if there are actions to show

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -597,8 +597,8 @@
 				Object.values = objectValues;
 			}
 
-			var menuActions = Object.values(this.actions.all).filter(function (action) {
-				return action.type !== OCA.Files.FileActions.TYPE_INLINE;
+			var menuActions = Object.values(actions).filter(function (action) {
+				return action.type !== OCA.Files.FileActions.TYPE_INLINE && (!defaultAction || action.name !== defaultAction.name)
 			});
 			// do not render the menu if nothing is in it
 			if (menuActions.length > 0) {


### PR DESCRIPTION
## Summary

Filter action list that is used to determine if the actions menu should be visible properly so that:
- Default actions are not included
- Only the list of available actions for a file is used

Steps to reproduce:
- Share a folder as read only link and enable "hide download"

This change will make sure that we don't show the 3 dots menu for the files in the share as the only option available is "View" which is not in the menu as it is the default. Before that an empty menu was shown.
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
