### PR TITLE
[Devcontainer] move git setup to postStartCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "nextclouddev",
 	"postCreateCommand": ".devcontainer/setup.sh",
+	"postStartCommand": ".devcontainer/postStart.sh",
 	"forwardPorts": [
 		80,
 		8080,

--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Set git safe.directory
+git config --global --add safe.directory /var/www/html
+git config --global --add safe.directory /var/www/html/3rdparty

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,10 +3,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" >/dev/null 2>&1 && pwd )"
 
 cd $DIR/
 
-# Set git safe.directory
-git config --global --add safe.directory /var/www/html
-git config --global --add safe.directory /var/www/html/3rdparty
-
 git submodule update --init
 
 # Codespace config


### PR DESCRIPTION
## Problem summary

If you create a new devcontainer (locally), you will find the following in the logs:

```bash
[5245 ms] 
Running the postCreateCommand from devcontainer.json...

[5246 ms] Start: Run in container: /bin/sh -c .devcontainer/setup.sh

# ...

[7822 ms] Start: Run in container: # Test for /home/devcontainer/.gitconfig and git
[7826 ms] /home/devcontainer/.gitconfig exists
[7827 ms] 
[7828 ms] Exit code 1
```

Like shown, the `git config --global` commands executed in `setup.sh` will create the file `/home/devcontainer/.gitconfig` which will prevent that the `.gitconfig` of the local user gets copied to the devcontainer. A similar issue is described here: https://github.com/devcontainers/cli/issues/98.

If you for example execute  `git config --global user.name` after the container has been created, you will see that the username is empty and not set to the local git user of the host system.

## Fix

The fix here moves the `git config --global` commands to a later setup stage. The logs will now look like the following (see also https://github.com/microsoft/vscode-remote-release/issues/4855#issuecomment-831920085):

```bash
[5519 ms] 
Running the postCreateCommand from devcontainer.json...

[5520 ms] Start: Run in container: /bin/sh -c .devcontainer/setup.sh

# ...

[7960 ms] Start: Run in container: # Test for /home/devcontainer/.gitconfig and git
[7962 ms] 
[7962 ms] 
[7963 ms] Start: Run in container: # Copy /home/robin/.gitconfig to /home/devcontainer/.gitconfig
[7965 ms] 

# ...

[8418 ms] 
Running the postStartCommand from devcontainer.json...

[8419 ms] Start: Run in container: /bin/sh -c .devcontainer/postStart.sh
```

Now `git config --global user.name` outputs `Robin Windey` in my case. 

Copying the local git settings into the container is usually necessary to execute `git commit` (and git signing).
