### PR TITLE
ci(32bit): fix failing test setup

### DIFF
--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install -y ffmpeg imagemagick libmagickcore-6.q16-3-extra
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d #v2.25.2
+        uses: shivammathur/setup-php@9c77701ae57b0c47f6732beebfbdec76e4e5c90a #debian bookworm fix
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ctype, curl, dom, fileinfo, gd, imagick, intl, json, mbstring, openssl, pdo_sqlite, posix, sqlite, xml, zip, apcu


### PR DESCRIPTION
We see the 32bit tests failing in the setup. The used image is Debian Bookworm based, and there is yet unreleased commit in setup-php that might help.

For example, failing tests setup at https://github.com/nextcloud/server/actions/runs/5509732480/jobs/10073230086?pr=39282

![Screenshot_20230711_234244](https://github.com/nextcloud/server/assets/2184312/16a783ef-07ee-4985-91dd-8aa0c6c2a332)
