### PR TITLE
fix(CalDAV): Check if the vObject exists before attempting any operations

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -231,10 +231,19 @@ class Manager implements IManager {
 		string $recipient,
 		string $calendarData,
 	): bool {
-		/** @var VCalendar $vObject */
+		/** @var VCalendar $vObject|null */
 		$vObject = Reader::read($calendarData);
-		/** @var VEvent $vEvent */
+
+		if ($vObject === null) {
+			return false;
+		}
+
+		/** @var VEvent|null $vEvent */
 		$vEvent = $vObject->{'VEVENT'};
+
+		if ($vEvent === null) {
+			return false;
+		}
 
 		// First, we check if the correct method is passed to us
 		if (strcasecmp('REPLY', $vObject->{'METHOD'}->getValue()) !== 0) {
@@ -306,9 +315,19 @@ class Manager implements IManager {
 		string $recipient,
 		string $calendarData,
 	): bool {
+		/** @var VCalendar $vObject|null */
 		$vObject = Reader::read($calendarData);
-		/** @var VEvent $vEvent */
+
+		if ($vObject === null) {
+			return false;
+		}
+
+		/** @var VEvent|null $vEvent */
 		$vEvent = $vObject->{'VEVENT'};
+
+		if ($vEvent === null) {
+			return false;
+		}
 
 		// First, we check if the correct method is passed to us
 		if (strcasecmp('CANCEL', $vObject->{'METHOD'}->getValue()) !== 0) {


### PR DESCRIPTION
Sabre\VObject\Reader::read might return null if the object can't be handled properly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
