### PR TITLE
fix(dav): close cursor when fetching max id

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3139,7 +3139,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$query->select($query->func()->max('id'))
 			->from('calendarchanges');
 
-		$maxId =  $query->executeQuery()->fetchOne();
+		$result = $query->executeQuery();
+		$maxId = (int) $result->fetchOne();
+		$result->closeCursor();
 		if (!$maxId || $maxId < $keep) {
 		    return 0;
 		}

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1404,7 +1404,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$query->select($query->func()->max('id'))
 			->from('addressbookchanges');
 
-		$maxId =  $query->executeQuery()->fetchOne();
+		$result = $query->executeQuery();
+		$maxId = (int) $result->fetchOne();
+		$result->closeCursor();
 		if (!$maxId || $maxId < $keep) {
 		    return 0;
 		}


### PR DESCRIPTION
* Resolves: _N/A_

## Summary

A small followup to #38639 as suggested by Joas.

https://github.com/nextcloud/server/pull/38920#discussion_r1257814588
https://github.com/nextcloud/server/pull/38920#discussion_r1257814674

Is already backported to all necessary branches (stable27 and stable26).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
