### PR TITLE
Add "-i" to sendmail's pipe

### DIFF
--- a/apps/settings/templates/settings/admin/additional-mail.php
+++ b/apps/settings/templates/settings/admin/additional-mail.php
@@ -45,7 +45,7 @@ if ($_['mail_smtpmode'] === 'qmail') {
 
 $mail_sendmailmode = [
 	'smtp' => 'smtp (-bs)',
-	'pipe' => 'pipe (-t)'
+	'pipe' => 'pipe (-t -i)'
 ];
 
 ?>

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -331,7 +331,7 @@ class Mailer implements IMailer {
 		}
 
 		$binaryParam = match ($this->config->getSystemValueString('mail_sendmailmode', 'smtp')) {
-			'pipe' => ' -t',
+			'pipe' => ' -t -i',
 			default => ' -bs',
 		};
 

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -72,7 +72,7 @@ class MailerTest extends TestCase {
 	public function sendmailModeProvider(): array {
 		return [
 			'smtp' => ['smtp', ' -bs'],
-			'pipe' => ['pipe', ' -t'],
+			'pipe' => ['pipe', ' -t -i'],
 		];
 	}
 


### PR DESCRIPTION
* Resolves: #39594 
* Fix https://github.com/nextcloud/server/issues/33754
* Fix https://github.com/nextcloud/server/issues/16379

## Summary
Symfony Mailer replaces `"\n."` with `"\n.."`.  
If the email to be sent contains links when they are breaklined a line may start with a `.`, thus can generating a URL like `https://www..example.com/[...]` or `https://www.example.com/index..php/[...]` .  
With "-i" this replacement is not performed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)