### PR TITLE
fix: Correctly add `module` content type to script tags with versions

### DIFF
--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -101,7 +101,8 @@ function emit_script_tag(string $src, string $script_content = '', string $conte
  */
 function emit_script_loading_tags($obj) {
 	foreach ($obj['jsfiles'] as $jsfile) {
-		$type = str_ends_with($jsfile, '.mjs') ? 'module' : '';
+		$fileName = explode('?', $jsfile, 2)[0];
+		$type = str_ends_with($fileName, '.mjs') ? 'module' : '';
 		emit_script_tag($jsfile, '', $type);
 	}
 	if (!empty($obj['inline_ocjs'])) {

--- a/tests/lib/TemplateFunctionsTest.php
+++ b/tests/lib/TemplateFunctionsTest.php
@@ -86,6 +86,18 @@ class TemplateFunctionsTest extends \Test\TestCase {
 		]);
 	}
 
+	public function testEmitScriptLoadingTagsWithVersion() {
+		// Test mjs js and inline content
+		$pattern = '/src="some\.mjs\?v=ab123cd"[^>]+type="module"[^>]*>.+\n'; // some.mjs with type = module
+		$pattern .= '<script[^>]+src="other\.js\?v=12abc34"[^>]*>.+\n'; // other.js as plain javascript
+		$pattern .= '/'; // no flags
+
+		$this->expectOutputRegex($pattern);
+		emit_script_loading_tags([
+			'jsfiles' => ['some.mjs?v=ab123cd', 'other.js?v=12abc34'],
+		]);
+	}
+
 	// ---------------------------------------------------------------------------
 	// Test relative_modified_date with dates only
 	// ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When server is in production mode, scripts will be have a version query (`...?v=....`), in this case module js script were not delivered with the `module` content type.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
