### PR TITLE
Migrate federated file sharing to PSR LoggerInterface

### DIFF
--- a/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
+++ b/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
@@ -30,7 +30,6 @@ use OCA\FederatedFileSharing\Notifications;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\Job;
-use OCP\ILogger;
 
 /**
  * Class RetryJob

--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -41,12 +41,12 @@ use OCP\Federation\ICloudIdManager;
 use OCP\HintException;
 use OCP\Http\Client\IClientService;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class MountPublicLinkController
@@ -56,66 +56,23 @@ use OCP\Share\IShare;
  * @package OCA\FederatedFileSharing\Controller
  */
 class MountPublicLinkController extends Controller {
-
-	/** @var FederatedShareProvider */
-	private $federatedShareProvider;
-
-	/** @var AddressHandler */
-	private $addressHandler;
-
-	/** @var IManager  */
-	private $shareManager;
-
-	/** @var  ISession */
-	private $session;
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var IUserSession */
-	private $userSession;
-
-	/** @var IClientService */
-	private $clientService;
-
-	/** @var ICloudIdManager  */
-	private $cloudIdManager;
-
 	/**
 	 * MountPublicLinkController constructor.
-	 *
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param FederatedShareProvider $federatedShareProvider
-	 * @param IManager $shareManager
-	 * @param AddressHandler $addressHandler
-	 * @param ISession $session
-	 * @param IL10N $l
-	 * @param IUserSession $userSession
-	 * @param IClientService $clientService
-	 * @param ICloudIdManager $cloudIdManager
 	 */
-	public function __construct($appName,
-								IRequest $request,
-								FederatedShareProvider $federatedShareProvider,
-								IManager $shareManager,
-								AddressHandler $addressHandler,
-								ISession $session,
-								IL10N $l,
-								IUserSession $userSession,
-								IClientService $clientService,
-								ICloudIdManager $cloudIdManager
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private FederatedShareProvider $federatedShareProvider,
+		private IManager $shareManager,
+		private AddressHandler $addressHandler,
+		private ISession $session,
+		private IL10N $l,
+		private IUserSession $userSession,
+		private IClientService $clientService,
+		private ICloudIdManager $cloudIdManager,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
-
-		$this->federatedShareProvider = $federatedShareProvider;
-		$this->shareManager = $shareManager;
-		$this->addressHandler = $addressHandler;
-		$this->session = $session;
-		$this->l = $l;
-		$this->userSession = $userSession;
-		$this->clientService = $clientService;
-		$this->cloudIdManager = $cloudIdManager;
 	}
 
 	/**
@@ -175,9 +132,9 @@ class MountPublicLinkController extends Controller {
 		try {
 			$this->federatedShareProvider->create($share);
 		} catch (\Exception $e) {
-			\OC::$server->getLogger()->logException($e, [
-				'level' => ILogger::WARN,
+			$this->logger->warning($e->getMessage(), [
 				'app' => 'federatedfilesharing',
+				'exception' => $e,
 			]);
 			return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -34,54 +34,22 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Http\Client\IClientService;
-use OCP\ILogger;
 use OCP\OCS\IDiscoveryService;
+use Psr\Log\LoggerInterface;
 
 class Notifications {
 	public const RESPONSE_FORMAT = 'json'; // default response format for ocs calls
 
-	/** @var AddressHandler */
-	private $addressHandler;
-
-	/** @var IClientService */
-	private $httpClientService;
-
-	/** @var IDiscoveryService */
-	private $discoveryService;
-
-	/** @var IJobList  */
-	private $jobList;
-
-	/** @var ICloudFederationProviderManager */
-	private $federationProviderManager;
-
-	/** @var ICloudFederationFactory */
-	private $cloudFederationFactory;
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
-
-	/** @var ILogger */
-	private $logger;
-
 	public function __construct(
-		AddressHandler $addressHandler,
-		IClientService $httpClientService,
-		IDiscoveryService $discoveryService,
-		ILogger $logger,
-		IJobList $jobList,
-		ICloudFederationProviderManager $federationProviderManager,
-		ICloudFederationFactory $cloudFederationFactory,
-		IEventDispatcher $eventDispatcher
+		private AddressHandler $addressHandler,
+		private IClientService $httpClientService,
+		private IDiscoveryService $discoveryService,
+		private IJobList $jobList,
+		private ICloudFederationProviderManager $federationProviderManager,
+		private ICloudFederationFactory $cloudFederationFactory,
+		private IEventDispatcher $eventDispatcher,
+		private LoggerInterface $logger,
 	) {
-		$this->addressHandler = $addressHandler;
-		$this->httpClientService = $httpClientService;
-		$this->discoveryService = $discoveryService;
-		$this->jobList = $jobList;
-		$this->logger = $logger;
-		$this->federationProviderManager = $federationProviderManager;
-		$this->cloudFederationFactory = $cloudFederationFactory;
-		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -48,48 +48,50 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class MountPublicLinkControllerTest extends \Test\TestCase {
-	/** @var IContactsManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IContactsManager|MockObject */
 	protected $contactsManager;
 
-	/** @var  MountPublicLinkController */
+	/** @var MountPublicLinkController */
 	private $controller;
 
-	/** @var  \OCP\IRequest | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var  FederatedShareProvider | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var FederatedShareProvider|MockObject */
 	private $federatedShareProvider;
 
-	/** @var  IManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IManager|MockObject */
 	private $shareManager;
 
-	/** @var  AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var AddressHandler|MockObject */
 	private $addressHandler;
 
-	/** @var  IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IRootFolder|MockObject */
 	private $rootFolder;
 
-	/** @var  IUserManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserManager|MockObject */
 	private $userManager;
 
-	/** @var  ISession | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var ISession|MockObject */
 	private $session;
 
-	/** @var  IL10N | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IL10N|MockObject */
 	private $l10n;
 
-	/** @var  IUserSession | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserSession|MockObject */
 	private $userSession;
 
-	/** @var  IClientService | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IClientService|MockObject */
 	private $clientService;
 
-	/** @var  IShare */
+	/** @var IShare */
 	private $share;
 
-	/** @var  ICloudIdManager */
+	/** @var ICloudIdManager */
 	private $cloudIdManager;
 
 	protected function setUp(): void {
@@ -126,7 +128,8 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 			$this->l10n,
 			$this->userSession,
 			$this->clientService,
-			$this->cloudIdManager
+			$this->cloudIdManager,
+			$this->createMock(LoggerInterface::class),
 		);
 	}
 

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -47,12 +47,12 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class FederatedShareProviderTest
@@ -61,39 +61,38 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @group DB
  */
 class FederatedShareProviderTest extends \Test\TestCase {
-
 	/** @var IDBConnection */
 	protected $connection;
-	/** @var AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var AddressHandler|MockObject */
 	protected $addressHandler;
-	/** @var Notifications | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var Notifications|MockObject */
 	protected $notifications;
-	/** @var TokenHandler|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var TokenHandler|MockObject */
 	protected $tokenHandler;
 	/** @var IL10N */
 	protected $l;
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	protected $logger;
-	/** @var IRootFolder | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IRootFolder|MockObject */
 	protected $rootFolder;
-	/** @var  IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var  IConfig|MockObject */
 	protected $config;
-	/** @var  IUserManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var  IUserManager|MockObject */
 	protected $userManager;
-	/** @var  \OCP\GlobalScale\IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var  \OCP\GlobalScale\IConfig|MockObject */
 	protected $gsConfig;
 
 	/** @var IManager */
 	protected $shareManager;
 	/** @var FederatedShareProvider */
 	protected $provider;
-	/** @var IContactsManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IContactsManager|MockObject */
 	protected $contactsManager;
 
 	/** @var  ICloudIdManager */
 	private $cloudIdManager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject|ICloudFederationProviderManager */
+	/** @var MockObject|ICloudFederationProviderManager */
 	private $cloudFederationProviderManager;
 
 	protected function setUp(): void {
@@ -111,7 +110,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->willReturnCallback(function ($text, $parameters = []) {
 				return vsprintf($text, $parameters);
 			});
-		$this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
@@ -137,13 +136,13 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			$this->notifications,
 			$this->tokenHandler,
 			$this->l,
-			$this->logger,
 			$this->rootFolder,
 			$this->config,
 			$this->userManager,
 			$this->cloudIdManager,
 			$this->gsConfig,
-			$this->cloudFederationProviderManager
+			$this->cloudFederationProviderManager,
+			$this->logger,
 		);
 
 		$this->shareManager = \OC::$server->getShareManager();
@@ -476,13 +475,13 @@ class FederatedShareProviderTest extends \Test\TestCase {
 					$this->notifications,
 					$this->tokenHandler,
 					$this->l,
-					$this->logger,
 					$this->rootFolder,
 					$this->config,
 					$this->userManager,
 					$this->cloudIdManager,
 					$this->gsConfig,
-					$this->cloudFederationProviderManager
+					$this->cloudFederationProviderManager,
+					$this->logger,
 				]
 			)->setMethods(['sendPermissionUpdate'])->getMock();
 

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -32,33 +32,33 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Http\Client\IClientService;
-use OCP\ILogger;
 use OCP\OCS\IDiscoveryService;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class NotificationsTest extends \Test\TestCase {
-
-	/** @var  AddressHandler | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var AddressHandler|MockObject */
 	private $addressHandler;
 
-	/** @var  IClientService | \PHPUnit\Framework\MockObject\MockObject*/
+	/** @var IClientService|MockObject*/
 	private $httpClientService;
 
-	/** @var  IDiscoveryService | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IDiscoveryService|MockObject */
 	private $discoveryService;
 
-	/** @var  IJobList | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IJobList|MockObject */
 	private $jobList;
 
-	/** @var ICloudFederationProviderManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ICloudFederationProviderManager|MockObject */
 	private $cloudFederationProviderManager;
 
-	/** @var ICloudFederationFactory|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ICloudFederationFactory|MockObject */
 	private $cloudFederationFactory;
 
-	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IEventDispatcher|MockObject */
 	private $eventDispatcher;
 
-	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var LoggerInterface|MockObject */
 	private $logger;
 
 	protected function setUp(): void {
@@ -69,7 +69,7 @@ class NotificationsTest extends \Test\TestCase {
 		$this->httpClientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->getMock();
 		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
 			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
 		$this->cloudFederationFactory = $this->createMock(ICloudFederationFactory::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -87,11 +87,11 @@ class NotificationsTest extends \Test\TestCase {
 				$this->addressHandler,
 				$this->httpClientService,
 				$this->discoveryService,
-				$this->logger,
 				$this->jobList,
 				$this->cloudFederationProviderManager,
 				$this->cloudFederationFactory,
-				$this->eventDispatcher
+				$this->eventDispatcher,
+				$this->logger,
 			);
 		} else {
 			$instance = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
@@ -100,11 +100,11 @@ class NotificationsTest extends \Test\TestCase {
 						$this->addressHandler,
 						$this->httpClientService,
 						$this->discoveryService,
-						$this->logger,
 						$this->jobList,
 						$this->cloudFederationProviderManager,
 						$this->cloudFederationFactory,
-						$this->eventDispatcher
+						$this->eventDispatcher,
+						$this->logger,
 					]
 				)->setMethods($mockedMethods)->getMock();
 		}

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -139,11 +139,11 @@ class ProviderFactory implements IProviderFactory {
 				$addressHandler,
 				$this->serverContainer->getHTTPClientService(),
 				$this->serverContainer->query(\OCP\OCS\IDiscoveryService::class),
-				$this->serverContainer->getLogger(),
 				$this->serverContainer->getJobList(),
 				\OC::$server->getCloudFederationProviderManager(),
 				\OC::$server->getCloudFederationFactory(),
-				$this->serverContainer->query(IEventDispatcher::class)
+				$this->serverContainer->query(IEventDispatcher::class),
+				$this->serverContainer->get(LoggerInterface::class),
 			);
 			$tokenHandler = new TokenHandler(
 				$this->serverContainer->getSecureRandom()
@@ -155,13 +155,13 @@ class ProviderFactory implements IProviderFactory {
 				$notifications,
 				$tokenHandler,
 				$l,
-				$this->serverContainer->getLogger(),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getConfig(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getCloudIdManager(),
 				$this->serverContainer->getGlobalScaleConfig(),
-				$this->serverContainer->getCloudFederationProviderManager()
+				$this->serverContainer->getCloudFederationProviderManager(),
+				$this->serverContainer->get(LoggerInterface::class),
 			);
 		}
 


### PR DESCRIPTION
See  #32127 

## Summary
Remove `OCP\ILogger` from `apps/federatedfilesharing` and use Psr\Log\LoggerInterface` instead.
