### PR TITLE
fix(db): no hardcoded table prefix is expected

### DIFF
--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -473,8 +473,8 @@ class AddMissingIndices extends Command {
 		}
 
 		$output->writeln('<info>Check indices of the oc_systemtag_object_mapping table.</info>');
-		if ($schema->hasTable('oc_systemtag_object_mapping')) {
-			$table = $schema->getTable('oc_systemtag_object_mapping');
+		if ($schema->hasTable('systemtag_object_mapping')) {
+			$table = $schema->getTable('systemtag_object_mapping');
 			if (!$table->hasIndex('systag_by_tagid')) {
 				$output->writeln('<info>Adding systag_by_tagid index to the oc_systemtag_object_mapping table, this can take some time...</info>');
 


### PR DESCRIPTION
* Resolves: #39379

## Summary

The database prefix is variable and can be set upon installation. The database methods expect table names without prefix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
