### PR TITLE
Distinguish 'done' from 'configuring' in 2FA

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -52,6 +52,7 @@ use function array_filter;
 class Manager {
 	public const SESSION_UID_KEY = 'two_factor_auth_uid';
 	public const SESSION_UID_DONE = 'two_factor_auth_passed';
+	public const SESSION_UID_CONFIGURING = 'two_factor_auth_configuring';
 	public const REMEMBER_LOGIN = 'two_factor_remember_login';
 	public const BACKUP_CODES_PROVIDER_ID = 'backup_codes';
 
@@ -342,7 +343,7 @@ class Manager {
 				$tokensNeeding2FA = $this->config->getUserKeys($user->getUID(), 'login_token_2fa');
 
 				if (!\in_array((string) $tokenId, $tokensNeeding2FA, true)) {
-					$this->session->set(self::SESSION_UID_DONE, $user->getUID());
+					$this->session->set(self::SESSION_UID_CONFIGURING, $user->getUID());
 					return false;
 				}
 			} catch (InvalidTokenException|SessionNotAvailableException $e) {

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -263,6 +263,7 @@ class Manager {
 			$this->session->remove(self::SESSION_UID_KEY);
 			$this->session->remove(self::REMEMBER_LOGIN);
 			$this->session->set(self::SESSION_UID_DONE, $user->getUID());
+			$this->session->remove(self::SESSION_UID_CONFIGURING);
 
 			// Clear token from db
 			$sessionId = $this->session->getId();

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -640,7 +640,7 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}
 
-	public function testNeedsSecondFactorSessionAuthFailDBPass() {
+	public function testNeedsSecondFactorWhileConfiguring() {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('user');
@@ -664,10 +664,12 @@ class ManagerTest extends TestCase {
 				'42', '43', '44'
 			]);
 
+		// the user is still configuring 2FA with token 40
 		$this->session->expects($this->once())
 			->method('set')
-			->with(Manager::SESSION_UID_DONE, 'user');
+			->with(Manager::SESSION_UID_CONFIGURING, 'user');
 
+		// 2FA should not be required if configuration is not complete
 		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}
 

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -369,11 +369,12 @@ class ManagerTest extends TestCase {
 			->method('get')
 			->with('two_factor_remember_login')
 			->willReturn(false);
-		$this->session->expects($this->exactly(2))
+		$this->session->expects($this->exactly(3))
 			->method('remove')
 			->withConsecutive(
 				['two_factor_auth_uid'],
-				['two_factor_remember_login']
+				['two_factor_remember_login'],
+				['two_factor_auth_configuring']
 			);
 		$this->session->expects($this->once())
 			->method('set')


### PR DESCRIPTION
* Resolves: #35554 

## Summary

When there is a token in the session for which the user is still [setting up 2FA](https://raw.githubusercontent.com/nextcloud/twofactor_totp/master/screenshots/settings.png), setting `self::SESSION_UID_DONE` ("two_factor_auth_passed") is a misnomer.

AFAICT, everything works fine if you set nothing into the session and just return 'false' from this if-statement, but in case there is some code (now or in the future) that needs to know if the user is configuring 2FA, to play it safe I would suggest storing `self::SESSION_UID_CONFIGURING` ("two_factor_auth_configuring") into the session.

## TODO

- [x] add tests
- [ ] test manually
- [ ] consider removing this session variable once configuration is successfully completed

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
