### PR TITLE
fix(s3): add SSE-C parameters to headObject call

### DIFF
--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -99,7 +99,7 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 		$stat = $this->getConnection()->headObject([
 			'Bucket' => $this->bucket,
 			'Key' => $urn,
-		]);
+		] + $this->getSSECParameters());
 		return (int)$stat->get('ContentLength');
 	}
 


### PR DESCRIPTION
This commit adds missing SSE-C Parameter to the headObject call used in the new S3 multipart upload feature.
Complementary to #38934.

Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html
