### PR TITLE
Refactors files_external app commands

### DIFF
--- a/apps/files_external/lib/Command/Backends.php
+++ b/apps/files_external/lib/Command/Backends.php
@@ -33,13 +33,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Backends extends Base {
-	private BackendService $backendService;
-
-	public function __construct(BackendService $backendService
+	public function __construct(
+		private BackendService $backendService,
 	) {
 		parent::__construct();
-
-		$this->backendService = $backendService;
 	}
 
 	protected function configure(): void {
@@ -72,24 +69,24 @@ class Backends extends Base {
 		if ($type) {
 			if (!isset($data[$type])) {
 				$output->writeln('<error>Invalid type "' . $type . '". Possible values are "authentication" or "storage"</error>');
-				return 1;
+				return self::FAILURE;
 			}
 			$data = $data[$type];
 
 			if ($backend) {
 				if (!isset($data[$backend])) {
 					$output->writeln('<error>Unknown backend "' . $backend . '" of type  "' . $type . '"</error>');
-					return 1;
+					return self::FAILURE;
 				}
 				$data = $data[$backend];
 			}
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $data);
-		return 0;
+		return self::SUCCESS;
 	}
 
-	private function serializeAuthBackend(\JsonSerializable $backend) {
+	private function serializeAuthBackend(\JsonSerializable $backend): array {
 		$data = $backend->jsonSerialize();
 		$result = [
 			'name' => $data['name'],
@@ -112,7 +109,7 @@ class Backends extends Base {
 	 * @param DefinitionParameter[] $parameters
 	 * @return string[]
 	 */
-	private function formatConfiguration(array $parameters) {
+	private function formatConfiguration(array $parameters): array {
 		$configuration = array_filter($parameters, function (DefinitionParameter $parameter) {
 			return $parameter->getType() !== DefinitionParameter::VALUE_HIDDEN;
 		});

--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -31,13 +31,13 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class Config extends Base {
-	protected GlobalStoragesService $globalService;
-
-	public function __construct(GlobalStoragesService $globalService) {
+	public function __construct(
+		protected GlobalStoragesService $globalService,
+	) {
 		parent::__construct();
-		$this->globalService = $globalService;
 	}
 
 	protected function configure(): void {
@@ -67,7 +67,7 @@ class Config extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return 404;
+			return Response::HTTP_NOT_FOUND;
 		}
 
 		$value = $input->getArgument('value');
@@ -76,15 +76,13 @@ class Config extends Base {
 		} else {
 			$this->getOption($mount, $key, $output);
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
 	/**
-	 * @param StorageConfig $mount
 	 * @param string $key
-	 * @param OutputInterface $output
 	 */
-	protected function getOption(StorageConfig $mount, $key, OutputInterface $output) {
+	protected function getOption(StorageConfig $mount, $key, OutputInterface $output): void {
 		if ($key === 'mountpoint' || $key === 'mount_point') {
 			$value = $mount->getMountPoint();
 		} else {
@@ -97,12 +95,10 @@ class Config extends Base {
 	}
 
 	/**
-	 * @param StorageConfig $mount
 	 * @param string $key
 	 * @param string $value
-	 * @param OutputInterface $output
 	 */
-	protected function setOption(StorageConfig $mount, $key, $value, OutputInterface $output) {
+	protected function setOption(StorageConfig $mount, $key, $value, OutputInterface $output): void {
 		$decoded = json_decode($value, true);
 		if (!is_null($decoded) && json_encode($decoded) === $value) {
 			$value = $decoded;

--- a/apps/files_external/lib/Command/Delete.php
+++ b/apps/files_external/lib/Command/Delete.php
@@ -35,19 +35,16 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\HttpFoundation\Response;
 
 class Delete extends Base {
-	protected GlobalStoragesService $globalService;
-	protected UserStoragesService $userService;
-	protected IUserSession $userSession;
-	protected IUserManager $userManager;
-
-	public function __construct(GlobalStoragesService $globalService, UserStoragesService $userService, IUserSession $userSession, IUserManager $userManager) {
+	public function __construct(
+		protected GlobalStoragesService $globalService,
+		protected UserStoragesService $userService,
+		protected IUserSession $userSession,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
-		$this->globalService = $globalService;
-		$this->userService = $userService;
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure(): void {
@@ -73,7 +70,7 @@ class Delete extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return 404;
+			return Response::HTTP_NOT_FOUND;
 		}
 
 		$noConfirm = $input->getOption('yes');
@@ -88,11 +85,11 @@ class Delete extends Base {
 			$question = new ConfirmationQuestion('Delete this mount? [y/N] ', false);
 
 			if (!$questionHelper->ask($input, $output, $question)) {
-				return 1;
+				return self::FAILURE;
 			}
 		}
 
 		$this->globalService->removeStorage($mountId);
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/files_external/lib/Command/Export.php
+++ b/apps/files_external/lib/Command/Export.php
@@ -54,6 +54,6 @@ class Export extends ListCommand {
 		$listInput->setOption('show-password', true);
 		$listInput->setOption('full', true);
 		$listCommand->execute($listInput, $output);
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -181,7 +181,7 @@ class Import extends Base {
 		}
 	}
 
-	protected function getStorageService($userId): StoragesService {
+	protected function getStorageService(string $userId): StoragesService {
 		if (empty($userId)) {
 			return $this->globalService;
 		}

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -30,6 +30,7 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\ImportLegacyStoragesService;
+use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -40,27 +41,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Import extends Base {
-	private GlobalStoragesService $globalService;
-	private UserStoragesService $userService;
-	private IUserSession $userSession;
-	private IUserManager $userManager;
-	private ImportLegacyStoragesService $importLegacyStorageService;
-	private BackendService $backendService;
-
-	public function __construct(GlobalStoragesService $globalService,
-						 UserStoragesService $userService,
-						 IUserSession $userSession,
-						 IUserManager $userManager,
-						 ImportLegacyStoragesService $importLegacyStorageService,
-						 BackendService $backendService
+	public function __construct(
+		private GlobalStoragesService $globalService,
+		private UserStoragesService $userService,
+		private IUserSession $userSession,
+		private IUserManager $userManager,
+		private ImportLegacyStoragesService $importLegacyStorageService,
+		private BackendService $backendService,
 	) {
 		parent::__construct();
-		$this->globalService = $globalService;
-		$this->userService = $userService;
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
-		$this->importLegacyStorageService = $importLegacyStorageService;
-		$this->backendService = $backendService;
 	}
 
 	protected function configure(): void {
@@ -95,18 +84,18 @@ class Import extends Base {
 		} else {
 			if (!file_exists($path)) {
 				$output->writeln('<error>File not found: ' . $path . '</error>');
-				return 1;
+				return self::FAILURE;
 			}
 			$json = file_get_contents($path);
 		}
 		if (!is_string($json) || strlen($json) < 2) {
 			$output->writeln('<error>Error while reading json</error>');
-			return 1;
+			return self::FAILURE;
 		}
 		$data = json_decode($json, true);
 		if (!is_array($data)) {
 			$output->writeln('<error>Error while parsing json</error>');
-			return 1;
+			return self::FAILURE;
 		}
 
 		$isLegacy = isset($data['user']) || isset($data['group']);
@@ -116,7 +105,7 @@ class Import extends Base {
 			foreach ($mounts as $mount) {
 				if ($mount->getBackendOption('password') === false) {
 					$output->writeln('<error>Failed to decrypt password</error>');
-					return 1;
+					return self::FAILURE;
 				}
 			}
 		} else {
@@ -147,7 +136,7 @@ class Import extends Base {
 					$existingMount->getBackendOptions() === $mount->getBackendOptions()
 				) {
 					$output->writeln("<error>Duplicate mount (" . $mount->getMountPoint() . ")</error>");
-					return 1;
+					return self::FAILURE;
 				}
 			}
 		}
@@ -155,7 +144,7 @@ class Import extends Base {
 		if ($input->getOption('dry')) {
 			if (count($mounts) === 0) {
 				$output->writeln('<error>No mounts to be imported</error>');
-				return 1;
+				return self::FAILURE;
 			}
 			$listCommand = new ListCommand($this->globalService, $this->userService, $this->userSession, $this->userManager);
 			$listInput = new ArrayInput([], $listCommand->getDefinition());
@@ -167,7 +156,7 @@ class Import extends Base {
 				$storageService->addStorage($mount);
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
 	private function parseData(array $data): StorageConfig {
@@ -178,8 +167,8 @@ class Import extends Base {
 		$mount->setAuthMechanism($authBackend);
 		$mount->setBackendOptions($data['configuration']);
 		$mount->setMountOptions($data['options']);
-		$mount->setApplicableUsers(isset($data['applicable_users']) ? $data['applicable_users'] : []);
-		$mount->setApplicableGroups(isset($data['applicable_groups']) ? $data['applicable_groups'] : []);
+		$mount->setApplicableUsers($data['applicable_users'] ?? []);
+		$mount->setApplicableGroups($data['applicable_groups'] ?? []);
 		return $mount;
 	}
 
@@ -192,16 +181,16 @@ class Import extends Base {
 		}
 	}
 
-	protected function getStorageService($userId) {
-		if (!empty($userId)) {
-			$user = $this->userManager->get($userId);
-			if (is_null($user)) {
-				throw new NoUserException("user $userId not found");
-			}
-			$this->userSession->setUser($user);
-			return $this->userService;
-		} else {
+	protected function getStorageService($userId): StoragesService {
+		if (empty($userId)) {
 			return $this->globalService;
 		}
+
+		$user = $this->userManager->get($userId);
+		if (is_null($user)) {
+			throw new NoUserException("user $userId not found");
+		}
+		$this->userSession->setUser($user);
+		return $this->userService;
 	}
 }

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -242,7 +242,7 @@ class ListCommand extends Base {
 		}
 	}
 
-	protected function getStorageService($userId): StoragesService {
+	protected function getStorageService(string $userId): StoragesService {
 		if (empty($userId)) {
 			return $this->globalService;
 		}

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -29,6 +29,7 @@ use OC\Core\Command\Base;
 use OC\User\NoUserException;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\GlobalStoragesService;
+use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -39,19 +40,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
-	protected GlobalStoragesService $globalService;
-	protected UserStoragesService $userService;
-	protected IUserSession $userSession;
-	protected IUserManager $userManager;
-
 	public const ALL = -1;
 
-	public function __construct(GlobalStoragesService $globalService, UserStoragesService $userService, IUserSession $userSession, IUserManager $userManager) {
+	public function __construct(
+		protected GlobalStoragesService $globalService,
+		protected UserStoragesService $userService,
+		protected IUserSession $userSession,
+		protected IUserManager $userManager,
+	) {
 		parent::__construct();
-		$this->globalService = $globalService;
-		$this->userService = $userService;
-		$this->userSession = $userSession;
-		$this->userManager = $userManager;
 	}
 
 	protected function configure(): void {
@@ -93,7 +90,7 @@ class ListCommand extends Base {
 		}
 
 		$this->listMounts($userId, $mounts, $input, $output);
-		return 0;
+		return self::SUCCESS;
 	}
 
 	/**
@@ -245,16 +242,16 @@ class ListCommand extends Base {
 		}
 	}
 
-	protected function getStorageService($userId) {
-		if (!empty($userId)) {
-			$user = $this->userManager->get($userId);
-			if (is_null($user)) {
-				throw new NoUserException("user $userId not found");
-			}
-			$this->userSession->setUser($user);
-			return $this->userService;
-		} else {
+	protected function getStorageService($userId): StoragesService {
+		if (empty($userId)) {
 			return $this->globalService;
 		}
+
+		$user = $this->userManager->get($userId);
+		if (is_null($user)) {
+			throw new NoUserException("user $userId not found");
+		}
+		$this->userSession->setUser($user);
+		return $this->userService;
 	}
 }

--- a/apps/files_external/lib/Command/Option.php
+++ b/apps/files_external/lib/Command/Option.php
@@ -47,11 +47,9 @@ class Option extends Config {
 	}
 
 	/**
-	 * @param StorageConfig $mount
 	 * @param string $key
-	 * @param OutputInterface $output
 	 */
-	protected function getOption(StorageConfig $mount, $key, OutputInterface $output) {
+	protected function getOption(StorageConfig $mount, $key, OutputInterface $output): void {
 		$value = $mount->getMountOption($key);
 		if (!is_string($value)) { // show bools and objects correctly
 			$value = json_encode($value);
@@ -60,12 +58,10 @@ class Option extends Config {
 	}
 
 	/**
-	 * @param StorageConfig $mount
 	 * @param string $key
 	 * @param string $value
-	 * @param OutputInterface $output
 	 */
-	protected function setOption(StorageConfig $mount, $key, $value, OutputInterface $output) {
+	protected function setOption(StorageConfig $mount, $key, $value, OutputInterface $output): void {
 		$decoded = json_decode($value, true);
 		if (!is_null($decoded)) {
 			$value = $decoded;


### PR DESCRIPTION
## Summary
I have made some adjustments to the `apps/files_external/lib/Command` classes to improve code readability.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Replacing return code integers with more readable strings.
- Using early returns

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
