### PR TITLE
Change color for primary element on hover

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -72,7 +72,7 @@
   --color-primary-light-text: #002a41;
   --color-primary-light-hover: #dbe5ea;
   --color-primary-element: #006aa3;
-  --color-primary-element-hover: #3287b5;
+  --color-primary-element-hover: #1f7cae;
   --color-primary-element-text: #ffffff;
   --color-primary-element-light: #e5f0f5;
   --color-primary-element-light-hover: #dbe5ea;

--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -64,7 +64,7 @@ trait CommonThemeTrait {
 
 			// used for buttons, inputs...
 			'--color-primary-element' => $colorPrimaryElement,
-			'--color-primary-element-hover' => $this->util->mix($colorPrimaryElement, $colorMainBackground, 60),
+			'--color-primary-element-hover' => $this->util->mix($colorPrimaryElement, $colorMainBackground, 75),
 			'--color-primary-element-text' => $this->util->invertTextColor($colorPrimaryElement) ? '#000000' : '#ffffff',
 
 			// used for hover/focus states


### PR DESCRIPTION
* Fixes: https://github.com/nextcloud/nextcloud-vue/issues/4193

## Summary

Fixes color for primary element on hover state https://github.com/nextcloud/nextcloud-vue/issues/4193#issuecomment-1630476883

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
