### PR TITLE
Prevent PHP warning when CacheEntry extension keys are not set

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -149,7 +149,7 @@ class Cache implements ICache {
 	 * get the stored metadata of a file or folder
 	 *
 	 * @param string | int $file either the path of a file or folder or the file id for a file or folder
-	 * @return ICacheEntry|false the cache entry as array of false if the file is not found in the cache
+	 * @return ICacheEntry|false the cache entry as array or false if the file is not found in the cache
 	 */
 	public function get($file) {
 		$query = $this->getQueryBuilder();

--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -114,15 +114,15 @@ class CacheEntry implements ICacheEntry {
 	}
 
 	public function getMetadataEtag(): ?string {
-		return $this->data['metadata_etag'];
+		return $this->data['metadata_etag'] ?? null;
 	}
 
 	public function getCreationTime(): ?int {
-		return $this->data['creation_time'];
+		return $this->data['creation_time'] ?? null;
 	}
 
 	public function getUploadTime(): ?int {
-		return $this->data['upload_time'];
+		return $this->data['upload_time'] ?? null;
 	}
 
 	public function getData() {

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -98,6 +98,31 @@ class CacheTest extends \Test\TestCase {
 		$this->assertEquals($cacheData1, $this->cache->get($id1));
 	}
 
+	public function testCacheEntryGetters() {
+		$file1 = 'foo';
+		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/file'];
+
+		$id1 = $this->cache->put($file1, $data1);
+		$entry = $this->cache->get($file1);
+
+		$this->assertEquals($entry->getId(), $id1);
+		$this->assertEquals($entry->getStorageId(), $this->cache->getNumericStorageId());
+		$this->assertEquals($entry->getPath(), 'foo');
+		$this->assertEquals($entry->getName(), 'foo');
+		$this->assertEquals($entry->getMimeType(), 'foo/file');
+		$this->assertEquals($entry->getMimePart(), 'foo');
+		$this->assertEquals($entry->getSize(), 100);
+		$this->assertEquals($entry->getMTime(), 50);
+		$this->assertEquals($entry->getStorageMTime(), 50);
+		$this->assertEquals($entry->getEtag(), null);
+		$this->assertEquals($entry->getPermissions(), 0);
+		$this->assertEquals($entry->isEncrypted(), false);
+		$this->assertEquals($entry->getMetadataEtag(), null);
+		$this->assertEquals($entry->getCreationTime(), null);
+		$this->assertEquals($entry->getUploadTime(), null);
+		$this->assertEquals($entry->getUnencryptedSize(), 100);
+	}
+
 	public function testPartial() {
 		$file1 = 'foo';
 


### PR DESCRIPTION
## Summary
Prevent warning when CacheEntry extensions are not set, for example prevents this:
![Attachment file 1 Error detail(4)](https://github.com/nextcloud/server/assets/1855448/1b16f162-d43b-4ba8-baf3-83c850b97286)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
