### PR TITLE
New OCS endpoint to list text processing tasks

### DIFF
--- a/core/Controller/TextProcessingApiController.php
+++ b/core/Controller/TextProcessingApiController.php
@@ -157,4 +157,36 @@ class TextProcessingApiController extends \OCP\AppFramework\OCSController {
 			return new DataResponse(['message' => $this->l->t('Internal error')], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
+
+	/**
+	 * This endpoint returns a list of tasks related with a specific appId and identifier
+	 *
+	 * @PublicPage
+	 * @UserRateThrottle(limit=20, period=120)
+	 *
+	 * @param string $appId
+	 * @param string|null $identifier
+	 * @return DataResponse<Http::STATUS_OK, array{tasks: array{CoreTextProcessingTask}}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 *  200: Task list returned
+	 */
+	public function listTasksByApp(string $appId, ?string $identifier = null): DataResponse {
+		if ($this->userId === null) {
+			return new DataResponse([
+				'tasks' => [],
+			]);
+		}
+		try {
+			$tasks = $this->languageModelManager->getTasksByApp($this->userId, $appId, $identifier);
+			$json = array_map(static function (Task $task) {
+				return $task->jsonSerialize();
+			}, $tasks);
+
+			return new DataResponse([
+				'tasks' => $json,
+			]);
+		} catch (\RuntimeException $e) {
+			return new DataResponse(['message' => $this->l->t('Internal error')], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
 }

--- a/core/Controller/TextProcessingApiController.php
+++ b/core/Controller/TextProcessingApiController.php
@@ -157,6 +157,36 @@ class TextProcessingApiController extends \OCP\AppFramework\OCSController {
 	}
 
 	/**
+	 * This endpoint allows to delete a scheduled task for a user
+	 *
+	 * @param int $id The id of the task
+	 *
+	 * @return DataResponse<Http::STATUS_OK, array{task: CoreTextProcessingTask}, array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 *
+	 * 200: Task returned
+	 * 404: Task not found
+	 */
+	#[NoAdminRequired]
+	public function deleteTask(int $id): DataResponse {
+		try {
+			$task = $this->textProcessingManager->getUserTask($id, $this->userId);
+
+			$this->textProcessingManager->deleteTask($task);
+
+			$json = $task->jsonSerialize();
+
+			return new DataResponse([
+				'task' => $json,
+			]);
+		} catch (NotFoundException $e) {
+			return new DataResponse(['message' => $this->l->t('Task not found')], Http::STATUS_NOT_FOUND);
+		} catch (\RuntimeException $e) {
+			return new DataResponse(['message' => $this->l->t('Internal error')], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+
+	/**
 	 * This endpoint returns a list of tasks of a user that are related
 	 * with a specific appId and optionally with an identifier
 	 *

--- a/core/Controller/TextProcessingApiController.php
+++ b/core/Controller/TextProcessingApiController.php
@@ -192,7 +192,7 @@ class TextProcessingApiController extends \OCP\AppFramework\OCSController {
 	 *
 	 * @param string $appId
 	 * @param string|null $identifier
-	 * @return DataResponse<Http::STATUS_OK, array{tasks: array{CoreTextProcessingTask}}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{tasks: CoreTextProcessingTask[]}, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 *  200: Task list returned
 	 */
@@ -200,6 +200,7 @@ class TextProcessingApiController extends \OCP\AppFramework\OCSController {
 	public function listTasksByApp(string $appId, ?string $identifier = null): DataResponse {
 		try {
 			$tasks = $this->textProcessingManager->getUserTasksByApp($this->userId, $appId, $identifier);
+			/** @var CoreTextProcessingTask[] $json */
 			$json = array_map(static function (Task $task) {
 				return $task->jsonSerialize();
 			}, $tasks);

--- a/core/Migrations/Version28000Date20230803221055.php
+++ b/core/Migrations/Version28000Date20230803221055.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adjust textprocessing_tasks table
+ */
+class Version28000Date20230803221055 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$changed = false;
+
+		if ($schema->hasTable('textprocessing_tasks')) {
+			$table = $schema->getTable('textprocessing_tasks');
+
+			$column = $table->getColumn('user_id');
+			$column->setNotnull(false);
+
+			$table->addIndex(['user_id', 'app_id', 'identifier'], 'tp_tasks_uid_appid_ident');
+
+			$changed = true;
+		}
+
+		if ($changed) {
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/core/routes.php
+++ b/core/routes.php
@@ -149,6 +149,7 @@ $application->registerRoutes($this, [
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#taskTypes', 'url' => '/tasktypes', 'verb' => 'GET'],
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#schedule', 'url' => '/schedule', 'verb' => 'POST'],
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#getTask', 'url' => '/task/{id}', 'verb' => 'GET'],
+		['root' => '/textprocessing', 'name' => 'TextProcessingApi#listTasksByApp', 'url' => '/tasks/app/{appId}', 'verb' => 'GET'],
 	],
 ]);
 

--- a/core/routes.php
+++ b/core/routes.php
@@ -149,6 +149,7 @@ $application->registerRoutes($this, [
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#taskTypes', 'url' => '/tasktypes', 'verb' => 'GET'],
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#schedule', 'url' => '/schedule', 'verb' => 'POST'],
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#getTask', 'url' => '/task/{id}', 'verb' => 'GET'],
+		['root' => '/textprocessing', 'name' => 'TextProcessingApi#deleteTask', 'url' => '/task/{id}', 'verb' => 'DELETE'],
 		['root' => '/textprocessing', 'name' => 'TextProcessingApi#listTasksByApp', 'url' => '/tasks/app/{appId}', 'verb' => 'GET'],
 	],
 ]);

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1153,6 +1153,7 @@ return array(
     'OC\\Core\\Migrations\\Version27000Date20230309104802' => $baseDir . '/core/Migrations/Version27000Date20230309104802.php',
     'OC\\Core\\Migrations\\Version28000Date20230616104802' => $baseDir . '/core/Migrations/Version28000Date20230616104802.php',
     'OC\\Core\\Migrations\\Version28000Date20230728104802' => $baseDir . '/core/Migrations/Version28000Date20230728104802.php',
+    'OC\\Core\\Migrations\\Version28000Date20230803221055' => $baseDir . '/core/Migrations/Version28000Date20230803221055.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1186,6 +1186,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version27000Date20230309104802' => __DIR__ . '/../../..' . '/core/Migrations/Version27000Date20230309104802.php',
         'OC\\Core\\Migrations\\Version28000Date20230616104802' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20230616104802.php',
         'OC\\Core\\Migrations\\Version28000Date20230728104802' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20230728104802.php',
+        'OC\\Core\\Migrations\\Version28000Date20230803221055' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20230803221055.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/private/TextProcessing/Db/Task.php
+++ b/lib/private/TextProcessing/Db/Task.php
@@ -39,11 +39,11 @@ use OCP\TextProcessing\Task as OCPTask;
  * @method string getOutput()
  * @method setStatus(int $type)
  * @method int getStatus()
- * @method setUserId(string $type)
- * @method string getuserId()
+ * @method setUserId(?string $userId)
+ * @method string|null getUserId()
  * @method setAppId(string $type)
  * @method string getAppId()
- * @method setIdentifier(string $type)
+ * @method setIdentifier(string $identifier)
  * @method string getIdentifier()
  */
 class Task extends Entity {

--- a/lib/private/TextProcessing/Db/TaskMapper.php
+++ b/lib/private/TextProcessing/Db/TaskMapper.php
@@ -91,8 +91,8 @@ class TaskMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(Task::$columns)
 			->from($this->tableName)
-			->where($qb->expr()->eq('app_id', $qb->createPositionalParameter($appId)))
-			->andWhere($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)));
+			->where($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)))
+			->andWhere($qb->expr()->eq('app_id', $qb->createPositionalParameter($appId)));
 		if ($identifier !== null) {
 			$qb->andWhere($qb->expr()->eq('identifier', $qb->createPositionalParameter($identifier)));
 		}

--- a/lib/private/TextProcessing/Db/TaskMapper.php
+++ b/lib/private/TextProcessing/Db/TaskMapper.php
@@ -60,13 +60,34 @@ class TaskMapper extends QBMapper {
 	}
 
 	/**
+	 * @param int $id
+	 * @param string|null $userId
+	 * @return Task
+	 * @throws DoesNotExistException
+	 * @throws Exception
+	 * @throws MultipleObjectsReturnedException
+	 */
+	public function findByIdAndUser(int $id, ?string $userId): Task {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(Task::$columns)
+			->from($this->tableName)
+			->where($qb->expr()->eq('id', $qb->createPositionalParameter($id)));
+		if ($userId === null) {
+			$qb->andWhere($qb->expr()->isNull('user_id'));
+		} else {
+			$qb->andWhere($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)));
+		}
+		return $this->findEntity($qb);
+	}
+
+	/**
 	 * @param string $userId
 	 * @param string $appId
 	 * @param string|null $identifier
 	 * @return array
 	 * @throws Exception
 	 */
-	public function findByApp(string $userId, string $appId, ?string $identifier = null): array {
+	public function findUserTasksByApp(string $userId, string $appId, ?string $identifier = null): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select(Task::$columns)
 			->from($this->tableName)

--- a/lib/private/TextProcessing/Db/TaskMapper.php
+++ b/lib/private/TextProcessing/Db/TaskMapper.php
@@ -60,6 +60,25 @@ class TaskMapper extends QBMapper {
 	}
 
 	/**
+	 * @param string $userId
+	 * @param string $appId
+	 * @param string|null $identifier
+	 * @return array
+	 * @throws Exception
+	 */
+	public function findByApp(string $userId, string $appId, ?string $identifier = null): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(Task::$columns)
+			->from($this->tableName)
+			->where($qb->expr()->eq('app_id', $qb->createPositionalParameter($appId)))
+			->andWhere($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)));
+		if ($identifier !== null) {
+			$qb->andWhere($qb->expr()->eq('identifier', $qb->createPositionalParameter($identifier)));
+		}
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * @param int $timeout
 	 * @return int the number of deleted tasks
 	 * @throws Exception

--- a/lib/private/TextProcessing/Manager.php
+++ b/lib/private/TextProcessing/Manager.php
@@ -28,6 +28,7 @@ namespace OC\TextProcessing;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\TextProcessing\Db\Task as DbTask;
 use OCP\IConfig;
+use OCP\TextProcessing\Task;
 use OCP\TextProcessing\Task as OCPTask;
 use OC\TextProcessing\Db\TaskMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -173,6 +174,17 @@ class Manager implements IManager {
 		$this->taskMapper->insert($taskEntity);
 		$task->setId($taskEntity->getId());
 		$this->jobList->add(TaskBackgroundJob::class, [
+			'taskId' => $task->getId()
+		]);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function deleteTask(Task $task): void {
+		$taskEntity = DbTask::fromPublicTask($task);
+		$this->taskMapper->delete($taskEntity);
+		$this->jobList->remove(TaskBackgroundJob::class, [
 			'taskId' => $task->getId()
 		]);
 	}

--- a/lib/private/TextProcessing/Manager.php
+++ b/lib/private/TextProcessing/Manager.php
@@ -192,7 +192,24 @@ class Manager implements IManager {
 		} catch (MultipleObjectsReturnedException $e) {
 			throw new RuntimeException('Could not uniquely identify task with given id', 0, $e);
 		} catch (Exception $e) {
-			throw new RuntimeException('Failure while trying to find task by id: '.$e->getMessage(), 0, $e);
+			throw new RuntimeException('Failure while trying to find task by id: ' . $e->getMessage(), 0, $e);
+		}
+	}
+
+	/**
+	 * @param string $userId
+	 * @param string $appId
+	 * @param string|null $identifier
+	 * @return array
+	 */
+	public function getTasksByApp(string $userId, string $appId, ?string $identifier = null): array {
+		try {
+			$taskEntities = $this->taskMapper->findByApp($userId, $appId, $identifier);
+			return array_map(static function (DbTask $taskEntity) {
+				return $taskEntity->toPublicTask();
+			}, $taskEntities);
+		} catch (Exception $e) {
+			throw new RuntimeException('Failure while trying to find tasks by appId and identifier: ' . $e->getMessage(), 0, $e);
 		}
 	}
 }

--- a/lib/public/TextProcessing/FreePromptTaskType.php
+++ b/lib/public/TextProcessing/FreePromptTaskType.php
@@ -61,6 +61,6 @@ class FreePromptTaskType implements ITaskType {
 	 * @since 27.1.0
 	 */
 	public function getDescription(): string {
-		return $this->l->t('Runs an arbitrary prompt through the built-in language model.');
+		return $this->l->t('Runs an arbitrary prompt through the language model.');
 	}
 }

--- a/lib/public/TextProcessing/IManager.php
+++ b/lib/public/TextProcessing/IManager.php
@@ -80,4 +80,12 @@ interface IManager {
 	 * @since 27.1.0
 	 */
 	public function getTask(int $id): Task;
+
+	/**
+	 * @param string $userId
+	 * @param string $appId
+	 * @param string|null $identifier
+	 * @return array
+	 */
+	public function getTasksByApp(string $userId, string $appId, ?string $identifier = null): array;
 }

--- a/lib/public/TextProcessing/IManager.php
+++ b/lib/public/TextProcessing/IManager.php
@@ -82,10 +82,21 @@ interface IManager {
 	public function getTask(int $id): Task;
 
 	/**
+	 * @param int $id The id of the task
+	 * @param string|null $userId The user id that scheduled the task
+	 * @return Task
+	 * @throws RuntimeException If the query failed
+	 * @throws NotFoundException If the task could not be found
+	 * @since 27.1.0
+	 */
+	public function getUserTask(int $id, ?string $userId): Task;
+
+	/**
 	 * @param string $userId
 	 * @param string $appId
 	 * @param string|null $identifier
 	 * @return array
+	 * @since 27.1.0
 	 */
-	public function getTasksByApp(string $userId, string $appId, ?string $identifier = null): array;
+	public function getUserTasksByApp(string $userId, string $appId, ?string $identifier = null): array;
 }

--- a/lib/public/TextProcessing/IManager.php
+++ b/lib/public/TextProcessing/IManager.php
@@ -73,6 +73,14 @@ interface IManager {
 	public function scheduleTask(Task $task) : void;
 
 	/**
+	 * Delete a task that has been scheduled before
+	 *
+	 * @param Task $task The task to delete
+	 * @since 27.1.0
+	 */
+	public function deleteTask(Task $task): void;
+
+	/**
 	 * @param int $id The id of the task
 	 * @return Task
 	 * @throws RuntimeException If the query failed

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [28, 0, 0, 1];
+$OC_Version = [28, 0, 0, 2];
 
 // The human-readable string
 $OC_VersionString = '28.0.0 dev';


### PR DESCRIPTION
refs https://github.com/nextcloud/text/issues/4613

This adds a `/tasks/app/{appId}` endpoint to get a list of tasks for the current user, for a specific app and optionally with a specific identifier.

While playing with the API, I discovered that it's impossible to schedule a task while not being authenticated (mostly because of a NotNull Db constraint on the user_id column). But all the endpoints are public. Maybe we should sort this out first.

* Do we want to allow non-authenticated users to schedule a job?
    * If so, do we want to be able to list all tasks that were scheduled publicly?
    * If not, should we require auth for all those endpoint?
* Are we fine with a user only being able to list his/her own tasks?
    * This would mean publicly scheduled tasks can be listed by any other non-authenticated user. Are we fine with that? 

TODO
* [x] add proper index(es)
* [x] allow authenticated users to list all their tasks by app (and optionally by identifier)