### PR TITLE
fix: make cancelOperation public

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -161,7 +161,7 @@ class Base extends Command implements CompletionAwareInterface {
 	 *
 	 * Gives a chance to the command to properly terminate what it's doing
 	 */
-	protected function cancelOperation() {
+	public function cancelOperation(): void {
 		$this->interrupted = true;
 	}
 


### PR DESCRIPTION
## Summary

I don't understand how that worked in the past, but it broke sometime ;)

**Before:**

[Screencast from 2023-08-27 17-19-45.webm](https://github.com/nextcloud/server/assets/3902676/238e66e9-1b66-436e-a860-f589f055d9f1)

**After:**

[Screencast from 2023-08-27 17-21-20.webm](https://github.com/nextcloud/server/assets/3902676/16e68007-d88c-4ab2-a531-0dcc44ea58b1)


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
