### PR TITLE
Allow ext storage Local to go unavailable

### DIFF
--- a/apps/files_external/lib/Lib/Backend/Local.php
+++ b/apps/files_external/lib/Lib/Backend/Local.php
@@ -26,8 +26,10 @@ namespace OCA\Files_External\Lib\Backend;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\NullMechanism;
 use OCA\Files_External\Lib\DefinitionParameter;
+use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\BackendService;
 use OCP\IL10N;
+use OCP\IUser;
 
 class Local extends Backend {
 	public function __construct(IL10N $l, NullMechanism $legacyAuth) {
@@ -44,5 +46,9 @@ class Local extends Backend {
 			->addAuthScheme(AuthMechanism::SCHEME_NULL)
 			->setLegacyAuthMechanism($legacyAuth)
 		;
+	}
+
+	public function manipulateStorageConfig(StorageConfig &$storage, IUser $user = null): void {
+		$storage->setBackendOption('isExternal', true);
 	}
 }

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -51,6 +51,7 @@ use OCP\Files\ForbiddenException;
 use OCP\Files\GenericFileException;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Storage\IStorage;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -95,6 +96,12 @@ class Local extends \OC\Files\Storage\Common {
 
 		// support Write-Once-Read-Many file systems
 		$this->unlinkOnTruncate = $this->config->getSystemValueBool('localstorage.unlink_on_truncate', false);
+
+		if (isset($arguments['isExternal']) && $arguments['isExternal'] && !$this->stat('')) {
+			// data dir not accessible or available, can happen when using an external storage of type Local
+			// on an unmounted system mount point
+			throw new StorageNotAvailableException('Local storage path does not exist "' . $this->getSourcePath('') . '"');
+		}
 	}
 
 	public function __destruct() {

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -139,4 +139,15 @@ class LocalTest extends Storage {
 		umask($oldMask);
 		$this->assertTrue($this->instance->isUpdatable('test.txt'));
 	}
+
+	public function testUnavailableExternal() {
+		$this->expectException(\OCP\Files\StorageNotAvailableException::class);
+		$this->instance = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir . '/unexist', 'isExternal' => true]);
+	}
+
+	public function testUnavailableNonExternal() {
+		$this->instance = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir . '/unexist']);
+		// no exception thrown
+		$this->assertNotNull($this->instance);
+	}
 }


### PR DESCRIPTION
* Resolves: #39706 

## Summary

Whenever an external storage of type Local points at a non-existing directory, process this as a StorageNotAvailable instead of returning 404.

This makes desktop clients ignore the folder instead of deleting it when it becomes unavailable.

The code change was limited to external storages to avoid issues during setup and with the default home storage.


## TODO

- [x] actually test with desktop client to confirm behavior: https://github.com/nextcloud/server/pull/39707#issuecomment-1664663872
- [ ] properly convert the exception so that it appears in Webdav response

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes -> N/A
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
