### PR TITLE
Convert isset ternary to null coalescing operator

### DIFF
--- a/apps/dav/lib/Avatars/AvatarHome.php
+++ b/apps/dav/lib/Avatars/AvatarHome.php
@@ -59,8 +59,8 @@ class AvatarHome implements ICollection {
 
 	public function getChild($name) {
 		$elements = pathinfo($name);
-		$ext = isset($elements['extension']) ? $elements['extension'] : '';
-		$size = (int)(isset($elements['filename']) ? $elements['filename'] : '64');
+		$ext = $elements['extension'] ?? '';
+		$size = (int)($elements['filename'] ?? '64');
 		if (!in_array($ext, ['jpeg', 'png'], true)) {
 			throw new MethodNotAllowed('File format not allowed');
 		}

--- a/apps/dav/lib/DAV/Sharing/Xml/ShareRequest.php
+++ b/apps/dav/lib/DAV/Sharing/Xml/ShareRequest.php
@@ -62,8 +62,8 @@ class ShareRequest implements XmlDeserializable {
 
 					$set[] = [
 						'href' => $sharee['{DAV:}href'],
-						'commonName' => isset($sharee[$commonName]) ? $sharee[$commonName] : null,
-						'summary' => isset($sharee[$sumElem]) ? $sharee[$sumElem] : null,
+						'commonName' => $sharee[$commonName] ?? null,
+						'summary' => $sharee[$sumElem] ?? null,
 						'readOnly' => !array_key_exists('{' . Plugin::NS_OWNCLOUD . '}read-write', $sharee),
 					];
 					break;

--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -216,7 +216,7 @@ class UserHooks implements IHook {
 		} else { // admin changed the password for a different user, create new keys and re-encrypt file keys
 			$userId = $params['uid'];
 			$this->initMountPoints($userId);
-			$recoveryPassword = isset($params['recoveryPassword']) ? $params['recoveryPassword'] : null;
+			$recoveryPassword = $params['recoveryPassword'] ?? null;
 
 			$recoveryKeyId = $this->keyManager->getRecoveryKeyId();
 			$recoveryKey = $this->keyManager->getSystemPrivateKey($recoveryKeyId);

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -345,7 +345,7 @@ class Notifications {
 		// Fall back to old API
 		$client = $this->httpClientService->newClient();
 		$federationEndpoints = $this->discoveryService->discover($remoteDomain, 'FEDERATED_SHARING');
-		$endpoint = isset($federationEndpoints['share']) ? $federationEndpoints['share'] : '/ocs/v2.php/cloud/shares';
+		$endpoint = $federationEndpoints['share'] ?? '/ocs/v2.php/cloud/shares';
 		try {
 			$response = $client->post($remoteDomain . $endpoint . $urlSuffix . '?format=' . self::RESPONSE_FORMAT, [
 				'body' => $fields,

--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -118,7 +118,7 @@ class GetSharedSecret extends Job {
 		}
 
 		$endPoints = $this->ocsDiscoveryService->discover($target, 'FEDERATED_SHARING');
-		$endPoint = isset($endPoints['shared-secret']) ? $endPoints['shared-secret'] : $this->defaultEndPoint;
+		$endPoint = $endPoints['shared-secret'] ?? $this->defaultEndPoint;
 
 		// make sure that we have a well formatted url
 		$url = rtrim($target, '/') . '/' . trim($endPoint, '/');

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -122,7 +122,7 @@ class RequestSharedSecret extends Job {
 		}
 
 		$endPoints = $this->ocsDiscoveryService->discover($target, 'FEDERATED_SHARING');
-		$endPoint = isset($endPoints['shared-secret']) ? $endPoints['shared-secret'] : $this->defaultEndPoint;
+		$endPoint = $endPoints['shared-secret'] ?? $this->defaultEndPoint;
 
 		// make sure that we have a well formatted url
 		$url = rtrim($target, '/') . '/' . trim($endPoint, '/');

--- a/apps/federation/lib/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/SyncFederationAddressBooks.php
@@ -60,7 +60,7 @@ class SyncFederationAddressBooks {
 			$syncToken = $trustedServer['sync_token'];
 
 			$endPoints = $this->ocsDiscoveryService->discover($url, 'FEDERATED_SHARING');
-			$cardDavUser = isset($endPoints['carddav-user']) ? $endPoints['carddav-user'] : 'system';
+			$cardDavUser = $endPoints['carddav-user'] ?? 'system';
 			$addressBookUrl = isset($endPoints['system-address-book']) ? trim($endPoints['system-address-book'], '/') : 'remote.php/dav/addressbooks/system/system/system';
 
 			if (is_null($sharedSecret)) {

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -37,7 +37,7 @@ function NavigationListElements($item, $l, $pinned) {
 		<?php if (isset($item['defaultExpandedState']) && $item['defaultExpandedState']) { ?> open<?php } ?>"
 		<?php if (isset($item['folderPosition'])) { ?> folderposition="<?php p($item['folderPosition']); ?>" <?php } ?>>
 
-		<a href="<?php p(isset($item['href']) ? $item['href'] : '#') ?>"
+		<a href="<?php p($item['href'] ?? '#') ?>"
 		   class="nav-icon-<?php p(isset($item['icon']) && $item['icon'] !== '' ? $item['icon'] : $item['id']) ?> svg"><?php p($item['name']); ?></a>
 
 

--- a/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Parser.php
+++ b/apps/files_external/3rdparty/icewind/smb/src/Wrapped/Parser.php
@@ -144,8 +144,8 @@ class Parser {
 			// A line = explode statement may not fill all array elements
 			// properly. May happen when accessing non Windows Fileservers
 			$words = explode(':', $line, 2);
-			$name = isset($words[0]) ? $words[0] : '';
-			$value = isset($words[1]) ? $words[1] : '';
+			$name = $words[0] ?? '';
+			$value = $words[1] ?? '';
 			$value = trim($value);
 
 			if (!isset($data[$name])) {

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -178,8 +178,8 @@ class Import extends Base {
 		$mount->setAuthMechanism($authBackend);
 		$mount->setBackendOptions($data['configuration']);
 		$mount->setMountOptions($data['options']);
-		$mount->setApplicableUsers(isset($data['applicable_users']) ? $data['applicable_users'] : []);
-		$mount->setApplicableGroups(isset($data['applicable_groups']) ? $data['applicable_groups'] : []);
+		$mount->setApplicableUsers($data['applicable_users'] ?? []);
+		$mount->setApplicableGroups($data['applicable_groups'] ?? []);
 		return $mount;
 	}
 

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -276,8 +276,8 @@ class MountConfig {
 				'a' => $config['authMechanism'],
 				'm' => $config['mountpoint'],
 				'o' => $config['options'],
-				'p' => isset($config['priority']) ? $config['priority'] : -1,
-				'mo' => isset($config['mountOptions']) ? $config['mountOptions'] : [],
+				'p' => $config['priority'] ?? -1,
+				'mo' => $config['mountOptions'] ?? [],
 			]
 		);
 		return hash('md5', $data);

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -472,7 +472,7 @@ class Manager {
 		}
 
 		$federationEndpoints = $this->discoveryService->discover($remote, 'FEDERATED_SHARING');
-		$endpoint = isset($federationEndpoints['share']) ? $federationEndpoints['share'] : '/ocs/v2.php/cloud/shares';
+		$endpoint = $federationEndpoints['share'] ?? '/ocs/v2.php/cloud/shares';
 
 		$url = rtrim($remote, '/') . $endpoint . '/' . $remoteId . '/' . $feedback . '?format=' . Share::RESPONSE_FORMAT;
 		$fields = ['token' => $token];

--- a/apps/files_sharing/public.php
+++ b/apps/files_sharing/public.php
@@ -25,7 +25,7 @@
 // This file is just used to redirect the legacy sharing URLs (< ownCloud 8) to the new ones
 
 $urlGenerator = \OC::$server->getURLGenerator();
-$token = isset($_GET['t']) ? $_GET['t'] : '';
+$token = $_GET['t'] ?? '';
 $route = isset($_GET['download']) ? 'files_sharing.sharecontroller.downloadShare' : 'files_sharing.sharecontroller.showShare';
 
 if ($token !== '') {

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -340,8 +340,8 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param string $message
 	 */
 	public function testSearchInvalid($getData, $message) {
-		$page = isset($getData['page']) ? $getData['page'] : 1;
-		$perPage = isset($getData['perPage']) ? $getData['perPage'] : 200;
+		$page = $getData['page'] ?? 1;
+		$perPage = $getData['perPage'] ?? 200;
 
 		/** @var IConfig|MockObject $config */
 		$config = $this->createMock(IConfig::class);

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -507,7 +507,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function (string $uid) use ($users) {
-				return isset($users[$uid]) ? $users[$uid] : null;
+				return $users[$uid] ?? null;
 			});
 
 		$group = $this->createGroup($gid);
@@ -552,7 +552,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$this->userManager->expects($this->any())
 			->method('get')
 			->willReturnCallback(function (string $uid) use ($users) {
-				return isset($users[$uid]) ? $users[$uid] : null;
+				return $users[$uid] ?? null;
 			});
 
 		$group = $this->createGroup($gid);

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -105,8 +105,8 @@ switch ($action) {
 	}
 
 	case 'save':
-		$key = isset($_POST['cfgkey']) ? $_POST['cfgkey'] : false;
-		$val = isset($_POST['cfgval']) ? $_POST['cfgval'] : null;
+		$key = $_POST['cfgkey'] ?? false;
+		$val = $_POST['cfgval'] ?? null;
 		if ($key === false || is_null($val)) {
 			\OC_JSON::error(['message' => $l->t('No data specified')]);
 			exit;

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1746,7 +1746,7 @@ class Access extends LDAPUtility {
 		$uuid = false;
 		if ($this->detectUuidAttribute($dn, $isUser, false, $ldapRecord)) {
 			$attr = $this->connection->$uuidAttr;
-			$uuid = isset($ldapRecord[$attr]) ? $ldapRecord[$attr] : $this->readAttribute($dn, $attr);
+			$uuid = $ldapRecord[$attr] ?? $this->readAttribute($dn, $attr);
 			if (!is_array($uuid)
 				&& $uuidOverride !== ''
 				&& $this->detectUuidAttribute($dn, $isUser, true, $ldapRecord)) {


### PR DESCRIPTION
## Summary
This PR aims to enhance code readability and simplify ternary operations in the codebase. It replaces all instances of `isset` ternary operations with the more concise and expressive null coalescing operator in `/apps/` namespace. The conversion eliminates unnecessary redundancy and improves maintainability.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
