### PR TITLE
[stable19] fix(core): Add password confirmation requirement for getapppassword

### DIFF
--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -76,6 +76,7 @@ class AppPasswordController extends \OCP\AppFramework\OCSController {
 
 	/**
 	 * @NoAdminRequired
+	 * @PasswordConfirmationRequired
 	 *
 	 * @return DataResponse
 	 * @throws OCSForbiddenException


### PR DESCRIPTION
Backport #39416 