### PR TITLE
always use the default fs owner when storing versions

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -42,6 +42,7 @@ namespace OCA\Files_Versions;
 use OC_User;
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCA\Files_Sharing\SharedMount;
 use OCA\Files_Versions\AppInfo\Application;
 use OCA\Files_Versions\Command\Expire;
 use OCA\Files_Versions\Events\CreateVersionEvent;
@@ -172,33 +173,45 @@ class Storage {
 			return false;
 		}
 
-		[$uid, $filename] = self::getUidAndFilename($filename);
+		// since hook paths are always relative to the "default filesystem view"
+		// we always use the owner from there to get the full node
+		$uid = Filesystem::getView()->getOwner('');
 
-		$files_view = new View('/'.$uid .'/files');
+		/** @var IRootFolder $rootFolder */
+		$rootFolder = \OC::$server->query(IRootFolder::class);
+		$userFolder = $rootFolder->getUserFolder($uid);
 
 		$eventDispatcher = \OC::$server->getEventDispatcher();
-		$fileInfo = $files_view->getFileInfo($filename);
-		$id = $fileInfo->getId();
-		$nodes = \OC::$server->getRootFolder()->getUserFolder($uid)->getById($id);
-		foreach ($nodes as $node) {
-			$event = new CreateVersionEvent($node);
-			$eventDispatcher->dispatch('OCA\Files_Versions::createVersion', $event);
-			if ($event->shouldCreateVersion() === false) {
-				return false;
+		try {
+			$file = $userFolder->get($filename);
+		} catch (NotFoundException $e) {
+			return false;
+		}
+
+		$mount = $file->getMountPoint();
+		if ($mount instanceof SharedMount) {
+			$ownerFolder = $rootFolder->getUserFolder($mount->getShare()->getShareOwner());
+			$ownerNodes = $ownerFolder->getById($file->getId());
+			if (count($ownerNodes)) {
+				$file = current($ownerNodes);
 			}
 		}
 
 		// no use making versions for empty files
-		if ($fileInfo->getSize() === 0) {
+		if ($file->getSize() === 0) {
+			return false;
+		}
+
+		$event = new CreateVersionEvent($file);
+		$eventDispatcher->dispatch('OCA\Files_Versions::createVersion', $event);
+		if ($event->shouldCreateVersion() === false) {
 			return false;
 		}
 
 		/** @var IVersionManager $versionManager */
 		$versionManager = \OC::$server->query(IVersionManager::class);
-		$userManager = \OC::$server->getUserManager();
-		$user = $userManager->get($uid);
 
-		$versionManager->createVersion($user, $fileInfo);
+		$versionManager->createVersion($file->getOwner(), $file);
 	}
 
 


### PR DESCRIPTION
Signed-off-by: Robin Appelman <robin@icewind.nl>


* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
