### PR TITLE
Use PHP8's match expression instead of switch

### DIFF
--- a/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
@@ -466,16 +466,12 @@ class GroupPluginTest extends TestCase {
 					if ($appName !== 'core') {
 						return $default;
 					}
-					switch ($key) {
-						case 'shareapi_only_share_with_group_members':
-							return $shareWithGroupOnly ? 'yes' : 'no';
-						case 'shareapi_allow_share_dialog_user_enumeration':
-							return $shareeEnumeration ? 'yes' : 'no';
-						case 'shareapi_allow_group_sharing':
-							return $groupSharingDisabled ? 'no' : 'yes';
-						default:
-							return $default;
-					}
+					return match ($key) {
+						'shareapi_only_share_with_group_members' => $shareWithGroupOnly ? 'yes' : 'no',
+						'shareapi_allow_share_dialog_user_enumeration' => $shareeEnumeration ? 'yes' : 'no',
+						'shareapi_allow_group_sharing' => $groupSharingDisabled ? 'no' : 'yes',
+						default => $default,
+					};
 				}
 			);
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -558,38 +558,36 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->any())
 			->method('inGroup')
 			->willReturnCallback(function ($uid, $gid) {
-				switch ($uid) {
-					case 'user1': return false;
-					case 'user2': return true;
-					case 'user3': return false;
-					case 'user33': return true;
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => false,
+					'user2' => false,
+					'user3' => false,
+					'user33' => true,
+					default => null,
+				};
 			});
 
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->willReturnCallback(function ($search, $limit, $offset) {
-				switch ($offset) {
-					case 0: return ['user3' => $this->getTestUser('user3'),
-						'user33' => $this->getTestUser('user33')];
-					case 2: return [];
-				}
-				return null;
+				return match ($offset) {
+					0 => ['user3' => $this->getTestUser('user3'),
+						'user33' => $this->getTestUser('user33')],
+					2 => [],
+					default => null,
+				};
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($uid) {
-				switch ($uid) {
-					case 'user1': return $this->getTestUser('user1');
-					case 'user2': return $this->getTestUser('user2');
-					case 'user3': return $this->getTestUser('user3');
-					case 'user33': return $this->getTestUser('user33');
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => $this->getTestUser('user1'),
+					'user2' => $this->getTestUser('user2'),
+					'user3' => $this->getTestUser('user3'),
+					'user33' => $this->getTestUser('user33'),
+					default => null,
+				};
 			});
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache);
@@ -616,40 +614,38 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->any())
 			->method('inGroup')
 			->willReturnCallback(function ($uid, $gid) {
-				switch ($uid) {
-					case 'user1': return false;
-					case 'user2': return true;
-					case 'user3': return false;
-					case 'user33': return true;
-					case 'user333': return true;
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => false,
+					'user2' => true,
+					'user3' => false,
+					'user33' => true,
+					'user333' => true,
+					default => null,
+				};
 			});
 
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->willReturnCallback(function ($search, $limit, $offset) {
-				switch ($offset) {
-					case 0: return ['user3' => $this->getTestUser('user3'),
-						'user33' => $this->getTestUser('user33')];
-					case 2: return ['user333' => $this->getTestUser('user333')];
-				}
-				return null;
+				return match ($offset) {
+					0 => ['user3' => $this->getTestUser('user3'),
+						'user33' => $this->getTestUser('user33')],
+					2 => ['user333' => $this->getTestUser('user333')],
+					default => null,
+				};
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($uid) {
-				switch ($uid) {
-					case 'user1': return $this->getTestUser('user1');
-					case 'user2': return $this->getTestUser('user2');
-					case 'user3': return $this->getTestUser('user3');
-					case 'user33': return $this->getTestUser('user33');
-					case 'user333': return $this->getTestUser('user333');
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => $this->getTestUser('user1'),
+					'user2' => $this->getTestUser('user2'),
+					'user3' => $this->getTestUser('user3'),
+					'user33' => $this->getTestUser('user33'),
+					'user333' => $this->getTestUser('user333'),
+					default => null,
+				};
 			});
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache);
@@ -677,43 +673,40 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->any())
 			->method('inGroup')
 			->willReturnCallback(function ($uid) {
-				switch ($uid) {
-					case 'user1': return false;
-					case 'user2': return true;
-					case 'user3': return false;
-					case 'user33': return true;
-					case 'user333': return true;
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => false,
+					'user2' => true,
+					'user3' => false,
+					'user33' => true,
+					'user333' => true,
+					default => null,
+				};
 			});
 
 		$this->userManager->expects($this->any())
 			->method('searchDisplayName')
 			->with('user3')
 			->willReturnCallback(function ($search, $limit, $offset) {
-				switch ($offset) {
-					case 0:
-						return [
-							'user3' => $this->getTestUser('user3'),
-							'user33' => $this->getTestUser('user33'),
-							'user333' => $this->getTestUser('user333')
-						];
-				}
-				return null;
+				return match ($offset) {
+					0 => [
+						'user3' => $this->getTestUser('user3'),
+						'user33' => $this->getTestUser('user33'),
+						'user333' => $this->getTestUser('user333')
+					],
+					default => null,
+				};
 			});
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function ($uid) {
-				switch ($uid) {
-					case 'user1': return $this->getTestUser('user1');
-					case 'user2': return $this->getTestUser('user2');
-					case 'user3': return $this->getTestUser('user3');
-					case 'user33': return $this->getTestUser('user33');
-					case 'user333': return $this->getTestUser('user333');
-					default:
-						return null;
-				}
+				return match ($uid) {
+					'user1' => $this->getTestUser('user1'),
+					'user2' => $this->getTestUser('user2'),
+					'user3' => $this->getTestUser('user3'),
+					'user33' => $this->getTestUser('user33'),
+					'user333' => $this->getTestUser('user333'),
+					default => null,
+				};
 			});
 
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -159,15 +159,10 @@ class SessionTest extends \Test\TestCase {
 		$session->expects($this->exactly(2))
 			->method('set')
 			->with($this->callback(function ($key) {
-				switch ($key) {
-					case 'user_id':
-					case 'loginname':
-						return true;
-						break;
-					default:
-						return false;
-						break;
-				}
+				return match ($key) {
+					'user_id', 'loginname' => true,
+					default => false,
+				};
 			}, 'foo'));
 
 		$managerMethods = get_class_methods(Manager::class);


### PR DESCRIPTION
## Summary
Using PHP8's `match` expression instead of `switch` in the `/tests/lib` namespace classes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
