### PR TITLE
Add l10n for files_reminders

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -74,6 +74,12 @@ source_file = translationfiles/templates/files_external.pot
 source_lang = en
 type        = PO
 
+[o:nextcloud:p:nextcloud:r:files_reminders]
+file_filter = translationfiles/<lang>/files_reminders.po
+source_file = translationfiles/templates/files_reminders.pot
+source_lang = en
+type        = PO
+
 [o:nextcloud:p:nextcloud:r:files_sharing]
 file_filter = translationfiles/<lang>/files_sharing.po
 source_file = translationfiles/templates/files_sharing.pot
@@ -175,4 +181,3 @@ file_filter = translationfiles/<lang>/workflowengine.po
 source_file = translationfiles/templates/workflowengine.pot
 source_lang = en
 type        = PO
-


### PR DESCRIPTION
## Summary

Add l10n support for files_reminders

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)