### PR TITLE
remove no longer accessible shares

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -146,9 +146,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 			/** @var Node|false $ownerNode */
 			$ownerNode = current($ownerNodes);
 			if (!$ownerNode) {
-				$this->storage = new FailedStorage(['exception' => new NotFoundException("File by id $sourceId not found")]);
-				$this->cache = new FailedCache();
-				$this->rootPath = '';
+				throw new NotFoundException("File by id $sourceId not found");
 			} else {
 				$this->nonMaskedStorage = $ownerNode->getStorage();
 				$this->sourcePath = $ownerNode->getPath();
@@ -163,6 +161,8 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 			$this->storage = new FailedStorage(['exception' => $e]);
 			$this->cache = new FailedCache();
 			$this->rootPath = '';
+			$this->logger->error("Share source no longer available, removing share", ['exception' => $e, 'app' => 'files_sharing']);
+			$this->unshareStorage();
 		} catch (NoUserException $e) {
 			// sharer user deleted, set FailedStorage
 			$this->storage = new FailedStorage(['exception' => $e]);


### PR DESCRIPTION
When trying to access a share where the owner no longer has access to the source file, remove the share instead of only marking it as failed.

To test:

- Setup user `A`, `B` and `C`. Create a groupfolder `G` and give `A` and `B` access to it.
- User `B` uploads a file `F` to `G` and shares it with `C`
- User `A` moves `F` outside `G`
- `C` tries to download the file

Downside is that the share is now gone "forever" even if the owner re-gains access to the file. So I'm not sure if this is actually desired behavior

- [ ] Do we actually want this?

An alternative solution would be to mark the share as unavailable *somehow*, show the state to the user and make the user choose whether to remove the share or complain to the admin/owner of the file to give him his access back.