### PR TITLE
[stable26] fix(TagSearchProvider): Short circuit if no tag matches the query

### DIFF
--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -113,7 +113,7 @@ class TagSearchProvider implements IProvider {
 	 * @inheritDoc
 	 */
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
-		$matchingTags = $this->tagManager->getAllTags(1, $query->getTerm());
+		$matchingTags = $this->tagManager->getAllTags(true, $query->getTerm());
 		if (count($matchingTags) === 0) {
 			return SearchResult::complete($this->l10n->t('Tags'), []);
 		}


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/39062