### PR TITLE
Refactor encryption app commands

### DIFF
--- a/apps/encryption/lib/Command/DisableMasterKey.php
+++ b/apps/encryption/lib/Command/DisableMasterKey.php
@@ -14,31 +14,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class DisableMasterKey extends Command {
-
-	/** @var Util */
-	protected $util;
-
-	/** @var IConfig */
-	protected $config;
-
-	/** @var  QuestionHelper */
-	protected $questionHelper;
-
-	/**
-	 * @param Util $util
-	 * @param IConfig $config
-	 * @param QuestionHelper $questionHelper
-	 */
-	public function __construct(Util $util,
-		IConfig $config,
-		QuestionHelper $questionHelper) {
-		$this->util = $util;
-		$this->config = $config;
-		$this->questionHelper = $questionHelper;
+	public function __construct(
+		protected Util $util,
+		protected IConfig $config,
+		protected QuestionHelper $questionHelper,
+	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('encryption:disable-master-key')
 			->setDescription('Disable the master key and use per-user keys instead. Only available for fresh installations with no existing encrypted data! There is no way to enable it again.');
@@ -61,9 +45,9 @@ class DisableMasterKey extends Command {
 				$output->writeln('Master key successfully disabled.');
 			} else {
 				$output->writeln('aborted.');
-				return 1;
+				return self::FAILURE;
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/encryption/lib/Command/DisableMasterKey.php
+++ b/apps/encryption/lib/Command/DisableMasterKey.php
@@ -33,21 +33,23 @@ class DisableMasterKey extends Command {
 
 		if (!$isMasterKeyEnabled) {
 			$output->writeln('Master key already disabled');
-		} else {
-			$question = new ConfirmationQuestion(
-				'Warning: Only perform this operation for a fresh installations with no existing encrypted data! '
-				. 'There is no way to enable the master key again. '
-				. 'We strongly recommend to keep the master key, it provides significant performance improvements '
-				. 'and is easier to handle for both, users and administrators. '
-				. 'Do you really want to switch to per-user keys? (y/n) ', false);
-			if ($this->questionHelper->ask($input, $output, $question)) {
-				$this->config->setAppValue('encryption', 'useMasterKey', '0');
-				$output->writeln('Master key successfully disabled.');
-			} else {
-				$output->writeln('aborted.');
-				return self::FAILURE;
-			}
+			return self::SUCCESS;
 		}
-		return self::SUCCESS;
+
+		$question = new ConfirmationQuestion(
+			'Warning: Only perform this operation for a fresh installations with no existing encrypted data! '
+			. 'There is no way to enable the master key again. '
+			. 'We strongly recommend to keep the master key, it provides significant performance improvements '
+			. 'and is easier to handle for both, users and administrators. '
+			. 'Do you really want to switch to per-user keys? (y/n) ', false);
+
+		if ($this->questionHelper->ask($input, $output, $question)) {
+			$this->config->setAppValue('encryption', 'useMasterKey', '0');
+			$output->writeln('Master key successfully disabled.');
+			return self::SUCCESS;
+		}
+
+		$output->writeln('aborted.');
+		return self::FAILURE;
 	}
 }

--- a/apps/encryption/lib/Command/DropLegacyFileKey.php
+++ b/apps/encryption/lib/Command/DropLegacyFileKey.php
@@ -58,10 +58,10 @@ class DropLegacyFileKey extends Command {
 
 		if ($result) {
 			$output->writeln('All scanned files are properly encrypted.');
-			return 0;
+			return self::SUCCESS;
 		}
 
-		return 1;
+		return self::FAILURE;
 	}
 
 	private function scanFolder(OutputInterface $output, string $folder): bool {

--- a/apps/encryption/lib/Command/EnableMasterKey.php
+++ b/apps/encryption/lib/Command/EnableMasterKey.php
@@ -16,31 +16,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class EnableMasterKey extends Command {
-
-	/** @var Util */
-	protected $util;
-
-	/** @var IConfig */
-	protected $config;
-
-	/** @var  QuestionHelper */
-	protected $questionHelper;
-
-	/**
-	 * @param Util $util
-	 * @param IConfig $config
-	 * @param QuestionHelper $questionHelper
-	 */
-	public function __construct(Util $util,
-		IConfig $config,
-		QuestionHelper $questionHelper) {
-		$this->util = $util;
-		$this->config = $config;
-		$this->questionHelper = $questionHelper;
+	public function __construct(
+		protected Util $util,
+		protected IConfig $config,
+		protected QuestionHelper $questionHelper,
+	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('encryption:enable-master-key')
 			->setDescription('Enable the master key. Only available for fresh installations with no existing encrypted data! There is also no way to disable it again.');
@@ -60,9 +44,9 @@ class EnableMasterKey extends Command {
 				$output->writeln('Master key successfully enabled.');
 			} else {
 				$output->writeln('aborted.');
-				return 1;
+				return self::FAILURE;
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/encryption/lib/Command/EnableMasterKey.php
+++ b/apps/encryption/lib/Command/EnableMasterKey.php
@@ -35,18 +35,20 @@ class EnableMasterKey extends Command {
 
 		if ($isAlreadyEnabled) {
 			$output->writeln('Master key already enabled');
-		} else {
-			$question = new ConfirmationQuestion(
-				'Warning: Only available for fresh installations with no existing encrypted data! '
-			. 'There is also no way to disable it again. Do you want to continue? (y/n) ', false);
-			if ($this->questionHelper->ask($input, $output, $question)) {
-				$this->config->setAppValue('encryption', 'useMasterKey', '1');
-				$output->writeln('Master key successfully enabled.');
-			} else {
-				$output->writeln('aborted.');
-				return self::FAILURE;
-			}
+			return self::SUCCESS;
 		}
-		return self::SUCCESS;
+
+		$question = new ConfirmationQuestion(
+			'Warning: Only available for fresh installations with no existing encrypted data! '
+			. 'There is also no way to disable it again. Do you want to continue? (y/n) ', false);
+
+		if ($this->questionHelper->ask($input, $output, $question)) {
+			$this->config->setAppValue('encryption', 'useMasterKey', '1');
+			$output->writeln('Master key successfully enabled.');
+			return self::SUCCESS;
+		}
+
+		$output->writeln('aborted.');
+		return self::FAILURE;
 	}
 }

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -79,6 +79,11 @@ class FixEncryptedVersion extends Command {
 		$all = $input->getOption('all');
 		$pathOption = \trim(($input->getOption('path') ?? ''), '/');
 
+		if (!$user && !$all) {
+			$output->writeln("Either a user id or --all needs to be provided");
+			return self::FAILURE;
+		}
+
 		if ($user) {
 			if ($all) {
 				$output->writeln("Specifying a user id and --all are mutually exclusive");
@@ -91,18 +96,15 @@ class FixEncryptedVersion extends Command {
 			}
 
 			return $this->runForUser($user, $pathOption, $output);
-		} elseif ($all) {
-			$result = 0;
-			$this->userManager->callForSeenUsers(function (IUser $user) use ($pathOption, $output, &$result) {
-				$output->writeln("Processing files for " . $user->getUID());
-				$result = $this->runForUser($user->getUID(), $pathOption, $output);
-				return $result === 0;
-			});
-			return $result;
-		} else {
-			$output->writeln("Either a user id or --all needs to be provided");
-			return self::FAILURE;
 		}
+
+		$result = 0;
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($pathOption, $output, &$result) {
+			$output->writeln("Processing files for " . $user->getUID());
+			$result = $this->runForUser($user->getUID(), $pathOption, $output);
+			return $result === 0;
+		});
+		return $result;
 	}
 
 	private function runForUser(string $user, string $pathOption, OutputInterface $output): int {

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FixEncryptedVersion extends Command {
-	private bool $supportLegacy;
+	private bool $supportLegacy = false;
 
 	public function __construct(
 		private IConfig $config,
@@ -35,8 +35,6 @@ class FixEncryptedVersion extends Command {
 		private Util $util,
 		private View $view,
 	) {
-		$this->supportLegacy = false;
-
 		parent::__construct();
 	}
 
@@ -69,12 +67,12 @@ class FixEncryptedVersion extends Command {
 
 		if ($skipSignatureCheck) {
 			$output->writeln("<error>Repairing is not possible when \"encryption_skip_signature_check\" is set. Please disable this flag in the configuration.</error>\n");
-			return 1;
+			return self::FAILURE;
 		}
 
 		if (!$this->util->isMasterKeyEnabled()) {
 			$output->writeln("<error>Repairing only works with master key encryption.</error>\n");
-			return 1;
+			return self::FAILURE;
 		}
 
 		$user = $input->getArgument('user');
@@ -84,12 +82,12 @@ class FixEncryptedVersion extends Command {
 		if ($user) {
 			if ($all) {
 				$output->writeln("Specifying a user id and --all are mutually exclusive");
-				return 1;
+				return self::FAILURE;
 			}
 
 			if ($this->userManager->get($user) === null) {
 				$output->writeln("<error>User id $user does not exist. Please provide a valid user id</error>");
-				return 1;
+				return self::FAILURE;
 			}
 
 			return $this->runForUser($user, $pathOption, $output);
@@ -103,7 +101,7 @@ class FixEncryptedVersion extends Command {
 			return $result;
 		} else {
 			$output->writeln("Either a user id or --all needs to be provided");
-			return 1;
+			return self::FAILURE;
 		}
 	}
 
@@ -122,13 +120,13 @@ class FixEncryptedVersion extends Command {
 		$this->setupUserFs($user);
 		if (!$this->view->file_exists($path)) {
 			$output->writeln("<error>Path \"$path\" does not exist. Please provide a valid path.</error>");
-			return 1;
+			return self::FAILURE;
 		}
 
 		if ($this->view->is_file($path)) {
 			$output->writeln("Verifying the content of file \"$path\"");
 			$this->verifyFileContent($path, $output);
-			return 0;
+			return self::SUCCESS;
 		}
 		$directories = [];
 		$directories[] = $path;
@@ -144,7 +142,7 @@ class FixEncryptedVersion extends Command {
 				}
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
 	/**

--- a/apps/encryption/lib/Command/FixKeyLocation.php
+++ b/apps/encryption/lib/Command/FixKeyLocation.php
@@ -28,25 +28,17 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FixKeyLocation extends Command {
-	private IUserManager $userManager;
-	private IUserMountCache $userMountCache;
-	private Util $encryptionUtil;
-	private IRootFolder $rootFolder;
 	private string $keyRootDirectory;
 	private View $rootView;
 	private Manager $encryptionManager;
 
 	public function __construct(
-		IUserManager $userManager,
-		IUserMountCache $userMountCache,
-		Util $encryptionUtil,
-		IRootFolder $rootFolder,
-		IManager $encryptionManager
+		private IUserManager $userManager,
+		private IUserMountCache $userMountCache,
+		private Util $encryptionUtil,
+		private IRootFolder $rootFolder,
+		IManager $encryptionManager,
 	) {
-		$this->userManager = $userManager;
-		$this->userMountCache = $userMountCache;
-		$this->encryptionUtil = $encryptionUtil;
-		$this->rootFolder = $rootFolder;
 		$this->keyRootDirectory = rtrim($this->encryptionUtil->getKeyStorageRoot(), '/');
 		$this->rootView = new View();
 		if (!$encryptionManager instanceof Manager) {
@@ -74,7 +66,7 @@ class FixKeyLocation extends Command {
 		$user = $this->userManager->get($userId);
 		if (!$user) {
 			$output->writeln("<error>User $userId not found</error>");
-			return 1;
+			return self::FAILURE;
 		}
 
 		\OC_Util::setupFS($user->getUID());
@@ -158,7 +150,7 @@ class FixKeyLocation extends Command {
 			}
 		}
 
-		return 0;
+		return self::SUCCESS;
 	}
 
 	private function getUserRelativePath(string $path): string {
@@ -171,7 +163,6 @@ class FixKeyLocation extends Command {
 	}
 
 	/**
-	 * @param IUser $user
 	 * @return ICachedMountInfo[]
 	 */
 	private function getSystemMountsForUser(IUser $user): array {
@@ -186,7 +177,6 @@ class FixKeyLocation extends Command {
 	/**
 	 * Get all files in a folder which are marked as encrypted
 	 *
-	 * @param Folder $folder
 	 * @return \Generator<File>
 	 */
 	private function getAllEncryptedFiles(Folder $folder) {
@@ -227,10 +217,6 @@ class FixKeyLocation extends Command {
 
 	/**
 	 * Check that the user key stored for a file can decrypt the file
-	 *
-	 * @param IUser $user
-	 * @param File $node
-	 * @return bool
 	 */
 	private function copyUserKeyToSystemAndValidate(IUser $user, File $node): bool {
 		$path = trim(substr($node->getPath(), strlen($user->getUID()) + 1), '/');
@@ -267,7 +253,6 @@ class FixKeyLocation extends Command {
 	/**
 	 * Get the contents of a file without decrypting it
 	 *
-	 * @param File $node
 	 * @return resource
 	 */
 	private function openWithoutDecryption(File $node, string $mode) {
@@ -295,9 +280,6 @@ class FixKeyLocation extends Command {
 
 	/**
 	 * Check if the data stored for a file is encrypted, regardless of it's metadata
-	 *
-	 * @param File $node
-	 * @return bool
 	 */
 	private function isDataEncrypted(File $node): bool {
 		$handle = $this->openWithoutDecryption($node, 'r');
@@ -310,9 +292,6 @@ class FixKeyLocation extends Command {
 
 	/**
 	 * Attempt to find a key (stored for user) for a file (that needs a system key) even when it's not stored in the expected location
-	 *
-	 * @param File $node
-	 * @return string
 	 */
 	private function findUserKeyForSystemFile(IUser $user, File $node): ?string {
 		$userKeyPath = $this->getUserBaseKeyPath($user);
@@ -328,8 +307,6 @@ class FixKeyLocation extends Command {
 	/**
 	 * Attempt to find a key for a file even when it's not stored in the expected location
 	 *
-	 * @param string $basePath
-	 * @param string $name
 	 * @return \Generator<string>
 	 */
 	private function findKeysByFileName(string $basePath, string $name) {
@@ -356,11 +333,6 @@ class FixKeyLocation extends Command {
 
 	/**
 	 * Test if the provided key is valid as a system key for the file
-	 *
-	 * @param IUser $user
-	 * @param string $key
-	 * @param File $node
-	 * @return bool
 	 */
 	private function testSystemKey(IUser $user, string $key, File $node): bool {
 		$systemKeyPath = $this->getSystemKeyPath($node);
@@ -378,10 +350,6 @@ class FixKeyLocation extends Command {
 
 	/**
 	 * Decrypt a file with the specified system key and mark the key as not-encrypted
-	 *
-	 * @param File $node
-	 * @param string $key
-	 * @return void
 	 */
 	private function decryptWithSystemKey(File $node, string $key): void {
 		$storage = $node->getStorage();

--- a/apps/encryption/lib/Command/RecoverUser.php
+++ b/apps/encryption/lib/Command/RecoverUser.php
@@ -16,33 +16,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 class RecoverUser extends Command {
-
-	/** @var Util */
-	protected $util;
-
-	/** @var IUserManager */
-	protected $userManager;
-
-	/** @var  QuestionHelper */
-	protected $questionHelper;
-
-	/**
-	 * @param Util $util
-	 * @param IConfig $config
-	 * @param IUserManager $userManager
-	 * @param QuestionHelper $questionHelper
-	 */
-	public function __construct(Util $util,
+	public function __construct(
+		protected Util $util,
 		IConfig $config,
-		IUserManager $userManager,
-		QuestionHelper $questionHelper) {
-		$this->util = $util;
-		$this->questionHelper = $questionHelper;
-		$this->userManager = $userManager;
+		protected IUserManager $userManager,
+		protected QuestionHelper $questionHelper,
+	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('encryption:recover-user')
 			->setDescription('Recover user data in case of password lost. This only works if the user enabled the recovery key.');
@@ -59,20 +42,20 @@ class RecoverUser extends Command {
 
 		if ($isMasterKeyEnabled) {
 			$output->writeln('You use the master key, no individual user recovery needed.');
-			return 0;
+			return self::SUCCESS;
 		}
 
 		$uid = $input->getArgument('user');
 		$userExists = $this->userManager->userExists($uid);
 		if ($userExists === false) {
 			$output->writeln('User "' . $uid . '" unknown.');
-			return 1;
+			return self::FAILURE;
 		}
 
 		$recoveryKeyEnabled = $this->util->isRecoveryEnabledForUser($uid);
 		if ($recoveryKeyEnabled === false) {
 			$output->writeln('Recovery key is not enabled for: ' . $uid);
-			return 1;
+			return self::FAILURE;
 		}
 
 		$question = new Question('Please enter the recovery key password: ');
@@ -88,6 +71,6 @@ class RecoverUser extends Command {
 		$output->write('Start to recover users files... This can take some time...');
 		$this->userManager->get($uid)->setPassword($newLoginPassword, $recoveryPassword);
 		$output->writeln('Done.');
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/encryption/lib/Command/ScanLegacyFormat.php
+++ b/apps/encryption/lib/Command/ScanLegacyFormat.php
@@ -18,40 +18,20 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ScanLegacyFormat extends Command {
-	/** @var Util */
-	protected $util;
+	private View $rootView;
 
-	/** @var IConfig */
-	protected $config;
-
-	/** @var  QuestionHelper */
-	protected $questionHelper;
-
-	/** @var IUserManager */
-	private $userManager;
-
-	/** @var View */
-	private $rootView;
-
-	/**
-	 * @param Util $util
-	 * @param IConfig $config
-	 * @param QuestionHelper $questionHelper
-	 */
-	public function __construct(Util $util,
-		IConfig $config,
-		QuestionHelper $questionHelper,
-		IUserManager $userManager) {
+	public function __construct(
+		protected Util $util,
+		protected IConfig $config,
+		protected QuestionHelper $questionHelper,
+		private IUserManager $userManager,
+	) {
 		parent::__construct();
 
-		$this->util = $util;
-		$this->config = $config;
-		$this->questionHelper = $questionHelper;
-		$this->userManager = $userManager;
 		$this->rootView = new View();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('encryption:scan:legacy-format')
 			->setDescription('Scan the files for the legacy format');
@@ -78,10 +58,10 @@ class ScanLegacyFormat extends Command {
 
 		if ($result) {
 			$output->writeln('All scanned files are properly encrypted. You can disable the legacy compatibility mode.');
-			return 0;
+			return self::SUCCESS;
 		}
 
-		return 1;
+		return self::FAILURE;
 	}
 
 	private function scanFolder(OutputInterface $output, string $folder): bool {
@@ -112,10 +92,8 @@ class ScanLegacyFormat extends Command {
 
 	/**
 	 * setup user file system
-	 *
-	 * @param string $uid
 	 */
-	protected function setupUserFS($uid) {
+	protected function setupUserFS(string $uid): void {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($uid);
 	}


### PR DESCRIPTION
## Summary
I have made some adjustments to the `apps/encryption/lib/Command` classes to improve the code readability.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Replacing return code integers with more readable strings.
- Using early returns

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
