### PR TITLE
handle more exceptions in AmazonS3::fopen

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -497,7 +497,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 				try {
 					return $this->readObject($path);
-				} catch (S3Exception $e) {
+				} catch (\Exception $e) {
 					$this->logger->error($e->getMessage(), [
 						'app' => 'files_external',
 						'exception' => $e,

--- a/lib/private/Files/Stream/SeekableHttpStream.php
+++ b/lib/private/Files/Stream/SeekableHttpStream.php
@@ -219,7 +219,9 @@ class SeekableHttpStream implements File {
 	public function stream_stat() {
 		if ($this->getCurrent()) {
 			$stat = fstat($this->getCurrent());
-			$stat['size'] = $this->totalSize;
+			if ($stat) {
+				$stat['size'] = $this->totalSize;
+			}
 			return $stat;
 		} else {
 			return false;


### PR DESCRIPTION
returning `false` instead of throwing is the expected behavior.