### PR TITLE
Refactor "substr" calls in lib/private to improve code readability

### DIFF
--- a/lib/private/DB/OracleMigrator.php
+++ b/lib/private/DB/OracleMigrator.php
@@ -206,7 +206,7 @@ class OracleMigrator extends Migrator {
 	 * @return string
 	 */
 	protected function convertStatementToScript($statement) {
-		if (substr($statement, -1) === ';') {
+		if (str_ends_with($statement, ';')) {
 			return $statement . PHP_EOL . '/' . PHP_EOL;
 		}
 		$script = $statement . ';';

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -125,7 +125,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 */
 	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (!str_ends_with($formatDate, '^') && !str_ends_with($formatDate, '*')) {
+		if (!str_ends_with($format, '^') && !str_ends_with($format, '*')) {
 			$format .= '^';
 		}
 

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -125,7 +125,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 */
 	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (substr($format, -1) !== '*' && substr($format, -1) !== '*') {
+		if (!str_ends_with($format, '*') && !str_ends_with($format, '*')) {
 			$format .= '^';
 		}
 
@@ -289,7 +289,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date and time string
 	 */
 	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (substr($formatDate, -1) !== '^' && substr($formatDate, -1) !== '*') {
+		if (!str_ends_with($formatDate, '^') && !str_ends_with($formatDate, '*')) {
 			$formatDate .= '^';
 		}
 

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -125,7 +125,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 */
 	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (!str_ends_with($format, '*')) {
+		if (!str_ends_with($formatDate, '^') && !str_ends_with($formatDate, '*')) {
 			$format .= '^';
 		}
 

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -125,7 +125,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 */
 	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (!str_ends_with($format, '*') && !str_ends_with($format, '*')) {
+		if (!str_ends_with($format, '*')) {
 			$format .= '^';
 		}
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -120,9 +120,9 @@ class DAV extends Common {
 		if (isset($params['host']) && isset($params['user']) && isset($params['password'])) {
 			$host = $params['host'];
 			//remove leading http[s], will be generated in createBaseUri()
-			if (substr($host, 0, 8) == "https://") {
+			if (str_starts_with($host, "https://")) {
 				$host = substr($host, 8);
-			} elseif (substr($host, 0, 7) == "http://") {
+			} elseif (str_starts_with($host, "http://")) {
 				$host = substr($host, 7);
 			}
 			$this->host = $host;

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -85,7 +85,7 @@ class Local extends \OC\Files\Storage\Common {
 			$realPath = realpath($this->datadir) ?: $this->datadir;
 			$this->realDataDir = rtrim($realPath, '/') . '/';
 		}
-		if (substr($this->datadir, -1) !== '/') {
+		if (!str_ends_with($this->datadir, '/')) {
 			$this->datadir .= '/';
 		}
 		$this->dataDirLength = strlen($this->realDataDir);
@@ -155,7 +155,7 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	public function is_dir($path) {
-		if (substr($path, -1) == '/') {
+		if (str_ends_with($path, '/')) {
 			$path = substr($path, 0, -1);
 		}
 		return is_dir($this->getSourcePath($path));

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -358,7 +358,7 @@ class Factory implements IFactory {
 			$files = scandir($dir);
 			if ($files !== false) {
 				foreach ($files as $file) {
-					if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
+					if (str_ends_with($file, '.json') && !str_starts_with($file, 'l10n')) {
 						$available[] = substr($file, 0, -5);
 					}
 				}
@@ -374,7 +374,7 @@ class Factory implements IFactory {
 				$files = scandir($themeDir);
 				if ($files !== false) {
 					foreach ($files as $file) {
-						if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
+						if (str_ends_with($file, '.json') && !str_starts_with($file, 'l10n')) {
 							$available[] = substr($file, 0, -5);
 						}
 					}

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -247,23 +247,23 @@ class Router implements IRouter {
 	 */
 	public function findMatchingRoute(string $url): array {
 		$this->eventLogger->start('route:match', 'Match route');
-		if (substr($url, 0, 6) === '/apps/') {
+		if (str_starts_with($url, '/apps/')) {
 			// empty string / 'apps' / $app / rest of the route
 			[, , $app,] = explode('/', $url, 4);
 
 			$app = \OC_App::cleanAppId($app);
 			\OC::$REQUESTEDAPP = $app;
 			$this->loadRoutes($app);
-		} elseif (substr($url, 0, 13) === '/ocsapp/apps/') {
+		} elseif (str_starts_with($url, '/ocsapp/apps/')) {
 			// empty string / 'ocsapp' / 'apps' / $app / rest of the route
 			[, , , $app,] = explode('/', $url, 5);
 
 			$app = \OC_App::cleanAppId($app);
 			\OC::$REQUESTEDAPP = $app;
 			$this->loadRoutes($app);
-		} elseif (substr($url, 0, 10) === '/settings/') {
+		} elseif (str_starts_with($url, '/settings/')) {
 			$this->loadRoutes('settings');
-		} elseif (substr($url, 0, 6) === '/core/') {
+		} elseif (str_starts_with($url, '/core/')) {
 			\OC::$REQUESTEDAPP = $url;
 			if (!$this->config->getSystemValueBool('maintenance') && !Util::needUpgrade()) {
 				\OC_App::loadApps();
@@ -277,7 +277,7 @@ class Router implements IRouter {
 		try {
 			$parameters = $matcher->match($url);
 		} catch (ResourceNotFoundException $e) {
-			if (substr($url, -1) !== '/') {
+			if (!str_ends_with($url, '/')) {
 				// We allow links to apps/files? for backwards compatibility reasons
 				// However, since Symfony does not allow empty route names, the route
 				// we need to match is '/', so we need to append the '/' here.

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -279,7 +279,7 @@ class TemplateLayout extends \OC_Template {
 			$web = $info[1];
 			$file = $info[2];
 
-			if (substr($file, -strlen('print.css')) === 'print.css') {
+			if (str_ends_with($file, 'print.css')) {
 				$this->append('printcssfiles', $web.'/'.$file . $this->getVersionHashSuffix());
 			} else {
 				$suffix = $this->getVersionHashSuffix($web, $file);

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -147,7 +147,7 @@ class URLGenerator implements IURLGenerator {
 			$app_path = $this->getAppManager()->getAppPath($appName);
 			// Check if the app is in the app folder
 			if (file_exists($app_path . '/' . $file)) {
-				if (substr($file, -3) === 'php') {
+				if (str_ends_with($file, 'php')) {
 					$urlLinkTo = \OC::$WEBROOT . '/index.php/apps/' . $appName;
 					if ($frontControllerActive) {
 						$urlLinkTo = \OC::$WEBROOT . '/apps/' . $appName;

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -610,7 +610,7 @@ class User implements IUser {
 	public function getCloudId() {
 		$uid = $this->getUID();
 		$server = rtrim($this->urlGenerator->getAbsoluteURL('/'), '/');
-		if (substr($server, -10) === '/index.php') {
+		if (str_ends_with($server, '/index.php')) {
 			$server = substr($server, 0, -10);
 		}
 		$server = $this->removeProtocolFromUrl($server);

--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -130,7 +130,7 @@ class OC_API {
 	protected static function isV2(\OCP\IRequest $request) {
 		$script = $request->getScriptName();
 
-		return substr($script, -11) === '/ocs/v2.php';
+		return str_ends_with($script, '/ocs/v2.php');
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Replacing `substr` with `str_starts_with` and `str_ends_with` in the `/lib/private` namespace to improve code readability

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
