### PR TITLE
[stable26] fix: check that object store backend supports multi part uploads

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -278,6 +278,9 @@ class ChunkingV2Plugin extends ServerPlugin {
 		if (!$this->uploadFolder->getStorage()->instanceOfStorage(IChunkedFileWrite::class)) {
 			throw new StorageInvalidException('Storage does not support chunked file writing');
 		}
+		if ($this->uploadFolder->getStorage()->instanceOfStorage(ObjectStoreStorage::class) && !$this->uploadFolder->getStorage()->getObjectStore() instanceof IObjectStoreMultiPartUpload) {
+			throw new StorageInvalidException('Storage does not support multi part uploads');
+		}
 
 		if ($checkUploadMetadata) {
 			if ($this->uploadId === null || $this->uploadPath === null) {


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/39432

## Summary

A object store backend may not support multi part uploads.

## TODO

- [ ] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
