### PR TITLE
[stable27] fix(core): Add password confirmation requirement for getapppassword

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -66,6 +66,7 @@ class AppPasswordController extends \OCP\AppFramework\OCSController {
 
 	/**
 	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
 	 *
 	 * @throws OCSForbiddenException
 	 */


### PR DESCRIPTION
Backport #39416 