### PR TITLE
fix: Don't try to access null array

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -261,6 +261,7 @@ class Notifications {
 		$status = json_decode($result['result'], true);
 
 		if ($result['success'] &&
+			isset($status['ocs']['meta']['statuscode']) &&
 			($status['ocs']['meta']['statuscode'] === 100 ||
 				$status['ocs']['meta']['statuscode'] === 200
 			)


### PR DESCRIPTION
## Summary

```
{
  "reqId": "lG61fZdZOHdsj68Xjdto",
  "level": 3,
  "time": "2023-08-06T03:32:25+02:00",
  "remoteAddr": "",
  "user": "--",
  "app": "PHP",
  "method": "",
  "url": "--",
  "message": "Trying to access array offset on value of type null at /var/www/nextcloud/apps/federatedfilesharing/lib/Notifications.php#297",
  "userAgent": "--",
  "version": "26.0.4.2",
  "data": {
    "app": "PHP"
  },
  "id": "64d15c8ebc6e2"
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
