### PR TITLE
Reduce the number of container queries

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -315,20 +315,19 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 		}
 	}
 
+	private function getLogger(): LoggerInterface {
+		return \OC::$server->get(LoggerInterface::class);
+	}
+
 	/**
 	 * Returns available diskspace information
 	 *
 	 * @return array
 	 */
 	public function getQuotaInfo() {
-		/** @var LoggerInterface $logger */
-		$logger = \OC::$server->get(LoggerInterface::class);
-		if ($this->quotaInfo) {
-			return $this->quotaInfo;
-		}
 		$relativePath = $this->fileView->getRelativePath($this->info->getPath());
 		if ($relativePath === null) {
-			$logger->warning("error while getting quota as the relative path cannot be found");
+			$this->getLogger()->warning("error while getting quota as the relative path cannot be found");
 			return [0, 0];
 		}
 
@@ -345,13 +344,13 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 			];
 			return $this->quotaInfo;
 		} catch (\OCP\Files\NotFoundException $e) {
-			$logger->warning("error while getting quota into", ['exception' => $e]);
+			$this->getLogger()->warning("error while getting quota into", ['exception' => $e]);
 			return [0, 0];
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			$logger->warning("error while getting quota into", ['exception' => $e]);
+			$this->getLogger()->warning("error while getting quota into", ['exception' => $e]);
 			return [0, 0];
 		} catch (NotPermittedException $e) {
-			$logger->warning("error while getting quota into", ['exception' => $e]);
+			$this->getLogger()->warning("error while getting quota into", ['exception' => $e]);
 			return [0, 0];
 		}
 	}

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -325,6 +325,9 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 	 * @return array
 	 */
 	public function getQuotaInfo() {
+		if ($this->quotaInfo) {
+			return $this->quotaInfo;
+		}
 		$relativePath = $this->fileView->getRelativePath($this->info->getPath());
 		if ($relativePath === null) {
 			$this->getLogger()->warning("error while getting quota as the relative path cannot be found");

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -40,35 +40,24 @@ use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
 use OCP\ILogger;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 
 class Storage extends Wrapper {
-	/** @var IMountPoint */
-	private $mountPoint;
-
-	/** @var  IUserManager */
-	private $userManager;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
-
-	/** @var IRootFolder */
-	private $rootFolder;
-
-	/** @var ITrashManager */
-	private $trashManager;
-
-	private $trashEnabled = true;
+	private string $mountPoint;
+	private  IUserManager$userManager;
+	private LoggerInterface $logger;
+	private IEventDispatcher $eventDispatcher;
+	private IRootFolder $rootFolder;
+	private ITrashManager $trashManager;
+	private bool $trashEnabled = true;
 
 	/**
 	 * Storage constructor.
 	 *
 	 * @param array $parameters
-	 * @param ITrashManager $trashManager
+	 * @param ITrashManager|null $trashManager
 	 * @param IUserManager|null $userManager
-	 * @param ILogger|null $logger
+	 * @param LoggerInterface|null $logger
 	 * @param IEventDispatcher|null $eventDispatcher
 	 * @param IRootFolder|null $rootFolder
 	 */
@@ -76,7 +65,7 @@ class Storage extends Wrapper {
 		$parameters,
 		ITrashManager $trashManager = null,
 		IUserManager $userManager = null,
-		ILogger $logger = null,
+		LoggerInterface $logger = null,
 		IEventDispatcher $eventDispatcher = null,
 		IRootFolder $rootFolder = null
 	) {
@@ -209,19 +198,27 @@ class Storage extends Wrapper {
 	}
 
 	/**
-	 * Setup the storate wrapper callback
+	 * Setup the storage wrapper callback
 	 */
 	public static function setupStorage() {
-		\OC\Files\Filesystem::addStorageWrapper('oc_trashbin', function ($mountPoint, $storage) {
-			return new \OCA\Files_Trashbin\Storage(
-				['storage' => $storage, 'mountPoint' => $mountPoint],
-				\OC::$server->query(ITrashManager::class),
-				\OC::$server->getUserManager(),
-				\OC::$server->getLogger(),
-				\OC::$server->get(IEventDispatcher::class),
-				\OC::$server->getLazyRootFolder()
-			);
-		}, 1);
+		$trashManager = \OC::$server->get(ITrashManager::class);
+		$userManager = \OC::$server->get(IUserManager::class);
+		$logger = \OC::$server->get(LoggerInterface::class);
+		$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
+		$rootFolder = \OC::$server->get(IRootFolder::class);
+		Filesystem::addStorageWrapper(
+			'oc_trashbin',
+			function (string $mountPoint, IStorage $storage) use ($trashManager, $userManager, $logger, $eventDispatcher, $rootFolder) {
+				return new Storage(
+					['storage' => $storage, 'mountPoint' => $mountPoint],
+					$trashManager,
+					$userManager,
+					$logger,
+					$eventDispatcher,
+					$rootFolder,
+				);
+			},
+		1);
 	}
 
 	public function getMountPoint() {

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -51,6 +51,7 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
 use Test\Traits\MountProviderTrait;
 
 class TemporaryNoCross extends Temporary {
@@ -606,7 +607,7 @@ class StorageTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$userManager->expects($this->any())
 			->method('userExists')->willReturn($userExists);
-		$logger = $this->getMockBuilder(ILogger::class)->getMock();
+		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$rootFolder = $this->createMock(IRootFolder::class);
 		$userFolder = $this->createMock(Folder::class);

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -33,8 +33,10 @@ use OC\Files\Cache\Cache;
 use OC\Files\Cache\QuerySearchHelper;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
+use OCP\IDBConnection;
 
 class CacheWrapper extends Cache {
 	/**
@@ -47,9 +49,15 @@ class CacheWrapper extends Cache {
 	 */
 	public function __construct($cache) {
 		$this->cache = $cache;
-		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
-		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->querySearchHelper = \OC::$server->get(QuerySearchHelper::class);
+		if ($cache instanceof Cache) {
+			$this->mimetypeLoader = $cache->mimetypeLoader;
+			$this->connection = $cache->connection;
+			$this->querySearchHelper = $cache->querySearchHelper;
+		} else {
+			$this->mimetypeLoader = \OC::$server->get(IMimeTypeLoader::class);
+			$this->connection = \OC::$server->get(IDBConnection::class);
+			$this->querySearchHelper = \OC::$server->get(QuerySearchHelper::class);
+		}
 	}
 
 	protected function getCache() {

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -164,7 +164,8 @@ class SetupManager {
 			return $storage;
 		});
 
-		Filesystem::addStorageWrapper('oc_quota', function ($mountPoint, $storage) {
+		$quotaIncludeExternal = $this->config->getSystemValue('quota_include_external_storage', false);
+		Filesystem::addStorageWrapper('oc_quota', function ($mountPoint, $storage) use ($quotaIncludeExternal) {
 			// set up quota for home storages, even for other users
 			// which can happen when using sharing
 
@@ -176,7 +177,7 @@ class SetupManager {
 					$user = $storage->getUser();
 					return new Quota(['storage' => $storage, 'quotaCallback' => function () use ($user) {
 						return OC_Util::getUserQuota($user);
-					}, 'root' => 'files']);
+					}, 'root' => 'files', 'include_external_storage' => $quotaIncludeExternal]);
 				}
 			}
 

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -45,6 +45,7 @@ class Quota extends Wrapper {
 	protected int|float|null $quota;
 	protected string $sizeRoot;
 	private SystemConfig $config;
+	private bool $quotaIncludeExternalStorage;
 
 	/**
 	 * @param array $parameters
@@ -54,7 +55,7 @@ class Quota extends Wrapper {
 		$this->quota = $parameters['quota'] ?? null;
 		$this->quotaCallback = $parameters['quotaCallback'] ?? null;
 		$this->sizeRoot = $parameters['root'] ?? '';
-		$this->config = \OC::$server->get(SystemConfig::class);
+		$this->quotaIncludeExternalStorage = $parameters['include_external_storage'] ?? false;
 	}
 
 	/**
@@ -82,7 +83,7 @@ class Quota extends Wrapper {
 	 * @return int|float
 	 */
 	protected function getSize($path, $storage = null) {
-		if ($this->config->getValue('quota_include_external_storage', false)) {
+		if ($this->quotaIncludeExternalStorage) {
 			$rootInfo = Filesystem::getFileInfo('', 'ext');
 			if ($rootInfo) {
 				return $rootInfo->getSize(true);

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -69,6 +69,8 @@ use Psr\Log\LoggerInterface;
  */
 class OC_Helper {
 	private static $templateManager;
+	private static ?ICacheFactory $cacheFactory = null;
+	private static ?bool $quotaIncludeExternalStorage = null;
 
 	/**
 	 * Make a human file size
@@ -475,12 +477,15 @@ class OC_Helper {
 	 * @throws \OCP\Files\NotFoundException
 	 */
 	public static function getStorageInfo($path, $rootInfo = null, $includeMountPoints = true, $useCache = true) {
-		/** @var ICacheFactory $cacheFactory */
-		$cacheFactory = \OC::$server->get(ICacheFactory::class);
-		$memcache = $cacheFactory->createLocal('storage_info');
+		if (!self::$cacheFactory) {
+			self::$cacheFactory = \OC::$server->get(ICacheFactory::class);
+		}
+		$memcache = self::$cacheFactory->createLocal('storage_info');
 
 		// return storage info without adding mount points
-		$includeExtStorage = \OC::$server->getSystemConfig()->getValue('quota_include_external_storage', false);
+		if (self::$quotaIncludeExternalStorage === null) {
+			self::$quotaIncludeExternalStorage = \OC::$server->getSystemConfig()->getValue('quota_include_external_storage', false);
+		}
 
 		$view = Filesystem::getView();
 		if (!$view) {
@@ -497,7 +502,7 @@ class OC_Helper {
 		}
 
 		if (!$rootInfo) {
-			$rootInfo = \OC\Files\Filesystem::getFileInfo($path, $includeExtStorage ? 'ext' : false);
+			$rootInfo = \OC\Files\Filesystem::getFileInfo($path, self::$quotaIncludeExternalStorage ? 'ext' : false);
 		}
 		if (!$rootInfo instanceof \OCP\Files\FileInfo) {
 			throw new \OCP\Files\NotFoundException('The root directory of the user\'s files is missing');
@@ -512,9 +517,9 @@ class OC_Helper {
 		$storage = $mount->getStorage();
 		$sourceStorage = $storage;
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
-			$includeExtStorage = false;
+			self::$quotaIncludeExternalStorage = false;
 		}
-		if ($includeExtStorage) {
+		if (self::$quotaIncludeExternalStorage) {
 			if ($storage->instanceOfStorage('\OC\Files\Storage\Home')
 				|| $storage->instanceOfStorage('\OC\Files\ObjectStore\HomeObjectStoreStorage')
 			) {

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -22,6 +22,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
+use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share\IShare;
@@ -1590,7 +1591,7 @@ class ViewTest extends \Test\TestCase {
 				->getMock();
 			$storage->method('getId')->willReturn('non-null-id');
 			$storage->method('getStorageCache')->willReturnCallback(function () use ($storage) {
-				return new \OC\Files\Cache\Storage($storage);
+				return new \OC\Files\Cache\Storage($storage, true, \OC::$server->get(IDBConnection::class));
 			});
 
 			$mounts[] = $this->getMockBuilder(TestMoveableMountPoint::class)


### PR DESCRIPTION
Tweaks DI in various places to prevent calling `Server::get` in a loop.

While the container is fairly fast, doing a lot of queries adds up.