### PR TITLE
Refactors lib/private/Log

### DIFF
--- a/lib/private/Log/ErrorHandler.php
+++ b/lib/private/Log/ErrorHandler.php
@@ -36,10 +36,9 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class ErrorHandler {
-	private LoggerInterface $logger;
-
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**
@@ -94,20 +93,11 @@ class ErrorHandler {
 	}
 
 	private static function errnoToLogLevel(int $errno): int {
-		switch ($errno) {
-			case E_USER_WARNING:
-				return ILogger::WARN;
-
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				return ILogger::DEBUG;
-
-			case E_USER_NOTICE:
-				return ILogger::INFO;
-
-			case E_USER_ERROR:
-			default:
-				return ILogger::ERROR;
-		}
+		return match ($errno) {
+			E_USER_WARNING => ILogger::WARN,
+			E_DEPRECATED, E_USER_DEPRECATED => ILogger::DEBUG,
+			E_USER_NOTICE => ILogger::INFO,
+			default => ILogger::ERROR,
+		};
 	}
 }

--- a/lib/private/Log/Errorlog.php
+++ b/lib/private/Log/Errorlog.php
@@ -32,22 +32,19 @@ use OC\SystemConfig;
 use OCP\Log\IWriter;
 
 class Errorlog extends LogDetails implements IWriter {
-	/** @var string */
-	protected $tag;
-
-	public function __construct(SystemConfig $config, string $tag = 'nextcloud') {
+	public function __construct(
+		SystemConfig $config,
+		protected string $tag = 'nextcloud',
+	) {
 		parent::__construct($config);
-		$this->tag = $tag;
 	}
 
 	/**
 	 * Write a message in the log
 	 *
-	 * @param string $app
 	 * @param string|array $message
-	 * @param int $level
 	 */
-	public function write(string $app, $message, int $level) {
+	public function write(string $app, $message, int $level): void {
 		error_log('[' . $this->tag . ']['.$app.']['.$level.'] '.$this->logDetailsAsJSON($app, $message, $level));
 	}
 }

--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -112,11 +112,9 @@ class ExceptionSerializer {
 
 	];
 
-	/** @var SystemConfig */
-	private $systemConfig;
-
-	public function __construct(SystemConfig $systemConfig) {
-		$this->systemConfig = $systemConfig;
+	public function __construct(
+		private SystemConfig $systemConfig,
+	) {
 	}
 
 	protected array $methodsWithSensitiveParametersByClass = [
@@ -219,7 +217,7 @@ class ExceptionSerializer {
 		}, $trace);
 	}
 
-	private function removeValuesFromArgs($args, $values) {
+	private function removeValuesFromArgs($args, $values): array {
 		$workArgs = [];
 		foreach ($args as $arg) {
 			if (in_array($arg, $values, true)) {
@@ -279,7 +277,7 @@ class ExceptionSerializer {
 		return $arg;
 	}
 
-	public function serializeException(\Throwable $exception) {
+	public function serializeException(\Throwable $exception): array {
 		$data = [
 			'Exception' => get_class($exception),
 			'Message' => $exception->getMessage(),

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -48,14 +48,15 @@ use OCP\Log\IWriter;
  */
 
 class File extends LogDetails implements IWriter, IFileBased {
-	/** @var string */
-	protected $logFile;
-	/** @var int */
-	protected $logFileMode;
-	/** @var SystemConfig */
-	private $config;
+	protected string $logFile;
 
-	public function __construct(string $path, string $fallbackPath, SystemConfig $config) {
+	protected int $logFileMode;
+
+	public function __construct(
+		string $path,
+		string $fallbackPath,
+		private SystemConfig $config,
+	) {
 		parent::__construct($config);
 		$this->logFile = $path;
 		if (!file_exists($this->logFile)) {
@@ -69,17 +70,14 @@ class File extends LogDetails implements IWriter, IFileBased {
 				$this->logFile = $fallbackPath;
 			}
 		}
-		$this->config = $config;
 		$this->logFileMode = $config->getValue('logfilemode', 0640);
 	}
 
 	/**
 	 * write a message in the log
-	 * @param string $app
 	 * @param string|array $message
-	 * @param int $level
 	 */
-	public function write(string $app, $message, int $level) {
+	public function write(string $app, $message, int $level): void {
 		$entry = $this->logDetailsAsJSON($app, $message, $level);
 		$handle = @fopen($this->logFile, 'a');
 		if ($this->logFileMode > 0 && is_file($this->logFile) && (fileperms($this->logFile) & 0777) != $this->logFileMode) {
@@ -102,11 +100,8 @@ class File extends LogDetails implements IWriter, IFileBased {
 
 	/**
 	 * get entries from the log in reverse chronological order
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array
 	 */
-	public function getEntries(int $limit = 50, int $offset = 0):array {
+	public function getEntries(int $limit = 50, int $offset = 0): array {
 		$minLevel = $this->config->getValue("loglevel", ILogger::WARN);
 		$entries = [];
 		$handle = @fopen($this->logFile, 'rb');
@@ -148,9 +143,6 @@ class File extends LogDetails implements IWriter, IFileBased {
 		return $entries;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getLogFilePath():string {
 		return $this->logFile;
 	}

--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -28,11 +28,9 @@ namespace OC\Log;
 use OC\SystemConfig;
 
 abstract class LogDetails {
-	/** @var SystemConfig */
-	private $config;
-
-	public function __construct(SystemConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		private SystemConfig $config,
+	) {
 	}
 
 	public function logDetails(string $app, $message, int $level): array {

--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -33,57 +33,37 @@ use OCP\Log\IWriter;
 use Psr\Log\LoggerInterface;
 
 class LogFactory implements ILogFactory {
-	/** @var IServerContainer */
-	private $c;
-	/** @var SystemConfig */
-	private $systemConfig;
-
-	public function __construct(IServerContainer $c, SystemConfig $systemConfig) {
-		$this->c = $c;
-		$this->systemConfig = $systemConfig;
+	public function __construct(
+		private IServerContainer $c,
+		private SystemConfig $systemConfig,
+	) {
 	}
 
 	/**
 	 * @throws \OCP\AppFramework\QueryException
 	 */
 	public function get(string $type):IWriter {
-		switch (strtolower($type)) {
-			case 'errorlog':
-				return new Errorlog($this->systemConfig);
-			case 'syslog':
-				return $this->c->resolve(Syslog::class);
-			case 'systemd':
-				return $this->c->resolve(Systemdlog::class);
-			case 'file':
-				return $this->buildLogFile();
-
-				// Backwards compatibility for old and fallback for unknown log types
-			case 'owncloud':
-			case 'nextcloud':
-			default:
-				return $this->buildLogFile();
-		}
+		return match (strtolower($type)) {
+			'errorlog' => new Errorlog($this->systemConfig),
+			'syslog' => $this->c->resolve(Syslog::class),
+			'systemd' => $this->c->resolve(Systemdlog::class),
+			'file' => $this->buildLogFile(),
+			default => $this->buildLogFile(),
+		};
 	}
 
-	public function getCustomLogger(string $path):ILogger {
+	public function getCustomLogger(string $path): ILogger {
 		$log = $this->buildLogFile($path);
 		return new Log($log, $this->systemConfig);
 	}
 
 	protected function createNewLogger(string $type, string $tag, string $path): IWriter {
-		switch (strtolower($type)) {
-			case 'errorlog':
-				return new Errorlog($this->systemConfig, $tag);
-			case 'syslog':
-				return new Syslog($this->systemConfig, $tag);
-			case 'systemd':
-				return new Systemdlog($this->systemConfig, $tag);
-			case 'file':
-			case 'owncloud':
-			case 'nextcloud':
-			default:
-				return $this->buildLogFile($path);
-		}
+		return match (strtolower($type)) {
+			'errorlog' => new Errorlog($this->systemConfig, $tag),
+			'syslog' => new Syslog($this->systemConfig, $tag),
+			'systemd' => new Systemdlog($this->systemConfig, $tag),
+			default => $this->buildLogFile($path),
+		};
 	}
 
 	public function getCustomPsrLogger(string $path, string $type = 'file', string $tag = 'Nextcloud'): LoggerInterface {
@@ -93,7 +73,7 @@ class LogFactory implements ILogFactory {
 		);
 	}
 
-	protected function buildLogFile(string $logFile = ''):File {
+	protected function buildLogFile(string $logFile = ''): File {
 		$defaultLogFile = $this->systemConfig->getValue('datadirectory', \OC::$SERVERROOT.'/data').'/nextcloud.log';
 		if ($logFile === '') {
 			$logFile = $this->systemConfig->getValue('logfile', $defaultLogFile);

--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -36,14 +36,12 @@ use function array_key_exists;
 use function array_merge;
 
 final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
-	/** @var Log */
-	private $logger;
-
-	public function __construct(Log $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		private Log $logger,
+	) {
 	}
 
-	public function setEventDispatcher(IEventDispatcher $eventDispatcher) {
+	public function setEventDispatcher(IEventDispatcher $eventDispatcher): void {
 		$this->logger->setEventDispatcher($eventDispatcher);
 	}
 
@@ -55,9 +53,6 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * System is unusable.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
 	public function emergency($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
@@ -80,11 +75,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * trigger the SMS alerts and wake you up.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function alert($message, array $context = []) {
+	public function alert($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -104,11 +96,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Example: Application component unavailable, unexpected exception.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function critical($message, array $context = []) {
+	public function critical($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -127,11 +116,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * be logged and monitored.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function error($message, array $context = []) {
+	public function error($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -152,11 +138,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * that are not necessarily wrong.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function warning($message, array $context = []) {
+	public function warning($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -174,11 +157,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Normal but significant events.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function notice($message, array $context = []) {
+	public function notice($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -198,11 +178,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Example: User logs in, SQL logs.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function info($message, array $context = []) {
+	public function info($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -220,11 +197,8 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * Detailed debug information.
 	 *
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 */
-	public function debug($message, array $context = []) {
+	public function debug($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
 				[
@@ -243,13 +217,10 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 *
 	 * @param mixed $level
 	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function log($level, $message, array $context = []) {
+	public function log($level, $message, array $context = []): void {
 		if (!is_int($level) || $level < ILogger::DEBUG || $level > ILogger::FATAL) {
 			throw new InvalidArgumentException('Nextcloud allows only integer log levels');
 		}

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -35,7 +35,7 @@ use OCP\Log\RotationTrait;
 class Rotate extends \OCP\BackgroundJob\Job {
 	use RotationTrait;
 
-	public function run($dummy) {
+	public function run($dummy): void {
 		$systemConfig = \OC::$server->getSystemConfig();
 		$this->filePath = $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/nextcloud.log');
 

--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -30,7 +30,7 @@ use OCP\ILogger;
 use OCP\Log\IWriter;
 
 class Syslog extends LogDetails implements IWriter {
-	protected $levels = [
+	protected array $levels = [
 		ILogger::DEBUG => LOG_DEBUG,
 		ILogger::INFO => LOG_INFO,
 		ILogger::WARN => LOG_WARNING,
@@ -38,7 +38,10 @@ class Syslog extends LogDetails implements IWriter {
 		ILogger::FATAL => LOG_CRIT,
 	];
 
-	public function __construct(SystemConfig $config, ?string $tag = null) {
+	public function __construct(
+		SystemConfig $config,
+		?string $tag = null,
+	) {
 		parent::__construct($config);
 		if ($tag === null) {
 			$tag = $config->getValue('syslog_tag', 'Nextcloud');
@@ -52,11 +55,9 @@ class Syslog extends LogDetails implements IWriter {
 
 	/**
 	 * write a message in the log
-	 * @param string $app
 	 * @param string|array $message
-	 * @param int $level
 	 */
-	public function write(string $app, $message, int $level) {
+	public function write(string $app, $message, int $level): void {
 		$syslog_level = $this->levels[$level];
 		syslog($syslog_level, $this->logDetailsAsJSON($app, $message, $level));
 	}

--- a/lib/private/Log/Systemdlog.php
+++ b/lib/private/Log/Systemdlog.php
@@ -46,7 +46,7 @@ use OCP\Log\IWriter;
 //     Syslog compatibility fields
 
 class Systemdlog extends LogDetails implements IWriter {
-	protected $levels = [
+	protected array $levels = [
 		ILogger::DEBUG => 7,
 		ILogger::INFO => 6,
 		ILogger::WARN => 4,
@@ -54,9 +54,12 @@ class Systemdlog extends LogDetails implements IWriter {
 		ILogger::FATAL => 2,
 	];
 
-	protected $syslogId;
+	protected string $syslogId;
 
-	public function __construct(SystemConfig $config, ?string $tag = null) {
+	public function __construct(
+		SystemConfig $config,
+		?string $tag = null,
+	) {
 		parent::__construct($config);
 		if (!function_exists('sd_journal_send')) {
 			throw new HintException(
@@ -71,11 +74,9 @@ class Systemdlog extends LogDetails implements IWriter {
 
 	/**
 	 * Write a message to the log.
-	 * @param string $app
 	 * @param string|array $message
-	 * @param int $level
 	 */
-	public function write(string $app, $message, int $level) {
+	public function write(string $app, $message, int $level): void {
 		$journal_level = $this->levels[$level];
 		sd_journal_send('PRIORITY='.$journal_level,
 			'SYSLOG_IDENTIFIER='.$this->syslogId,


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Log` namespace.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks