### PR TITLE
refactor federatedfilesharing app controllers

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
+++ b/apps/federatedfilesharing/lib/Controller/MountPublicLinkController.php
@@ -57,30 +57,6 @@ use OCP\Share\IShare;
  */
 class MountPublicLinkController extends Controller {
 
-	/** @var FederatedShareProvider */
-	private $federatedShareProvider;
-
-	/** @var AddressHandler */
-	private $addressHandler;
-
-	/** @var IManager  */
-	private $shareManager;
-
-	/** @var  ISession */
-	private $session;
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var IUserSession */
-	private $userSession;
-
-	/** @var IClientService */
-	private $clientService;
-
-	/** @var ICloudIdManager  */
-	private $cloudIdManager;
-
 	/**
 	 * MountPublicLinkController constructor.
 	 *
@@ -95,27 +71,19 @@ class MountPublicLinkController extends Controller {
 	 * @param IClientService $clientService
 	 * @param ICloudIdManager $cloudIdManager
 	 */
-	public function __construct($appName,
-								IRequest $request,
-								FederatedShareProvider $federatedShareProvider,
-								IManager $shareManager,
-								AddressHandler $addressHandler,
-								ISession $session,
-								IL10N $l,
-								IUserSession $userSession,
-								IClientService $clientService,
-								ICloudIdManager $cloudIdManager
+	public function __construct(
+		$appName,
+		IRequest $request,
+		private FederatedShareProvider $federatedShareProvider,
+		private IManager $shareManager,
+		private AddressHandler $addressHandler,
+		private ISession $session,
+		private IL10N $l,
+		private IUserSession $userSession,
+		private IClientService $clientService,
+		private ICloudIdManager $cloudIdManager,
 	) {
 		parent::__construct($appName, $request);
-
-		$this->federatedShareProvider = $federatedShareProvider;
-		$this->shareManager = $shareManager;
-		$this->addressHandler = $addressHandler;
-		$this->session = $session;
-		$this->l = $l;
-		$this->userSession = $userSession;
-		$this->clientService = $clientService;
-		$this->cloudIdManager = $cloudIdManager;
 	}
 
 	/**
@@ -130,7 +98,7 @@ class MountPublicLinkController extends Controller {
 	 * @param string $password
 	 * @return JSONResponse
 	 */
-	public function createFederatedShare($shareWith, $token, $password = '') {
+	public function createFederatedShare(string $shareWith, string $token, string $password = ''): JSONResponse {
 		if (!$this->federatedShareProvider->isOutgoingServer2serverShareEnabled()) {
 			return new JSONResponse(
 				['message' => 'This server doesn\'t support outgoing federated shares'],
@@ -198,7 +166,7 @@ class MountPublicLinkController extends Controller {
 	 * @param string $name (only for legacy reasons, can be removed with legacyMountPublicLink())
 	 * @return JSONResponse
 	 */
-	public function askForFederatedShare($token, $remote, $password = '', $owner = '', $ownerDisplayName = '', $name = '') {
+	public function askForFederatedShare(string $token, string $remote, string $password = '', string $owner = '', string $ownerDisplayName = '', string $name = ''): JSONResponse {
 		// check if server admin allows to mount public links from other servers
 		if ($this->federatedShareProvider->isIncomingServer2serverShareEnabled() === false) {
 			return new JSONResponse(['message' => $this->l->t('Server to server sharing is not enabled on this server')], Http::STATUS_BAD_REQUEST);
@@ -236,7 +204,7 @@ class MountPublicLinkController extends Controller {
 			return new JSONResponse(['message' => $this->l->t('Federated Share request sent, you will receive an invitation. Check your notifications.')]);
 		}
 
-		// if we doesn't get the expected response we assume that we try to add
+		// if we don't get the expected response we assume that we try to add
 		// a federated share from a Nextcloud <= 9 server
 		$message = $this->l->t("Couldn't establish a federated share, it looks like the server to federate with is too old (Nextcloud <= 9).");
 		return new JSONResponse(['message' => $message], Http::STATUS_BAD_REQUEST);

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -290,7 +290,7 @@ class RequestHandlerController extends OCSController {
 		return new Http\DataResponse();
 	}
 
-	private function cleanupRemote($remote): string {
+	private function cleanupRemote(?string $remote = null): string {
 		$remote = substr($remote, strpos($remote, '://') + 3);
 
 		return rtrim($remote, '/');
@@ -374,7 +374,7 @@ class RequestHandlerController extends OCSController {
 	 * @param $ncPermissions
 	 * @return array
 	 */
-	protected function ncPermissions2ocmPermissions($ncPermissions): array {
+	protected function ncPermissions2ocmPermissions(?int $ncPermissions = null): array {
 		$ocmPermissions = [];
 
 		if ($ncPermissions & Constants::PERMISSION_SHARE) {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -371,7 +371,7 @@ class RequestHandlerController extends OCSController {
 	/**
 	 * translate Nextcloud permissions to OCM Permissions
 	 *
-	 * @param $ncPermissions
+	 * @param int|null $ncPermissions
 	 * @return array
 	 */
 	protected function ncPermissions2ocmPermissions(?int $ncPermissions = null): array {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -290,7 +290,7 @@ class RequestHandlerController extends OCSController {
 		return new Http\DataResponse();
 	}
 
-	private function cleanupRemote(string $remote): string {
+	private function cleanupRemote(?string $remote = null): string {
 		$remote = substr($remote, strpos($remote, '://') + 3);
 
 		return rtrim($remote, '/');
@@ -324,8 +324,6 @@ class RequestHandlerController extends OCSController {
 	 *
 	 * @param bool $incoming
 	 * @return bool
-	 * @throws ContainerExceptionInterface
-	 * @throws NotFoundExceptionInterface
 	 */
 	private function isS2SEnabled(bool $incoming = false): bool {
 		$result = \OCP\Server::get(IAppManager::class)->isEnabledForUser('files_sharing');
@@ -371,10 +369,10 @@ class RequestHandlerController extends OCSController {
 	/**
 	 * translate Nextcloud permissions to OCM Permissions
 	 *
-	 * @param int|null $ncPermissions
+	 * @param int $ncPermissions
 	 * @return array
 	 */
-	protected function ncPermissions2ocmPermissions(?int $ncPermissions = null): array {
+	protected function ncPermissions2ocmPermissions(int $ncPermissions): array {
 		$ocmPermissions = [];
 
 		if ($ncPermissions & Constants::PERMISSION_SHARE) {
@@ -404,8 +402,6 @@ class RequestHandlerController extends OCSController {
 	 * @param string|null $remote
 	 * @param string|null $remote_id
 	 * @return DataResponse
-	 * @throws ContainerExceptionInterface
-	 * @throws NotFoundExceptionInterface
 	 * @throws OCSBadRequestException
 	 * @throws OCSException
 	 * @throws Exception

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -290,7 +290,7 @@ class RequestHandlerController extends OCSController {
 		return new Http\DataResponse();
 	}
 
-	private function cleanupRemote(?string $remote = null): string {
+	private function cleanupRemote(string $remote): string {
 		$remote = substr($remote, strpos($remote, '://') + 3);
 
 		return rtrim($remote, '/');


### PR DESCRIPTION
## Summary
The required adjustments have been made to the classes in `/lib/private/Remote ` namespace.

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding throws types
- Adding types to properties
- Replacing qualifiers with imports
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
