### PR TITLE
fix(CS): Ignore apps*/ directories which are gitignored

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,4 +21,17 @@ $config
 	->notPath('node_modules')
 	->notPath('vendor')
 	->in(__DIR__);
+
+// Ignore additional app directories
+$rootDir = new \DirectoryIterator(__DIR__);
+foreach ($rootDir as $node) {
+	if (str_starts_with($node->getFilename(), 'apps')) {
+		$return = shell_exec('git check-ignore ' . escapeshellarg($node->getFilename() . '/'));
+
+		if ($return !== null) {
+			$config->getFinder()->exclude($node->getFilename());
+		}
+	}
+}
+
 return $config;


### PR DESCRIPTION
Following the pattern of https://github.com/nextcloud/server/blob/821ad805d205c6a5da00ae485f93bb7035c93e1a/build/autoloaderchecker.sh#L34-L39
We can skip some directories which we don't care about to make app devs live easier.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
