### PR TITLE
fix(dav): fix event birthday alarms not being updated

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -317,6 +317,11 @@ class BirthdayService {
 	}
 
 	/**
+	 * The birthday event is considered changed if either
+	 *  - the start date has changed
+	 *  - the title has changed
+	 *  - the time for the alarm has changed
+	 *
 	 * @param string $existingCalendarData
 	 * @param VCalendar $newCalendarData
 	 * @return bool
@@ -331,7 +336,8 @@ class BirthdayService {
 
 		return (
 			$newCalendarData->VEVENT->DTSTART->getValue() !== $existingBirthday->VEVENT->DTSTART->getValue() ||
-			$newCalendarData->VEVENT->SUMMARY->getValue() !== $existingBirthday->VEVENT->SUMMARY->getValue()
+			$newCalendarData->VEVENT->SUMMARY->getValue() !== $existingBirthday->VEVENT->SUMMARY->getValue() ||
+			($newCalendarData->VEVENT->VALARM && $existingBirthday->VEVENT->VALARM && $newCalendarData->VEVENT->VALARM->TRIGGER->getValue() !== $existingBirthday->VEVENT->VALARM->TRIGGER->getValue())
 		);
 	}
 

--- a/apps/dav/lib/Migration/RegenerateBirthdayCalendars.php
+++ b/apps/dav/lib/Migration/RegenerateBirthdayCalendars.php
@@ -4,6 +4,7 @@
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Georg Ehrke <oc.list@georgehrke.com>
+ * @author Thomas Citharel <nextcloud@tcit.fr>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -30,36 +31,22 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 class RegenerateBirthdayCalendars implements IRepairStep {
+	private IJobList $jobList;
+	private IConfig $config;
 
-	/** @var IJobList */
-	private $jobList;
-
-	/** @var IConfig */
-	private $config;
-
-	/**
-	 * @param IJobList $jobList
-	 * @param IConfig $config
-	 */
 	public function __construct(IJobList $jobList,
 		IConfig $config) {
 		$this->jobList = $jobList;
 		$this->config = $config;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getName() {
+	public function getName(): string {
 		return 'Regenerating birthday calendars to use new icons and fix old birthday events without year';
 	}
 
-	/**
-	 * @param IOutput $output
-	 */
-	public function run(IOutput $output) {
+	public function run(IOutput $output): void {
 		// only run once
-		if ($this->config->getAppValue('dav', 'regeneratedBirthdayCalendarsForYearFix') === 'yes') {
+		if ($this->config->getAppValue('dav', 'regeneratedBirthdayCalendarsForYearFix') === 'yes' && $this->config->getAppValue('dav', 'regeneratedBirthdayCalendarsForAlarmFix') === 'yes') {
 			$output->info('Repair step already executed');
 			return;
 		}
@@ -69,5 +56,6 @@ class RegenerateBirthdayCalendars implements IRepairStep {
 
 		// if all were done, no need to redo the repair during next upgrade
 		$this->config->setAppValue('dav', 'regeneratedBirthdayCalendarsForYearFix', 'yes');
+		$this->config->setAppValue('dav', 'regeneratedBirthdayCalendarsForAlarmFix', 'yes');
 	}
 }


### PR DESCRIPTION
In https://github.com/nextcloud/server/pull/33251 the default offset for a birthday event alarm was changed to 9AM on the day of the event.

However the `birthdayEvenChanged` method did not account for alarm changes, so it was never propagated to existing birthday events, which were kept on midnight.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
