### PR TITLE
fix(TagSearchProvider): Short circuit if no tag matches the query

### DIFF
--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -113,7 +113,7 @@ class TagSearchProvider implements IProvider {
 	 * @inheritDoc
 	 */
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
-		$matchingTags = $this->tagManager->getAllTags(1, $query->getTerm());
+		$matchingTags = $this->tagManager->getAllTags(true, $query->getTerm());
 		if (count($matchingTags) === 0) {
 			return SearchResult::complete($this->l10n->t('Tags'), []);
 		}


### PR DESCRIPTION
## Summary
Avoids running a full files search if no tag matches in the first place.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
