### PR TITLE
Refactor cloud_federation_api app

### DIFF
--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -26,18 +26,15 @@ use OCP\Capabilities\ICapability;
 use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	public function __construct(IURLGenerator $urlGenerator) {
-		$this->urlGenerator = $urlGenerator;
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+	) {
 	}
 
 	/**
 	 * Function an app uses to return the capabilities
 	 */
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		$url = $this->urlGenerator->linkToRouteAbsolute('cloud_federation_api.requesthandlercontroller.addShare');
 		$capabilities = ['ocm' =>
 			[

--- a/apps/cloud_federation_api/lib/Config.php
+++ b/apps/cloud_federation_api/lib/Config.php
@@ -33,12 +33,9 @@ use OCP\Federation\ICloudFederationProviderManager;
  * @package OCA\CloudFederationAPI
  */
 class Config {
-
-	/** @var ICloudFederationProviderManager */
-	private $cloudFederationProviderManager;
-
-	public function __construct(ICloudFederationProviderManager $cloudFederationProviderManager) {
-		$this->cloudFederationProviderManager = $cloudFederationProviderManager;
+	public function __construct(
+		private ICloudFederationProviderManager $cloudFederationProviderManager,
+	) {
 	}
 
 	/**
@@ -47,7 +44,7 @@ class Config {
 	 * @param string $resourceType
 	 * @return array
 	 */
-	public function getSupportedShareTypes($resourceType) {
+	public function getSupportedShareTypes(string $resourceType): array {
 		try {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
 			return $provider->getSupportedShareTypes();

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -51,52 +51,19 @@ use Psr\Log\LoggerInterface;
  * @package OCA\CloudFederationAPI\Controller
  */
 class RequestHandlerController extends Controller {
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var IGroupManager */
-	private $groupManager;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var ICloudFederationProviderManager */
-	private $cloudFederationProviderManager;
-
-	/** @var Config */
-	private $config;
-
-	/** @var ICloudFederationFactory */
-	private $factory;
-
-	/** @var ICloudIdManager */
-	private $cloudIdManager;
-
-	public function __construct($appName,
-								IRequest $request,
-								LoggerInterface $logger,
-								IUserManager $userManager,
-								IGroupManager $groupManager,
-								IURLGenerator $urlGenerator,
-								ICloudFederationProviderManager $cloudFederationProviderManager,
-								Config $config,
-								ICloudFederationFactory $factory,
-								ICloudIdManager $cloudIdManager
+	public function __construct(
+		$appName,
+		IRequest $request,
+		private LoggerInterface $logger,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
+		private IURLGenerator $urlGenerator,
+		private ICloudFederationProviderManager $cloudFederationProviderManager,
+		private Config $config,
+		private ICloudFederationFactory $factory,
+		private ICloudIdManager $cloudIdManager
 	) {
 		parent::__construct($appName, $request);
-
-		$this->logger = $logger;
-		$this->userManager = $userManager;
-		$this->groupManager = $groupManager;
-		$this->urlGenerator = $urlGenerator;
-		$this->cloudFederationProviderManager = $cloudFederationProviderManager;
-		$this->config = $config;
-		$this->factory = $factory;
-		$this->cloudIdManager = $cloudIdManager;
 	}
 
 	/**
@@ -121,8 +88,7 @@ class RequestHandlerController extends Controller {
 	 *
 	 * Example: curl -H "Content-Type: application/json" -X POST -d '{"shareWith":"admin1@serve1","name":"welcome server2.txt","description":"desc","providerId":"2","owner":"admin2@http://localhost/server2","ownerDisplayName":"admin2 display","shareType":"user","resourceType":"file","protocol":{"name":"webdav","options":{"sharedSecret":"secret","permissions":"webdav-property"}}}' http://localhost/server/index.php/ocm/shares
 	 */
-	public function addShare($shareWith, $name, $description, $providerId, $owner, $ownerDisplayName, $sharedBy, $sharedByDisplayName, $protocol, $shareType, $resourceType) {
-
+	public function addShare(string $shareWith, string $name, string $description, string $providerId, string $owner, string $ownerDisplayName, string $sharedBy, string $sharedByDisplayName, array $protocol, string $shareType, $resourceType): Http\DataResponse|JSONResponse {
 		// check if all required parameters are set
 		if ($shareWith === null ||
 			$name === null ||
@@ -234,8 +200,7 @@ class RequestHandlerController extends Controller {
 	 * @param array $notification the actual payload of the notification
 	 * @return JSONResponse
 	 */
-	public function receiveNotification($notificationType, $resourceType, $providerId, array $notification) {
-
+	public function receiveNotification(string $notificationType, string $resourceType, string $providerId, array $notification): JSONResponse {
 		// check if all required parameters are set
 		if ($notificationType === null ||
 			$resourceType === null ||
@@ -281,7 +246,7 @@ class RequestHandlerController extends Controller {
 			);
 		}
 
-		return new JSONResponse($result,Http::STATUS_CREATED);
+		return new JSONResponse($result, Http::STATUS_CREATED);
 	}
 
 	/**
@@ -290,7 +255,7 @@ class RequestHandlerController extends Controller {
 	 * @param string $uid
 	 * @return string mixed
 	 */
-	private function mapUid($uid) {
+	private function mapUid(string $uid): string {
 		// FIXME this should be a method in the user management instead
 		$this->logger->debug('shareWith before, ' . $uid, ['app' => $this->appName]);
 		\OCP\Util::emitHook(


### PR DESCRIPTION
## Summary
The required adjustments have been made to the `cloud_federation_api` app.

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Updating doc blocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
