### PR TITLE
Rename apps pack install button

### DIFF
--- a/apps/settings/src/components/AppList.vue
+++ b/apps/settings/src/components/AppList.vue
@@ -210,7 +210,7 @@ export default {
 				if (this.allBundlesEnabled(id)) {
 					return t('settings', 'Disable all')
 				}
-				return t('settings', 'Enable all')
+				return t('settings', 'Download and enable all')
 			}
 		},
 	},

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -86,7 +86,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function enableAllBundleButton($bundle) {
-		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input[@value='Download and enable all']")->
+		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input[@value='Enable all']")->
 				descendantOf(self::appsList())->
 				describedAs("Button to enable bundles");
 	}

--- a/tests/acceptance/features/bootstrap/AppsManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppsManagementContext.php
@@ -86,7 +86,7 @@ class AppsManagementContext implements Context, ActorAwareInterface {
 	 * @return Locator
 	 */
 	public static function enableAllBundleButton($bundle) {
-		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input[@value='Enable all']")->
+		return Locator::forThe()->xpath("//div[@class='apps-header']/h2[normalize-space() = '$bundle']/input[@value='Download and enable all']")->
 				descendantOf(self::appsList())->
 				describedAs("Button to enable bundles");
 	}


### PR DESCRIPTION
More precise wording about the actions which are triggered by the button.

I cannot test from my side ... can a reviewer do this ? 
Also, the wording isn't located in the usual syntax which is "t('project', 'text')" ... so I'm not sure if it works correctly ?!

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
