### PR TITLE
Avoid adding (attribute=) part to filter which will confuse LDAP servers

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1545,12 +1545,16 @@ class Access extends LDAPUtility {
 				return '';
 			}
 			// wildcards don't work with some attributes
-			$filter[] = $fallbackAttribute . '=' . $originalSearch;
+			if ($originalSearch !== '') {
+				$filter[] = $fallbackAttribute . '=' . $originalSearch;
+			}
 			$filter[] = $fallbackAttribute . '=' . $search;
 		} else {
 			foreach ($searchAttributes as $attribute) {
 				// wildcards don't work with some attributes
-				$filter[] = $attribute . '=' . $originalSearch;
+				if ($originalSearch !== '') {
+					$filter[] = $attribute . '=' . $originalSearch;
+				}
 				$filter[] = $attribute . '=' . $search;
 			}
 		}


### PR DESCRIPTION
* Resolves: #38902

## Summary
Fix empty filter search part introduced by https://github.com/nextcloud/server/pull/32499

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
