### PR TITLE
Fix root mounts not being setup in some cases

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -606,6 +606,10 @@ class Manager {
 			$this->logger->error('Mount point to remove share not found', ['mountPoint' => $mountPoint]);
 			return false;
 		}
+		if (!$mountPointObj instanceof Mount) {
+			$this->logger->error('Mount point to remove share is not an external share, share probably doesn\'t exist', ['mountPoint' => $mountPoint]);
+			return false;
+		}
 		$id = $mountPointObj->getStorage()->getCache()->getId('');
 
 		$mountPoint = $this->stripPath($mountPoint);

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -31,8 +31,10 @@
 namespace OCA\Files_Sharing\Tests\External;
 
 use OC\Federation\CloudIdManager;
+use OC\Files\Mount\MountPoint;
 use OC\Files\SetupManagerFactory;
 use OC\Files\Storage\StorageFactory;
+use OC\Files\Storage\Temporary;
 use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\External\MountProvider;
 use OCA\Files_Sharing\Tests\TestCase;
@@ -191,11 +193,16 @@ class ManagerTest extends TestCase {
 	}
 
 	private function setupMounts() {
-		$this->mountManager->clear();
+		$this->clearMounts();
 		$mounts = $this->testMountProvider->getMountsForUser($this->user, new StorageFactory());
 		foreach ($mounts as $mount) {
 			$this->mountManager->addMount($mount);
 		}
+	}
+
+	private function clearMounts() {
+		$this->mountManager->clear();
+		$this->mountManager->addMount(new MountPoint(Temporary::class, '', []));
 	}
 
 	public function testAddUserShare() {
@@ -235,7 +242,7 @@ class ManagerTest extends TestCase {
 		if ($isGroup) {
 			$this->manager->expects($this->never())->method('tryOCMEndPoint');
 		} else {
-			$this->manager->expects($this->any())->method('tryOCMEndPoint')
+			$this->manager->method('tryOCMEndPoint')
 				->withConsecutive(
 					['http://localhost', 'token1', '2342', 'accept'],
 					['http://localhost', 'token3', '2342', 'decline'],
@@ -415,7 +422,7 @@ class ManagerTest extends TestCase {
 
 		$this->assertEmpty(self::invokePrivate($this->manager, 'getShares', [null]), 'Asserting all shares for the user have been deleted');
 
-		$this->mountManager->clear();
+		$this->clearMounts();
 		self::invokePrivate($this->manager, 'setupMounts');
 		$this->assertNotMount($shareData1['name']);
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}');

--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -238,6 +238,11 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		$mounts = array_reduce($mounts, function (array $mounts, array $providerMounts) {
 			return array_merge($mounts, $providerMounts);
 		}, []);
+
+		if (count($mounts) === 0) {
+			throw new \Exception("No root mounts provided by any provider");
+		}
+
 		return $mounts;
 	}
 

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -99,6 +99,15 @@ class Manager implements IMountManager {
 			return $this->pathCache[$path];
 		}
 
+
+
+		if (count($this->mounts) === 0) {
+			$this->setupManager->setupRoot();
+			if (count($this->mounts) === 0) {
+				throw new \Exception("No mounts even after explicitly setting up the root mounts");
+			}
+		}
+
 		$current = $path;
 		while (true) {
 			$mountPoint = $current . '/';
@@ -115,7 +124,7 @@ class Manager implements IMountManager {
 			}
 		}
 
-		throw new NotFoundException("No mount for path " . $path . " existing mounts: " . implode(",", array_keys($this->mounts)));
+		throw new NotFoundException("No mount for path " . $path . " existing mounts (" . count($this->mounts) ."): " . implode(",", array_keys($this->mounts)));
 	}
 
 	/**

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -337,11 +337,12 @@ class SetupManager {
 		if ($this->rootSetup) {
 			return;
 		}
+
+		$this->setupBuiltinWrappers();
+
 		$this->rootSetup = true;
 
 		$this->eventLogger->start('fs:setup:root', 'Setup root filesystem');
-
-		$this->setupBuiltinWrappers();
 
 		$rootMounts = $this->mountProviderCollection->getRootMounts();
 		foreach ($rootMounts as $rootMountProvider) {


### PR DESCRIPTION
In some cases, the root setup is triggered before the `filesystem` apps are loaded. These are then loading during the filesystem wrapper setup, if the loading of an app attempts to interact with the filesystem, it will attempt to setup the filesystem recursively.

This recursion is prevented by the `SetupManager`, but that also means that the app loading code sees the filesystem with no mounts setup. Which will lead to errors.

By moving the wrapper setup to before the recursion setup we can prevent this issue