### PR TITLE
Fix error (SystemTagNode::setReferenceFileId() must be of the type int, string given)

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
+++ b/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php
@@ -99,8 +99,8 @@ class SystemTagsInUseCollection extends SimpleCollection {
 			$tag = new SystemTag((string)$tagData['id'], $tagData['name'], (bool)$tagData['visibility'], (bool)$tagData['editable']);
 			// read only, so we can submit the isAdmin parameter as false generally
 			$node = new SystemTagNode($tag, $user, false, $this->systemTagManager);
-			$node->setNumberOfFiles($tagData['number_files']);
-			$node->setReferenceFileId($tagData['ref_file_id']);
+			$node->setNumberOfFiles((int)$tagData['number_files']);
+			$node->setReferenceFileId((int)$tagData['ref_file_id']);
 			$children[] = $node;
 		}
 		return $children;


### PR DESCRIPTION
* Resolves: Tags category in photos app working incorectly. <!-- related github issue -->

## Summary
```
TypeError: Argument 1 passed to OCA\DAV\SystemTag\SystemTagNode::setReferenceFileId() must be of the type int, string given, called in /disk/cloud/www/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php on line 103
/disk/cloud/www/apps/dav/lib/SystemTag/SystemTagsInUseCollection.php - line 103:

OCA\DAV\SystemTag\SystemTagNode->setReferenceFileId()

/disk/cloud/www/3rdparty/sabre/dav/lib/DAV/Tree.php - line 200:

OCA\DAV\SystemTag\SystemTagsInUseCollection->getChildren()

/disk/cloud/www/3rdparty/sabre/dav/lib/DAV/Server.php - line 900:

Sabre\DAV\Tree->getChildren()

/disk/cloud/www/3rdparty/sabre/dav/lib/DAV/Server.php - line 982:

Sabre\DAV\Server->generatePathNodes()
```
|   Before   |    After    |
| ---------   | ---------  |
| ![image](https://github.com/nextcloud/server/assets/18057310/9c84bb4b-a52d-4d50-ab46-ed50c1c90a9c) | ![image](https://github.com/nextcloud/server/assets/18057310/33ba0bd1-cad6-4356-81ce-33d352c3896a) |



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
