### PR TITLE
fix: copy-and-delete fallback should use unlink

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -368,7 +368,7 @@ class Local extends \OC\Files\Storage\Common {
 			return true;
 		}
 
-		return $this->copy($source, $target) && $this->rmdir($source);
+		return $this->copy($source, $target) && $this->unlink($source);
 	}
 
 	public function copy($source, $target) {


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/server/pull/38623

## Summary

rmdir does not work for files :see_no_evil: 

**To test**

- Comment the rename() block 
- Try to upload a file
- copy works, rmdir files because a directory is expected

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
