### PR TITLE
Refactor "substr" calls in lib/public to improve code readability

### DIFF
--- a/lib/public/AppFramework/AuthPublicShareController.php
+++ b/lib/public/AppFramework/AuthPublicShareController.php
@@ -189,7 +189,7 @@ abstract class AuthPublicShareController extends PublicShareController {
 	private function getRoute(string $function): string {
 		$app = strtolower($this->appName);
 		$class = (new \ReflectionClass($this))->getShortName();
-		if (substr($class, -10) === 'Controller') {
+		if (str_ends_with($class, 'Controller')) {
 			$class = substr($class, 0, -10);
 		}
 		return $app .'.'. $class .'.'. $function;


### PR DESCRIPTION
## Summary
Replacing `substr` with `str_ends_with` in the `/lib/public` namespace to improve code readability

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
