### PR TITLE
feat(dav): Emit a typed event to deprecate OCA\DAV\Connector\Sabre::addPlugin

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -51,6 +51,9 @@ $authBackend = new OCA\DAV\Connector\PublicAuth(
 );
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 
+/** @var IEventDispatcher $eventDispatcher */
+$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
+
 $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getConfig(),
 	\OC::$server->get(LoggerInterface::class),
@@ -60,7 +63,7 @@ $serverFactory = new OCA\DAV\Connector\Sabre\ServerFactory(
 	\OC::$server->getTagManager(),
 	\OC::$server->getRequest(),
 	\OC::$server->getPreviewManager(),
-	\OC::$server->getEventDispatcher(),
+	$eventDispatcher,
 	\OC::$server->getL10N('dav')
 );
 
@@ -115,8 +118,6 @@ $server->addPlugin($linkCheckPlugin);
 $server->addPlugin($filesDropPlugin);
 // allow setup of additional plugins
 $event = new BeforeSabrePubliclyLoadedEvent($server);
-/** @var IEventDispatcher $eventDispatcher */
-$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 $eventDispatcher->dispatchTyped($event);
 
 // And off we go!

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -233,6 +233,7 @@ return array(
     'OCA\\DAV\\Events\\CardDeletedEvent' => $baseDir . '/../lib/Events/CardDeletedEvent.php',
     'OCA\\DAV\\Events\\CardMovedEvent' => $baseDir . '/../lib/Events/CardMovedEvent.php',
     'OCA\\DAV\\Events\\CardUpdatedEvent' => $baseDir . '/../lib/Events/CardUpdatedEvent.php',
+    'OCA\\DAV\\Events\\SabrePluginAddEvent' => $baseDir . '/../lib/Events/SabrePluginAddEvent.php',
     'OCA\\DAV\\Events\\SabrePluginAuthInitEvent' => $baseDir . '/../lib/Events/SabrePluginAuthInitEvent.php',
     'OCA\\DAV\\Events\\SubscriptionCreatedEvent' => $baseDir . '/../lib/Events/SubscriptionCreatedEvent.php',
     'OCA\\DAV\\Events\\SubscriptionDeletedEvent' => $baseDir . '/../lib/Events/SubscriptionDeletedEvent.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -248,6 +248,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Events\\CardDeletedEvent' => __DIR__ . '/..' . '/../lib/Events/CardDeletedEvent.php',
         'OCA\\DAV\\Events\\CardMovedEvent' => __DIR__ . '/..' . '/../lib/Events/CardMovedEvent.php',
         'OCA\\DAV\\Events\\CardUpdatedEvent' => __DIR__ . '/..' . '/../lib/Events/CardUpdatedEvent.php',
+        'OCA\\DAV\\Events\\SabrePluginAddEvent' => __DIR__ . '/..' . '/../lib/Events/SabrePluginAddEvent.php',
         'OCA\\DAV\\Events\\SabrePluginAuthInitEvent' => __DIR__ . '/..' . '/../lib/Events/SabrePluginAuthInitEvent.php',
         'OCA\\DAV\\Events\\SubscriptionCreatedEvent' => __DIR__ . '/..' . '/../lib/Events/SubscriptionCreatedEvent.php',
         'OCA\\DAV\\Events\\SubscriptionDeletedEvent' => __DIR__ . '/..' . '/../lib/Events/SubscriptionDeletedEvent.php',

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -31,6 +31,7 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\DAV\ViewOnlyPlugin;
@@ -46,7 +47,6 @@ use OCP\IUserSession;
 use OCP\SabrePluginEvent;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Auth\Plugin;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ServerFactory {
 	private IConfig $config;
@@ -57,7 +57,7 @@ class ServerFactory {
 	private ITagManager $tagManager;
 	private IRequest $request;
 	private IPreview $previewManager;
-	private EventDispatcherInterface $eventDispatcher;
+	private IEventDispatcher $eventDispatcher;
 	private IL10N $l10n;
 
 	public function __construct(
@@ -69,7 +69,7 @@ class ServerFactory {
 		ITagManager $tagManager,
 		IRequest $request,
 		IPreview $previewManager,
-		EventDispatcherInterface $eventDispatcher,
+		IEventDispatcher $eventDispatcher,
 		IL10N $l10n
 	) {
 		$this->config = $config;
@@ -199,7 +199,7 @@ class ServerFactory {
 
 			// Load dav plugins from apps
 			$event = new SabrePluginEvent($server);
-			$this->eventDispatcher->dispatch($event);
+			$this->eventDispatcher->dispatchTyped($event);
 			$pluginManager = new PluginManager(
 				\OC::$server,
 				\OC::$server->getAppManager()

--- a/apps/dav/lib/Events/SabrePluginAddEvent.php
+++ b/apps/dav/lib/Events/SabrePluginAddEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\DAV\Events;
+
+use OCP\EventDispatcher\Event;
+use Sabre\DAV\Server;
+
+/**
+ * This event is triggered during the setup of the SabreDAV server to allow the
+ * registration of additional plugins.
+ *
+ * @since 28.0.0
+ */
+class SabrePluginAddEvent extends Event {
+
+	/** @var Server */
+	private $server;
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function __construct(Server $server) {
+		parent::__construct();
+		$this->server = $server;
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getServer(): Server {
+		return $this->server;
+	}
+}

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -31,6 +31,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Server;
 use OCA\DAV\Connector\Sabre\ServerFactory;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 use Sabre\HTTP\Request;
@@ -70,7 +71,7 @@ abstract class RequestTestCase extends TestCase {
 				->disableOriginalConstructor()
 				->getMock(),
 			\OC::$server->getPreviewManager(),
-			\OC::$server->getEventDispatcher(),
+			\OC::$server->get(IEventDispatcher::class),
 			\OC::$server->getL10N('dav')
 		);
 	}


### PR DESCRIPTION
* One step closer for https://github.com/nextcloud/server/pull/38546

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
