### PR TITLE
Refactor "substr" calls in dav app to improve code readability

### DIFF
--- a/apps/dav/lib/BulkUpload/MultipartRequestParser.php
+++ b/apps/dav/lib/BulkUpload/MultipartRequestParser.php
@@ -82,7 +82,7 @@ class MultipartRequestParser {
 		$boundaryValue = trim($boundaryValue);
 
 		// Remove potential quotes around boundary value.
-		if (substr($boundaryValue, 0, 1) === '"' && substr($boundaryValue, -1) === '"') {
+		if (str_starts_with($boundaryValue, '"') && str_ends_with($boundaryValue, '"')) {
 			$boundaryValue = substr($boundaryValue, 1, -1);
 		}
 

--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -419,7 +419,7 @@ class BirthdayService {
 	 * @return string|null
 	 */
 	private function principalToUserId(string $userPrincipal):?string {
-		if (substr($userPrincipal, 0, 17) === 'principals/users/') {
+		if (str_starts_with($userPrincipal, 'principals/users/')) {
 			return substr($userPrincipal, 17);
 		}
 		return null;

--- a/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php
@@ -108,7 +108,7 @@ class FakeLockerPlugin extends ServerPlugin {
 			if (isset($fileCondition['tokens'])) {
 				foreach ($fileCondition['tokens'] as &$token) {
 					if (isset($token['token'])) {
-						if (substr($token['token'], 0, 16) === 'opaquelocktoken:') {
+						if (str_starts_with($token['token'], 'opaquelocktoken:')) {
 							$token['validToken'] = true;
 						}
 					}

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -303,7 +303,7 @@ abstract class Node implements \Sabre\DAV\INode {
 		$mountpoint = $this->info->getMountPoint();
 		if (!($mountpoint instanceof MoveableMount)) {
 			$mountpointpath = $mountpoint->getMountPoint();
-			if (substr($mountpointpath, -1) === '/') {
+			if (str_ends_with($mountpointpath, '/')) {
 				$mountpointpath = substr($mountpointpath, 0, -1);
 			}
 

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -505,7 +505,7 @@ class Principal implements BackendInterface {
 				return $this->principalPrefix . '/' . $user->getUID();
 			}
 		}
-		if (substr($uri, 0, 10) === 'principal:') {
+		if (str_starts_with($uri, 'principal:')) {
 			$principal = substr($uri, 10);
 			$principal = $this->getPrincipalByPath($principal);
 			if ($principal !== null) {

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -166,7 +166,7 @@ class CustomPropertiesBackend implements BackendInterface {
 
 		// substr of calendars/ => path is inside the CalDAV component
 		// two '/' => this a calendar (no calendar-home nor calendar object)
-		if (substr($path, 0, 10) === 'calendars/' && substr_count($path, '/') === 2) {
+		if (str_starts_with($path, 'calendars/') && substr_count($path, '/') === 2) {
 			$allRequestedProps = $propFind->getRequestedProperties();
 			$customPropertiesForShares = [
 				'{DAV:}displayname',

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1134,7 +1134,7 @@ class FileTest extends TestCase {
 			$realPath = $storage->getSourcePath($internalPath);
 			$dh = opendir($realPath);
 			while (($file = readdir($dh)) !== false) {
-				if (substr($file, strlen($file) - 5, 5) === '.part') {
+				if (str_ends_with($file, '.part')) {
 					$files[] = $file;
 				}
 			}


### PR DESCRIPTION
## Summary
Replacing `substr` with `str_starts_with` and `str_ends_with` in the `dav` app to improve code readability

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
