### PR TITLE
Remove litmus locks tests

### DIFF
--- a/apps/dav/tests/travis/litmus-v1/script.sh
+++ b/apps/dav/tests/travis/litmus-v1/script.sh
@@ -10,4 +10,4 @@ sleep 30
 
 # run the tests
 cd /tmp/litmus/litmus-0.13
-make URL=http://127.0.0.1:8888/remote.php/webdav CREDS="admin admin" TESTS="basic copymove props locks" check
+make URL=http://127.0.0.1:8888/remote.php/webdav CREDS="admin admin" TESTS="basic copymove props" check

--- a/apps/dav/tests/travis/litmus-v2/script.sh
+++ b/apps/dav/tests/travis/litmus-v2/script.sh
@@ -10,4 +10,4 @@ sleep 30
 
 # run the tests
 cd /tmp/litmus/litmus-0.13
-make URL=http://127.0.0.1:8888/remote.php/dav/files/admin CREDS="admin admin" TESTS="basic copymove props locks" check
+make URL=http://127.0.0.1:8888/remote.php/dav/files/admin CREDS="admin admin" TESTS="basic copymove props" check


### PR DESCRIPTION
## Summary

According to https://github.com/nextcloud/server/blob/master/apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php we don't expose the WebDAV server as class 2. Litmus only runs the locks tests on servers that support class 2, thus the tests are always skipped when running in CI.

You can verify that behavior in https://drone.nextcloud.com/nextcloud/server/37905/2/3 (just scroll to the bottom of the logs).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
