### PR TITLE
fix(apps): Fix loading info.xml file

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -588,6 +588,11 @@ class OC {
 	}
 
 	public static function init(): void {
+		// prevent any XML processing from loading external entities
+		libxml_set_external_entity_loader(static function () {
+			return null;
+		});
+
 		// calculate the root directories
 		OC::$SERVERROOT = str_replace("\\", '/', substr(__DIR__, 0, -4));
 

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -31,7 +31,7 @@ namespace OC\App;
 
 use OCP\ICache;
 use function libxml_disable_entity_loader;
-use function simplexml_load_file;
+use function simplexml_load_string;
 
 class InfoParser {
 	/** @var \OCP\ICache|null */
@@ -63,10 +63,10 @@ class InfoParser {
 		libxml_use_internal_errors(true);
 		if ((PHP_VERSION_ID < 80000)) {
 			$loadEntities = libxml_disable_entity_loader(false);
-			$xml = simplexml_load_file($file);
+			$xml = simplexml_load_string(file_get_contents($file));
 			libxml_disable_entity_loader($loadEntities);
 		} else {
-			$xml = simplexml_load_file($file);
+			$xml = simplexml_load_string(file_get_contents($file));
 		}
 
 		if ($xml === false) {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -334,10 +334,10 @@ class Installer {
 					// Check if appinfo/info.xml has the same app ID as well
 					if ((PHP_VERSION_ID < 80000)) {
 						$loadEntities = libxml_disable_entity_loader(false);
-						$xml = simplexml_load_file($extractDir . '/' . $folders[0] . '/appinfo/info.xml');
+						$xml = simplexml_load_string(file_get_contents($extractDir . '/' . $folders[0] . '/appinfo/info.xml'));
 						libxml_disable_entity_loader($loadEntities);
 					} else {
-						$xml = simplexml_load_file($extractDir . '/' . $folders[0] . '/appinfo/info.xml');
+						$xml = simplexml_load_string(file_get_contents($extractDir . '/' . $folders[0] . '/appinfo/info.xml'));
 					}
 					if ((string)$xml->id !== $appId) {
 						throw new \Exception(


### PR DESCRIPTION
Ref: https://bugs.php.net/bug.php?id=62577

![Bildschirmfoto vom 2023-07-12 09-25-46](https://github.com/nextcloud-gmbh/server/assets/213943/be84c68c-ac14-4401-a897-45c1d3fab69b)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
