### PR TITLE
Silent `imagecreatefromstring()` errors

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -758,7 +758,7 @@ class OC_Image implements \OCP\IImage {
 				if (!$this->checkImageDataSize($data)) {
 					return false;
 				}
-				$this->resource = imagecreatefromstring($data);
+				$this->resource = @imagecreatefromstring($data);
 				$iType = IMAGETYPE_PNG;
 				$this->logger->debug('OC_Image->loadFromFile, Default', ['app' => 'core']);
 				break;


### PR DESCRIPTION
## Summary

There isn't much we can do about, and all other calls to this same function on the same file are already silent.

```
Error: imagecreatefromstring(): Data is not in a recognized format at /lib/private/legacy/OC_Image.php#758
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
