### PR TITLE
Refactor files_trashbin app commands

### DIFF
--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -37,29 +37,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanUp extends Command {
-
-	/** @var IUserManager */
-	protected $userManager;
-
-	/** @var IRootFolder */
-	protected $rootFolder;
-
-	/** @var \OCP\IDBConnection */
-	protected $dbConnection;
-
-	/**
-	 * @param IRootFolder $rootFolder
-	 * @param IUserManager $userManager
-	 * @param IDBConnection $dbConnection
-	 */
-	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, IDBConnection $dbConnection) {
+	public function __construct(
+		protected IRootFolder $rootFolder,
+		protected IUserManager $userManager,
+		protected IDBConnection $dbConnection,
+	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->rootFolder = $rootFolder;
-		$this->dbConnection = $dbConnection;
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('trashbin:cleanup')
 			->setDescription('Remove deleted files')
@@ -88,7 +74,7 @@ class CleanUp extends Command {
 					$this->removeDeletedFiles($user, $output, $verbose);
 				} else {
 					$output->writeln("<error>Unknown user $user</error>");
-					return 1;
+					return self::FAILURE;
 				}
 			}
 		} elseif ($input->getOption('all-users')) {
@@ -113,7 +99,7 @@ class CleanUp extends Command {
 		} else {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Command/Expire.php
+++ b/apps/files_trashbin/lib/Command/Expire.php
@@ -33,19 +33,12 @@ use OCP\Command\ICommand;
 class Expire implements ICommand {
 	use FileAccess;
 
-	/**
-	 * @var string
-	 */
-	private $user;
-
-	/**
-	 * @param string $user
-	 */
-	public function __construct($user) {
-		$this->user = $user;
+	public function __construct(
+		private string $user,
+	) {
 	}
 
-	public function handle() {
+	public function handle(): void {
 		$userManager = \OC::$server->getUserManager();
 		if (!$userManager->userExists($this->user)) {
 			// User has been deleted already

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -65,25 +65,28 @@ class ExpireTrash extends Command {
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {
 			foreach ($users as $user) {
-				if ($this->userManager->userExists($user)) {
-					$output->writeln("Remove deleted files of   <info>$user</info>");
-					$userObject = $this->userManager->get($user);
-					$this->expireTrashForUser($userObject);
-				} else {
+				if (! $this->userManager->userExists($user)) {
 					$output->writeln("<error>Unknown user $user</error>");
 					return self::FAILURE;
 				}
+
+				$output->writeln("Remove deleted files of   <info>$user</info>");
+				$userObject = $this->userManager->get($user);
+				$this->expireTrashForUser($userObject);
 			}
-		} else {
-			$p = new ProgressBar($output);
-			$p->start();
-			$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
-				$p->advance();
-				$this->expireTrashForUser($user);
-			});
-			$p->finish();
-			$output->writeln('');
+
+			return self::SUCCESS;
 		}
+
+		$p = new ProgressBar($output);
+		$p->start();
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
+			$p->advance();
+			$this->expireTrashForUser($user);
+		});
+		$p->finish();
+		$output->writeln('');
+
 		return self::SUCCESS;
 	}
 

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -136,6 +136,7 @@ class RestoreAllFiles extends Base {
 		} else {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		}
+
 		return self::SUCCESS;
 	}
 

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -44,33 +44,16 @@ class RestoreAllFiles extends Base {
 		'all' => self::SCOPE_ALL
 	];
 
-	/** @var IUserManager */
-	protected $userManager;
+	protected IL10N $l10n;
 
-	/** @var IRootFolder */
-	protected $rootFolder;
-
-	/** @var \OCP\IDBConnection */
-	protected $dbConnection;
-
-	protected ITrashManager $trashManager;
-
-	/** @var IL10N */
-	protected $l10n;
-
-	/**
-	 * @param IRootFolder $rootFolder
-	 * @param IUserManager $userManager
-	 * @param IDBConnection $dbConnection
-	 * @param ITrashManager $trashManager
-	 * @param IFactory $l10nFactory
-	 */
-	public function __construct(IRootFolder $rootFolder, IUserManager $userManager, IDBConnection $dbConnection, ITrashManager $trashManager, IFactory $l10nFactory) {
+	public function __construct(
+		protected IRootFolder $rootFolder,
+		protected IUserManager $userManager,
+		protected IDBConnection $dbConnection,
+		protected ITrashManager $trashManager,
+		IFactory $l10nFactory,
+	) {
 		parent::__construct();
-		$this->userManager = $userManager;
-		$this->rootFolder = $rootFolder;
-		$this->dbConnection = $dbConnection;
-		$this->trashManager = $trashManager;
 		$this->l10n = $l10nFactory->get('files_trashbin');
 	}
 
@@ -153,7 +136,7 @@ class RestoreAllFiles extends Base {
 		} else {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Command/Size.php
+++ b/apps/files_trashbin/lib/Command/Size.php
@@ -36,23 +36,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Size extends Base {
-	private $config;
-	private $userManager;
-	private $commandBus;
-
 	public function __construct(
-		IConfig $config,
-		IUserManager $userManager,
-		IBus $commandBus
+		private IConfig $config,
+		private IUserManager $userManager,
+		private IBus $commandBus
 	) {
 		parent::__construct();
-
-		$this->config = $config;
-		$this->userManager = $userManager;
-		$this->commandBus = $commandBus;
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		parent::configure();
 		$this
 			->setName('trashbin:size')
@@ -73,7 +65,7 @@ class Size extends Base {
 			$parsedSize = \OC_Helper::computerFileSize($size);
 			if ($parsedSize === false) {
 				$output->writeln("<error>Failed to parse input size</error>");
-				return -1;
+				return self::FAILURE;
 			}
 			if ($user) {
 				$this->config->setUserValue($user, 'files_trashbin', 'trashbin_size', (string)$parsedSize);
@@ -87,10 +79,10 @@ class Size extends Base {
 			$this->printTrashbinSize($input, $output, $user);
 		}
 
-		return 0;
+		return self::SUCCESS;
 	}
 
-	private function printTrashbinSize(InputInterface $input, OutputInterface $output, ?string $user) {
+	private function printTrashbinSize(InputInterface $input, OutputInterface $output, ?string $user): void {
 		$globalSize = (int)$this->config->getAppValue('files_trashbin', 'trashbin_size', '-1');
 		if ($globalSize < 0) {
 			$globalHumanSize = "default (50% of available space)";


### PR DESCRIPTION
## Summary
I have made some adjustments to the `apps/files_trashbin/lib/Command` classes to improve the code readability.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Replacing return code integers with more readable strings.
- Using early returns

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
