### PR TITLE
fix!: Remove symfony EventDispatcherInterface from OC\User and OC\Group

### DIFF
--- a/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
@@ -28,13 +28,13 @@ namespace OCA\Files_External\Tests\Controller;
 use OC\User\User;
 use OCA\Files_External\Controller\GlobalStoragesController;
 use OCA\Files_External\Service\BackendService;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class GlobalStoragesControllerTest extends StoragesControllerTest {
 	protected function setUp(): void {
@@ -53,7 +53,7 @@ class GlobalStoragesControllerTest extends StoragesControllerTest {
 	private function createController($allowCreateLocal = true) {
 		$session = $this->createMock(IUserSession::class);
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(EventDispatcherInterface::class)));
+			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
 
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -31,13 +31,13 @@ use OCA\Files_External\Controller\UserStoragesController;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCP\AppFramework\Http;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class UserStoragesControllerTest extends StoragesControllerTest {
 
@@ -61,7 +61,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 	private function createController($allowCreateLocal = true) {
 		$session = $this->createMock(IUserSession::class);
 		$session->method('getUser')
-			->willReturn(new User('test', null, $this->createMock(EventDispatcherInterface::class)));
+			->willReturn(new User('test', null, $this->createMock(IEventDispatcher::class)));
 
 		$config = $this->createMock(IConfig::class);
 		$config->method('getSystemValue')

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -31,6 +31,7 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -66,7 +67,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 		$this->globalStoragesService = $this->service;
 
-		$this->user = new \OC\User\User(self::USER_ID, null, \OC::$server->getEventDispatcher());
+		$this->user = new \OC\User\User(self::USER_ID, null, \OC::$server->get(IEventDispatcher::class));
 		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -39,7 +39,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IServerContainer;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class LDAPProviderTest
@@ -76,7 +75,6 @@ class LDAPProviderTest extends \Test\TestCase {
 			->setMethods(['getBackends'])
 			->setConstructorArgs([
 				$this->createMock(IConfig::class),
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])

--- a/lib/private/Collaboration/Resources/Listener.php
+++ b/lib/private/Collaboration/Resources/Listener.php
@@ -32,6 +32,7 @@ use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroup;
 use OCP\IUser;
+use OCP\User\Events\UserDeletedEvent;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Listener {
@@ -47,9 +48,8 @@ class Listener {
 		$symfonyDispatcher->addListener(IGroup::class . '::postAddUser', $listener);
 		$symfonyDispatcher->addListener(IGroup::class . '::postRemoveUser', $listener);
 
-		$symfonyDispatcher->addListener(IUser::class . '::postDelete', function (GenericEvent $event) {
-			/** @var IUser $user */
-			$user = $event->getSubject();
+		$eventDispatcher->addListener(UserDeletedEvent::class, function (UserDeletedEvent $event) {
+			$user = $event->getUser();
 			/** @var IManager $resourceManager */
 			$resourceManager = \OCP\Server::get(IManager::class);
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -192,14 +192,6 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\Files\Template\ITemplateManager;
 use OCP\FullTextSearch\IFullTextSearchManager;
 use OCP\GlobalScale\IConfig;
-use OCP\Group\Events\BeforeGroupCreatedEvent;
-use OCP\Group\Events\BeforeGroupDeletedEvent;
-use OCP\Group\Events\BeforeUserAddedEvent;
-use OCP\Group\Events\BeforeUserRemovedEvent;
-use OCP\Group\Events\GroupCreatedEvent;
-use OCP\Group\Events\GroupDeletedEvent;
-use OCP\Group\Events\UserAddedEvent;
-use OCP\Group\Events\UserRemovedEvent;
 use OCP\Group\ISubAdmin;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
@@ -253,12 +245,10 @@ use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\Talk\IBroker;
 use OCP\Translation\ITranslationManager;
-use OCP\User\Events\BeforePasswordUpdatedEvent;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\BeforeUserLoggedInWithCookieEvent;
 use OCP\User\Events\BeforeUserLoggedOutEvent;
-use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\PostLoginEvent;
 use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserLoggedInEvent;
@@ -268,7 +258,6 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use OCA\Files_External\Service\UserStoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\GlobalStoragesService;
@@ -491,50 +480,10 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(\OCP\IGroupManager::class, function (ContainerInterface $c) {
 			$groupManager = new \OC\Group\Manager(
 				$this->get(IUserManager::class),
-				$c->get(SymfonyAdapter::class),
+				$this->get(IEventDispatcher::class),
 				$this->get(LoggerInterface::class),
 				$this->get(ICacheFactory::class)
 			);
-			$groupManager->listen('\OC\Group', 'preCreate', function ($gid) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new BeforeGroupCreatedEvent($gid));
-			});
-			$groupManager->listen('\OC\Group', 'postCreate', function (\OC\Group\Group $group) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new GroupCreatedEvent($group));
-			});
-			$groupManager->listen('\OC\Group', 'preDelete', function (\OC\Group\Group $group) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new BeforeGroupDeletedEvent($group));
-			});
-			$groupManager->listen('\OC\Group', 'postDelete', function (\OC\Group\Group $group) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new GroupDeletedEvent($group));
-			});
-			$groupManager->listen('\OC\Group', 'preAddUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new BeforeUserAddedEvent($group, $user));
-			});
-			$groupManager->listen('\OC\Group', 'postAddUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new UserAddedEvent($group, $user));
-			});
-			$groupManager->listen('\OC\Group', 'preRemoveUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new BeforeUserRemovedEvent($group, $user));
-			});
-			$groupManager->listen('\OC\Group', 'postRemoveUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				/** @var IEventDispatcher $dispatcher */
-				$dispatcher = $this->get(IEventDispatcher::class);
-				$dispatcher->dispatchTyped(new UserRemovedEvent($group, $user));
-			});
 			return $groupManager;
 		});
 		/** @deprecated 19.0.0 */

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -55,7 +55,6 @@ use OCP\User\Backend\ICountUsersBackend;
 use OCP\User\Events\BeforeUserCreatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\UserInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class Manager
@@ -88,9 +87,6 @@ class Manager extends PublicEmitter implements IUserManager {
 	/** @var IConfig */
 	private $config;
 
-	/** @var EventDispatcherInterface */
-	private $dispatcher;
-
 	/** @var ICache */
 	private $cache;
 
@@ -100,11 +96,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	private DisplayNameCache $displayNameCache;
 
 	public function __construct(IConfig $config,
-								EventDispatcherInterface $oldDispatcher,
 								ICacheFactory $cacheFactory,
 								IEventDispatcher $eventDispatcher) {
 		$this->config = $config;
-		$this->dispatcher = $oldDispatcher;
 		$this->cache = new WithLocalCache($cacheFactory->createDistributed('user_backend_map'));
 		$cachedUsers = &$this->cachedUsers;
 		$this->listen('\OC\User', 'postDelete', function ($user) use (&$cachedUsers) {
@@ -211,7 +205,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			return $this->cachedUsers[$uid];
 		}
 
-		$user = new User($uid, $backend, $this->dispatcher, $this, $this->config);
+		$user = new User($uid, $backend, $this->eventDispatcher, $this, $this->config);
 		if ($cacheUser) {
 			$this->cachedUsers[$uid] = $user;
 		}

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 use OC\Files\Cache\Cache;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IUser;
 
@@ -329,7 +330,7 @@ class CacheTest extends \Test\TestCase {
 		$userId = static::getUniqueID('user');
 		\OC::$server->getUserManager()->createUser($userId, $userId);
 		static::loginAsUser($userId);
-		$user = new \OC\User\User($userId, null, \OC::$server->getEventDispatcher());
+		$user = new \OC\User\User($userId, null, \OC::$server->get(IEventDispatcher::class));
 
 		$file1 = 'folder';
 		$file2 = 'folder/foobar';

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -12,8 +12,8 @@ use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\User\User;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Search\ISearchComparison;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Files\Cache\CacheTest;
 
 /**
@@ -85,7 +85,7 @@ class CacheJailTest extends CacheTest {
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
-		$user = new User('foo', null, $this->createMock(EventDispatcherInterface::class));
+		$user = new User('foo', null, $this->createMock(IEventDispatcher::class));
 		$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'name', 'foobar'), 10, 0, [], $user);
 		$result = $this->cache->searchQuery($query);
 

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -21,7 +21,6 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 use Test\Util\User\Dummy;
 
@@ -62,7 +61,7 @@ class UserMountCacheTest extends TestCase {
 			->expects($this->any())
 			->method('getAppValue')
 			->willReturnArgument(2);
-		$this->userManager = new Manager($config, $this->createMock(EventDispatcherInterface::class), $this->createMock(ICacheFactory::class), $this->createMock(IEventDispatcher::class));
+		$this->userManager = new Manager($config, $this->createMock(ICacheFactory::class), $this->createMock(IEventDispatcher::class));
 		$userBackend = new Dummy();
 		$userBackend->createUser('u1', '');
 		$userBackend->createUser('u2', '');

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -20,7 +20,6 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Files\Storage\Storage;
 
 class EncryptionTest extends Storage {
@@ -133,7 +132,6 @@ class EncryptionTest extends Storage {
 			->setMethods(['getUidAndFilename', 'isFile', 'isExcluded'])
 			->setConstructorArgs([new View(), new Manager(
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class)
 			), $this->groupManager, $this->config, $this->arrayCache])
@@ -574,7 +572,6 @@ class EncryptionTest extends Storage {
 					new View(),
 					new Manager(
 						$this->config,
-						$this->createMock(EventDispatcherInterface::class),
 						$this->createMock(ICacheFactory::class),
 						$this->createMock(IEventDispatcher::class)
 					),
@@ -657,7 +654,6 @@ class EncryptionTest extends Storage {
 		$util = $this->getMockBuilder('\OC\Encryption\Util')
 			->setConstructorArgs([new View(), new Manager(
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class)
 			), $this->groupManager, $this->config, $this->arrayCache])

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -9,7 +9,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EncryptionTest extends \Test\TestCase {
 	public const DEFAULT_WRAPPER = '\OC\Files\Stream\Encryption';
@@ -53,7 +52,6 @@ class EncryptionTest extends \Test\TestCase {
 			->setMethods(['getUidAndFilename'])
 			->setConstructorArgs([new View(), new \OC\User\Manager(
 				$config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class)
 			), $groupManager, $config, $arrayCache])

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -10,6 +10,7 @@
 namespace Test\Group;
 
 use OC\User\User;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -17,10 +18,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class GroupTest extends \Test\TestCase {
 	/** @var EventDispatcherInterface|MockObject */
 	protected $dispatcher;
+	/** @var EventDispatcherInterface|MockObject */
+	protected $eventDispatcher;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 	}
 
 	/**
@@ -305,7 +309,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
 
 		$users = $group->searchUsers('2');
 
@@ -327,11 +331,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
 
 		$users = $group->searchUsers('2');
 
@@ -350,7 +354,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 1, 1)
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
 
 		$users = $group->searchUsers('user', 1, 1);
 
@@ -372,11 +376,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user1' => new \OC\User\User('user1', null, $this->dispatcher)]);
+			->willReturn(['user1' => new \OC\User\User('user1', null, $this->eventDispatcher)]);
 
 		$users = $group->searchUsers('user', 2, 1);
 

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -13,18 +13,14 @@ use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class GroupTest extends \Test\TestCase {
-	/** @var EventDispatcherInterface|MockObject */
+	/** @var IEventDispatcher|MockObject */
 	protected $dispatcher;
-	/** @var EventDispatcherInterface|MockObject */
-	protected $eventDispatcher;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 	}
 
 	/**
@@ -309,7 +305,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
 
 		$users = $group->searchUsers('2');
 
@@ -331,11 +327,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', '2')
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
 
 		$users = $group->searchUsers('2');
 
@@ -354,7 +350,7 @@ class GroupTest extends \Test\TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 1, 1)
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
 
 		$users = $group->searchUsers('user', 1, 1);
 
@@ -376,11 +372,11 @@ class GroupTest extends \Test\TestCase {
 		$backend1->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user2' => new \OC\User\User('user2', null, $this->eventDispatcher)]);
+			->willReturn(['user2' => new \OC\User\User('user2', null, $this->dispatcher)]);
 		$backend2->expects($this->once())
 			->method('searchInGroup')
 			->with('group1', 'user', 2, 1)
-			->willReturn(['user1' => new \OC\User\User('user1', null, $this->eventDispatcher)]);
+			->willReturn(['user1' => new \OC\User\User('user1', null, $this->dispatcher)]);
 
 		$users = $group->searchUsers('user', 2, 1);
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -33,7 +33,6 @@ use OCP\ICacheFactory;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 interface ISearchableGroupInterface extends ISearchableGroupBackend, GroupInterface {
@@ -42,10 +41,8 @@ interface ISearchableGroupInterface extends ISearchableGroupBackend, GroupInterf
 class ManagerTest extends TestCase {
 	/** @var Manager|MockObject */
 	protected $userManager;
-	/** @var EventDispatcherInterface|MockObject */
-	protected $dispatcher;
 	/** @var IEventDispatcher|MockObject */
-	protected $eventDispatcher;
+	protected $dispatcher;
 	/** @var LoggerInterface|MockObject */
 	protected $logger;
 	/** @var ICacheFactory|MockObject */
@@ -55,8 +52,7 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->userManager = $this->createMock(Manager::class);
-		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->cache = $this->createMock(ICacheFactory::class);
 	}
@@ -773,7 +769,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('testgroup', '', 1, 0)
-			->willReturn([new User('user2', null, $this->eventDispatcher)]);
+			->willReturn([new User('user2', null, $this->dispatcher)]);
 
 		$this->userManager->expects($this->never())->method('get');
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -26,6 +26,7 @@ namespace Test\Group;
 use OC\Group\Database;
 use OC\User\User;
 use OC\User\Manager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\GroupInterface;
 use OCP\Group\Backend\ISearchableGroupBackend;
 use OCP\ICacheFactory;
@@ -43,6 +44,8 @@ class ManagerTest extends TestCase {
 	protected $userManager;
 	/** @var EventDispatcherInterface|MockObject */
 	protected $dispatcher;
+	/** @var IEventDispatcher|MockObject */
+	protected $eventDispatcher;
 	/** @var LoggerInterface|MockObject */
 	protected $logger;
 	/** @var ICacheFactory|MockObject */
@@ -53,6 +56,7 @@ class ManagerTest extends TestCase {
 
 		$this->userManager = $this->createMock(Manager::class);
 		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->cache = $this->createMock(ICacheFactory::class);
 	}
@@ -769,7 +773,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->once())
 			->method('searchInGroup')
 			->with('testgroup', '', 1, 0)
-			->willReturn([new User('user2', null, $this->dispatcher)]);
+			->willReturn([new User('user2', null, $this->eventDispatcher)]);
 
 		$this->userManager->expects($this->never())->method('get');
 

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -27,11 +27,10 @@ namespace Test\Security\CSP;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 class ContentSecurityPolicyManagerTest extends TestCase {
-	/** @var EventDispatcherInterface */
+	/** @var IEventDispatcher */
 	private $dispatcher;
 
 	/** @var ContentSecurityPolicyManager */

--- a/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
+++ b/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
@@ -29,11 +29,10 @@ use OC\Security\FeaturePolicy\FeaturePolicyManager;
 use OCP\AppFramework\Http\FeaturePolicy;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Security\FeaturePolicy\AddFeaturePolicyEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 class FeaturePolicyManagerTest extends TestCase {
-	/** @var EventDispatcherInterface */
+	/** @var IEventDispatcher */
 	private $dispatcher;
 
 	/** @var FeaturePolicyManager */

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -28,7 +28,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class DatabaseTest
@@ -130,8 +129,8 @@ class DatabaseTest extends Backend {
 		$user2 = $this->getUser();
 		$this->backend->createUser($user2, 'pass1');
 
-		$user1Obj = new User($user1, $this->backend, $this->createMock(EventDispatcherInterface::class));
-		$user2Obj = new User($user2, $this->backend, $this->createMock(EventDispatcherInterface::class));
+		$user1Obj = new User($user1, $this->backend, $this->createMock(IEventDispatcher::class));
+		$user2Obj = new User($user2, $this->backend, $this->createMock(IEventDispatcher::class));
 		$emailAddr1 = "$user1@nextcloud.com";
 		$emailAddr2 = "$user2@nextcloud.com";
 

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -17,7 +17,6 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
@@ -30,8 +29,6 @@ use Test\TestCase;
 class ManagerTest extends TestCase {
 	/** @var IConfig */
 	private $config;
-	/** @var EventDispatcherInterface */
-	private $oldDispatcher;
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 	/** @var ICacheFactory */
@@ -43,7 +40,6 @@ class ManagerTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->oldDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->cache = $this->createMock(ICache::class);
@@ -54,7 +50,7 @@ class ManagerTest extends TestCase {
 
 	public function testGetBackends() {
 		$userDummyBackend = $this->createMock(\Test\Util\User\Dummy::class);
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($userDummyBackend);
 		$this->assertEquals([$userDummyBackend], $manager->getBackends());
 		$dummyDatabaseBackend = $this->createMock(Database::class);
@@ -73,7 +69,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertTrue($manager->userExists('foo'));
@@ -89,14 +85,14 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->userExists('foo'));
 	}
 
 	public function testUserExistsNoBackends() {
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 
 		$this->assertFalse($manager->userExists('foo'));
 	}
@@ -120,7 +116,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -144,7 +140,7 @@ class ManagerTest extends TestCase {
 		$backend2->expects($this->never())
 			->method('userExists');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -171,7 +167,7 @@ class ManagerTest extends TestCase {
 				}
 			});
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$user = $manager->checkPassword('foo', 'bar');
@@ -190,7 +186,7 @@ class ManagerTest extends TestCase {
 			->method('implementsActions')
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->checkPassword('foo', 'bar'));
@@ -208,7 +204,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals('foo', $manager->get('foo')->getUID());
@@ -224,7 +220,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(false);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals(null, $manager->get('foo'));
@@ -242,7 +238,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertEquals('bLeNdEr', $manager->get('bLeNdEr')->getUID());
@@ -260,7 +256,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$result = $manager->search('fo');
@@ -294,7 +290,7 @@ class ManagerTest extends TestCase {
 		$backend2->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -348,7 +344,7 @@ class ManagerTest extends TestCase {
 			->willReturn(true);
 
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->expectException(\InvalidArgumentException::class, $exception);
@@ -375,7 +371,7 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('loginName2UserName');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$user = $manager->createUser('foo', 'bar');
@@ -402,7 +398,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$manager->createUser('foo', 'bar');
@@ -423,14 +419,14 @@ class ManagerTest extends TestCase {
 		$backend->expects($this->never())
 			->method('userExists');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$this->assertFalse($manager->createUser('foo', 'bar'));
 	}
 
 	public function testCreateUserNoBackends() {
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 
 		$this->assertFalse($manager->createUser('foo', 'bar'));
 	}
@@ -450,7 +446,7 @@ class ManagerTest extends TestCase {
 			->with('MyUid', 'MyPassword')
 			->willReturn(false);
 
-		$manager = new Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->createUserFromBackend('MyUid', 'MyPassword', $backend);
 	}
 
@@ -490,7 +486,7 @@ class ManagerTest extends TestCase {
 			->with($this->equalTo('foo'))
 			->willReturn(true);
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -498,7 +494,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCountUsersNoBackend() {
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 
 		$result = $manager->countUsers();
 		$this->assertTrue(is_array($result));
@@ -523,7 +519,7 @@ class ManagerTest extends TestCase {
 			->method('getBackendName')
 			->willReturn('Mock_Test_Util_User_Dummy');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$result = $manager->countUsers();
@@ -564,7 +560,7 @@ class ManagerTest extends TestCase {
 			->method('getBackendName')
 			->willReturn('Mock_Test_Util_User_Dummy');
 
-		$manager = new \OC\User\Manager($this->config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend1);
 		$manager->registerBackend($backend2);
 
@@ -677,7 +673,7 @@ class ManagerTest extends TestCase {
 			->method('getAppValue')
 			->willReturnArgument(2);
 
-		$manager = new \OC\User\Manager($config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($config, $this->cacheFactory, $this->eventDispatcher);
 		$backend = new \Test\Util\User\Dummy();
 
 		$manager->registerBackend($backend);
@@ -711,7 +707,7 @@ class ManagerTest extends TestCase {
 				true
 			);
 
-		$manager = new \OC\User\Manager($config, $this->oldDispatcher, $this->cacheFactory, $this->eventDispatcher);
+		$manager = new \OC\User\Manager($config, $this->cacheFactory, $this->eventDispatcher);
 		$manager->registerBackend($backend);
 
 		$users = $manager->getByEmail('test@example.com');

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -34,7 +34,6 @@ use OCP\Security\ISecureRandom;
 use OCP\User\Events\PostLoginEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OC\Security\CSRF\CsrfTokenManager;
 
 /**
@@ -122,7 +121,7 @@ class SessionTest extends \Test\TestCase {
 				'getUser'
 			])
 			->getMock();
-		$user = new User('sepp', null, $this->createMock(EventDispatcherInterface::class));
+		$user = new User('sepp', null, $this->createMock(IEventDispatcher::class));
 		$userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($isLoggedIn ? $user : null);
@@ -177,7 +176,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -244,7 +242,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -278,7 +275,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -492,7 +488,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -582,7 +577,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -647,7 +641,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -700,7 +693,6 @@ class SessionTest extends \Test\TestCase {
 			->setMethods($mockedManagerMethods)
 			->setConstructorArgs([
 				$this->config,
-				$this->createMock(EventDispatcherInterface::class),
 				$this->createMock(ICacheFactory::class),
 				$this->createMock(IEventDispatcher::class),
 			])
@@ -739,8 +731,8 @@ class SessionTest extends \Test\TestCase {
 
 	public function testActiveUserAfterSetSession() {
 		$users = [
-			'foo' => new User('foo', null, $this->createMock(EventDispatcherInterface::class)),
-			'bar' => new User('bar', null, $this->createMock(EventDispatcherInterface::class))
+			'foo' => new User('foo', null, $this->createMock(IEventDispatcher::class)),
+			'bar' => new User('bar', null, $this->createMock(IEventDispatcher::class))
 		];
 
 		$manager = $this->getMockBuilder(Manager::class)

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -14,15 +14,16 @@ use OC\Files\Mount\ObjectHomeMountProvider;
 use OC\Hooks\PublicEmitter;
 use OC\User\User;
 use OCP\Comments\ICommentsManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
+use OCP\Server;
 use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
@@ -33,12 +34,12 @@ use Test\TestCase;
  * @package Test\User
  */
 class UserTest extends TestCase {
-	/** @var EventDispatcherInterface|MockObject */
+	/** @var IEventDispatcher|MockObject */
 	protected $dispatcher;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->dispatcher = Server::get(IEventDispatcher::class);
 	}
 
 	public function testDisplayName() {
@@ -408,7 +409,7 @@ class UserTest extends TestCase {
 			->with('foo', 'Foo')
 			->willReturn(true);
 
-		$user = new User('foo', $backend, $this->dispatcher);
+		$user = new User('foo', $backend, $this->createMock(IEventDispatcher::class));
 		$this->assertTrue($user->setDisplayName('Foo'));
 		$this->assertEquals('Foo', $user->getDisplayName());
 	}
@@ -702,7 +703,8 @@ class UserTest extends TestCase {
 		$emitter->expects($this->never())
 			->method('emit');
 
-		$this->dispatcher->expects($this->never())
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->expects($this->never())
 			->method('dispatch');
 
 		$config = $this->createMock(IConfig::class);
@@ -712,7 +714,7 @@ class UserTest extends TestCase {
 		$config->expects($this->any())
 			->method('setUserValue');
 
-		$user = new User('foo', $backend, $this->dispatcher, $emitter, $config);
+		$user = new User('foo', $backend, $dispatcher, $emitter, $config);
 		$user->setEMailAddress('foo@bar.com');
 	}
 


### PR DESCRIPTION
* Another step towards #38546

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
