### PR TITLE
(enh) Change `occ background-job:list` limit default 10->500

### DIFF
--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -66,11 +66,12 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$jobs = $this->jobList->getJobsIterator($input->getOption('class'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
-		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
-			$output->writeln("Output is currently limited to first " .  $input->getOption('limit') . " jobs. Specify `-l, --limit[=LIMIT]` to override.");
+		$limit = (int)$input->getOption('limit');
+		$jobsInfo = $this->formatJobs($this->jobList->getJobsIterator($input->getOption('class'), $limit, (int)$input->getOption('offset')));
+		$this->writeTableInOutputFormat($input, $output, $jobsInfo);
+		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN && count($jobsInfo) >= $limit) {
+			$output->writeln("\n<comment>Output is currently limited to first " .  $limit . " jobs. Specify `-l, --limit[=LIMIT]` to override.</comment>");
 		}
-		$this->writeTableInOutputFormat($input, $output, $this->formatJobs($jobs));
 		return 0;
 	}
 

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -53,7 +53,7 @@ class ListCommand extends Base {
 				'l',
 				InputOption::VALUE_OPTIONAL,
 				'Number of jobs to retrieve',
-				'100'
+				'500'
 			)->addOption(
 				'offset',
 				'o',

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -67,7 +67,9 @@ class ListCommand extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$jobs = $this->jobList->getJobsIterator($input->getOption('class'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
-		$output->writeln("Output is currently limited to first " .  $input->getOption('limit') . " jobs. Specify `-l, --limit[=LIMIT]` to override.");
+		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
+			$output->writeln("Output is currently limited to first " .  $input->getOption('limit') . " jobs. Specify `-l, --limit[=LIMIT]` to override.");
+		}
 		$this->writeTableInOutputFormat($input, $output, $this->formatJobs($jobs));
 		return 0;
 	}

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -53,7 +53,7 @@ class ListCommand extends Base {
 				'l',
 				InputOption::VALUE_OPTIONAL,
 				'Number of jobs to retrieve',
-				'10'
+				'100'
 			)->addOption(
 				'offset',
 				'o',
@@ -67,6 +67,7 @@ class ListCommand extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$jobs = $this->jobList->getJobsIterator($input->getOption('class'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
+		$output->writeln("Output is currently limited to first " .  $input->getOption('limit') . " jobs. Specify `-l, --limit[=LIMIT]` to override.");
 		$this->writeTableInOutputFormat($input, $output, $this->formatJobs($jobs));
 		return 0;
 	}

--- a/core/Command/Background/ListCommand.php
+++ b/core/Command/Background/ListCommand.php
@@ -70,7 +70,7 @@ class ListCommand extends Base {
 		$jobsInfo = $this->formatJobs($this->jobList->getJobsIterator($input->getOption('class'), $limit, (int)$input->getOption('offset')));
 		$this->writeTableInOutputFormat($input, $output, $jobsInfo);
 		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN && count($jobsInfo) >= $limit) {
-			$output->writeln("\n<comment>Output is currently limited to first " .  $limit . " jobs. Specify `-l, --limit[=LIMIT]` to override.</comment>");
+			$output->writeln("\n<comment>Output is currently limited to " .  $limit . " jobs. Specify `-l, --limit[=LIMIT]` to override.</comment>");
 		}
 		return 0;
 	}


### PR DESCRIPTION
## Summary

I'd been wondering for awhile why not all background jobs would show up under `occ background-job:list` even though all jobs were clearly being executed. Spent an embarrassing amount of time reviewing the code on this... only to realize there was a default limit of `10` in the command. :rofl: 

I understand why there is a limit (large environments) - and it can be easily overridden - but I feel 10 is  bit _too_ conservative for a default. Being this low means the job list is nearly always incomplete in the default execution mode, which makes the overriding of the default nearly a 100% certainty in day to day use.

Nearly all environments >10 and many (most?) <100 jobs. This changes the default to 100 so fewer have to feel as silly as me. :smiley:  And a lot more people get all their jobs shown by default. At the same time, this higher default still remains conservative enough to avoid problems in really large environments.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- ~~[ ] Screenshots before/after for front-end changes~~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- ~~[ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~~
