### PR TITLE
fix(IParallelAwareJob): Check for other reserved jobs before setting new ones as reserved

### DIFF
--- a/lib/public/BackgroundJob/Job.php
+++ b/lib/public/BackgroundJob/Job.php
@@ -75,11 +75,6 @@ abstract class Job implements IJob, IParallelAwareJob {
 		$jobList->setLastRun($this);
 		$logger = $this->logger ?? \OCP\Server::get(LoggerInterface::class);
 
-		if (!$this->getAllowParallelRuns() && $jobList->hasReservedJob(get_class($this))) {
-			$logger->debug('Skipping ' . get_class($this) . ' job with ID ' . $this->getId() . ' because another job with the same class is already running', ['app' => 'cron']);
-			return;
-		}
-
 		try {
 			$jobStartTime = $this->time->getTime();
 			$logger->debug('Run ' . get_class($this) . ' job with ID ' . $this->getId(), ['app' => 'cron']);

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -250,18 +250,64 @@ class JobListTest extends TestCase {
 
 	public function testHasReservedJobs() {
 		$this->clearJobsList();
+
+		$this->timeFactory->expects($this->atLeastOnce())
+			->method('getTime')
+			->willReturn(123456789);
+
 		$job = new TestJob($this->timeFactory, $this, function () {
-			$this->assertTrue($this->instance->hasReservedJob());
-			$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
 		});
-		$this->instance->add($job);
+
+		$job2 = new TestJob($this->timeFactory, $this, function () {
+		});
+
+		$this->instance->add($job, 1);
+		$this->instance->add($job2, 2);
+
+		$this->assertCount(2, iterator_to_array($this->instance->getJobsIterator(null, 10, 0)));
 
 		$this->assertFalse($this->instance->hasReservedJob());
 		$this->assertFalse($this->instance->hasReservedJob(TestJob::class));
 
-		$job->start($this->instance);
+		$job = $this->instance->getNext();
+		$this->assertNotNull($job);
+		$this->assertTrue($this->instance->hasReservedJob());
+		$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
+		$job = $this->instance->getNext();
+		$this->assertNotNull($job);
+		$this->assertTrue($this->instance->hasReservedJob());
+		$this->assertTrue($this->instance->hasReservedJob(TestJob::class));
+	}
 
-		$this->assertTrue($this->ran);
+	public function testHasReservedJobsAndParallelAwareJob() {
+		$this->clearJobsList();
+
+		$this->timeFactory->expects($this->atLeastOnce())
+			->method('getTime')
+			->willReturnCallback(function () use (&$time) {
+				return time();
+			});
+
+		$job = new TestParallelAwareJob($this->timeFactory, $this, function () {
+		});
+
+		$job2 = new TestParallelAwareJob($this->timeFactory, $this, function () {
+		});
+
+		$this->instance->add($job, 1);
+		$this->instance->add($job2, 2);
+
+		$this->assertCount(2, iterator_to_array($this->instance->getJobsIterator(null, 10, 0)));
+
+		$this->assertFalse($this->instance->hasReservedJob());
+		$this->assertFalse($this->instance->hasReservedJob(TestParallelAwareJob::class));
+
+		$job = $this->instance->getNext();
+		$this->assertNotNull($job);
+		$this->assertTrue($this->instance->hasReservedJob());
+		$this->assertTrue($this->instance->hasReservedJob(TestParallelAwareJob::class));
+		$job = $this->instance->getNext();
+		$this->assertNull($job); // Job doesn't allow parallel runs
 	}
 
 	public function markRun() {

--- a/tests/lib/BackgroundJob/JobTest.php
+++ b/tests/lib/BackgroundJob/JobTest.php
@@ -61,58 +61,6 @@ class JobTest extends \Test\TestCase {
 		$this->assertCount(1, $jobList->getAll());
 	}
 
-	public function testDisallowParallelRunsWithNoOtherJobs() {
-		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function () {
-		});
-		$job->setAllowParallelRuns(false);
-		$jobList->add($job);
-
-		$jobList->setHasReservedJob(null, false);
-		$jobList->setHasReservedJob(TestJob::class, false);
-		$job->start($jobList);
-		$this->assertTrue($this->run);
-	}
-
-	public function testAllowParallelRunsWithNoOtherJobs() {
-		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function () {
-		});
-		$job->setAllowParallelRuns(true);
-		$jobList->add($job);
-
-		$jobList->setHasReservedJob(null, false);
-		$jobList->setHasReservedJob(TestJob::class, false);
-		$job->start($jobList);
-		$this->assertTrue($this->run);
-	}
-
-	public function testAllowParallelRunsWithOtherJobs() {
-		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function () {
-		});
-		$job->setAllowParallelRuns(true);
-		$jobList->add($job);
-
-		$jobList->setHasReservedJob(null, true);
-		$jobList->setHasReservedJob(TestJob::class, true);
-		$job->start($jobList);
-		$this->assertTrue($this->run);
-	}
-
-	public function testDisallowParallelRunsWithOtherJobs() {
-		$jobList = new DummyJobList();
-		$job = new TestJob($this->timeFactory, $this, function () {
-		});
-		$job->setAllowParallelRuns(false);
-		$jobList->add($job);
-
-		$jobList->setHasReservedJob(null, true);
-		$jobList->setHasReservedJob(TestJob::class, true);
-		$job->start($jobList);
-		$this->assertFalse($this->run);
-	}
-
 	public function markRun() {
 		$this->run = true;
 	}

--- a/tests/lib/BackgroundJob/TestParallelAwareJob.php
+++ b/tests/lib/BackgroundJob/TestParallelAwareJob.php
@@ -9,7 +9,6 @@
 namespace Test\BackgroundJob;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use Test\BackgroundJob\JobTest;
 
 class TestParallelAwareJob extends \OCP\BackgroundJob\Job {
 	private $testCase;

--- a/tests/lib/BackgroundJob/TestParallelAwareJob.php
+++ b/tests/lib/BackgroundJob/TestParallelAwareJob.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright (c) 2014 Robin Appelman <icewind@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use Test\BackgroundJob\JobTest;
+
+class TestParallelAwareJob extends \OCP\BackgroundJob\Job {
+	private $testCase;
+
+	/**
+	 * @var callable $callback
+	 */
+	private $callback;
+
+	/**
+	 * @param JobTest $testCase
+	 * @param callable $callback
+	 */
+	public function __construct(ITimeFactory $time = null, $testCase = null, $callback = null) {
+		parent::__construct($time ?? \OC::$server->get(ITimeFactory::class));
+		$this->setAllowParallelRuns(false);
+		$this->testCase = $testCase;
+		$this->callback = $callback;
+	}
+
+	public function run($argument) {
+		$this->testCase->markRun();
+		$callback = $this->callback;
+		$callback($argument);
+	}
+}


### PR DESCRIPTION
* Resolves: #39466

## Summary
When setting `allowParallelJobs` to `false`, it checks whether other jobs with the same class are already reserved. This is always the case though, because we wait with this check until after setting the current job to reserved. This PR changes this order.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
