### PR TITLE
fix(dav): Move DAV app to non deprecated event dispatcher

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -236,14 +236,14 @@ class Application extends App implements IBootstrap {
 		});
 
 
-		$dispatcher->addListener('\OCA\DAV\CalDAV\CalDavBackend::updateShares', function (GenericEvent $event) use ($container) {
+		$dispatcher->addListener(CalendarShareUpdatedEvent::class, function (CalendarShareUpdatedEvent $event) use ($container) {
 			/** @var Backend $backend */
 			$backend = $container->query(Backend::class);
 			$backend->onCalendarUpdateShares(
-				$event->getArgument('calendarData'),
-				$event->getArgument('shares'),
-				$event->getArgument('add'),
-				$event->getArgument('remove')
+				$event->getCalendarData(),
+				$event->getOldShares(),
+				$event->getAdded(),
+				$event->getRemoved()
 			);
 
 			// Here we should recalculate if reminders should be sent to new or old sharees

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -32,8 +32,6 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\AppInfo;
 
-use Exception;
-use OCA\DAV\BackgroundJob\UpdateCalendarResourcesRoomsBackgroundJob;
 use OCA\DAV\CalDAV\Activity\Backend;
 use OCA\DAV\CalDAV\AppCalendar\AppCalendarPlugin;
 use OCA\DAV\CalDAV\CalendarManager;
@@ -106,7 +104,6 @@ use OCP\IServerContainer;
 use OCP\IUser;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Throwable;
 use function is_null;
@@ -217,8 +214,7 @@ class Application extends App implements IBootstrap {
 
 	public function registerHooks(HookManager $hm,
 								   IEventDispatcher $dispatcher,
-								   IAppContainer $container,
-								   IServerContainer $serverContainer) {
+								   IAppContainer $container) {
 		$hm->setup();
 
 		// first time login event setup
@@ -248,20 +244,6 @@ class Application extends App implements IBootstrap {
 
 			// Here we should recalculate if reminders should be sent to new or old sharees
 		});
-
-		$eventHandler = function () use ($container, $serverContainer): void {
-			try {
-				/** @var UpdateCalendarResourcesRoomsBackgroundJob $job */
-				$job = $container->query(UpdateCalendarResourcesRoomsBackgroundJob::class);
-				$job->run([]);
-				$serverContainer->getJobList()->setLastRun($job);
-			} catch (Exception $ex) {
-				$serverContainer->get(LoggerInterface::class)->error($ex->getMessage(), ['exception' => $ex]);
-			}
-		};
-
-		$dispatcher->addListener('\OCP\Calendar\Resource\ForceRefreshEvent', $eventHandler);
-		$dispatcher->addListener('\OCP\Calendar\Room\ForceRefreshEvent', $eventHandler);
 	}
 
 	public function registerContactsManager(IContactsManager $cm, IAppContainer $container): void {

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -71,6 +71,7 @@ use OCA\DAV\Events\CardDeletedEvent;
 use OCA\DAV\Events\CardUpdatedEvent;
 use OCA\DAV\Events\SubscriptionCreatedEvent;
 use OCA\DAV\Events\SubscriptionDeletedEvent;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 use OCA\DAV\HookManager;
 use OCA\DAV\Listener\ActivityUpdaterListener;
@@ -215,7 +216,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function registerHooks(HookManager $hm,
-								   EventDispatcherInterface $dispatcher,
+								   IEventDispatcher $dispatcher,
 								   IAppContainer $container,
 								   IServerContainer $serverContainer) {
 		$hm->setup();
@@ -227,7 +228,7 @@ class Application extends App implements IBootstrap {
 			}
 		});
 
-		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) use ($container) {
+		$dispatcher->addListener('OC\AccountManager::userUpdated', function ($event) use ($container) {
 			$user = $event->getSubject();
 			/** @var SyncService $syncService */
 			$syncService = $container->query(SyncService::class);

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -225,10 +225,12 @@ class Application extends App implements IBootstrap {
 		});
 
 		$dispatcher->addListener('OC\AccountManager::userUpdated', function ($event) use ($container) {
-			$user = $event->getSubject();
-			/** @var SyncService $syncService */
-			$syncService = $container->query(SyncService::class);
-			$syncService->updateUser($user);
+			if ($event instanceof GenericEvent) {
+				$user = $event->getSubject();
+				/** @var SyncService $syncService */
+				$syncService = $container->query(SyncService::class);
+				$syncService->updateUser($user);
+			}
 		});
 
 

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2841,7 +2841,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			$calendarId = $shareable->getResourceId();
 			$calendarRow = $this->getCalendarById($calendarId);
 			if ($calendarRow === null) {
-				throw new \RuntimeException('Trying to update shares for innexistant calendar: ' . $calendarId);
+				throw new \RuntimeException('Trying to update shares for non-existing calendar: ' . $calendarId);
 			}
 			$oldShares = $this->getShares($calendarId);
 


### PR DESCRIPTION
One step closer for #38546 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
