### PR TITLE
Convert isset ternary to null coalescing operator

### DIFF
--- a/lib/private/App/AppStore/Version/VersionParser.php
+++ b/lib/private/App/AppStore/Version/VersionParser.php
@@ -54,9 +54,9 @@ class VersionParser {
 		// Count the amount of =, if it is one then it's either maximum or minimum
 		// version. If it is two then it is maximum and minimum.
 		$versionElements = explode(' ', $versionSpec);
-		$firstVersion = isset($versionElements[0]) ? $versionElements[0] : '';
+		$firstVersion = $versionElements[0] ?? '';
 		$firstVersionNumber = substr($firstVersion, 2);
-		$secondVersion = isset($versionElements[1]) ? $versionElements[1] : '';
+		$secondVersion = $versionElements[1] ?? '';
 		$secondVersionNumber = substr($secondVersion, 2);
 
 		switch (count($versionElements)) {

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -373,7 +373,7 @@ class AppConfig implements IAppConfig {
 		} else {
 			$appIds = $this->getApps();
 			$values = array_map(function ($appId) use ($key) {
-				return isset($this->cache[$appId][$key]) ? $this->cache[$appId][$key] : null;
+				return $this->cache[$appId][$key] ?? null;
 			}, $appIds);
 			$result = array_combine($appIds, $values);
 

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -193,9 +193,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 */
 	#[\ReturnTypeWillChange]
 	public function offsetGet($offset) {
-		return isset($this->items['parameters'][$offset])
-			? $this->items['parameters'][$offset]
-			: null;
+		return $this->items['parameters'][$offset] ?? null;
 	}
 
 	/**
@@ -255,9 +253,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			case 'cookies':
 			case 'urlParams':
 			case 'method':
-				return isset($this->items[$name])
-					? $this->items[$name]
-					: null;
+				return $this->items[$name] ?? null;
 			case 'parameters':
 			case 'params':
 				if ($this->isPutStreamContent()) {

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -139,7 +139,7 @@ class ConnectionFactory {
 					$additionalConnectionParams = array_merge($additionalConnectionParams, $additionalConnectionParams['driverOptions']);
 				}
 				$host = $additionalConnectionParams['host'];
-				$port = isset($additionalConnectionParams['port']) ? $additionalConnectionParams['port'] : null;
+				$port = $additionalConnectionParams['port'] ?? null;
 				$dbName = $additionalConnectionParams['dbname'];
 
 				// we set the connect string as dbname and unset the host to coerce doctrine into using it as connect string

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -439,7 +439,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		$childQueue = [];
 		$newChildNames = [];
 		foreach ($newChildren as $fileMeta) {
-			$permissions = isset($fileMeta['scan_permissions']) ? $fileMeta['scan_permissions'] : $fileMeta['permissions'];
+			$permissions = $fileMeta['scan_permissions'] ?? $fileMeta['permissions'];
 			if ($permissions === 0) {
 				continue;
 			}
@@ -456,7 +456,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			$newChildNames[] = $file;
 			$child = $path ? $path . '/' . $file : $file;
 			try {
-				$existingData = isset($existingChildren[$file]) ? $existingChildren[$file] : false;
+				$existingData = $existingChildren[$file] ?? false;
 				$data = $this->scanFile($child, $reuse, $folderId, $existingData, $lock, $fileMeta);
 				if ($data) {
 					if ($data['mimetype'] === 'httpd/unix-directory' && $recursive === self::SCAN_RECURSIVE) {

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -238,7 +238,7 @@ class UserMountCache implements IUserMountCache {
 			$row['mount_point'],
 			$row['mount_provider_class'] ?? '',
 			$mount_id,
-			isset($row['path']) ? $row['path'] : '',
+			$row['path'] ?? '',
 		);
 	}
 

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -272,7 +272,7 @@ class MountPoint implements IMountPoint {
 	 * @return mixed
 	 */
 	public function getOption($name, $default) {
-		return isset($this->mountOptions[$name]) ? $this->mountOptions[$name] : $default;
+		return $this->mountOptions[$name] ?? $default;
 	}
 
 	/**

--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -122,7 +122,7 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 				$config['arguments']['bucket'] = '';
 			}
 			$mapper = new \OC\Files\ObjectStore\Mapper($user, $this->config);
-			$numBuckets = isset($config['arguments']['num_buckets']) ? $config['arguments']['num_buckets'] : 64;
+			$numBuckets = $config['arguments']['num_buckets'] ?? 64;
 			$config['arguments']['bucket'] .= $mapper->getBucket($numBuckets);
 
 			$this->config->setUserValue($user->getUID(), 'homeobjectstore', 'bucket', $config['arguments']['bucket']);

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -128,7 +128,7 @@ trait S3ConnectionTrait {
 		);
 
 		$options = [
-			'version' => isset($this->params['version']) ? $this->params['version'] : 'latest',
+			'version' => $this->params['version'] ?? 'latest',
 			'credentials' => $provider,
 			'endpoint' => $base_url,
 			'region' => $this->params['region'],

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -601,7 +601,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @return mixed
 	 */
 	public function getMountOption($name, $default = null) {
-		return isset($this->mountOptions[$name]) ? $this->mountOptions[$name] : $default;
+		return $this->mountOptions[$name] ?? $default;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -140,7 +140,7 @@ class PermissionsMask extends Wrapper {
 		$data = parent::getMetaData($path);
 
 		if ($data && isset($data['permissions'])) {
-			$data['scan_permissions'] = isset($data['scan_permissions']) ? $data['scan_permissions'] : $data['permissions'];
+			$data['scan_permissions'] = $data['scan_permissions'] ?? $data['permissions'];
 			$data['permissions'] &= $this->mask;
 		}
 		return $data;
@@ -155,7 +155,7 @@ class PermissionsMask extends Wrapper {
 
 	public function getDirectoryContent($directory): \Traversable {
 		foreach ($this->getWrapperStorage()->getDirectoryContent($directory) as $data) {
-			$data['scan_permissions'] = isset($data['scan_permissions']) ? $data['scan_permissions'] : $data['permissions'];
+			$data['scan_permissions'] = $data['scan_permissions'] ?? $data['permissions'];
 			$data['permissions'] &= $this->mask;
 
 			yield $data;

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -101,7 +101,7 @@ class NavigationManager implements INavigationManager {
 		}
 
 		$id = $entry['id'];
-		$entry['unread'] = isset($this->unreadCounters[$id]) ? $this->unreadCounters[$id] : 0;
+		$entry['unread'] = $this->unreadCounters[$id] ?? 0;
 
 		$this->entries[$id] = $entry;
 	}
@@ -313,7 +313,7 @@ class NavigationManager implements INavigationManager {
 				if (!isset($nav['route']) && $nav['type'] !== 'settings') {
 					continue;
 				}
-				$role = isset($nav['@attributes']['role']) ? $nav['@attributes']['role'] : 'all';
+				$role = $nav['@attributes']['role'] ?? 'all';
 				if ($role === 'admin' && !$this->isAdmin()) {
 					continue;
 				}
@@ -322,7 +322,7 @@ class NavigationManager implements INavigationManager {
 				$order = $customOrders[$app][$key] ?? $nav['order'] ?? 100;
 				$type = $nav['type'];
 				$route = !empty($nav['route']) ? $this->urlGenerator->linkToRoute($nav['route']) : '';
-				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';
+				$icon = $nav['icon'] ?? 'app.svg';
 				foreach ([$icon, "$app.svg"] as $i) {
 					try {
 						$icon = $this->urlGenerator->imagePath($app, $i);

--- a/lib/private/Remote/User.php
+++ b/lib/private/Remote/User.php
@@ -92,7 +92,7 @@ class User implements IUser {
 	 * @return string
 	 */
 	public function getTwitter() {
-		return isset($this->data['twitter']) ? $this->data['twitter'] : '';
+		return $this->data['twitter'] ?? '';
 	}
 
 	/**

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -88,7 +88,7 @@ abstract class AbstractDatabase {
 		$dbName = $config['dbname'];
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbPort = !empty($config['dbport']) ? $config['dbport'] : '';
-		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
+		$dbTablePrefix = $config['dbtableprefix'] ?? 'oc_';
 
 		$createUserConfig = $this->config->getValue("setup_create_db_user", true);
 		// accept `false` both as bool and string, since setting config values from env will result in a string

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1364,7 +1364,7 @@ class DefaultShareProvider implements IShareProvider {
 			$type = (int)$row['share_type'];
 			if ($type === IShare::TYPE_USER) {
 				$uid = $row['share_with'];
-				$users[$uid] = isset($users[$uid]) ? $users[$uid] : [];
+				$users[$uid] = $users[$uid] ?? [];
 				$users[$uid][$row['id']] = $row;
 			} elseif ($type === IShare::TYPE_GROUP) {
 				$gid = $row['share_with'];
@@ -1377,14 +1377,14 @@ class DefaultShareProvider implements IShareProvider {
 				$userList = $group->getUsers();
 				foreach ($userList as $user) {
 					$uid = $user->getUID();
-					$users[$uid] = isset($users[$uid]) ? $users[$uid] : [];
+					$users[$uid] = $users[$uid] ?? [];
 					$users[$uid][$row['id']] = $row;
 				}
 			} elseif ($type === IShare::TYPE_LINK) {
 				$link = true;
 			} elseif ($type === IShare::TYPE_USERGROUP && $currentAccess === true) {
 				$uid = $row['share_with'];
-				$users[$uid] = isset($users[$uid]) ? $users[$uid] : [];
+				$users[$uid] = $users[$uid] ?? [];
 				$users[$uid][$row['id']] = $row;
 			}
 		}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -390,7 +390,7 @@ class OC_App {
 	public static function getAppVersionByPath(string $path): string {
 		$infoFile = $path . '/appinfo/info.xml';
 		$appData = \OC::$server->getAppManager()->getAppInfo($infoFile, true);
-		return isset($appData['version']) ? $appData['version'] : '';
+		return $appData['version'] ?? '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR aims to enhance code readability and simplify ternary operations in the codebase. It replaces all instances of `isset` ternary operations with the more concise and expressive null coalescing operator in `/lib/private` namespace. The conversion eliminates unnecessary redundancy and improves maintainability.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
