### PR TITLE
[stable25] fix: always use display name from correct backend

### DIFF
--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -61,6 +61,7 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Security\ICrypto;
 use OCP\Security\VerificationToken\IVerificationToken;
+use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -791,6 +792,10 @@ class AccountManager implements IAccountManager {
 			return $this->internalCache->get($user->getUID());
 		}
 		$account = $this->parseAccountData($user, $this->getUser($user));
+		if ($user->getBackend() instanceof IGetDisplayNameBackend) {
+			$property = $account->getProperty(self::PROPERTY_DISPLAYNAME);
+			$account->setProperty(self::PROPERTY_DISPLAYNAME, $user->getDisplayName(), $property->getScope(), $property->getVerified());
+		}
 		$this->internalCache->set($user->getUID(), $account);
 		return $account;
 	}


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/39770

Overwrite the display name after the account is initialized when using an instacne of IGetDisplayNameBackend.

Before when using a variation of user_oidc and registering a Backend.php implementing IGetDisplayNameBackend
the personal setting page shows 'uid'.

The UserManager/AccountManager seems not to use consistently the correct backend.

The correct backend is used in this sequence:

server/lib/private/TemplateLayout.php

          $userDisplayName = \OC_User::getDisplayName();
          $this->assign(user_displayname, $userDisplayName);

In the settings page, it definitely not calls the registered backend, but seems to fall back to default Backend and shows (usually) uid or a value from the standard account property table.

