### PR TITLE
Remove check for very old PGsql version

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -68,7 +68,6 @@ use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\SetupManager;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
-use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -715,48 +715,9 @@ class OC_Util {
 			}
 		}
 
-		$errors = array_merge($errors, self::checkDatabaseVersion());
-
 		// Cache the result of this function
 		\OC::$server->getSession()->set('checkServer_succeeded', count($errors) == 0);
 
-		return $errors;
-	}
-
-	/**
-	 * Check the database version
-	 *
-	 * @return array errors array
-	 */
-	public static function checkDatabaseVersion() {
-		$l = \OC::$server->getL10N('lib');
-		$errors = [];
-		$dbType = \OC::$server->getSystemConfig()->getValue('dbtype', 'sqlite');
-		if ($dbType === 'pgsql') {
-			// check PostgreSQL version
-			// TODO latest postgresql 8 released was 8 years ago, maybe remove the
-			// check completely?
-			try {
-				/** @var IDBConnection $connection */
-				$connection = \OC::$server->get(IDBConnection::class);
-				$result = $connection->executeQuery('SHOW SERVER_VERSION');
-				$data = $result->fetch();
-				$result->closeCursor();
-				if (isset($data['server_version'])) {
-					$version = $data['server_version'];
-					if (version_compare($version, '9.0.0', '<')) {
-						$errors[] = [
-							'error' => $l->t('PostgreSQL >= 9 required.'),
-							'hint' => $l->t('Please upgrade your database version.')
-						];
-					}
-				}
-			} catch (\Doctrine\DBAL\Exception $e) {
-				$logger = \OC::$server->getLogger();
-				$logger->warning('Error occurred while checking PostgreSQL version, assuming >= 9');
-				$logger->logException($e);
-			}
-		}
 		return $errors;
 	}
 


### PR DESCRIPTION
## Summary

PGSQL 8 is unsupported since... July 24, **2014**, assuming no one uses it in production. 🧑‍🔧 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)