### PR TITLE
chore: update codeowners for 2fa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,9 +31,9 @@
 
 # Two-Factor Authentication
 # https://github.com/nextcloud/wg-two-factor-authentication#members
-/apps/twofactor_backupcodes         @ChristophWurst @miaulalala @nickvergessen
-*/TwoFactorAuth/*                   @ChristophWurst @miaulalala @nickvergessen
-/core/templates/twofactor*          @ChristophWurst @miaulalala @nickvergessen
+**/TwoFactorAuth                    @ChristophWurst @miaulalala @nickvergessen @st3iny
+/apps/twofactor_backupcodes         @ChristophWurst @miaulalala @nickvergessen @st3iny
+/core/templates/twofactor*          @ChristophWurst @miaulalala @nickvergessen @st3iny
 
 # Personal interest
 */Activity/*                        @nickvergessen


### PR DESCRIPTION
## Summary

The pull request https://github.com/nextcloud/server/pull/39411 modified `lib/private/Authentication/TwoFactorAuth/Manager.php` but did not request a review from the code owners. 

## TODO

- [x] Pull request after merge for a final test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
