### PR TITLE
[stable27] allow to upgrade from 26.0.x to 27.1.x directly

### DIFF
--- a/version.php
+++ b/version.php
@@ -37,6 +37,7 @@ $OC_VersionString = '27.1.0 beta 2';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
+		'26.0' => true,
 		'27.0' => true,
 		'27.1' => true,
 	],


### PR DESCRIPTION
Do this to prevent upgrade issues if custom update solutions are in place that are not written to handle the case needing to upgrade from 26.0.x to 27.0.x and then to 27.1.x

As discussed with @skjnldsv and @AndyScherzinger 