### PR TITLE
[stable25] fix(caldav): harden null handling of iMip scheduling method

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -70,11 +70,15 @@ class IMipService {
 	}
 
 	/**
-	 * @param string $senderName
-	 * @param $default
+	 * @param string|null $senderName
+	 * @param string $default
 	 * @return string
 	 */
-	public function getFrom(string $senderName, $default): string {
+	public function getFrom(?string $senderName, string $default): string {
+		if ($senderName === null) {
+			return $default;
+		}
+
 		return $this->l10n->t('%1$s via %2$s', [$senderName, $default]);
 	}
 


### PR DESCRIPTION
* Resolves: #39576 

## Summary

Manual backport of #36935

## TODO

- [x] CI
- [x] Testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
