### PR TITLE
Fix a bug in the recursive rmdir

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -173,7 +173,7 @@ class OC_Helper {
 				if ($fileInfo->isLink()) {
 					unlink($fileInfo->getPathname());
 				} elseif ($fileInfo->isDir()) {
-					rmdir($fileInfo->getRealPath());
+					self::rmdirr($fileInfo->getRealPath());
 				} else {
 					unlink($fileInfo->getRealPath());
 				}


### PR DESCRIPTION
## Summary

The rmdirr tried to delete a non-empty directory, thus, it was failing.


______


A directory containing a directory containing files where never deleted.

Example:

Let's consider this configuration:

```
/tmp/root
└── intermediate
    ├── file1
    ├── file2
    └── file3
```

This configuration was able to occured during a plugin update.

If NC was running a `rmdirr("/tmp/root");` (which seems to be done during a cron, but, that's not important), it would never deleted anything.

Indeed, the `$files` variable would contians only the `intermediate` directory.

Thus, during the loop to delete the content of the `/tmp/root` content, when `$fileInfo` will contains the descriptor of `/tmp/root/intermediate`, the `rmdir` PHP function would fails because this directory is not empty.... And maked the final `rmdir` (in the `$deleteSelf` condition).

Tested on `PHP 8.1.20 (built: Jun 15 2023 01:23:25) (NTS)`, the PHP version of the docker container provided by NC-AIO.




## Checklist

* Code should be [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) (linted using php -l and tested in prod on my server)
* [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
* Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are not included. I am currently testing it on my server, and it seems that does not break. I also have doubt about the presence of unit testing on this topic, else, the TypeError should never become in prod.
* No screenshots before/after for front-end changes: not a UI change.
* No Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) is required: not a new feature.
* No [Backports requested](https://github.com/nextcloud/backportbot/#usage), but feel free to request it.
