### PR TITLE
Migrate more apps to IEventDispatcher

### DIFF
--- a/apps/files_trashbin/lib/Events/MoveToTrashEvent.php
+++ b/apps/files_trashbin/lib/Events/MoveToTrashEvent.php
@@ -33,6 +33,7 @@ use OCP\Files\Node;
  * Event to allow other apps to disable the trash bin for specific files
  *
  * @package OCA\Files_Trashbin\Events
+ * @since 28.0.0 Dispatched as a typed event
  */
 class MoveToTrashEvent extends Event {
 

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -41,6 +41,7 @@ use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -50,7 +51,6 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Share\IShare;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Traits\MountProviderTrait;
 
 class TemporaryNoCross extends Temporary {
@@ -607,7 +607,7 @@ class StorageTest extends \Test\TestCase {
 		$userManager->expects($this->any())
 			->method('userExists')->willReturn($userExists);
 		$logger = $this->getMockBuilder(ILogger::class)->getMock();
-		$eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userFolder = $this->createMock(Folder::class);
 		$node = $this->getMockBuilder(Node::class)->disableOriginalConstructor()->getMock();

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -34,9 +34,9 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Application extends App implements IBootstrap {
@@ -56,15 +56,17 @@ class Application extends App implements IBootstrap {
 	/**
 	 * @todo move the OCP events and then move the registration to `register`
 	 */
-	private function registerEventListeners(EventDispatcherInterface $dispatcher,
+	private function registerEventListeners(IEventDispatcher $dispatcher,
 											ContainerInterface $appContainer): void {
-		$dispatcher->addListener('OC\AccountManager::userUpdated', function (GenericEvent $event) use ($appContainer) {
-			/** @var IUser $user */
-			$user = $event->getSubject();
+		$dispatcher->addListener('OC\AccountManager::userUpdated', function ($event) use ($appContainer) {
+			if ($event instanceof GenericEvent) {
+				/** @var IUser $user */
+				$user = $event->getSubject();
 
-			/** @var UpdateLookupServer $updateLookupServer */
-			$updateLookupServer = $appContainer->get(UpdateLookupServer::class);
-			$updateLookupServer->userUpdated($user);
+				/** @var UpdateLookupServer $updateLookupServer */
+				$updateLookupServer = $appContainer->get(UpdateLookupServer::class);
+				$updateLookupServer->userUpdated($user);
+			}
 		});
 	}
 }

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -66,8 +66,6 @@ use OCP\WorkflowEngine\IEntityEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IOperation;
 use OCP\WorkflowEngine\IRuleMatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface as LegacyDispatcher;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Manager implements IManager {
 	/** @var IStorage */
@@ -93,9 +91,6 @@ class Manager implements IManager {
 
 	/** @var IL10N */
 	protected $l;
-
-	/** @var LegacyDispatcher */
-	protected $legacyEventDispatcher;
 
 	/** @var IEntity[] */
 	protected $registeredEntities = [];
@@ -126,7 +121,6 @@ class Manager implements IManager {
 		IDBConnection $connection,
 		IServerContainer $container,
 		IL10N $l,
-		LegacyDispatcher $eventDispatcher,
 		ILogger $logger,
 		IUserSession $session,
 		IEventDispatcher $dispatcher,
@@ -136,7 +130,6 @@ class Manager implements IManager {
 		$this->connection = $connection;
 		$this->container = $container;
 		$this->l = $l;
-		$this->legacyEventDispatcher = $eventDispatcher;
 		$this->logger = $logger;
 		$this->operationsByScope = new CappedMemoryCache(64);
 		$this->session = $session;
@@ -694,7 +687,6 @@ class Manager implements IManager {
 	 */
 	public function getEntitiesList(): array {
 		$this->dispatcher->dispatchTyped(new RegisterEntitiesEvent($this));
-		$this->legacyEventDispatcher->dispatch(IManager::EVENT_NAME_REG_ENTITY, new GenericEvent($this));
 
 		return array_values(array_merge($this->getBuildInEntities(), $this->registeredEntities));
 	}
@@ -704,7 +696,6 @@ class Manager implements IManager {
 	 */
 	public function getOperatorList(): array {
 		$this->dispatcher->dispatchTyped(new RegisterOperationsEvent($this));
-		$this->legacyEventDispatcher->dispatch(IManager::EVENT_NAME_REG_OPERATION, new GenericEvent($this));
 
 		return array_merge($this->getBuildInOperators(), $this->registeredOperators);
 	}
@@ -714,7 +705,6 @@ class Manager implements IManager {
 	 */
 	public function getCheckList(): array {
 		$this->dispatcher->dispatchTyped(new RegisterChecksEvent($this));
-		$this->legacyEventDispatcher->dispatch(IManager::EVENT_NAME_REG_CHECK, new GenericEvent($this));
 
 		return array_merge($this->getBuildInChecks(), $this->registeredChecks);
 	}

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -45,6 +45,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
+use OCP\WorkflowEngine\Events\RegisterEntitiesEvent;
 use OCP\WorkflowEngine\ICheck;
 use OCP\WorkflowEngine\IEntity;
 use OCP\WorkflowEngine\IEntityEvent;
@@ -67,8 +68,6 @@ class ManagerTest extends TestCase {
 	protected $db;
 	/** @var \PHPUnit\Framework\MockObject\MockObject|ILogger */
 	protected $logger;
-	/** @var \PHPUnit\Framework\MockObject\MockObject|EventDispatcherInterface */
-	protected $legacyDispatcher;
 	/** @var MockObject|IServerContainer */
 	protected $container;
 	/** @var MockObject|IUserSession */
@@ -94,7 +93,6 @@ class ManagerTest extends TestCase {
 				return vsprintf($text, $parameters);
 			});
 
-		$this->legacyDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$this->logger = $this->createMock(ILogger::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
@@ -105,7 +103,6 @@ class ManagerTest extends TestCase {
 			\OC::$server->getDatabaseConnection(),
 			$this->container,
 			$this->l,
-			$this->legacyDispatcher,
 			$this->logger,
 			$this->session,
 			$this->dispatcher,
@@ -532,10 +529,9 @@ class ManagerTest extends TestCase {
 		/** @var MockObject|IEntity $extraEntity */
 		$extraEntity = $this->createMock(IEntity::class);
 
-		$this->legacyDispatcher->expects($this->once())
-			->method('dispatch')
-			->with('OCP\WorkflowEngine::registerEntities', $this->anything())
-			->willReturnCallback(function () use ($extraEntity) {
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->willReturnCallback(function (RegisterEntitiesEvent $e) use ($extraEntity) {
 				$this->manager->registerEntity($extraEntity);
 			});
 

--- a/lib/public/WorkflowEngine/IManager.php
+++ b/lib/public/WorkflowEngine/IManager.php
@@ -45,21 +45,6 @@ interface IManager {
 	public const MAX_OPERATION_VALUE_BYTES = 4096;
 
 	/**
-	 * @deprecated 17.0.0 Will be removed in NC19. Use the dedicated events in OCP\WorkflowEngine\Events
-	 */
-	public const EVENT_NAME_REG_OPERATION = 'OCP\WorkflowEngine::registerOperations';
-
-	/**
-	 * @deprecated 17.0.0
-	 */
-	public const EVENT_NAME_REG_ENTITY = 'OCP\WorkflowEngine::registerEntities';
-
-	/**
-	 * @deprecated 17.0.0
-	 */
-	public const EVENT_NAME_REG_CHECK = 'OCP\WorkflowEngine::registerChecks';
-
-	/**
 	 * Listen to `OCP\WorkflowEngine\Events\RegisterEntitiesEvent` at the
 	 * IEventDispatcher for registering your entities.
 	 *


### PR DESCRIPTION
One step closer for #38546 

- [x] files_trashbin: Emit existing event additionally as dispatchTyped
    - [x] documentation: https://github.com/nextcloud/documentation/pull/10737
- [x] workflowengine: Remove legacy event (deprecated since 17 (so allowed to drop since 26))
    - [x] documentation: https://github.com/nextcloud/documentation/pull/10737
- [X] lookup…: Move listener to IEventDispatcher

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
