### PR TITLE
fix(cache): Remove displayname cache entry on delete

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -65,12 +65,14 @@ use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\IRootFolder;
 use OCP\Group\Events\GroupChangedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IUserSession;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\User\Events\UserChangedEvent;
+use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent as OldGenericEvent;
@@ -104,7 +106,9 @@ class Application extends App implements IBootstrap {
 
 		$context->registerNotifierService(Notifier::class);
 		$context->registerEventListener(UserChangedEvent::class, DisplayNameCache::class);
+		$context->registerEventListener(UserDeletedEvent::class, DisplayNameCache::class);
 		$context->registerEventListener(GroupChangedEvent::class, GroupDisplayNameCache::class);
+		$context->registerEventListener(GroupDeletedEvent::class, GroupDisplayNameCache::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/private/Group/DisplayNameCache.php
+++ b/lib/private/Group/DisplayNameCache.php
@@ -29,6 +29,7 @@ use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Events\GroupChangedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IGroupManager;
@@ -82,6 +83,11 @@ class DisplayNameCache implements IEventListener {
 			$newDisplayName = $event->getValue();
 			$this->cache[$groupId] = $newDisplayName;
 			$this->memCache->set($groupId, $newDisplayName, 60 * 10); // 10 minutes
+		}
+		if ($event instanceof GroupDeletedEvent) {
+			$groupId = $event->getGroup()->getGID();
+			unset($this->cache[$groupId]);
+			$this->memCache->remove($groupId);
 		}
 	}
 }

--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -29,6 +29,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IUserManager;
 use OCP\User\Events\UserChangedEvent;
+use OCP\User\Events\UserDeletedEvent;
 
 /**
  * Class that cache the relation UserId -> Display name
@@ -80,6 +81,11 @@ class DisplayNameCache implements IEventListener {
 			$newDisplayName = $event->getValue();
 			$this->cache[$userId] = $newDisplayName;
 			$this->memCache->set($userId, $newDisplayName, 60 * 10); // 10 minutes
+		}
+		if ($event instanceof UserDeletedEvent) {
+			$userId = $event->getUser()->getUID();
+			unset($this->cache[$userId]);
+			$this->memCache->remove($userId);
 		}
 	}
 }


### PR DESCRIPTION
* Resolves checkbox 1 from https://github.com/nextcloud/spreed/issues/10377
* Found while trying to enable APCu on Talk integration tests to speed them up: https://github.com/nextcloud/spreed/pull/10374

## TODO

- [x] Remove cached user display name on deletion
- [x] Remove cached group display name on deletion

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
