### PR TITLE
admin have no special rights on users' entries

### DIFF
--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -108,7 +108,7 @@ class AjaxController extends Controller {
 		$currentUser = $this->userSession->getUser();
 
 		// Non-admins can only edit their own credentials
-		$allowedToEdit = ($this->groupManager->isAdmin($currentUser->getUID()) || $currentUser->getUID() === $uid);
+		$allowedToEdit = ($currentUser->getUID() === $uid);
 
 		if ($allowedToEdit) {
 			$this->globalAuth->saveAuth($uid, $user, $password);

--- a/apps/files_external/tests/Controller/AjaxControllerTest.php
+++ b/apps/files_external/tests/Controller/AjaxControllerTest.php
@@ -102,17 +102,11 @@ class AjaxControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
-		$this->groupManager
-			->expects($this->once())
-			->method('isAdmin')
-			->with('MyAdminUid')
-			->willReturn(true);
 		$this->globalAuth
-			->expects($this->once())
-			->method('saveAuth')
-			->with('UidOfTestUser', 'test', 'password');
+			->expects($this->never())
+			->method('saveAuth');
 
-		$this->assertSame(true, $this->ajaxController->saveGlobalCredentials('UidOfTestUser', 'test', 'password'));
+		$this->assertSame(false, $this->ajaxController->saveGlobalCredentials('UidOfTestUser', 'test', 'password'));
 	}
 
 	public function testSaveGlobalCredentialsAsAdminForSelf() {
@@ -125,11 +119,6 @@ class AjaxControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
-		$this->groupManager
-			->expects($this->once())
-			->method('isAdmin')
-			->with('MyAdminUid')
-			->willReturn(true);
 		$this->globalAuth
 			->expects($this->once())
 			->method('saveAuth')
@@ -141,20 +130,12 @@ class AjaxControllerTest extends TestCase {
 	public function testSaveGlobalCredentialsAsNormalUserForSelf() {
 		$user = $this->createMock(IUser::class);
 		$user
-			->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyUserUid');
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
-		$this->groupManager
-			->expects($this->once())
-			->method('isAdmin')
-			->with('MyUserUid')
-			->willReturn(false);
 		$this->globalAuth
-			->expects($this->once())
 			->method('saveAuth')
 			->with('MyUserUid', 'test', 'password');
 
@@ -164,18 +145,14 @@ class AjaxControllerTest extends TestCase {
 	public function testSaveGlobalCredentialsAsNormalUserForAnotherUser() {
 		$user = $this->createMock(IUser::class);
 		$user
-			->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyUserUid');
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->willReturn($user);
-		$this->groupManager
-			->expects($this->once())
-			->method('isAdmin')
-			->with('MyUserUid')
-			->willReturn(false);
+		$this->globalAuth
+			->expects($this->never())
+			->method('saveAuth');
 
 		$this->assertSame(false, $this->ajaxController->saveGlobalCredentials('AnotherUserUid', 'test', 'password'));
 	}


### PR DESCRIPTION
remove admin's right to modify users' external filesystem configuration.
