### PR TITLE
fix(dav): use quota of destination in s3 chunk upload

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -168,7 +168,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 			[$destinationDir, $destinationName] = Uri\split($this->uploadPath);
 			/** @var Directory $destinationParent */
 			$destinationParent = $this->server->tree->getNodeForPath($destinationDir);
-			$free = $storage->free_space($destinationParent->getInternalPath());
+			$free = $destinationParent->getNode()->getFreeSpace();
 			$newSize = $tempTargetFile->getSize() + $additionalSize;
 			if ($free >= 0 && ($tempTargetFile->getSize() > $free || $newSize > $free)) {
 				throw new InsufficientStorage("Insufficient space in $this->uploadPath");
@@ -225,7 +225,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 			foreach ($parts as $part) {
 				$size += $part['Size'];
 			}
-			$free = $storage->free_space($destinationParent->getInternalPath());
+			$free = $destinationParent->getNode()->getFreeSpace();
 			if ($free >= 0 && ($size > $free)) {
 				throw new InsufficientStorage("Insufficient space in $this->uploadPath");
 			}


### PR DESCRIPTION
* Resolves: #39228.

## Summary

Check the free space on the destination.

Before it was checking the free space on `$storage` which is the upload storage of the user who triggered the upload. This led to user quota being applied
even when uploading to a share with unlimited space.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Screenshots are not applicable
- Documentation is not required
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
