### PR TITLE
Allow null capabilities

### DIFF
--- a/lib/private/CapabilitiesManager.php
+++ b/lib/private/CapabilitiesManager.php
@@ -71,7 +71,7 @@ class CapabilitiesManager {
 						// that we would otherwise inject to every page load
 						continue;
 					}
-					$capabilities = array_replace_recursive($capabilities, $c->getCapabilities());
+					$capabilities = array_replace_recursive($capabilities, $c->getCapabilities() ?? []);
 				}
 			} else {
 				throw new \InvalidArgumentException('The given Capability (' . get_class($c) . ') does not implement the ICapability interface');

--- a/lib/public/Capabilities/ICapability.php
+++ b/lib/public/Capabilities/ICapability.php
@@ -37,7 +37,7 @@ interface ICapability {
 	/**
 	 * Function an app uses to return the capabilities
 	 *
-	 * @return array Array containing the apps capabilities
+	 * @return ?array Array containing the apps capabilities
 	 * @since 8.2.0
 	 */
 	public function getCapabilities();


### PR DESCRIPTION
## Summary

From https://github.com/nextcloud/server/pull/36666

Allows apps to return null capabilities. This is needed to correctly type the capabilities and let apps return null for certain cases.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
