### PR TITLE
reuse l10n and request in dav folder listing

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -35,16 +35,19 @@ namespace OCA\DAV\Connector\Sabre;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
 use OC\Metadata\FileMetadata;
+use OCA\DAV\AppInfo\Application;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
-use OCA\DAV\Upload\FutureFile;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\L10N\IFactory;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
@@ -203,7 +206,7 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 	 * @throws \Sabre\DAV\Exception\NotFound
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
-	public function getChild($name, $info = null) {
+	public function getChild($name, $info = null, IRequest $request = null, IL10N $l10n = null) {
 		if (!$this->info->isReadable()) {
 			// avoid detecting files through this way
 			throw new NotFound();
@@ -230,7 +233,7 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 		if ($info->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
 			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this->tree, $this->shareManager);
 		} else {
-			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info, $this->shareManager);
+			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info, $this->shareManager, $request, $l10n);
 		}
 		if ($this->tree) {
 			$this->tree->cacheNode($node);
@@ -265,8 +268,11 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 		}
 
 		$nodes = [];
+		$request = \OC::$server->get(IRequest::class);
+		$l10nFactory = \OC::$server->get(IFactory::class);
+		$l10n = $l10nFactory->get(Application::APP_ID);
 		foreach ($folderContent as $info) {
-			$node = $this->getChild($info->getName(), $info);
+			$node = $this->getChild($info->getName(), $info, $request, $l10n);
 			$nodes[] = $node;
 		}
 		$this->dirContent = $nodes;

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -73,9 +73,6 @@ class FileTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		unset($_SERVER['HTTP_OC_CHUNKED']);
-		unset($_SERVER['CONTENT_LENGTH']);
-		unset($_SERVER['REQUEST_METHOD']);
 
 		\OC_Hook::clear();
 
@@ -91,7 +88,6 @@ class FileTest extends TestCase {
 	protected function tearDown(): void {
 		$userManager = \OC::$server->getUserManager();
 		$userManager->get($this->user)->delete();
-		unset($_SERVER['HTTP_OC_CHUNKED']);
 
 		parent::tearDown();
 	}
@@ -271,13 +267,17 @@ class FileTest extends TestCase {
 			->method('getRelativePath')
 			->willReturnArgument(0);
 
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
+		$request = new Request([
+			'server' => [
+				'HTTP_OC_CHUNKED' => 'true'
+			]
+		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/test.txt-chunking-12345-2-0', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// put first chunk
 		$file->acquireLock(ILockingProvider::LOCK_SHARED);
@@ -288,7 +288,7 @@ class FileTest extends TestCase {
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// action
 		$caughtException = null;
@@ -421,7 +421,7 @@ class FileTest extends TestCase {
 	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime): void {
 		$request = new Request([
 			'server' => [
-				'HTTP_X_OC_MTIME' => $requestMtime,
+				'HTTP_X_OC_MTIME' => (string)$requestMtime,
 			]
 		], $this->requestId, $this->config, null);
 		$file = 'foo.txt';
@@ -444,11 +444,11 @@ class FileTest extends TestCase {
 	public function testChunkedPutLegalMtime($requestMtime, $resultMtime): void {
 		$request = new Request([
 			'server' => [
-				'HTTP_X_OC_MTIME' => $requestMtime,
+				'HTTP_X_OC_MTIME' => (string)$requestMtime,
+				'HTTP_OC_CHUNKED' => 'true'
 			]
 		], $this->requestId, $this->config, null);
 
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
 		$file = 'foo.txt';
 
 		if ($resultMtime === null) {
@@ -467,9 +467,13 @@ class FileTest extends TestCase {
 	 * Test putting a file using chunking
 	 */
 	public function testChunkedPut(): void {
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
-		$this->assertNull($this->doPut('/test.txt-chunking-12345-2-0'));
-		$this->assertNotEmpty($this->doPut('/test.txt-chunking-12345-2-1'));
+		$request = new Request([
+			'server' => [
+				'HTTP_OC_CHUNKED' => 'true'
+			]
+		], $this->requestId, $this->config, null);
+		$this->assertNull($this->doPut('/test.txt-chunking-12345-2-0', null, $request));
+		$this->assertNotEmpty($this->doPut('/test.txt-chunking-12345-2-1', null, $request));
 	}
 
 	/**
@@ -580,9 +584,13 @@ class FileTest extends TestCase {
 	public function testPutChunkedFileTriggersHooks(): void {
 		HookHelper::setUpHooks();
 
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
-		$this->assertNull($this->doPut('/foo.txt-chunking-12345-2-0'));
-		$this->assertNotEmpty($this->doPut('/foo.txt-chunking-12345-2-1'));
+		$request = new Request([
+			'server' => [
+				'HTTP_OC_CHUNKED' => 'true'
+			]
+		], $this->requestId, $this->config, null);
+		$this->assertNull($this->doPut('/foo.txt-chunking-12345-2-0', null, $request));
+		$this->assertNotEmpty($this->doPut('/foo.txt-chunking-12345-2-1', null, $request));
 
 		$this->assertCount(4, HookHelper::$hookCalls);
 		$this->assertHookCall(
@@ -616,9 +624,13 @@ class FileTest extends TestCase {
 
 		HookHelper::setUpHooks();
 
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
-		$this->assertNull($this->doPut('/foo.txt-chunking-12345-2-0'));
-		$this->assertNotEmpty($this->doPut('/foo.txt-chunking-12345-2-1'));
+		$request = new Request([
+			'server' => [
+				'HTTP_OC_CHUNKED' => 'true'
+			]
+		], $this->requestId, $this->config, null);
+		$this->assertNull($this->doPut('/foo.txt-chunking-12345-2-0', null, $request));
+		$this->assertNotEmpty($this->doPut('/foo.txt-chunking-12345-2-1', null, $request));
 
 		$this->assertCount(4, HookHelper::$hookCalls);
 		$this->assertHookCall(
@@ -693,15 +705,19 @@ class FileTest extends TestCase {
 			->method('filesize')
 			->willReturn(123456);
 
-		$_SERVER['CONTENT_LENGTH'] = 123456;
-		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$request = new Request([
+			'server' => [
+				'CONTENT_LENGTH' => '123456',
+			],
+			'method' => 'PUT',
+		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// action
 		$thrown = false;
@@ -764,13 +780,17 @@ class FileTest extends TestCase {
 		// simulate situation where the target file is locked
 		$view->lockFile('/test.txt', ILockingProvider::LOCK_EXCLUSIVE);
 
-		$_SERVER['HTTP_OC_CHUNKED'] = true;
+		$request = new Request([
+			'server' => [
+				'HTTP_OC_CHUNKED' => 'true'
+			]
+		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt-chunking-12345-2-0', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 		$file->acquireLock(ILockingProvider::LOCK_SHARED);
 		$this->assertNull($file->put('test data one'));
 		$file->releaseLock(ILockingProvider::LOCK_SHARED);
@@ -779,7 +799,7 @@ class FileTest extends TestCase {
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// action
 		$thrown = false;
@@ -872,15 +892,19 @@ class FileTest extends TestCase {
 			->method('filesize')
 			->willReturn(123456);
 
-		$_SERVER['CONTENT_LENGTH'] = 12345;
-		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$request = new Request([
+			'server' => [
+				'CONTENT_LENGTH' => '123456',
+			],
+			'method' => 'PUT',
+		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
 
 		// action
 		$thrown = false;

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -32,7 +32,9 @@ use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Server;
 use OCA\DAV\Connector\Sabre\ServerFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IRequestId;
 use Psr\Log\LoggerInterface;
 use Sabre\HTTP\Request;
 use Test\TestCase;
@@ -57,8 +59,6 @@ abstract class RequestTestCase extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		unset($_SERVER['HTTP_OC_CHUNKED']);
 
 		$this->serverFactory = new ServerFactory(
 			\OC::$server->getConfig(),
@@ -106,20 +106,25 @@ abstract class RequestTestCase extends TestCase {
 
 		// since sabre catches all exceptions we need to save them and throw them from outside the sabre server
 
-		$originalServer = $_SERVER;
-
+		$serverParams = [];
 		if (is_array($headers)) {
 			foreach ($headers as $header => $value) {
-				$_SERVER['HTTP_' . strtoupper(str_replace('-', '_', $header))] = $value;
+				$serverParams['HTTP_' . strtoupper(str_replace('-', '_', $header))] = $value;
 			}
 		}
+		$ncRequest = new \OC\AppFramework\Http\Request([
+			'server' => $serverParams
+		], $this->createMock(IRequestId::class), $this->createMock(IConfig::class), null);
+
+		$this->overwriteService(IRequest::class, $ncRequest);
 
 		$result = $this->makeRequest($server, $request);
+
+		$this->restoreService(IRequest::class);
 
 		foreach ($exceptionPlugin->getExceptions() as $exception) {
 			throw $exception;
 		}
-		$_SERVER = $originalServer;
 		return $result;
 	}
 


### PR DESCRIPTION
instead of having to query those once for every node

saved 15-20% when loading large folders during local testing: https://blackfire.io/profiles/compare/d33a9993-e3a4-4ea4-b9f2-f1b38f576937/graph