### PR TITLE
[2/2] Refactors lib/private/Collaboration

### DIFF
--- a/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
+++ b/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
@@ -36,10 +36,9 @@ use OCP\Share\Events\ShareDeletedEvent;
 
 /** @template-implements IEventListener<Event|NodeDeletedEvent|ShareDeletedEvent|ShareCreatedEvent> */
 class FileReferenceEventListener implements IEventListener {
-	private IReferenceManager $manager;
-
-	public function __construct(IReferenceManager $manager) {
-		$this->manager = $manager;
+	public function __construct(
+		private IReferenceManager $manager,
+	) {
 	}
 
 	public static function register(IEventDispatcher $eventDispatcher): void {

--- a/lib/private/Collaboration/Reference/File/FileReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/File/FileReferenceProvider.php
@@ -41,26 +41,18 @@ use OCP\IUserSession;
 use OCP\L10N\IFactory;
 
 class FileReferenceProvider extends ADiscoverableReferenceProvider {
-	private IURLGenerator $urlGenerator;
-	private IRootFolder $rootFolder;
 	private ?string $userId;
-	private IPreview $previewManager;
-	private IMimeTypeDetector $mimeTypeDetector;
 	private IL10N $l10n;
 
 	public function __construct(
-		IURLGenerator $urlGenerator,
-		IRootFolder $rootFolder,
+		private IURLGenerator $urlGenerator,
+		private IRootFolder $rootFolder,
 		IUserSession $userSession,
-		IMimeTypeDetector $mimeTypeDetector,
-		IPreview $previewManager,
-		IFactory $l10n
+		private IMimeTypeDetector $mimeTypeDetector,
+		private IPreview $previewManager,
+		IFactory $l10n,
 	) {
-		$this->urlGenerator = $urlGenerator;
-		$this->rootFolder = $rootFolder;
-		$this->userId = $userSession->getUser() ? $userSession->getUser()->getUID() : null;
-		$this->previewManager = $previewManager;
-		$this->mimeTypeDetector = $mimeTypeDetector;
+		$this->userId = $userSession->getUser()?->getUID();
 		$this->l10n = $l10n->get('files');
 	}
 

--- a/lib/private/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/private/Collaboration/Reference/LinkReferenceProvider.php
@@ -54,24 +54,16 @@ class LinkReferenceProvider implements IReferenceProvider {
 		'image/webp'
 	];
 
-	private IClientService $clientService;
-	private LoggerInterface $logger;
-	private SystemConfig $systemConfig;
-	private IAppDataFactory $appDataFactory;
-	private IURLGenerator $urlGenerator;
-	private Limiter $limiter;
-	private IUserSession $userSession;
-	private IRequest $request;
-
-	public function __construct(IClientService $clientService, LoggerInterface $logger, SystemConfig $systemConfig, IAppDataFactory $appDataFactory, IURLGenerator $urlGenerator, Limiter $limiter, IUserSession $userSession, IRequest $request) {
-		$this->clientService = $clientService;
-		$this->logger = $logger;
-		$this->systemConfig = $systemConfig;
-		$this->appDataFactory = $appDataFactory;
-		$this->urlGenerator = $urlGenerator;
-		$this->limiter = $limiter;
-		$this->userSession = $userSession;
-		$this->request = $request;
+	public function __construct(
+		private IClientService $clientService,
+		private LoggerInterface $logger,
+		private SystemConfig $systemConfig,
+		private IAppDataFactory $appDataFactory,
+		private IURLGenerator $urlGenerator,
+		private Limiter $limiter,
+		private IUserSession $userSession,
+		private IRequest $request,
+	) {
 	}
 
 	public function matchReference(string $referenceText): bool {
@@ -119,7 +111,7 @@ class LinkReferenceProvider implements IReferenceProvider {
 		$linkContentType = $headResponse->getHeader('Content-Type');
 		$expectedContentType = 'text/html';
 		$suffixedExpectedContentType = $expectedContentType . ';';
-		$startsWithSuffixed = substr($linkContentType, 0, strlen($suffixedExpectedContentType)) === $suffixedExpectedContentType;
+		$startsWithSuffixed = str_starts_with($linkContentType, $suffixedExpectedContentType);
 		// check the header begins with the expected content type
 		if ($linkContentType !== $expectedContentType && !$startsWithSuffixed) {
 			$this->logger->debug('Skip resolving links pointing to content type that is not "text/html"');

--- a/lib/private/Collaboration/Reference/ReferenceManager.php
+++ b/lib/private/Collaboration/Reference/ReferenceManager.php
@@ -46,33 +46,22 @@ class ReferenceManager implements IReferenceManager {
 	/** @var IReferenceProvider[]|null */
 	private ?array $providers = null;
 	private ICache $cache;
-	private Coordinator $coordinator;
-	private ContainerInterface $container;
-	private LinkReferenceProvider $linkReferenceProvider;
-	private LoggerInterface $logger;
-	private IConfig $config;
-	private IUserSession $userSession;
 
-	public function __construct(LinkReferenceProvider $linkReferenceProvider,
-								ICacheFactory $cacheFactory,
-								Coordinator $coordinator,
-								ContainerInterface $container,
-								LoggerInterface $logger,
-								IConfig $config,
-								IUserSession $userSession) {
-		$this->linkReferenceProvider = $linkReferenceProvider;
+	public function __construct(
+		private LinkReferenceProvider $linkReferenceProvider,
+		ICacheFactory $cacheFactory,
+		private Coordinator $coordinator,
+		private ContainerInterface $container,
+		private LoggerInterface $logger,
+		private IConfig $config,
+		private IUserSession $userSession,
+	) {
 		$this->cache = $cacheFactory->createDistributed('reference');
-		$this->coordinator = $coordinator;
-		$this->container = $container;
-		$this->logger = $logger;
-		$this->config = $config;
-		$this->userSession = $userSession;
 	}
 
 	/**
 	 * Extract a list of URLs from a text
 	 *
-	 * @param string $text
 	 * @return string[]
 	 */
 	public function extractReferences(string $text): array {
@@ -85,9 +74,6 @@ class ReferenceManager implements IReferenceManager {
 
 	/**
 	 * Try to get a cached reference object from a reference string
-	 *
-	 * @param string $referenceId
-	 * @return IReference|null
 	 */
 	public function getReferenceFromCache(string $referenceId): ?IReference {
 		$matchedProvider = $this->getMatchedProvider($referenceId);
@@ -102,9 +88,6 @@ class ReferenceManager implements IReferenceManager {
 
 	/**
 	 * Try to get a cached reference object from a full cache key
-	 *
-	 * @param string $cacheKey
-	 * @return IReference|null
 	 */
 	public function getReferenceByCacheKey(string $cacheKey): ?IReference {
 		$cached = $this->cache->get($cacheKey);
@@ -118,9 +101,6 @@ class ReferenceManager implements IReferenceManager {
 	/**
 	 * Get a reference object from a reference string with a matching provider
 	 * Use a cached reference if possible
-	 *
-	 * @param string $referenceId
-	 * @return IReference|null
 	 */
 	public function resolveReference(string $referenceId): ?IReference {
 		$matchedProvider = $this->getMatchedProvider($referenceId);
@@ -148,7 +128,6 @@ class ReferenceManager implements IReferenceManager {
 	 * Try to match a reference string with all the registered providers
 	 * Fallback to the link reference provider (using OpenGraph)
 	 *
-	 * @param string $referenceId
 	 * @return IReferenceProvider|null the first matching provider
 	 */
 	private function getMatchedProvider(string $referenceId): ?IReferenceProvider {
@@ -169,10 +148,6 @@ class ReferenceManager implements IReferenceManager {
 
 	/**
 	 * Get a hashed full cache key from a key and prefix given by a provider
-	 *
-	 * @param IReferenceProvider $provider
-	 * @param string $referenceId
-	 * @return string
 	 */
 	private function getFullCacheKey(IReferenceProvider $provider, string $referenceId): string {
 		$cacheKey = $provider->getCacheKey($referenceId);
@@ -183,10 +158,6 @@ class ReferenceManager implements IReferenceManager {
 
 	/**
 	 * Remove a specific cache entry from its key+prefix
-	 *
-	 * @param string $cachePrefix
-	 * @param string|null $cacheKey
-	 * @return void
 	 */
 	public function invalidateCache(string $cachePrefix, ?string $cacheKey = null): void {
 		if ($cacheKey === null) {

--- a/lib/private/Collaboration/Reference/RenderReferenceEventListener.php
+++ b/lib/private/Collaboration/Reference/RenderReferenceEventListener.php
@@ -34,12 +34,10 @@ use OCP\IInitialStateService;
 
 /** @template-implements IEventListener<Event|RenderReferenceEvent> */
 class RenderReferenceEventListener implements IEventListener {
-	private IReferenceManager $manager;
-	private IInitialStateService $initialStateService;
-
-	public function __construct(IReferenceManager $manager, IInitialStateService $initialStateService) {
-		$this->manager = $manager;
-		$this->initialStateService = $initialStateService;
+	public function __construct(
+		private IReferenceManager $manager,
+		private IInitialStateService $initialStateService,
+	) {
 	}
 
 	public static function register(IEventDispatcher $eventDispatcher): void {

--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -37,46 +37,21 @@ use OCP\IDBConnection;
 use OCP\IUser;
 
 class Collection implements ICollection {
-	/** @var Manager */
-	protected $manager;
-
-	/** @var IDBConnection */
-	protected $connection;
-
-	/** @var int */
-	protected $id;
-
-	/** @var string */
-	protected $name;
-
-	/** @var IUser|null */
-	protected $userForAccess;
-
-	/** @var bool|null */
-	protected $access;
-
 	/** @var IResource[] */
-	protected $resources;
+	protected array $resources = [];
 
 	public function __construct(
-		IManager $manager,
-		IDBConnection $connection,
-		int $id,
-		string $name,
-		?IUser $userForAccess = null,
-		?bool $access = null
+		/** @var Manager $manager */
+		protected IManager $manager,
+		protected IDBConnection $connection,
+		protected int $id,
+		protected string $name,
+		protected ?IUser $userForAccess = null,
+		protected ?bool $access = null
 	) {
-		$this->manager = $manager;
-		$this->connection = $connection;
-		$this->id = $id;
-		$this->name = $name;
-		$this->userForAccess = $userForAccess;
-		$this->access = $access;
-		$this->resources = [];
 	}
 
 	/**
-	 * @return int
 	 * @since 16.0.0
 	 */
 	public function getId(): int {
@@ -84,7 +59,6 @@ class Collection implements ICollection {
 	}
 
 	/**
-	 * @return string
 	 * @since 16.0.0
 	 */
 	public function getName(): string {
@@ -92,7 +66,6 @@ class Collection implements ICollection {
 	}
 
 	/**
-	 * @param string $name
 	 * @since 16.0.0
 	 */
 	public function setName(string $name): void {
@@ -120,7 +93,6 @@ class Collection implements ICollection {
 	/**
 	 * Adds a resource to a collection
 	 *
-	 * @param IResource $resource
 	 * @throws ResourceException when the resource is already part of the collection
 	 * @since 16.0.0
 	 */
@@ -153,7 +125,6 @@ class Collection implements ICollection {
 	/**
 	 * Removes a resource from a collection
 	 *
-	 * @param IResource $resource
 	 * @since 16.0.0
 	 */
 	public function removeResource(IResource $resource): void {
@@ -178,8 +149,6 @@ class Collection implements ICollection {
 	/**
 	 * Can a user/guest access the collection
 	 *
-	 * @param IUser|null $user
-	 * @return bool
 	 * @since 16.0.0
 	 */
 	public function canAccess(?IUser $user): bool {

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -45,26 +45,17 @@ class Manager implements IManager {
 	public const TABLE_RESOURCES = 'collres_resources';
 	public const TABLE_ACCESS_CACHE = 'collres_accesscache';
 
-	/** @var IDBConnection */
-	protected $connection;
-	/** @var IProviderManager */
-	protected $providerManager;
-	/** @var LoggerInterface */
-	protected $logger;
-
 	/** @var string[] */
-	protected $providers = [];
+	protected array $providers = [];
 
-
-	public function __construct(IDBConnection $connection, IProviderManager $providerManager, LoggerInterface $logger) {
-		$this->connection = $connection;
-		$this->providerManager = $providerManager;
-		$this->logger = $logger;
+	public function __construct(
+		protected IDBConnection $connection,
+		protected IProviderManager $providerManager,
+		protected LoggerInterface $logger,
+	) {
 	}
 
 	/**
-	 * @param int $id
-	 * @return ICollection
 	 * @throws CollectionException when the collection could not be found
 	 * @since 16.0.0
 	 */
@@ -85,9 +76,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param int $id
-	 * @param IUser|null $user
-	 * @return ICollection
 	 * @throws CollectionException when the collection could not be found
 	 * @since 16.0.0
 	 */
@@ -122,10 +110,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param IUser $user
-	 * @param string $filter
-	 * @param int $limit
-	 * @param int $start
 	 * @return ICollection[]
 	 * @since 16.0.0
 	 */
@@ -173,8 +157,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $name
-	 * @return ICollection
 	 * @since 16.0.0
 	 */
 	public function newCollection(string $name): ICollection {
@@ -189,9 +171,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $type
-	 * @param string $id
-	 * @return IResource
 	 * @since 16.0.0
 	 */
 	public function createResource(string $type, string $id): IResource {
@@ -199,10 +178,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $type
-	 * @param string $id
-	 * @param IUser|null $user
-	 * @return IResource
 	 * @throws ResourceException
 	 * @since 16.0.0
 	 */
@@ -239,8 +214,6 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param ICollection $collection
-	 * @param IUser|null $user
 	 * @return IResource[]
 	 * @since 16.0.0
 	 */
@@ -274,8 +247,6 @@ class Manager implements IManager {
 	/**
 	 * Get the rich object data of a resource
 	 *
-	 * @param IResource $resource
-	 * @return array
 	 * @since 16.0.0
 	 */
 	public function getResourceRichObject(IResource $resource): array {
@@ -294,9 +265,6 @@ class Manager implements IManager {
 	/**
 	 * Can a user/guest access the collection
 	 *
-	 * @param IResource $resource
-	 * @param IUser|null $user
-	 * @return bool
 	 * @since 16.0.0
 	 */
 	public function canAccessResource(IResource $resource, ?IUser $user): bool {
@@ -325,9 +293,6 @@ class Manager implements IManager {
 	/**
 	 * Can a user/guest access the collection
 	 *
-	 * @param ICollection $collection
-	 * @param IUser|null $user
-	 * @return bool
 	 * @since 16.0.0
 	 */
 	public function canAccessCollection(ICollection $collection, ?IUser $user): bool {
@@ -505,9 +470,6 @@ class Manager implements IManager {
 		$query->execute();
 	}
 
-	/**
-	 * @param string $provider
-	 */
 	public function registerResourceProvider(string $provider): void {
 		$this->logger->debug('\OC\Collaboration\Resources\Manager::registerResourceProvider is deprecated', ['provider' => $provider]);
 		$this->providerManager->registerResourceProvider($provider);
@@ -516,7 +478,6 @@ class Manager implements IManager {
 	/**
 	 * Get the resource type of the provider
 	 *
-	 * @return string
 	 * @since 16.0.0
 	 */
 	public function getType(): string {

--- a/lib/private/Collaboration/Resources/ProviderManager.php
+++ b/lib/private/Collaboration/Resources/ProviderManager.php
@@ -34,20 +34,15 @@ use Psr\Log\LoggerInterface;
 
 class ProviderManager implements IProviderManager {
 	/** @var string[] */
-	protected $providers = [];
+	protected array $providers = [];
 
 	/** @var IProvider[] */
-	protected $providerInstances = [];
+	protected array $providerInstances = [];
 
-	/** @var IServerContainer */
-	protected $serverContainer;
-
-	/** @var LoggerInterface */
-	protected $logger;
-
-	public function __construct(IServerContainer $serverContainer, LoggerInterface $logger) {
-		$this->serverContainer = $serverContainer;
-		$this->logger = $logger;
+	public function __construct(
+		protected IServerContainer $serverContainer,
+		protected LoggerInterface $logger,
+	) {
 	}
 
 	public function getResourceProviders(): array {

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -33,45 +33,19 @@ use OCP\IDBConnection;
 use OCP\IUser;
 
 class Resource implements IResource {
-	/** @var IManager */
-	protected $manager;
-
-	/** @var IDBConnection */
-	protected $connection;
-
-	/** @var string */
-	protected $type;
-
-	/** @var string */
-	protected $id;
-
-	/** @var IUser|null */
-	protected $userForAccess;
-
-	/** @var bool|null */
-	protected $access;
-
-	/** @var array|null */
-	protected $data;
+	protected ?array $data = null;
 
 	public function __construct(
-		IManager $manager,
-		IDBConnection $connection,
-		string $type,
-		string $id,
-		?IUser $userForAccess = null,
-		?bool $access = null
+		protected IManager $manager,
+		protected IDBConnection $connection,
+		protected string $type,
+		protected string $id,
+		protected ?IUser $userForAccess = null,
+		protected ?bool $access = null
 	) {
-		$this->manager = $manager;
-		$this->connection = $connection;
-		$this->type = $type;
-		$this->id = $id;
-		$this->userForAccess = $userForAccess;
-		$this->access = $access;
 	}
 
 	/**
-	 * @return string
 	 * @since 16.0.0
 	 */
 	public function getType(): string {
@@ -79,7 +53,6 @@ class Resource implements IResource {
 	}
 
 	/**
-	 * @return string
 	 * @since 16.0.0
 	 */
 	public function getId(): string {
@@ -87,7 +60,6 @@ class Resource implements IResource {
 	}
 
 	/**
-	 * @return array
 	 * @since 16.0.0
 	 */
 	public function getRichObject(): array {
@@ -101,8 +73,6 @@ class Resource implements IResource {
 	/**
 	 * Can a user/guest access the resource
 	 *
-	 * @param IUser|null $user
-	 * @return bool
 	 * @since 16.0.0
 	 */
 	public function canAccess(?IUser $user): bool {


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor+Uses+PHP8%27s+constructor+property+promotion) in `/core/` namespace, I have also made the required adjustments to the classes in `/lib/private/Collaboration` namespace.

I figured I should split the changes into two PRs to make reviewing the changes easier.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Removing redundant docblocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
