### PR TITLE
add command get get bruteforce stats

### DIFF
--- a/core/Command/Security/BruteforceStatus.php
+++ b/core/Command/Security/BruteforceStatus.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OC\Security\Bruteforce\Throttler;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BruteforceStatus extends Base {
+	public function __construct(
+		protected Throttler $throttler,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('security:bruteforce:status')
+			->setDescription('List bruteforce attempts summary')
+			->addOption('ipaddress', 'i', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only list attempts from the specified ip range in CIDR notation')
+			->addOption('action', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only list attempts for the specified action')
+			->addOption('count', 'c', InputOption::VALUE_REQUIRED, 'Only list a limited number of items with the most occurrences');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$ips = $input->getOption('ipaddress');
+		$actions = $input->getOption('action');
+		$count = $input->getOption('count');
+
+		$summary = $this->throttler->summarizeAttempts();
+
+		if ($ips) {
+			$summary = array_filter($summary, function (array $item) use ($ips) {
+				return $this->throttler->inSubnets($item['ip'], $ips);
+			});
+		}
+
+		if ($actions) {
+			$actions = array_map(function (string $action) {
+				return strtolower($action);
+			}, $actions);
+			$summary = array_filter($summary, function (array $item) use ($actions) {
+				$lowerAction = strtolower($item['action']);
+				foreach ($actions as $action) {
+					return str_contains($lowerAction, $action);
+				}
+				return false;
+			});
+		}
+
+		if ($count) {
+			$summary = array_slice($summary, 0, $count);
+		}
+
+		if ($input->getOption('output') === self::OUTPUT_FORMAT_JSON || $input->getOption('output') === self::OUTPUT_FORMAT_JSON_PRETTY) {
+			$this->writeArrayInOutputFormat($input, $output, $summary);
+		} else {
+			$table = new Table($output);
+			$table
+				->setHeaders(['IP', 'Action', 'Count'])
+				->setRows(array_map(function (array $item) {
+					return [$item['ip'], $item['action'], $item['count']];
+				}, $summary));
+			$table->render();
+		}
+		return 0;
+	}
+}

--- a/core/Command/Security/ResetBruteforceAttempts.php
+++ b/core/Command/Security/ResetBruteforceAttempts.php
@@ -39,7 +39,7 @@ class ResetBruteforceAttempts extends Base {
 	protected function configure() {
 		$this
 			->setName('security:bruteforce:reset')
-			->setDescription('resets bruteforce attemps for given IP address')
+			->setDescription('resets bruteforce attempts for given IP address')
 			->addArgument(
 				'ipaddress',
 				InputArgument::REQUIRED,

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\Core\Command\Security\BruteforceStatus;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -210,6 +212,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager()));
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager()));
 	$application->add(new OC\Core\Command\Security\ResetBruteforceAttempts(\OC::$server->getBruteForceThrottler()));
+	$application->add(\OC::$server->get(BruteforceStatus::class));
 } else {
 	$application->add(\OC::$server->get(\OC\Core\Command\Maintenance\Install::class));
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1010,6 +1010,7 @@ return array(
     'OC\\Core\\Command\\Preview\\Generate' => $baseDir . '/core/Command/Preview/Generate.php',
     'OC\\Core\\Command\\Preview\\Repair' => $baseDir . '/core/Command/Preview/Repair.php',
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',
+    'OC\\Core\\Command\\Security\\BruteforceStatus' => $baseDir . '/core/Command/Security/BruteforceStatus.php',
     'OC\\Core\\Command\\Security\\ImportCertificate' => $baseDir . '/core/Command/Security/ImportCertificate.php',
     'OC\\Core\\Command\\Security\\ListCertificates' => $baseDir . '/core/Command/Security/ListCertificates.php',
     'OC\\Core\\Command\\Security\\RemoveCertificate' => $baseDir . '/core/Command/Security/RemoveCertificate.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1043,6 +1043,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Preview\\Generate' => __DIR__ . '/../../..' . '/core/Command/Preview/Generate.php',
         'OC\\Core\\Command\\Preview\\Repair' => __DIR__ . '/../../..' . '/core/Command/Preview/Repair.php',
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',
+        'OC\\Core\\Command\\Security\\BruteforceStatus' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceStatus.php',
         'OC\\Core\\Command\\Security\\ImportCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/ImportCertificate.php',
         'OC\\Core\\Command\\Security\\ListCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ListCertificates.php',
         'OC\\Core\\Command\\Security\\RemoveCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/RemoveCertificate.php',


### PR DESCRIPTION
Can be useful for debugging.

Provides the count for each `ip`, `action` pair with the option to filter by ip ranges or action substrings.