### PR TITLE
fix(richdocuments): Mark some parameters of richdocuments WopiMapper as sensitive

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -39,6 +39,7 @@ use OCA\Encryption\Crypto\Encryption;
 use OCA\Encryption\Hooks\UserHooks;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
+use OCA\Richdocuments\Db\WopiMapper;
 use OCP\HintException;
 
 class ExceptionSerializer {
@@ -186,6 +187,10 @@ class ExceptionSerializer {
 			'preSetPassphrase',
 			'setPassphrase',
 		],
+		WopiMapper::class => [
+			'getPathForToken',
+			'getWopiForToken',
+		]
 	];
 
 	private function editTrace(array &$sensitiveValues, array $traceLine): array {


### PR DESCRIPTION
Found in our own logs

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
