### PR TITLE
Replaces hard-coded text with translatable keys

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -184,16 +184,16 @@ OCA.Files_External.StatusManager = {
 						// personal mount whit credentials problems
 						this.showCredentialsDialog(name, mountData);
 					} else if (mountData.canEdit) {
-						OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in admin settings page?', t('files_external', 'External mount error'), function (e) {
+						OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. ' + t('files_external', 'Do you want to review mount point config in admin settings page?'), t('files_external', 'External mount error'), function (e) {
 							if (e === true) {
 								OC.redirect(OC.generateUrl('/settings/admin/externalstorages'));
 							}
 						});
 					} else {
-						OC.dialogs.info(t('files_external', 'There was an error with message: ') + mountData.error + '. Please contact your system administrator.', t('files_external', 'External mount error'), () => {});
+						OC.dialogs.info(t('files_external', 'There was an error with message: ') + mountData.error + '. ' + t('files_external', 'Please contact your system administrator.'), t('files_external', 'External mount error'), () => {});
 					}
 				} else {
-					OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in personal settings page?', t('files_external', 'External mount error'), function (e) {
+					OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. ' + t('files_external', 'Do you want to review mount point config in personal settings page?'), t('files_external', 'External mount error'), function (e) {
 						if (e === true) {
 							OC.redirect(OC.generateUrl('/settings/personal#' + t('files_external', 'external-storage')));
 						}


### PR DESCRIPTION
## Summary
When attempting to access an external storage that is broken (for example, when creating any arbitrary external storage which cannot work due to faulty settings), the text is partially translated.

In the screenshot below, I have configured the app to use the "de" locale.
![Partially translated text](https://github.com/nextcloud/server/assets/4992968/efc49fc9-41e2-46b8-a07f-a0d1187a9c78)

In this PR, I have changed the hard-coded text with the translatable keys. However, I'm not quite familiar with the process of adding a new translation key to the translation files. Is this something that the bots take care of? Please let me know if any further steps need to be taken in this regard.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Screenshots before/after for front-end changes
