### PR TITLE
fix(ocp): TimedJob can't have a more specific argument than Job

### DIFF
--- a/build/psalm-baseline-ocp.xml
+++ b/build/psalm-baseline-ocp.xml
@@ -45,12 +45,6 @@
       <code>\OC</code>
     </UndefinedClass>
   </file>
-  <file src="lib/public/BackgroundJob/TimedJob.php">
-    <MoreSpecificImplementedParamType>
-      <code>$jobList</code>
-      <code>$jobList</code>
-    </MoreSpecificImplementedParamType>
-  </file>
   <file src="lib/public/Cache/CappedMemoryCache.php">
     <MissingTemplateParam>
       <code>\ArrayAccess</code>

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
  */
 namespace OCP\BackgroundJob;
 
-use OC\BackgroundJob\JobList;
 use OCP\ILogger;
 
 /**
@@ -81,20 +80,20 @@ abstract class TimedJob extends Job {
 	}
 
 	/**
-	 * run the job if the last run is is more than the interval ago
+	 * Run the job if the last run is more than the interval ago
 	 *
-	 * @param JobList $jobList
+	 * @param IJobList $jobList
 	 * @param ILogger|null $logger
 	 *
 	 * @since 15.0.0
 	 * @deprecated since 25.0.0 Use start() instead
 	 */
-	final public function execute($jobList, ILogger $logger = null) {
+	final public function execute(IJobList $jobList, ILogger $logger = null) {
 		$this->start($jobList);
 	}
 
 	/**
-	 * Run the job if the last run is is more than the interval ago
+	 * Run the job if the last run is more than the interval ago
 	 *
 	 * @since 25.0.0
 	 */


### PR DESCRIPTION
## Summary

``\OCP\BackgroundJob\Job::execute`` takes an ``IJobList``, so ``\OCP\BackgroundJob\TimedJob::execute`` has to accept the same.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
