### PR TITLE
fix(CardDAV): only run upgrade sync if 1000 users or less

### DIFF
--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -24,22 +24,18 @@
 namespace OCA\DAV\Command;
 
 use OCA\DAV\CardDAV\SyncService;
+use OCP\IConfig;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SyncSystemAddressBook extends Command {
-
-	/** @var SyncService */
-	private $syncService;
-
 	/**
 	 * @param SyncService $syncService
 	 */
-	public function __construct(SyncService $syncService) {
+	public function __construct(private SyncService $syncService, private IConfig $config) {
 		parent::__construct();
-		$this->syncService = $syncService;
 	}
 
 	protected function configure() {
@@ -62,6 +58,7 @@ class SyncSystemAddressBook extends Command {
 
 		$progress->finish();
 		$output->writeln('');
+		$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'no');
 		return 0;
 	}
 }

--- a/apps/dav/lib/Migration/Version1027Date20230504122946.php
+++ b/apps/dav/lib/Migration/Version1027Date20230504122946.php
@@ -29,6 +29,8 @@ namespace OCA\DAV\Migration;
 use Closure;
 use OCA\DAV\CardDAV\SyncService;
 use OCP\DB\ISchemaWrapper;
+use OCP\IConfig;
+use OCP\IUserManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Psr\Container\ContainerExceptionInterface;
@@ -37,22 +39,27 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class Version1027Date20230504122946 extends SimpleMigrationStep {
-	private SyncService $syncService;
-	private LoggerInterface $logger;
-
-	public function __construct(SyncService $syncService, LoggerInterface $logger) {
-		$this->syncService = $syncService;
-		$this->logger = $logger;
-	}
+	public function __construct(private SyncService $syncService,
+								private LoggerInterface $logger,
+								private IUserManager $userManager,
+								private IConfig $config) {}
 	/**
 	 * @param IOutput $output
 	 * @param Closure(): ISchemaWrapper $schemaClosure
 	 * @param array $options
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		if($this->userManager->countUsers() > 1000) {
+			$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'yes');
+			$output->info('Could not sync system address books during update - too many user records have been found. Please call occ dav:sync-system-addressbook manually.');
+			return;
+		}
+
 		try {
 			$this->syncService->syncInstance();
+			$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'no');
 		} catch (Throwable $e) {
+			$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'yes');
 			$this->logger->error('Could not sync system address books during update', [
 				'exception' => $e,
 			]);

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -75,6 +75,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\CheckUserCertificates' => $baseDir . '/../lib/SetupChecks/CheckUserCertificates.php',
     'OCA\\Settings\\SetupChecks\\LdapInvalidUuids' => $baseDir . '/../lib/SetupChecks/LdapInvalidUuids.php',
     'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => $baseDir . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
+    'OCA\\Settings\\SetupChecks\\NeedsSystemAddressBookSync' => $baseDir . '/../lib/SetupChecks/NeedsSystemAddressBookSync.php',
     'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => $baseDir . '/../lib/SetupChecks/PhpDefaultCharset.php',
     'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => $baseDir . '/../lib/SetupChecks/PhpOutputBuffering.php',
     'OCA\\Settings\\SetupChecks\\SupportedDatabase' => $baseDir . '/../lib/SetupChecks/SupportedDatabase.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -90,6 +90,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\CheckUserCertificates' => __DIR__ . '/..' . '/../lib/SetupChecks/CheckUserCertificates.php',
         'OCA\\Settings\\SetupChecks\\LdapInvalidUuids' => __DIR__ . '/..' . '/../lib/SetupChecks/LdapInvalidUuids.php',
         'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => __DIR__ . '/..' . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
+        'OCA\\Settings\\SetupChecks\\NeedsSystemAddressBookSync' => __DIR__ . '/..' . '/../lib/SetupChecks/NeedsSystemAddressBookSync.php',
         'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpDefaultCharset.php',
         'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOutputBuffering.php',
         'OCA\\Settings\\SetupChecks\\SupportedDatabase' => __DIR__ . '/..' . '/../lib/SetupChecks/SupportedDatabase.php',

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -63,6 +63,7 @@ use OC\Lock\NoopLockingProvider;
 use OC\Lock\DBLockingProvider;
 use OC\MemoryInfo;
 use OCA\Settings\SetupChecks\CheckUserCertificates;
+use OCA\Settings\SetupChecks\NeedsSystemAddressBookSync;
 use OCA\Settings\SetupChecks\LdapInvalidUuids;
 use OCA\Settings\SetupChecks\LegacySSEKeyFormat;
 use OCA\Settings\SetupChecks\PhpDefaultCharset;
@@ -911,6 +912,7 @@ Raw output
 		$checkUserCertificates = new CheckUserCertificates($this->l10n, $this->config, $this->urlGenerator);
 		$supportedDatabases = new SupportedDatabase($this->l10n, $this->connection);
 		$ldapInvalidUuids = new LdapInvalidUuids($this->appManager, $this->l10n, $this->serverContainer);
+		$needsSystemAddressBookSync = new NeedsSystemAddressBookSync($this->config, $this->l10n);
 
 		return new DataResponse(
 			[
@@ -966,6 +968,7 @@ Raw output
 				SupportedDatabase::class => ['pass' => $supportedDatabases->run(), 'description' => $supportedDatabases->description(), 'severity' => $supportedDatabases->severity()],
 				'temporaryDirectoryWritable' => $this->isTemporaryDirectoryWritable(),
 				LdapInvalidUuids::class => ['pass' => $ldapInvalidUuids->run(), 'description' => $ldapInvalidUuids->description(), 'severity' => $ldapInvalidUuids->severity()],
+				NeedsSystemAddressBookSync::class => ['pass' => $needsSystemAddressBookSync->run(), 'description' => $needsSystemAddressBookSync->description(), 'severity' => $needsSystemAddressBookSync->severity()],
 			]
 		);
 	}

--- a/apps/settings/lib/SetupChecks/NeedsSystemAddressBookSync.php
+++ b/apps/settings/lib/SetupChecks/NeedsSystemAddressBookSync.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+
+class NeedsSystemAddressBookSync {
+	public function __construct(private IConfig $config, private IL10N $l10n) {}
+
+	public function description(): string {
+		return $this->l10n->t('The DAV system address book sync has not run yet as your instance has more than 1000 users or because an error occured. Please run it manually by calling occ dav:sync-system-addressbook.');
+	}
+
+	public function severity(): string {
+		return 'warning';
+	}
+
+	public function run(): bool {
+		return $this->config->getAppValue('dav', 'needs_system_address_book_sync', 'no') === 'no';
+	}
+}

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -92,6 +92,7 @@ class CheckSetupControllerTest extends TestCase {
 	private $dispatcher;
 	/** @var Connection|\PHPUnit\Framework\MockObject\MockObject */
 	private $db;
+	private IThrottler $throttler;
 	/** @var ILockingProvider|\PHPUnit\Framework\MockObject\MockObject */
 	private $lockingProvider;
 	/** @var IDateTimeFormatter|\PHPUnit\Framework\MockObject\MockObject */
@@ -435,6 +436,7 @@ class CheckSetupControllerTest extends TestCase {
 			->willReturnMap([
 				['files_external', 'user_certificate_scan', '', '["a", "b"]'],
 				['core', 'cronErrors', '', ''],
+				['dav', 'needs_system_address_book_sync', 'no', 'no'],
 			]);
 		$this->config->expects($this->any())
 			->method('getSystemValue')
@@ -662,6 +664,7 @@ class CheckSetupControllerTest extends TestCase {
 				'isFairUseOfFreePushService' => false,
 				'temporaryDirectoryWritable' => false,
 				\OCA\Settings\SetupChecks\LdapInvalidUuids::class => ['pass' => true, 'description' => 'Invalid UUIDs of LDAP users or groups have been found. Please review your "Override UUID detection" settings in the Expert part of the LDAP configuration and use "occ ldap:update-uuid" to update them.', 'severity' => 'warning'],
+				\OCA\Settings\SetupChecks\NeedsSystemAddressBookSync::class => ['pass' => true, 'description' => 'The DAV system address book sync has not run yet as your instance has more than 1000 users or because an error occured. Please run it manually by calling occ dav:sync-system-addressbook.', 'severity' => 'warning'],
 				'isBruteforceThrottled' => false,
 				'bruteforceRemoteAddress' => '',
 			]

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -542,7 +542,7 @@
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\CheckUserCertificates', messages)
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\SupportedDatabase', messages)
 					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\LdapInvalidUuids', messages)
-
+					OC.SetupChecks.addGenericSetupCheck(data, 'OCA\\Settings\\SetupChecks\\NeedsSystemAddressBookSync', messages)
 				} else {
 					messages.push({
 						msg: t('core', 'Error occurred while checking server setup'),


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/39744 
* Resolves: https://github.com/nextcloud/server/issues/39769

## Summary
Limit the upgrade sync to instances with 1000 users or less and show a warning in the admin section if the sync hasn't been run:

![image](https://github.com/nextcloud/server/assets/7427347/973e4822-2a33-4125-901c-92f327a98923)


## TODO

- [ ] Adjust tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
