### PR TITLE
feat(ocp): More specific type for ICapabilities::getCapabilities

### DIFF
--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -36,9 +36,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Function an app uses to return the capabilities
-	 *
-	 * @return array Array containing the apps capabilities
-	 * @since 8.2.0
 	 */
 	public function getCapabilities() {
 		$url = $this->urlGenerator->linkToRouteAbsolute('cloud_federation_api.requesthandlercontroller.addShare');

--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -38,8 +38,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		return [

--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -50,8 +50,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		$res = [];

--- a/apps/files_trashbin/lib/Capabilities.php
+++ b/apps/files_trashbin/lib/Capabilities.php
@@ -33,8 +33,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		return [

--- a/apps/files_versions/lib/Capabilities.php
+++ b/apps/files_versions/lib/Capabilities.php
@@ -42,8 +42,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		$groupFolderInstalled = $this->appManager->isInstalled('groupfolders');

--- a/apps/provisioning_api/lib/Capabilities.php
+++ b/apps/provisioning_api/lib/Capabilities.php
@@ -37,8 +37,6 @@ class Capabilities implements ICapability {
 
 	/**
 	 * Function an app uses to return the capabilities
-	 *
-	 * @return array Array containing the apps capabilities
 	 */
 	public function getCapabilities() {
 		$federatedScopeEnabled = $this->appManager->isEnabledForUser('federation');

--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -64,8 +64,6 @@ class Capabilities implements IPublicCapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime', '');

--- a/apps/user_status/lib/Capabilities.php
+++ b/apps/user_status/lib/Capabilities.php
@@ -40,9 +40,6 @@ class Capabilities implements ICapability {
 		$this->emojiHelper = $emojiHelper;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function getCapabilities() {
 		return [
 			'user_status' => [

--- a/apps/weather_status/lib/Capabilities.php
+++ b/apps/weather_status/lib/Capabilities.php
@@ -43,9 +43,6 @@ class Capabilities implements ICapability {
 	public function __construct() {
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function getCapabilities() {
 		return [
 			Application::APP_ID => [

--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -44,8 +44,6 @@ class CoreCapabilities implements ICapability {
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
 	public function getCapabilities() {
 		return [

--- a/lib/public/Capabilities/ICapability.php
+++ b/lib/public/Capabilities/ICapability.php
@@ -25,11 +25,8 @@ namespace OCP\Capabilities;
  * Minimal interface that has to be implemented for a class to be considered
  * a capability.
  *
- * In an application use:
- *   $this->getContainer()->registerCapability('OCA\MY_APP\Capabilities');
- * To register capabilities.
- *
- * The class 'OCA\MY_APP\Capabilities' must then implement ICapability
+ * In an application use \OCP\AppFramework\Bootstrap\IRegistrationContext::registerCapability
+ * to register capabilities.
  *
  * @since 8.2.0
  */

--- a/lib/public/Capabilities/ICapability.php
+++ b/lib/public/Capabilities/ICapability.php
@@ -37,7 +37,19 @@ interface ICapability {
 	/**
 	 * Function an app uses to return the capabilities
 	 *
-	 * @return array Array containing the apps capabilities
+	 * ```php
+	 * return [
+	 *     'myapp' => [
+	 *         'awesomefeature' => true,
+	 *         'featureversion' => 3,
+	 *     ],
+	 *     'morecomplex' => [
+	 *         'a' => [1, 2],
+	 *     ],
+	 * ];
+	 * ```
+	 *
+	 * @return array<string, array<string, mixed>> Indexed array containing the app's capabilities
 	 * @since 8.2.0
 	 */
 	public function getCapabilities();


### PR DESCRIPTION
## Summary

Be more specific about what we expect the method to return. We can become more specific in the future. For now this seems generic enough to allow the existing implementation to stay correct. This should not be a breaking change: https://psalm.dev/r/d635121f7c

Idea sparked in https://github.com/nextcloud/server/pull/39052#issuecomment-1612550369.

![image](https://github.com/nextcloud/server/assets/1374172/c014c41d-6930-4484-a4cd-9d5c56c8bf66)

## TODO

- [x] Improve typing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
