### PR TITLE
Refactors lib/private/Lock

### DIFF
--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -33,13 +33,17 @@ use OCP\Lock\ILockingProvider;
  * to release any leftover locks at the end of the request
  */
 abstract class AbstractLockingProvider implements ILockingProvider {
-	/** how long until we clear stray locks in seconds */
-	protected int $ttl;
-
-	protected $acquiredLocks = [
+	protected array $acquiredLocks = [
 		'shared' => [],
 		'exclusive' => []
 	];
+
+	/**
+	 *
+	 * @param int $ttl how long until we clear stray locks in seconds
+	 */
+	public function __construct(protected int $ttl) {
+	}
 
 	/** @inheritDoc */
 	protected function hasAcquiredLock(string $path, int $type): bool {

--- a/lib/private/Lock/DBLockingProvider.php
+++ b/lib/private/Lock/DBLockingProvider.php
@@ -39,21 +39,15 @@ use OCP\Lock\LockedException;
  * Locking provider that stores the locks in the database
  */
 class DBLockingProvider extends AbstractLockingProvider {
-	private IDBConnection $connection;
-	private ITimeFactory $timeFactory;
 	private array $sharedLocks = [];
-	private bool $cacheSharedLocks;
 
 	public function __construct(
-		IDBConnection $connection,
-		ITimeFactory $timeFactory,
+		private IDBConnection $connection,
+		private ITimeFactory $timeFactory,
 		int $ttl = 3600,
-		bool $cacheSharedLocks = true
+		private bool $cacheSharedLocks = true
 	) {
-		$this->connection = $connection;
-		$this->timeFactory = $timeFactory;
-		$this->ttl = $ttl;
-		$this->cacheSharedLocks = $cacheSharedLocks;
+		parent::__construct($ttl);
 	}
 
 	/**

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -32,11 +32,11 @@ use OCP\IMemcacheTTL;
 use OCP\Lock\LockedException;
 
 class MemcacheLockingProvider extends AbstractLockingProvider {
-	private IMemcache $memcache;
-
-	public function __construct(IMemcache $memcache, int $ttl = 3600) {
-		$this->memcache = $memcache;
-		$this->ttl = $ttl;
+	public function __construct(
+		private IMemcache $memcache,
+		int $ttl = 3600,
+	) {
+		parent::__construct($ttl);
 	}
 
 	private function setTTL(string $path): void {


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Lock` namespace.

The improvements in this PR include:

- Using PHP8's constructor property promotion
- Using match expression
- Adding types to properties

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits

