### PR TITLE
fix: close cursor after reading the invitation

### DIFF
--- a/apps/dav/lib/Controller/InvitationResponseController.php
+++ b/apps/dav/lib/Controller/InvitationResponseController.php
@@ -169,8 +169,9 @@ class InvitationResponseController extends Controller {
 		$query->select('*')
 			->from('calendar_invitations')
 			->where($query->expr()->eq('token', $query->createNamedParameter($token)));
-		$stmt = $query->execute();
+		$stmt = $query->executeQuery();
 		$row = $stmt->fetch(\PDO::FETCH_ASSOC);
+		$stmt->closeCursor();
 
 		if (!$row) {
 			return null;

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -465,6 +465,8 @@ EOF;
 			->method('fetch')
 			->with(\PDO::FETCH_ASSOC)
 			->willReturn($return);
+		$stmt->expects($this->once())
+			->method('closeCursor');
 
 		$function = 'functionToken';
 		$expr->expects($this->once())
@@ -490,7 +492,7 @@ EOF;
 			->with($function)
 			->willReturn($queryBuilder);
 		$queryBuilder->expects($this->once())
-			->method('execute')
+			->method('executeQuery')
 			->with()
 			->willReturn($stmt);
 


### PR DESCRIPTION
## Summary

:rocket: 

## TODO

- [x] Ci
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
