### PR TITLE
Fix various file reminders bugs

### DIFF
--- a/apps/files_reminders/lib/Command/ListCommand.php
+++ b/apps/files_reminders/lib/Command/ListCommand.php
@@ -77,10 +77,6 @@ class ListCommand extends Base {
 		}
 
 		$reminders = $this->reminderService->getAll($user ?? null);
-		if (empty($reminders)) {
-			$io->text('No reminders');
-			return 0;
-		}
 
 		$outputOption = $input->getOption('output');
 		switch ($outputOption) {
@@ -97,6 +93,11 @@ class ListCommand extends Base {
 				);
 				return 0;
 			default:
+				if (empty($reminders)) {
+					$io->text('No reminders');
+					return 0;
+				}
+
 				$io->table(
 					['User Id', 'File Id', 'Path', 'Due Date', 'Updated At', 'Created At', 'Notified'],
 					array_map(

--- a/apps/files_reminders/lib/Controller/ApiController.php
+++ b/apps/files_reminders/lib/Controller/ApiController.php
@@ -34,6 +34,7 @@ use OCA\FilesReminders\Exception\NodeNotFoundException;
 use OCA\FilesReminders\Service\ReminderService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -54,6 +55,7 @@ class ApiController extends OCSController {
 	/**
 	 * Get a reminder
 	 */
+	#[NoAdminRequired]
 	public function get(int $fileId): DataResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
@@ -79,6 +81,7 @@ class ApiController extends OCSController {
 	 *
 	 * @param string $dueDate ISO 8601 formatted date time string
 	 */
+	#[NoAdminRequired]
 	public function set(int $fileId, string $dueDate): DataResponse {
 		try {
 			$dueDate = (new DateTime($dueDate))->setTimezone(new DateTimeZone('UTC'));
@@ -106,6 +109,7 @@ class ApiController extends OCSController {
 	/**
 	 * Remove a reminder
 	 */
+	#[NoAdminRequired]
 	public function remove(int $fileId): DataResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {

--- a/apps/files_reminders/lib/Db/ReminderMapper.php
+++ b/apps/files_reminders/lib/Db/ReminderMapper.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Node;
+use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use OCP\IUser;
 
@@ -111,11 +112,17 @@ class ReminderMapper extends QBMapper {
 	 * @return Reminder[]
 	 */
 	public function findAllForNode(Node $node) {
+		try {
+			$nodeId = $node->getId();
+		} catch (NotFoundException $e) {
+			return [];
+		}
+
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('id', 'user_id', 'file_id', 'due_date', 'updated_at', 'created_at', 'notified')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($node->getId(), IQueryBuilder::PARAM_INT)))
+			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($nodeId, IQueryBuilder::PARAM_INT)))
 			->orderBy('due_date', 'ASC');
 
 		return $this->findEntities($qb);

--- a/apps/files_reminders/lib/Listener/NodeDeletedListener.php
+++ b/apps/files_reminders/lib/Listener/NodeDeletedListener.php
@@ -26,8 +26,6 @@ declare(strict_types=1);
 
 namespace OCA\FilesReminders\Listener;
 
-use OC\Files\Node\NonExistingFile;
-use OC\Files\Node\NonExistingFolder;
 use OCA\FilesReminders\Service\ReminderService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -44,10 +42,6 @@ class NodeDeletedListener implements IEventListener {
 		}
 
 		$node = $event->getNode();
-		if ($node instanceof NonExistingFile || $node instanceof NonExistingFolder) {
-			return;
-		}
-
 		$this->reminderService->removeAllForNode($node);
 	}
 }


### PR DESCRIPTION
## Summary

- Allow non-admin users to access the API #ionlydevasadmin
- Always output valid json e.g. `files:reminders --output json`, `files:reminders --output json_pretty`
- Correctly delete reminders when node is deleted

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)