### PR TITLE
feat(db): Ensure that index names are unique across the database

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -448,6 +448,7 @@ class MigrationService {
 
 		if ($toSchema instanceof SchemaWrapper) {
 			$targetSchema = $toSchema->getWrappedSchema();
+			$this->ensureUniqueNamesConstraints($targetSchema);
 			if ($this->checkOracle) {
 				$beforeSchema = $this->connection->createSchema();
 				$this->ensureOracleConstraints($beforeSchema, $targetSchema, strlen($this->connection->getPrefix()));
@@ -525,6 +526,7 @@ class MigrationService {
 
 		if ($toSchema instanceof SchemaWrapper) {
 			$targetSchema = $toSchema->getWrappedSchema();
+			$this->ensureUniqueNamesConstraints($targetSchema);
 			if ($this->checkOracle) {
 				$sourceSchema = $this->connection->createSchema();
 				$this->ensureOracleConstraints($sourceSchema, $targetSchema, strlen($this->connection->getPrefix()));
@@ -656,6 +658,59 @@ class MigrationService {
 			if (!$sourceSchema->hasSequence($sequence->getName()) && \strlen($sequence->getName()) > 30) {
 				throw new \InvalidArgumentException('Sequence name "' . $sequence->getName() . '" is too long.');
 			}
+		}
+	}
+
+	/**
+	 * Naming constraints:
+	 * - Index, sequence and primary key names must be unique within a Postgres Schema
+	 *
+	 * @param Schema $targetSchema
+	 */
+	public function ensureUniqueNamesConstraints(Schema $targetSchema): void {
+		$constraintNames = [];
+
+		$sequences = $targetSchema->getSequences();
+
+		foreach ($targetSchema->getTables() as $table) {
+			foreach ($table->getIndexes() as $thing) {
+				$indexName = strtolower($thing->getName());
+				if ($indexName === 'primary' || $thing->isPrimary()) {
+					continue;
+				}
+
+				if (isset($constraintNames[$thing->getName()])) {
+					throw new \InvalidArgumentException('Index name "' . $thing->getName() . '" for table "' . $table->getName() . '" collides with the constraint on table "' . $constraintNames[$thing->getName()] . '".');
+				}
+				$constraintNames[$thing->getName()] = $table->getName();
+			}
+
+			foreach ($table->getForeignKeys() as $thing) {
+				if (isset($constraintNames[$thing->getName()])) {
+					throw new \InvalidArgumentException('Foreign key name "' . $thing->getName() . '" for table "' . $table->getName() . '" collides with the constraint on table "' . $constraintNames[$thing->getName()] . '".');
+				}
+				$constraintNames[$thing->getName()] = $table->getName();
+			}
+
+			$primaryKey = $table->getPrimaryKey();
+			if ($primaryKey instanceof Index) {
+				$indexName = strtolower($primaryKey->getName());
+				if ($indexName === 'primary') {
+					continue;
+				}
+
+				if (isset($constraintNames[$indexName])) {
+					throw new \InvalidArgumentException('Primary index name "' . $indexName . '" for table "' . $table->getName() . '" collides with the constraint on table "' . $constraintNames[$thing->getName()] . '".');
+				}
+				$constraintNames[$indexName] = $table->getName();
+			}
+		}
+
+		foreach ($sequences as $sequence) {
+			if (isset($constraintNames[$sequence->getName()])) {
+				throw new \InvalidArgumentException('Sequence name "' . $sequence->getName() . '" for table "' . $table->getName() . '" collides with the constraint on table "' . $constraintNames[$thing->getName()] . '".');
+			}
+			$constraintNames[$sequence->getName()] = 'sequence';
 		}
 	}
 

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -101,10 +101,10 @@ class MigrationsTest extends \Test\TestCase {
 			->method('migrateToSchema');
 
 		$wrappedSchema = $this->createMock(Schema::class);
-		$wrappedSchema->expects($this->once())
+		$wrappedSchema->expects($this->exactly(2))
 			->method('getTables')
 			->willReturn([]);
-		$wrappedSchema->expects($this->once())
+		$wrappedSchema->expects($this->exactly(2))
 			->method('getSequences')
 			->willReturn([]);
 


### PR DESCRIPTION
* Resolves: #39488 

## Error when enabling Talk after Text was enabled (before https://github.com/nextcloud/text/pull/4553 )
```
Index name "ts_session" for table "oc_talk_sessions" collides with the constraint on table "oc_text_steps".
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
