### PR TITLE
don't preload metadata for the sub-childen

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -465,7 +465,7 @@ class FilesPlugin extends ServerPlugin {
 
 			$requestProperties = $propFind->getRequestedProperties();
 
-			if ($this->config->getSystemValueBool('enable_file_metadata', true)) {
+			if ($this->config->getSystemValueBool('enable_file_metadata', true) && $propFind->getDepth() === 1) {
 				$requestedMetaData = [];
 				foreach ($requestProperties as $requestProperty) {
 					if (isset(self::ALL_METADATA_PROPS[$requestProperty])) {

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -465,13 +465,17 @@ class FilesPlugin extends ServerPlugin {
 
 			$requestProperties = $propFind->getRequestedProperties();
 
-			if ($this->config->getSystemValueBool('enable_file_metadata', true) && $propFind->getDepth() === 1) {
-				$requestedMetaData = [];
-				foreach ($requestProperties as $requestProperty) {
-					if (isset(self::ALL_METADATA_PROPS[$requestProperty])) {
-						$requestedMetaData[] = self::ALL_METADATA_PROPS[$requestProperty];
-					}
+			$requestedMetaData = [];
+			foreach ($requestProperties as $requestProperty) {
+				if (isset(self::ALL_METADATA_PROPS[$requestProperty])) {
+					$requestedMetaData[] = self::ALL_METADATA_PROPS[$requestProperty];
 				}
+			}
+			if (
+				$this->config->getSystemValueBool('enable_file_metadata', true) &&
+				$propFind->getDepth() === 1 &&
+				$requestedMetaData
+			) {
 				$children = $node->getChildren();
 				// Preloading of the metadata
 


### PR DESCRIPTION
Fixes to broad preloading logic introduced with https://github.com/nextcloud/server/pull/39694

- Only preload when `Depth = 1`, this stops preloading for the children of sub-folders
- Don't trigger preload logic when no metadata is requested.