### PR TITLE
docs(dav): remove outdated comment

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -334,8 +334,6 @@ class FilesReportPlugin extends ServerPlugin {
 
 		$nodes = [];
 
-		// type check to ensure searchBySystemTag is available, it is not
-		// exposed in API yet
 		if (!empty($systemTagIds)) {
 			$tags = $this->tagManager->getTagsByIds($systemTagIds, $this->userSession->getUser());
 


### PR DESCRIPTION
The method was added actually to PHP API in 28 and the mentioned check is not in place anymore.