### PR TITLE
[stable27] fix(CardDAV): set owner-principal, displayname properties for SAB

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -223,10 +223,7 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMov
 	}
 
 	public function propPatch(PropPatch $propPatch) {
-		// shared address books will be handled by
-		// \OCA\DAV\DAV\CustomPropertiesBackend::propPatch
-		// to save values in db table instead of dav object
-		if (!$this->isShared()) {
+		if (!isset($this->addressBookInfo['{http://owncloud.org/ns}owner-principal'])) {
 			parent::propPatch($propPatch);
 		}
 	}

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -311,10 +311,12 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			'{' . Plugin::NS_CARDDAV . '}addressbook-description' => $row['description'],
 			'{http://calendarserver.org/ns/}getctag' => $row['synctoken'],
 			'{http://sabredav.org/ns}sync-token' => $row['synctoken'] ?: '0',
+
 		];
 
 		// system address books are always read only
 		if ($principal === 'principals/system/system') {
+			$addressBook['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal'] = $row['principaluri'];
 			$addressBook['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only'] = true;
 		}
 

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -208,6 +208,11 @@ class Principal implements BackendInterface {
 					'{DAV:}displayname' => $group->getDisplayName(),
 				];
 			}
+		} elseif ($prefix === 'principals/system') {
+			return [
+				'uri' => 'principals/system/' . $name,
+				'{DAV:}displayname' => $this->languageFactory->get('dav')->t("Accounts"),
+			];
 		}
 		return null;
 	}

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -124,7 +124,6 @@ class AddressBookTest extends TestCase {
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
 		$backend->expects($this->atLeast(1))->method('updateAddressBook');
 		$addressBookInfo = [
-			'{http://owncloud.org/ns}owner-principal' => 'user1',
 			'{DAV:}displayname' => 'Test address book',
 			'principaluri' => 'user1',
 			'id' => 666,


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/39525