### PR TITLE
refactor lib/private/OCS

### DIFF
--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -32,20 +32,18 @@ use OCP\IURLGenerator;
  * @package OC\OCS
  */
 class CoreCapabilities implements ICapability {
-	/** @var IConfig */
-	private $config;
-
 	/**
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		private IConfig $config,
+	) {
 	}
 
 	/**
 	 * Return this classes capabilities
 	 */
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		return [
 			'core' => [
 				'pollinterval' => $this->config->getSystemValue('pollinterval', 60),

--- a/lib/private/OCS/DiscoveryService.php
+++ b/lib/private/OCS/DiscoveryService.php
@@ -37,10 +37,10 @@ use OCP\OCS\IDiscoveryService;
 
 class DiscoveryService implements IDiscoveryService {
 	/** @var ICache */
-	private $cache;
+	private ICache $cache;
 
 	/** @var IClient */
-	private $client;
+	private IClient $client;
 
 	/**
 	 * @param ICacheFactory $cacheFactory

--- a/lib/private/OCS/Exception.php
+++ b/lib/private/OCS/Exception.php
@@ -23,15 +23,13 @@
 namespace OC\OCS;
 
 class Exception extends \Exception {
-	/** @var Result */
-	private $result;
-
-	public function __construct(Result $result) {
+	public function __construct(
+		private Result $result,
+	) {
 		parent::__construct();
-		$this->result = $result;
 	}
 
-	public function getResult() {
+	public function getResult(): Result {
 		return $this->result;
 	}
 }

--- a/lib/private/OCS/Provider.php
+++ b/lib/private/OCS/Provider.php
@@ -24,26 +24,27 @@
  */
 namespace OC\OCS;
 
-class Provider extends \OCP\AppFramework\Controller {
-	/** @var \OCP\App\IAppManager */
-	private $appManager;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
 
+class Provider extends Controller {
 	/**
 	 * @param string $appName
-	 * @param \OCP\IRequest $request
-	 * @param \OCP\App\IAppManager $appManager
+	 * @param IRequest $request
+	 * @param IAppManager $appManager
 	 */
 	public function __construct($appName,
 		\OCP\IRequest $request,
-		\OCP\App\IAppManager $appManager) {
+		private \OCP\App\IAppManager $appManager) {
 		parent::__construct($appName, $request);
-		$this->appManager = $appManager;
 	}
 
 	/**
-	 * @return \OCP\AppFramework\Http\JSONResponse
+	 * @return JSONResponse
 	 */
-	public function buildProviderList() {
+	public function buildProviderList(): JSONResponse {
 		$services = [
 			'PRIVATE_DATA' => [
 				'version' => 1,
@@ -108,7 +109,7 @@ class Provider extends \OCP\AppFramework\Controller {
 			];
 		}
 
-		return new \OCP\AppFramework\Http\JSONResponse([
+		return new JSONResponse([
 			'version' => 2,
 			'services' => $services,
 		]);

--- a/lib/private/OCS/Result.php
+++ b/lib/private/OCS/Result.php
@@ -31,14 +31,13 @@
 namespace OC\OCS;
 
 class Result {
-	/** @var array  */
-	protected $data;
+	protected array $data;
 
 	/** @var null|string */
-	protected $message;
+	protected ?string $message;
 
 	/** @var int */
-	protected $statusCode;
+	protected int $statusCode;
 
 	/** @var integer */
 	protected $items;
@@ -47,16 +46,17 @@ class Result {
 	protected $perPage;
 
 	/** @var array */
-	private $headers = [];
+	private array $headers = [];
 
 	/**
 	 * create the OCS_Result object
-	 * @param mixed $data the data to return
+	 *
+	 * @param mixed|null $data the data to return
 	 * @param int $code
-	 * @param null|string $message
+	 * @param string|null $message
 	 * @param array $headers
 	 */
-	public function __construct($data = null, $code = 100, $message = null, $headers = []) {
+	public function __construct(mixed $data = null, int $code = 100, string $message = null, array $headers = []) {
 		if ($data === null) {
 			$this->data = [];
 		} elseif (!is_array($data)) {
@@ -71,17 +71,19 @@ class Result {
 
 	/**
 	 * optionally set the total number of items available
+	 *
 	 * @param int $items
 	 */
-	public function setTotalItems($items) {
+	public function setTotalItems(int $items): void {
 		$this->items = $items;
 	}
 
 	/**
-	 * optionally set the the number of items per page
+	 * optionally set the number of items per page
+	 *
 	 * @param int $items
 	 */
-	public function setItemsPerPage($items) {
+	public function setItemsPerPage(int $items): void {
 		$this->perPage = $items;
 	}
 
@@ -89,7 +91,7 @@ class Result {
 	 * get the status code
 	 * @return int
 	 */
-	public function getStatusCode() {
+	public function getStatusCode(): int {
 		return $this->statusCode;
 	}
 
@@ -97,7 +99,7 @@ class Result {
 	 * get the meta data for the result
 	 * @return array
 	 */
-	public function getMeta() {
+	public function getMeta(): array {
 		$meta = [];
 		$meta['status'] = $this->succeeded() ? 'ok' : 'failure';
 		$meta['statuscode'] = $this->statusCode;
@@ -115,7 +117,7 @@ class Result {
 	 * get the result data
 	 * @return array
 	 */
-	public function getData() {
+	public function getData(): array {
 		return $this->data;
 	}
 
@@ -123,17 +125,18 @@ class Result {
 	 * return bool Whether the method succeeded
 	 * @return bool
 	 */
-	public function succeeded() {
+	public function succeeded(): bool {
 		return ($this->statusCode == 100);
 	}
 
 	/**
 	 * Adds a new header to the response
+	 *
 	 * @param string $name The name of the HTTP header
 	 * @param string $value The value, null will delete it
 	 * @return $this
 	 */
-	public function addHeader($name, $value) {
+	public function addHeader(string $name, ?string $value): static {
 		$name = trim($name);  // always remove leading and trailing whitespace
 		// to be able to reliably check for security
 		// headers
@@ -151,7 +154,7 @@ class Result {
 	 * Returns the set headers
 	 * @return array the headers
 	 */
-	public function getHeaders() {
+	public function getHeaders(): array {
 		return $this->headers;
 	}
 }


### PR DESCRIPTION
## Summary
The required adjustments have been made to the classes in `/lib/private/OCS ` namespace.

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Replacing qualifiers with imports

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
