### PR TITLE
chore(3rdparty): update punic to 3.8.1

### DIFF
--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -163,8 +163,8 @@ class DateTimeFormatterTest extends TestCase {
 
 	public function formatDateTimeData() {
 		return [
-			[1350129205, null, 'October 13, 2012 at 11:53:25 AM GMT+0'],
-			[1350129205, new \DateTimeZone('Europe/Berlin'), 'October 13, 2012 at 1:53:25 PM GMT+2'],
+			[1350129205, null, "October 13, 2012, 11:53:25\xE2\x80\xAFAM UTC"],
+			[1350129205, new \DateTimeZone('Europe/Berlin'), "October 13, 2012, 1:53:25\xE2\x80\xAFPM GMT+2"],
 		];
 	}
 
@@ -175,7 +175,7 @@ class DateTimeFormatterTest extends TestCase {
 		$this->assertEquals($expected, (string) $this->formatter->formatDateTime($timestamp, 'long', 'long', $timeZone));
 	}
 
-	
+
 	public function testFormatDateWithInvalidTZ() {
 		$this->expectException(\Exception::class);
 

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -118,34 +118,34 @@ class L10nTest extends TestCase {
 	public function localizationData() {
 		return [
 			// timestamp as string
-			['February 13, 2009 at 11:31:30 PM UTC', 'en', 'en_US', 'datetime', '1234567890'],
-			['13. Februar 2009 um 23:31:30 UTC', 'de', 'de_DE', 'datetime', '1234567890'],
+			["February 13, 2009, 11:31:30\xE2\x80\xAFPM UTC", 'en', 'en_US', 'datetime', '1234567890'],
+			['13. Februar 2009, 23:31:30 UTC', 'de', 'de_DE', 'datetime', '1234567890'],
 			['February 13, 2009', 'en', 'en_US', 'date', '1234567890'],
 			['13. Februar 2009', 'de', 'de_DE', 'date', '1234567890'],
-			['11:31:30 PM UTC', 'en', 'en_US', 'time', '1234567890'],
+			["11:31:30\xE2\x80\xAFPM UTC", 'en', 'en_US', 'time', '1234567890'],
 			['23:31:30 UTC', 'de', 'de_DE', 'time', '1234567890'],
 
 			// timestamp as int
-			['February 13, 2009 at 11:31:30 PM UTC', 'en', 'en_US', 'datetime', 1234567890],
-			['13. Februar 2009 um 23:31:30 UTC', 'de', 'de_DE', 'datetime', 1234567890],
+			["February 13, 2009, 11:31:30\xE2\x80\xAFPM UTC", 'en', 'en_US', 'datetime', 1234567890],
+			['13. Februar 2009, 23:31:30 UTC', 'de', 'de_DE', 'datetime', 1234567890],
 			['February 13, 2009', 'en', 'en_US', 'date', 1234567890],
 			['13. Februar 2009', 'de', 'de_DE', 'date', 1234567890],
-			['11:31:30 PM UTC', 'en', 'en_US', 'time', 1234567890],
+			["11:31:30\xE2\x80\xAFPM UTC", 'en', 'en_US', 'time', 1234567890],
 			['23:31:30 UTC', 'de', 'de_DE', 'time', 1234567890],
 
 			// DateTime object
-			['February 13, 2009 at 11:31:30 PM GMT+0', 'en', 'en_US', 'datetime', new DateTime('@1234567890')],
-			['13. Februar 2009 um 23:31:30 GMT+0', 'de', 'de_DE', 'datetime', new DateTime('@1234567890')],
+			["February 13, 2009, 11:31:30\xE2\x80\xAFPM GMT+0", 'en', 'en_US', 'datetime', new DateTime('@1234567890')],
+			['13. Februar 2009, 23:31:30 GMT+0', 'de', 'de_DE', 'datetime', new DateTime('@1234567890')],
 			['February 13, 2009', 'en', 'en_US', 'date', new DateTime('@1234567890')],
 			['13. Februar 2009', 'de', 'de_DE', 'date', new DateTime('@1234567890')],
-			['11:31:30 PM GMT+0', 'en', 'en_US', 'time', new DateTime('@1234567890')],
+			["11:31:30\xE2\x80\xAFPM GMT+0", 'en', 'en_US', 'time', new DateTime('@1234567890')],
 			['23:31:30 GMT+0', 'de', 'de_DE', 'time', new DateTime('@1234567890')],
 
 			// en_GB
-			['13 February 2009 at 23:31:30 GMT+0', 'en_GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
+			['13 February 2009, 23:31:30 GMT+0', 'en_GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
 			['13 February 2009', 'en_GB', 'en_GB', 'date', new DateTime('@1234567890')],
 			['23:31:30 GMT+0', 'en_GB', 'en_GB', 'time', new DateTime('@1234567890')],
-			['13 February 2009 at 23:31:30 GMT+0', 'en-GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
+			['13 February 2009, 23:31:30 GMT+0', 'en-GB', 'en_GB', 'datetime', new DateTime('@1234567890')],
 			['13 February 2009', 'en-GB', 'en_GB', 'date', new DateTime('@1234567890')],
 			['23:31:30 GMT+0', 'en-GB', 'en_GB', 'time', new DateTime('@1234567890')],
 		];

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -118,20 +118,20 @@ class L10nTest extends TestCase {
 	public function localizationData() {
 		return [
 			// timestamp as string
-			['February 13, 2009 at 11:31:30 PM GMT+0', 'en', 'en_US', 'datetime', '1234567890'],
-			['13. Februar 2009 um 23:31:30 GMT+0', 'de', 'de_DE', 'datetime', '1234567890'],
+			['February 13, 2009 at 11:31:30 PM UTC', 'en', 'en_US', 'datetime', '1234567890'],
+			['13. Februar 2009 um 23:31:30 UTC', 'de', 'de_DE', 'datetime', '1234567890'],
 			['February 13, 2009', 'en', 'en_US', 'date', '1234567890'],
 			['13. Februar 2009', 'de', 'de_DE', 'date', '1234567890'],
-			['11:31:30 PM GMT+0', 'en', 'en_US', 'time', '1234567890'],
-			['23:31:30 GMT+0', 'de', 'de_DE', 'time', '1234567890'],
+			['11:31:30 PM UTC', 'en', 'en_US', 'time', '1234567890'],
+			['23:31:30 UTC', 'de', 'de_DE', 'time', '1234567890'],
 
 			// timestamp as int
-			['February 13, 2009 at 11:31:30 PM GMT+0', 'en', 'en_US', 'datetime', 1234567890],
-			['13. Februar 2009 um 23:31:30 GMT+0', 'de', 'de_DE', 'datetime', 1234567890],
+			['February 13, 2009 at 11:31:30 PM UTC', 'en', 'en_US', 'datetime', 1234567890],
+			['13. Februar 2009 um 23:31:30 UTC', 'de', 'de_DE', 'datetime', 1234567890],
 			['February 13, 2009', 'en', 'en_US', 'date', 1234567890],
 			['13. Februar 2009', 'de', 'de_DE', 'date', 1234567890],
-			['11:31:30 PM GMT+0', 'en', 'en_US', 'time', 1234567890],
-			['23:31:30 GMT+0', 'de', 'de_DE', 'time', 1234567890],
+			['11:31:30 PM UTC', 'en', 'en_US', 'time', 1234567890],
+			['23:31:30 UTC', 'de', 'de_DE', 'time', 1234567890],
 
 			// DateTime object
 			['February 13, 2009 at 11:31:30 PM GMT+0', 'en', 'en_US', 'datetime', new DateTime('@1234567890')],


### PR DESCRIPTION
## Summary

**Beware! The Punic and CLDR updates brought some changes to the generated date and time formats. I don't think that's a problem unless we parse those strings somewhere else.**

Update punic to 3.8.1.

Major library update. The directory structure changed and thus almost everything is changed.

We are using the Calendar component in `lib/private/L10N/L10N.php`. 

If we make php-intl a required extension, we could use IntlCalendar and drop punic as a dependency.

## TODO

- [x] Testing 
- [x] CI
- [x] Merge https://github.com/nextcloud/3rdparty/pull/1484
- [x] Rebase

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
