### PR TITLE
fix(middleware): Fix header injection for bruteforce middleware

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php
@@ -130,11 +130,7 @@ class BruteForceMiddleware extends Middleware {
 		}
 
 		if ($this->delaySlept) {
-			$headers = $response->getHeaders();
-			if (!isset($headers['X-Nextcloud-Bruteforce-Throttled'])) {
-				$headers['X-Nextcloud-Bruteforce-Throttled'] = $this->delaySlept . 'ms';
-				$response->setHeaders($headers);
-			}
+			$response->addHeader('X-Nextcloud-Bruteforce-Throttled', $this->delaySlept . 'ms');
 		}
 
 		return parent::afterController($controller, $methodName, $response);


### PR DESCRIPTION
Calling `setHeaders(getHeaders())` breaks the CSP nonce for unknown reasons So shifting back to old standard practise for now

## Summary

* Open a talk conversation you are not a member off so you get bruteforce throttled
* Load the index.php/apps/spreed
* See console glowing red with weird unrelated errors (CSP is the route cause)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
