### PR TITLE
fix(dispatcher): Move remaining simple cases in apps/ folder to IEven…

### DIFF
--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -132,7 +132,7 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getSystemTagObjectMapper(),
 			\OC::$server->getUserSession(),
 			$groupManager,
-			\OC::$server->getEventDispatcher()
+			$dispatcher
 		);
 		$systemTagInUseCollection = \OCP\Server::get(SystemTag\SystemTagsInUseCollection::class);
 		$commentsCollection = new Comments\RootCollection(

--- a/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php
@@ -26,6 +26,7 @@
  */
 namespace OCA\DAV\SystemTag;
 
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
@@ -33,25 +34,14 @@ use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\SystemTag\SystemTagsEntityEvent;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\SimpleCollection;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SystemTagsRelationsCollection extends SimpleCollection {
-
-	/**
-	 * SystemTagsRelationsCollection constructor.
-	 *
-	 * @param ISystemTagManager $tagManager
-	 * @param ISystemTagObjectMapper $tagMapper
-	 * @param IUserSession $userSession
-	 * @param IGroupManager $groupManager
-	 * @param EventDispatcherInterface $dispatcher
-	 */
 	public function __construct(
 		ISystemTagManager $tagManager,
 		ISystemTagObjectMapper $tagMapper,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
-		EventDispatcherInterface $dispatcher
+		IEventDispatcher $dispatcher,
 	) {
 		$children = [
 			new SystemTagsObjectTypeCollection(
@@ -67,8 +57,9 @@ class SystemTagsRelationsCollection extends SimpleCollection {
 			),
 		];
 
-		$event = new SystemTagsEntityEvent(SystemTagsEntityEvent::EVENT_ENTITY);
+		$event = new SystemTagsEntityEvent();
 		$dispatcher->dispatch(SystemTagsEntityEvent::EVENT_ENTITY, $event);
+		$dispatcher->dispatchTyped($event);
 
 		foreach ($event->getEntityCollections() as $entity => $entityExistsFunction) {
 			$children[] = new SystemTagsObjectTypeCollection(

--- a/apps/files/lib/Collaboration/Resources/Listener.php
+++ b/apps/files/lib/Collaboration/Resources/Listener.php
@@ -25,12 +25,12 @@ declare(strict_types=1);
  */
 namespace OCA\Files\Collaboration\Resources;
 
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Server;
 use OCP\Collaboration\Resources\IManager;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Listener {
-	public static function register(EventDispatcherInterface $dispatcher): void {
+	public static function register(IEventDispatcher $dispatcher): void {
 		$dispatcher->addListener('OCP\Share::postShare', [self::class, 'shareModification']);
 		$dispatcher->addListener('OCP\Share::postUnshare', [self::class, 'shareModification']);
 		$dispatcher->addListener('OCP\Share::postUnshareFromSelf', [self::class, 'shareModification']);

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -52,7 +52,6 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use OCP\Template;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
@@ -69,7 +68,7 @@ class ViewControllerTest extends TestCase {
 	private $l10n;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var EventDispatcherInterface */
+	/** @var IEventDispatcher */
 	private $eventDispatcher;
 	/** @var ViewController|\PHPUnit\Framework\MockObject\MockObject */
 	private $viewController;

--- a/apps/files_external/tests/Controller/StoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTest.php
@@ -34,7 +34,9 @@ use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
+use OCA\Files_External\Service\UserStoragesService;
 use OCP\AppFramework\Http;
+use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class StoragesControllerTest extends \Test\TestCase {
 
@@ -44,7 +46,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	protected $controller;
 
 	/**
-	 * @var GlobalStoragesService
+	 * @var GlobalStoragesService|UserStoragesService|MockObject
 	 */
 	protected $service;
 
@@ -57,7 +59,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OCA\Files_External\Lib\Backend\Backend
+	 * @return \OCA\Files_External\Lib\Backend\Backend|MockObject
 	 */
 	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
 		$backend = $this->getMockBuilder(Backend::class)
@@ -73,7 +75,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism
+	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism|MockObject
 	 */
 	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
 		$authMech = $this->getMockBuilder(AuthMechanism::class)

--- a/apps/files_sharing/tests/ApplicationTest.php
+++ b/apps/files_sharing/tests/ApplicationTest.php
@@ -25,16 +25,11 @@ namespace OCA\Files_Sharing\Tests;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use Psr\Log\LoggerInterface;
-use OC\Share20\LegacyHooks;
 use OC\Share20\Manager;
 use OC\EventDispatcher\EventDispatcher;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\SharedStorage;
-use OCP\Constants;
-use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Cache\ICacheEntry;
-use OCP\Files\Event\BeforeDirectGetEvent;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -57,7 +52,8 @@ class ApplicationTest extends TestCase {
 	/** @var IRootFolder */
 	private $rootFolder;
 
-	/** @var Manager */ private $manager;
+	/** @var Manager */
+	private $manager;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -59,7 +59,6 @@ use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\IManager as IShareManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Application extends App implements IBootstrap {
 	public function __construct() {
@@ -120,7 +119,6 @@ class Application extends App implements IBootstrap {
 		$context->injectFn(function (
 			INotificationManager $notificationManager,
 			IAppContainer $appContainer,
-			EventDispatcherInterface $legacyDispatcher,
 			IEventDispatcher $dispatcher,
 			IGroupManager $groupManager,
 			User_Proxy $userBackend,
@@ -136,7 +134,7 @@ class Application extends App implements IBootstrap {
 				$groupManager->addBackend($groupBackend);
 
 				$userBackendRegisteredEvent = new UserBackendRegistered($userBackend, $userPluginManager);
-				$legacyDispatcher->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', $userBackendRegisteredEvent);
+				$dispatcher->dispatch('OCA\\User_LDAP\\User\\User::postLDAPBackendAdded', $userBackendRegisteredEvent);
 				$dispatcher->dispatchTyped($userBackendRegisteredEvent);
 				$groupBackendRegisteredEvent = new GroupBackendRegistered($groupBackend, $groupPluginManager);
 				$dispatcher->dispatchTyped($groupBackendRegisteredEvent);
@@ -153,7 +151,7 @@ class Application extends App implements IBootstrap {
 		);
 	}
 
-	private function registerBackendDependents(IAppContainer $appContainer, EventDispatcherInterface $dispatcher) {
+	private function registerBackendDependents(IAppContainer $appContainer, IEventDispatcher $dispatcher) {
 		$dispatcher->addListener(
 			'OCA\\Files_External::loadAdditionalBackends',
 			function () use ($appContainer) {

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -52,7 +52,6 @@ use OCP\WorkflowEngine\IEntityEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IOperation;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**

--- a/lib/public/SystemTag/SystemTagsEntityEvent.php
+++ b/lib/public/SystemTag/SystemTagsEntityEvent.php
@@ -33,26 +33,22 @@ use OCP\EventDispatcher\Event;
  * Class SystemTagsEntityEvent
  *
  * @since 9.1.0
+ * @since 28.0.0 Dispatched as a typed event
  */
 class SystemTagsEntityEvent extends Event {
 	/**
-	 * @deprecated 22.0.0
+	 * @deprecated 22.0.0 Listen to the typed event instead
 	 */
 	public const EVENT_ENTITY = 'OCP\SystemTag\ISystemTagManager::registerEntity';
 
-	/** @var string */
-	protected $event;
 	/** @var \Closure[] */
 	protected $collections;
 
 	/**
-	 * SystemTagsEntityEvent constructor.
-	 *
-	 * @param string $event
 	 * @since 9.1.0
 	 */
-	public function __construct(string $event) {
-		$this->event = $event;
+	public function __construct() {
+		parent::__construct();
 		$this->collections = [];
 	}
 


### PR DESCRIPTION
…tDispatcher


* One step closer for https://github.com/nextcloud/server/pull/38546

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
