### PR TITLE
Do not log passwords in debug mode

### DIFF
--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -33,6 +33,7 @@
  */
 namespace OCA\User_LDAP;
 
+use OCP\IConfig;
 use OCP\Profiler\IProfiler;
 use OC\ServerNotAvailableException;
 use OCA\User_LDAP\DataCollector\LdapDataCollector;
@@ -317,6 +318,14 @@ class LDAP implements ILDAPWrapper {
 
 	private function preFunctionCall(string $functionName, array $args): void {
 		$this->curArgs = $args;
+		if(strcasecmp($functionName, 'ldap_bind') === 0) {
+			// The arguments are not key value pairs
+			// \OCA\User_LDAP\LDAP::bind passes 3 arguments, the 3rd being the pw
+			// Remove it via direct array access for now, although a better solution could be found mebbe?
+			// @link https://github.com/nextcloud/server/issues/38461
+			$args[2] = IConfig::SENSITIVE_VALUE;
+		}
+
 		$this->logger->debug('Calling LDAP function {func} with parameters {args}', [
 			'app' => 'user_ldap',
 			'func' => $functionName,


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/38461

## Summary

In debug mode, the passwords were logged.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
