### PR TITLE
log imaginary errors as info to not spam the server logs

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -148,14 +148,14 @@ class Imaginary extends ProviderV2 {
 					'connect_timeout' => 3,
 				]);
 		} catch (\Exception $e) {
-			$this->logger->error('Imaginary preview generation failed: ' . $e->getMessage(), [
+			$this->logger->info('Imaginary preview generation failed: ' . $e->getMessage(), [
 				'exception' => $e,
 			]);
 			return null;
 		}
 
 		if ($response->getStatusCode() !== 200) {
-			$this->logger->error('Imaginary preview generation failed: ' . json_decode($response->getBody())['message']);
+			$this->logger->info('Imaginary preview generation failed: ' . json_decode($response->getBody())['message']);
 			return null;
 		}
 


### PR DESCRIPTION
Reason: usually if preview generation fails, the admin cannot do much about it. In order to not spam the error logs, move the logs to info mode. Additional logs are shown in the imaginary container anyway, so should still be pretty easy to debug.