### PR TITLE
move share permission logic to storage wrapper

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -36,6 +36,8 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Cache\Scanner;
+use OC\Files\Filesystem;
+use OC\Files\SetupManager;
 use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCP\App\IAppManager;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -73,6 +75,8 @@ class ApiTest extends TestCase {
 
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups', 'no');
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_expire_after_n_days', '7');
+
+		Filesystem::getLoader()->removeStorageWrapper('sharing_mask');
 
 		$this->folder = self::TEST_FOLDER_NAME;
 		$this->subfolder = '/subfolder_share_api_test';

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -30,6 +30,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\KnownUser\KnownUserService;
 use OC\Share20\Manager;
+use OC\Share20\ShareDisableChecker;
 use OCA\Files_Sharing\Capabilities;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
@@ -94,7 +95,8 @@ class CapabilitiesTest extends \Test\TestCase {
 			$this->createMock(\OC_Defaults::class),
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(IUserSession::class),
-			$this->createMock(KnownUserService::class)
+			$this->createMock(KnownUserService::class),
+			$this->createMock(ShareDisableChecker::class)
 		);
 		$cap = new Capabilities($config, $shareManager);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1642,6 +1642,7 @@ return array(
     'OC\\Share20\\PublicShareTemplateFactory' => $baseDir . '/lib/private/Share20/PublicShareTemplateFactory.php',
     'OC\\Share20\\Share' => $baseDir . '/lib/private/Share20/Share.php',
     'OC\\Share20\\ShareAttributes' => $baseDir . '/lib/private/Share20/ShareAttributes.php',
+    'OC\\Share20\\ShareDisableChecker' => $baseDir . '/lib/private/Share20/ShareDisableChecker.php',
     'OC\\Share20\\ShareHelper' => $baseDir . '/lib/private/Share20/ShareHelper.php',
     'OC\\Share20\\UserRemovedListener' => $baseDir . '/lib/private/Share20/UserRemovedListener.php',
     'OC\\Share\\Constants' => $baseDir . '/lib/private/Share/Constants.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1675,6 +1675,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Share20\\PublicShareTemplateFactory' => __DIR__ . '/../../..' . '/lib/private/Share20/PublicShareTemplateFactory.php',
         'OC\\Share20\\Share' => __DIR__ . '/../../..' . '/lib/private/Share20/Share.php',
         'OC\\Share20\\ShareAttributes' => __DIR__ . '/../../..' . '/lib/private/Share20/ShareAttributes.php',
+        'OC\\Share20\\ShareDisableChecker' => __DIR__ . '/../../..' . '/lib/private/Share20/ShareDisableChecker.php',
         'OC\\Share20\\ShareHelper' => __DIR__ . '/../../..' . '/lib/private/Share20/ShareHelper.php',
         'OC\\Share20\\UserRemovedListener' => __DIR__ . '/../../..' . '/lib/private/Share20/UserRemovedListener.php',
         'OC\\Share\\Constants' => __DIR__ . '/../../..' . '/lib/private/Share/Constants.php',

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -231,7 +231,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
-	 * Return the currently version used for the HMAC in the encryption app
+	 * Return the current version used for the HMAC in the encryption app
 	 */
 	public function getEncryptedVersion(): int {
 		return isset($this->data['encryptedVersion']) ? (int) $this->data['encryptedVersion'] : 1;
@@ -241,11 +241,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return int
 	 */
 	public function getPermissions() {
-		$perms = (int) $this->data['permissions'];
-		if (\OCP\Util::isSharingDisabledForUser() || ($this->isShared() && !\OC\Share\Share::isResharingAllowed())) {
-			$perms = $perms & ~\OCP\Constants::PERMISSION_SHARE;
-		}
-		return $perms;
+		return (int) $this->data['permissions'];
 	}
 
 	/**

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -26,6 +26,7 @@
 namespace OC\Files\ObjectStore;
 
 use OC\User\User;
+use OCP\IUser;
 
 class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IHomeStorage {
 	/**
@@ -61,7 +62,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 	 * @param string $path, optional
 	 * @return \OC\User\User
 	 */
-	public function getUser($path = null) {
+	public function getUser($path = null): IUser {
 		return $this->user;
 	}
 }

--- a/lib/private/Files/SetupManagerFactory.php
+++ b/lib/private/Files/SetupManagerFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OC\Files;
 
+use OC\Share20\ShareDisableChecker;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProviderCollection;
@@ -36,40 +37,21 @@ use OCP\Lockdown\ILockdownManager;
 use Psr\Log\LoggerInterface;
 
 class SetupManagerFactory {
-	private IEventLogger $eventLogger;
-	private IMountProviderCollection $mountProviderCollection;
-	private IUserManager $userManager;
-	private IEventDispatcher $eventDispatcher;
-	private IUserMountCache $userMountCache;
-	private ILockdownManager $lockdownManager;
-	private IUserSession $userSession;
 	private ?SetupManager $setupManager;
-	private ICacheFactory $cacheFactory;
-	private LoggerInterface $logger;
-	private IConfig $config;
 
 	public function __construct(
-		IEventLogger $eventLogger,
-		IMountProviderCollection $mountProviderCollection,
-		IUserManager $userManager,
-		IEventDispatcher $eventDispatcher,
-		IUserMountCache $userMountCache,
-		ILockdownManager $lockdownManager,
-		IUserSession $userSession,
-		ICacheFactory $cacheFactory,
-		LoggerInterface $logger,
-		IConfig $config
+		private IEventLogger $eventLogger,
+		private IMountProviderCollection $mountProviderCollection,
+		private IUserManager $userManager,
+		private IEventDispatcher $eventDispatcher,
+		private IUserMountCache $userMountCache,
+		private ILockdownManager $lockdownManager,
+		private IUserSession $userSession,
+		private ICacheFactory $cacheFactory,
+		private LoggerInterface $logger,
+		private IConfig $config,
+		private ShareDisableChecker $shareDisableChecker,
 	) {
-		$this->eventLogger = $eventLogger;
-		$this->mountProviderCollection = $mountProviderCollection;
-		$this->userManager = $userManager;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->userMountCache = $userMountCache;
-		$this->lockdownManager = $lockdownManager;
-		$this->userSession = $userSession;
-		$this->cacheFactory = $cacheFactory;
-		$this->logger = $logger;
-		$this->config = $config;
 		$this->setupManager = null;
 	}
 
@@ -86,7 +68,8 @@ class SetupManagerFactory {
 				$this->userSession,
 				$this->cacheFactory,
 				$this->logger,
-				$this->config
+				$this->config,
+				$this->shareDisableChecker,
 			);
 		}
 		return $this->setupManager;

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -26,6 +26,7 @@
 namespace OC\Files\Storage;
 
 use OC\Files\Cache\HomePropagator;
+use OCP\IUser;
 
 /**
  * Specialized version of Local storage for home directory usage
@@ -94,7 +95,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 	 *
 	 * @return \OC\User\User owner of this home storage
 	 */
-	public function getUser() {
+	public function getUser(): IUser {
 		return $this->user;
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -146,6 +146,7 @@ use OC\Security\TrustedDomainHelper;
 use OC\Security\VerificationToken\VerificationToken;
 use OC\Session\CryptoWrapper;
 use OC\Share20\ProviderFactory;
+use OC\Share20\ShareDisableChecker;
 use OC\Share20\ShareHelper;
 use OC\SpeechToText\SpeechToTextManager;
 use OC\SystemTag\ManagerFactory as SystemTagManagerFactory;
@@ -1237,7 +1238,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get('ThemingDefaults'),
 				$c->get(IEventDispatcher::class),
 				$c->get(IUserSession::class),
-				$c->get(KnownUserService::class)
+				$c->get(KnownUserService::class),
+				$c->get(ShareDisableChecker::class)
 			);
 
 			return $manager;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -41,7 +41,6 @@
  */
 namespace OC\Share20;
 
-use OCP\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\KnownUser\KnownUserService;
 use OC\Share20\Exception\ProviderException;
@@ -106,8 +105,6 @@ class Manager implements IManager {
 	private $userManager;
 	/** @var IRootFolder */
 	private $rootFolder;
-	/** @var CappedMemoryCache */
-	private $sharingDisabledForUsersCache;
 	/** @var LegacyHooks */
 	private $legacyHooks;
 	/** @var IMailer */
@@ -122,6 +119,7 @@ class Manager implements IManager {
 	private $userSession;
 	/** @var KnownUserService */
 	private $knownUserService;
+	private ShareDisableChecker $shareDisableChecker;
 
 	public function __construct(
 		LoggerInterface $logger,
@@ -140,7 +138,8 @@ class Manager implements IManager {
 		\OC_Defaults $defaults,
 		IEventDispatcher $dispatcher,
 		IUserSession $userSession,
-		KnownUserService $knownUserService
+		KnownUserService $knownUserService,
+		ShareDisableChecker $shareDisableChecker
 	) {
 		$this->logger = $logger;
 		$this->config = $config;
@@ -153,7 +152,6 @@ class Manager implements IManager {
 		$this->factory = $factory;
 		$this->userManager = $userManager;
 		$this->rootFolder = $rootFolder;
-		$this->sharingDisabledForUsersCache = new CappedMemoryCache();
 		// The constructor of LegacyHooks registers the listeners of share events
 		// do not remove if those are not properly migrated
 		$this->legacyHooks = new LegacyHooks($dispatcher);
@@ -163,6 +161,7 @@ class Manager implements IManager {
 		$this->dispatcher = $dispatcher;
 		$this->userSession = $userSession;
 		$this->knownUserService = $knownUserService;
+		$this->shareDisableChecker = $shareDisableChecker;
 	}
 
 	/**
@@ -2011,37 +2010,7 @@ class Manager implements IManager {
 	 * @return bool
 	 */
 	public function sharingDisabledForUser($userId) {
-		if ($userId === null) {
-			return false;
-		}
-
-		if (isset($this->sharingDisabledForUsersCache[$userId])) {
-			return $this->sharingDisabledForUsersCache[$userId];
-		}
-
-		if ($this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes') {
-			$groupsList = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
-			$excludedGroups = json_decode($groupsList);
-			if (is_null($excludedGroups)) {
-				$excludedGroups = explode(',', $groupsList);
-				$newValue = json_encode($excludedGroups);
-				$this->config->setAppValue('core', 'shareapi_exclude_groups_list', $newValue);
-			}
-			$user = $this->userManager->get($userId);
-			$usersGroups = $this->groupManager->getUserGroupIds($user);
-			if (!empty($usersGroups)) {
-				$remainingGroups = array_diff($usersGroups, $excludedGroups);
-				// if the user is only in groups which are disabled for sharing then
-				// sharing is also disabled for the user
-				if (empty($remainingGroups)) {
-					$this->sharingDisabledForUsersCache[$userId] = true;
-					return true;
-				}
-			}
-		}
-
-		$this->sharingDisabledForUsersCache[$userId] = false;
-		return false;
+		return $this->shareDisableChecker->sharingDisabledForUser($userId);
 	}
 
 	/**

--- a/lib/private/Share20/ShareDisableChecker.php
+++ b/lib/private/Share20/ShareDisableChecker.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace OC\Share20;
+
+use OCP\Cache\CappedMemoryCache;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+
+/**
+ * split of from the share manager to allow using it with minimal DI
+ */
+class ShareDisableChecker {
+	private CappedMemoryCache $sharingDisabledForUsersCache;
+
+	public function __construct(
+		private IConfig $config,
+		private IUserManager $userManager,
+		private IGroupManager $groupManager,
+	) {
+		$this->sharingDisabledForUsersCache = new CappedMemoryCache();
+	}
+
+
+	/**
+	 * @param ?string $userId
+	 * @return bool
+	 */
+	public function sharingDisabledForUser(?string $userId) {
+		if ($userId === null) {
+			return false;
+		}
+
+		if (isset($this->sharingDisabledForUsersCache[$userId])) {
+			return $this->sharingDisabledForUsersCache[$userId];
+		}
+
+		if ($this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes') {
+			$groupsList = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
+			$excludedGroups = json_decode($groupsList);
+			if (is_null($excludedGroups)) {
+				$excludedGroups = explode(',', $groupsList);
+				$newValue = json_encode($excludedGroups);
+				$this->config->setAppValue('core', 'shareapi_exclude_groups_list', $newValue);
+			}
+			$user = $this->userManager->get($userId);
+			if (!$user) {
+				return false;
+			}
+			$usersGroups = $this->groupManager->getUserGroupIds($user);
+			if (!empty($usersGroups)) {
+				$remainingGroups = array_diff($usersGroups, $excludedGroups);
+				// if the user is only in groups which are disabled for sharing then
+				// sharing is also disabled for the user
+				if (empty($remainingGroups)) {
+					$this->sharingDisabledForUsersCache[$userId] = true;
+					return true;
+				}
+			}
+		}
+
+		$this->sharingDisabledForUsersCache[$userId] = false;
+		return false;
+	}
+}

--- a/lib/public/Files/IHomeStorage.php
+++ b/lib/public/Files/IHomeStorage.php
@@ -27,6 +27,7 @@
 namespace OCP\Files;
 
 use OCP\Files\Storage\IStorage;
+use OCP\IUser;
 
 /**
  * Interface IHomeStorage
@@ -34,4 +35,11 @@ use OCP\Files\Storage\IStorage;
  * @since 7.0.0
  */
 interface IHomeStorage extends IStorage {
+	/**
+	 * Get the user for this home storage
+	 *
+	 * @return IUser
+	 * @since 28.0.0
+	 */
+	public function getUser(): IUser;
 }

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -7,6 +7,7 @@
 
 namespace Test\Files;
 
+use OC\Share20\ShareDisableChecker;
 use OCP\Cache\CappedMemoryCache;
 use OC\Files\Cache\Watcher;
 use OC\Files\Filesystem;
@@ -295,7 +296,7 @@ class ViewTest extends \Test\TestCase {
 	 */
 	public function testRemoveSharePermissionWhenSharingDisabledForUser($excludeGroups, $excludeGroupsList, $expectedShareable) {
 		// Reset sharing disabled for users cache
-		self::invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
+		self::invokePrivate(\OC::$server->get(ShareDisableChecker::class), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 
 		$config = \OC::$server->getConfig();
 		$oldExcludeGroupsFlag = $config->getAppValue('core', 'shareapi_exclude_groups', 'no');
@@ -320,7 +321,7 @@ class ViewTest extends \Test\TestCase {
 		$config->setAppValue('core', 'shareapi_exclude_groups_list', $oldExcludeGroupsList);
 
 		// Reset sharing disabled for users cache
-		self::invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
+		self::invokePrivate(\OC::$server->get(ShareDisableChecker::class), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 	}
 
 	public function testCacheIncompleteFolder() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -27,6 +27,7 @@ use OC\Share20\DefaultShareProvider;
 use OC\Share20\Exception;
 use OC\Share20\Manager;
 use OC\Share20\Share;
+use OC\Share20\ShareDisableChecker;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -111,6 +112,8 @@ class ManagerTest extends \Test\TestCase {
 	protected $userSession;
 	/** @var KnownUserService|MockObject  */
 	protected $knownUserService;
+	/** @var ShareDisableChecker|MockObject  */
+	protected $shareDisabledChecker;
 
 	protected function setUp(): void {
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -127,6 +130,8 @@ class ManagerTest extends \Test\TestCase {
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
+
+		$this->shareDisabledChecker = new ShareDisableChecker($this->config, $this->userManager, $this->groupManager);
 
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l = $this->createMock(IL10N::class);
@@ -158,7 +163,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker
 		);
 
 		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
@@ -188,7 +194,8 @@ class ManagerTest extends \Test\TestCase {
 				$this->defaults,
 				$this->dispatcher,
 				$this->userSession,
-				$this->knownUserService
+				$this->knownUserService,
+				$this->shareDisabledChecker,
 			]);
 	}
 
@@ -2753,7 +2760,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2798,7 +2806,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2850,7 +2859,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -4191,7 +4201,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 		$this->assertSame($expected,
 			$manager->shareProviderExists($shareType)
@@ -4225,7 +4236,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4290,7 +4302,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4407,7 +4420,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4533,7 +4547,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->defaults,
 			$this->dispatcher,
 			$this->userSession,
-			$this->knownUserService
+			$this->knownUserService,
+			$this->shareDisabledChecker
 		);
 
 		$factory->setProvider($this->defaultProvider);


### PR DESCRIPTION
this way we only have to determine the share permissions once per storage instead of once per file

Saves about 30% time in large file listings: https://blackfire.io/profiles/compare/e6ab53a7-9b04-415b-ba07-1dd069fb19a1/graph
