### PR TITLE
Refactor comments app

### DIFF
--- a/apps/comments/lib/Activity/Filter.php
+++ b/apps/comments/lib/Activity/Filter.php
@@ -27,12 +27,10 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class Filter implements IFilter {
-	protected IL10N $l;
-	protected IURLGenerator $url;
-
-	public function __construct(IL10N $l, IURLGenerator $url) {
-		$this->l = $l;
-		$this->url = $url;
+	public function __construct(
+		protected IL10N $l,
+		protected IURLGenerator $url,
+	) {
 	}
 
 	public function getIdentifier(): string {

--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -35,9 +35,6 @@ use OCP\IUserSession;
 use OCP\Share\IShareHelper;
 
 class Listener {
-	/**
-	 * Listener constructor.
-	 */
 	public function __construct(
 		protected IManager $activityManager,
 		protected IUserSession $session,

--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -35,28 +35,17 @@ use OCP\IUserSession;
 use OCP\Share\IShareHelper;
 
 class Listener {
-	protected IManager $activityManager;
-	protected IUserSession $session;
-	protected IAppManager $appManager;
-	protected IMountProviderCollection $mountCollection;
-	protected IRootFolder $rootFolder;
-	protected IShareHelper $shareHelper;
-
 	/**
 	 * Listener constructor.
 	 */
-	public function __construct(IManager $activityManager,
-								IUserSession $session,
-								IAppManager $appManager,
-								IMountProviderCollection $mountCollection,
-								IRootFolder $rootFolder,
-								IShareHelper $shareHelper) {
-		$this->activityManager = $activityManager;
-		$this->session = $session;
-		$this->appManager = $appManager;
-		$this->mountCollection = $mountCollection;
-		$this->rootFolder = $rootFolder;
-		$this->shareHelper = $shareHelper;
+	public function __construct(
+		protected IManager $activityManager,
+		protected IUserSession $session,
+		protected IAppManager $appManager,
+		protected IMountProviderCollection $mountCollection,
+		protected IRootFolder $rootFolder,
+		protected IShareHelper $shareHelper,
+	) {
 	}
 
 	public function commentEvent(CommentsEvent $event): void {

--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -35,19 +35,14 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 
 class Provider implements IProvider {
-	protected IFactory $languageFactory;
 	protected ?IL10N $l = null;
-	protected IUrlGenerator $url;
-	protected ICommentsManager $commentsManager;
-	protected IUserManager $userManager;
-	protected IManager $activityManager;
 
-	public function __construct(IFactory $languageFactory, IURLGenerator $url, ICommentsManager $commentsManager, IUserManager $userManager, IManager $activityManager) {
-		$this->languageFactory = $languageFactory;
-		$this->url = $url;
-		$this->commentsManager = $commentsManager;
-		$this->userManager = $userManager;
-		$this->activityManager = $activityManager;
+	public function __construct(
+		protected IFactory $languageFactory,
+		protected IURLGenerator $url, protected ICommentsManager $commentsManager,
+		protected IUserManager $userManager,
+		protected IManager $activityManager,
+	) {
 	}
 
 	/**
@@ -168,7 +163,7 @@ class Provider implements IProvider {
 			return;
 		}
 
-		$commentId = isset($messageParameters['commentId']) ? $messageParameters['commentId'] : $messageParameters[0];
+		$commentId = $messageParameters['commentId'] ?? $messageParameters[0];
 
 		try {
 			$comment = $this->commentsManager->get((string) $commentId);

--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -39,7 +39,8 @@ class Provider implements IProvider {
 
 	public function __construct(
 		protected IFactory $languageFactory,
-		protected IURLGenerator $url, protected ICommentsManager $commentsManager,
+		protected IURLGenerator $url,
+		protected ICommentsManager $commentsManager,
 		protected IUserManager $userManager,
 		protected IManager $activityManager,
 	) {

--- a/apps/comments/lib/Activity/Setting.php
+++ b/apps/comments/lib/Activity/Setting.php
@@ -26,10 +26,9 @@ use OCP\Activity\ISetting;
 use OCP\IL10N;
 
 class Setting implements ISetting {
-	protected IL10N $l;
-
-	public function __construct(IL10N $l) {
-		$this->l = $l;
+	public function __construct(
+		protected IL10N $l,
+	) {
 	}
 
 	public function getIdentifier(): string {

--- a/apps/comments/lib/Collaboration/CommentersSorter.php
+++ b/apps/comments/lib/Collaboration/CommentersSorter.php
@@ -27,10 +27,9 @@ use OCP\Collaboration\AutoComplete\ISorter;
 use OCP\Comments\ICommentsManager;
 
 class CommentersSorter implements ISorter {
-	private ICommentsManager $commentsManager;
-
-	public function __construct(ICommentsManager $commentsManager) {
-		$this->commentsManager = $commentsManager;
+	public function __construct(
+		private ICommentsManager $commentsManager,
+	) {
 	}
 
 	public function getId(): string {

--- a/apps/comments/lib/Controller/NotificationsController.php
+++ b/apps/comments/lib/Controller/NotificationsController.php
@@ -43,9 +43,6 @@ use OCP\Notification\IManager;
  */
 #[IgnoreOpenAPI]
 class NotificationsController extends Controller {
-	/**
-	 * NotificationsController constructor.
-	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,

--- a/apps/comments/lib/Controller/NotificationsController.php
+++ b/apps/comments/lib/Controller/NotificationsController.php
@@ -43,31 +43,19 @@ use OCP\Notification\IManager;
  */
 #[IgnoreOpenAPI]
 class NotificationsController extends Controller {
-
-	protected IRootFolder $rootFolder;
-	protected ICommentsManager $commentsManager;
-	protected IURLGenerator $urlGenerator;
-	protected IManager $notificationManager;
-	protected IUserSession $userSession;
-
 	/**
 	 * NotificationsController constructor.
 	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		ICommentsManager $commentsManager,
-		IRootFolder $rootFolder,
-		IURLGenerator $urlGenerator,
-		IManager $notificationManager,
-		IUserSession $userSession
+		protected ICommentsManager $commentsManager,
+		protected IRootFolder $rootFolder,
+		protected IURLGenerator $urlGenerator,
+		protected IManager $notificationManager,
+		protected IUserSession $userSession
 	) {
 		parent::__construct($appName, $request);
-		$this->commentsManager = $commentsManager;
-		$this->rootFolder = $rootFolder;
-		$this->urlGenerator = $urlGenerator;
-		$this->notificationManager = $notificationManager;
-		$this->userSession = $userSession;
 	}
 
 	/**

--- a/apps/comments/lib/EventHandler.php
+++ b/apps/comments/lib/EventHandler.php
@@ -34,12 +34,10 @@ use OCP\Comments\ICommentsEventHandler;
  * @package OCA\Comments
  */
 class EventHandler implements ICommentsEventHandler {
-	private ActivityListener $activityListener;
-	private NotificationListener $notificationListener;
-
-	public function __construct(ActivityListener $activityListener, NotificationListener $notificationListener) {
-		$this->activityListener = $activityListener;
-		$this->notificationListener = $notificationListener;
+	public function __construct(
+		private ActivityListener $activityListener,
+		private NotificationListener $notificationListener,
+	) {
 	}
 
 	public function handle(CommentsEvent $event): void {

--- a/apps/comments/lib/Listener/CommentsEntityEventListener.php
+++ b/apps/comments/lib/Listener/CommentsEntityEventListener.php
@@ -31,12 +31,10 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Files\IRootFolder;
 
 class CommentsEntityEventListener implements IEventListener {
-	private IRootFolder $rootFolder;
-	private ?string $userId;
-
-	public function  __construct(IRootFolder $rootFolder, ?string $userId = null) {
-		$this->rootFolder = $rootFolder;
-		$this->userId = $userId;
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private ?string $userId = null,
+	) {
 	}
 
 	public function handle(Event $event): void {

--- a/apps/comments/lib/Listener/LoadSidebarScripts.php
+++ b/apps/comments/lib/Listener/LoadSidebarScripts.php
@@ -34,11 +34,9 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
 class LoadSidebarScripts implements IEventListener {
-
-	private ICommentsManager $commentsManager;
-
-	public function __construct(ICommentsManager $commentsManager) {
-		$this->commentsManager = $commentsManager;
+	public function __construct(
+		private ICommentsManager $commentsManager,
+	) {
 	}
 
 	public function handle(Event $event): void {

--- a/apps/comments/lib/MaxAutoCompleteResultsInitialState.php
+++ b/apps/comments/lib/MaxAutoCompleteResultsInitialState.php
@@ -31,10 +31,9 @@ use OCP\AppFramework\Services\InitialStateProvider;
 use OCP\IConfig;
 
 class MaxAutoCompleteResultsInitialState extends InitialStateProvider {
-	private IConfig $config;
-
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		private IConfig $config,
+	) {
 	}
 
 	public function getKey(): string {

--- a/apps/comments/lib/Notification/Listener.php
+++ b/apps/comments/lib/Notification/Listener.php
@@ -30,15 +30,10 @@ use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 
 class Listener {
-	protected IManager $notificationManager;
-	protected IUserManager $userManager;
-
 	public function __construct(
-		IManager $notificationManager,
-		IUserManager $userManager
+		protected IManager $notificationManager,
+		protected IUserManager $userManager
 	) {
-		$this->notificationManager = $notificationManager;
-		$this->userManager = $userManager;
 	}
 
 	public function evaluate(CommentsEvent $event): void {

--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -36,24 +36,13 @@ use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
 class Notifier implements INotifier {
-	protected IFactory $l10nFactory;
-	protected IRootFolder $rootFolder;
-	protected ICommentsManager $commentsManager;
-	protected IURLGenerator $url;
-	protected IUserManager $userManager;
-
 	public function __construct(
-		IFactory $l10nFactory,
-		IRootFolder $rootFolder,
-		ICommentsManager $commentsManager,
-		IURLGenerator $url,
-		IUserManager $userManager
+		protected IFactory $l10nFactory,
+		protected IRootFolder $rootFolder,
+		protected ICommentsManager $commentsManager,
+		protected IURLGenerator $url,
+		protected IUserManager $userManager
 	) {
-		$this->l10nFactory = $l10nFactory;
-		$this->rootFolder = $rootFolder;
-		$this->commentsManager = $commentsManager;
-		$this->url = $url;
-		$this->userManager = $userManager;
 	}
 
 	/**

--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -39,19 +39,12 @@ use function array_map;
 use function pathinfo;
 
 class CommentsSearchProvider implements IProvider {
-	private IUserManager $userManager;
-	private IL10N $l10n;
-	private IURLGenerator $urlGenerator;
-	private LegacyProvider $legacyProvider;
-
-	public function __construct(IUserManager $userManager,
-								IL10N $l10n,
-								IURLGenerator $urlGenerator,
-								LegacyProvider $legacyProvider) {
-		$this->userManager = $userManager;
-		$this->l10n = $l10n;
-		$this->urlGenerator = $urlGenerator;
-		$this->legacyProvider = $legacyProvider;
+	public function __construct(
+		private IUserManager $userManager,
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+		private LegacyProvider $legacyProvider,
+	) {
 	}
 
 	public function getId(): string {
@@ -84,7 +77,7 @@ class CommentsSearchProvider implements IProvider {
 					$avatarUrl,
 					$result->name,
 					$path,
-					$this->urlGenerator->linkToRouteAbsolute('files.view.index',[
+					$this->urlGenerator->linkToRouteAbsolute('files.view.index', [
 						'dir' => $pathInfo['dirname'],
 						'scrollto' => $pathInfo['basename'],
 					]),

--- a/apps/comments/lib/Search/LegacyProvider.php
+++ b/apps/comments/lib/Search/LegacyProvider.php
@@ -35,7 +35,6 @@ use OCP\Comments\ICommentsManager;
 use function count;
 
 class LegacyProvider extends Provider {
-
 	/**
 	 * Search for $query
 	 *

--- a/apps/comments/lib/Search/Result.php
+++ b/apps/comments/lib/Search/Result.php
@@ -39,41 +39,38 @@ class Result extends BaseResult {
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public $comment;
+	public string $comment;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public $authorId;
+	public string $authorId;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public $authorName;
+	public string $path;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public $path;
-	/**
-	 * @deprecated 20.0.0
-	 */
-	public $fileName;
+	public string $fileName;
 
 	/**
 	 * @throws NotFoundException
 	 * @deprecated 20.0.0
 	 */
-	public function __construct(string $search,
-								IComment $comment,
-								string $authorName,
-								string $path) {
+	public function __construct(
+		string $search,
+		IComment $comment,
+		public string $authorName,
+		string $path,
+	) {
 		parent::__construct(
 			$comment->getId(),
 			$comment->getMessage()
-		/* @todo , [link to file] */
+			/* @todo , [link to file] */
 		);
 
 		$this->comment = $this->getRelevantMessagePart($comment->getMessage(), $search);
 		$this->authorId = $comment->getActorId();
-		$this->authorName = $authorName;
 		$this->fileName = basename($path);
 		$this->path = $this->getVisiblePath($path);
 	}

--- a/apps/comments/lib/Search/Result.php
+++ b/apps/comments/lib/Search/Result.php
@@ -39,19 +39,23 @@ class Result extends BaseResult {
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public string $comment;
+	public $comment;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public string $authorId;
+	public $authorId;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public string $path;
+	public string $authorName;
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public string $fileName;
+	public $path;
+	/**
+	 * @deprecated 20.0.0
+	 */
+	public $fileName;
 
 	/**
 	 * @throws NotFoundException
@@ -60,7 +64,7 @@ class Result extends BaseResult {
 	public function __construct(
 		string $search,
 		IComment $comment,
-		public string $authorName,
+		string $authorName,
 		string $path,
 	) {
 		parent::__construct(
@@ -71,6 +75,7 @@ class Result extends BaseResult {
 
 		$this->comment = $this->getRelevantMessagePart($comment->getMessage(), $search);
 		$this->authorId = $comment->getActorId();
+		$this->authorName = $authorName;
 		$this->fileName = basename($path);
 		$this->path = $this->getVisiblePath($path);
 	}


### PR DESCRIPTION
## Summary
The required adjustments have been made to the `comments` app.

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Updating doc blocks
- Converting `isset` ternary to null coalescing operator

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
