### PR TITLE
Migrate files external to PSR LoggerInterface

### DIFF
--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -34,9 +34,9 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Global storages controller
@@ -49,7 +49,7 @@ class GlobalStoragesController extends StoragesController {
 	 * @param IRequest $request request object
 	 * @param IL10N $l10n l10n service
 	 * @param GlobalStoragesService $globalStoragesService storage service
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
 	 * @param IConfig $config
@@ -59,7 +59,7 @@ class GlobalStoragesController extends StoragesController {
 		IRequest $request,
 		IL10N $l10n,
 		GlobalStoragesService $globalStoragesService,
-		ILogger $logger,
+		LoggerInterface $logger,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
 		IConfig $config

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -42,49 +42,14 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Base class for storages controllers
  */
 abstract class StoragesController extends Controller {
-
-	/**
-	 * L10N service
-	 *
-	 * @var IL10N
-	 */
-	protected $l10n;
-
-	/**
-	 * Storages service
-	 *
-	 * @var StoragesService
-	 */
-	protected $service;
-
-	/**
-	 * @var ILogger
-	 */
-	protected $logger;
-
-	/**
-	 * @var IUserSession
-	 */
-	protected $userSession;
-
-	/**
-	 * @var IGroupManager
-	 */
-	protected $groupManager;
-
-	/**
-	 * @var IConfig
-	 */
-	protected $config;
-
 	/**
 	 * Creates a new storages controller.
 	 *
@@ -92,25 +57,19 @@ abstract class StoragesController extends Controller {
 	 * @param IRequest $request request object
 	 * @param IL10N $l10n l10n service
 	 * @param StoragesService $storagesService storage service
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 */
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		IL10N $l10n,
-		StoragesService $storagesService,
-		ILogger $logger,
-		IUserSession $userSession,
-		IGroupManager $groupManager,
-		IConfig $config
+		protected IL10N $l10n,
+		protected StoragesService $service,
+		protected LoggerInterface $logger,
+		protected IUserSession $userSession,
+		protected IGroupManager $groupManager,
+		protected IConfig $config
 	) {
 		parent::__construct($AppName, $request);
-		$this->l10n = $l10n;
-		$this->service = $storagesService;
-		$this->logger = $logger;
-		$this->userSession = $userSession;
-		$this->groupManager = $groupManager;
-		$this->config = $config;
 	}
 
 	/**
@@ -159,7 +118,7 @@ abstract class StoragesController extends Controller {
 				$priority
 			);
 		} catch (\InvalidArgumentException $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new DataResponse(
 				[
 					'message' => $this->l10n->t('Invalid backend or authentication mechanism class')

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -39,9 +39,9 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * User global storages controller
@@ -54,7 +54,7 @@ class UserGlobalStoragesController extends StoragesController {
 	 * @param IRequest $request request object
 	 * @param IL10N $l10n l10n service
 	 * @param UserGlobalStoragesService $userGlobalStoragesService storage service
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
 	 */
@@ -63,7 +63,7 @@ class UserGlobalStoragesController extends StoragesController {
 		IRequest $request,
 		IL10N $l10n,
 		UserGlobalStoragesService $userGlobalStoragesService,
-		ILogger $logger,
+		LoggerInterface $logger,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
 		IConfig $config

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -38,9 +38,9 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * User storages controller
@@ -53,7 +53,7 @@ class UserStoragesController extends StoragesController {
 	 * @param IRequest $request request object
 	 * @param IL10N $l10n l10n service
 	 * @param UserStoragesService $userStoragesService storage service
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 * @param IUserSession $userSession
 	 * @param IGroupManager $groupManager
 	 */
@@ -62,7 +62,7 @@ class UserStoragesController extends StoragesController {
 		IRequest $request,
 		IL10N $l10n,
 		UserStoragesService $userStoragesService,
-		ILogger $logger,
+		LoggerInterface $logger,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
 		IConfig $config

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -29,6 +29,7 @@ use OC\Files\Storage\PolyFill\CopyDirectory;
 use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\StorageNotAvailableException;
+use Psr\Log\LoggerInterface;
 
 class FTP extends Common {
 	use CopyDirectory;
@@ -116,7 +117,7 @@ class FTP extends Common {
 			if ($this->is_dir($path)) {
 				$list = $this->getConnection()->mlsd($this->buildPath($path));
 				if (!$list) {
-					\OC::$server->getLogger()->warning("Unable to get last modified date for ftp folder ($path), failed to list folder contents");
+					\OC::$server->get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), failed to list folder contents");
 					return time();
 				}
 				$currentDir = current(array_filter($list, function ($item) {
@@ -130,7 +131,7 @@ class FTP extends Common {
 					}
 					return $time->getTimestamp();
 				} else {
-					\OC::$server->getLogger()->warning("Unable to get last modified date for ftp folder ($path), folder contents doesn't include current folder");
+					\OC::$server->get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), folder contents doesn't include current folder");
 					return time();
 				}
 			} else {

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -54,10 +54,10 @@ use Icewind\SMB\ServerFactory;
 use Icewind\SMB\System;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
-use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
 use OCA\Files_External\Lib\Notify\SMBNotifyHandler;
+use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\EntityTooLargeException;
 use OCP\Files\Notify\IChange;
@@ -66,7 +66,7 @@ use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\INotifyStorage;
 use OCP\Files\StorageAuthException;
 use OCP\Files\StorageNotAvailableException;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class SMB extends Common implements INotifyStorage {
 	/**
@@ -87,7 +87,7 @@ class SMB extends Common implements INotifyStorage {
 	/** @var CappedMemoryCache<IFileInfo> */
 	protected CappedMemoryCache $statCache;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	protected $logger;
 
 	/** @var bool */
@@ -111,9 +111,16 @@ class SMB extends Common implements INotifyStorage {
 		}
 
 		if (isset($params['logger'])) {
+			if (!$params['logger'] instanceof LoggerInterface) {
+				throw new \Exception(
+					'Invalid logger. Got '
+					. get_class($params['logger'])
+					. ' Expected ' . LoggerInterface::class
+				);
+			}
 			$this->logger = $params['logger'];
 		} else {
-			$this->logger = \OC::$server->getLogger();
+			$this->logger = \OC::$server->get(LoggerInterface::class);
 		}
 
 		$options = new Options();
@@ -212,7 +219,7 @@ class SMB extends Common implements INotifyStorage {
 	 * @throws StorageAuthException
 	 */
 	protected function throwUnavailable(\Exception $e) {
-		$this->logger->logException($e, ['message' => 'Error while getting file info']);
+		$this->logger->error('Error while getting file info', ['exception' => $e]);
 		throw new StorageAuthException($e->getMessage(), $e);
 	}
 
@@ -277,13 +284,13 @@ class SMB extends Common implements INotifyStorage {
 						yield $file;
 					}
 				} catch (ForbiddenException $e) {
-					$this->logger->logException($e, ['level' => ILogger::DEBUG, 'message' => 'Hiding forbidden entry ' . $file->getName()]);
+					$this->logger->debug($e->getMessage(), ['exception' => $e]);
 				} catch (NotFoundException $e) {
-					$this->logger->logException($e, ['level' => ILogger::DEBUG, 'message' => 'Hiding not found entry ' . $file->getName()]);
+					$this->logger->debug('Hiding forbidden entry ' . $file->getName(), ['exception' => $e]);
 				}
 			}
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while getting folder content']);
+			$this->logger->error('Error while getting folder content', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		} catch (NotFoundException $e) {
 			throw new \OCP\Files\NotFoundException($e->getMessage(), 0, $e);
@@ -328,7 +335,7 @@ class SMB extends Common implements INotifyStorage {
 				$this->remove($target);
 				$result = $this->share->rename($absoluteSource, $absoluteTarget);
 			} else {
-				$this->logger->logException($e, ['level' => ILogger::WARN]);
+				$this->logger->warning($e->getMessage(), ['exception' => $e]);
 				return false;
 			}
 		} catch (InvalidArgumentException $e) {
@@ -336,11 +343,11 @@ class SMB extends Common implements INotifyStorage {
 				$this->remove($target);
 				$result = $this->share->rename($absoluteSource, $absoluteTarget);
 			} else {
-				$this->logger->logException($e, ['level' => ILogger::WARN]);
+				$this->logger->warning($e->getMessage(), ['exception' => $e]);
 				return false;
 			}
 		} catch (\Exception $e) {
-			$this->logger->logException($e, ['level' => ILogger::WARN]);
+			$this->logger->warning($e->getMessage(), ['exception' => $e]);
 			return false;
 		}
 		unset($this->statCache[$absoluteSource], $this->statCache[$absoluteTarget]);
@@ -431,7 +438,7 @@ class SMB extends Common implements INotifyStorage {
 		} catch (ForbiddenException $e) {
 			return false;
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while deleting file']);
+			$this->logger->error('Error while deleting file', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		}
 	}
@@ -518,7 +525,7 @@ class SMB extends Common implements INotifyStorage {
 		} catch (OutOfSpaceException $e) {
 			throw new EntityTooLargeException("not enough available space to create file", 0, $e);
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while opening file']);
+			$this->logger->error('Error while opening file', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		}
 	}
@@ -545,7 +552,7 @@ class SMB extends Common implements INotifyStorage {
 		} catch (ForbiddenException $e) {
 			return false;
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while removing folder']);
+			$this->logger->error('Error while removing folder', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		}
 	}
@@ -561,7 +568,7 @@ class SMB extends Common implements INotifyStorage {
 		} catch (OutOfSpaceException $e) {
 			throw new EntityTooLargeException("not enough available space to create file", 0, $e);
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while creating file']);
+			$this->logger->error('Error while creating file', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		}
 	}
@@ -658,7 +665,7 @@ class SMB extends Common implements INotifyStorage {
 			$this->share->mkdir($path);
 			return true;
 		} catch (ConnectException $e) {
-			$this->logger->logException($e, ['message' => 'Error while creating folder']);
+			$this->logger->error('Error while creating folder', ['exception' => $e]);
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
 		} catch (Exception $e) {
 			return false;
@@ -736,7 +743,7 @@ class SMB extends Common implements INotifyStorage {
 		} catch (ForbiddenException $e) {
 			return false;
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return false;
 		}
 	}

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -47,8 +47,8 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\Files\StorageNotAvailableException;
-use OCP\IUser;
 use phpseclib\Crypt\AES;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class to configure mount.json globally and for users
@@ -138,7 +138,7 @@ class MountConfig {
 					throw $e;
 				}
 			} catch (\Exception $exception) {
-				\OC::$server->getLogger()->logException($exception, ['app' => 'files_external']);
+				\OC::$server->get(LoggerInterface::class)->error($exception->getMessage(), ['exception' => $exception, 'app' => 'files_external']);
 				throw $exception;
 			}
 		}

--- a/apps/files_external/lib/Service/LegacyStoragesService.php
+++ b/apps/files_external/lib/Service/LegacyStoragesService.php
@@ -27,7 +27,7 @@
 namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Lib\StorageConfig;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Read mount config from legacy mount.json
@@ -143,7 +143,7 @@ abstract class LegacyStoragesService {
 					$parts = explode('/', ltrim($rootMountPath, '/'), 3);
 					if (count($parts) < 3) {
 						// something went wrong, skip
-						\OC::$server->getLogger()->error('Could not parse mount point "' . $rootMountPath . '"', ['app' => 'files_external']);
+						\OC::$server->get(LoggerInterface::class)->error('Could not parse mount point "' . $rootMountPath . '"', ['app' => 'files_external']);
 						continue;
 					}
 					$relativeMountPath = rtrim($parts[2], '/');
@@ -191,10 +191,9 @@ abstract class LegacyStoragesService {
 						}
 					} catch (\UnexpectedValueException $e) {
 						// don't die if a storage backend doesn't exist
-						\OC::$server->getLogger()->logException($e, [
-							'message' => 'Could not load storage.',
-							'level' => ILogger::ERROR,
+						\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
 							'app' => 'files_external',
+							'exception' => $e,
 						]);
 					}
 				}

--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -44,7 +44,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\StorageNotAvailableException;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Service class to manage external storage
@@ -119,17 +119,15 @@ abstract class StoragesService {
 			return $config;
 		} catch (\UnexpectedValueException $e) {
 			// don't die if a storage backend doesn't exist
-			\OC::$server->getLogger()->logException($e, [
-				'message' => 'Could not load storage.',
-				'level' => ILogger::ERROR,
+			\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
 				'app' => 'files_external',
+				'exception' => $e,
 			]);
 			return null;
 		} catch (\InvalidArgumentException $e) {
-			\OC::$server->getLogger()->logException($e, [
-				'message' => 'Could not load storage.',
-				'level' => ILogger::ERROR,
+			\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
 				'app' => 'files_external',
+				'exception' => $e,
 			]);
 			return null;
 		}

--- a/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
@@ -32,9 +32,10 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class GlobalStoragesControllerTest extends StoragesControllerTest {
 	protected function setUp(): void {
@@ -65,7 +66,7 @@ class GlobalStoragesControllerTest extends StoragesControllerTest {
 			$this->createMock(IRequest::class),
 			$this->createMock(IL10N::class),
 			$this->service,
-			$this->createMock(ILogger::class),
+			$this->createMock(LoggerInterface::class),
 			$session,
 			$this->createMock(IGroupManager::class),
 			$config

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -35,9 +35,10 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class UserStoragesControllerTest extends StoragesControllerTest {
 
@@ -73,7 +74,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 			$this->createMock(IRequest::class),
 			$this->createMock(IL10N::class),
 			$this->service,
-			$this->createMock(ILogger::class),
+			$this->createMock(LoggerInterface::class),
 			$session,
 			$this->createMock(IGroupManager::class),
 			$config


### PR DESCRIPTION
See  #32127 

## Summary
Remove `OCP\ILogger` from `apps/files_external` and use `Psr\Log\LoggerInterface` instead.