### PR TITLE
Replacing "To-dos" with "Tasks" to fit wording in Calendar

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Filter/Todo.php
+++ b/apps/dav/lib/CalDAV/Activity/Filter/Todo.php
@@ -52,7 +52,7 @@ class Todo implements IFilter {
 	 * @since 11.0.0
 	 */
 	public function getName() {
-		return $this->l->t('To-dos');
+		return $this->l->t('Tasks');
 	}
 
 	/**


### PR DESCRIPTION
![2023-08-08_11-26](https://github.com/nextcloud/server/assets/33763786/a74fcaf6-c94c-4564-a9fb-d73096c39d8f)
Because the above wording should fit : 
![2023-08-08_11-28](https://github.com/nextcloud/server/assets/33763786/658d89c2-d057-470f-801d-187569dce974)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
