### PR TITLE
Clean up PHPDoc params and return values

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2602,7 +2602,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 *
 	 * @param string $principalUri
 	 * @param string $objectUri
-	 * @return array
+	 * @return array|null
 	 */
 	public function getSchedulingObject($principalUri, $objectUri) {
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
+++ b/apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php
@@ -157,7 +157,7 @@ abstract class AbstractPrincipalBackend implements BackendInterface {
 	 *
 	 * @param string $prefixPath
 	 *
-	 * @return array
+	 * @return array|null
 	 */
 	public function getPrincipalByPath($path) {
 		if (strpos($path, $this->principalPrefix) !== 0) {

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -543,7 +543,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 *
 	 * @param mixed $addressBookId
 	 * @param string $cardUri
-	 * @return array
+	 * @return array|false
 	 */
 	public function getCard($addressBookId, $cardUri) {
 		$query = $this->db->getQueryBuilder();

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -183,7 +183,7 @@ class FilesReportPlugin extends ServerPlugin {
 	public function onReport($reportName, $report, $uri) {
 		$reportTargetNode = $this->server->tree->getNodeForPath($uri);
 		if (!$reportTargetNode instanceof Directory || $reportName !== self::REPORT_NAME) {
-			return;
+			return false;
 		}
 
 		$ns = '{' . $this::NS_OWNCLOUD . '}';

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -159,7 +159,7 @@ class Principal implements BackendInterface {
 	 * getPrincipalsByPrefix.
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|null
 	 */
 	public function getPrincipalByPath($path) {
 		[$prefix, $name] = \Sabre\Uri\split($path);

--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -158,7 +158,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 	 * Returns tags for the given file id
 	 *
 	 * @param integer $fileId file id
-	 * @return array list of tags for that file
+	 * @return array|null list of tags for that file
 	 */
 	private function getTags($fileId) {
 		if (isset($this->cachedTags[$fileId])) {

--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -101,7 +101,7 @@ class GroupPrincipalBackend implements BackendInterface {
 	 * getPrincipalsByPrefix.
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|null
 	 */
 	public function getPrincipalByPath($path) {
 		$elements = explode('/', $path,  3);

--- a/apps/dav/lib/DAV/SystemPrincipalBackend.php
+++ b/apps/dav/lib/DAV/SystemPrincipalBackend.php
@@ -65,7 +65,7 @@ class SystemPrincipalBackend extends AbstractBackend {
 	 * getPrincipalsByPrefix.
 	 *
 	 * @param string $path
-	 * @return array
+	 * @return array|null
 	 */
 	public function getPrincipalByPath($path) {
 		if ($path === 'principals/system/system') {

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -135,7 +135,7 @@ class ListConfigs extends Base {
 	 */
 	protected function getAppConfigs($app, $noSensitiveValues) {
 		if ($noSensitiveValues) {
-			return $this->appConfig->getFilteredValues($app, false);
+			return $this->appConfig->getFilteredValues($app);
 		} else {
 			return $this->appConfig->getValues($app, false);
 		}

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -187,7 +187,7 @@ abstract class Fetcher {
 
 		// Refresh the file content
 		try {
-			$responseJson = $this->fetch($ETag, $content, $allowUnstable);
+			$responseJson = $this->fetch($ETag, $content);
 
 			if (empty($responseJson)) {
 				return [];

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -235,7 +235,7 @@ class InfoParser {
 
 	/**
 	 * @param \SimpleXMLElement $xml
-	 * @return array
+	 * @return array|string
 	 */
 	public function xmlToArray($xml) {
 		if (!$xml->children()) {

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -618,7 +618,7 @@ class Manager implements ICommentsManager {
 	 * @param \DateTime $notOlderThan optional, timestamp of the oldest comments
 	 * that may be returned
 	 * @param string $verb Limit the verb of the comment - Added in 14.0.0
-	 * @return Int
+	 * @return int
 	 * @since 9.0.0
 	 */
 	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null, $verb = '') {

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -92,7 +92,7 @@ class ContactsManager implements IManager {
 	 *
 	 * @param int $id the unique identifier to a contact
 	 * @param string $address_book_key identifier of the address book in which the contact shall be deleted
-	 * @return bool successful or not
+	 * @return bool|null successful or not
 	 */
 	public function delete($id, $address_book_key) {
 		$addressBook = $this->getAddressBook($address_book_key);
@@ -113,7 +113,7 @@ class ContactsManager implements IManager {
 	 *
 	 * @param array $properties this array if key-value-pairs defines a contact
 	 * @param string $address_book_key identifier of the address book in which the contact shall be created or updated
-	 * @return array representing the contact just created or updated
+	 * @return array|null representing the contact just created or updated
 	 */
 	public function createOrUpdate($properties, $address_book_key) {
 		$addressBook = $this->getAddressBook($address_book_key);
@@ -194,7 +194,7 @@ class ContactsManager implements IManager {
 	 * Get (and load when needed) the address book for $key
 	 *
 	 * @param string $addressBookKey
-	 * @return IAddressBook
+	 * @return IAddressBook|null
 	 */
 	protected function getAddressBook($addressBookKey) {
 		$this->loadAddressBooks();

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -321,7 +321,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 	 *
 	 * @param string $seqName Name of the sequence object from which the ID should be returned.
 	 *
-	 * @return string the last inserted ID.
+	 * @return int the last inserted ID.
 	 * @throws Exception
 	 */
 	public function lastInsertId($seqName = null) {

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -1066,7 +1066,7 @@ class Cache implements ICache {
 	 * instead does a global search in the cache table
 	 *
 	 * @param int $id
-	 * @return array first element holding the storage id, second the path
+	 * @return array|null first element holding the storage id, second the path
 	 * @deprecated use getPathById() instead
 	 */
 	public static function getById($id) {

--- a/lib/private/Files/Mount/ObjectHomeMountProvider.php
+++ b/lib/private/Files/Mount/ObjectHomeMountProvider.php
@@ -53,7 +53,7 @@ class ObjectHomeMountProvider implements IHomeMountProvider {
 	 *
 	 * @param IUser $user
 	 * @param IStorageFactory $loader
-	 * @return \OCP\Files\Mount\IMountPoint
+	 * @return \OCP\Files\Mount\IMountPoint|null
 	 */
 	public function getHomeMountForUser(IUser $user, IStorageFactory $loader) {
 		$config = $this->getMultiBucketObjectStoreConfig($user);

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -114,7 +114,7 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the federated share provider
 	 *
-	 * @return FederatedShareProvider
+	 * @return FederatedShareProvider|null
 	 */
 	protected function federatedShareProvider() {
 		if ($this->federatedProvider === null) {
@@ -171,7 +171,7 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the federated share provider
 	 *
-	 * @return ShareByMailProvider
+	 * @return ShareByMailProvider|null
 	 */
 	protected function getShareByMailProvider() {
 		if ($this->shareByMailProvider === null) {
@@ -211,7 +211,7 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the circle share provider
 	 *
-	 * @return FederatedShareProvider
+	 * @return FederatedShareProvider|null
 	 *
 	 * @suppress PhanUndeclaredClassMethod
 	 */
@@ -245,7 +245,7 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the room share provider
 	 *
-	 * @return RoomShareProvider
+	 * @return RoomShareProvider|null
 	 */
 	protected function getRoomShareProvider() {
 		if ($this->roomShareProvider === null) {

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -63,7 +63,7 @@ class TagManager implements ITagManager, IEventListener {
 	 * @param boolean $includeShared Whether to include tags for items shared with this user by others.
 	 * @param string $userId user for which to retrieve the tags, defaults to the currently
 	 * logged in user
-	 * @return \OCP\ITags
+	 * @return \OCP\ITags|null
 	 *
 	 * since 20.0.0 $includeShared isn't used anymore
 	 */

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -342,7 +342,7 @@ class Database extends ABackend implements
 	 *
 	 * @param string $loginName The loginname
 	 * @param string $password The password
-	 * @return string
+	 * @return string|false
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false

--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -135,7 +135,7 @@ class OC_API {
 
 	/**
 	 * @param integer $sc
-	 * @return int
+	 * @return int|null
 	 */
 	public static function mapStatusCodes($sc) {
 		switch ($sc) {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -283,7 +283,7 @@ class OC_App {
 	/**
 	 * Get the path where to install apps
 	 *
-	 * @return string|false
+	 * @return string|false|null
 	 */
 	public static function getInstallPath() {
 		foreach (OC::$APPSROOTS as $dir) {

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -234,7 +234,7 @@ class OC_Defaults {
 	 */
 	public function getSlogan(?string $lang = null) {
 		if ($this->themeExist('getSlogan')) {
-			return $this->theme->getSlogan($lang);
+			return $this->theme->getSlogan();
 		} else {
 			if ($this->defaultSlogan === null) {
 				$l10n = \OC::$server->getL10N('lib', $lang);

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -198,7 +198,7 @@ interface ICommentsManager {
 	 * @param \DateTime|null $notOlderThan optional, timestamp of the oldest comments
 	 * that may be returned
 	 * @param string $verb Limit the verb of the comment - Added in 14.0.0
-	 * @return Int
+	 * @return int
 	 * @since 9.0.0
 	 */
 	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null, $verb = '');


### PR DESCRIPTION
* Resolves: # N/A

## Summary
This just cleans up some PHPDoc issues. Nothing critical. Let me know if I touched something I shouldn't have.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
