### PR TITLE
pass the share to the cache instead of having to ask the storage

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -413,7 +413,8 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 		$this->cache = new \OCA\Files_Sharing\Cache(
 			$storage,
 			$sourceRoot,
-			\OC::$server->get(DisplayNameCache::class)
+			\OC::$server->get(DisplayNameCache::class),
+			$this->getShare()
 		);
 		return $this->cache;
 	}


### PR DESCRIPTION
Going through the storage includes storage wrappers so it has a bit more overhead than you might expect.

A [modest improvement](https://blackfire.io/profiles/compare/6741c0d9-f280-482b-a03b-139bda1c25c7/graph) for a small change