### PR TITLE
[1/2] Refactors lib/private/Collaboration

### DIFF
--- a/lib/private/Collaboration/AutoComplete/Manager.php
+++ b/lib/private/Collaboration/AutoComplete/Manager.php
@@ -29,47 +29,46 @@ use OCP\IServerContainer;
 
 class Manager implements IManager {
 	/** @var string[] */
-	protected $sorters = [];
+	protected array $sorters = [];
 
 	/** @var ISorter[]  */
-	protected $sorterInstances = [];
-	/** @var IServerContainer */
-	private $c;
+	protected array $sorterInstances = [];
 
-	public function __construct(IServerContainer $container) {
-		$this->c = $container;
+	public function __construct(
+		private IServerContainer $container,
+	) {
 	}
 
-	public function runSorters(array $sorters, array &$sortArray, array $context) {
+	public function runSorters(array $sorters, array &$sortArray, array $context): void {
 		$sorterInstances = $this->getSorters();
 		while ($sorter = array_shift($sorters)) {
 			if (isset($sorterInstances[$sorter])) {
 				$sorterInstances[$sorter]->sort($sortArray, $context);
 			} else {
-				$this->c->getLogger()->warning('No sorter for ID "{id}", skipping', [
+				$this->container->getLogger()->warning('No sorter for ID "{id}", skipping', [
 					'app' => 'core', 'id' => $sorter
 				]);
 			}
 		}
 	}
 
-	public function registerSorter($className) {
+	public function registerSorter($className): void {
 		$this->sorters[] = $className;
 	}
 
-	protected function getSorters() {
+	protected function getSorters(): array {
 		if (count($this->sorterInstances) === 0) {
 			foreach ($this->sorters as $sorter) {
 				/** @var ISorter $instance */
-				$instance = $this->c->resolve($sorter);
+				$instance = $this->container->resolve($sorter);
 				if (!$instance instanceof ISorter) {
-					$this->c->getLogger()->notice('Skipping sorter which is not an instance of ISorter. Class name: {class}',
+					$this->container->getLogger()->notice('Skipping sorter which is not an instance of ISorter. Class name: {class}',
 						['app' => 'core', 'class' => $sorter]);
 					continue;
 				}
 				$sorterId = trim($instance->getId());
 				if (trim($sorterId) === '') {
-					$this->c->getLogger()->notice('Skipping sorter with empty ID. Class name: {class}',
+					$this->container->getLogger()->notice('Skipping sorter with empty ID. Class name: {class}',
 						['app' => 'core', 'class' => $sorter]);
 					continue;
 				}

--- a/lib/private/Collaboration/Collaborators/GroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/GroupPlugin.php
@@ -37,34 +37,26 @@ use OCP\IUserSession;
 use OCP\Share\IShare;
 
 class GroupPlugin implements ISearchPlugin {
-	/** @var bool */
-	protected $shareeEnumeration;
-	/** @var bool */
-	protected $shareWithGroupOnly;
-	/** @var bool */
-	protected $shareeEnumerationInGroupOnly;
-	/** @var bool */
-	protected $groupSharingDisabled;
+	protected bool $shareeEnumeration;
 
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var IConfig */
-	private $config;
-	/** @var IUserSession */
-	private $userSession;
+	protected bool $shareWithGroupOnly;
 
-	public function __construct(IConfig $config, IGroupManager $groupManager, IUserSession $userSession) {
-		$this->groupManager = $groupManager;
-		$this->config = $config;
-		$this->userSession = $userSession;
+	protected bool $shareeEnumerationInGroupOnly;
 
+	protected bool $groupSharingDisabled;
+
+	public function __construct(
+		private IConfig $config,
+		private IGroupManager $groupManager,
+		private IUserSession $userSession,
+	) {
 		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$this->shareWithGroupOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
 		$this->shareeEnumerationInGroupOnly = $this->shareeEnumeration && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$this->groupSharingDisabled = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'no';
 	}
 
-	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
 		if ($this->groupSharingDisabled) {
 			return false;
 		}

--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -41,50 +41,27 @@ use OCP\Share\IShare;
 use OCP\Mail\IMailer;
 
 class MailPlugin implements ISearchPlugin {
-	/* @var bool */
-	protected $shareWithGroupOnly;
-	/* @var bool */
-	protected $shareeEnumeration;
-	/* @var bool */
-	protected $shareeEnumerationInGroupOnly;
-	/* @var bool */
-	protected $shareeEnumerationPhone;
-	/* @var bool */
-	protected $shareeEnumerationFullMatch;
-	/* @var bool */
-	protected $shareeEnumerationFullMatchEmail;
+	protected bool $shareWithGroupOnly;
 
-	/** @var IManager */
-	private $contactsManager;
-	/** @var ICloudIdManager */
-	private $cloudIdManager;
-	/** @var IConfig */
-	private $config;
+	protected bool $shareeEnumeration;
 
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var KnownUserService */
-	private $knownUserService;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var IMailer */
-	private $mailer;
+	protected bool $shareeEnumerationInGroupOnly;
 
-	public function __construct(IManager $contactsManager,
-								ICloudIdManager $cloudIdManager,
-								IConfig $config,
-								IGroupManager $groupManager,
-								KnownUserService $knownUserService,
-								IUserSession $userSession,
-								IMailer $mailer) {
-		$this->contactsManager = $contactsManager;
-		$this->cloudIdManager = $cloudIdManager;
-		$this->config = $config;
-		$this->groupManager = $groupManager;
-		$this->knownUserService = $knownUserService;
-		$this->userSession = $userSession;
-		$this->mailer = $mailer;
+	protected bool $shareeEnumerationPhone;
 
+	protected bool $shareeEnumerationFullMatch;
+
+	protected bool $shareeEnumerationFullMatchEmail;
+
+	public function __construct(
+		private IManager $contactsManager,
+		private ICloudIdManager $cloudIdManager,
+		private IConfig $config,
+		private IGroupManager $groupManager,
+		private KnownUserService $knownUserService,
+		private IUserSession $userSession,
+		private IMailer $mailer,
+	) {
 		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$this->shareWithGroupOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
 		$this->shareeEnumerationInGroupOnly = $this->shareeEnumeration && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
@@ -96,7 +73,7 @@ class MailPlugin implements ISearchPlugin {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
 		if ($this->shareeEnumerationFullMatch && !$this->shareeEnumerationFullMatchEmail) {
 			return false;
 		}
@@ -120,8 +97,8 @@ class MailPlugin implements ISearchPlugin {
 			[
 				'limit' => $limit,
 				'offset' => $offset,
-				'enumeration' => (bool) $this->shareeEnumeration,
-				'fullmatch' => (bool) $this->shareeEnumerationFullMatch,
+				'enumeration' => $this->shareeEnumeration,
+				'fullmatch' => $this->shareeEnumerationFullMatch,
 			]
 		);
 		$lowerSearch = strtolower($search);
@@ -286,6 +263,6 @@ class MailPlugin implements ISearchPlugin {
 
 	public function isCurrentUser(ICloudId $cloud): bool {
 		$currentUser = $this->userSession->getUser();
-		return $currentUser instanceof IUser ? $currentUser->getUID() === $cloud->getUser() : false;
+		return $currentUser instanceof IUser && $currentUser->getUID() === $cloud->getUser();
 	}
 }

--- a/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php
@@ -33,14 +33,12 @@ use OCP\Share;
 use OCP\Share\IShare;
 
 class RemoteGroupPlugin implements ISearchPlugin {
-	protected $shareeEnumeration;
+	private bool $enabled = false;
 
-	/** @var ICloudIdManager */
-	private $cloudIdManager;
-	/** @var bool */
-	private $enabled = false;
-
-	public function __construct(ICloudFederationProviderManager $cloudFederationProviderManager, ICloudIdManager $cloudIdManager) {
+	public function __construct(
+		ICloudFederationProviderManager $cloudFederationProviderManager,
+		private ICloudIdManager $cloudIdManager,
+	) {
 		try {
 			$fileSharingProvider = $cloudFederationProviderManager->getCloudFederationProvider('file');
 			$supportedShareTypes = $fileSharingProvider->getSupportedShareTypes();
@@ -50,10 +48,9 @@ class RemoteGroupPlugin implements ISearchPlugin {
 		} catch (\Exception $e) {
 			// do nothing, just don't enable federated group shares
 		}
-		$this->cloudIdManager = $cloudIdManager;
 	}
 
-	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
 		$result = ['wide' => [], 'exact' => []];
 		$resultType = new SearchResultType('remote_groups');
 
@@ -83,7 +80,7 @@ class RemoteGroupPlugin implements ISearchPlugin {
 	 * @return array [user, remoteURL]
 	 * @throws \InvalidArgumentException
 	 */
-	public function splitGroupRemote($address) {
+	public function splitGroupRemote($address): array {
 		try {
 			$cloudId = $this->cloudIdManager->resolveCloudId($address);
 			return [$cloudId->getUser(), $cloudId->getRemote()];

--- a/lib/private/Collaboration/Collaborators/RemotePlugin.php
+++ b/lib/private/Collaboration/Collaborators/RemotePlugin.php
@@ -175,7 +175,7 @@ class RemotePlugin implements ISearchPlugin {
 	 * @return array [user, remoteURL]
 	 * @throws \InvalidArgumentException
 	 */
-	public function splitUserRemote($address): array {
+	public function splitUserRemote(string $address): array {
 		try {
 			$cloudId = $this->cloudIdManager->resolveCloudId($address);
 			return [$cloudId->getUser(), $cloudId->getRemote()];

--- a/lib/private/Collaboration/Collaborators/Search.php
+++ b/lib/private/Collaboration/Collaborators/Search.php
@@ -35,32 +35,28 @@ use OCP\IContainer;
 use OCP\Share;
 
 class Search implements ISearch {
-	/** @var IContainer */
-	private $c;
+	protected array $pluginList = [];
 
-	protected $pluginList = [];
-
-	public function __construct(IContainer $c) {
-		$this->c = $c;
+	public function __construct(
+		private IContainer $container,
+	) {
 	}
 
 	/**
 	 * @param string $search
-	 * @param array $shareTypes
 	 * @param bool $lookup
 	 * @param int|null $limit
 	 * @param int|null $offset
-	 * @return array
 	 * @throws \OCP\AppFramework\QueryException
 	 */
-	public function search($search, array $shareTypes, $lookup, $limit, $offset) {
+	public function search($search, array $shareTypes, $lookup, $limit, $offset): array {
 		$hasMoreResults = false;
 
 		// Trim leading and trailing whitespace characters, e.g. when query is copy-pasted
 		$search = trim($search);
 
 		/** @var ISearchResult $searchResult */
-		$searchResult = $this->c->resolve(SearchResult::class);
+		$searchResult = $this->container->resolve(SearchResult::class);
 
 		foreach ($shareTypes as $type) {
 			if (!isset($this->pluginList[$type])) {
@@ -68,14 +64,14 @@ class Search implements ISearch {
 			}
 			foreach ($this->pluginList[$type] as $plugin) {
 				/** @var ISearchPlugin $searchPlugin */
-				$searchPlugin = $this->c->resolve($plugin);
+				$searchPlugin = $this->container->resolve($plugin);
 				$hasMoreResults = $searchPlugin->search($search, $limit, $offset, $searchResult) || $hasMoreResults;
 			}
 		}
 
 		// Get from lookup server, not a separate share type
 		if ($lookup) {
-			$searchPlugin = $this->c->resolve(LookupPlugin::class);
+			$searchPlugin = $this->container->resolve(LookupPlugin::class);
 			$hasMoreResults = $searchPlugin->search($search, $limit, $offset, $searchResult) || $hasMoreResults;
 		}
 
@@ -105,7 +101,7 @@ class Search implements ISearch {
 		return [$searchResult->asArray(), $hasMoreResults];
 	}
 
-	public function registerPlugin(array $pluginInfo) {
+	public function registerPlugin(array $pluginInfo): void {
 		$shareType = constant(Share::class . '::' . $pluginInfo['shareType']);
 		if ($shareType === null) {
 			throw new \InvalidArgumentException('Provided ShareType is invalid');

--- a/lib/private/Collaboration/Collaborators/SearchResult.php
+++ b/lib/private/Collaboration/Collaborators/SearchResult.php
@@ -28,13 +28,13 @@ use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Collaborators\SearchResultType;
 
 class SearchResult implements ISearchResult {
-	protected $result = [
+	protected array $result = [
 		'exact' => [],
 	];
 
-	protected $exactIdMatches = [];
+	protected array $exactIdMatches = [];
 
-	public function addResultSet(SearchResultType $type, array $matches, array $exactMatches = null) {
+	public function addResultSet(SearchResultType $type, array $matches, array $exactMatches = null): void {
 		$type = $type->getLabel();
 		if (!isset($this->result[$type])) {
 			$this->result[$type] = [];
@@ -47,15 +47,15 @@ class SearchResult implements ISearchResult {
 		}
 	}
 
-	public function markExactIdMatch(SearchResultType $type) {
+	public function markExactIdMatch(SearchResultType $type): void {
 		$this->exactIdMatches[$type->getLabel()] = 1;
 	}
 
-	public function hasExactIdMatch(SearchResultType $type) {
+	public function hasExactIdMatch(SearchResultType $type): bool {
 		return isset($this->exactIdMatches[$type->getLabel()]);
 	}
 
-	public function hasResult(SearchResultType $type, $collaboratorId) {
+	public function hasResult(SearchResultType $type, $collaboratorId): bool {
 		$type = $type->getLabel();
 		if (!isset($this->result[$type])) {
 			return false;
@@ -73,11 +73,11 @@ class SearchResult implements ISearchResult {
 		return false;
 	}
 
-	public function asArray() {
+	public function asArray(): array {
 		return $this->result;
 	}
 
-	public function unsetResult(SearchResultType $type) {
+	public function unsetResult(SearchResultType $type): void {
 		$type = $type->getLabel();
 		$this->result[$type] = [];
 		if (isset($this->result['exact'][$type])) {

--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -44,50 +44,30 @@ use OCP\Share\IShare;
 use OCP\UserStatus\IManager as IUserStatusManager;
 
 class UserPlugin implements ISearchPlugin {
-	/* @var bool */
-	protected $shareWithGroupOnly;
-	/* @var bool */
-	protected $shareeEnumeration;
-	/* @var bool */
-	protected $shareeEnumerationInGroupOnly;
-	/* @var bool */
-	protected $shareeEnumerationPhone;
-	/* @var bool */
-	protected $shareeEnumerationFullMatch;
-	/* @var bool */
-	protected $shareeEnumerationFullMatchUserId;
-	/* @var bool */
-	protected $shareeEnumerationFullMatchEmail;
-	/* @var bool */
-	protected $shareeEnumerationFullMatchIgnoreSecondDisplayName;
+	protected bool $shareWithGroupOnly;
 
-	/** @var IConfig */
-	private $config;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var KnownUserService */
-	private $knownUserService;
-	/** @var IUserStatusManager */
-	private $userStatusManager;
+	protected bool $shareeEnumeration;
 
-	public function __construct(IConfig $config,
-								IUserManager $userManager,
-								IGroupManager $groupManager,
-								IUserSession $userSession,
-								KnownUserService $knownUserService,
-								IUserStatusManager $userStatusManager) {
-		$this->config = $config;
+	protected bool $shareeEnumerationInGroupOnly;
 
-		$this->groupManager = $groupManager;
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
-		$this->knownUserService = $knownUserService;
-		$this->userStatusManager = $userStatusManager;
+	protected bool $shareeEnumerationPhone;
 
+	protected bool $shareeEnumerationFullMatch;
+
+	protected bool $shareeEnumerationFullMatchUserId;
+
+	protected bool $shareeEnumerationFullMatchEmail;
+
+	protected bool $shareeEnumerationFullMatchIgnoreSecondDisplayName;
+
+	public function __construct(
+		private IConfig $config,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
+		private IUserSession $userSession,
+		private KnownUserService $knownUserService,
+		private IUserStatusManager $userStatusManager,
+	) {
 		$this->shareWithGroupOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
 		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$this->shareeEnumerationInGroupOnly = $this->shareeEnumeration && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
@@ -98,7 +78,7 @@ class UserPlugin implements ISearchPlugin {
 		$this->shareeEnumerationFullMatchIgnoreSecondDisplayName = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_ignore_second_dn', 'no') === 'yes';
 	}
 
-	public function search($search, $limit, $offset, ISearchResult $searchResult) {
+	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
 		$result = ['wide' => [], 'exact' => []];
 		$users = [];
 		$hasMoreResults = false;
@@ -282,8 +262,6 @@ class UserPlugin implements ISearchPlugin {
 			}
 		}
 
-
-
 		$type = new SearchResultType('users');
 		$searchResult->addResultSet($type, $result['wide'], $result['exact']);
 		if (count($result['exact'])) {
@@ -293,7 +271,7 @@ class UserPlugin implements ISearchPlugin {
 		return $hasMoreResults;
 	}
 
-	public function takeOutCurrentUser(array &$users) {
+	public function takeOutCurrentUser(array &$users): void {
 		$currentUser = $this->userSession->getUser();
 		if (!is_null($currentUser)) {
 			if (isset($users[$currentUser->getUID()])) {


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Collaboration` namespace.

I figured I should split the changes into two PRs to make reviewing the changes easier.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
