### PR TITLE
Use PHP8's match expression instead of switch

### DIFF
--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -247,7 +247,6 @@ abstract class QBMapper {
 			'json' => IQueryBuilder::PARAM_JSON,
 			default => IQueryBuilder::PARAM_STR,
 		};
-
 	}
 
 	/**

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -238,24 +238,16 @@ abstract class QBMapper {
 			return IQueryBuilder::PARAM_STR;
 		}
 
-		switch ($types[ $property ]) {
-			case 'int':
-			case 'integer':
-				return IQueryBuilder::PARAM_INT;
-			case 'string':
-				return IQueryBuilder::PARAM_STR;
-			case 'bool':
-			case 'boolean':
-				return IQueryBuilder::PARAM_BOOL;
-			case 'blob':
-				return IQueryBuilder::PARAM_LOB;
-			case 'datetime':
-				return IQueryBuilder::PARAM_DATE;
-			case 'json':
-				return IQueryBuilder::PARAM_JSON;
-		}
+		return match ($types[$property]) {
+			'int', 'integer' => IQueryBuilder::PARAM_INT,
+			'string' => IQueryBuilder::PARAM_STR,
+			'bool', 'boolean' => IQueryBuilder::PARAM_BOOL,
+			'blob' => IQueryBuilder::PARAM_LOB,
+			'datetime' => IQueryBuilder::PARAM_DATE,
+			'json' => IQueryBuilder::PARAM_JSON,
+			default => IQueryBuilder::PARAM_STR,
+		};
 
-		return IQueryBuilder::PARAM_STR;
 	}
 
 	/**

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -68,21 +68,14 @@ class StorageNotAvailableException extends HintException {
 	 * @since 9.0.0
 	 */
 	public static function getStateCodeName($code) {
-		switch ($code) {
-			case self::STATUS_SUCCESS:
-				return 'ok';
-			case self::STATUS_ERROR:
-				return 'error';
-			case self::STATUS_INDETERMINATE:
-				return 'indeterminate';
-			case self::STATUS_UNAUTHORIZED:
-				return 'unauthorized';
-			case self::STATUS_TIMEOUT:
-				return 'timeout';
-			case self::STATUS_NETWORK_ERROR:
-				return 'network error';
-			default:
-				return 'unknown';
-		}
+		return match ($code) {
+			self::STATUS_SUCCESS => 'ok',
+			self::STATUS_ERROR => 'error',
+			self::STATUS_INDETERMINATE => 'indeterminate',
+			self::STATUS_UNAUTHORIZED => 'unauthorized',
+			self::STATUS_TIMEOUT => 'timeout',
+			self::STATUS_NETWORK_ERROR => 'network error',
+			default => 'unknown',
+		};
 	}
 }


### PR DESCRIPTION
## Summary
The required adjustments have been made to the classes in the `/lib/public` namespace.

The improvements:

- Using PHP8's `match` expression instead of `switch`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
