### PR TITLE
fix(updatenotification): Skip update check

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -57,6 +57,11 @@ class BackgroundJob extends TimedJob {
 	}
 
 	protected function run($argument) {
+		// Do not check for updates if not connected to the internet
+		if (!$this->config->getSystemValueBool('has_internet_connection', true)) {
+			return;
+		}
+
 		if (\OC::$CLI && !$this->config->getSystemValueBool('debug', false)) {
 			try {
 				// Jitter the pinging of the updater server and the appstore a bit.

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -112,9 +112,34 @@ class BackgroundJobTest extends TestCase {
 		$job->expects($this->once())
 			->method('checkAppUpdates');
 
+		$this->config->expects($this->exactly(2))
+			->method('getSystemValueBool')
+			->withConsecutive(
+				['has_internet_connection', true],
+				['debug', false],
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				true,
+			);
+
+		self::invokePrivate($job, 'run', [null]);
+	}
+
+	public function testRunNoInternet() {
+		$job = $this->getJob([
+			'checkCoreUpdate',
+			'checkAppUpdates',
+		]);
+
+		$job->expects($this->never())
+			->method('checkCoreUpdate');
+		$job->expects($this->never())
+			->method('checkAppUpdates');
+
 		$this->config->method('getSystemValueBool')
-			->with('debug', false)
-			->willReturn(true);
+			->with('has_internet_connection', true)
+			->willReturn(false);
 
 		self::invokePrivate($job, 'run', [null]);
 	}


### PR DESCRIPTION
## Summary

Skip update check if the config option https://github.com/nextcloud/server/blob/f0db3d0de1785c17097f6e8ffd73e0f9221528d9/config/config.sample.php#L818-L823 is `false`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)