### PR TITLE
ci: move phpunit-nodb to actions

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,0 +1,13 @@
+# Filters for https://github.com/dorny/paths-filter
+
+phpunit:
+  - '**/*.php'
+  - '**/*.sh'
+  - '**/*.xml'
+  - '**/*.yml'
+  - '**/l10n/*.json'
+  - '**/tests/**'
+  - '3rdparty'
+  - 'apps/theming/css'
+  - 'composer.(json|lock)'
+  - 'vendor-bin/phpunit/composer.(json|lock)'

--- a/.github/workflows/nodb.yml
+++ b/.github/workflows/nodb.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: apcu, ctype, curl, dom, fileinfo, gd, imagick, intl, json, ldap, mbstring, openssl, pcntl, pdo_sqlite, posix, redis, sqlite, xml, zip
-          tools: phpunit:9
           coverage: none
           ini-file: development
           ini-values:
@@ -75,6 +74,7 @@ jobs:
         env:
           DB_PORT: 4444
         run: |
+          composer install
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
           php -f index.php
@@ -83,8 +83,7 @@ jobs:
         run: ./occ app:enable admin_audit encryption federatedfilesharing federation files_sharing files_trashbin files_versions provisioning_api user_ldap
 
       - name: PHPUnit
-        working-directory: tests
-        run: phpunit --configuration phpunit-autotest.xml --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift
+        run: composer run test -- --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift
 
   summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodb.yml
+++ b/.github/workflows/nodb.yml
@@ -1,0 +1,79 @@
+name: PHPUnit nodb
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+      - stable*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  phpunit-nodb:
+    runs-on: ubuntu-latest
+
+    if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
+
+    strategy:
+      matrix:
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg imagemagick libmagickcore-6.q16-3-extra
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@9c77701ae57b0c47f6732beebfbdec76e4e5c90a #debian bookworm fix
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: apcu, ctype, curl, dom, fileinfo, gd, imagick, intl, json, ldap, mbstring, openssl, pcntl, pdo_sqlite, posix, redis, sqlite, xml, zip
+          tools: phpunit:9
+          coverage: none
+          ini-file: development
+          ini-values:
+            apc.enabled=on, apc.enable_cli=on, disable_functions= # https://github.com/shivammathur/setup-php/discussions/573
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
+          php -f index.php
+
+      - name: Enable additional apps
+        run: ./occ app:enable admin_audit encryption federatedfilesharing federation files_sharing files_trashbin files_versions provisioning_api user_ldap
+
+      - name: PHPUnit
+        working-directory: tests
+        run: phpunit --configuration phpunit-autotest.xml --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift
+
+  summary-nodb:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest
+    needs: phpunit-nodb
+
+    if: always()
+
+    name: phpunit-nodb-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.phpunit-nodb.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/nodb.yml
+++ b/.github/workflows/nodb.yml
@@ -16,10 +16,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  phpunit-nodb:
+  changes:
     runs-on: ubuntu-latest
+    name: nodb-changes
 
-    if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      phpunit: ${{ steps.filter.outputs.phpunit }}
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: filter
+        with:
+          filters: .github/filters.yml
+
+  phpunit:
+    runs-on: ubuntu-latest
+    name: nodb-phpunit
+
+    needs: changes
+    if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.phpunit == 'true'  }}
 
     strategy:
       matrix:
@@ -64,16 +86,16 @@ jobs:
         working-directory: tests
         run: phpunit --configuration phpunit-autotest.xml --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift
 
-  summary-nodb:
-    permissions:
-      contents: none
+  summary:
     runs-on: ubuntu-latest
-    needs: phpunit-nodb
+    name: nodb-summary
 
+    needs: [changes, phpunit]
     if: always()
 
-    name: phpunit-nodb-summary
+    permissions:
+      contents: none
 
     steps:
       - name: Summary status
-        run: if ${{ needs.phpunit-nodb.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.phpunit == 'true' && needs.phpunit.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/nodb.yml
+++ b/.github/workflows/nodb.yml
@@ -83,7 +83,7 @@ jobs:
         run: ./occ app:enable admin_audit encryption federatedfilesharing federation files_sharing files_trashbin files_versions provisioning_api user_ldap
 
       - name: PHPUnit
-        run: composer run test -- --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift
+        run: composer run test -- --exclude-group DB,SLOWDB,PRIMARY-azure,PRIMARY-s3,PRIMARY-swift,Memcached,Redis
 
   summary:
     runs-on: ubuntu-latest

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -40,6 +40,7 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
 use OCP\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -87,6 +88,9 @@ class EncryptAllTest extends TestCase {
 
 	/** @var  \PHPUnit\Framework\MockObject\MockObject | \OCP\Security\ISecureRandom  */
 	protected $secureRandom;
+
+	/** @var MockObject|IFactory  */
+	protected $l10nFactory;
 
 	/** @var  EncryptAll */
 	protected $encryptAll;


### PR DESCRIPTION
## Learnings

#### Learning 1 

`phpunit -c autotest-external` only runs tests for enable apps. 

This seems to make sense, but it is not obvious and does not make the CI configuration any easier.

The following apps are part of the server repository and are not enabled by default. 
Therefore, they must be enabled for CI runs.

```
admin_audit
encryption
files_external
user_ldap
```

#### Learning 2

`phpunit --list-tests` lists the available tests. 

Unfortunately, it does not list tests from dynamically enabled apps. 
I assume that's related to the way the tests are added. 

## TODO

- [x] CI
- [x] Decide: Run nodb tests for PHP 8.0, 8.1 and 8.2 or only PHP 8.0 (like on drone)
- [ ] Review
- [ ] Follow-up to remove nodb from drone
- [x] Follow-up to exclude PRIMARY-azure,PRIMARY-s3,PRIMARY-swift 
- [x] Follow-up to add php 8.3 (after https://github.com/nextcloud/server/pull/40630)
- [ ] Ask Côme if the additional apps should be enabled for phpunit-32bits too

## Migration

**Round 1:**

 - No changes to test suite

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10554 | 10861 | 
| Warnings | 28 | 25 | 
| Skipped | 76 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

Warnings on Actions but not on Drone:

```
26) OCA\Theming\Tests\IconBuilderTest::testGetFaviconNotFound
Expecting E_WARNING and E_USER_WARNING is deprecated and will no longer be possible in PHPUnit 10.

27) OCA\Theming\Tests\IconBuilderTest::testGetTouchIconNotFound
Expecting E_WARNING and E_USER_WARNING is deprecated and will no longer be possible in PHPUnit 10.

28) OCA\Theming\Tests\IconBuilderTest::testColorSvgNotFound
Expecting E_WARNING and E_USER_WARNING is deprecated and will no longer be possible in PHPUnit 10.
```
expectWarning is deprecated since PHPUnit 9.6

**Round 2:**

- Exclude PRIMARY-azure,PRIMARY-s3,PRIMARY-swift (they are skipped anyway because the configuration is missing)
- Added redis extension

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10524 | 10861 | 
| Warnings | 28 | 25 | 
| Skipped | 46 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

**Round 3:**

- Added ldap extension
- Print list of tests to be executed

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10524  | 10861 | 
| Warnings | 28 | 25 | 
| Skipped | 46 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

**Round 4:**

- Enable additional apps: `admin_audit encryption federatedfilesharing federation files_sharing files_trashbin files_versions provisioning_api user_ldap` (cf. https://github.com/nextcloud/server/blob/master/tests/enable_all.php)

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10831 | 10861 | 
| Assertions | 23081 | 23020 | 
| Warnings | 28 | 25 | 
| Skipped | 46 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

Actions: https://github.com/nextcloud/server/actions/runs/5777400665/job/15657527803
Drone: https://drone.nextcloud.com/nextcloud/server/38222/9/4

**Round 5:**

- Include test suite PRIMARY-azure,PRIMARY-s3,PRIMARY-swift again because this cleanup should be done as follow up.

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10861 | 10861 | 
| Assertions | 23081 | 23020 | 
| Warnings | 28 | 25 | 
| Skipped | 76 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

Actions: https://github.com/nextcloud/server/actions/runs/5777508182/job/15657761644
Drone: https://drone.nextcloud.com/nextcloud/server/38223/9/4

**Round 6:**

- Squashed the commits
- Removed the --list-tests step 

| | Actions | Drone |
|--------|--------|--------|
| Tests executed | 10861 | 10861 | 
| Assertions | 23081 | 23020 | 
| Warnings | 28 | 25 | 
| Skipped | 76 | 96 | 
| PHPUnit | 9.6.10 | 9.5.28 |

Actions: https://github.com/nextcloud/server/actions/runs/5777613755/job/15657986497
Drone: https://drone.nextcloud.com/nextcloud/server/38224/9/4

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
