### PR TITLE
fix(cypress): Flaky tests

### DIFF
--- a/cypress/e2e/settings/users.cy.ts
+++ b/cypress/e2e/settings/users.cy.ts
@@ -150,6 +150,20 @@ describe('Settings: Create and delete users', function() {
 		cy.get('.action-item__popper .action').contains('Delete user').should('exist').click()
 		// And confirmation dialog accepted
 		cy.get('.oc-dialog button').contains(`Delete ${jdoe.userId}`).click()
+
+		// Ignore failure if modal is not shown
+		cy.once('fail', (error) => {
+			expect(error.name).to.equal('AssertionError')
+			expect(error).to.have.property('node', '.modal-container')
+		})
+		// Make sure no confirmation modal is shown
+		cy.get('body').find('.modal-container').then(($modal) => {
+			if ($modal.length > 0) {
+				cy.wrap($modal).find('input[type="password"]').type(admin.password)
+				cy.wrap($modal).find('button').contains('Confirm').click()
+			}
+		})
+
 		// deleted clicked the user is not shown anymore
 		cy.get(`tbody.user-list__body tr td[data-test="${jdoe.userId}"]`).parents('tr').should('not.be.visible')
 	})

--- a/cypress/e2e/settings/usersUtils.ts
+++ b/cypress/e2e/settings/usersUtils.ts
@@ -1,0 +1,33 @@
+/**
+ * @copyright 2023 Christopher Ng <chrng8@gmail.com>
+ *
+ * @author Christopher Ng <chrng8@gmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Assert that `element` does not exist or is not visible
+ *
+ * Useful in cases such as when NcModal is opened/closed rapidly
+ */
+export function assertNotExistOrNotVisible(element: JQuery<HTMLElement>) {
+	const doesNotExist = element.length === 0
+	const isNotVisible = !element.is(':visible')
+
+	expect(doesNotExist || isNotVisible, 'does not exist or is not visible').to.be.true
+}

--- a/cypress/e2e/settings/users_columns.cy.ts
+++ b/cypress/e2e/settings/users_columns.cy.ts
@@ -21,6 +21,7 @@
  */
 
 import { User } from '@nextcloud/cypress'
+import { assertNotExistOrNotVisible } from './usersUtils.js'
 
 const admin = new User('admin', 'admin')
 
@@ -43,7 +44,7 @@ describe('Settings: Show and hide columns', function() {
 			// close the settings dialog
 			cy.get('button.modal-container__close').click()
 		})
-		cy.waitUntil(() => cy.get('.modal-container').should('not.be.visible'))
+		cy.waitUntil(() => cy.get('.modal-container').should(el => assertNotExistOrNotVisible(el)))
 	})
 
 	it('Can show a column', function() {
@@ -68,7 +69,7 @@ describe('Settings: Show and hide columns', function() {
 			// close the settings dialog
 			cy.get('button.modal-container__close').click()
 		})
-		cy.waitUntil(() => cy.get('.modal-container').should('not.be.visible'))
+		cy.waitUntil(() => cy.get('.modal-container').should(el => assertNotExistOrNotVisible(el)))
 
 		// see that the language column is in the header
 		cy.get(`.user-list__header tr`).within(() => {
@@ -103,7 +104,7 @@ describe('Settings: Show and hide columns', function() {
 			// close the settings dialog
 			cy.get('button.modal-container__close').click()
 		})
-		cy.waitUntil(() => cy.get('.modal-container').should('not.be.visible'))
+		cy.waitUntil(() => cy.get('.modal-container').should(el => assertNotExistOrNotVisible(el)))
 
 		// see that the last login column is not in the header
 		cy.get(`.user-list__header tr`).within(() => {


### PR DESCRIPTION
## Summary

Fix flaky cypress tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)