### PR TITLE
Refactor lib/private/Remote

### DIFF
--- a/lib/private/Remote/Api/ApiBase.php
+++ b/lib/private/Remote/Api/ApiBase.php
@@ -73,25 +73,14 @@ class ApiBase {
 
 		$client = $this->getHttpClient();
 
-		switch ($method) {
-			case 'get':
-				$response = $client->get($fullUrl, $options);
-				break;
-			case 'post':
-				$response = $client->post($fullUrl, $options);
-				break;
-			case 'put':
-				$response = $client->put($fullUrl, $options);
-				break;
-			case 'delete':
-				$response = $client->delete($fullUrl, $options);
-				break;
-			case 'options':
-				$response = $client->options($fullUrl, $options);
-				break;
-			default:
-				throw new \InvalidArgumentException('Invalid method ' . $method);
-		}
+		$response = match ($method) {
+			'get' => $client->get($fullUrl, $options),
+			'post' => $client->post($fullUrl, $options),
+			'put' => $client->put($fullUrl, $options),
+			'delete' => $client->delete($fullUrl, $options),
+			'options' => $client->options($fullUrl, $options),
+			default => throw new \InvalidArgumentException('Invalid method ' . $method),
+		};
 
 		return $response->getBody();
 	}

--- a/lib/private/Remote/Api/ApiBase.php
+++ b/lib/private/Remote/Api/ApiBase.php
@@ -27,17 +27,11 @@ use OCP\Remote\ICredentials;
 use OCP\Remote\IInstance;
 
 class ApiBase {
-	/** @var IInstance */
-	private $instance;
-	/** @var ICredentials */
-	private $credentials;
-	/** @var IClientService */
-	private $clientService;
-
-	public function __construct(IInstance $instance, ICredentials $credentials, IClientService $clientService) {
-		$this->instance = $instance;
-		$this->credentials = $credentials;
-		$this->clientService = $clientService;
+	public function __construct(
+		private IInstance $instance,
+		private ICredentials $credentials,
+		private IClientService $clientService,
+	) {
 	}
 
 	protected function getHttpClient() {

--- a/lib/private/Remote/Api/ApiBase.php
+++ b/lib/private/Remote/Api/ApiBase.php
@@ -22,6 +22,7 @@
  */
 namespace OC\Remote\Api;
 
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Remote\ICredentials;
 use OCP\Remote\IInstance;
@@ -34,11 +35,11 @@ class ApiBase {
 	) {
 	}
 
-	protected function getHttpClient() {
+	protected function getHttpClient(): IClient {
 		return $this->clientService->newClient();
 	}
 
-	protected function addDefaultHeaders(array $headers) {
+	protected function addDefaultHeaders(array $headers): array {
 		return array_merge([
 			'OCS-APIREQUEST' => 'true',
 			'Accept' => 'application/json'
@@ -52,9 +53,9 @@ class ApiBase {
 	 * @param array $query
 	 * @param array $headers
 	 * @return resource|string
-	 * @throws \InvalidArgumentException
+	 * @throws \InvalidArgumentException|\Exception
 	 */
-	protected function request($method, $url, array $body = [], array $query = [], array $headers = []) {
+	protected function request(string $method, string $url, array $body = [], array $query = [], array $headers = []) {
 		$fullUrl = trim($this->instance->getFullUrl(), '/') . '/' . $url;
 		$options = [
 			'query' => $query,

--- a/lib/private/Remote/Api/ApiCollection.php
+++ b/lib/private/Remote/Api/ApiCollection.php
@@ -35,11 +35,11 @@ class ApiCollection implements IApiCollection {
 	) {
 	}
 
-	public function getCapabilitiesApi() {
+	public function getCapabilitiesApi(): OCS {
 		return new OCS($this->instance, $this->credentials, $this->clientService);
 	}
 
-	public function getUserApi() {
+	public function getUserApi(): OCS {
 		return new OCS($this->instance, $this->credentials, $this->clientService);
 	}
 }

--- a/lib/private/Remote/Api/ApiCollection.php
+++ b/lib/private/Remote/Api/ApiCollection.php
@@ -28,17 +28,11 @@ use OCP\Remote\ICredentials;
 use OCP\Remote\IInstance;
 
 class ApiCollection implements IApiCollection {
-	/** @var IInstance */
-	private $instance;
-	/** @var ICredentials */
-	private $credentials;
-	/** @var IClientService */
-	private $clientService;
-
-	public function __construct(IInstance $instance, ICredentials $credentials, IClientService $clientService) {
-		$this->instance = $instance;
-		$this->credentials = $credentials;
-		$this->clientService = $clientService;
+	public function __construct(
+		private IInstance $instance,
+		private ICredentials $credentials,
+		private IClientService $clientService,
+	) {
 	}
 
 	public function getCapabilitiesApi() {

--- a/lib/private/Remote/Api/ApiFactory.php
+++ b/lib/private/Remote/Api/ApiFactory.php
@@ -28,11 +28,9 @@ use OCP\Remote\ICredentials;
 use OCP\Remote\IInstance;
 
 class ApiFactory implements IApiFactory {
-	/** @var IClientService */
-	private $clientService;
-
-	public function __construct(IClientService $clientService) {
-		$this->clientService = $clientService;
+	public function __construct(
+		private IClientService $clientService,
+	) {
 	}
 
 	public function getApiCollection(IInstance $instance, ICredentials $credentials) {

--- a/lib/private/Remote/Api/ApiFactory.php
+++ b/lib/private/Remote/Api/ApiFactory.php
@@ -33,7 +33,7 @@ class ApiFactory implements IApiFactory {
 	) {
 	}
 
-	public function getApiCollection(IInstance $instance, ICredentials $credentials) {
+	public function getApiCollection(IInstance $instance, ICredentials $credentials): ApiCollection {
 		return new ApiCollection($instance, $credentials, $this->clientService);
 	}
 }

--- a/lib/private/Remote/Api/OCS.php
+++ b/lib/private/Remote/Api/OCS.php
@@ -43,7 +43,7 @@ class OCS extends ApiBase implements ICapabilitiesApi, IUserApi {
 	 * @throws NotFoundException
 	 * @throws \Exception
 	 */
-	protected function request($method, $url, array $body = [], array $query = [], array $headers = []) {
+	protected function request(string $method, string $url, array $body = [], array $query = [], array $headers = []): array {
 		try {
 			$response = json_decode(parent::request($method, 'ocs/v2.php/' . $url, $body, $query, $headers), true);
 		} catch (ClientException $e) {
@@ -77,7 +77,7 @@ class OCS extends ApiBase implements ICapabilitiesApi, IUserApi {
 	 * @param string[] $keys
 	 * @throws \Exception
 	 */
-	private function checkResponseArray(array $data, $type, array $keys) {
+	private function checkResponseArray(array $data, string $type, array $keys): void {
 		foreach ($keys as $key) {
 			if (!array_key_exists($key, $data)) {
 				throw new \Exception('Invalid ' . $type . ' response, expected field ' . $key . ' not found');
@@ -85,7 +85,12 @@ class OCS extends ApiBase implements ICapabilitiesApi, IUserApi {
 		}
 	}
 
-	public function getUser($userId) {
+	/**
+	 * @throws ForbiddenException
+	 * @throws NotFoundException
+	 * @throws \Exception
+	 */
+	public function getUser($userId): User {
 		$result = $this->request('get', 'cloud/users/' . $userId);
 		$this->checkResponseArray($result, 'user', User::EXPECTED_KEYS);
 		return new User($result);
@@ -93,8 +98,10 @@ class OCS extends ApiBase implements ICapabilitiesApi, IUserApi {
 
 	/**
 	 * @return array The capabilities in the form of [$appId => [$capability => $value]]
+	 * @throws ForbiddenException
+	 * @throws NotFoundException
 	 */
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		$result = $this->request('get', 'cloud/capabilities');
 		return $result['capabilities'];
 	}

--- a/lib/private/Remote/Credentials.php
+++ b/lib/private/Remote/Credentials.php
@@ -38,14 +38,14 @@ class Credentials implements ICredentials {
 	/**
 	 * @return string
 	 */
-	public function getUsername() {
+	public function getUsername(): string {
 		return $this->user;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getPassword() {
+	public function getPassword(): string {
 		return $this->password;
 	}
 }

--- a/lib/private/Remote/Credentials.php
+++ b/lib/private/Remote/Credentials.php
@@ -25,18 +25,14 @@ namespace OC\Remote;
 use OCP\Remote\ICredentials;
 
 class Credentials implements ICredentials {
-	/** @var string */
-	private $user;
-	/** @var string */
-	private $password;
-
 	/**
 	 * @param string $user
 	 * @param string $password
 	 */
-	public function __construct($user, $password) {
-		$this->user = $user;
-		$this->password = $password;
+	public function __construct(
+		private string $user,
+		private string $password,
+	) {
 	}
 
 	/**

--- a/lib/private/Remote/Credentials.php
+++ b/lib/private/Remote/Credentials.php
@@ -31,9 +31,6 @@ class Credentials implements ICredentials {
 	) {
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getUsername(): string {
 		return $this->user;
 	}

--- a/lib/private/Remote/Credentials.php
+++ b/lib/private/Remote/Credentials.php
@@ -25,10 +25,6 @@ namespace OC\Remote;
 use OCP\Remote\ICredentials;
 
 class Credentials implements ICredentials {
-	/**
-	 * @param string $user
-	 * @param string $password
-	 */
 	public function __construct(
 		private string $user,
 		private string $password,

--- a/lib/private/Remote/Credentials.php
+++ b/lib/private/Remote/Credentials.php
@@ -35,9 +35,6 @@ class Credentials implements ICredentials {
 		return $this->user;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPassword(): string {
 		return $this->password;
 	}

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -34,12 +34,6 @@ class Instance implements IInstance {
 	/** @var string */
 	private $url;
 
-	/** @var ICache */
-	private $cache;
-
-	/** @var IClientService */
-	private $clientService;
-
 	/** @var array|null */
 	private $status;
 
@@ -48,11 +42,13 @@ class Instance implements IInstance {
 	 * @param ICache $cache
 	 * @param IClientService $clientService
 	 */
-	public function __construct($url, ICache $cache, IClientService $clientService) {
+	public function __construct(
+		$url,
+		private ICache $cache,
+		private IClientService $clientService,
+	) {
 		$url = str_replace('https://', '', $url);
 		$this->url = str_replace('http://', '', $url);
-		$this->cache = $cache;
-		$this->clientService = $clientService;
 	}
 
 	/**

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -66,10 +66,10 @@ class Instance implements IInstance {
 	}
 
 	/**
-	 * @return string The full version string in '13.1.2.3' format
+	 * @return string|null The full version string in '13.1.2.3' format
 	 * @throws NotFoundException
 	 */
-	public function getVersion(): string {
+	public function getVersion(): ?string {
 		$status = $this->getStatus();
 		return $status['version'];
 	}

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -75,10 +75,10 @@ class Instance implements IInstance {
 	}
 
 	/**
-	 * @return string 'http' or 'https'
+	 * @return string|null 'http' or 'https'
 	 * @throws NotFoundException
 	 */
-	public function getProtocol(): string {
+	public function getProtocol(): ?string {
 		$status = $this->getStatus();
 		return $status['protocol'];
 	}

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -32,10 +32,10 @@ use OCP\Remote\IInstance;
  */
 class Instance implements IInstance {
 	/** @var string */
-	private $url;
+	private string $url;
 
 	/** @var array|null */
-	private $status;
+	private ?array $status;
 
 	/**
 	 * @param string $url
@@ -54,29 +54,31 @@ class Instance implements IInstance {
 	/**
 	 * @return string The url of the remote server without protocol
 	 */
-	public function getUrl() {
+	public function getUrl(): string {
 		return $this->url;
 	}
 
 	/**
 	 * @return string The of of the remote server with protocol
 	 */
-	public function getFullUrl() {
+	public function getFullUrl(): string {
 		return $this->getProtocol() . '://' . $this->getUrl();
 	}
 
 	/**
 	 * @return string The full version string in '13.1.2.3' format
+	 * @throws NotFoundException
 	 */
-	public function getVersion() {
+	public function getVersion(): string {
 		$status = $this->getStatus();
 		return $status['version'];
 	}
 
 	/**
 	 * @return string 'http' or 'https'
+	 * @throws NotFoundException
 	 */
-	public function getProtocol() {
+	public function getProtocol(): string {
 		$status = $this->getStatus();
 		return $status['protocol'];
 	}
@@ -85,8 +87,9 @@ class Instance implements IInstance {
 	 * Check that the remote server is installed and not in maintenance mode
 	 *
 	 * @return bool
+	 * @throws NotFoundException
 	 */
-	public function isActive() {
+	public function isActive(): bool {
 		$status = $this->getStatus();
 		return $status['installed'] && !$status['maintenance'];
 	}
@@ -96,7 +99,7 @@ class Instance implements IInstance {
 	 * @throws NotFoundException
 	 * @throws \Exception
 	 */
-	private function getStatus() {
+	private function getStatus(): ?array {
 		if ($this->status) {
 			return $this->status;
 		}
@@ -133,7 +136,7 @@ class Instance implements IInstance {
 	 * @param string $url
 	 * @return bool|string
 	 */
-	private function downloadStatus($url) {
+	private function downloadStatus(string $url): bool|string {
 		try {
 			$request = $this->clientService->newClient()->get($url);
 			return $request->getBody();

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -43,7 +43,7 @@ class Instance implements IInstance {
 	 * @param IClientService $clientService
 	 */
 	public function __construct(
-		$url,
+		string $url,
 		private ICache $cache,
 		private IClientService $clientService,
 	) {

--- a/lib/private/Remote/InstanceFactory.php
+++ b/lib/private/Remote/InstanceFactory.php
@@ -33,7 +33,7 @@ class InstanceFactory implements IInstanceFactory {
 	) {
 	}
 
-	public function getInstance($url) {
+	public function getInstance($url): Instance {
 		return new Instance($url, $this->cache, $this->clientService);
 	}
 }

--- a/lib/private/Remote/InstanceFactory.php
+++ b/lib/private/Remote/InstanceFactory.php
@@ -27,14 +27,10 @@ use OCP\ICache;
 use OCP\Remote\IInstanceFactory;
 
 class InstanceFactory implements IInstanceFactory {
-	/** @var ICache */
-	private $cache;
-	/** @var IClientService */
-	private $clientService;
-
-	public function __construct(ICache $cache, IClientService $clientService) {
-		$this->cache = $cache;
-		$this->clientService = $clientService;
+	public function __construct(
+		private ICache $cache,
+		private IClientService $clientService
+	) {
 	}
 
 	public function getInstance($url) {

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -38,11 +38,9 @@ class User implements IUser {
 		'quota'
 	];
 
-	/** @var array */
-	private $data;
-
-	public function __construct(array $data) {
-		$this->data = $data;
+	public function __construct(
+		private array $data,
+	) {
 	}
 
 

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -108,30 +108,30 @@ class User implements IUser {
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 */
-	public function getUsedSpace(): int {
+	public function getUsedSpace(): int|float {
 		return $this->data['quota']['used'];
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 */
-	public function getFreeSpace(): int {
+	public function getFreeSpace(): int|float {
 		return $this->data['quota']['free'];
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 */
-	public function getTotalSpace(): int {
+	public function getTotalSpace(): int|float {
 		return $this->data['quota']['total'];
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 */
-	public function getQuota(): int {
+	public function getQuota(): int|float {
 		return $this->data['quota']['quota'];
 	}
 }

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -48,9 +48,6 @@ class User implements IUser {
 		return $this->data['id'];
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getEmail(): string {
 		return $this->data['email'];
 	}

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -47,91 +47,91 @@ class User implements IUser {
 	/**
 	 * @return string
 	 */
-	public function getUserId() {
+	public function getUserId(): string {
 		return $this->data['id'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getEmail() {
+	public function getEmail(): string {
 		return $this->data['email'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDisplayName() {
+	public function getDisplayName(): string {
 		return $this->data['displayname'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getPhone() {
+	public function getPhone(): string {
 		return $this->data['phone'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getAddress() {
+	public function getAddress(): string {
 		return $this->data['address'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getWebsite() {
+	public function getWebsite(): string {
 		return $this->data['website'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getTwitter() {
+	public function getTwitter(): string {
 		return isset($this->data['twitter']) ? $this->data['twitter'] : '';
 	}
 
 	/**
 	 * @return string[]
 	 */
-	public function getGroups() {
+	public function getGroups(): array {
 		return $this->data['groups'];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getLanguage() {
+	public function getLanguage(): string {
 		return $this->data['language'];
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getUsedSpace() {
+	public function getUsedSpace(): int {
 		return $this->data['quota']['used'];
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getFreeSpace() {
+	public function getFreeSpace(): int {
 		return $this->data['quota']['free'];
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getTotalSpace() {
+	public function getTotalSpace(): int {
 		return $this->data['quota']['total'];
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getQuota() {
+	public function getQuota(): int {
 		return $this->data['quota']['quota'];
 	}
 }

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -44,9 +44,6 @@ class User implements IUser {
 	}
 
 
-	/**
-	 * @return string
-	 */
 	public function getUserId(): string {
 		return $this->data['id'];
 	}

--- a/lib/public/Remote/IInstance.php
+++ b/lib/public/Remote/IInstance.php
@@ -46,7 +46,7 @@ interface IInstance {
 	public function getFullUrl();
 
 	/**
-	 * @return string The full version string in '13.1.2.3' format
+	 * @return string|null The full version string in '13.1.2.3' format
 	 *
 	 * @since 13.0.0
 	 * @deprecated 23.0.0

--- a/lib/public/Remote/IUser.php
+++ b/lib/public/Remote/IUser.php
@@ -102,7 +102,7 @@ interface IUser {
 	public function getLanguage();
 
 	/**
-	 * @return int
+	 * @return int|float
 	 *
 	 * @since 13.0.0
 	 * @deprecated 23.0.0
@@ -110,7 +110,7 @@ interface IUser {
 	public function getUsedSpace();
 
 	/**
-	 * @return int
+	 * @return int|float
 	 *
 	 * @since 13.0.0
 	 * @deprecated 23.0.0
@@ -118,7 +118,7 @@ interface IUser {
 	public function getFreeSpace();
 
 	/**
-	 * @return int
+	 * @return int|float
 	 *
 	 * @since 13.0.0
 	 * @deprecated 23.0.0
@@ -126,7 +126,7 @@ interface IUser {
 	public function getTotalSpace();
 
 	/**
-	 * @return int
+	 * @return int|float
 	 *
 	 * @since 13.0.0
 	 * @deprecated 23.0.0


### PR DESCRIPTION
## Summary
The required adjustments have been made to the classes in `/lib/private/Remote ` namespace.

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding throws types
- Adding types to properties
- Using PHP8's `match` expression instead of `switch`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
