### PR TITLE
Bugfix/bulk upload empty files

### DIFF
--- a/apps/dav/lib/BulkUpload/MultipartRequestParser.php
+++ b/apps/dav/lib/BulkUpload/MultipartRequestParser.php
@@ -211,13 +211,17 @@ class MultipartRequestParser {
 			throw new BadRequest("Computed md5 hash is incorrect.");
 		}
 
-		$content = stream_get_line($this->stream, $length);
+		if ($length === 0) {
+			$content = '';
+		} else {
+			$content = stream_get_line($this->stream, $length);
+		}
 
 		if ($content === false) {
 			throw new Exception("Fail to read part's content.");
 		}
 
-		if (feof($this->stream)) {
+		if ($length !== 0 && feof($this->stream)) {
 			throw new Exception("Unexpected EOF while reading stream.");
 		}
 


### PR DESCRIPTION
## Summary

Solve long running issue with bulk upload of empty files.
Require also fixes from desktop client see https://github.com/nextcloud/desktop/pull/5871


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
should probably be backported to all maintained releases with bulk upload