### PR TITLE
[stable27] fix(files): Fix legacy files list sorting

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2185,11 +2185,22 @@
 			}
 
 			if (persist && OC.getCurrentUser().uid) {
-				$.post(OC.generateUrl('/apps/files/api/v1/sorting'), {
-					// Compatibility with new files-to-vue API
-					mode: sort === 'name' ? 'basename' : sort,
-					direction: direction,
-					view: 'files'
+				$.ajax({
+					type: 'PUT',
+					url: OC.generateUrl('apps/files/api/v1/views/files/sorting_mode'),
+					contentType: 'application/json',
+					data: JSON.stringify({
+						// Compatibility with new files-to-vue API
+						value: sort === 'name' ? 'basename' : sort,
+					})
+				});
+				$.ajax({
+					type: 'PUT',
+					url: OC.generateUrl('apps/files/api/v1/views/files/sorting_direction'),
+					contentType: 'application/json',
+					data: JSON.stringify({
+						value: direction,
+					})
 				});
 			}
 		},

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -255,7 +255,7 @@ class ViewController extends Controller {
 		$this->initialState->provideInitialState('viewConfigs', $this->viewConfig->getConfigs());
 
 		// File sorting user config
-		$filesSortingConfig = json_decode($this->config->getUserValue($userId, 'files', 'files_sorting_configs', '{}'), true);
+		$filesSortingConfig = $this->viewConfig->getConfigs();
 		$this->initialState->provideInitialState('filesSortingConfig', $filesSortingConfig);
 
 		// render the container content for every navigation item
@@ -301,8 +301,8 @@ class ViewController extends Controller {
 		$params['ownerDisplayName'] = $storageInfo['ownerDisplayName'] ?? '';
 		$params['isPublic'] = false;
 		$params['allowShareWithLink'] = $this->shareManager->shareApiAllowLinks() ? 'yes' : 'no';
-		$params['defaultFileSorting'] = $filesSortingConfig['files']['mode'] ?? 'basename';
-		$params['defaultFileSortingDirection'] = $filesSortingConfig['files']['direction'] ?? 'asc';
+		$params['defaultFileSorting'] = $filesSortingConfig['files']['sorting_mode'] ?? 'basename';
+		$params['defaultFileSortingDirection'] = $filesSortingConfig['files']['sorting_direction'] ?? 'asc';
 		$params['showgridview'] = $this->config->getUserValue($userId, 'files', 'show_grid', false);
 		$showHidden = (bool) $this->config->getUserValue($userId, 'files', 'show_hidden', false);
 		$params['showHiddenFiles'] = $showHidden ? 1 : 0;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2561,10 +2561,11 @@ describe('OCA.Files.FileList tests', function() {
 		});
 
 		it('Toggles the sort indicator when clicking on a column header', function() {
-			var ASC_CLASS = fileList.SORT_INDICATOR_ASC_CLASS;
-			var DESC_CLASS = fileList.SORT_INDICATOR_DESC_CLASS;
+			const ASC_CLASS = fileList.SORT_INDICATOR_ASC_CLASS;
+			const DESC_CLASS = fileList.SORT_INDICATOR_DESC_CLASS;
 			var request;
-			var sortingUrl = OC.generateUrl('/apps/files/api/v1/sorting');
+			const sortingDirectionUrl = OC.generateUrl('/apps/files/api/v1/views/files/sorting_direction');
+			const sortingModeUrl = OC.generateUrl('/apps/files/api/v1/views/files/sorting_mode');
 			fileList.$el.find('.column-size .columntitle').click();
 			// moves triangle to size column, check indicator on name is hidden
 			expect(
@@ -2578,9 +2579,9 @@ describe('OCA.Files.FileList tests', function() {
 				fileList.$el.find('.column-size .sort-indicator').hasClass(DESC_CLASS)
 			).toEqual(true);
 			// check if changes are persisted
-			expect(fakeServer.requests.length).toEqual(1);
-			request = fakeServer.requests[0];
-			expect(request.url).toEqual(sortingUrl);
+			expect(fakeServer.requests.length).toEqual(2);
+			expect(fakeServer.requests.some((request) => request.url === sortingDirectionUrl)).toBe(true)
+			expect(fakeServer.requests.some((request) => request.url === sortingModeUrl)).toBe(true)
 
 			// click again on size column, reverses direction
 			fileList.$el.find('.column-size .columntitle').click();
@@ -2591,9 +2592,9 @@ describe('OCA.Files.FileList tests', function() {
 				fileList.$el.find('.column-size .sort-indicator').hasClass(ASC_CLASS)
 			).toEqual(true);
 			// check if changes are persisted
-			expect(fakeServer.requests.length).toEqual(2);
-			request = fakeServer.requests[1];
-			expect(request.url).toEqual(sortingUrl);
+			expect(fakeServer.requests.length).toEqual(4);
+			expect(fakeServer.requests.slice(2).some((request) => request.url === sortingDirectionUrl)).toBe(true)
+			expect(fakeServer.requests.slice(2).some((request) => request.url === sortingModeUrl)).toBe(true)
 
 			// click again on size column, reverses direction
 			fileList.$el.find('.column-size .columntitle').click();
@@ -2603,9 +2604,9 @@ describe('OCA.Files.FileList tests', function() {
 			expect(
 				fileList.$el.find('.column-size .sort-indicator').hasClass(DESC_CLASS)
 			).toEqual(true);
-			expect(fakeServer.requests.length).toEqual(3);
-			request = fakeServer.requests[2];
-			expect(request.url).toEqual(sortingUrl);
+			expect(fakeServer.requests.length).toEqual(6);
+			expect(fakeServer.requests.slice(4).some((request) => request.url === sortingDirectionUrl)).toBe(true)
+			expect(fakeServer.requests.slice(4).some((request) => request.url === sortingModeUrl)).toBe(true)
 
 			// click on mtime column, moves indicator there
 			fileList.$el.find('.column-mtime .columntitle').click();
@@ -2618,10 +2619,11 @@ describe('OCA.Files.FileList tests', function() {
 			expect(
 				fileList.$el.find('.column-mtime .sort-indicator').hasClass(DESC_CLASS)
 			).toEqual(true);
-			expect(fakeServer.requests.length).toEqual(4);
-			request = fakeServer.requests[3];
-			expect(request.url).toEqual(sortingUrl);
+			expect(fakeServer.requests.length).toEqual(8);
+			expect(fakeServer.requests.slice(6).some((request) => request.url === sortingDirectionUrl)).toBe(true)
+			expect(fakeServer.requests.slice(6).some((request) => request.url === sortingModeUrl)).toBe(true)
 		});
+
 		it('Uses correct sort comparator when inserting files', function() {
 			testFiles.sort(OCA.Files.FileList.Comparators.size);
 			testFiles.reverse();	//default is descending


### PR DESCRIPTION
* Resolves: #38758

## Summary
The sorting was not saved since files2vue changes in Nextcloud 27, as a new API endpoint was introduced and the old one was dropped without adjusting the legacy file list to use it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
