### PR TITLE
Stop sending deprecated Pragma header

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -98,7 +98,6 @@ class ImageExportPlugin extends ServerPlugin {
 
 		$response->setHeader('Cache-Control', 'private, max-age=3600, must-revalidate');
 		$response->setHeader('Etag', $node->getETag());
-		$response->setHeader('Pragma', 'public');
 
 		try {
 			$file = $this->cache->get($addressbook->getResourceId(), $node->getName(), $size, $node);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -162,12 +162,11 @@ class ImageExportPluginTest extends TestCase {
 				->with(1, 'card', $size, $card)
 				->willReturn($file);
 
-			$this->response->expects($this->exactly(5))
+			$this->response->expects($this->exactly(4))
 				->method('setHeader')
 				->withConsecutive(
 					['Cache-Control', 'private, max-age=3600, must-revalidate'],
 					['Etag', '"myEtag"'],
-					['Pragma', 'public'],
 					['Content-Type', 'image/jpeg'],
 					['Content-Disposition', 'attachment; filename=card.jpg'],
 				);
@@ -179,12 +178,11 @@ class ImageExportPluginTest extends TestCase {
 				->method('setBody')
 				->with('imgdata');
 		} else {
-			$this->response->expects($this->exactly(3))
+			$this->response->expects($this->exactly(2))
 				->method('setHeader')
 				->withConsecutive(
 					['Cache-Control', 'private, max-age=3600, must-revalidate'],
 					['Etag', '"myEtag"'],
-					['Pragma', 'public'],
 				);
 			$this->cache->method('get')
 				->with(1, 'card', $size, $card)

--- a/core/Controller/CssController.php
+++ b/core/Controller/CssController.php
@@ -90,7 +90,6 @@ class CssController extends Controller {
 		$expires->setTimestamp($this->timeFactory->getTime());
 		$expires->add(new \DateInterval('PT'.$ttl.'S'));
 		$response->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$response->addHeader('Pragma', 'cache');
 		return $response;
 	}
 

--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -90,7 +90,6 @@ class JsController extends Controller {
 		$expires->setTimestamp($this->timeFactory->getTime());
 		$expires->add(new \DateInterval('PT'.$ttl.'S'));
 		$response->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$response->addHeader('Pragma', 'cache');
 		return $response;
 	}
 

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -76,7 +76,6 @@ class OC_Files {
 	private static function sendHeaders($filename, $name, array $rangeArray): void {
 		OC_Response::setContentDispositionHeader($name, 'attachment');
 		header('Content-Transfer-Encoding: binary', true);
-		header('Pragma: public');// enable caching in IE
 		header('Expires: 0');
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		$fileSize = \OC\Files\Filesystem::filesize($filename);

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -112,9 +112,8 @@ class Response {
 	 */
 	public function cacheFor(int $cacheSeconds, bool $public = false, bool $immutable = false) {
 		if ($cacheSeconds > 0) {
-			$pragma = $public ? 'public' : 'private';
-			$this->addHeader('Cache-Control', sprintf('%s, max-age=%s, %s', $pragma, $cacheSeconds, ($immutable ? 'immutable' : 'must-revalidate')));
-			$this->addHeader('Pragma', $pragma);
+			$cacheStore = $public ? 'public' : 'private';
+			$this->addHeader('Cache-Control', sprintf('%s, max-age=%s, %s', $cacheStore, $cacheSeconds, ($immutable ? 'immutable' : 'must-revalidate')));
 
 			// Set expires header
 			$expires = new \DateTime();
@@ -125,7 +124,7 @@ class Response {
 			$this->addHeader('Expires', $expires->format(\DateTimeInterface::RFC2822));
 		} else {
 			$this->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-			unset($this->headers['Expires'], $this->headers['Pragma']);
+			unset($this->headers['Expires']);
 		}
 
 		return $this;

--- a/tests/Core/Controller/CssControllerTest.php
+++ b/tests/Core/Controller/CssControllerTest.php
@@ -117,7 +117,6 @@ class CssControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getCss('file.css', 'myapp');
 		$this->assertEquals($expected, $result);
@@ -147,7 +146,6 @@ class CssControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getCss('file.css', 'myapp');
 		$this->assertEquals($expected, $result);
@@ -182,7 +180,6 @@ class CssControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getCss('file.css', 'myapp');
 		$this->assertEquals($expected, $result);

--- a/tests/Core/Controller/JsControllerTest.php
+++ b/tests/Core/Controller/JsControllerTest.php
@@ -117,7 +117,6 @@ class JsControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getJs('file.js', 'myapp');
 		$this->assertEquals($expected, $result);
@@ -147,7 +146,6 @@ class JsControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getJs('file.js', 'myapp');
 		$this->assertEquals($expected, $result);
@@ -182,7 +180,6 @@ class JsControllerTest extends TestCase {
 		$expires->setTimestamp(1337);
 		$expires->add(new \DateInterval('PT31536000S'));
 		$expected->addHeader('Expires', $expires->format(\DateTime::RFC1123));
-		$expected->addHeader('Pragma', 'cache');
 
 		$result = $this->controller->getJs('file.js', 'myapp');
 		$this->assertEquals($expected, $result);

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -229,7 +229,6 @@ class ResponseTest extends \Test\TestCase {
 
 		$headers = $this->childResponse->getHeaders();
 		$this->assertEquals('no-cache, no-store, must-revalidate', $headers['Cache-Control']);
-		$this->assertFalse(isset($headers['Pragma']));
 		$this->assertFalse(isset($headers['Expires']));
 	}
 
@@ -245,7 +244,6 @@ class ResponseTest extends \Test\TestCase {
 
 		$headers = $this->childResponse->getHeaders();
 		$this->assertEquals('private, max-age=33, must-revalidate', $headers['Cache-Control']);
-		$this->assertEquals('private', $headers['Pragma']);
 		$this->assertEquals('Thu, 15 Jan 1970 06:56:40 +0000', $headers['Expires']);
 	}
 


### PR DESCRIPTION
## Summary
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma
![image](https://github.com/nextcloud/server/assets/12234510/72bdf9c3-3790-4aeb-a423-3d6b52275ce4)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)