### PR TITLE
Add optional to add backtrace to log items

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -999,6 +999,16 @@ $CONFIG = [
 ],
 
 /**
+ * Enables logging a backtrace with each log line. Normally, only Exceptions
+ * are carrying backtrace information which are logged automatically. This
+ * switch turns them on for any log message. Enabling this option will lead
+ * to increased log data size.
+ *
+ * Defaults to ``false``.
+ */
+'log.backtrace' => false,
+
+/**
  * This uses PHP.date formatting; see https://www.php.net/manual/en/function.date.php
  *
  * Defaults to ISO 8601 ``2005-08-15T15:52:01+00:00`` - see \DateTime::ATOM

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -221,6 +221,12 @@ class Log implements ILogger, IDataLogger {
 			$this->eventDispatcher->dispatchTyped(new BeforeMessageLoggedEvent($app, $level, $entry));
 		}
 
+		$hasBacktrace = isset($entry['exception']);
+		$logBacktrace = $this->config->getValue('log.backtrace', false);
+		if (!$hasBacktrace && $logBacktrace) {
+			$entry['backtrace'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+		}
+
 		try {
 			if ($level >= $minLevel) {
 				$this->writeLog($app, $entry, $level);


### PR DESCRIPTION
Disabled by default (for now?) due to the increased log size.