### PR TITLE
Refactor lib/public

### DIFF
--- a/lib/public/Accounts/IAccount.php
+++ b/lib/public/Accounts/IAccount.php
@@ -148,11 +148,11 @@ interface IAccount extends \JsonSerializable {
 	 * as IAccountProperty instances. They for properties of IAccountPropertyCollection are
 	 * suffixed incrementally, i.e. #0, #1 ... #n – the numbers have no further meaning.
 	 *
+	 * @param string|null $scope Must be one of the VISIBILITY_ prefixed constants of \OCP\Accounts\IAccountManager
+	 * @param string|null $verified \OCP\Accounts\IAccountManager::NOT_VERIFIED | \OCP\Accounts\IAccountManager::VERIFICATION_IN_PROGRESS | \OCP\Accounts\IAccountManager::VERIFIED
+	 * @return IAccountProperty[]
 	 * @since 15.0.0
 	 *
-	 * @param string $scope Must be one of the VISIBILITY_ prefixed constants of \OCP\Accounts\IAccountManager
-	 * @param string $verified \OCP\Accounts\IAccountManager::NOT_VERIFIED | \OCP\Accounts\IAccountManager::VERIFICATION_IN_PROGRESS | \OCP\Accounts\IAccountManager::VERIFIED
-	 * @return IAccountProperty[]
 	 */
 	public function getFilteredProperties(string $scope = null, string $verified = null): array;
 

--- a/lib/public/Accounts/PropertyDoesNotExistException.php
+++ b/lib/public/Accounts/PropertyDoesNotExistException.php
@@ -32,7 +32,8 @@ namespace OCP\Accounts;
 class PropertyDoesNotExistException extends \Exception {
 	/**
 	 * Constructor
-	 * @param string $msg the error message
+	 *
+	 * @param $property
 	 * @since 15.0.0
 	 */
 	public function __construct($property) {

--- a/lib/public/Activity/ActivitySettings.php
+++ b/lib/public/Activity/ActivitySettings.php
@@ -33,25 +33,25 @@ abstract class ActivitySettings implements ISetting {
 	 * @return string Lowercase a-z and underscore only identifier
 	 * @since 20.0.0
 	 */
-	abstract public function getIdentifier();
+	abstract public function getIdentifier(): string;
 
 	/**
 	 * @return string A translated string
 	 * @since 20.0.0
 	 */
-	abstract public function getName();
+	abstract public function getName(): string;
 
 	/**
 	 * @return string Lowercase a-z and underscore only group identifier
 	 * @since 20.0.0
 	 */
-	abstract public function getGroupIdentifier();
+	abstract public function getGroupIdentifier(): string;
 
 	/**
 	 * @return string A translated string for the settings group
 	 * @since 20.0.0
 	 */
-	abstract public function getGroupName();
+	abstract public function getGroupName(): string;
 
 	/**
 	 * @return int whether the filter should be rather on the top or bottom of
@@ -59,13 +59,13 @@ abstract class ActivitySettings implements ISetting {
 	 * priority values. It is required to return a value between 0 and 100.
 	 * @since 20.0.0
 	 */
-	abstract public function getPriority();
+	abstract public function getPriority(): int;
 
 	/**
 	 * @return bool True when the option can be changed for the mail
 	 * @since 20.0.0
 	 */
-	public function canChangeMail() {
+	public function canChangeMail(): bool {
 		return true;
 	}
 
@@ -73,23 +73,23 @@ abstract class ActivitySettings implements ISetting {
 	 * @return bool True when the option can be changed for the notification
 	 * @since 20.0.0
 	 */
-	public function canChangeNotification() {
+	public function canChangeNotification(): bool {
 		return true;
 	}
 
 	/**
-	 * @return bool Whether or not an activity email should be send by default
+	 * @return bool Whether an activity email should be sent by default
 	 * @since 20.0.0
 	 */
-	public function isDefaultEnabledMail() {
+	public function isDefaultEnabledMail(): bool {
 		return false;
 	}
 
 	/**
-	 * @return bool Whether or not an activity notification should be send by default
+	 * @return bool Whether an activity notification should be sent by default
 	 * @since 20.0.0
 	 */
-	public function isDefaultEnabledNotification() {
+	public function isDefaultEnabledNotification(): bool {
 		return $this->isDefaultEnabledMail() && !$this->canChangeMail();
 	}
 
@@ -99,7 +99,7 @@ abstract class ActivitySettings implements ISetting {
 	 * @return bool
 	 * @since 20.0.0
 	 */
-	public function canChangeStream() {
+	public function canChangeStream(): bool {
 		return false;
 	}
 
@@ -109,7 +109,7 @@ abstract class ActivitySettings implements ISetting {
 	 * @return bool
 	 * @since 20.0.0
 	 */
-	public function isDefaultEnabledStream() {
+	public function isDefaultEnabledStream(): bool {
 		return true;
 	}
 }

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -337,7 +337,7 @@ interface IEvent {
 	 * @return IEvent|null
 	 * @since 11.0.0
 	 */
-	public function getChildEvent();
+	public function getChildEvent(): ?IEvent;
 
 	/**
 	 * @return bool
@@ -352,7 +352,7 @@ interface IEvent {
 	public function isValidParsed(): bool;
 
 	/**
-	 * Set whether or not a notification should be automatically generated for this activity.
+	 * Set whether a notification should be automatically generated for this activity.
 	 *
 	 * Set this to `false` if the app already generates a notification for the event.
 	 *
@@ -363,7 +363,7 @@ interface IEvent {
 	public function setGenerateNotification(bool $generate): self;
 
 	/**
-	 * whether or not a notification should be automatically generated for this activity.
+	 * whether a notification should be automatically generated for this activity.
 	 *
 	 * @return bool
 	 * @since 20.0.0

--- a/lib/public/Activity/IEventMerger.php
+++ b/lib/public/Activity/IEventMerger.php
@@ -57,5 +57,5 @@ interface IEventMerger {
 	 * @return IEvent
 	 * @since 11.0
 	 */
-	public function mergeEvents($mergeParameter, IEvent $event, IEvent $previousEvent = null);
+	public function mergeEvents(string $mergeParameter, IEvent $event, IEvent $previousEvent = null): IEvent;
 }

--- a/lib/public/Activity/IFilter.php
+++ b/lib/public/Activity/IFilter.php
@@ -32,13 +32,13 @@ interface IFilter {
 	 * @return string Lowercase a-z and underscore only identifier
 	 * @since 11.0.0
 	 */
-	public function getIdentifier();
+	public function getIdentifier(): string;
 
 	/**
 	 * @return string A translated string
 	 * @since 11.0.0
 	 */
-	public function getName();
+	public function getName(): string;
 
 	/**
 	 * @return int whether the filter should be rather on the top or bottom of
@@ -46,24 +46,24 @@ interface IFilter {
 	 * priority values. It is required to return a value between 0 and 100.
 	 * @since 11.0.0
 	 */
-	public function getPriority();
+	public function getPriority(): int;
 
 	/**
 	 * @return string Full URL to an icon, empty string when none is given
 	 * @since 11.0.0
 	 */
-	public function getIcon();
+	public function getIcon(): string;
 
 	/**
 	 * @param string[] $types
 	 * @return string[] An array of allowed apps from which activities should be displayed
 	 * @since 11.0.0
 	 */
-	public function filterTypes(array $types);
+	public function filterTypes(array $types): array;
 
 	/**
 	 * @return string[] An array of allowed apps from which activities should be displayed
 	 * @since 11.0.0
 	 */
-	public function allowedApps();
+	public function allowedApps(): array;
 }

--- a/lib/public/Activity/IProvider.php
+++ b/lib/public/Activity/IProvider.php
@@ -38,5 +38,5 @@ interface IProvider {
 	 * @throws \InvalidArgumentException Should be thrown if your provider does not know this event
 	 * @since 11.0.0
 	 */
-	public function parse($language, IEvent $event, IEvent $previousEvent = null);
+	public function parse(string $language, IEvent $event, IEvent $previousEvent = null): IEvent;
 }

--- a/lib/public/Activity/ISetting.php
+++ b/lib/public/Activity/ISetting.php
@@ -32,13 +32,13 @@ interface ISetting {
 	 * @return string Lowercase a-z and underscore only identifier
 	 * @since 11.0.0
 	 */
-	public function getIdentifier();
+	public function getIdentifier(): string;
 
 	/**
 	 * @return string A translated string
 	 * @since 11.0.0
 	 */
-	public function getName();
+	public function getName(): string;
 
 	/**
 	 * @return int whether the filter should be rather on the top or bottom of
@@ -46,29 +46,29 @@ interface ISetting {
 	 * priority values. It is required to return a value between 0 and 100.
 	 * @since 11.0.0
 	 */
-	public function getPriority();
+	public function getPriority(): int;
 
 	/**
 	 * @return bool True when the option can be changed for the stream
 	 * @since 11.0.0
 	 */
-	public function canChangeStream();
+	public function canChangeStream(): bool;
 
 	/**
 	 * @return bool True when the option can be changed for the stream
 	 * @since 11.0.0
 	 */
-	public function isDefaultEnabledStream();
+	public function isDefaultEnabledStream(): bool;
 
 	/**
 	 * @return bool True when the option can be changed for the mail
 	 * @since 11.0.0
 	 */
-	public function canChangeMail();
+	public function canChangeMail(): bool;
 
 	/**
 	 * @return bool True when the option can be changed for the stream
 	 * @since 11.0.0
 	 */
-	public function isDefaultEnabledMail();
+	public function isDefaultEnabledMail(): bool;
 }

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -46,10 +46,12 @@ interface IAppManager {
 	 * Returns the app information from "appinfo/info.xml".
 	 *
 	 * @param string $appId
+	 * @param bool $path
+	 * @param null $lang
 	 * @return mixed
 	 * @since 14.0.0
 	 */
-	public function getAppInfo(string $appId, bool $path = false, $lang = null);
+	public function getAppInfo(string $appId, bool $path = false, $lang = null): mixed;
 
 	/**
 	 * Returns the app information from "appinfo/info.xml".
@@ -65,11 +67,11 @@ interface IAppManager {
 	 * Check if an app is enabled for user
 	 *
 	 * @param string $appId
-	 * @param \OCP\IUser $user (optional) if not defined, the currently loggedin user will be used
+	 * @param IUser|null $user (optional) if not defined, the currently loggedin user will be used
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function isEnabledForUser($appId, $user = null);
+	public function isEnabledForUser(string $appId, IUser $user = null): bool;
 
 	/**
 	 * Check if an app is enabled in the instance
@@ -80,7 +82,7 @@ interface IAppManager {
 	 * @return bool
 	 * @since 8.0.0
 	 */
-	public function isInstalled($appId);
+	public function isInstalled(string $appId): bool;
 
 	/**
 	 * Check if an app should be enabled by default
@@ -124,13 +126,13 @@ interface IAppManager {
 	 * @return bool
 	 * @since 12.0.0
 	 */
-	public function hasProtectedAppType($types);
+	public function hasProtectedAppType(array $types): bool;
 
 	/**
 	 * Enable an app only for specific groups
 	 *
 	 * @param string $appId
-	 * @param \OCP\IGroup[] $groups
+	 * @param IGroup[] $groups
 	 * @param bool $forceEnable
 	 * @throws \Exception
 	 * @since 8.0.0
@@ -144,17 +146,17 @@ interface IAppManager {
 	 * @param bool $automaticDisabled
 	 * @since 8.0.0
 	 */
-	public function disableApp($appId, $automaticDisabled = false);
+	public function disableApp(string $appId, bool $automaticDisabled = false);
 
 	/**
 	 * Get the directory for the given app.
 	 *
 	 * @param string $appId
 	 * @return string
-	 * @since 11.0.0
 	 * @throws AppPathNotFoundException
+	 *@since 11.0.0
 	 */
-	public function getAppPath($appId);
+	public function getAppPath(string $appId): string;
 
 	/**
 	 * Get the web path for the given app.
@@ -169,11 +171,11 @@ interface IAppManager {
 	/**
 	 * List all apps enabled for a user
 	 *
-	 * @param \OCP\IUser $user
+	 * @param IUser $user
 	 * @return string[]
 	 * @since 8.1.0
 	 */
-	public function getEnabledAppsForUser(IUser $user);
+	public function getEnabledAppsForUser(IUser $user): array;
 
 	/**
 	 * List all installed apps
@@ -181,7 +183,7 @@ interface IAppManager {
 	 * @return string[]
 	 * @since 8.1.0
 	 */
-	public function getInstalledApps();
+	public function getInstalledApps(): array;
 
 	/**
 	 * Clear the cached list of apps when enabling/disabling an app
@@ -194,7 +196,7 @@ interface IAppManager {
 	 * @return boolean
 	 * @since 9.0.0
 	 */
-	public function isShipped($appId);
+	public function isShipped(string $appId): bool;
 
 	/**
 	 * Loads all apps
@@ -221,7 +223,7 @@ interface IAppManager {
 	 * @return string[]
 	 * @since 9.0.0
 	 */
-	public function getAlwaysEnabledApps();
+	public function getAlwaysEnabledApps(): array;
 
 	/**
 	 * @return string[] app IDs
@@ -230,7 +232,7 @@ interface IAppManager {
 	public function getDefaultEnabledApps(): array;
 
 	/**
-	 * @param \OCP\IGroup $group
+	 * @param IGroup $group
 	 * @return String[]
 	 * @since 17.0.0
 	 */

--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -24,6 +24,7 @@
 namespace OCP\App;
 
 use OCP\EventDispatcher\Event;
+use OCP\IGroup;
 
 /**
  * Class ManagerEvent
@@ -52,32 +53,26 @@ class ManagerEvent extends Event {
 	 */
 	public const EVENT_APP_UPDATE = 'OCP\App\IAppManager::updateApp';
 
-	/** @var string */
-	protected $event;
-	/** @var string */
-	protected $appID;
-	/** @var \OCP\IGroup[]|null */
-	protected $groups;
-
 	/**
 	 * DispatcherEvent constructor.
 	 *
 	 * @param string $event
-	 * @param $appID
-	 * @param \OCP\IGroup[]|null $groups
+	 * @param string $appID
+	 * @param IGroup[]|null $groups
 	 * @since 9.0.0
 	 */
-	public function __construct($event, $appID, array $groups = null) {
-		$this->event = $event;
-		$this->appID = $appID;
-		$this->groups = $groups;
+	public function __construct(
+		protected string $event,
+		protected string $appID,
+		protected ?array $groups = null,
+	) {
 	}
 
 	/**
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getEvent() {
+	public function getEvent(): string {
 		return $this->event;
 	}
 
@@ -85,7 +80,7 @@ class ManagerEvent extends Event {
 	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getAppID() {
+	public function getAppID(): string {
 		return $this->appID;
 	}
 
@@ -94,7 +89,7 @@ class ManagerEvent extends Event {
 	 * @return string[]
 	 * @since 9.0.0
 	 */
-	public function getGroups() {
+	public function getGroups(): array {
 		return array_map(function ($group) {
 			/** @var \OCP\IGroup $group */
 			return $group->getGID();


### PR DESCRIPTION
## Summary
The required adjustments have been made to the classes in the following namespaces:
- `/lib/public/Accounts`
- `/lib/public/Activity`
- `/lib/public/App`

The improvements:

- Adding return types
- Adding type to properties
- Updating doc blocks
- Removing unnecessary qualifiers
- Using PHP8's constructor property promotions
- Updating comments (Grammer correction)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
