### PR TITLE
Refactors /Metadata, /Migration, and /Net namespaces in /lib/private/

### DIFF
--- a/lib/private/Metadata/Capabilities.php
+++ b/lib/private/Metadata/Capabilities.php
@@ -26,15 +26,13 @@ use OCP\Capabilities\IPublicCapability;
 use OCP\IConfig;
 
 class Capabilities implements IPublicCapability {
-	private IMetadataManager $manager;
-	private IConfig $config;
-
-	public function __construct(IMetadataManager $manager, IConfig $config) {
-		$this->manager = $manager;
-		$this->config = $config;
+	public function __construct(
+		private IMetadataManager $manager,
+		private IConfig $config,
+	) {
 	}
 
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		if ($this->config->getSystemValueBool('enable_file_metadata', true)) {
 			return ['metadataAvailable' => $this->manager->getCapabilities()];
 		}

--- a/lib/private/Metadata/FileEventListener.php
+++ b/lib/private/Metadata/FileEventListener.php
@@ -39,12 +39,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<NodeWrittenEvent>
  */
 class FileEventListener implements IEventListener {
-	private IMetadataManager $manager;
-	private LoggerInterface $logger;
-
-	public function __construct(IMetadataManager $manager, LoggerInterface $logger) {
-		$this->manager = $manager;
-		$this->logger = $logger;
+	public function __construct(
+		private IMetadataManager $manager,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	private function shouldExtractMetadata(Node $node): bool {

--- a/lib/private/Metadata/MetadataManager.php
+++ b/lib/private/Metadata/MetadataManager.php
@@ -24,17 +24,12 @@ use OCP\Files\File;
 
 class MetadataManager implements IMetadataManager {
 	/** @var array<string, IMetadataProvider> */
-	private array $providers;
-	private array $providerClasses;
-	private FileMetadataMapper $fileMetadataMapper;
+	private array $providers = [];
+	private array $providerClasses = [];
 
 	public function __construct(
-		FileMetadataMapper $fileMetadataMapper
+		private FileMetadataMapper $fileMetadataMapper,
 	) {
-		$this->providers = [];
-		$this->providerClasses = [];
-		$this->fileMetadataMapper = $fileMetadataMapper;
-
 		// TODO move to another place, where?
 		$this->registerProvider(ExifProvider::class);
 	}

--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -28,12 +28,9 @@ use OCP\Files\File;
 use Psr\Log\LoggerInterface;
 
 class ExifProvider implements IMetadataProvider {
-	private LoggerInterface $logger;
-
 	public function __construct(
-		LoggerInterface $logger
+		private LoggerInterface $logger,
 	) {
-		$this->logger = $logger;
 	}
 
 	public static function groupsProvided(): array {

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -41,15 +41,13 @@ use Psr\Log\LoggerInterface;
  * @package OC\Migration
  */
 class BackgroundRepair extends TimedJob {
-	private IJobList $jobList;
-	private LoggerInterface $logger;
-	private IEventDispatcher $dispatcher;
-
-	public function __construct(IEventDispatcher $dispatcher, ITimeFactory $time, LoggerInterface $logger, IJobList $jobList) {
+	public function __construct(
+		private IEventDispatcher $dispatcher,
+		ITimeFactory $time,
+		private LoggerInterface $logger,
+		private IJobList $jobList,
+	) {
 		parent::__construct($time);
-		$this->dispatcher = $dispatcher;
-		$this->logger = $logger;
-		$this->jobList = $jobList;
 		$this->setInterval(15 * 60);
 	}
 
@@ -58,7 +56,7 @@ class BackgroundRepair extends TimedJob {
 	 * @throws \Exception
 	 * @throws \OC\NeedsUpdateException
 	 */
-	protected function run($argument) {
+	protected function run($argument): void {
 		if (!isset($argument['app']) || !isset($argument['step'])) {
 			// remove the job - we can never execute it
 			$this->jobList->remove($this, $this->argument);
@@ -101,7 +99,7 @@ class BackgroundRepair extends TimedJob {
 	 * @param $app
 	 * @throws NeedsUpdateException
 	 */
-	protected function loadApp($app) {
+	protected function loadApp($app): void {
 		OC_App::loadApp($app);
 	}
 }

--- a/lib/private/Migration/ConsoleOutput.php
+++ b/lib/private/Migration/ConsoleOutput.php
@@ -34,34 +34,31 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @package OC\Migration
  */
 class ConsoleOutput implements IOutput {
-	/** @var OutputInterface */
-	private $output;
+	private ?ProgressBar $progressBar = null;
 
-	/** @var ProgressBar */
-	private $progressBar;
-
-	public function __construct(OutputInterface $output) {
-		$this->output = $output;
+	public function __construct(
+		private OutputInterface $output,
+	) {
 	}
 
 	/**
 	 * @param string $message
 	 */
-	public function info($message) {
+	public function info($message): void {
 		$this->output->writeln("<info>$message</info>");
 	}
 
 	/**
 	 * @param string $message
 	 */
-	public function warning($message) {
+	public function warning($message): void {
 		$this->output->writeln("<comment>$message</comment>");
 	}
 
 	/**
 	 * @param int $max
 	 */
-	public function startProgress($max = 0) {
+	public function startProgress($max = 0): void {
 		if (!is_null($this->progressBar)) {
 			$this->progressBar->finish();
 		}
@@ -73,7 +70,7 @@ class ConsoleOutput implements IOutput {
 	 * @param int $step
 	 * @param string $description
 	 */
-	public function advance($step = 1, $description = '') {
+	public function advance($step = 1, $description = ''): void {
 		if (is_null($this->progressBar)) {
 			$this->progressBar = new ProgressBar($this->output);
 			$this->progressBar->start();
@@ -84,7 +81,7 @@ class ConsoleOutput implements IOutput {
 		}
 	}
 
-	public function finishProgress() {
+	public function finishProgress(): void {
 		if (is_null($this->progressBar)) {
 			return;
 		}

--- a/lib/private/Migration/SimpleOutput.php
+++ b/lib/private/Migration/SimpleOutput.php
@@ -33,19 +33,17 @@ use Psr\Log\LoggerInterface;
  * @package OC\Migration
  */
 class SimpleOutput implements IOutput {
-	private LoggerInterface $logger;
-	private $appName;
-
-	public function __construct(LoggerInterface $logger, $appName) {
-		$this->logger = $logger;
-		$this->appName = $appName;
+	public function __construct(
+		private LoggerInterface $logger,
+		private $appName,
+	) {
 	}
 
 	/**
 	 * @param string $message
 	 * @since 9.1.0
 	 */
-	public function info($message) {
+	public function info($message): void {
 		$this->logger->info($message, ['app' => $this->appName]);
 	}
 
@@ -53,7 +51,7 @@ class SimpleOutput implements IOutput {
 	 * @param string $message
 	 * @since 9.1.0
 	 */
-	public function warning($message) {
+	public function warning($message): void {
 		$this->logger->warning($message, ['app' => $this->appName]);
 	}
 
@@ -61,7 +59,7 @@ class SimpleOutput implements IOutput {
 	 * @param int $max
 	 * @since 9.1.0
 	 */
-	public function startProgress($max = 0) {
+	public function startProgress($max = 0): void {
 	}
 
 	/**
@@ -69,12 +67,12 @@ class SimpleOutput implements IOutput {
 	 * @param string $description
 	 * @since 9.1.0
 	 */
-	public function advance($step = 1, $description = '') {
+	public function advance($step = 1, $description = ''): void {
 	}
 
 	/**
 	 * @since 9.1.0
 	 */
-	public function finishProgress() {
+	public function finishProgress(): void {
 	}
 }

--- a/lib/private/Net/HostnameClassifier.php
+++ b/lib/private/Net/HostnameClassifier.php
@@ -52,10 +52,6 @@ class HostnameClassifier {
 	 * Check host identifier for local hostname
 	 *
 	 * IP addresses are not considered local. Use the IpAddressClassifier for those.
-	 *
-	 * @param string $hostname
-	 *
-	 * @return bool
 	 */
 	public function isLocalHostname(string $hostname): bool {
 		// Disallow local network top-level domains from RFC 6762

--- a/lib/private/Net/IpAddressClassifier.php
+++ b/lib/private/Net/IpAddressClassifier.php
@@ -46,10 +46,6 @@ class IpAddressClassifier {
 	 * Check host identifier for local IPv4 and IPv6 address ranges
 	 *
 	 * Hostnames are not considered local. Use the HostnameClassifier for those.
-	 *
-	 * @param string $ip
-	 *
-	 * @return bool
 	 */
 	public function isLocalAddress(string $ip): bool {
 		$parsedIp = Factory::parseAddressString(


### PR DESCRIPTION
## Summary

Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Metadata`, `/lib/private/Migration`, and `/lib/private/Net` namespaces.

The improvements in this PR include:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
