### PR TITLE
Fix sharing of encrypted files

### DIFF
--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -441,7 +441,7 @@ class Encryption implements IEncryptionModule {
 			$this->keyManager->deleteAllFileKeys($path);
 
 			foreach ($shareKeys as $uid => $keyFile) {
-				$this->keyManager->setShareKey($this->path, $uid, $keyFile);
+				$this->keyManager->setShareKey($path, $uid, $keyFile);
 			}
 		} else {
 			$this->logger->debug('no file key found, we assume that the file "{file}" is not encrypted',


### PR DESCRIPTION
* Resolves: #39034

## Summary

When sharing an encrypted file through a public link, an exception was breaking the update of file keys.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
