### PR TITLE
fix(ldap): avatar is not being fetched

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -695,9 +695,9 @@ class User {
 
 	/**
 	 * @brief attempts to get an image from LDAP and sets it as Nextcloud avatar
-	 * @return bool
+	 * @return bool true when the avatar was set successfully or is up to date
 	 */
-	public function updateAvatar($force = false) {
+	public function updateAvatar(bool $force = false): bool {
 		if (!$force && $this->wasRefreshed('avatar')) {
 			return false;
 		}

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -714,7 +714,7 @@ class User {
 		// use the checksum before modifications
 		$checksum = md5($this->image->data());
 
-		if ($checksum === $this->config->getUserValue($this->uid, 'user_ldap', 'lastAvatarChecksum', '')) {
+		if ($checksum === $this->config->getUserValue($this->uid, 'user_ldap', 'lastAvatarChecksum', '') && $this->avatarExists()) {
 			return true;
 		}
 
@@ -726,6 +726,15 @@ class User {
 		}
 
 		return $isSet;
+	}
+
+	private function avatarExists(): bool {
+		try {
+			$currentAvatar = $this->avatarManager->getAvatar($this->uid);
+			return $currentAvatar->exists() && $currentAvatar->isCustomAvatar();
+		} catch (\Exception $e) {
+			return false;
+		}
 	}
 
 	/**

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -585,9 +585,17 @@ class UserTest extends \Test\TestCase {
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->expects($this->never())
 			->method('set');
+		$avatar->expects($this->any())
+			->method('exists')
+			->willReturn(true);
+		$avatar->expects($this->any())
+			->method('isCustomAvatar')
+			->willReturn(true);
 
-		$this->avatarManager->expects($this->never())
-			->method('getAvatar');
+		$this->avatarManager->expects($this->any())
+			->method('getAvatar')
+			->with($this->uid)
+			->willReturn($avatar);
 
 		$this->connection->expects($this->any())
 			->method('resolveRule')


### PR DESCRIPTION
* Resolves: #35319

## Summary

Before leaving early, double check whether the avatar is actually present.

This is a quick attempt based on this observation https://github.com/nextcloud/server/issues/35319#issuecomment-1605670739, ~~but I have not tested it yet.~~

Tested now and working.

## TODO

- [x] Testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
