### PR TITLE
feat(request): Add RateLimit and RateLimit-Policy headers

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php
@@ -65,6 +65,10 @@ use ReflectionMethod;
  * @package OC\AppFramework\Middleware\Security
  */
 class RateLimitingMiddleware extends Middleware {
+	protected int $limit;
+	protected int $period;
+	protected int $attempts;
+
 	public function __construct(
 		protected IRequest $request,
 		protected IUserSession $userSession,
@@ -85,7 +89,9 @@ class RateLimitingMiddleware extends Middleware {
 			$rateLimit = $this->readLimitFromAnnotationOrAttribute($controller, $methodName, 'UserRateThrottle', UserRateLimit::class);
 
 			if ($rateLimit !== null) {
-				$this->limiter->registerUserRequest(
+				$this->limit = $rateLimit->getLimit();
+				$this->period = $rateLimit->getPeriod();
+				$this->attempts = $this->limiter->registerUserRequest(
 					$rateLimitIdentifier,
 					$rateLimit->getLimit(),
 					$rateLimit->getPeriod(),
@@ -100,7 +106,9 @@ class RateLimitingMiddleware extends Middleware {
 		$rateLimit = $this->readLimitFromAnnotationOrAttribute($controller, $methodName, 'AnonRateThrottle', AnonRateLimit::class);
 
 		if ($rateLimit !== null) {
-			$this->limiter->registerAnonRequest(
+			$this->limit = $rateLimit->getLimit();
+			$this->period = $rateLimit->getPeriod();
+			$this->attempts = $this->limiter->registerAnonRequest(
 				$rateLimitIdentifier,
 				$rateLimit->getLimit(),
 				$rateLimit->getPeriod(),
@@ -143,6 +151,17 @@ class RateLimitingMiddleware extends Middleware {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function afterController(Controller $controller, string $methodName, Response $response): Response {
+		$response->setHeaders([
+			'RateLimit' => 'limit=' . $this->limit . ', remaining=' . max(0, $this->limit - $this->attempts) . ', reset=' . $this->period,
+			'RateLimit-Policy' => $this->limit . ';w=' . $this->period,
+		]);
+		return $response;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function afterException(Controller $controller, string $methodName, \Exception $exception): Response {
 		if ($exception instanceof RateLimitExceededException) {
 			if (stripos($this->request->getHeader('Accept'), 'html') === false) {
@@ -154,8 +173,13 @@ class RateLimitingMiddleware extends Middleware {
 					[],
 					TemplateResponse::RENDER_AS_GUEST
 				);
-				$response->setStatus($exception->getCode());
 			}
+
+			$response->setStatus($exception->getCode());
+			$response->setHeaders([
+				'RateLimit' => 'limit=' . $this->limit . ', remaining=' . max(0, $this->limit - $this->attempts) . ', reset=' . $this->period,
+				'RateLimit-Policy' => $this->limit . ';w=' . $this->period,
+			]);
 
 			return $response;
 		}

--- a/lib/private/Security/RateLimiting/Limiter.php
+++ b/lib/private/Security/RateLimiting/Limiter.php
@@ -46,13 +46,15 @@ class Limiter {
 		string $userIdentifier,
 		int $period,
 		int $limit,
-	): void {
+	): int {
 		$existingAttempts = $this->backend->getAttempts($methodIdentifier, $userIdentifier);
 		if ($existingAttempts >= $limit) {
 			throw new RateLimitExceededException();
 		}
 
 		$this->backend->registerAttempt($methodIdentifier, $userIdentifier, $period);
+
+		return $existingAttempts;
 	}
 
 	/**
@@ -66,11 +68,11 @@ class Limiter {
 		int $anonLimit,
 		int $anonPeriod,
 		string $ip,
-	): void {
+	): int {
 		$ipSubnet = (new IpAddress($ip))->getSubnet();
 
 		$anonHashIdentifier = hash('sha512', 'anon::' . $identifier . $ipSubnet);
-		$this->register($identifier, $anonHashIdentifier, $anonPeriod, $anonLimit);
+		return $this->register($identifier, $anonHashIdentifier, $anonPeriod, $anonLimit);
 	}
 
 	/**
@@ -84,8 +86,8 @@ class Limiter {
 		int $userLimit,
 		int $userPeriod,
 		IUser $user,
-	): void {
+	): int {
 		$userHashIdentifier = hash('sha512', 'user::' . $identifier . $user->getUID());
-		$this->register($identifier, $userHashIdentifier, $userPeriod, $userLimit);
+		return $this->register($identifier, $userHashIdentifier, $userPeriod, $userLimit);
 	}
 }


### PR DESCRIPTION
## Summary

> [!NOTE]
> I finished the work already, before noticing that https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-07.html is still a draft. So also setting the PR to draft.

Adds the RateLimit and RateLimit-Policy headers, so that clients can see if the next request makes sense. Also it makes debugging rate limits a lot easier.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
