### PR TITLE
Refactor files_sharing app commands

### DIFF
--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -38,24 +38,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  * shares_external table.
  */
 class CleanupRemoteStorages extends Command {
-
-	/**
-	 * @var IDBConnection
-	 */
-	protected $connection;
-
-	/**
-	 * @var ICloudIdManager
-	 */
-	private $cloudIdManager;
-
-	public function __construct(IDBConnection $connection, ICloudIdManager $cloudIdManager) {
-		$this->connection = $connection;
-		$this->cloudIdManager = $cloudIdManager;
+	public function __construct(
+		protected IDBConnection $connection,
+		private ICloudIdManager $cloudIdManager,
+	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('sharing:cleanup-remote-storages')
 			->setDescription('Cleanup shared storage entries that have no matching entry in the shares_external table')
@@ -101,10 +91,10 @@ class CleanupRemoteStorages extends Command {
 				}
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 
-	public function countFiles($numericId, OutputInterface $output) {
+	public function countFiles($numericId, OutputInterface $output): void {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->select($queryBuilder->func()->count('fileid'))
 			->from('filecache')
@@ -118,7 +108,7 @@ class CleanupRemoteStorages extends Command {
 		$output->writeln("$count files can be deleted for storage $numericId");
 	}
 
-	public function deleteStorage($id, $numericId, OutputInterface $output) {
+	public function deleteStorage($id, $numericId, OutputInterface $output): void {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->delete('storages')
 			->where($queryBuilder->expr()->eq(
@@ -132,7 +122,7 @@ class CleanupRemoteStorages extends Command {
 		$this->deleteFiles($numericId, $output);
 	}
 
-	public function deleteFiles($numericId, OutputInterface $output) {
+	public function deleteFiles($numericId, OutputInterface $output): void {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->delete('filecache')
 			->where($queryBuilder->expr()->eq(
@@ -145,7 +135,7 @@ class CleanupRemoteStorages extends Command {
 		$output->writeln("deleted $count files");
 	}
 
-	public function getRemoteStorages() {
+	public function getRemoteStorages(): array {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->select(['id', 'numeric_id'])
 			->from('storages')
@@ -172,7 +162,7 @@ class CleanupRemoteStorages extends Command {
 		return $remoteStorages;
 	}
 
-	public function getRemoteShareIds() {
+	public function getRemoteShareIds(): array {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->select(['id', 'share_token', 'owner', 'remote'])
 			->from('share_external');

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -67,30 +67,34 @@ class CleanupRemoteStorages extends Command {
 		$output->writeln(count($remoteShareIds) . ' remote share(s) exist');
 
 		foreach ($remoteShareIds as $id => $remoteShareId) {
-			if (isset($remoteStorages[$remoteShareId])) {
-				if ($input->getOption('dry-run') || $output->isVerbose()) {
-					$output->writeln("<info>$remoteShareId belongs to remote share $id</info>");
-				}
-
-				unset($remoteStorages[$remoteShareId]);
-			} else {
+			if (!isset($remoteStorages[$remoteShareId])) {
 				$output->writeln("<comment>$remoteShareId for share $id has no matching storage, yet</comment>");
+				continue;
 			}
+
+			if ($input->getOption('dry-run') || $output->isVerbose()) {
+				$output->writeln("<info>$remoteShareId belongs to remote share $id</info>");
+			}
+
+			unset($remoteStorages[$remoteShareId]);
 		}
 
 		if (empty($remoteStorages)) {
 			$output->writeln('<info>no storages deleted</info>');
-		} else {
-			$dryRun = $input->getOption('dry-run');
-			foreach ($remoteStorages as $id => $numericId) {
-				if ($dryRun) {
-					$output->writeln("<error>$id [$numericId] can be deleted</error>");
-					$this->countFiles($numericId, $output);
-				} else {
-					$this->deleteStorage($id, $numericId, $output);
-				}
-			}
+			return self::SUCCESS;
 		}
+
+		$dryRun = $input->getOption('dry-run');
+		foreach ($remoteStorages as $id => $numericId) {
+			if (!$dryRun) {
+				$this->deleteStorage($id, $numericId, $output);
+				continue;
+			}
+
+			$output->writeln("<error>$id [$numericId] can be deleted</error>");
+			$this->countFiles($numericId, $output);
+		}
+
 		return self::SUCCESS;
 	}
 

--- a/apps/files_sharing/lib/Command/DeleteOrphanShares.php
+++ b/apps/files_sharing/lib/Command/DeleteOrphanShares.php
@@ -57,15 +57,17 @@ class DeleteOrphanShares extends Base {
 
 		$orphans = [];
 		foreach ($shares as $share) {
-			if (!$this->orphanHelper->isShareValid($share['owner'], $share['fileid'])) {
-				$orphans[] = $share['id'];
-				$exists = $this->orphanHelper->fileExists($share['fileid']);
-				$output->writeln("<info>{$share['target']}</info> owned by <info>{$share['owner']}</info>");
-				if ($exists) {
-					$output->writeln("  file still exists but the share owner lost access to it, run <info>occ info:file {$share['fileid']}</info> for more information about the file");
-				} else {
-					$output->writeln("  file no longer exists");
-				}
+			if ($this->orphanHelper->isShareValid($share['owner'], $share['fileid'])) {
+				continue;
+			}
+
+			$orphans[] = $share['id'];
+			$exists = $this->orphanHelper->fileExists($share['fileid']);
+			$output->writeln("<info>{$share['target']}</info> owned by <info>{$share['owner']}</info>");
+			if ($exists) {
+				$output->writeln("  file still exists but the share owner lost access to it, run <info>occ info:file {$share['fileid']}</info> for more information about the file");
+			} else {
+				$output->writeln("  file no longer exists");
 			}
 		}
 

--- a/apps/files_sharing/lib/Command/DeleteOrphanShares.php
+++ b/apps/files_sharing/lib/Command/DeleteOrphanShares.php
@@ -33,11 +33,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DeleteOrphanShares extends Base {
-	private OrphanHelper $orphanHelper;
-
-	public function __construct(OrphanHelper $orphanHelper) {
+	public function __construct(
+		private OrphanHelper $orphanHelper,
+	) {
 		parent::__construct();
-		$this->orphanHelper = $orphanHelper;
 	}
 
 	protected function configure(): void {
@@ -74,7 +73,7 @@ class DeleteOrphanShares extends Base {
 
 		if ($count === 0) {
 			$output->writeln("No orphan shares detected");
-			return 0;
+			return self::SUCCESS;
 		}
 
 		if ($force) {
@@ -91,6 +90,6 @@ class DeleteOrphanShares extends Base {
 			$this->orphanHelper->deleteShares($orphans);
 		}
 
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/apps/files_sharing/lib/Command/ExiprationNotification.php
+++ b/apps/files_sharing/lib/Command/ExiprationNotification.php
@@ -36,28 +36,16 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ExiprationNotification extends Command {
-	/** @var NotificationManager */
-	private $notificationManager;
-	/** @var IDBConnection */
-	private $connection;
-	/** @var ITimeFactory */
-	private $time;
-	/** @var ShareManager */
-	private $shareManager;
-
-	public function __construct(ITimeFactory $time,
-								NotificationManager $notificationManager,
-								IDBConnection $connection,
-								ShareManager $shareManager) {
+	public function __construct(
+		private ITimeFactory $time,
+		private NotificationManager $notificationManager,
+		private IDBConnection $connection,
+		private ShareManager $shareManager,
+	) {
 		parent::__construct();
-
-		$this->notificationManager = $notificationManager;
-		$this->connection = $connection;
-		$this->time = $time;
-		$this->shareManager = $shareManager;
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('sharing:expiration-notification')
 			->setDescription('Notify share initiators when a share will expire the next day.');
@@ -67,7 +55,7 @@ class ExiprationNotification extends Command {
 		//Current time
 		$minTime = $this->time->getDateTime();
 		$minTime->add(new \DateInterval('P1D'));
-		$minTime->setTime(0,0,0);
+		$minTime->setTime(0, 0, 0);
 
 		$maxTime = clone $minTime;
 		$maxTime->setTime(23, 59, 59);
@@ -94,6 +82,6 @@ class ExiprationNotification extends Command {
 			$notification->setUser($share->getSharedBy());
 			$this->notificationManager->notify($notification);
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 }


### PR DESCRIPTION
## Summary
I have made some adjustments to the `apps/files_sharing/lib/Command` classes to improve the code readability.

The improvements in this PR include but are not limited to:

- Using PHP8's constructor property promotion
- Adding return types
- Replacing return code integers with more readable strings.
- Using early returns

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
