### PR TITLE
feat: Use file cache query builder for searching for favorites

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -33,6 +33,7 @@ use OCP\Files\Folder;
 use OCP\Files\Node as INode;
 use OCP\IGroupManager;
 use OCP\ITagManager;
+use OCP\ITags;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
@@ -49,6 +50,10 @@ class FilesReportPlugin extends ServerPlugin {
 	// namespace
 	public const NS_OWNCLOUD = 'http://owncloud.org/ns';
 	public const NS_NEXTCLOUD = 'http://nextcloud.org/ns';
+
+	public const NS_OWNCLOUD_PREFIX = '{' . self::NS_OWNCLOUD. '}';
+	public const NS_NEXTCLOUD_PREFIX = '{' . self::NS_NEXTCLOUD. '}';
+
 	public const REPORT_NAME = '{http://owncloud.org/ns}filter-files';
 	public const SYSTEMTAG_PROPERTYNAME = '{http://owncloud.org/ns}systemtag';
 	public const CIRCLE_PROPERTYNAME = '{http://owncloud.org/ns}circle';
@@ -186,15 +191,13 @@ class FilesReportPlugin extends ServerPlugin {
 			return;
 		}
 
-		$ns = '{' . $this::NS_OWNCLOUD . '}';
-		$ncns = '{' . $this::NS_NEXTCLOUD . '}';
 		$requestedProps = [];
 		$filterRules = [];
 
 		// parse report properties and gather filter info
 		foreach ($report as $reportProps) {
 			$name = $reportProps['name'];
-			if ($name === $ns . 'filter-rules') {
+			if ($name === self::NS_OWNCLOUD_PREFIX . 'filter-rules') {
 				$filterRules = $reportProps['value'];
 			} elseif ($name === '{DAV:}prop') {
 				// propfind properties
@@ -205,7 +208,7 @@ class FilesReportPlugin extends ServerPlugin {
 				foreach ($reportProps['value'] as $propVal) {
 					if ($propVal['name'] === '{DAV:}nresults') {
 						$limit = (int)$propVal['value'];
-					} elseif ($propVal['name'] === $ncns . 'firstresult') {
+					} elseif ($propVal['name'] === self::NS_NEXTCLOUD_PREFIX . 'firstresult') {
 						$offset = (int)$propVal['value'];
 					}
 				}
@@ -292,36 +295,18 @@ class FilesReportPlugin extends ServerPlugin {
 	 * @return array array of unique file id results
 	 */
 	protected function processFilterRulesForFileIDs(array $filterRules): array {
-		$ns = '{' . $this::NS_OWNCLOUD . '}';
-		$resultFileIds = [];
 		$circlesIds = [];
-		$favoriteFilter = null;
 		foreach ($filterRules as $filterRule) {
 			if ($filterRule['name'] === self::CIRCLE_PROPERTYNAME) {
 				$circlesIds[] = $filterRule['value'];
 			}
-			if ($filterRule['name'] === $ns . 'favorite') {
-				$favoriteFilter = true;
-			}
-		}
-
-		if ($favoriteFilter !== null) {
-			$resultFileIds = $this->fileTagger->load('files')->getFavorites();
-			if (empty($resultFileIds)) {
-				return [];
-			}
 		}
 
 		if (!empty($circlesIds)) {
-			$fileIds = $this->getCirclesFileIds($circlesIds);
-			if (empty($resultFileIds)) {
-				$resultFileIds = $fileIds;
-			} else {
-				$resultFileIds = array_intersect($fileIds, $resultFileIds);
-			}
+			return $this->getCirclesFileIds($circlesIds);
 		}
 
-		return $resultFileIds;
+		return [];
 	}
 
 	protected function processFilterRulesForFileNodes(array $filterRules, ?int $limit, ?int $offset): array {
@@ -345,13 +330,7 @@ class FilesReportPlugin extends ServerPlugin {
 			foreach ($tags as $tag) {
 				$tagName = $tag->getName();
 				$tmpNodes = $this->userFolder->searchBySystemTag($tagName, $this->userSession->getUser()->getUID(), $dbLimit, $dbOffset);
-				if (count($nodes) === 0) {
-					$nodes = $tmpNodes;
-				} else {
-					$nodes = array_uintersect($nodes, $tmpNodes, function (INode $a, INode $b): int {
-						return $a->getId() - $b->getId();
-					});
-				}
+				$nodes = $this->intersectNodes($nodes, $tmpNodes);
 				if ($nodes === []) {
 					// there cannot be a common match when nodes are empty early.
 					return $nodes;
@@ -359,11 +338,47 @@ class FilesReportPlugin extends ServerPlugin {
 			}
 
 			if (!$oneTagSearch && ($limit !== null || $offset !== null)) {
-				$nodes = array_slice($nodes, $offset, $limit);
+				$nodes = array_slice($nodes, $offset ?? 0, $limit);
 			}
 		}
 
+		if ($this->hasFilterFavorites($filterRules)) {
+			$tmpNodes = $this->userFolder->searchByTag(ITags::TAG_FAVORITE, $this->userSession->getUser()->getUID());
+			$nodes = $this->intersectNodes($nodes, $tmpNodes);
+			if ($nodes === []) {
+				// there cannot be a common match when nodes are empty early.
+				return $nodes;
+			}
+		}
+
+		if ($limit !== null || $offset !== null) {
+			$nodes = array_slice($nodes, $offset ?? 0, $limit);
+		}
+
 		return $nodes;
+	}
+
+	private function intersectNodes(array $nodes, array $newNodes): array {
+		if (count($nodes) === 0) {
+			$nodes = $newNodes;
+		} else {
+			$nodes = array_uintersect($nodes, $newNodes, function (INode $a, INode $b): int {
+				return $a->getId() - $b->getId();
+			});
+		}
+
+		return $nodes;
+	}
+
+	private function hasFilterFavorites(array $filterRules): bool {
+		$favoriteFilter = null;
+		foreach ($filterRules as $filterRule) {
+			if ($filterRule['name'] === self::NS_OWNCLOUD_PREFIX . 'favorite') {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -343,7 +343,7 @@ class FilesReportPlugin extends ServerPlugin {
 		}
 
 		if ($this->hasFilterFavorites($filterRules)) {
-			$tmpNodes = $this->userFolder->searchByTag(ITags::TAG_FAVORITE, $this->userSession->getUser()->getUID());
+			$tmpNodes = $this->userFolder->searchByTag(ITags::TAG_FAVORITE, $this->userSession->getUser()->getUID(), $limit ?? 0, $offset ?? 0);
 			$nodes = $this->intersectNodes($nodes, $tmpNodes);
 			if ($nodes === []) {
 				// there cannot be a common match when nodes are empty early.

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -495,7 +495,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->with('OneTwoThree')
 			->willReturn([$filesNode1, $filesNode2]);
 
-		$this->assertEquals([$filesNode1, $filesNode2], $this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, 0, 0]));
+		$this->assertEquals([$filesNode1, $filesNode2], $this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null]));
 	}
 
 	public function testProcessFilterRulesAndCondition(): void {
@@ -934,11 +934,25 @@ class FilesReportPluginTest extends \Test\TestCase {
 			['name' => '{http://owncloud.org/ns}favorite', 'value' => '1'],
 		];
 
-		$this->privateTags->expects($this->once())
-			->method('getFavorites')
-			->willReturn(['456', '789']);
+		$filesNode1 = $this->createMock(File::class);
+		$filesNode1->expects($this->any())
+			->method('getId')
+			->willReturn(111);
 
-		$this->assertEquals(['456', '789'], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileIDs', [$rules])));
+		$filesNode2 = $this->createMock(File::class);
+		$filesNode2->expects($this->any())
+			->method('getId')
+			->willReturn(222);
+
+		$this->userFolder->expects($this->exactly(1))
+			->method('searchByTag')
+			->with('_$!<Favorite>!$_')
+			->willReturn([
+				$filesNode2,
+				$filesNode1,
+			]);
+
+		$this->assertEquals([$filesNode1, $filesNode2], array_values($this->invokePrivate($this->plugin, 'processFilterRulesForFileNodes', [$rules, null, null])));
 	}
 
 	public function filesBaseUriProvider() {

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -295,8 +295,8 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @param string $userId owner of the tags
 	 * @return Node[]
 	 */
-	public function searchByTag($tag, $userId) {
-		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tagname', $tag), $userId);
+	public function searchByTag($tag, $userId, int $limit = 0, int $offset = 0) {
+		$query = $this->queryFromOperator(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'tagname', $tag), $userId, $limit, $offset);
 		return $this->search($query);
 	}
 

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -480,7 +480,7 @@ class LazyFolder implements Folder {
 	/**
 	 * @inheritDoc
 	 */
-	public function searchByTag($tag, $userId) {
+	public function searchByTag($tag, $userId, int $limit = 0, int $offset = 0) {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/lib/private/Files/Node/NonExistingFolder.php
+++ b/lib/private/Files/Node/NonExistingFolder.php
@@ -150,7 +150,7 @@ class NonExistingFolder extends Folder {
 		throw new NotFoundException();
 	}
 
-	public function searchByTag($tag, $userId) {
+	public function searchByTag($tag, $userId, int $limit = 0, int $offset = 0) {
 		throw new NotFoundException();
 	}
 

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -136,10 +136,12 @@ interface Folder extends Node {
 	 *
 	 * @param string|int $tag tag name or tag id
 	 * @param string $userId owner of the tags
+	 * @param int $limit since 28.0.0
+	 * @param int $offset since 28.0.0
 	 * @return \OCP\Files\Node[]
 	 * @since 8.0.0
 	 */
-	public function searchByTag($tag, $userId);
+	public function searchByTag($tag, $userId, int $limit = 0, int $offset = 0);
 
 	/**
 	 * search for files by system tag


### PR DESCRIPTION
When trying to REPORT files that are favorites we still used the old code path to aggregate them, this moves this over to the filecache search query builder methods.

Request to trigger:

```
blackfire curl -X REPORT \
  --url http://admin:admin@nextcloud.local/remote.php/dav/files/admin/MyGroupfolder4 \
  --header 'Content-Type: application/xml' \
  --data '<?xml version="1.0"?>
<oc:filter-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
         <oc:filter-rules>
                 <oc:favorite>1</oc:favorite>
         </oc:filter-rules>
        <d:prop>
            <d:resourcetype />
        </d:prop>
 </oc:filter-files> '
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
