### PR TITLE
Rewrite OCS CSRF check to be readable

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -206,7 +206,7 @@ class SecurityMiddleware extends Middleware {
 		}
 		// CSRF check - also registers the CSRF token since the session may be closed later
 		Util::callRegister();
-		if (!$this->hasAnnotationOrAttribute($reflectionMethod, 'NoCSRFRequired', NoCSRFRequired::class)) {
+		if ($this->isInvalidCSRFRequired($reflectionMethod)) {
 			/*
 			 * Only allow the CSRF check to fail on OCS Requests. This kind of
 			 * hacks around that we have no full token auth in place yet and we
@@ -215,12 +215,7 @@ class SecurityMiddleware extends Middleware {
 			 * Additionally we allow Bearer authenticated requests to pass on OCS routes.
 			 * This allows oauth apps (e.g. moodle) to use the OCS endpoints
 			 */
-			if (!$this->request->passesCSRFCheck() && !(
-				$controller instanceof OCSController && (
-					$this->request->getHeader('OCS-APIREQUEST') === 'true' ||
-					str_starts_with($this->request->getHeader('Authorization'), 'Bearer ')
-				)
-			)) {
+			if (!$controller instanceof OCSController || !$this->isValidOCSRequest()) {
 				throw new CrossSiteRequestForgeryException();
 			}
 		}
@@ -240,6 +235,19 @@ class SecurityMiddleware extends Middleware {
 		if ($appPath !== false && !$isPublicPage && !$this->appManager->isEnabledForUser($this->appName)) {
 			throw new AppNotEnabledException();
 		}
+	}
+
+	private function isInvalidCSRFRequired(ReflectionMethod $reflectionMethod): bool {
+		if ($this->hasAnnotationOrAttribute($reflectionMethod, 'NoCSRFRequired', NoCSRFRequired::class)) {
+			return false;
+		}
+
+		return !$this->request->passesCSRFCheck();
+	}
+
+	private function isValidOCSRequest(): bool {
+		return $this->request->getHeader('OCS-APIREQUEST') === 'true'
+			|| str_starts_with($this->request->getHeader('Authorization'), 'Bearer ');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Previous code was unreadable and every time I come across it I had to read it multiple times to understand what it does. Should be much clearer now (at least it is to me).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
