### PR TITLE
fix(notifications): Remove share notification when the node is deleted

### DIFF
--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\Files_Sharing\Notification;
 
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -114,6 +115,13 @@ class Notifier implements INotifier {
 		try {
 			$share = $this->shareManager->getShareById($attemptId, $notification->getUser());
 		} catch (ShareNotFound $e) {
+			throw new AlreadyProcessedException();
+		}
+
+		try {
+			$share->getNode();
+		} catch (NotFoundException $e) {
+			// Node is already deleted, so discard the notification
 			throw new AlreadyProcessedException();
 		}
 


### PR DESCRIPTION
* Resolves: #39135 

## Steps

1. Optional: Set up a mobile app for better testing
2. As UserA go to index.php/settings/user/sharing and disable the checkbox
![grafik](https://github.com/nextcloud/server/assets/213943/b4114aa0-573a-4e8c-94a5-4c710fe0fbaf)

3. As UserB create a folder and share it to UserA
4. As UserA reload the page or refresh the notifications on the mobile app, so you see the share notification
5. As UserB delete the the folder from 3.
6. As UserA repeat 4.

## Expected
No notification anymore

## Actual

Notification was still visible and "Decline" yields an error

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
