### PR TITLE
fix(utility): De- deprecate getDateTime and getTime as now() only returns DateTimeImmutable

### DIFF
--- a/lib/public/AppFramework/Utility/ITimeFactory.php
+++ b/lib/public/AppFramework/Utility/ITimeFactory.php
@@ -41,7 +41,6 @@ interface ITimeFactory extends ClockInterface {
 	/**
 	 * @return int the result of a call to time()
 	 * @since 8.0.0
-	 * @deprecated 26.0.0 {@see ITimeFactory::now()}
 	 */
 	public function getTime(): int;
 
@@ -50,7 +49,6 @@ interface ITimeFactory extends ClockInterface {
 	 * @param \DateTimeZone|null $timezone
 	 * @return \DateTime
 	 * @since 15.0.0
-	 * @deprecated 26.0.0 {@see ITimeFactory::now()}
 	 */
 	public function getDateTime(string $time = 'now', \DateTimeZone $timezone = null): \DateTime;
 


### PR DESCRIPTION
This will mean lots of code like
```$dateTime = (new DateTime())->setTimestamp(ITimeFactory::now()->getTimestamp())```
if a regular DateTime object is needed

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
