### PR TITLE
Add `occ user:welcome` command to send user welcome email from CLI

### DIFF
--- a/core/Command/User/Welcome.php
+++ b/core/Command/User/Welcome.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2023 FedericoHeichou <federicoheichou@gmail.com>
+ *
+ * @author FedericoHeichou <federicoheichou@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCA\Settings\Mailer\NewUserMailHelper;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Welcome extends Base {
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var NewUserMailHelper */
+	private $newUserMailHelper;
+
+	/**
+	 * @param IUserManager $userManager
+	 * @param NewUserMailHelper $newUserMailHelper
+	 */
+	public function __construct(
+		IUserManager $userManager,
+		NewUserMailHelper $newUserMailHelper
+	) {
+		parent::__construct();
+
+		$this->userManager = $userManager;
+		$this->newUserMailHelper = $newUserMailHelper;
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function configure() {
+		$this
+			->setName('user:welcome')
+			->setDescription('Sends the welcome email')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'The user to send the email to'
+			)
+			->addOption(
+				'reset-password',
+				'r',
+				InputOption::VALUE_NONE,
+				'Add the reset password link to the email'
+			)
+		;
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument('user');
+		// check if user exists
+		$user = $this->userManager->get($userId);
+		if ($user === null) {
+			$output->writeln('<error>User does not exist</error>');
+			return 1;
+		}
+		$email = $user->getEMailAddress();
+		if ($email === '' || $email === null) {
+			$output->writeln('<error>User does not have an email address</error>');
+			return 1;
+		}
+		try {
+			$emailTemplate = $this->newUserMailHelper->generateTemplate($user, $input->getOption('reset-password'));
+			$this->newUserMailHelper->sendMail($user, $emailTemplate);
+		} catch (\Exception $e) {
+			$output->writeln('<error>Failed to send email: ' . $e->getMessage() . '</error>');
+			return 1;
+		}
+		return 0;
+	}
+}

--- a/core/Command/User/Welcome.php
+++ b/core/Command/User/Welcome.php
@@ -1,25 +1,7 @@
 <?php
-
 /**
- * @copyright Copyright (c) 2023 FedericoHeichou <federicoheichou@gmail.com>
- *
- * @author FedericoHeichou <federicoheichou@gmail.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2023 FedericoHeichou <federicoheichou@gmail.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OC\Core\Command\User;

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -122,6 +122,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\User\AuthTokens\ListCommand::class));
 	$application->add(Server::get(Command\User\AuthTokens\Delete::class));
 	$application->add(Server::get(Command\User\Keys\Verify::class));
+	$application->add(Server::get(Command\User\Welcome::class));
 
 	$application->add(Server::get(Command\Group\Add::class));
 	$application->add(Server::get(Command\Group\Delete::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1241,6 +1241,7 @@ return array(
     'OC\\Core\\Command\\User\\ResetPassword' => $baseDir . '/core/Command/User/ResetPassword.php',
     'OC\\Core\\Command\\User\\Setting' => $baseDir . '/core/Command/User/Setting.php',
     'OC\\Core\\Command\\User\\SyncAccountDataCommand' => $baseDir . '/core/Command/User/SyncAccountDataCommand.php',
+    'OC\\Core\\Command\\User\\Welcome' => $baseDir . '/core/Command/User/Welcome.php',
     'OC\\Core\\Controller\\AppPasswordController' => $baseDir . '/core/Controller/AppPasswordController.php',
     'OC\\Core\\Controller\\AutoCompleteController' => $baseDir . '/core/Controller/AutoCompleteController.php',
     'OC\\Core\\Controller\\AvatarController' => $baseDir . '/core/Controller/AvatarController.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1274,6 +1274,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\ResetPassword' => __DIR__ . '/../../..' . '/core/Command/User/ResetPassword.php',
         'OC\\Core\\Command\\User\\Setting' => __DIR__ . '/../../..' . '/core/Command/User/Setting.php',
         'OC\\Core\\Command\\User\\SyncAccountDataCommand' => __DIR__ . '/../../..' . '/core/Command/User/SyncAccountDataCommand.php',
+        'OC\\Core\\Command\\User\\Welcome' => __DIR__ . '/../../..' . '/core/Command/User/Welcome.php',
         'OC\\Core\\Controller\\AppPasswordController' => __DIR__ . '/../../..' . '/core/Controller/AppPasswordController.php',
         'OC\\Core\\Controller\\AutoCompleteController' => __DIR__ . '/../../..' . '/core/Controller/AutoCompleteController.php',
         'OC\\Core\\Controller\\AvatarController' => __DIR__ . '/../../..' . '/core/Controller/AvatarController.php',


### PR DESCRIPTION
* Resolves: #39610 

## Summary
Implements `user:welcome` command.  
I tested in 26 and master

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
