### PR TITLE
fix(ocp): Fix reference of dashboard IAPIWidget::getItems from WidgetItem

### DIFF
--- a/lib/public/Dashboard/Model/WidgetItem.php
+++ b/lib/public/Dashboard/Model/WidgetItem.php
@@ -33,7 +33,7 @@ use JsonSerializable;
  *
  * This class is used by IAPIWidget interface.
  * It represents an widget item data that can be provided to clients via the Dashboard API
- * @see IAPIWidget::getWidgetItems
+ * @see IAPIWidget::getItems
  *
  * @since 22.0.0
  *


### PR DESCRIPTION
## Summary

The ref goes to /dev/null on master. It now points to an existent method.

## TODO

- [x] Fix PHPDoc

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
