### PR TITLE
fix(comments): Emit CommentsEntityEvent as typed event

### DIFF
--- a/apps/comments/lib/AppInfo/Application.php
+++ b/apps/comments/lib/AppInfo/Application.php
@@ -66,7 +66,7 @@ class Application extends App implements IBootstrap {
 			LoadSidebarScripts::class
 		);
 		$context->registerEventListener(
-			CommentsEntityEvent::EVENT_ENTITY,
+			CommentsEntityEvent::class,
 			CommentsEntityEventListener::class
 		);
 		$context->registerSearchProvider(CommentsSearchProvider::class);

--- a/apps/dav/lib/Comments/RootCollection.php
+++ b/apps/dav/lib/Comments/RootCollection.php
@@ -26,6 +26,7 @@ namespace OCA\DAV\Comments;
 
 use OCP\Comments\CommentsEntityEvent;
 use OCP\Comments\ICommentsManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -33,7 +34,6 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotAuthenticated;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RootCollection implements ICollection {
 	/** @var EntityTypeCollection[]|null */
@@ -43,13 +43,13 @@ class RootCollection implements ICollection {
 	protected LoggerInterface $logger;
 	protected IUserManager $userManager;
 	protected IUserSession $userSession;
-	protected EventDispatcherInterface $dispatcher;
+	protected IEventDispatcher $dispatcher;
 
 	public function __construct(
 		ICommentsManager $commentsManager,
 		IUserManager $userManager,
 		IUserSession $userSession,
-		EventDispatcherInterface $dispatcher,
+		IEventDispatcher $dispatcher,
 		LoggerInterface $logger) {
 		$this->commentsManager = $commentsManager;
 		$this->logger = $logger;
@@ -74,7 +74,8 @@ class RootCollection implements ICollection {
 			throw new NotAuthenticated();
 		}
 
-		$event = new CommentsEntityEvent(CommentsEntityEvent::EVENT_ENTITY);
+		$event = new CommentsEntityEvent();
+		$this->dispatcher->dispatchTyped($event);
 		$this->dispatcher->dispatch(CommentsEntityEvent::EVENT_ENTITY, $event);
 
 		$this->entityTypeCollections = [];

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -139,7 +139,7 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getCommentsManager(),
 			$userManager,
 			\OC::$server->getUserSession(),
-			\OC::$server->getEventDispatcher(),
+			$dispatcher,
 			$logger
 		);
 

--- a/apps/dav/tests/unit/Comments/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/RootCollectionTest.php
@@ -26,15 +26,14 @@
 namespace OCA\DAV\Tests\unit\Comments;
 
 use OC\EventDispatcher\EventDispatcher;
-use OC\EventDispatcher\SymfonyAdapter;
 use OCA\DAV\Comments\EntityTypeCollection as EntityTypeCollectionImplementation;
 use OCP\Comments\CommentsEntityEvent;
 use OCP\Comments\ICommentsManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RootCollectionTest extends \Test\TestCase {
 
@@ -48,7 +47,7 @@ class RootCollectionTest extends \Test\TestCase {
 	protected $collection;
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
-	/** @var EventDispatcherInterface */
+	/** @var IEventDispatcher */
 	protected $dispatcher;
 	/** @var \OCP\IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
@@ -72,12 +71,9 @@ class RootCollectionTest extends \Test\TestCase {
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->dispatcher = new SymfonyAdapter(
-			new EventDispatcher(
-				new \Symfony\Component\EventDispatcher\EventDispatcher(),
-				\OC::$server,
-				$this->logger
-			),
+		$this->dispatcher = new EventDispatcher(
+			new \Symfony\Component\EventDispatcher\EventDispatcher(),
+			\OC::$server,
 			$this->logger
 		);
 
@@ -99,7 +95,7 @@ class RootCollectionTest extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($this->user);
 
-		$this->dispatcher->addListener(CommentsEntityEvent::EVENT_ENTITY, function (CommentsEntityEvent $event): void {
+		$this->dispatcher->addListener(CommentsEntityEvent::class, function (CommentsEntityEvent $event): void {
 			$event->addEntityCollection('files', function () {
 				return true;
 			});

--- a/lib/public/Comments/CommentsEntityEvent.php
+++ b/lib/public/Comments/CommentsEntityEvent.php
@@ -29,26 +29,24 @@ use OCP\EventDispatcher\Event;
  * Class CommentsEntityEvent
  *
  * @since 9.1.0
+ * @since 28.0.0 Dispatched as a typed event
  */
 class CommentsEntityEvent extends Event {
 	/**
-	 * @deprecated 22.0.0
+	 * @deprecated 22.0.0 - Listen to the typed event instead.
 	 */
 	public const EVENT_ENTITY = 'OCP\Comments\ICommentsManager::registerEntity';
 
-	/** @var string */
-	protected $event;
 	/** @var \Closure[] */
 	protected $collections;
 
 	/**
 	 * DispatcherEvent constructor.
 	 *
-	 * @param string $event
 	 * @since 9.1.0
 	 */
-	public function __construct($event) {
-		$this->event = $event;
+	public function __construct() {
+		parent::__construct();
 		$this->collections = [];
 	}
 


### PR DESCRIPTION
* One step closer for https://github.com/nextcloud/server/pull/38546

Fix #1539

- [x] Need to rebase after https://github.com/nextcloud/server/pull/39305

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
