### PR TITLE
Refactors lib/private/Profile.

### DIFF
--- a/lib/private/Profile/Actions/EmailAction.php
+++ b/lib/private/Profile/Actions/EmailAction.php
@@ -33,26 +33,13 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class EmailAction implements ILinkAction {
-	/** @var string */
-	private $value;
-
-	/** @var IAccountManager */
-	private $accountManager;
-
-	/** @var IFactory */
-	private $l10nFactory;
-
-	/** @var IUrlGenerator */
-	private $urlGenerator;
+	private string $value = '';
 
 	public function __construct(
-		IAccountManager $accountManager,
-		IFactory $l10nFactory,
-		IURLGenerator $urlGenerator
+		private IAccountManager $accountManager,
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->accountManager = $accountManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function preload(IUser $targetUser): void {

--- a/lib/private/Profile/Actions/FediverseAction.php
+++ b/lib/private/Profile/Actions/FediverseAction.php
@@ -34,19 +34,13 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class FediverseAction implements ILinkAction {
-	private ?string $value = null;
-	private IAccountManager $accountManager;
-	private IFactory $l10nFactory;
-	private IURLGenerator $urlGenerator;
+	private ?string $value = '';
 
 	public function __construct(
-		IAccountManager $accountManager,
-		IFactory $l10nFactory,
-		IURLGenerator $urlGenerator
+		private IAccountManager $accountManager,
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->accountManager = $accountManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function preload(IUser $targetUser): void {

--- a/lib/private/Profile/Actions/FediverseAction.php
+++ b/lib/private/Profile/Actions/FediverseAction.php
@@ -34,7 +34,7 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class FediverseAction implements ILinkAction {
-	private ?string $value = '';
+	private string $value = '';
 
 	public function __construct(
 		private IAccountManager $accountManager,

--- a/lib/private/Profile/Actions/PhoneAction.php
+++ b/lib/private/Profile/Actions/PhoneAction.php
@@ -33,26 +33,13 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class PhoneAction implements ILinkAction {
-	/** @var string */
-	private $value;
-
-	/** @var IAccountManager */
-	private $accountManager;
-
-	/** @var IFactory */
-	private $l10nFactory;
-
-	/** @var IUrlGenerator */
-	private $urlGenerator;
+	private string $value = '';
 
 	public function __construct(
-		IAccountManager $accountManager,
-		IFactory $l10nFactory,
-		IURLGenerator $urlGenerator
+		private IAccountManager $accountManager,
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->accountManager = $accountManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function preload(IUser $targetUser): void {

--- a/lib/private/Profile/Actions/TwitterAction.php
+++ b/lib/private/Profile/Actions/TwitterAction.php
@@ -34,26 +34,13 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class TwitterAction implements ILinkAction {
-	/** @var string */
-	private $value;
-
-	/** @var IAccountManager */
-	private $accountManager;
-
-	/** @var IFactory */
-	private $l10nFactory;
-
-	/** @var IUrlGenerator */
-	private $urlGenerator;
+	private string $value = '';
 
 	public function __construct(
-		IAccountManager $accountManager,
-		IFactory $l10nFactory,
-		IURLGenerator $urlGenerator
+		private IAccountManager $accountManager,
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->accountManager = $accountManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function preload(IUser $targetUser): void {

--- a/lib/private/Profile/Actions/WebsiteAction.php
+++ b/lib/private/Profile/Actions/WebsiteAction.php
@@ -33,26 +33,13 @@ use OCP\L10N\IFactory;
 use OCP\Profile\ILinkAction;
 
 class WebsiteAction implements ILinkAction {
-	/** @var string */
-	private $value;
-
-	/** @var IAccountManager */
-	private $accountManager;
-
-	/** @var IFactory */
-	private $l10nFactory;
-
-	/** @var IUrlGenerator */
-	private $urlGenerator;
+	private string $value = '';
 
 	public function __construct(
-		IAccountManager $accountManager,
-		IFactory $l10nFactory,
-		IURLGenerator $urlGenerator
+		private IAccountManager $accountManager,
+		private IFactory $l10nFactory,
+		private IURLGenerator $urlGenerator,
 	) {
-		$this->accountManager = $accountManager;
-		$this->l10nFactory = $l10nFactory;
-		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function preload(IUser $targetUser): void {


### PR DESCRIPTION
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Profile` namespace.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties