### PR TITLE
Migrate away from ILogger in encryption

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -39,6 +39,7 @@ use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\Encryption\IManager;
 use OCP\IConfig;
+use Psr\Log\LoggerInterface;
 
 class Application extends \OCP\AppFramework\App {
 	/**
@@ -69,7 +70,7 @@ class Application extends \OCP\AppFramework\App {
 			$hookManager->registerHook([
 				new UserHooks($container->query(KeyManager::class),
 					$server->getUserManager(),
-					$server->getLogger(),
+					$server->get(LoggerInterface::class),
 					$container->query(Setup::class),
 					$server->getUserSession(),
 					$container->query(Util::class),
@@ -93,15 +94,15 @@ class Application extends \OCP\AppFramework\App {
 			Encryption::DISPLAY_NAME,
 			function () use ($container) {
 				return new Encryption(
-				$container->query(Crypt::class),
-				$container->query(KeyManager::class),
-				$container->query(Util::class),
-				$container->query(Session::class),
-				$container->query(EncryptAll::class),
-				$container->query(DecryptAll::class),
-				$container->getServer()->getLogger(),
-				$container->getServer()->getL10N($container->getAppName())
-			);
+					$container->query(Crypt::class),
+					$container->query(KeyManager::class),
+					$container->query(Util::class),
+					$container->query(Session::class),
+					$container->query(EncryptAll::class),
+					$container->query(DecryptAll::class),
+					$container->getServer()->get(LoggerInterface::class),
+					$container->getServer()->getL10N($container->getAppName())
+				);
 			});
 	}
 }

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -29,9 +29,9 @@ use OCA\Encryption\Util;
 use OCP\Files\IRootFolder;
 use OCP\HintException;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,41 +39,16 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FixEncryptedVersion extends Command {
-	/** @var IConfig */
-	private $config;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var IRootFolder  */
-	private $rootFolder;
-
-	/** @var IUserManager  */
-	private $userManager;
-
-	/** @var Util */
-	private $util;
-
-	/** @var View  */
-	private $view;
-
-	/** @var bool */
-	private $supportLegacy;
+	private bool $supportLegacy;
 
 	public function __construct(
-		IConfig $config,
-		ILogger $logger,
-		IRootFolder $rootFolder,
-		IUserManager $userManager,
-		Util $util,
-		View $view
+		private IConfig $config,
+		private LoggerInterface $logger,
+		private IRootFolder $rootFolder,
+		private IUserManager $userManager,
+		private Util $util,
+		private View $view,
 	) {
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->rootFolder = $rootFolder;
-		$this->userManager = $userManager;
-		$this->util = $util;
-		$this->view = $view;
 		$this->supportLegacy = false;
 
 		parent::__construct();
@@ -134,7 +109,7 @@ class FixEncryptedVersion extends Command {
 			return $this->runForUser($user, $pathOption, $output);
 		} elseif ($all) {
 			$result = 0;
-			$this->userManager->callForSeenUsers(function(IUser $user) use ($pathOption, $output, &$result) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($pathOption, $output, &$result) {
 				$output->writeln("Processing files for " . $user->getUID());
 				$result = $this->runForUser($user->getUID(), $pathOption, $output);
 				return $result === 0;

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -153,9 +153,6 @@ class Crypt {
 		return openssl_pkey_new($config);
 	}
 
-	/**
-	 * get openSSL Config
-	 */
 	private function getOpenSSLConfig(): array {
 		$config = ['private_key_bits' => 4096];
 		$config = array_merge(
@@ -217,13 +214,9 @@ class Crypt {
 	}
 
 	/**
-	 * @param string $plainContent
-	 * @param string $iv
-	 * @param string $passPhrase
-	 * @param string $cipher
 	 * @throws EncryptionFailedException
 	 */
-	private function encrypt($plainContent, $iv, $passPhrase = '', $cipher = self::DEFAULT_CIPHER): string {
+	private function encrypt(string $plainContent, string $iv, string $passPhrase = '', string $cipher = self::DEFAULT_CIPHER): string {
 		$options = $this->useLegacyBase64Encoding ? 0 : OPENSSL_RAW_DATA;
 		$encryptedContent = openssl_encrypt($plainContent,
 			$cipher,
@@ -311,19 +304,11 @@ class Crypt {
 		return self::LEGACY_CIPHER;
 	}
 
-	/**
-	 * @param string $encryptedContent
-	 * @param string $iv
-	 */
-	private function concatIV($encryptedContent, $iv): string {
+	private function concatIV(string $encryptedContent, string $iv): string {
 		return $encryptedContent . '00iv00' . $iv;
 	}
 
-	/**
-	 * @param string $encryptedContent
-	 * @param string $signature
-	 */
-	private function concatSig($encryptedContent, $signature): string {
+	private function concatSig(string $encryptedContent, string $signature): string {
 		return $encryptedContent . '00sig00' . $signature;
 	}
 
@@ -331,10 +316,8 @@ class Crypt {
 	 * Note: This is _NOT_ a padding used for encryption purposes. It is solely
 	 * used to achieve the PHP stream size. It has _NOTHING_ to do with the
 	 * encrypted content and is not used in any crypto primitive.
-	 *
-	 * @param string $data
 	 */
-	private function addPadding($data): string {
+	private function addPadding(string $data): string {
 		return $data . 'xxx';
 	}
 
@@ -514,12 +497,9 @@ class Crypt {
 
 
 	/**
-	 * remove padding
-	 *
-	 * @param string $padded
 	 * @param bool $hasSignature did the block contain a signature, in this case we use a different padding
 	 */
-	private function removePadding($padded, $hasSignature = false): string|false {
+	private function removePadding(string $padded, bool $hasSignature = false): string|false {
 		if ($hasSignature === false && substr($padded, -2) === 'xx') {
 			return substr($padded, 0, -2);
 		} elseif ($hasSignature === true && substr($padded, -3) === 'xxx') {
@@ -532,11 +512,8 @@ class Crypt {
 	 * split meta data from encrypted file
 	 * Note: for now, we assume that the meta data always start with the iv
 	 *       followed by the signature, if available
-	 *
-	 * @param string $catFile
-	 * @param string $cipher
 	 */
-	private function splitMetaData($catFile, $cipher): array {
+	private function splitMetaData(string $catFile, string $cipher): array {
 		if ($this->hasSignature($catFile, $cipher)) {
 			$catFile = $this->removePadding($catFile, true);
 			$meta = substr($catFile, -93);
@@ -561,11 +538,9 @@ class Crypt {
 	/**
 	 * check if encrypted block is signed
 	 *
-	 * @param string $catFile
-	 * @param string $cipher
 	 * @throws GenericEncryptionException
 	 */
-	private function hasSignature($catFile, $cipher): bool {
+	private function hasSignature(string $catFile, string $cipher): bool {
 		$skipSignatureCheck = $this->config->getSystemValueBool('encryption_skip_signature_check', false);
 
 		$meta = substr($catFile, -93);

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -42,18 +42,13 @@ use OCA\Encryption\Session;
 use OCA\Encryption\Util;
 use OCP\Encryption\IEncryptionModule;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Encryption implements IEncryptionModule {
 	public const ID = 'OC_DEFAULT_MODULE';
 	public const DISPLAY_NAME = 'Default encryption module';
-
-	/**
-	 * @var Crypt
-	 */
-	private $crypt;
 
 	/** @var string */
 	private $cipher;
@@ -64,8 +59,7 @@ class Encryption implements IEncryptionModule {
 	/** @var string */
 	private $user;
 
-	/** @var  array */
-	private $owner;
+	private array $owner;
 
 	/** @var string */
 	private $fileKey;
@@ -73,76 +67,36 @@ class Encryption implements IEncryptionModule {
 	/** @var string */
 	private $writeCache;
 
-	/** @var KeyManager */
-	private $keyManager;
-
 	/** @var array */
 	private $accessList;
 
 	/** @var boolean */
 	private $isWriteOperation;
 
-	/** @var Util */
-	private $util;
-
-	/** @var  Session */
-	private $session;
-
-	/** @var  ILogger */
-	private $logger;
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var EncryptAll */
-	private $encryptAll;
-
-	/** @var  bool */
-	private $useMasterPassword;
-
-	/** @var DecryptAll  */
-	private $decryptAll;
+	private bool $useMasterPassword;
 
 	private bool $useLegacyBase64Encoding = false;
 
 	/** @var int Current version of the file */
-	private $version = 0;
+	private int $version = 0;
 
 	private bool $useLegacyFileKey = true;
 
 	/** @var array remember encryption signature version */
 	private static $rememberVersion = [];
 
-
-	/**
-	 *
-	 * @param Crypt $crypt
-	 * @param KeyManager $keyManager
-	 * @param Util $util
-	 * @param Session $session
-	 * @param EncryptAll $encryptAll
-	 * @param DecryptAll $decryptAll
-	 * @param ILogger $logger
-	 * @param IL10N $il10n
-	 */
-	public function __construct(Crypt $crypt,
-								KeyManager $keyManager,
-								Util $util,
-								Session $session,
-								EncryptAll $encryptAll,
-								DecryptAll $decryptAll,
-								ILogger $logger,
-								IL10N $il10n) {
-		$this->crypt = $crypt;
-		$this->keyManager = $keyManager;
-		$this->util = $util;
-		$this->session = $session;
-		$this->encryptAll = $encryptAll;
-		$this->decryptAll = $decryptAll;
-		$this->logger = $logger;
-		$this->l = $il10n;
+	public function __construct(
+		private Crypt $crypt,
+		private KeyManager $keyManager,
+		private Util $util,
+		private Session $session,
+		private EncryptAll $encryptAll,
+		private DecryptAll $decryptAll,
+		private LoggerInterface $logger,
+		private IL10N $l,
+	) {
 		$this->owner = [];
-		$this->useMasterPassword = $util->isMasterKeyEnabled();
+		$this->useMasterPassword = $this->util->isMasterKeyEnabled();
 	}
 
 	/**

--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -36,87 +36,29 @@ use OCA\Encryption\Session;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
-use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util as OCUtil;
+use Psr\Log\LoggerInterface;
 
 class UserHooks implements IHook {
-
 	/**
 	 * list of user for which we perform a password reset
-	 * @var array
+	 * @var array<string, true>
 	 */
-	protected static $passwordResetUsers = [];
+	protected static array $passwordResetUsers = [];
 
-	/**
-	 * @var KeyManager
-	 */
-	private $keyManager;
-	/**
-	 * @var IUserManager
-	 */
-	private $userManager;
-	/**
-	 * @var ILogger
-	 */
-	private $logger;
-	/**
-	 * @var Setup
-	 */
-	private $userSetup;
-	/**
-	 * @var IUserSession
-	 */
-	private $userSession;
-	/**
-	 * @var Util
-	 */
-	private $util;
-	/**
-	 * @var Session
-	 */
-	private $session;
-	/**
-	 * @var Recovery
-	 */
-	private $recovery;
-	/**
-	 * @var Crypt
-	 */
-	private $crypt;
-
-	/**
-	 * UserHooks constructor.
-	 *
-	 * @param KeyManager $keyManager
-	 * @param IUserManager $userManager
-	 * @param ILogger $logger
-	 * @param Setup $userSetup
-	 * @param IUserSession $userSession
-	 * @param Util $util
-	 * @param Session $session
-	 * @param Crypt $crypt
-	 * @param Recovery $recovery
-	 */
-	public function __construct(KeyManager $keyManager,
-								IUserManager $userManager,
-								ILogger $logger,
-								Setup $userSetup,
-								IUserSession $userSession,
-								Util $util,
-								Session $session,
-								Crypt $crypt,
-								Recovery $recovery) {
-		$this->keyManager = $keyManager;
-		$this->userManager = $userManager;
-		$this->logger = $logger;
-		$this->userSetup = $userSetup;
-		$this->userSession = $userSession;
-		$this->util = $util;
-		$this->session = $session;
-		$this->recovery = $recovery;
-		$this->crypt = $crypt;
+	public function __construct(
+		private KeyManager $keyManager,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+		private Setup $userSetup,
+		private IUserSession $userSession,
+		private Util $util,
+		private Session $session,
+		private Crypt $crypt,
+		private Recovery $recovery,
+	) {
 	}
 
 	/**
@@ -244,7 +186,6 @@ class UserHooks implements IHook {
 	 * @return boolean|null
 	 */
 	public function setPassphrase($params) {
-
 		// if we are in the process to resetting a user password, we have nothing
 		// to do here
 		if (isset(self::$passwordResetUsers[$params['uid']])) {
@@ -298,7 +239,6 @@ class UserHooks implements IHook {
 				|| !$this->keyManager->userHasKeys($userId)
 				|| !$this->util->userHasFiles($userId)
 			) {
-
 				// backup old keys
 				//$this->backupAllKeys('recovery');
 

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -39,106 +39,34 @@ use OCA\Encryption\Exceptions\PrivateKeyMissingException;
 use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use OCP\Encryption\Keys\IStorage;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
+use Psr\Log\LoggerInterface;
 
 class KeyManager {
-	/**
-	 * @var Session
-	 */
-	protected $session;
-	/**
-	 * @var IStorage
-	 */
-	private $keyStorage;
-	/**
-	 * @var Crypt
-	 */
-	private $crypt;
-	/**
-	 * @var string
-	 */
-	private $recoveryKeyId;
-	/**
-	 * @var string
-	 */
-	private $publicShareKeyId;
-	/**
-	 * @var string
-	 */
-	private $masterKeyId;
-	/**
-	 * @var string UserID
-	 */
-	private $keyId;
-	/**
-	 * @var string
-	 */
-	private $publicKeyId = 'publicKey';
-	/**
-	 * @var string
-	 */
-	private $privateKeyId = 'privateKey';
+	private string $recoveryKeyId;
+	private string $publicShareKeyId;
+	private string $masterKeyId;
+	private string $keyId;
+	private string $publicKeyId = 'publicKey';
+	private string $privateKeyId = 'privateKey';
+	private string $shareKeyId = 'shareKey';
+	private string $fileKeyId = 'fileKey';
 
-	/**
-	 * @var string
-	 */
-	private $shareKeyId = 'shareKey';
-
-	/**
-	 * @var string
-	 */
-	private $fileKeyId = 'fileKey';
-	/**
-	 * @var IConfig
-	 */
-	private $config;
-	/**
-	 * @var ILogger
-	 */
-	private $log;
-	/**
-	 * @var Util
-	 */
-	private $util;
-
-	/**
-	 * @var ILockingProvider
-	 */
-	private $lockingProvider;
-
-	/**
-	 * @param IStorage $keyStorage
-	 * @param Crypt $crypt
-	 * @param IConfig $config
-	 * @param IUserSession $userSession
-	 * @param Session $session
-	 * @param ILogger $log
-	 * @param Util $util
-	 */
 	public function __construct(
-		IStorage $keyStorage,
-		Crypt $crypt,
-		IConfig $config,
+		private IStorage $keyStorage,
+		private Crypt $crypt,
+		private IConfig $config,
 		IUserSession $userSession,
-		Session $session,
-		ILogger $log,
-		Util $util,
-		ILockingProvider $lockingProvider
+		private Session $session,
+		private LoggerInterface $logger,
+		private Util $util,
+		private ILockingProvider $lockingProvider,
 	) {
-		$this->util = $util;
-		$this->session = $session;
-		$this->keyStorage = $keyStorage;
-		$this->crypt = $crypt;
-		$this->config = $config;
-		$this->log = $log;
-		$this->lockingProvider = $lockingProvider;
-
 		$this->recoveryKeyId = $this->config->getAppValue('encryption',
 			'recoveryKeyId');
 		if (empty($this->recoveryKeyId)) {
-			$this->recoveryKeyId = 'recoveryKey_' . substr(md5(time()), 0, 8);
+			$this->recoveryKeyId = 'recoveryKey_' . substr(md5((string)time()), 0, 8);
 			$this->config->setAppValue('encryption',
 				'recoveryKeyId',
 				$this->recoveryKeyId);
@@ -147,19 +75,18 @@ class KeyManager {
 		$this->publicShareKeyId = $this->config->getAppValue('encryption',
 			'publicShareKeyId');
 		if (empty($this->publicShareKeyId)) {
-			$this->publicShareKeyId = 'pubShare_' . substr(md5(time()), 0, 8);
+			$this->publicShareKeyId = 'pubShare_' . substr(md5((string)time()), 0, 8);
 			$this->config->setAppValue('encryption', 'publicShareKeyId', $this->publicShareKeyId);
 		}
 
 		$this->masterKeyId = $this->config->getAppValue('encryption',
 			'masterKeyId');
 		if (empty($this->masterKeyId)) {
-			$this->masterKeyId = 'master_' . substr(md5(time()), 0, 8);
+			$this->masterKeyId = 'master_' . substr(md5((string)time()), 0, 8);
 			$this->config->setAppValue('encryption', 'masterKeyId', $this->masterKeyId);
 		}
 
 		$this->keyId = $userSession->isLoggedIn() ? $userSession->getUser()->getUID() : false;
-		$this->log = $log;
 	}
 
 	/**
@@ -223,10 +150,10 @@ class KeyManager {
 			}
 			$this->lockingProvider->releaseLock('encryption-generateMasterKey', ILockingProvider::LOCK_EXCLUSIVE);
 		} elseif (empty($publicMasterKey)) {
-			$this->log->error('A private master key is available but the public key could not be found. This should never happen.');
+			$this->logger->error('A private master key is available but the public key could not be found. This should never happen.');
 			return;
 		} elseif (empty($privateMasterKey)) {
-			$this->log->error('A public master key is available but the private key could not be found. This should never happen.');
+			$this->logger->error('A public master key is available but the private key could not be found. This should never happen.');
 			return;
 		}
 
@@ -405,11 +332,13 @@ class KeyManager {
 		} catch (DecryptionFailedException $e) {
 			return false;
 		} catch (\Exception $e) {
-			$this->log->logException($e, [
-				'message' => 'Could not decrypt the private key from user "' . $uid . '"" during login. Assume password change on the user back-end.',
-				'level' => ILogger::WARN,
-				'app' => 'encryption',
-			]);
+			$this->logger->warning(
+				'Could not decrypt the private key from user "' . $uid . '"" during login. Assume password change on the user back-end.',
+				[
+					'app' => 'encryption',
+					'exception' => $e,
+				]
+			);
 			return false;
 		}
 

--- a/apps/encryption/lib/Settings/Admin.php
+++ b/apps/encryption/lib/Settings/Admin.php
@@ -32,46 +32,21 @@ use OCA\Encryption\Util;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\ISession;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Settings\ISettings;
+use Psr\Log\LoggerInterface;
 
 class Admin implements ISettings {
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var IUserSession */
-	private $userSession;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var ISession */
-	private $session;
-
 	public function __construct(
-		IL10N $l,
-		ILogger $logger,
-		IUserSession $userSession,
-		IConfig $config,
-		IUserManager $userManager,
-		ISession $session
+		private IL10N $l,
+		private LoggerInterface $logger,
+		private IUserSession $userSession,
+		private IConfig $config,
+		private IUserManager $userManager,
+		private ISession $session
 	) {
-		$this->l = $l;
-		$this->logger = $logger;
-		$this->userSession = $userSession;
-		$this->config = $config;
-		$this->userManager = $userManager;
-		$this->session = $session;
 	}
 
 	/**
@@ -87,7 +62,6 @@ class Admin implements ISettings {
 		$util = new Util(
 			new View(),
 			$crypt,
-			$this->logger,
 			$this->userSession,
 			$this->config,
 			$this->userManager);

--- a/apps/encryption/lib/Util.php
+++ b/apps/encryption/lib/Util.php
@@ -29,59 +29,24 @@ namespace OCA\Encryption;
 use OC\Files\View;
 use OCA\Encryption\Crypto\Crypt;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\PreConditionNotMetException;
 
 class Util {
-	/**
-	 * @var View
-	 */
-	private $files;
-	/**
-	 * @var Crypt
-	 */
-	private $crypt;
-	/**
-	 * @var ILogger
-	 */
-	private $logger;
-	/**
-	 * @var bool|IUser
-	 */
-	private $user;
-	/**
-	 * @var IConfig
-	 */
-	private $config;
-	/**
-	 * @var IUserManager
-	 */
-	private $userManager;
+	private IUser|false $user;
 
-	/**
-	 * Util constructor.
-	 *
-	 * @param View $files
-	 * @param Crypt $crypt
-	 * @param ILogger $logger
-	 * @param IUserSession $userSession
-	 * @param IConfig $config
-	 * @param IUserManager $userManager
-	 */
-	public function __construct(View $files,
-								Crypt $crypt,
-								ILogger $logger,
-								IUserSession $userSession,
-								IConfig $config,
-								IUserManager $userManager
+	public function __construct(
+		private View $files,
+		private Crypt $crypt,
+		IUserSession $userSession,
+		private IConfig $config,
+		private IUserManager $userManager,
 	) {
 		$this->files = $files;
 		$this->crypt = $crypt;
-		$this->logger = $logger;
-		$this->user = $userSession && $userSession->isLoggedIn() ? $userSession->getUser() : false;
+		$this->user = $userSession->isLoggedIn() ? $userSession->getUser() : false;
 		$this->config = $config;
 		$this->userManager = $userManager;
 	}
@@ -132,10 +97,8 @@ class Util {
 
 	/**
 	 * check if master key is enabled
-	 *
-	 * @return bool
 	 */
-	public function isMasterKeyEnabled() {
+	public function isMasterKeyEnabled(): bool {
 		$userMasterKey = $this->config->getAppValue('encryption', 'useMasterKey', '1');
 		return ($userMasterKey === '1');
 	}

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -24,6 +24,7 @@ namespace OCA\Encryption\Tests\Command;
 use OC\Files\View;
 use OCA\Encryption\Command\FixEncryptedVersion;
 use OCA\Encryption\Util;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 use Test\Traits\EncryptionTrait;
@@ -70,7 +71,7 @@ class FixEncryptedVersionTest extends TestCase {
 
 		$this->fixEncryptedVersion = new FixEncryptedVersion(
 			\OC::$server->getConfig(),
-			\OC::$server->getLogger(),
+			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->getRootFolder(),
 			\OC::$server->getUserManager(),
 			$this->util,

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -29,12 +29,12 @@ namespace OCA\Encryption\Tests\Crypto;
 use OCA\Encryption\Crypto\Crypt;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IUserSession;
 use Test\TestCase;
 
 class CryptTest extends TestCase {
-	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
@@ -52,7 +52,7 @@ class CryptTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->logger = $this->getMockBuilder(ILogger::class)
+		$this->logger = $this->getMockBuilder(LoggerInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->logger->expects($this->any())

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -36,7 +36,7 @@ use OCA\Encryption\Session;
 use OCA\Encryption\Util;
 use OCP\Files\Storage;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -63,7 +63,7 @@ class EncryptionTest extends TestCase {
 	/** @var \OCA\Encryption\Util|\PHPUnit\Framework\MockObject\MockObject */
 	private $utilMock;
 
-	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $loggerMock;
 
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
@@ -95,7 +95,7 @@ class EncryptionTest extends TestCase {
 		$this->decryptAllMock = $this->getMockBuilder(DecryptAll::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->loggerMock = $this->getMockBuilder(ILogger::class)
+		$this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l10nMock = $this->getMockBuilder(IL10N::class)

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -34,7 +34,7 @@ use OCA\Encryption\Recovery;
 use OCA\Encryption\Session;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -160,7 +160,6 @@ class UserHooksTest extends TestCase {
 	 * @dataProvider dataTestPreSetPassphrase
 	 */
 	public function testPreSetPassphrase($canChange) {
-
 		/** @var UserHooks | \PHPUnit\Framework\MockObject\MockObject  $instance */
 		$instance = $this->getMockBuilder(UserHooks::class)
 			->setConstructorArgs(
@@ -332,7 +331,7 @@ class UserHooksTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->loggerMock = $this->createMock(ILogger::class);
+		$this->loggerMock = $this->createMock(LoggerInterface::class);
 		$this->keyManagerMock = $this->getMockBuilder(KeyManager::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -41,7 +41,7 @@ use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Storage;
 use OCP\IConfig;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IUserSession;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
@@ -73,7 +73,7 @@ class KeyManagerTest extends TestCase {
 	/** @var \OCA\Encryption\Session|\PHPUnit\Framework\MockObject\MockObject */
 	private $sessionMock;
 
-	/** @var \OCP\ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logMock;
 
 	/** @var \OCA\Encryption\Util|\PHPUnit\Framework\MockObject\MockObject */
@@ -101,7 +101,7 @@ class KeyManagerTest extends TestCase {
 		$this->sessionMock = $this->getMockBuilder(Session::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logMock = $this->createMock(ILogger::class);
+		$this->logMock = $this->createMock(LoggerInterface::class);
 		$this->utilMock = $this->getMockBuilder(Util::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -600,6 +600,9 @@ class KeyManagerTest extends TestCase {
 			)->setMethods(['getPublicMasterKey', 'setSystemPrivateKey', 'getMasterKeyPassword'])
 			->getMock();
 
+		$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
+			->willReturn(true);
+
 		$instance->expects($this->once())->method('getPublicMasterKey')
 			->willReturn($masterKey);
 
@@ -644,6 +647,9 @@ class KeyManagerTest extends TestCase {
 				]
 			)->setMethods(['getPublicMasterKey', 'getPrivateMasterKey', 'setSystemPrivateKey', 'getMasterKeyPassword'])
 			->getMock();
+
+		$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
+			->willReturn(true);
 
 		$instance->expects($this->once())->method('getPublicMasterKey')
 			->willReturn('');

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -29,7 +29,7 @@ use OCA\Encryption\Settings\Admin;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\ISession;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -40,7 +40,7 @@ class AdminTest extends TestCase {
 	private $admin;
 	/** @var IL10N */
 	private $l;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 	/** @var IUserSession */
 	private $userSession;
@@ -55,7 +55,7 @@ class AdminTest extends TestCase {
 		parent::setUp();
 
 		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
-		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$this->userSession = $this->getMockBuilder(IUserSession::class)->getMock();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -33,7 +33,6 @@ use OCA\Encryption\Util;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -89,8 +88,6 @@ class UtilTest extends TestCase {
 		$cryptMock = $this->getMockBuilder(Crypt::class)
 			->disableOriginalConstructor()
 			->getMock();
-		/** @var \OCP\ILogger $loggerMock */
-		$loggerMock = $this->createMock(ILogger::class);
 
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
@@ -116,7 +113,7 @@ class UtilTest extends TestCase {
 			->method('setUserValue')
 			->willReturnCallback([$this, 'setValueTester']);
 
-		$this->instance = new Util($this->filesMock, $cryptMock, $loggerMock, $userSessionMock, $this->configMock, $this->userManagerMock);
+		$this->instance = new Util($this->filesMock, $cryptMock, $userSessionMock, $this->configMock, $this->userManagerMock);
 	}
 
 	/**

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -171,36 +171,8 @@ class ChangePasswordController extends Controller {
 
 		if ($this->appManager->isEnabledForUser('encryption')) {
 			//handle the recovery case
-			$crypt = new \OCA\Encryption\Crypto\Crypt(
-				\OC::$server->getLogger(),
-				\OC::$server->getUserSession(),
-				\OC::$server->getConfig(),
-				\OC::$server->getL10N('encryption'));
-			$keyStorage = \OC::$server->getEncryptionKeyStorage();
-			$util = new \OCA\Encryption\Util(
-				new \OC\Files\View(),
-				$crypt,
-				\OC::$server->getLogger(),
-				\OC::$server->getUserSession(),
-				\OC::$server->getConfig(),
-				\OC::$server->getUserManager());
-			$keyManager = new \OCA\Encryption\KeyManager(
-				$keyStorage,
-				$crypt,
-				\OC::$server->getConfig(),
-				\OC::$server->getUserSession(),
-				new \OCA\Encryption\Session(\OC::$server->getSession()),
-				\OC::$server->getLogger(),
-				$util,
-				\OC::$server->getLockingProvider()
-			);
-			$recovery = new \OCA\Encryption\Recovery(
-				\OC::$server->getUserSession(),
-				$crypt,
-				$keyManager,
-				\OC::$server->getConfig(),
-				\OC::$server->getEncryptionFilesHelper(),
-				new \OC\Files\View());
+			$keyManager = \OCP\Server::get(\OCA\Encryption\KeyManager::class);
+			$recovery = \OCP\Server::get(\OCA\Encryption\Recovery::class);
 			$recoveryAdminEnabled = $recovery->isRecoveryKeyEnabled();
 
 			$validRecoveryPassword = false;


### PR DESCRIPTION
Migrate away from ILogger in encryption and switch to constructor parameter promotion in concerned classes.

See #32127 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
