### PR TITLE
occ: Add `--all` support to `user:lastseen`

### DIFF
--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -59,7 +59,7 @@ class LastSeen extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output): int	{
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$singleUserId = $input->getArgument('uid');
 		if ($singleUserId) {
 			$user = $this->userManager->get($singleUserId);
@@ -67,13 +67,34 @@ class LastSeen extends Base {
 				$output->writeln('<error>User does not exist</error>');
 				return 1;
 			}
-			$users = [$user];
-		} elseif ($input->getOption('all')) {
-			$users = $this->userManager->search('');
-		} else {
+
+			$lastLogin = $user->getLastLogin();
+			if ($lastLogin === 0) {
+				$output->writeln($user->getUID() . ' has never logged in.');
+			} else {
+				$date = new \DateTime();
+				$date->setTimestamp($lastLogin);
+				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i'));
+			}
+
+			return 0;
+		}
+
+		if (!$input->getOption('all')) {
 			$output->writeln("<error>Please specify a username, or \"--all\" to list all</error>");
 			return 1;
 		}
+
+		$this->userManager->callForAllUsers(static function (IUser $user) use ($output) {
+			$lastLogin = $user->getLastLogin();
+			if ($lastLogin === 0) {
+				$output->writeln($user->getUID() . ' has never logged in.');
+			} else {
+				$date = new \DateTime();
+				$date->setTimestamp($lastLogin);
+				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i'));
+			}
+		});
 		return 0;
 	}
 

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -31,6 +31,7 @@ use OCP\IUserManager;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class LastSeen extends Base {
@@ -40,33 +41,38 @@ class LastSeen extends Base {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('user:lastseen')
 			->setDescription('shows when the user was logged in last time')
 			->addArgument(
 				'uid',
-				InputArgument::REQUIRED,
+				InputArgument::OPTIONAL,
 				'the username'
-			);
+			)
+			->addOption(
+				'all',
+				null,
+				InputOption::VALUE_NONE,
+				'shows a list of when all users were last logged in'
+			)
+		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$user = $this->userManager->get($input->getArgument('uid'));
-		if (is_null($user)) {
-			$output->writeln('<error>User does not exist</error>');
-			return 1;
-		}
-
-		$lastLogin = $user->getLastLogin();
-		if ($lastLogin === 0) {
-			$output->writeln('Account ' . $user->getUID() .
-				' has never logged in, yet.');
+	protected function execute(InputInterface $input, OutputInterface $output): int	{
+		$singleUserId = $input->getArgument('uid');
+		if ($singleUserId) {
+			$user = $this->userManager->get($singleUserId);
+			if (is_null($user)) {
+				$output->writeln('<error>User does not exist</error>');
+				return 1;
+			}
+			$users = [$user];
+		} elseif ($input->getOption('all')) {
+			$users = $this->userManager->search('');
 		} else {
-			$date = new \DateTime();
-			$date->setTimestamp($lastLogin);
-			$output->writeln($user->getUID() .
-				'`s last login: ' . $date->format('d.m.Y H:i'));
+			$output->writeln("<error>Please specify a username, or \"--all\" to list all</error>");
+			return 1;
 		}
 		return 0;
 	}


### PR DESCRIPTION
* Resolves: #39048

## Summary
Adds `--all` argument to `user:lastseen` for `occ`.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
