### PR TITLE
Enable litmus largefile tests

### DIFF
--- a/apps/dav/tests/travis/litmus-v1/script.sh
+++ b/apps/dav/tests/travis/litmus-v1/script.sh
@@ -10,4 +10,4 @@ sleep 30
 
 # run the tests
 cd /tmp/litmus/litmus-0.13
-make URL=http://127.0.0.1:8888/remote.php/webdav CREDS="admin admin" TESTS="basic copymove props" check
+make URL=http://127.0.0.1:8888/remote.php/webdav CREDS="admin admin" TESTS="basic copymove props largefile" check

--- a/apps/dav/tests/travis/litmus-v2/script.sh
+++ b/apps/dav/tests/travis/litmus-v2/script.sh
@@ -10,4 +10,4 @@ sleep 30
 
 # run the tests
 cd /tmp/litmus/litmus-0.13
-make URL=http://127.0.0.1:8888/remote.php/dav/files/admin CREDS="admin admin" TESTS="basic copymove props" check
+make URL=http://127.0.0.1:8888/remote.php/dav/files/admin CREDS="admin admin" TESTS="basic copymove props largefile" check


### PR DESCRIPTION
## Summary

largefile tests pass locally, should also be enabled on CI.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
