### PR TITLE
feat(testing): Add fake providers for translations and text processing

### DIFF
--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -13,4 +13,6 @@ return array(
     'OCA\\Testing\\Controller\\LockingController' => $baseDir . '/../lib/Controller/LockingController.php',
     'OCA\\Testing\\Controller\\RateLimitTestController' => $baseDir . '/../lib/Controller/RateLimitTestController.php',
     'OCA\\Testing\\Locking\\FakeDBLockingProvider' => $baseDir . '/../lib/Locking/FakeDBLockingProvider.php',
+    'OCA\\Testing\\Provider\\FakeTextProcessingProvider' => $baseDir . '/../lib/Provider/FakeTextProcessingProvider.php',
+    'OCA\\Testing\\Provider\\FakeTranslationProvider' => $baseDir . '/../lib/Provider/FakeTranslationProvider.php',
 );

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -28,6 +28,8 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\Controller\\LockingController' => __DIR__ . '/..' . '/../lib/Controller/LockingController.php',
         'OCA\\Testing\\Controller\\RateLimitTestController' => __DIR__ . '/..' . '/../lib/Controller/RateLimitTestController.php',
         'OCA\\Testing\\Locking\\FakeDBLockingProvider' => __DIR__ . '/..' . '/../lib/Locking/FakeDBLockingProvider.php',
+        'OCA\\Testing\\Provider\\FakeTextProcessingProvider' => __DIR__ . '/..' . '/../lib/Provider/FakeTextProcessingProvider.php',
+        'OCA\\Testing\\Provider\\FakeTranslationProvider' => __DIR__ . '/..' . '/../lib/Provider/FakeTranslationProvider.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/testing/lib/AppInfo/Application.php
+++ b/apps/testing/lib/AppInfo/Application.php
@@ -25,6 +25,8 @@
 namespace OCA\Testing\AppInfo;
 
 use OCA\Testing\AlternativeHomeUserBackend;
+use OCA\Testing\Provider\FakeTranslationProvider;
+use OCA\Testing\Provider\FakeTextProcessingProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -36,6 +38,8 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		$context->registerTranslationProvider(FakeTranslationProvider::class);
+		$context->registerTextProcessingProvider(FakeTextProcessingProvider::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/apps/testing/lib/Provider/FakeTextProcessingProvider.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProvider.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Testing\Provider;
+
+use OCP\TextProcessing\FreePromptTaskType;
+use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\ITaskType;
+
+/** @template-implements IProvider<FreePromptTaskType|ITaskType> */
+class FakeTextProcessingProvider implements IProvider {
+
+	public function getName(): string {
+		return 'Fake text processing provider';
+	}
+
+	public function process(string $prompt): string {
+		return strrev($prompt);
+	}
+
+	public function getTaskType(): string {
+		return FreePromptTaskType::class;
+	}
+}

--- a/apps/testing/lib/Provider/FakeTranslationProvider.php
+++ b/apps/testing/lib/Provider/FakeTranslationProvider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Testing\Provider;
+
+use OCP\Translation\ITranslationProvider;
+use OCP\Translation\LanguageTuple;
+
+class FakeTranslationProvider implements ITranslationProvider {
+
+	public function getName(): string {
+		return 'Fake translation';
+	}
+
+	public function getAvailableLanguages(): array {
+		return [
+			new LanguageTuple('de', 'German', 'en', 'English'),
+			new LanguageTuple('en', 'English', 'de', 'German'),
+		];
+	}
+
+	public function translate(?string $fromLanguage, string $toLanguage, string $text): string {
+		return strrev($text);
+	}
+}


### PR DESCRIPTION
Make it easier to test integration with translation and text processing API for app developers and have fake providers available for e2e tests in apps more easily.

Will allow us to write cypress tests for this in text.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
