### PR TITLE
Refactor "strpos" and "substr" calls in federatedfilesharing app to improve code readability

### DIFF
--- a/apps/federatedfilesharing/lib/AddressHandler.php
+++ b/apps/federatedfilesharing/lib/AddressHandler.php
@@ -130,9 +130,9 @@ class AddressHandler {
 	 * @return string
 	 */
 	public function removeProtocolFromUrl($url) {
-		if (strpos($url, 'https://') === 0) {
+		if (str_starts_with($url, 'https://')) {
 			return substr($url, strlen('https://'));
-		} elseif (strpos($url, 'http://') === 0) {
+		} elseif (str_starts_with($url, 'http://')) {
 			return substr($url, strlen('http://'));
 		}
 
@@ -146,8 +146,8 @@ class AddressHandler {
 	 * @return bool
 	 */
 	public function urlContainProtocol($url) {
-		if (strpos($url, 'https://') === 0 ||
-			strpos($url, 'http://') === 0) {
+		if (str_starts_with($url, 'https://') ||
+			str_starts_with($url, 'http://')) {
 			return true;
 		}
 

--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -202,9 +202,9 @@ class Notifier implements INotifier {
 	protected function getDisplayName(ICloudId $cloudId): string {
 		$server = $cloudId->getRemote();
 		$user = $cloudId->getUser();
-		if (strpos($server, 'http://') === 0) {
+		if (str_starts_with($server, 'http://')) {
 			$server = substr($server, strlen('http://'));
-		} elseif (strpos($server, 'https://') === 0) {
+		} elseif (str_starts_with($server, 'https://')) {
 			$server = substr($server, strlen('https://'));
 		}
 

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -116,7 +116,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 		[$ownerUid, $remote] = $this->addressHandler->splitUserRemote($share->getOwner());
 		// for backward compatibility make sure that the remote url stored in the
 		// database ends with a trailing slash
-		if (substr($remote, -1) !== '/') {
+		if (!str_ends_with($remote, '/')) {
 			$remote = $remote . '/';
 		}
 


### PR DESCRIPTION
## Summary
Replacing `strpos` and `substr` in the `federatedfilesharing` app to improve code readability

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
