### PR TITLE
Refactor lib/private

### DIFF
--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -63,7 +63,7 @@ class TagManager implements ITagManager, IEventListener {
 	 * since 20.0.0 $includeShared isn't used anymore
 	 * @see \OCP\ITags
 	 */
-	public function load($type, $defaultTags = [], $includeShared = false, ?string $userId = null) {
+	public function load($type, $defaultTags = [], $includeShared = false, $userId = null) {
 		if (is_null($userId)) {
 			$user = $this->userSession->getUser();
 			if ($user === null) {

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -56,14 +56,14 @@ class TagManager implements ITagManager, IEventListener {
 	 * @param string $type The type identifier e.g. 'contact' or 'event'.
 	 * @param array $defaultTags An array of default tags to be used if none are stored.
 	 * @param boolean $includeShared Whether to include tags for items shared with this user by others.
-	 * @param null $userId user for which to retrieve the tags, defaults to the currently
+	 * @param string|null $userId user for which to retrieve the tags, defaults to the currently
 	 * logged in user
-	 * @return Tags|null since 20.0.0 $includeShared isn't used anymore
+	 * @return \OCP\ITags
 	 *
 	 * since 20.0.0 $includeShared isn't used anymore
 	 * @see \OCP\ITags
 	 */
-	public function load($type, $defaultTags = [], $includeShared = false, $userId = null): Tags|null {
+	public function load($type, $defaultTags = [], $includeShared = false, ?string $userId = null) {
 		if (is_null($userId)) {
 			$user = $this->userSession->getUser();
 			if ($user === null) {

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -42,32 +42,28 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<UserDeletedEvent>
  */
 class TagManager implements ITagManager, IEventListener {
-	private TagMapper $mapper;
-	private IUserSession $userSession;
-	private IDBConnection $connection;
-	private LoggerInterface $logger;
-
-	public function __construct(TagMapper $mapper, IUserSession $userSession, IDBConnection $connection, LoggerInterface $logger) {
-		$this->mapper = $mapper;
-		$this->userSession = $userSession;
-		$this->connection = $connection;
-		$this->logger = $logger;
+	public function __construct(
+		private TagMapper $mapper,
+		private IUserSession $userSession,
+		private IDBConnection $connection,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**
 	 * Create a new \OCP\ITags instance and load tags from db.
 	 *
-	 * @see \OCP\ITags
 	 * @param string $type The type identifier e.g. 'contact' or 'event'.
 	 * @param array $defaultTags An array of default tags to be used if none are stored.
 	 * @param boolean $includeShared Whether to include tags for items shared with this user by others.
-	 * @param string $userId user for which to retrieve the tags, defaults to the currently
+	 * @param null $userId user for which to retrieve the tags, defaults to the currently
 	 * logged in user
-	 * @return \OCP\ITags
+	 * @return Tags|null since 20.0.0 $includeShared isn't used anymore
 	 *
 	 * since 20.0.0 $includeShared isn't used anymore
+	 * @see \OCP\ITags
 	 */
-	public function load($type, $defaultTags = [], $includeShared = false, $userId = null) {
+	public function load($type, $defaultTags = [], $includeShared = false, $userId = null): Tags|null {
 		if (is_null($userId)) {
 			$user = $this->userSession->getUser();
 			if ($user === null) {

--- a/lib/private/TempManager.php
+++ b/lib/private/TempManager.php
@@ -75,9 +75,9 @@ class TempManager implements ITempManager {
 	 * Create a temporary file and return the path
 	 *
 	 * @param string $postFix Postfix appended to the temporary file name
-	 * @return bool|string
+	 * @return string
 	 */
-	public function getTemporaryFile($postFix = ''): bool|string {
+	public function getTemporaryFile($postFix = '') {
 		if (is_writable($this->tmpBaseDir)) {
 			// To create a unique file and prevent the risk of race conditions
 			// or duplicated temporary files by other means such as collisions
@@ -112,9 +112,9 @@ class TempManager implements ITempManager {
 	 * Create a temporary folder and return the path
 	 *
 	 * @param string $postFix Postfix appended to the temporary folder name
-	 * @return bool|string
+	 * @return string
 	 */
-	public function getTemporaryFolder($postFix = ''): bool|string {
+	public function getTemporaryFolder($postFix = '') {
 		if (is_writable($this->tmpBaseDir)) {
 			// To create an unique directory and prevent the risk of race conditions
 			// or duplicated temporary files by other means such as collisions

--- a/lib/private/TempManager.php
+++ b/lib/private/TempManager.php
@@ -38,23 +38,18 @@ use Psr\Log\LoggerInterface;
 
 class TempManager implements ITempManager {
 	/** @var string[] Current temporary files and folders, used for cleanup */
-	protected $current = [];
+	protected array $current = [];
 	/** @var string i.e. /tmp on linux systems */
-	protected $tmpBaseDir;
-	/** @var LoggerInterface */
-	protected $log;
-	/** @var IConfig */
-	protected $config;
-	/** @var IniGetWrapper */
-	protected $iniGetWrapper;
+	protected string $tmpBaseDir;
 
 	/** Prefix */
 	public const TMP_PREFIX = 'oc_tmp_';
 
-	public function __construct(LoggerInterface $logger, IConfig $config, IniGetWrapper $iniGetWrapper) {
-		$this->log = $logger;
-		$this->config = $config;
-		$this->iniGetWrapper = $iniGetWrapper;
+	public function __construct(
+		protected LoggerInterface $log,
+		protected IConfig $config,
+		protected IniGetWrapper $iniGetWrapper,
+	) {
 		$this->tmpBaseDir = $this->getTempBaseDir();
 	}
 
@@ -66,7 +61,7 @@ class TempManager implements ITempManager {
 	 * @param string $postFix Postfix appended to the temporary file name, may be user controlled
 	 * @return string
 	 */
-	private function buildFileNameWithSuffix($absolutePath, $postFix = '') {
+	private function buildFileNameWithSuffix(string $absolutePath, string $postFix = ''): string {
 		if ($postFix !== '') {
 			$postFix = '.' . ltrim($postFix, '.');
 			$postFix = str_replace(['\\', '/'], '', $postFix);
@@ -80,11 +75,11 @@ class TempManager implements ITempManager {
 	 * Create a temporary file and return the path
 	 *
 	 * @param string $postFix Postfix appended to the temporary file name
-	 * @return string
+	 * @return bool|string
 	 */
-	public function getTemporaryFile($postFix = '') {
+	public function getTemporaryFile($postFix = ''): bool|string {
 		if (is_writable($this->tmpBaseDir)) {
-			// To create an unique file and prevent the risk of race conditions
+			// To create a unique file and prevent the risk of race conditions
 			// or duplicated temporary files by other means such as collisions
 			// we need to create the file using `tempnam` and append a possible
 			// postfix to it later
@@ -117,9 +112,9 @@ class TempManager implements ITempManager {
 	 * Create a temporary folder and return the path
 	 *
 	 * @param string $postFix Postfix appended to the temporary folder name
-	 * @return string
+	 * @return bool|string
 	 */
-	public function getTemporaryFolder($postFix = '') {
+	public function getTemporaryFolder($postFix = ''): bool|string {
 		if (is_writable($this->tmpBaseDir)) {
 			// To create an unique directory and prevent the risk of race conditions
 			// or duplicated temporary files by other means such as collisions
@@ -148,14 +143,14 @@ class TempManager implements ITempManager {
 	/**
 	 * Remove the temporary files and folders generated during this request
 	 */
-	public function clean() {
+	public function clean(): void {
 		$this->cleanFiles($this->current);
 	}
 
 	/**
 	 * @param string[] $files
 	 */
-	protected function cleanFiles($files) {
+	protected function cleanFiles(array $files): void {
 		foreach ($files as $file) {
 			if (file_exists($file)) {
 				try {
@@ -176,7 +171,7 @@ class TempManager implements ITempManager {
 	/**
 	 * Remove old temporary files and folders that were failed to be cleaned
 	 */
-	public function cleanOld() {
+	public function cleanOld(): void {
 		$this->cleanFiles($this->getOldFiles());
 	}
 
@@ -185,7 +180,7 @@ class TempManager implements ITempManager {
 	 *
 	 * @return string[]
 	 */
-	protected function getOldFiles() {
+	protected function getOldFiles(): array {
 		$cutOfTime = time() - 3600;
 		$files = [];
 		$dh = opendir($this->tmpBaseDir);
@@ -209,7 +204,7 @@ class TempManager implements ITempManager {
 	 * @return string Path to the temporary directory or null
 	 * @throws \UnexpectedValueException
 	 */
-	public function getTempBaseDir() {
+	public function getTempBaseDir(): string {
 		if ($this->tmpBaseDir) {
 			return $this->tmpBaseDir;
 		}
@@ -254,7 +249,7 @@ class TempManager implements ITempManager {
 	 * @param mixed $directory
 	 * @return bool
 	 */
-	private function checkTemporaryDirectory($directory) {
+	private function checkTemporaryDirectory(mixed $directory): bool {
 		// suppress any possible errors caused by is_writable
 		// checks missing or invalid path or characters, wrong permissions etc
 		try {
@@ -274,7 +269,7 @@ class TempManager implements ITempManager {
 	 *
 	 * @param string $directory
 	 */
-	public function overrideTempBaseDir($directory) {
+	public function overrideTempBaseDir(string $directory): void {
 		$this->tmpBaseDir = $directory;
 	}
 }

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -57,22 +57,22 @@ use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
 
 class TemplateLayout extends \OC_Template {
-	private static $versionHash = '';
+	private static string $versionHash = '';
 
 	/** @var CSSResourceLocator|null */
-	public static $cssLocator = null;
+	public static ?CSSResourceLocator $cssLocator = null;
 
 	/** @var JSResourceLocator|null */
-	public static $jsLocator = null;
+	public static ?JSResourceLocator $jsLocator = null;
 
 	/** @var IConfig */
-	private $config;
+	private mixed $config;
 
 	/** @var IInitialStateService */
-	private $initialState;
+	private mixed $initialState;
 
 	/** @var INavigationManager */
-	private $navigationManager;
+	private mixed $navigationManager;
 
 	/**
 	 * @param string $renderAs
@@ -279,7 +279,7 @@ class TemplateLayout extends \OC_Template {
 			$web = $info[1];
 			$file = $info[2];
 
-			if (substr($file, -strlen('print.css')) === 'print.css') {
+			if (str_ends_with($file, 'print.css')) {
 				$this->append('printcssfiles', $web.'/'.$file . $this->getVersionHashSuffix());
 			} else {
 				$suffix = $this->getVersionHashSuffix($web, $file);
@@ -299,11 +299,11 @@ class TemplateLayout extends \OC_Template {
 	}
 
 	/**
-	 * @param string $path
-	 * @param string $file
+	 * @param bool|string $path
+	 * @param bool|string $file
 	 * @return string
 	 */
-	protected function getVersionHashSuffix($path = false, $file = false) {
+	protected function getVersionHashSuffix(bool|string $path = false, bool|string $file = false): string {
 		if ($this->config->getSystemValueBool('debug', false)) {
 			// allows chrome workspace mapping in debug mode
 			return "";
@@ -342,7 +342,7 @@ class TemplateLayout extends \OC_Template {
 	 * @param array $styles
 	 * @return array
 	 */
-	public static function findStylesheetFiles($styles, $compileScss = true) {
+	public static function findStylesheetFiles(array $styles, $compileScss = true): array {
 		if (!self::$cssLocator) {
 			self::$cssLocator = \OCP\Server::get(CSSResourceLocator::class);
 		}
@@ -354,7 +354,7 @@ class TemplateLayout extends \OC_Template {
 	 * @param string $path
 	 * @return string|boolean
 	 */
-	public function getAppNamefromPath($path) {
+	public function getAppNamefromPath(string $path): bool|string {
 		if ($path !== '' && is_string($path)) {
 			$pathParts = explode('/', $path);
 			if ($pathParts[0] === 'css') {
@@ -370,7 +370,7 @@ class TemplateLayout extends \OC_Template {
 	 * @param array $scripts
 	 * @return array
 	 */
-	public static function findJavascriptFiles($scripts) {
+	public static function findJavascriptFiles(array $scripts): array {
 		if (!self::$jsLocator) {
 			self::$jsLocator = \OCP\Server::get(JSResourceLocator::class);
 		}
@@ -380,11 +380,12 @@ class TemplateLayout extends \OC_Template {
 
 	/**
 	 * Converts the absolute file path to a relative path from \OC::$SERVERROOT
+	 *
 	 * @param string $filePath Absolute path
 	 * @return string Relative path
 	 * @throws \Exception If $filePath is not under \OC::$SERVERROOT
 	 */
-	public static function convertToRelativePath($filePath) {
+	public static function convertToRelativePath(string $filePath): string {
 		$relativePath = explode(\OC::$SERVERROOT, $filePath);
 		if (count($relativePath) !== 2) {
 			throw new \Exception('$filePath is not under the \OC::$SERVERROOT');

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -55,31 +55,17 @@ use RuntimeException;
  * Class to generate URLs
  */
 class URLGenerator implements IURLGenerator {
-	/** @var IConfig */
-	private $config;
-	/** @var IUserSession */
-	public $userSession;
-	/** @var ICacheFactory */
-	private $cacheFactory;
-	/** @var IRequest */
-	private $request;
-	/** @var Router */
-	private $router;
 	/** @var null|string */
-	private $baseUrl = null;
+	private ?string $baseUrl = null;
 	private ?IAppManager $appManager = null;
 
-	public function __construct(IConfig $config,
-								IUserSession $userSession,
-								ICacheFactory $cacheFactory,
-								IRequest $request,
-								Router $router
+	public function __construct(
+		private IConfig $config,
+		public IUserSession $userSession,
+		private ICacheFactory $cacheFactory,
+		private IRequest $request,
+		private Router $router,
 	) {
-		$this->config = $config;
-		$this->userSession = $userSession;
-		$this->cacheFactory = $cacheFactory;
-		$this->request = $request;
-		$this->router = $router;
 	}
 
 	private function getAppManager(): IAppManager {
@@ -147,7 +133,7 @@ class URLGenerator implements IURLGenerator {
 			$app_path = $this->getAppManager()->getAppPath($appName);
 			// Check if the app is in the app folder
 			if (file_exists($app_path . '/' . $file)) {
-				if (substr($file, -3) === 'php') {
+				if (str_ends_with($file, 'php')) {
 					$urlLinkTo = \OC::$WEBROOT . '/index.php/apps/' . $appName;
 					if ($frontControllerActive) {
 						$urlLinkTo = \OC::$WEBROOT . '/apps/' . $appName;
@@ -183,7 +169,7 @@ class URLGenerator implements IURLGenerator {
 	 *
 	 * @param string $appName app
 	 * @param string $file image name
-	 * @throws \RuntimeException If the image does not exist
+	 * @throws \RuntimeException|AppPathNotFoundException If the image does not exist
 	 * @return string the url
 	 *
 	 * Returns the path to the image.
@@ -198,7 +184,7 @@ class URLGenerator implements IURLGenerator {
 		// Read the selected theme from the config file
 		$theme = \OC_Util::getTheme();
 
-		//if a theme has a png but not an svg always use the png
+		//if a theme has a png but not a svg always use the png
 		$basename = substr(basename($file), 0, -4);
 
 		try {

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -73,19 +73,7 @@ use Psr\Log\LoggerInterface;
  *  - failure(string $message)
  */
 class Updater extends BasicEmitter {
-	/** @var LoggerInterface */
-	private $log;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var Checker */
-	private $checker;
-
-	/** @var Installer */
-	private $installer;
-
-	private $logLevelNames = [
+	private array $logLevelNames = [
 		0 => 'Debug',
 		1 => 'Info',
 		2 => 'Warning',
@@ -93,14 +81,12 @@ class Updater extends BasicEmitter {
 		4 => 'Fatal',
 	];
 
-	public function __construct(IConfig $config,
-								Checker $checker,
-								?LoggerInterface $log,
-								Installer $installer) {
-		$this->log = $log;
-		$this->config = $config;
-		$this->checker = $checker;
-		$this->installer = $installer;
+	public function __construct(
+		private IConfig $config,
+		private Checker $checker,
+		private ?LoggerInterface $log,
+		private Installer $installer,
+	) {
 	}
 
 	/**
@@ -271,7 +257,7 @@ class Updater extends BasicEmitter {
 		$this->checkAppsRequirements();
 		$this->doAppUpgrade();
 
-		// Update the appfetchers version so it downloads the correct list from the appstore
+		// Update the appfetchers version, so it downloads the correct list from the appstore
 		\OC::$server->getAppFetcher()->setVersion($currentVersion);
 
 		/** @var AppManager $appManager */


### PR DESCRIPTION
## Summary
The required adjustments have been made to the following classes under `/lib/private ` namespace:
- `Updater.php`
- `TempManager.php`
- `Tags.php`
- `TagManager.php`
- `TemplateLayout.php`
- `URLGenerator.php`

The improvements:

- Using PHP8's constructor property promotion
- Adding return types
- Adding types to properties
- Updating doc blocks
- Replacing `substr` with PHP8's `str_ends_with` and `str_starts_with`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
