### PR TITLE
Convert isset ternary to null coalescing operator

### DIFF
--- a/tests/lib/Util/User/Dummy.php
+++ b/tests/lib/Util/User/Dummy.php
@@ -168,7 +168,7 @@ class Dummy extends Backend implements \OCP\IUserBackend {
 	}
 
 	public function getDisplayName($uid) {
-		return isset($this->displayNames[$uid])? $this->displayNames[$uid]: $uid;
+		return $this->displayNames[$uid] ?? $uid;
 	}
 
 	/**

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -30,7 +30,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 		$config->expects($this->any())
 			->method('getValue')
 			->willReturnCallback(function ($key, $default) use ($systemOptions) {
-				return isset($systemOptions[$key]) ? $systemOptions[$key] : $default;
+				return $systemOptions[$key] ?? $default;
 			});
 		return $config;
 	}


### PR DESCRIPTION
## Summary
This PR aims to enhance code readability and simplify ternary operations in the codebase. It replaces all instances of `isset` ternary operations with the more concise and expressive null coalescing operator in `/tests/` namespace. The conversion eliminates unnecessary redundancy and improves maintainability.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
