### PR TITLE
Let `occ trashbin:restore` restore also from groupfolders and add filters

### DIFF
--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -39,6 +39,12 @@ class RestoreAllFiles extends Base {
 	private const SCOPE_USER = 1;
 	private const SCOPE_GROUPFOLDERS = 2;
 
+	private static $SCOPE_MAP = [
+		'user' => self::SCOPE_USER,
+		'groupfolders' => self::SCOPE_GROUPFOLDERS,
+		'all' => self::SCOPE_ALL
+	];
+
 	/** @var IUserManager */
 	protected $userManager;
 
@@ -243,16 +249,11 @@ class RestoreAllFiles extends Base {
 	 * @return int
 	 */
 	protected function parseScope(string $scope): int {
-		switch ($scope) {
-			case 'user':
-				return self::SCOPE_USER;
-			case 'groupfolders':
-				return self::SCOPE_GROUPFOLDERS;
-			case 'all':
-				return self::SCOPE_ALL;
-			default:
-				throw new InvalidOptionException("Invalid scope '$scope'");
+		if (isset(self::$SCOPE_MAP[$scope])) {
+			return self::$SCOPE_MAP[$scope];
 		}
+
+		throw new InvalidOptionException("Invalid scope '$scope'");
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -276,13 +276,13 @@ class RestoreAllFiles extends Base {
 
 			// Check left timestamp boundary
 			if ($since !== null && $trashItem->getDeletedTime() <= $since) {
-				$output->writeln("Skipping <info>" . $trashItem->getName() . "</info> because it was deleted before the restore-from timestamp", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("Skipping <info>" . $trashItem->getName() . "</info> because it was deleted before the 'since' timestamp", OutputInterface::VERBOSITY_VERBOSE);
 				continue;
 			}
 
 			// Check right timestamp boundary
 			if ($until !== null && $trashItem->getDeletedTime() >= $until) {
-				$output->writeln("Skipping <info>" . $trashItem->getName() . "</info> because it was deleted after the restore-to timestamp", OutputInterface::VERBOSITY_VERBOSE);
+				$output->writeln("Skipping <info>" . $trashItem->getName() . "</info> because it was deleted after the 'until' timestamp", OutputInterface::VERBOSITY_VERBOSE);
 				continue;
 			}
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1305,6 +1305,12 @@
       <code><![CDATA[isset($_['hideFileList']) && $_['hideFileList'] !== true]]></code>
     </RedundantCondition>
   </file>
+  <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
+    <RedundantCondition>
+      <code><![CDATA[$scope === self::SCOPE_GROUPFOLDERS && $trashItemClass !== 'OCA\GroupFolders\Trash\GroupTrashItem']]></code>
+      <code><![CDATA[$trashItemClass !== 'OCA\GroupFolders\Trash\GroupTrashItem']]></code>
+    </RedundantCondition>
+  </file>
   <file src="apps/files_trashbin/lib/Listeners/LoadAdditionalScripts.php">
     <MissingTemplateParam>
       <code>IEventListener</code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1305,12 +1305,6 @@
       <code><![CDATA[isset($_['hideFileList']) && $_['hideFileList'] !== true]]></code>
     </RedundantCondition>
   </file>
-  <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
-    <RedundantCondition>
-      <code><![CDATA[$scope === self::SCOPE_GROUPFOLDERS && $trashItemClass !== 'OCA\GroupFolders\Trash\GroupTrashItem']]></code>
-      <code><![CDATA[$trashItemClass !== 'OCA\GroupFolders\Trash\GroupTrashItem']]></code>
-    </RedundantCondition>
-  </file>
   <file src="apps/files_trashbin/lib/Listeners/LoadAdditionalScripts.php">
     <MissingTemplateParam>
       <code>IEventListener</code>


### PR DESCRIPTION
Resolves: #39724

## Summary

Let `occ trashbin:restore` restore also from groupfolders and add additional filters
* Using the TrashManager allows access to all deleted files
* Add 'scope' parameter to choose where to restore from (user or groupfolders)
* Add 'restore-from' and 'restore-to' date parameters to filter files to be
  restored by their deletion date
* Add 'dry-run' flag to be able to see which files would be restored and being
  able to adjust the filter parameters accordingly

## Manual testcases

```bash
# Will still only restore user deleted files (backward compat)
php occ trashbin:restore --all-users

# Will only restore files from groupfolders visible to user "admin"
php occ trashbin:restore  --scope groupfolders admin

# Will only list files to be restored
php occ trashbin:restore --all-users --dry-run

# Will only restore files from groupfolders which have been deleted between 01.08.2023 10:00 and 02.08.2023 11:55:02
php occ trashbin:restore  --scope groupfolders --all-users --restore-from "01.08.2023 10:00" --restore-to "02.08.2023 11:55:02"

# Will restore all files from all users (user-files and groupfolders)
php occ trashbin:restore --all-users --scope all
```

## Showcase

Assume we have two files in our trashbin. One is `Userfile.txt` which was deleted from a users private directory. The other one is `GroupfoldersFile.jpg` which was deleted from a groupfolder `gf1` where user `admin` (which we use for restore) has access to.

```bash
# Lets get a list of all deleted files ...
devcontainer@b03e2fb2a292:/var/www/html$ php occ trashbin:restore --dry-run --all-users --scope all 2>/dev/null 
Restoring deleted files for all users
Restoring deleted files for users on backend Database
admin
Would restore 2 files...
Would restore Userfile.txt originally deleted at August 12, 2023, 1:04:52 PM UTC to /Userfile.txt
Would restore GroupfoldersFile.jpg originally deleted at August 12, 2023, 1:04:45 PM UTC to /gf1/GroupfoldersFile.jpg
```

```bash
# Only show me the local ones and activate verbose output...
devcontainer@b03e2fb2a292:/var/www/html$ php occ trashbin:restore --dry-run --all-users --scope user -v 2>/dev/null 
Restoring deleted files for all users
Restoring deleted files for users on backend Database
admin
Skipping GroupfoldersFile.jpg because it is not a user trash item
Would restore 1 files...
Would restore Userfile.txt originally deleted at August 12, 2023, 1:04:52 PM UTC to /Userfile.txt
```

```bash
# Ok, only groupfolder ones please ...
devcontainer@b03e2fb2a292:/var/www/html$ php occ trashbin:restore --dry-run --all-users --scope groupfolders -v 2>/dev/null 
Restoring deleted files for all users
Restoring deleted files for users on backend Database
admin
Skipping Userfile.txt because it is not a groupfolders trash item
Would restore 1 files...
Would restore GroupfoldersFile.jpg originally deleted at August 12, 2023, 1:04:45 PM UTC to /gf1/GroupfoldersFile.jpg
```

```bash
# Let's try some time filtering, again with "all" deleted files and please be verbose about the filters...
devcontainer@b03e2fb2a292:/var/www/html$ php occ trashbin:restore --dry-run --all-users --scope all --restore-from "12.08.2023 13:04:44" --restore-to "12.08.2023 13:04:46" -v 2>/dev/null 
Restoring deleted files for all users
Restoring deleted files for users on backend Database
admin
Skipping Userfile.txt because it was deleted after the restore-to timestamp
Would restore 1 files...
Would restore GroupfoldersFile.jpg originally deleted at August 12, 2023, 1:04:45 PM UTC to /gf1/GroupfoldersFile.jpg
```

> **Note:** I only used `2>/dev/null` to cleanup the output in my dev environment. Should not be needed in production environments.

## TODO

- [x] Add new parameters and samples to occ documentation (done: https://github.com/nextcloud/documentation/pull/11011)
- [x] Feedback about other implementations of `ITrashBackend` which would be found by the `TrashManager`: are there any of them and if yes, how to deal with them?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
