### PR TITLE
Fix php 8.3 support in tests

### DIFF
--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -656,7 +656,7 @@ EOS;
 		try {
 			$actual = $this->backend->getDenormalizedData($calData);
 			$this->assertEquals($expected, $actual[$key]);
-		} catch (\ValueError $e) {
+		} catch (\Throwable $e) {
 			if (($e->getMessage() === 'Epoch doesn\'t fit in a PHP integer') && (PHP_INT_SIZE < 8)) {
 				$this->markTestSkipped('This fail on 32bits because of PHP limitations in DateTime');
 			}

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -158,6 +158,7 @@ class ViewControllerTest extends TestCase {
 			->willReturnMap([
 				[$this->user->getUID(), 'files', 'file_sorting', 'name', 'name'],
 				[$this->user->getUID(), 'files', 'file_sorting_direction', 'asc', 'asc'],
+				[$this->user->getUID(), 'files', 'files_sorting_configs', '{}', '{}'],
 				[$this->user->getUID(), 'files', 'show_hidden', false, false],
 				[$this->user->getUID(), 'files', 'crop_image_previews', true, true],
 				[$this->user->getUID(), 'files', 'show_grid', true],

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -642,6 +642,11 @@ class AppManagerTest extends TestCase {
 			->with('defaultapp', $this->anything())
 			->willReturn($defaultApps);
 
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('user1', 'core', 'defaultapp')
+			->willReturn('');
+
 		$this->assertEquals($expectedApp, $this->manager->getDefaultAppForUser());
 	}
 }

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
+use OCP\Security\IHasher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -47,6 +48,8 @@ class PublicKeyTokenProviderTest extends TestCase {
 	private $tokenProvider;
 	/** @var PublicKeyTokenMapper|\PHPUnit\Framework\MockObject\MockObject */
 	private $mapper;
+	/** @var IHasher|\PHPUnit\Framework\MockObject\MockObject */
+	private $hasher;
 	/** @var ICrypto */
 	private $crypto;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */

--- a/tests/lib/Contacts/ContactsMenu/Providers/LocalTimeProviderTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Providers/LocalTimeProviderTest.php
@@ -46,6 +46,8 @@ class LocalTimeProviderTest extends TestCase {
 	private $actionFactory;
 	/** @var IL10N|MockObject */
 	private $l;
+	/** @var IL10NFactory|MockObject */
+	private $l10nFactory;
 	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 	/** @var IUserManager|MockObject */

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1568,10 +1568,10 @@ class ViewTest extends \Test\TestCase {
 		$defaultRootValue->setAccessible(true);
 		$oldRoot = $defaultRootValue->getValue();
 		$defaultView = new View('/foo/files');
-		$defaultRootValue->setValue($defaultView);
+		$defaultRootValue->setValue(null, $defaultView);
 		$view = new View($root);
 		$result = self::invokePrivate($view, 'shouldEmitHooks', [$path]);
-		$defaultRootValue->setValue($oldRoot);
+		$defaultRootValue->setValue(null, $oldRoot);
 		$this->assertEquals($shouldEmit, $result);
 	}
 

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -36,6 +36,7 @@ class ClientTest extends \Test\TestCase {
 	private $config;
 	/** @var IRemoteHostValidator|MockObject */
 	private IRemoteHostValidator $remoteHostValidator;
+	private LoggerInterface $logger;
 	/** @var array */
 	private $defaultRequestOptions;
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -230,7 +230,11 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			$property->setAccessible(true);
 
 			if (!empty($parameters)) {
-				$property->setValue($object, array_pop($parameters));
+				if ($property->isStatic()) {
+					$property->setValue(null, array_pop($parameters));
+				} else {
+					$property->setValue($object, array_pop($parameters));
+				}
 			}
 
 			if (is_object($object)) {

--- a/tests/lib/TextProcessing/TextProcessingTest.php
+++ b/tests/lib/TextProcessing/TextProcessingTest.php
@@ -19,6 +19,7 @@ use OC\TextProcessing\RemoveOldTasksBackgroundJob;
 use OC\TextProcessing\TaskBackgroundJob;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
 use OCP\Common\Exception\NotFoundException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -90,6 +91,14 @@ class FreePromptProvider implements IProvider {
 class TextProcessingTest extends \Test\TestCase {
 	private IManager $manager;
 	private Coordinator $coordinator;
+	private array $providers;
+	private IServerContainer $serverContainer;
+	private IEventDispatcher $eventDispatcher;
+	private RegistrationContext $registrationContext;
+	private \DateTimeImmutable $currentTime;
+	private TaskMapper $taskMapper;
+	private array $tasksDb;
+	private IJobList $jobList;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
## Summary

Cherry-picks from https://github.com/nextcloud/server/pull/39796 to improve PHP 8.3 support of our test suite.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
