### PR TITLE
set Doctrine to use nest transactions with savepoints

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -127,6 +127,8 @@ class Connection extends PrimaryReadReplicaConnection {
 			$this->dbDataCollector->setDebugStack($debugStack);
 			$this->_config->setSQLLogger($debugStack);
 		}
+
+		$this->setNestTransactionsWithSavepoints(true);
 	}
 
 	/**


### PR DESCRIPTION
Using nested transactions without savepoints is actually deprecated by Doctrine: https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/transactions.html#transaction-nesting

Without savepoints, a nested transaction can be rollbacked but not handled properly in the "real" transaction, leading to the following error:
Transaction commit failed because the transaction has been marked for rollback only.

Ref
https://github.com/nextcloud/server/pull/36528#issuecomment-1639913965 (and possibly) https://github.com/nextcloud/server/issues/38902#issuecomment-1598075391

## TODO

- [x] See how existing tests go
- [ ] Add a test with a example of nested transaction rollback

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
