### PR TITLE
fix: always use display name from correct backend

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -62,6 +62,7 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Security\ICrypto;
 use OCP\Security\VerificationToken\IVerificationToken;
+use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 use function array_flip;
@@ -744,6 +745,10 @@ class AccountManager implements IAccountManager {
 			return $cached;
 		}
 		$account = $this->parseAccountData($user, $this->getUser($user));
+		if ($user->getBackend() instanceof IGetDisplayNameBackend) {
+			$property = $account->getProperty(self::PROPERTY_DISPLAYNAME);
+			$account->setProperty(self::PROPERTY_DISPLAYNAME, $user->getDisplayName(), $property->getScope(), $property->getVerified());
+		}
 		$this->internalCache->set($user->getUID(), $account);
 		return $account;
 	}


### PR DESCRIPTION
Overwrite the display name after the account is initialized when using an instacne of IGetDisplayNameBackend.

Before when using a variation of user_oidc and registering a Backend.php implementing IGetDisplayNameBackend
the personal setting page shows 'uid'.

The UserManager/AccountManager seems not to use consistently the correct backend.

The correct backend is used in this sequence:

server/lib/private/TemplateLayout.php

          $userDisplayName = \OC_User::getDisplayName();
          $this->assign(user_displayname, $userDisplayName);

In the settings page, it definitely not calls the registered backend, but seems to fall back to default Backend and shows (usually) uid or a value from the standard account property table.


* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
