### PR TITLE
psalm: Disable cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/stubs/*' -print0 | xargs -0 -n1 php -l",
-		"psalm": "psalm --threads=$(nproc)",
-		"psalm:ci": "psalm --threads=1",
-		"psalm:update-baseline": "psalm --threads=$(nproc) --update-baseline"
+		"psalm": "psalm --no-cache --threads=$(nproc)",
+		"psalm:ci": "psalm --no-cache --threads=1",
+		"psalm:update-baseline": "psalm --no-cache --threads=$(nproc) --update-baseline"
 	}
 }


### PR DESCRIPTION
## Summary

Psalm doesn't work at all when you have the cache enabled. I always have to disable the cache manually and this makes it the default.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
