### PR TITLE
fix(CalDAV): initialise properties to avoid access before initialisation errors

### DIFF
--- a/lib/private/Calendar/CalendarQuery.php
+++ b/lib/private/Calendar/CalendarQuery.php
@@ -30,15 +30,15 @@ use OCP\Calendar\ICalendarQuery;
 class CalendarQuery implements ICalendarQuery {
 	public array $searchProperties = [];
 
-	private ?string $searchPattern;
+	private ?string $searchPattern = null;
 
 	private array $options = [
 		'types' => [],
 	];
 
-	private ?int $offset;
+	private ?int $offset = null;
 
-	private ?int $limit;
+	private ?int $limit = null;
 
 	/** @var string[] */
 	private array $calendarUris = [];


### PR DESCRIPTION
Discovered while testing appointments.

```Typed property OC\\Calendar\\CalendarQuery::$searchPattern must not be accessed before initialization in file '/var/www/nextcloud/lib/private/Calendar/CalendarQuery.php' line 64```


Regression from https://github.com/nextcloud/server/pull/38990

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
