### PR TITLE
Clean up (many) deprecated functions

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -52,7 +52,7 @@ $principalBackend = new Principal(
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getAppManager(),
-	\OC::$server->query(\OCA\DAV\CalDAV\Proxy\ProxyMapper::class),
+	\OC::$server->get(\OCA\DAV\CalDAV\Proxy\ProxyMapper::class),
 	\OC::$server->get(KnownUserService::class),
 	\OC::$server->getConfig(),
 	\OC::$server->getL10NFactory(),
@@ -113,7 +113,7 @@ $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
 $server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class)));
 
 if ($sendInvitations) {
-	$server->addPlugin(\OC::$server->query(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
+	$server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
 }
 $server->addPlugin(new ExceptionLoggerPlugin('caldav', $logger));
 

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -39,6 +39,7 @@ use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
+use OCP\Files\AppData\IAppDataFactory;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Plugin;
 
@@ -57,7 +58,7 @@ $principalBackend = new Principal(
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getAppManager(),
-	\OC::$server->query(\OCA\DAV\CalDAV\Proxy\ProxyMapper::class),
+	\OC::$server->get(\OCA\DAV\CalDAV\Proxy\ProxyMapper::class),
 	\OC::$server->get(KnownUserService::class),
 	\OC::$server->getConfig(),
 	\OC::$server->getL10NFactory(),
@@ -72,7 +73,7 @@ $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
 $principalCollection->disableListing = !$debugging; // Disable listing
 
-$pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
+$pluginManager = new PluginManager(\OC::$server, \OC::$server->get(IAppManager::class));
 $addressBookRoot = new AddressBookRoot($principalBackend, $cardDavBackend, $pluginManager, \OC::$server->getUserSession()->getUser(), \OC::$server->get(\OCP\IGroupManager::class));
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
@@ -99,7 +100,7 @@ if ($debugging) {
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
 $server->addPlugin(new \OCA\DAV\CardDAV\ImageExportPlugin(new \OCA\DAV\CardDAV\PhotoCache(
-	\OC::$server->getAppDataDir('dav-photocache'),
+	\OC::$server->get(IAppDataFactory::class)->get('dav-photocache'),
 	\OC::$server->get(LoggerInterface::class)
 )));
 $server->addPlugin(new ExceptionLoggerPlugin('carddav', \OC::$server->get(LoggerInterface::class)));

--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -75,7 +75,7 @@ $filesDropPlugin = new \OCA\DAV\Files\Sharing\FilesDropPlugin();
 $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, function (\Sabre\DAV\Server $server) use ($authBackend, $linkCheckPlugin, $filesDropPlugin) {
 	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest');
 	/** @var \OCA\FederatedFileSharing\FederatedShareProvider $shareProvider */
-	$federatedShareProvider = \OC::$server->query(\OCA\FederatedFileSharing\FederatedShareProvider::class);
+	$federatedShareProvider = \OC::$server->get(\OCA\FederatedFileSharing\FederatedShareProvider::class);
 	if ($federatedShareProvider->isOutgoingServer2serverShareEnabled() === false && !$isAjax) {
 		// this is what is thrown when trying to access a non-existing share
 		throw new \Sabre\DAV\Exception\NotAuthenticated();

--- a/apps/dav/appinfo/v2/direct.php
+++ b/apps/dav/appinfo/v2/direct.php
@@ -38,13 +38,13 @@ ignore_user_abort(true);
 $requestUri = \OC::$server->getRequest()->getRequestUri();
 
 /** @var ServerFactory $serverFactory */
-$serverFactory = \OC::$server->query(ServerFactory::class);
+$serverFactory = \OC::$server->get(ServerFactory::class);
 $server = $serverFactory->createServer(
 	$baseuri,
 	$requestUri,
 	\OC::$server->getRootFolder(),
-	\OC::$server->query(\OCA\DAV\Db\DirectMapper::class),
-	\OC::$server->query(\OCP\AppFramework\Utility\ITimeFactory::class),
+	\OC::$server->get(\OCA\DAV\Db\DirectMapper::class),
+	\OC::$server->get(\OCP\AppFramework\Utility\ITimeFactory::class),
 	\OC::$server->getBruteForceThrottler(),
 	\OC::$server->getRequest()
 );

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -49,7 +49,7 @@ class InvitationResponseServer {
 		$baseUri = \OC::$WEBROOT . '/remote.php/dav/';
 		$logger = \OC::$server->get(LoggerInterface::class);
 		/** @var IEventDispatcher $dispatcher */
-		$dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$dispatcher = \OC::$server->get(IEventDispatcher::class);
 
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
@@ -73,7 +73,7 @@ class NotificationProviderManager {
 	 * @throws \OCP\AppFramework\QueryException
 	 */
 	public function registerProvider(string $providerClassName):void {
-		$provider = \OC::$server->query($providerClassName);
+		$provider = \OC::$server->get($providerClassName);
 
 		if (!$provider instanceof INotificationProvider) {
 			throw new \InvalidArgumentException('Invalid notification provider registered');

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -88,7 +88,7 @@ class CreateCalendar extends Command {
 			\OC::$server->getShareManager(),
 			\OC::$server->getUserSession(),
 			\OC::$server->getAppManager(),
-			\OC::$server->query(ProxyMapper::class),
+			\OC::$server->get(ProxyMapper::class),
 			\OC::$server->get(KnownUserService::class),
 			\OC::$server->getConfig(),
 			\OC::$server->getL10NFactory(),

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -66,7 +66,7 @@ class RootCollection extends SimpleCollection {
 		$db = \OC::$server->getDatabaseConnection();
 		$dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$config = \OC::$server->get(IConfig::class);
-		$proxyMapper = \OC::$server->query(ProxyMapper::class);
+		$proxyMapper = \OC::$server->get(ProxyMapper::class);
 		$rootFolder = \OCP\Server::get(IRootFolder::class);
 
 		$userPrincipalBackend = new Principal(
@@ -143,7 +143,7 @@ class RootCollection extends SimpleCollection {
 			$logger
 		);
 
-		$pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
+		$pluginManager = new PluginManager(\OC::$server, \OC::$server->get(IAppManager::class));
 		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $userManager, $groupManager, $dispatcher);
 		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, $pluginManager, $userSession->getUser(), $groupManager, 'principals/users');
 		$usersAddressBookRoot->disableListing = $disableListing;
@@ -155,14 +155,14 @@ class RootCollection extends SimpleCollection {
 		$uploadCollection = new Upload\RootCollection(
 			$userPrincipalBackend,
 			'principals/users',
-			\OC::$server->query(CleanupService::class));
+			\OC::$server->get(CleanupService::class));
 		$uploadCollection->disableListing = $disableListing;
 
 		$avatarCollection = new Avatars\RootCollection($userPrincipalBackend, 'principals/users');
 		$avatarCollection->disableListing = $disableListing;
 
 		$appleProvisioning = new AppleProvisioningNode(
-			\OC::$server->query(ITimeFactory::class));
+			\OC::$server->get(ITimeFactory::class));
 
 		$children = [
 			new SimpleCollection('principals', [

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -76,6 +76,7 @@ use OCA\DAV\Upload\ChunkingV2Plugin;
 use OCP\AppFramework\Http\Response;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\AppData\IAppDataFactory;
 use OCP\ICacheFactory;
 use OCP\IRequest;
 use OCP\Profiler\IProfiler;
@@ -177,7 +178,7 @@ class Server {
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\ICSExportPlugin\ICSExportPlugin(\OC::$server->getConfig(), $logger));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class)));
 			if (\OC::$server->getConfig()->getAppValue('dav', 'sendInvitations', 'yes') === 'yes') {
-				$this->server->addPlugin(\OC::$server->query(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
+				$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
 			}
 
 			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
@@ -202,7 +203,7 @@ class Server {
 			$this->server->addPlugin(new MultiGetExportPlugin());
 			$this->server->addPlugin(new HasPhotoPlugin());
 			$this->server->addPlugin(new ImageExportPlugin(new PhotoCache(
-				\OC::$server->getAppDataDir('dav-photocache'),
+				\OC::$server->get(IAppDataFactory::class)->get('dav-photocache'),
 				$logger)
 			));
 		}
@@ -327,7 +328,7 @@ class Server {
 				}
 				$this->server->addPlugin(new \OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin(
 					\OC::$server->getConfig(),
-					\OC::$server->query(BirthdayService::class)
+					\OC::$server->get(BirthdayService::class)
 				));
 				$this->server->addPlugin(new AppleProvisioningPlugin(
 					\OC::$server->getUserSession(),

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -44,7 +44,7 @@ class GenericTest extends TestCase {
 	 * @param string $filterClass
 	 */
 	public function testImplementsInterface($filterClass): void {
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
@@ -54,7 +54,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
@@ -64,7 +64,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
@@ -74,7 +74,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$priority = $filter->getPriority();
 		$this->assertIsInt($filter->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -87,7 +87,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIcon($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getIcon());
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
@@ -98,7 +98,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testFilterTypes($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
@@ -108,7 +108,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testAllowedApps($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsArray($filter->allowedApps());
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
@@ -43,7 +43,7 @@ class GenericTest extends TestCase {
 	 * @param string $settingClass
 	 */
 	public function testImplementsInterface($settingClass): void {
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
@@ -53,7 +53,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
@@ -63,7 +63,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
@@ -73,7 +73,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$priority = $setting->getPriority();
 		$this->assertIsInt($setting->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -86,7 +86,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
@@ -96,7 +96,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
@@ -106,7 +106,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
@@ -116,7 +116,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledMail());
 	}
 }

--- a/apps/encryption/appinfo/app.php
+++ b/apps/encryption/appinfo/app.php
@@ -30,7 +30,7 @@ $encryptionManager = \OC::$server->getEncryptionManager();
 $encryptionSystemReady = $encryptionManager->isReady();
 
 /** @var Application $app */
-$app = \OC::$server->query(Application::class);
+$app = \OC::$server->get(Application::class);
 if ($encryptionSystemReady) {
 	$app->registerEncryptionModule($encryptionManager);
 	$app->registerHooks(\OC::$server->getConfig());

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -92,7 +92,7 @@ class ScanAppData extends Base {
 		$scanner = new \OC\Files\Utils\Scanner(
 			null,
 			new ConnectionAdapter($connection),
-			\OC::$server->query(IEventDispatcher::class),
+			\OC::$server->get(IEventDispatcher::class),
 			\OC::$server->get(LoggerInterface::class)
 		);
 

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -122,7 +122,7 @@ class ViewController extends Controller {
 	 */
 	protected function renderScript($appName, $scriptName) {
 		$content = '';
-		$appPath = \OC_App::getAppPath($appName);
+		$appPath = \OC::$server->get(IAppManager::class)->getAppPath($appName);
 		$scriptPath = $appPath . '/' . $scriptName;
 		if (file_exists($scriptPath)) {
 			// TODO: sanitize path / script name ?

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -47,7 +47,7 @@ class GenericTest extends TestCase {
 	 * @param string $filterClass
 	 */
 	public function testImplementsInterface($filterClass) {
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
@@ -57,7 +57,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
@@ -67,7 +67,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
@@ -77,7 +77,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$priority = $filter->getPriority();
 		$this->assertIsInt($filter->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -90,7 +90,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIcon($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsString($filter->getIcon());
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
@@ -101,7 +101,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testFilterTypes($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
@@ -111,7 +111,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testAllowedApps($filterClass) {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = \OC::$server->get($filterClass);
 		$this->assertIsArray($filter->allowedApps());
 	}
 }

--- a/apps/files/tests/Activity/Setting/GenericTest.php
+++ b/apps/files/tests/Activity/Setting/GenericTest.php
@@ -43,7 +43,7 @@ class GenericTest extends TestCase {
 	 * @param string $settingClass
 	 */
 	public function testImplementsInterface($settingClass) {
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
@@ -53,7 +53,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
@@ -63,7 +63,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
@@ -73,7 +73,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$priority = $setting->getPriority();
 		$this->assertIsInt($setting->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -86,7 +86,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeStream($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
@@ -96,7 +96,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledStream($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
@@ -106,7 +106,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeMail($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
@@ -116,7 +116,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledMail($settingClass) {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = \OC::$server->get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledMail());
 	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -75,7 +75,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 
 		$this->manager = $options['manager'];
 		$this->cloudId = $options['cloudId'];
-		$discoveryService = \OC::$server->query(\OCP\OCS\IDiscoveryService::class);
+		$discoveryService = \OC::$server->get(\OCP\OCS\IDiscoveryService::class);
 
 		[$protocol, $remote] = explode('://', $this->cloudId->getRemote());
 		if (str_contains($remote, '/')) {

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -54,7 +54,7 @@ class File implements \OCP\Share_Backend_File_Dependent {
 		if ($federatedShareProvider) {
 			$this->federatedShareProvider = $federatedShareProvider;
 		} else {
-			$this->federatedShareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$this->federatedShareProvider = \OC::$server->get(FederatedShareProvider::class);
 		}
 	}
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -178,7 +178,7 @@ class ManagerTest extends TestCase {
 					new StorageFactory(),
 					$this->clientService,
 					\OC::$server->getNotificationManager(),
-					\OC::$server->query(\OCP\OCS\IDiscoveryService::class),
+					\OC::$server->get(\OCP\OCS\IDiscoveryService::class),
 					$this->cloudFederationProviderManager,
 					$this->cloudFederationFactory,
 					$this->groupManager,

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -87,7 +87,7 @@ class Application extends App implements IBootstrap {
 					$for = $backend['@attributes']['for'];
 
 					try {
-						$backendObject = $serverContainer->query($class);
+						$backendObject = \OC::$server->get($class);
 						$trashManager->registerBackend($for, $backendObject);
 					} catch (\Exception $e) {
 						$logger->logException($e);

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -272,7 +272,7 @@ class Trashbin {
 		$filename = $path_parts['basename'];
 		$location = $path_parts['dirname'];
 		/** @var ITimeFactory $timeFactory */
-		$timeFactory = \OC::$server->query(ITimeFactory::class);
+		$timeFactory = \OC::$server->get(ITimeFactory::class);
 		$timestamp = $timeFactory->getTime();
 
 		$lockingProvider = \OC::$server->getLockingProvider();
@@ -851,7 +851,7 @@ class Trashbin {
 	private static function scheduleExpire($user) {
 		// let the admin disable auto expire
 		/** @var Application $application */
-		$application = \OC::$server->query(Application::class);
+		$application = \OC::$server->get(Application::class);
 		$expiration = $application->getContainer()->query('Expiration');
 		if ($expiration->isEnabled()) {
 			\OC::$server->getCommandBus()->push(new Expire($user));
@@ -869,7 +869,7 @@ class Trashbin {
 	 */
 	protected static function deleteFiles(array $files, string $user, int|float $availableSpace): int|float {
 		/** @var Application $application */
-		$application = \OC::$server->query(Application::class);
+		$application = \OC::$server->get(Application::class);
 		$expiration = $application->getContainer()->query('Expiration');
 		$size = 0;
 
@@ -897,7 +897,7 @@ class Trashbin {
 	 */
 	public static function deleteExpiredFiles($files, $user) {
 		/** @var Expiration $expiration */
-		$expiration = \OC::$server->query(Expiration::class);
+		$expiration = \OC::$server->get(Expiration::class);
 		$size = 0;
 		$count = 0;
 		foreach ($files as $file) {

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -83,7 +83,7 @@ class TrashbinTest extends \Test\TestCase {
 		//configure trashbin
 		self::$rememberRetentionObligation = $config->getSystemValue('trashbin_retention_obligation', \OCA\Files_Trashbin\Expiration::DEFAULT_RETENTION_OBLIGATION);
 		/** @var \OCA\Files_Trashbin\Expiration $expiration */
-		$expiration = \OC::$server->query(\OCA\Files_Trashbin\Expiration::class);
+		$expiration = \OC::$server->get(\OCA\Files_Trashbin\Expiration::class);
 		$expiration->setRetentionObligation('auto, 2');
 
 		// register trashbin hooks
@@ -104,7 +104,7 @@ class TrashbinTest extends \Test\TestCase {
 		}
 
 		/** @var \OCA\Files_Trashbin\Expiration $expiration */
-		$expiration = \OC::$server->query(\OCA\Files_Trashbin\Expiration::class);
+		$expiration = \OC::$server->get(\OCA\Files_Trashbin\Expiration::class);
 		$expiration->setRetentionObligation(self::$rememberRetentionObligation);
 
 		\OC_Hook::clear();
@@ -174,7 +174,7 @@ class TrashbinTest extends \Test\TestCase {
 	public function testExpireOldFiles() {
 
 		/** @var \OCP\AppFramework\Utility\ITimeFactory $time */
-		$time = \OC::$server->query(\OCP\AppFramework\Utility\ITimeFactory::class);
+		$time = \OC::$server->get(\OCP\AppFramework\Utility\ITimeFactory::class);
 		$currentTime = $time->getTime();
 		$expireAt = $currentTime - 2 * 24 * 60 * 60;
 		$expiredDate = $currentTime - 3 * 24 * 60 * 60;

--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -28,7 +28,7 @@
 namespace OCA\Files_Versions\AppInfo;
 
 /** @var Application $application */
-$application = \OC::$server->query(Application::class);
+$application = \OC::$server->get(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		[

--- a/apps/provisioning_api/lib/Capabilities.php
+++ b/apps/provisioning_api/lib/Capabilities.php
@@ -56,7 +56,7 @@ class Capabilities implements ICapability {
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
-			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$shareProvider = \OC::$server->get(FederatedShareProvider::class);
 			$publishedScopeEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -108,7 +108,7 @@ class Application extends App implements IBootstrap {
 		$context->registerService(IProvider::class, function (IAppContainer $appContainer) {
 			/** @var IServerContainer $serverContainer */
 			$serverContainer = $appContainer->query(IServerContainer::class);
-			return $serverContainer->query(IProvider::class);
+			return \OC::$server->get(IProvider::class);
 		});
 		$context->registerService(IManager::class, function (IAppContainer $appContainer) {
 			/** @var IServerContainer $serverContainer */

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -444,7 +444,7 @@ class AppSettingsController extends Controller {
 
 				// Check if app is already downloaded
 				/** @var Installer $installer */
-				$installer = \OC::$server->query(Installer::class);
+				$installer = \OC::$server->get(Installer::class);
 				$isDownloaded = $installer->isDownloaded($appId);
 
 				if (!$isDownloaded) {

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -117,7 +117,7 @@ class PersonalInfo implements ISettings {
 		$lookupServerUploadEnabled = false;
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
-			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$shareProvider = \OC::$server->get(FederatedShareProvider::class);
 			$lookupServerUploadEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -59,7 +59,7 @@ class BackupCodeMapperTest extends TestCase {
 		parent::setUp();
 
 		$this->db = \OC::$server->getDatabaseConnection();
-		$this->mapper = \OC::$server->query(BackupCodeMapper::class);
+		$this->mapper = \OC::$server->get(BackupCodeMapper::class);
 
 		$this->resetDB();
 	}

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -50,11 +50,11 @@ class BackupCodeStorageTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->storage = \OC::$server->query(BackupCodeStorage::class);
+		$this->storage = \OC::$server->get(BackupCodeStorage::class);
 
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->notificationManager->method('createNotification')
-			->willReturn(\OC::$server->query(IManager::class)->createNotification());
+			->willReturn(\OC::$server->get(IManager::class)->createNotification());
 		$this->overwriteService(IManager::class, $this->notificationManager);
 	}
 

--- a/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/RememberBackupCodesJobTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/RememberBackupCodesJobTest.php
@@ -165,7 +165,7 @@ class RememberBackupCodesJobTest extends TestCase {
 		$date->setTimestamp($this->time->getTime());
 
 		$this->notificationManager->method('createNotification')
-			->willReturn(\OC::$server->query(IManager::class)->createNotification());
+			->willReturn(\OC::$server->get(IManager::class)->createNotification());
 
 		$this->notificationManager->expects($this->once())
 			->method('notify')

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
@@ -47,7 +47,7 @@ class ClearNotificationsTest extends TestCase {
 
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->notificationManager->method('createNotification')
-			->willReturn(\OC::$server->query(IManager::class)->createNotification());
+			->willReturn(\OC::$server->get(IManager::class)->createNotification());
 
 		$this->listener = new ClearNotifications($this->notificationManager);
 	}

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -52,7 +52,7 @@ $application->registerRoutes($this, [
 ]);
 
 /** @var \OCA\User_LDAP\AppInfo\Application $application */
-$application = \OC::$server->query(\OCA\User_LDAP\AppInfo\Application::class);
+$application = \OC::$server->get(\OCA\User_LDAP\AppInfo\Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'renewPassword#tryRenewPassword', 'url' => '/renewpassword', 'verb' => 'POST'],

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
@@ -58,7 +58,7 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		$userManager->clearBackends();
 		$userManager->registerBackend($userBackend);
 
-		$groupBackend = new Group_LDAP($this->access, \OC::$server->query(GroupPluginManager::class));
+		$groupBackend = new Group_LDAP($this->access, \OC::$server->get(GroupPluginManager::class));
 		$groupManger = \OC::$server->getGroupManager();
 		$groupManger->clearBackends();
 		$groupManger->addBackend($groupBackend);

--- a/console.php
+++ b/console.php
@@ -90,11 +90,11 @@ try {
 	}
 
 	$application = new Application(
-		\OC::$server->getConfig(),
+		\OC::$server->get(\OC\AllConfig::class),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
-		\OC::$server->getRequest(),
+		\OC::$server->get(\OCP\IRequest::class),
 		\OC::$server->get(\Psr\Log\LoggerInterface::class),
-		\OC::$server->query(\OC\MemoryInfo::class)
+		\OC::$server->get(\OC\MemoryInfo::class)
 	);
 	$application->loadCommands(new ArgvInput(), new ConsoleOutput());
 	$application->run();

--- a/core/Application.php
+++ b/core/Application.php
@@ -57,6 +57,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\Events\NodeRemovedFromCache;
+use OCP\Notification\IManager;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
@@ -81,7 +82,7 @@ class Application extends App {
 		/** @var IEventDispatcher $eventDispatcher */
 		$eventDispatcher = $server->get(IEventDispatcher::class);
 
-		$notificationManager = $server->getNotificationManager();
+		$notificationManager = $server->get(IManager::class);
 		$notificationManager->registerNotifierService(CoreNotifier::class);
 		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -101,7 +101,7 @@ class Enable extends Command implements CompletionAwareInterface {
 
 		try {
 			/** @var Installer $installer */
-			$installer = \OC::$server->query(Installer::class);
+			$installer = \OC::$server->get(Installer::class);
 
 			if (false === $installer->isDownloaded($appId)) {
 				$installer->downloadApp($appId);

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -77,7 +77,7 @@ class Install extends Command {
 
 		try {
 			/** @var Installer $installer */
-			$installer = \OC::$server->query(Installer::class);
+			$installer = \OC::$server->get(Installer::class);
 			$installer->downloadApp($appId, $input->getOption('allow-unstable'));
 			$result = $installer->installApp($appId, $forceEnable);
 		} catch (\Exception $e) {

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -298,7 +298,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		$query->automaticTablePrefix(false);
 		$query->select($query->func()->count('*', 'num_entries'))
 			->from($table->getName());
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -337,7 +337,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		for ($chunk = 0; $chunk < $numChunks; $chunk++) {
 			$query->setFirstResult($chunk * $chunkSize);
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 
 			try {
 				$toDB->beginTransaction();
@@ -359,7 +359,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 							$insertQuery->setParameter($key, $value);
 						}
 					}
-					$insertQuery->execute();
+					$insertQuery->executeQuery();
 				}
 				$result->closeCursor();
 

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -36,6 +36,8 @@ use OC\Installer;
 use OC\Setup;
 use OC\SystemConfig;
 use OCP\Defaults;
+use OCP\L10N\IFactory;
+use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -77,11 +79,11 @@ class Install extends Command {
 		$setupHelper = new Setup(
 			$this->config,
 			$this->iniGetWrapper,
-			$server->getL10N('lib'),
-			$server->query(Defaults::class),
+			$server->get(IFactory::class)->get('lib'),
+			$server->get(Defaults::class),
 			$server->get(LoggerInterface::class),
-			$server->getSecureRandom(),
-			\OC::$server->query(Installer::class)
+			$server->get(ISecureRandom::class),
+			\OC::$server->get(Installer::class)
 		);
 		$sysInfo = $setupHelper->getSystemInfo(true);
 		$errors = $sysInfo['errors'];

--- a/core/Command/Preview/ResetRenderedTexts.php
+++ b/core/Command/Preview/ResetRenderedTexts.php
@@ -137,7 +137,7 @@ class ResetRenderedTexts extends Command {
 		$qb->select('path', 'mimetype')
 			->from('filecache')
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($this->previewFolder->getId())));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -170,7 +170,7 @@ class ResetRenderedTexts extends Command {
 				)
 			);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row;

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -93,7 +93,7 @@ class Upgrade extends Command {
 			$self = $this;
 			$updater = new Updater(
 				$this->config,
-				\OC::$server->getIntegrityCodeChecker(),
+				\OC::$server->get('IntegrityCodeChecker'),
 				$this->logger,
 				$this->installer
 			);

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -53,6 +53,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use OCP\Security\VerificationToken\IVerificationToken;
 use OCP\Security\VerificationToken\InvalidTokenException;
@@ -239,7 +240,7 @@ class LostController extends Controller {
 			$this->twoFactorManager->clearTwoFactorPending($userId);
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
-			@\OC::$server->getUserSession()->unsetMagicInCookie();
+			@\OC::$server->get(IUserSession::class)->unsetMagicInCookie();
 		} catch (HintException $e) {
 			$response = new JSONResponse($this->error($e->getHint()));
 			$response->throttle();

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -33,6 +33,7 @@ namespace OC\Core\Controller;
 
 use OC\Setup;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 
 class SetupController {
 	private string $autoConfigFile;
@@ -102,13 +103,13 @@ class SetupController {
 		if (file_exists($this->autoConfigFile)) {
 			unlink($this->autoConfigFile);
 		}
-		\OC::$server->getIntegrityCodeChecker()->runInstanceVerification();
+		\OC::$server->get('IntegrityCodeChecker')->runInstanceVerification();
 
 		if ($this->setupHelper->shouldRemoveCanInstallFile()) {
 			\OC_Template::printGuestPage('', 'installation_incomplete');
 		}
 
-		header('Location: ' . \OC::$server->getURLGenerator()->getAbsoluteURL('index.php/core/apps/recommended'));
+		header('Location: ' . \OC::$server->get(IURLGenerator::class)->getAbsoluteURL('index.php/core/apps/recommended'));
 		exit();
 	}
 

--- a/core/Db/LoginFlowV2Mapper.php
+++ b/core/Db/LoginFlowV2Mapper.php
@@ -88,7 +88,7 @@ class LoginFlowV2Mapper extends QBMapper {
 				$qb->expr()->lt('timestamp', $qb->createNamedParameter($this->timeFactory->getTime() - self::lifetime))
 			);
 
-		$qb->execute();
+		$qb->executeQuery();
 	}
 
 	/**

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,11 +48,12 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+use OCP\App\IAppManager;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
-$application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
+$application->add(new OC\Core\Command\Check(\OC::$server->get(\OC\SystemConfig::class)));
 $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(
 	\OC::$server->getIntegrityCodeChecker(),
@@ -71,83 +72,83 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 ));
 
 
-if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
-	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getGroupManager()));
+if (\OC::$server->get(\OC\AllConfig::class)->getSystemValue('installed', false)) {
+	$application->add(new OC\Core\Command\App\Disable(\OC::$server->get(IAppManager::class)));
+	$application->add(new OC\Core\Command\App\Enable(\OC::$server->get(IAppManager::class), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
-	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
-	$application->add(\OC::$server->query(\OC\Core\Command\App\Update::class));
+	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->get(IAppManager::class)));
+	$application->add(new OC\Core\Command\App\Remove(\OC::$server->get(IAppManager::class), \OC::$server->get(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
+	$application->add(\OC::$server->get(\OC\Core\Command\App\Update::class));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Disable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\State::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Enforce::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Enable::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Disable::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\State::class));
 
-	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->get(\OC\AllConfig::class)));
 	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Broadcast\Test::class));
 
-	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\Import(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->getSystemConfig(), \OC::$server->getAppConfig()));
-	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
+	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\Import(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->get(\OC\SystemConfig::class), \OC::$server->getAppConfig()));
+	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->get(\OC\SystemConfig::class)));
+	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->get(\OC\SystemConfig::class)));
+	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->get(\OC\SystemConfig::class)));
 
 	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
 	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
 
-	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
-	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
+	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->get(\OC\AllConfig::class), new \OC\DB\ConnectionFactory(\OC::$server->get(\OC\SystemConfig::class))));
+	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->get(\OC\AllConfig::class), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingColumns::class));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingIndices::class));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingPrimaryKeys::class));
 
-	if (\OC::$server->getConfig()->getSystemValueBool('debug', false)) {
+	if (\OC::$server->get(\OC\AllConfig::class)->getSystemValueBool('debug', false)) {
 		$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->get(\OC\DB\Connection::class)));
 		$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->get(\OC\DB\Connection::class)));
-		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getAppManager()));
-		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getConfig()));
+		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->get(IAppManager::class)));
+		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->get(\OC\AllConfig::class)));
 	}
 
-	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->get(\OC\AllConfig::class), \OC::$server->getEncryptionManager()));
+	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->get(\OC\AllConfig::class)));
 	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
+	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->get(IAppManager::class), \OC::$server->get(\OC\AllConfig::class), new \Symfony\Component\Console\Helper\QuestionHelper()));
 	$application->add(new OC\Core\Command\Encryption\DecryptAll(
 		\OC::$server->getEncryptionManager(),
-		\OC::$server->getAppManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(IAppManager::class),
+		\OC::$server->get(\OC\AllConfig::class),
 		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
 	);
 
-	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Log\File(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->get(\OC\AllConfig::class)));
+	$application->add(new OC\Core\Command\Log\File(\OC::$server->get(\OC\AllConfig::class)));
 
 	$view = new \OC\Files\View();
 	$util = new \OC\Encryption\Util(
 		$view,
 		\OC::$server->getUserManager(),
 		\OC::$server->getGroupManager(),
-		\OC::$server->getConfig()
+		\OC::$server->get(\OC\AllConfig::class)
 	);
 	$application->add(new OC\Core\Command\Encryption\ChangeKeyStorageRoot(
 		$view,
 		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(\OC\AllConfig::class),
 		$util,
 		new \Symfony\Component\Console\Helper\QuestionHelper()
 	)
@@ -156,31 +157,31 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Encryption\MigrateKeyStorage(
 		$view,
 		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(\OC\AllConfig::class),
 		$util,
 		\OC::$server->getCrypto()
 	)
 	);
 
-	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
+	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->get(\OC\AllConfig::class), new \OC\AppFramework\Utility\TimeFactory()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
-	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->get(\OC\AllConfig::class)));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->get(\OC\AllConfig::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair([], \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class)),
-		\OC::$server->getConfig(),
+		\OC::$server->get(\OC\AllConfig::class),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
-		\OC::$server->getAppManager()
+		\OC::$server->get(IAppManager::class)
 	));
-	$application->add(\OC::$server->query(OC\Core\Command\Maintenance\RepairShareOwnership::class));
+	$application->add(\OC::$server->get(OC\Core\Command\Maintenance\RepairShareOwnership::class));
 
 	$application->add(\OC::$server->get(\OC\Core\Command\Preview\Generate::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\Repair::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\ResetRenderedTexts::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Preview\Repair::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Preview\ResetRenderedTexts::class));
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
@@ -188,8 +189,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
-	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->get(IAppManager::class)));
+	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->get(\OC\AllConfig::class)));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\AddAppPassword(\OC::$server->get(\OCP\IUserManager::class), \OC::$server->get(\OC\Authentication\Token\IProvider::class), \OC::$server->get(\OCP\Security\ISecureRandom::class), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class)));

--- a/core/routes.php
+++ b/core/routes.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
 use OC\Core\Application;
 
 /** @var Application $application */
-$application = \OC::$server->query(Application::class);
+$application = \OC::$server->get(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],

--- a/core/strings.php
+++ b/core/strings.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
  *
  */
 //some strings that are used in /lib but won't be translatable unless they are in /core too
-$l = \OC::$server->getL10N('core');
+$l = \OC::$server->get(\OCP\L10N\IFactory::class)->get('core');
 $l->t("Personal");
 $l->t("Users");
 $l->t("Apps");

--- a/core/templates/403.php
+++ b/core/templates/403.php
@@ -3,7 +3,7 @@
 if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(\OCP\IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }

--- a/core/templates/404-profile.php
+++ b/core/templates/404-profile.php
@@ -7,7 +7,7 @@
 if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(\OCP\IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }
@@ -20,7 +20,7 @@ if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 		<div class="icon-big icon-error"></div>
 		<h2><?php p($l->t('Profile not found')); ?></h2>
 		<p class="infogroup"><?php p($l->t('The profile does not exist.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
+		<p><a class="button primary" href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
 				<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 			</a></p>
 	</div>

--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -6,7 +6,7 @@
 if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(\OCP\IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }
@@ -19,7 +19,7 @@ if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 		<div class="icon-big icon-search"></div>
 		<h2><?php p($l->t('Page not found')); ?></h2>
 		<p class="infogroup"><?php p($l->t('The page could not be found on the server or you may not be allowed to view it.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
+		<p><a class="button primary" href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
 			<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 		</a></p>
 	</div>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -5,7 +5,7 @@
  */
 
 $getUserAvatar = static function (int $size) use ($_): string {
-	return \OC::$server->getURLGenerator()->linkToRoute('core.avatar.getAvatar', [
+	return \OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.avatar.getAvatar', [
 		'userId' => $_['user_uid'],
 		'size' => $size,
 		'v' => $_['userAvatarVersion']

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -19,7 +19,7 @@ $noProviders = empty($_['providers']);
 				<strong><?php p($l->t('Two-factor authentication is enforced but has not been configured on your account. Contact your admin for assistance.')) ?></strong>
 			<?php } else { ?>
 				<strong><?php p($l->t('Two-factor authentication is enforced but has not been configured on your account. Please continue to setup two-factor authentication.')) ?></strong>
-				<a class="button primary two-factor-primary" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.setupProviders',
+				<a class="button primary two-factor-primary" href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.setupProviders',
 					[
 						'redirect_url' => $_['redirect_url'],
 					]
@@ -36,7 +36,7 @@ $noProviders = empty($_['providers']);
 	<?php foreach ($_['providers'] as $provider): ?>
 		<li>
 			<a class="two-factor-provider"
-			   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+			   href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			   	[
 			   		'challengeProviderId' => $provider->getId(),
 			   		'redirect_url' => $_['redirect_url'],
@@ -61,7 +61,7 @@ $noProviders = empty($_['providers']);
 	<?php endif ?>
 	<?php if (!is_null($_['backupProvider'])): ?>
 	<p>
-		<a class="<?php if ($noProviders): ?>button primary two-factor-primary<?php else: ?>two-factor-secondary<?php endif ?>" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="<?php if ($noProviders): ?>button primary two-factor-primary<?php else: ?>two-factor-secondary<?php endif ?>" href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			[
 				'challengeProviderId' => $_['backupProvider']->getId(),
 				'redirect_url' => $_['redirect_url'],

--- a/core/templates/twofactorsetupselection.php
+++ b/core/templates/twofactorsetupselection.php
@@ -30,7 +30,7 @@ declare(strict_types=1);
 	<?php foreach ($_['providers'] as $provider): ?>
 		<li>
 			<a class="two-factor-provider"
-			   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.setupProvider',
+			   href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.setupProvider',
 			   	[
 			   		'providerId' => $provider->getId(),
 			   	]

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -23,7 +23,7 @@ $template = $_['template'];
 	<?php print_unescaped($template); ?>
 	<?php if (!is_null($_['backupProvider'])): ?>
 	<p>
-		<a class="two-factor-secondary" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="two-factor-secondary" href="<?php p(\OC::$server->get(\OCP\IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			[
 				'challengeProviderId' => $_['backupProvider']->getId(),
 				'redirect_url' => $_['redirect_url'],

--- a/cron.php
+++ b/cron.php
@@ -46,7 +46,7 @@ try {
 		\OC::$server->getLogger()->debug('Update required, skipping cron', ['app' => 'cron']);
 		exit;
 	}
-	if ((bool) \OC::$server->getSystemConfig()->getValue('maintenance', false)) {
+	if ((bool) \OC::$server->get(\OC\SystemConfig::class)->getValue('maintenance', false)) {
 		\OC::$server->getLogger()->debug('We are in maintenance mode, skipping cron', ['app' => 'cron']);
 		exit;
 	}

--- a/index.php
+++ b/index.php
@@ -29,6 +29,7 @@
  *
  */
 require_once __DIR__ . '/lib/versioncheck.php';
+use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 try {
@@ -64,7 +65,7 @@ try {
 		OC_Template::printExceptionErrorPage($ex, 500);
 	}
 } catch (\OC\User\LoginException $ex) {
-	$request = \OC::$server->getRequest();
+	$request = \OC::$server->get(IRequest::class);
 	/**
 	 * Routes with the @CORS annotation and other API endpoints should
 	 * not return a webpage, so we only print the error page when html is accepted,

--- a/lib/base.php
+++ b/lib/base.php
@@ -68,6 +68,7 @@ declare(strict_types=1);
 
 use OC\Encryption\HookManager;
 use OC\Share20\Hooks;
+use OC\User\Session;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
@@ -753,7 +754,7 @@ class OC {
 
 		// User and Groups
 		if (!$systemConfig->getValue("installed", false)) {
-			self::$server->getSession()->set('user_id', '');
+			self::$server->get(Session::class)->getSession()->set('user_id', '');
 		}
 
 		OC_User::useBackend(new \OC\User\Database());
@@ -989,7 +990,7 @@ class OC {
 
 		// Check if Nextcloud is installed or in maintenance (update) mode
 		if (!$systemConfig->getValue('installed', false)) {
-			\OC::$server->getSession()->clear();
+			\OC::$server->get(Session::class)->getSession()->clear();
 			$setupHelper = new OC\Setup(
 				$systemConfig,
 				Server::get(\bantu\IniGetWrapper\IniGetWrapper::class),

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -273,7 +273,7 @@ class AccountManager implements IAccountManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete($this->table)
 			->where($query->expr()->eq('uid', $query->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 
 		$this->deleteUserData($user);
 	}
@@ -286,7 +286,7 @@ class AccountManager implements IAccountManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete($this->dataTable)
 			->where($query->expr()->eq('uid', $query->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -306,7 +306,7 @@ class AppConfig implements IAppConfig {
 			}
 		}
 
-		$changedRow = (bool) $sql->execute();
+		$changedRow = (bool) $sql->executeQuery();
 
 		$this->cache[$app][$key] = $value;
 
@@ -329,7 +329,7 @@ class AppConfig implements IAppConfig {
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
 			->setParameter('app', $app)
 			->setParameter('configkey', $key);
-		$sql->execute();
+		$sql->executeQuery();
 
 		unset($this->cache[$app][$key]);
 		return false;
@@ -350,7 +350,7 @@ class AppConfig implements IAppConfig {
 		$sql->delete('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
 			->setParameter('app', $app);
-		$sql->execute();
+		$sql->executeQuery();
 
 		unset($this->cache[$app]);
 		return false;
@@ -415,7 +415,7 @@ class AppConfig implements IAppConfig {
 		$sql = $this->conn->getQueryBuilder();
 		$sql->select('*')
 			->from('appconfig');
-		$result = $sql->execute();
+		$result = $sql->executeQuery();
 
 		// we are going to store the result in memory anyway
 		$rows = $result->fetchAll();

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -37,13 +37,13 @@ use OC\AppFramework\Http\Request;
 use OCP\App\IAppManager;
 use OCP\Profiler\IProfiler;
 use OC\Profiler\RoutingDataCollector;
-use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ICallbackResponse;
 use OCP\AppFramework\Http\IOutput;
 use OCP\Diagnostics\IEventLogger;
 use OCP\HintException;
 use OCP\IRequest;
+use \Psr\Container\ContainerExceptionInterface;
 
 /**
  * Entry point for every request in your app. You can consider this as your
@@ -147,7 +147,7 @@ class App {
 		// first try $controllerName then go for \OCA\AppName\Controller\$controllerName
 		try {
 			$controller = $container->get($controllerName);
-		} catch (QueryException $e) {
+		} catch (ContainerExceptionInterface $e) {
 			if (str_contains($controllerName, '\\Controller\\')) {
 				// This is from a global registered app route that is not enabled.
 				[/*OC(A)*/, $app, /* Controller/Name*/] = explode('\\', $controllerName, 3);
@@ -216,7 +216,7 @@ class App {
 				$expireDate,
 				$container->getServer()->getWebRoot(),
 				null,
-				$container->getServer()->getRequest()->getServerProtocol() === 'https',
+				$container->getServer()->get(IRequest::class)->getServerProtocol() === 'https',
 				true,
 				$sameSite
 			);

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -58,6 +58,7 @@ use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Group\ISubAdmin;
@@ -130,7 +131,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 
 		$this->registerService(IAppData::class, function (ContainerInterface $c) {
-			return $this->getServer()->getAppDataDir($c->get('AppName'));
+			return $this->getServer()->get(IAppDataFactory::class)->get($c->get('AppName'));
 		});
 
 		$this->registerService(IL10N::class, function (ContainerInterface $c) {

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -33,6 +33,7 @@
 namespace OC\Archive;
 
 use Icewind\Streams\CallbackWrapper;
+use OCP\ITempManager;
 
 class TAR extends Archive {
 	public const PLAIN = 0;
@@ -91,7 +92,7 @@ class TAR extends Archive {
 	 * add an empty folder to the archive
 	 */
 	public function addFolder(string $path): bool {
-		$tmpBase = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpBase = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$path = rtrim($path, '/') . '/';
 		if ($this->fileExists($path)) {
 			return false;
@@ -134,7 +135,7 @@ class TAR extends Archive {
 	 */
 	public function rename(string $source, string $dest): bool {
 		//no proper way to delete, rename entire archive, rename file and remake archive
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tar->extract($tmp);
 		rename($tmp . $source, $tmp . $dest);
 		$this->tar = null;
@@ -241,7 +242,7 @@ class TAR extends Archive {
 	 * extract a single file from the archive
 	 */
 	public function extractFile(string $path, string $dest): bool {
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		if (!$this->fileExists($path)) {
 			return false;
 		}
@@ -253,7 +254,7 @@ class TAR extends Archive {
 		if ($success) {
 			rename($tmp . $path, $dest);
 		}
-		\OCP\Files::rmdirr($tmp);
+		\OC_Helper::rmdirr($tmp);
 		return $success;
 	}
 
@@ -297,9 +298,9 @@ class TAR extends Archive {
 		$this->fileList = false;
 		$this->cachedHeaders = false;
 		//no proper way to delete, extract entire archive, delete file and remake archive
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tar->extract($tmp);
-		\OCP\Files::rmdirr($tmp . $path);
+		\OC_Helper::rmdirr($tmp . $path);
 		$this->tar = null;
 		unlink($this->path);
 		$this->reopen();
@@ -319,7 +320,7 @@ class TAR extends Archive {
 		} else {
 			$ext = '';
 		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 		if ($this->fileExists($path)) {
 			$this->extractFile($path, $tmpFile);
 		} elseif ($mode == 'r' or $mode == 'rb') {

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -32,6 +32,7 @@
 namespace OC\Archive;
 
 use Icewind\Streams\CallbackWrapper;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class ZIP extends Archive {
@@ -224,7 +225,7 @@ class ZIP extends Archive {
 			} else {
 				$ext = '';
 			}
-			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+			$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 			if ($this->fileExists($path)) {
 				$this->extractFile($path, $tmpFile);
 			}

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -51,7 +51,7 @@ class PublicKeyTokenMapper extends QBMapper {
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 	}
 
 	/**
@@ -66,7 +66,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('type', $qb->createNamedParameter(IToken::TEMPORARY_TOKEN, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('remember', $qb->createNamedParameter($remember, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 	}
 
 	/**
@@ -81,7 +81,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->from($this->tableName)
 			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -103,7 +103,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->from($this->tableName)
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -130,7 +130,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(1000);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$data = $result->fetchAll();
 		$result->closeCursor();
 
@@ -148,7 +148,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
-		$qb->execute();
+		$qb->executeQuery();
 	}
 
 	/**
@@ -161,7 +161,7 @@ class PublicKeyTokenMapper extends QBMapper {
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('name', $qb->createNamedParameter($name), IQueryBuilder::PARAM_STR))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
-		$qb->execute();
+		$qb->executeQuery();
 	}
 
 	public function deleteTempToken(PublicKeyToken $except) {
@@ -173,7 +173,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->neq('id', $qb->createNamedParameter($except->getId())))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
 
-		$qb->execute();
+		$qb->executeQuery();
 	}
 
 	public function hasExpiredTokens(string $uid): bool {
@@ -184,7 +184,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('password_invalid', $qb->createNamedParameter(true), IQueryBuilder::PARAM_BOOL))
 			->setMaxResults(1);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 

--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -56,7 +56,7 @@ class ProviderUserAssignmentDao {
 		$query = $qb->select('provider_id', 'enabled')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$providers = [];
 		foreach ($result->fetchAll() as $row) {
 			$providers[(string)$row['provider_id']] = 1 === (int)$row['enabled'];
@@ -80,14 +80,14 @@ class ProviderUserAssignmentDao {
 				'enabled' => $qb->createNamedParameter($enabled, IQueryBuilder::PARAM_INT),
 			]);
 
-			$insertQuery->execute();
+			$insertQuery->executeQuery();
 		} catch (UniqueConstraintViolationException $ex) {
 			// There is already an entry -> update it
 			$updateQuery = $qb->update(self::TABLE_NAME)
 				->set('enabled', $qb->createNamedParameter($enabled))
 				->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
 				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-			$updateQuery->execute();
+			$updateQuery->executeQuery();
 		}
 	}
 
@@ -103,7 +103,7 @@ class ProviderUserAssignmentDao {
 		$selectQuery = $qb1->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb1->expr()->eq('uid', $qb1->createNamedParameter($uid)));
-		$selectResult = $selectQuery->execute();
+		$selectResult = $selectQuery->executeQuery();
 		$rows = $selectResult->fetchAll();
 		$selectResult->closeCursor();
 
@@ -111,7 +111,7 @@ class ProviderUserAssignmentDao {
 		$deleteQuery = $qb2
 			->delete(self::TABLE_NAME)
 			->where($qb2->expr()->eq('uid', $qb2->createNamedParameter($uid)));
-		$deleteQuery->execute();
+		$deleteQuery->executeQuery();
 
 		return array_map(function (array $row) {
 			return [
@@ -128,6 +128,6 @@ class ProviderUserAssignmentDao {
 		$deleteQuery = $qb->delete(self::TABLE_NAME)
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)));
 
-		$deleteQuery->execute();
+		$deleteQuery->executeQuery();
 	}
 }

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -44,6 +44,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use function array_diff;
@@ -257,7 +258,7 @@ class Manager {
 		if ($passed) {
 			if ($this->session->get(self::REMEMBER_LOGIN) === true) {
 				// TODO: resolve cyclic dependency and use DI
-				\OC::$server->getUserSession()->createRememberMeToken($user);
+				\OC::$server->get(IUserSession::class)->createRememberMeToken($user);
 			}
 			$this->session->remove(self::SESSION_UID_KEY);
 			$this->session->remove(self::REMEMBER_LOGIN);

--- a/lib/private/BackgroundJob/Job.php
+++ b/lib/private/BackgroundJob/Job.php
@@ -28,6 +28,7 @@ namespace OC\BackgroundJob;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * @deprecated internal class, use \OCP\BackgroundJob\Job
@@ -45,7 +46,7 @@ abstract class Job implements IJob {
 	public function execute(IJobList $jobList, ILogger $logger = null) {
 		$jobList->setLastRun($this);
 		if ($logger === null) {
-			$logger = \OC::$server->getLogger();
+			$logger = \OC::$server->get(LoggerInterface::class);
 		}
 
 		try {

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -119,11 +119,11 @@ class JobList implements IJobList {
 			$query->setMaxResults($max);
 
 			do {
-				$deleted = $query->execute();
+				$deleted = $query->executeQuery();
 			} while ($deleted === $max);
 		} else {
 			// Dont use chunked delete - let the DB handle the large row count natively
-			$query->execute();
+			$query->executeQuery();
 		}
 	}
 

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -32,6 +32,7 @@ namespace OC\Cache;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\ICache;
+use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -50,9 +51,9 @@ class File implements ICache {
 		if ($this->storage !== null) {
 			return $this->storage;
 		}
-		if (\OC::$server->getUserSession()->isLoggedIn()) {
+		if (\OC::$server->get(IUserSession::class)->isLoggedIn()) {
 			$rootView = new View();
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			Filesystem::initMountPoints($user->getUID());
 			if (!$rootView->file_exists('/' . $user->getUID() . '/cache')) {
 				$rootView->mkdir('/' . $user->getUID() . '/cache');
@@ -105,7 +106,7 @@ class File implements ICache {
 		$storage = $this->getStorage();
 		$result = false;
 		// unique id to avoid chunk collision, just in case
-		$uniqueId = \OC::$server->getSecureRandom()->generate(
+		$uniqueId = \OC::$server->get(ISecureRandom::class)->generate(
 			16,
 			ISecureRandom::CHAR_ALPHANUMERIC
 		);
@@ -192,11 +193,11 @@ class File implements ICache {
 						}
 					} catch (\OCP\Lock\LockedException $e) {
 						// ignore locked chunks
-						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
 					} catch (\OCP\Files\ForbiddenException $e) {
-						\OC::$server->getLogger()->debug('Could not cleanup forbidden chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup forbidden chunk "' . $file . '"', ['app' => 'core']);
 					} catch (\OCP\Files\LockNotAcquiredException $e) {
-						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
 					}
 				}
 			}

--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -100,7 +100,7 @@ class Collection implements ICollection {
 		$query->update(Manager::TABLE_COLLECTIONS)
 			->set('name', $query->createNamedParameter($name))
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeQuery();
 
 		$this->name = $name;
 	}
@@ -142,7 +142,7 @@ class Collection implements ICollection {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeQuery();
 		} catch (ConstraintViolationException $e) {
 			throw new ResourceException('Already part of the collection');
 		}
@@ -166,7 +166,7 @@ class Collection implements ICollection {
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($this->id, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('resource_type', $query->createNamedParameter($resource->getType())))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())));
-		$query->execute();
+		$query->executeQuery();
 
 		if (empty($this->resources)) {
 			$this->removeCollection();
@@ -222,7 +222,7 @@ class Collection implements ICollection {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(Manager::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->id, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeQuery();
 
 		$this->manager->invalidateAccessCacheForCollection($this);
 		$this->id = 0;

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -73,7 +73,7 @@ class Manager implements IManager {
 		$query->select('*')
 			->from(self::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -105,7 +105,7 @@ class Manager implements IManager {
 				)
 			)
 			->where($query->expr()->eq('c.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -151,7 +151,7 @@ class Manager implements IManager {
 			$query->andWhere($query->expr()->iLike('c.name', $query->createNamedParameter('%' . $this->connection->escapeLikeParameter($filter) . '%')));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$collections = [];
 
 		$foundResults = 0;
@@ -183,7 +183,7 @@ class Manager implements IManager {
 			->values([
 				'name' => $query->createNamedParameter($name),
 			]);
-		$query->execute();
+		$query->executeQuery();
 
 		return new Collection($this, $this->connection, $query->getLastInsertId(), $name);
 	}
@@ -222,7 +222,7 @@ class Manager implements IManager {
 			)
 			->where($query->expr()->eq('r.resource_type', $query->createNamedParameter($type, IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('r.resource_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -261,7 +261,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('r.collection_id', $query->createNamedParameter($collection->getId(), IQueryBuilder::PARAM_INT)));
 
 		$resources = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$access = $row['access'] === null ? null : (bool) $row['access'];
 			$resources[] = new Resource($this, $this->connection, $row['resource_type'], $row['resource_id'], $user, $access);
@@ -363,7 +363,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool) $row['access'];
 		}
@@ -383,7 +383,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool) $row['access'];
 		}
@@ -404,7 +404,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeQuery();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -420,7 +420,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeQuery();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -431,7 +431,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	public function invalidateAccessCacheForResource(IResource $resource): void {
@@ -440,7 +440,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('resource_type', $query->createNamedParameter($resource->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeQuery();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollection($collection);
@@ -452,7 +452,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->neq('collection_id', $query->createNamedParameter(0)));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	public function invalidateAccessCacheForCollection(ICollection $collection): void {
@@ -460,7 +460,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	public function invalidateAccessCacheForProvider(IProvider $provider): void {
@@ -468,7 +468,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	public function invalidateAccessCacheForResourceByUser(IResource $resource, ?IUser $user): void {
@@ -478,7 +478,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeQuery();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollectionByUser($collection, $user);
@@ -492,7 +492,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	public function invalidateAccessCacheForProviderByUser(IProvider $provider, ?IUser $user): void {
@@ -502,7 +502,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeQuery();
 	}
 
 	/**

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -150,7 +150,7 @@ class Resource implements IResource {
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($this->getType())))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($this->getId())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$collections[] = $this->manager->getCollection((int) $row['collection_id']);
 		}

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -200,7 +200,7 @@ class Manager implements ICommentsManager {
 			->where($qb->expr()->eq('parent_id', $qb->createParameter('id')))
 			->setParameter('id', $id);
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();
 		$children = (int)$data[0];
@@ -274,7 +274,7 @@ class Manager implements ICommentsManager {
 			->from('comments')
 			->where($qb->expr()->eq('id', $qb->createParameter('id')))
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -310,7 +310,7 @@ class Manager implements ICommentsManager {
 			$query->setFirstResult($offset);
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -369,7 +369,7 @@ class Manager implements ICommentsManager {
 				->setParameter('notOlderThan', $notOlderThan, 'datetime');
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -503,7 +503,7 @@ class Manager implements ICommentsManager {
 			}
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -529,7 +529,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
 			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -601,7 +601,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$comments = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($data = $result->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -640,7 +640,7 @@ class Manager implements ICommentsManager {
 			$query->andWhere($qb->expr()->eq('verb', $qb->createNamedParameter($verb)));
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();
 		return (int)$data[0];
@@ -755,7 +755,7 @@ class Manager implements ICommentsManager {
 			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$data = $result->fetch();
 		$result->closeCursor();
 
@@ -792,7 +792,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->in('actor_id', $query->createNamedParameter($actors, IQueryBuilder::PARAM_STR_ARRAY)))
 			->groupBy('actor_id');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$lastComments[$row['actor_id']] = $this->timeFactory->getDateTime($row['last_comment']);
 		}
@@ -844,7 +844,7 @@ class Manager implements ICommentsManager {
 				)
 			)->groupBy('f.fileid');
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 
 		$results = [];
 		while ($row = $resultStatement->fetch()) {
@@ -903,7 +903,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 			$this->uncache($id);
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
@@ -1173,7 +1173,7 @@ class Manager implements ICommentsManager {
 
 		$affectedRows = $qb->insert('comments')
 			->values($values)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			$comment->setId((string)$qb->getLastInsertId());
@@ -1311,7 +1311,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$affectedRows = $qb->where($qb->expr()->eq('id', $qb->createNamedParameter($comment->getId())))
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows === 0) {
 			throw new NotFoundException('Comment to update does ceased to exist');
@@ -1341,7 +1341,7 @@ class Manager implements ICommentsManager {
 			->andWhere($qb->expr()->eq('actor_id', $qb->createParameter('id')))
 			->setParameter('type', $actorType)
 			->setParameter('id', $actorId)
-			->execute();
+			->executeStatement();
 
 		$this->commentsCache = [];
 
@@ -1366,7 +1366,7 @@ class Manager implements ICommentsManager {
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('id')))
 			->setParameter('type', $objectType)
 			->setParameter('id', $objectId)
-			->execute();
+			->executeStatement();
 
 		$this->commentsCache = [];
 
@@ -1387,7 +1387,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID());
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,
@@ -1432,7 +1432,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			return;
@@ -1440,7 +1440,7 @@ class Manager implements ICommentsManager {
 
 		$qb->insert('comments_read_markers')
 			->values($values)
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -1464,7 +1464,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -1494,7 +1494,7 @@ class Manager implements ICommentsManager {
 			->setParameter('object_id', $objectId);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -32,6 +32,7 @@ namespace OC\Console;
 
 use OC\MemoryInfo;
 use OC\NeedsUpdateException;
+use OC\SystemConfig;
 use OC_App;
 use OCP\App\IAppManager;
 use OCP\Console\ConsoleEvent;
@@ -64,7 +65,7 @@ class Application {
 								IRequest $request,
 								LoggerInterface $logger,
 								MemoryInfo $memoryInfo) {
-		$defaults = \OC::$server->getThemingDefaults();
+		$defaults = \OC::$server->get('ThemingDefaults');
 		$this->config = $config;
 		$this->application = new SymfonyApplication($defaults->getName(), \OC_Util::getVersionString());
 		$this->dispatcher = $dispatcher;
@@ -157,7 +158,7 @@ class Application {
 		}
 
 		if ($input->getFirstArgument() !== 'check') {
-			$errors = \OC_Util::checkServer(\OC::$server->getSystemConfig());
+			$errors = \OC_Util::checkServer(\OC::$server->get(SystemConfig::class));
 			if (!empty($errors)) {
 				foreach ($errors as $error) {
 					$output->writeln((string)$error['error']);

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -142,7 +142,7 @@ class Adapter {
 			foreach ($values as $key => $value) {
 				$builder->setValue($key, $builder->createNamedParameter($value));
 			}
-			return $builder->execute();
+			return $builder->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			return 0;
 		}

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -52,6 +52,8 @@ use OCP\Diagnostics\IEventLogger;
 use OCP\IRequestId;
 use OCP\PreConditionNotMetException;
 use OCP\Profiler\IProfiler;
+use OCP\Security\ISecureRandom;
+use OC\AllConfig;
 use OC\DB\QueryBuilder\QueryBuilder;
 use OC\SystemConfig;
 use Psr\Log\LoggerInterface;
@@ -103,7 +105,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 		$this->adapter = new $params['adapter']($this);
 		$this->tablePrefix = $params['tablePrefix'];
 
-		$this->systemConfig = \OC::$server->getSystemConfig();
+		$this->systemConfig = \OC::$server->get(SystemConfig::class);
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 
 		/** @var \OCP\Profiler\IProfiler */
@@ -592,9 +594,9 @@ class Connection extends \Doctrine\DBAL\Connection {
 
 	private function getMigrator() {
 		// TODO properly inject those dependencies
-		$random = \OC::$server->getSecureRandom();
+		$random = \OC::$server->get(ISecureRandom::class);
 		$platform = $this->getDatabasePlatform();
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$dispatcher = \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class);
 		if ($platform instanceof SqlitePlatform) {
 			return new SQLiteMigrator($this, $config, $dispatcher);

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -35,6 +35,7 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use OC\AllConfig;
 use OC\App\InfoParser;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\Migration\SimpleOutput;
@@ -116,7 +117,7 @@ class MigrationService {
 			return false;
 		}
 
-		if ($this->connection->tableExists('migrations') && \OC::$server->getConfig()->getAppValue('core', 'vendor', '') !== 'owncloud') {
+		if ($this->connection->tableExists('migrations') && \OC::$server->get(AllConfig::class)->getAppValue('core', 'vendor', '') !== 'owncloud') {
 			$this->migrationTableCreated = true;
 			return false;
 		}

--- a/lib/private/DB/PreparedStatement.php
+++ b/lib/private/DB/PreparedStatement.php
@@ -83,7 +83,7 @@ class PreparedStatement implements IPreparedStatement {
 	}
 
 	public function execute($params = null): IResult {
-		return ($this->result = new ResultAdapter($this->statement->execute($params)));
+		return ($this->result = new ResultAdapter($this->statement->executeQuery($params)));
 	}
 
 	public function rowCount(): int {

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -277,7 +277,7 @@ class QueryBuilder implements IQueryBuilder {
 			]);
 		}
 
-		$result = $this->queryBuilder->execute();
+		$result = $this->queryBuilder->executeQuery();
 		if (is_int($result)) {
 			return $result;
 		}

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -229,7 +229,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')->from(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($tokenRow = $result->fetch(FetchMode::ASSOCIATIVE)) {
 			return new Token($this, $tokenRow);
 		}
@@ -240,7 +240,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TABLE_TOKENS)
 			->where($query->expr()->lt('timestamp', $query->createNamedParameter(time() - self::TOKEN_CLEANUP_TIME)));
-		return $query->execute();
+		return $query->executeStatement();
 	}
 
 	public function refreshToken(string $token): bool {
@@ -248,7 +248,7 @@ class Manager implements IManager {
 		$query->update(self::TABLE_TOKENS)
 			->set('timestamp', $query->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -257,7 +257,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -267,7 +267,7 @@ class Manager implements IManager {
 			->set('accessed', $query->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
 			->set('timestamp', $query->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -294,7 +294,7 @@ class Manager implements IManager {
 				'share_id' => $query->createNamedParameter($share !== null ? $share->getId(): null),
 				'timestamp' => $query->createNamedParameter(time())
 			]);
-		$query->execute();
+		$query->executeStatement();
 		return $token;
 	}
 

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -24,12 +24,18 @@
  */
 namespace OC\Encryption;
 
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
+use OCP\Encryption\IFile;
+use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,17 +82,17 @@ class EncryptionWrapper {
 		];
 
 		if (!$storage->instanceOfStorage(Storage\IDisableEncryptionStorage::class) && $mountPoint !== '/') {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			$mountManager = Filesystem::getMountManager();
 			$uid = $user ? $user->getUID() : null;
-			$fileHelper = \OC::$server->getEncryptionFilesHelper();
-			$keyStorage = \OC::$server->getEncryptionKeyStorage();
+			$fileHelper = \OC::$server->get(IFile::class);
+			$keyStorage = \OC::$server->get(IStorage::class);
 
 			$util = new Util(
 				new View(),
-				\OC::$server->getUserManager(),
-				\OC::$server->getGroupManager(),
-				\OC::$server->getConfig()
+				\OC::$server->get(IUserManager::class),
+				\OC::$server->get(IGroupManager::class),
+				\OC::$server->get(AllConfig::class)
 			);
 			$update = new Update(
 				new View(),

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -23,9 +23,15 @@
  */
 namespace OC\Encryption;
 
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
+use OCP\Encryption\IFile;
+use OCP\Encryption\IManager;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class HookManager {
@@ -52,9 +58,9 @@ class HookManager {
 
 	private static function getUpdate(?string $owner = null): Update {
 		if (is_null(self::$updater)) {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			if (!$user && $owner) {
-				$user = \OC::$server->getUserManager()->get($owner);
+				$user = \OC::$server->get(IUserManager::class)->get($owner);
 			}
 			if (!$user) {
 				throw new \Exception("Inconsistent data, File unshared, but owner not found. Should not happen");
@@ -74,12 +80,12 @@ class HookManager {
 				new View(),
 				new Util(
 					new View(),
-					\OC::$server->getUserManager(),
-					\OC::$server->getGroupManager(),
-					\OC::$server->getConfig()),
+					\OC::$server->get(IUserManager::class),
+					\OC::$server->get(IGroupManager::class),
+					\OC::$server->get(AllConfig::class)),
 				Filesystem::getMountManager(),
-				\OC::$server->getEncryptionManager(),
-				\OC::$server->getEncryptionFilesHelper(),
+				\OC::$server->get(IManager::class),
+				\OC::$server->get(IFile::class),
 				\OC::$server->get(LoggerInterface::class),
 				$uid
 			);

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -217,13 +217,13 @@ class Propagator implements IPropagator {
 			$query->setParameter('time', $item['time'], IQueryBuilder::PARAM_INT);
 			$query->setParameter('hash', $item['hash']);
 
-			$query->execute();
+			$query->executeStatement();
 
 			if ($item['size']) {
 				$sizeQuery->setParameter('size', $item['size'], IQueryBuilder::PARAM_INT);
 				$sizeQuery->setParameter('hash', $item['hash']);
 
-				$sizeQuery->execute();
+				$sizeQuery->executeStatement();
 			}
 		}
 

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -36,9 +36,11 @@
 namespace OC\Files\Cache;
 
 use Doctrine\DBAL\Exception;
+use OC\AllConfig;
 use OC\Files\Storage\Wrapper\Encryption;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IReliableEtagStorage;
 use OCP\IDBConnection;
@@ -95,8 +97,8 @@ class Scanner extends BasicEmitter implements IScanner {
 		$this->storage = $storage;
 		$this->storageId = $this->storage->getId();
 		$this->cache = $storage->getCache();
-		$this->cacheActive = !\OC::$server->getConfig()->getSystemValueBool('filesystem_cache_readonly', false);
-		$this->lockingProvider = \OC::$server->getLockingProvider();
+		$this->cacheActive = !\OC::$server->get(AllConfig::class)->getSystemValueBool('filesystem_cache_readonly', false);
+		$this->lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$this->connection = \OC::$server->get(IDBConnection::class);
 	}
 
@@ -500,7 +502,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			// inserted mimetypes but those weren't available yet inside the transaction
 			// To make sure to have the updated mime types in such cases,
 			// we reload them here
-			\OC::$server->getMimeTypeLoader()->reset();
+			\OC::$server->get(IMimeTypeLoader::class)->reset();
 		}
 		return $childQueue;
 	}

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -59,7 +59,7 @@ class StorageGlobal {
 			->from('storages')
 			->where($builder->expr()->in('id', $builder->createNamedParameter(array_values($storageIds), IQueryBuilder::PARAM_STR_ARRAY)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$this->cache[$row['id']] = $row;
 		}
@@ -77,7 +77,7 @@ class StorageGlobal {
 				->from('storages')
 				->where($builder->expr()->eq('id', $builder->createNamedParameter($storageId)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 
@@ -100,7 +100,7 @@ class StorageGlobal {
 				->from('storages')
 				->where($builder->expr()->eq('numeric_id', $builder->createNamedParameter($numericId)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -31,9 +31,11 @@ use OC\Files\Cache\Cache;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOperator;
+use OCP\IDBConnection;
 
 /**
  * Jail to a subdirectory of the wrapped cache
@@ -52,8 +54,8 @@ class CacheJail extends CacheWrapper {
 	public function __construct($cache, $root) {
 		parent::__construct($cache);
 		$this->root = $root;
-		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->mimetypeLoader = \OC::$server->getMimeTypeLoader();
+		$this->connection = \OC::$server->get(IDBConnection::class);
+		$this->mimetypeLoader = \OC::$server->get(IMimeTypeLoader::class);
 
 		if ($cache instanceof CacheJail) {
 			$this->unjailedRoot = $cache->getSourcePath($root);

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -209,7 +209,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
 			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)));
 
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function removeFromCache(ICachedMountInfo $mount) {
@@ -219,7 +219,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
 			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->eq('mount_point', $builder->createNamedParameter($mount->getMountPoint())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function dbRowToMountInfo(array $row) {
@@ -254,7 +254,7 @@ class UserMountCache implements IUserMountCache {
 				->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
 				->where($builder->expr()->eq('user_id', $builder->createPositionalParameter($user->getUID())));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$rows = $result->fetchAll();
 			$result->closeCursor();
 
@@ -279,7 +279,7 @@ class UserMountCache implements IUserMountCache {
 			$query->andWhere($builder->expr()->eq('user_id', $builder->createPositionalParameter($user)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 
@@ -297,7 +297,7 @@ class UserMountCache implements IUserMountCache {
 			->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
 			->where($builder->expr()->eq('root_id', $builder->createPositionalParameter($rootFileId, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 
@@ -316,7 +316,7 @@ class UserMountCache implements IUserMountCache {
 				->from('filecache')
 				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 
@@ -355,7 +355,7 @@ class UserMountCache implements IUserMountCache {
 			$query->andWhere($builder->expr()->eq('user_id', $builder->createPositionalParameter($user)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		// filter mounts that are from the same storage but a different directory
@@ -393,7 +393,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($user->getUID())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function removeUserStorageMount($storageId, $userId) {
@@ -402,7 +402,7 @@ class UserMountCache implements IUserMountCache {
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($userId)))
 			->andWhere($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function remoteStorageMounts($storageId) {
@@ -410,7 +410,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**
@@ -441,7 +441,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('m.mount_point', $mountPoint))
 			->andWhere($builder->expr()->in('m.user_id', $builder->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$results = [];
 		while ($row = $result->fetch()) {

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -38,6 +38,7 @@
 namespace OC\Files;
 
 use OCP\Cache\CappedMemoryCache;
+use OC\AllConfig;
 use OC\Files\Mount\MountPoint;
 use OC\User\NoUserException;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -48,6 +49,7 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 class Filesystem {
 	private static ?Mount\Manager $mounts = null;
@@ -200,7 +202,7 @@ class Filesystem {
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper, $priority = 50) {
 		if (self::$logWarningWhenAddingStorageWrapper) {
-			\OC::$server->getLogger()->warning("Storage wrapper '{wrapper}' was not registered via the 'OC_Filesystem - preSetup' hook which could cause potential problems.", [
+			\OC::$server->get(LoggerInterface::class)->warning("Storage wrapper '{wrapper}' was not registered via the 'OC_Filesystem - preSetup' hook which could cause potential problems.", [
 				'wrapper' => $wrapperName,
 				'app' => 'filesystem',
 			]);
@@ -465,7 +467,7 @@ class Filesystem {
 		$filename = self::normalizePath($filename);
 
 		if (self::$blacklist === null) {
-			self::$blacklist = \OC::$server->getConfig()->getSystemValue('blacklisted_files', ['.htaccess']);
+			self::$blacklist = \OC::$server->get(AllConfig::class)->getSystemValue('blacklisted_files', ['.htaccess']);
 		}
 
 		$filename = strtolower(basename($filename));

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Files\Node;
 
+use OC\AllConfig;
 use OC\Files\Cache\QuerySearchHelper;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
@@ -314,7 +315,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	}
 
 	protected function getAppDataDirectoryName(): string {
-		$instanceId = \OC::$server->getConfig()->getSystemValueString('instanceid');
+		$instanceId = \OC::$server->get(AllConfig::class)->getSystemValueString('instanceid');
 		return 'appdata_' . $instanceId;
 	}
 

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -473,7 +473,7 @@ class Root extends Folder implements IRootFolder {
 			$absolutePath = rtrim($mount->getMountPoint() . $pathRelativeToMount, '/');
 			return $this->createNode($absolutePath, new FileInfo(
 				$absolutePath, $mount->getStorage(), $cacheEntry->getPath(), $cacheEntry, $mount,
-				\OC::$server->getUserManager()->get($mount->getStorage()->getOwner($pathRelativeToMount))
+				\OC::$server->get(IUserManager::class)->get($mount->getStorage()->getOwner($pathRelativeToMount))
 			));
 		}, $mountsContainingFile);
 

--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -32,6 +32,8 @@ use Icewind\Streams\RetryWrapper;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\StorageAuthException;
+use OCP\ICacheFactory;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 const SWIFT_SEGMENT_SIZE = 1073741824; // 1GB
@@ -47,7 +49,7 @@ class Swift implements IObjectStore {
 
 	public function __construct($params, SwiftFactory $connectionFactory = null) {
 		$this->swiftFactory = $connectionFactory ?: new SwiftFactory(
-			\OC::$server->getMemCacheFactory()->createDistributed('swift::'),
+			\OC::$server->get(ICacheFactory::class)->createDistributed('swift::'),
 			$params,
 			\OC::$server->get(LoggerInterface::class)
 		);
@@ -75,7 +77,7 @@ class Swift implements IObjectStore {
 	}
 
 	public function writeObject($urn, $stream, string $mimetype = null) {
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('swiftwrite');
 		file_put_contents($tmpFile, $stream);
 		$handle = fopen($tmpFile, 'rb');
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -40,6 +40,7 @@ namespace OC\Files\Storage;
 use Exception;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\MemCache\ArrayCache;
 use OCP\AppFramework\Http;
@@ -53,6 +54,7 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
 use OCP\IConfig;
+use OCP\ITempManager;
 use OCP\Util;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV\Client;
@@ -116,7 +118,7 @@ class DAV extends Common {
 	 */
 	public function __construct($params) {
 		$this->statCache = new ArrayCache();
-		$this->httpClientService = \OC::$server->getHTTPClientService();
+		$this->httpClientService = \OC::$server->get(IClientService::class);
 		if (isset($params['host']) && isset($params['user']) && isset($params['password'])) {
 			$host = $params['host'];
 			//remove leading http[s], will be generated in createBaseUri()
@@ -154,7 +156,7 @@ class DAV extends Common {
 		$this->eventLogger = \OC::$server->get(IEventLogger::class);
 		// This timeout value will be used for the download and upload of files
 		$this->timeout = \OC::$server->get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', 30);
-		$this->mimeTypeDetector = \OC::$server->getMimeTypeDetector();
+		$this->mimeTypeDetector = \OC::$server->get(IMimeTypeDetector::class);
 	}
 
 	protected function init() {
@@ -172,7 +174,7 @@ class DAV extends Common {
 			$settings['authType'] = $this->authType;
 		}
 
-		$proxy = \OC::$server->getConfig()->getSystemValueString('proxy', '');
+		$proxy = \OC::$server->get(AllConfig::class)->getSystemValueString('proxy', '');
 		if ($proxy !== '') {
 			$settings['proxy'] = $proxy;
 		}
@@ -400,7 +402,7 @@ class DAV extends Common {
 			case 'c':
 			case 'c+':
 				//emulate these
-				$tempManager = \OC::$server->getTempManager();
+				$tempManager = \OC::$server->get(ITempManager::class);
 				if (strrpos($path, '.') !== false) {
 					$ext = substr($path, strrpos($path, '.'));
 				} else {

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -26,6 +26,7 @@
 namespace OC\Files\Storage;
 
 use OC\Files\Cache\HomePropagator;
+use OCP\IDBConnection;
 
 /**
  * Specialized version of Local storage for home directory usage
@@ -83,7 +84,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 			$storage = $this;
 		}
 		if (!isset($this->propagator)) {
-			$this->propagator = new HomePropagator($storage, \OC::$server->getDatabaseConnection());
+			$this->propagator = new HomePropagator($storage, \OC::$server->get(IDBConnection::class));
 		}
 		return $this->propagator;
 	}

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -23,6 +23,8 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\ITempManager;
+
 /**
  * Storage backend class for providing common filesystem operation methods
  * which are not storage-backend specific.
@@ -62,7 +64,7 @@ trait LocalTempFileTrait {
 		} else {
 			$extension = '';
 		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($extension);
 		$target = fopen($tmpFile, 'w');
 		\OC_Helper::streamCopy($source, $target);
 		fclose($target);

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -25,12 +25,14 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\ITempManager;
+
 /**
  * local storage backend in temporary folder for testing purpose
  */
 class Temporary extends Local {
 	public function __construct($arguments = null) {
-		parent::__construct(['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]);
+		parent::__construct(['datadir' => \OC::$server->get(ITempManager::class)->getTemporaryFolder()]);
 	}
 
 	public function cleanUp() {

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -26,6 +26,7 @@
  */
 namespace OC\Files\Storage\Wrapper;
 
+use OC\AllConfig;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageAuthException;
 use OCP\Files\StorageNotAvailableException;
@@ -43,7 +44,7 @@ class Availability extends Wrapper {
 	protected $config;
 
 	public function __construct($parameters) {
-		$this->config = $parameters['config'] ?? \OC::$server->getConfig();
+		$this->config = $parameters['config'] ?? \OC::$server->get(AllConfig::class);
 		parent::__construct($parameters);
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -33,6 +33,7 @@ use OC\Files\Cache\Wrapper\JailPropagator;
 use OC\Files\Filesystem;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
+use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
 
 /**
@@ -513,7 +514,7 @@ class Jail extends Wrapper {
 		if (!$storage) {
 			$storage = $this;
 		}
-		$this->propagator = new JailPropagator($storage, \OC::$server->getDatabaseConnection());
+		$this->propagator = new JailPropagator($storage, \OC::$server->get(IDBConnection::class));
 		return $this->propagator;
 	}
 

--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OC\Files\Type;
 
 use OCP\Files\IMimeTypeDetector;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -311,7 +312,7 @@ class Detection implements IMimeTypeDetector {
 			return str_contains($info, ';') ? substr($info, 0, strpos($info, ';')) : $info;
 		}
 
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 		$fh = fopen($tmpFile, 'wb');
 		fwrite($fh, $data, 8024);
 		fclose($fh);

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -160,7 +160,7 @@ class Loader implements IMimeTypeLoader {
 		$qb->select('id', 'mimetype')
 			->from('mimetypes');
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$results = $result->fetchAll();
 		$result->closeCursor();
 
@@ -192,6 +192,6 @@ class Loader implements IMimeTypeLoader {
 				$update->func()->lower('name'),
 				$update->createNamedParameter('%' . $this->dbConnection->escapeLikeParameter('.' . $ext))
 			));
-		return $update->execute();
+		return $update->executeStatement();
 	}
 }

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -50,6 +50,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
+use OCP\Lock\ILockingProvider;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -100,7 +101,7 @@ class Scanner extends PublicEmitter {
 		$this->dispatcher = $dispatcher;
 		$this->logger = $logger;
 		// when DB locking is used, no DB transactions will be used
-		$this->useTransaction = !(\OC::$server->getLockingProvider() instanceof DBLockingProvider);
+		$this->useTransaction = !(\OC::$server->get(ILockingProvider::class) instanceof DBLockingProvider);
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -65,7 +65,10 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\IStorage;
+use OCP\ITempManager;
 use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
@@ -103,9 +106,9 @@ class View {
 		}
 
 		$this->fakeRoot = $root;
-		$this->lockingProvider = \OC::$server->getLockingProvider();
+		$this->lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$this->lockingEnabled = !($this->lockingProvider instanceof \OC\Lock\NoopLockingProvider);
-		$this->userManager = \OC::$server->getUserManager();
+		$this->userManager = \OC::$server->get(IUserManager::class);
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 	}
 
@@ -997,7 +1000,7 @@ class View {
 			$source = $this->fopen($path, 'r');
 			if ($source) {
 				$extension = pathinfo($path, PATHINFO_EXTENSION);
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+				$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($extension);
 				file_put_contents($tmpFile, $source);
 				return $tmpFile;
 			} else {
@@ -1626,7 +1629,7 @@ class View {
 		$mount = $this->getMount('');
 		$mountPoint = $mount->getMountPoint();
 		$storage = $mount->getStorage();
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		if ($storage) {
 			$cache = $storage->getCache('');
 
@@ -1803,7 +1806,7 @@ class View {
 		$mount = $this->getMount($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($this->getAbsolutePath($path));
-		$owner = \OC::$server->getUserManager()->get($storage->getOwner($internalPath));
+		$owner = \OC::$server->get(IUserManager::class)->get($storage->getOwner($internalPath));
 		return new FileInfo(
 			$this->getAbsolutePath($path),
 			$storage,
@@ -1834,19 +1837,19 @@ class View {
 			[$storage, $internalPath] = $this->resolvePath($path);
 			$storage->verifyPath($internalPath, $fileName);
 		} catch (ReservedWordException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name is a reserved word'));
 		} catch (InvalidCharacterInPathException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name contains at least one invalid character'));
 		} catch (FileNameTooLongException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name is too long'));
 		} catch (InvalidDirectoryException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('Dot files are not allowed'));
 		} catch (EmptyFileNameException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('Empty filename is not allowed'));
 		}
 	}

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -82,7 +82,7 @@ class Database extends ABackend implements
 	 */
 	private function fixDI() {
 		if ($this->dbConn === null) {
-			$this->dbConn = \OC::$server->getDatabaseConnection();
+			$this->dbConn = \OC::$server->get(IDBConnection::class);
 		}
 	}
 
@@ -103,7 +103,7 @@ class Database extends ABackend implements
 			$result = $builder->insert('groups')
 				->setValue('gid', $builder->createNamedParameter($gid))
 				->setValue('displayname', $builder->createNamedParameter($gid))
-				->execute();
+				->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			$result = 0;
 		}
@@ -131,19 +131,19 @@ class Database extends ABackend implements
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete the group-user relation
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('group_user')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete the group-groupadmin relation
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete from cache
 		unset($this->groupCache[$gid]);
@@ -168,7 +168,7 @@ class Database extends ABackend implements
 			->from('group_user')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 
 		$result = $cursor->fetch();
 		$cursor->closeCursor();
@@ -193,7 +193,7 @@ class Database extends ABackend implements
 			$qb->insert('group_user')
 				->setValue('uid', $qb->createNamedParameter($uid))
 				->setValue('gid', $qb->createNamedParameter($gid))
-				->execute();
+				->executeStatement();
 			return true;
 		} else {
 			return false;
@@ -215,7 +215,7 @@ class Database extends ABackend implements
 		$qb->delete('group_user')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		return true;
 	}
@@ -242,7 +242,7 @@ class Database extends ABackend implements
 			->from('group_user', 'gu')
 			->leftJoin('gu', 'groups', 'g', $qb->expr()->eq('gu.gid', 'g.gid'))
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 
 		$groups = [];
 		while ($row = $cursor->fetch()) {
@@ -289,7 +289,7 @@ class Database extends ABackend implements
 		if ($offset > 0) {
 			$query->setFirstResult($offset);
 		}
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$groups = [];
 		while ($row = $result->fetch()) {
@@ -317,7 +317,7 @@ class Database extends ABackend implements
 		$cursor = $qb->select('gid', 'displayname')
 			->from('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeQuery();
 		$result = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -411,7 +411,7 @@ class Database extends ABackend implements
 			)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -443,7 +443,7 @@ class Database extends ABackend implements
 			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter('false'), IQueryBuilder::PARAM_STR))
 			->andWhere($query->expr()->eq('gid', $query->createNamedParameter($gid), IQueryBuilder::PARAM_STR));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -472,7 +472,7 @@ class Database extends ABackend implements
 			->from('groups')
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$displayName = $result->fetchOne();
 		$result->closeCursor();
 
@@ -504,7 +504,7 @@ class Database extends ABackend implements
 		$query->update('groups')
 			->set('displayname', $query->createNamedParameter($displayName))
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
-		$query->execute();
+		$query->executeStatement();
 
 		return true;
 	}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -45,6 +45,7 @@ use OCP\Group\Events\BeforeGroupCreatedEvent;
 use OCP\Group\Events\GroupCreatedEvent;
 use OCP\GroupInterface;
 use OCP\ICacheFactory;
+use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -425,7 +426,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 			$this->subAdmin = new \OC\SubAdmin(
 				$this->userManager,
 				$this,
-				\OC::$server->getDatabaseConnection(),
+				\OC::$server->get(IDBConnection::class),
 				$this->dispatcher
 			);
 		}

--- a/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
  */
 namespace OC\IntegrityCheck\Iterator;
 
+use OC\AllConfig;
+
 class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 	private $excludedFolders;
 
@@ -51,7 +53,7 @@ class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 			rtrim($root . '/updater', '/'),
 			rtrim($root . '/_oc_upgrade', '/'),
 		];
-		$customDataDir = \OC::$server->getConfig()->getSystemValueString('datadirectory', '');
+		$customDataDir = \OC::$server->get(AllConfig::class)->getSystemValueString('datadirectory', '');
 		if ($customDataDir !== '') {
 			$excludedFolders[] = rtrim($customDataDir, '/');
 		}

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -31,6 +31,7 @@ namespace OC\L10N;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use Punic\Calendar;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\IdentityTranslator;
 
 class L10N implements IL10N {
@@ -234,7 +235,7 @@ class L10N implements IL10N {
 		$json = json_decode(file_get_contents($translationFile), true);
 		if (!\is_array($json)) {
 			$jsonError = json_last_error();
-			\OC::$server->getLogger()->warning("Failed to load $translationFile - json error code: $jsonError", ['app' => 'l10n']);
+			\OC::$server->get(LoggerInterface::class)->warning("Failed to load $translationFile - json error code: $jsonError", ['app' => 'l10n']);
 			return false;
 		}
 

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -24,6 +24,7 @@ namespace OC\Lockdown\Filesystem;
 
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Search\SearchComparison;
+use OC\ForbiddenException;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
@@ -63,15 +64,15 @@ class NullCache implements ICache {
 	}
 
 	public function put($file, array $data) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function insert($file, array $data) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function update($id, array $data) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function getId($file) {
@@ -87,15 +88,15 @@ class NullCache implements ICache {
 	}
 
 	public function remove($file) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function move($source, $target) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function getStatus($file) {
@@ -127,7 +128,7 @@ class NullCache implements ICache {
 	}
 
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {
-		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
+		throw new ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
 	public function getQueryFilterForStorage(): ISearchOperator {

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -40,6 +40,7 @@ use Exception;
 use Nextcloud\LogNormalizer\Normalizer;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Log\BeforeMessageLoggedEvent;
 use OCP\Log\IDataLogger;
@@ -48,6 +49,7 @@ use OCP\Log\IWriter;
 use OCP\Support\CrashReport\IRegistry;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Log\ExceptionSerializer;
+use OC\SystemConfig;
 use Throwable;
 use function array_merge;
 use function strtr;
@@ -83,7 +85,7 @@ class Log implements ILogger, IDataLogger {
 	) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {
-			$config = \OC::$server->getSystemConfig();
+			$config = \OC::$server->get(SystemConfig::class);
 		}
 
 		$this->config = $config;
@@ -263,7 +265,7 @@ class Log implements ILogger, IDataLogger {
 			if (!empty($logCondition)) {
 				// check for secret token in the request
 				if (isset($logCondition['shared_secret'])) {
-					$request = \OC::$server->getRequest();
+					$request = \OC::$server->get(IRequest::class);
 
 					if ($request->getMethod() === 'PUT' &&
 						!str_contains($request->getHeader('Content-Type'), 'application/x-www-form-urlencoded') &&

--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -26,6 +26,7 @@
 namespace OC\Log;
 
 use OC\SystemConfig;
+use OCP\IRequest;
 
 abstract class LogDetails {
 	/** @var SystemConfig */
@@ -51,7 +52,7 @@ abstract class LogDetails {
 			// apply timezone if $time is created from UNIX timestamp
 			$time->setTimezone($timezone);
 		}
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 		$reqId = $request->getId();
 		$remoteAddr = $request->getRemoteAddress();
 		// remove username/passwords from URLs before writing the to the log file

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -24,7 +24,10 @@
  */
 namespace OC\Log;
 
+use OC\AllConfig;
+use OC\SystemConfig;
 use OCP\Log\RotationTrait;
+use Psr\Log\LoggerInterface;
 
 /**
  * This rotates the current logfile to a new name, this way the total log usage
@@ -36,14 +39,14 @@ class Rotate extends \OCP\BackgroundJob\Job {
 	use RotationTrait;
 
 	public function run($dummy) {
-		$systemConfig = \OC::$server->getSystemConfig();
+		$systemConfig = \OC::$server->get(SystemConfig::class);
 		$this->filePath = $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/nextcloud.log');
 
-		$this->maxSize = \OC::$server->getConfig()->getSystemValueInt('log_rotate_size', 100 * 1024 * 1024);
+		$this->maxSize = \OC::$server->get(AllConfig::class)->getSystemValueInt('log_rotate_size', 100 * 1024 * 1024);
 		if ($this->shouldRotateBySize()) {
 			$rotatedFile = $this->rotate();
 			$msg = 'Log file "'.$this->filePath.'" was over '.$this->maxSize.' bytes, moved to "'.$rotatedFile.'"';
-			\OC::$server->getLogger()->warning($msg, ['app' => Rotate::class]);
+			\OC::$server->get(LoggerInterface::class)->warning($msg, ['app' => Rotate::class]);
 		}
 	}
 }

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -65,7 +65,7 @@ use Symfony\Component\Mime\Exception\RfcComplianceException;
  *
  * Example usage:
  *
- * 	$mailer = \OC::$server->getMailer();
+ * 	$mailer = \OC::$server->get(\OCP\Mail\IMailer::class);
  * 	$message = $mailer->createMessage();
  * 	$message->setSubject('Your Subject');
  * 	$message->setFrom(array('cloud@domain.org' => 'ownCloud Notifier'));

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -32,6 +32,7 @@
 namespace OC\Memcache;
 
 use OCP\Profiler\IProfiler;
+use OCP\HintException;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IMemcache;
@@ -88,12 +89,12 @@ class Factory implements ICacheFactory {
 		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
 		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
 		if (!class_exists($localCacheClass) || !$localCacheClass::isAvailable()) {
-			throw new \OCP\HintException(strtr($missingCacheMessage, [
+			throw new HintException(strtr($missingCacheMessage, [
 				'{class}' => $localCacheClass, '{use}' => 'local'
 			]), $missingCacheHint);
 		}
 		if (!class_exists($distributedCacheClass) || !$distributedCacheClass::isAvailable()) {
-			throw new \OCP\HintException(strtr($missingCacheMessage, [
+			throw new HintException(strtr($missingCacheMessage, [
 				'{class}' => $distributedCacheClass, '{use}' => 'distributed'
 			]), $missingCacheHint);
 		}

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -31,6 +31,8 @@
  */
 namespace OC\Memcache;
 
+use OC\AllConfig;
+use OC\SystemConfig;
 use OCP\HintException;
 use OCP\IMemcache;
 
@@ -76,7 +78,7 @@ class Memcached extends Cache implements IMemcache {
 				$defaultOptions[\Memcached::OPT_SERIALIZER] =
 					\Memcached::SERIALIZER_IGBINARY;
 			}
-			$options = \OC::$server->getConfig()->getSystemValue('memcached_options', []);
+			$options = \OC::$server->get(AllConfig::class)->getSystemValue('memcached_options', []);
 			if (is_array($options)) {
 				$options = $options + $defaultOptions;
 				self::$cache->setOptions($options);
@@ -84,9 +86,9 @@ class Memcached extends Cache implements IMemcache {
 				throw new HintException("Expected 'memcached_options' config to be an array, got $options");
 			}
 
-			$servers = \OC::$server->getSystemConfig()->getValue('memcached_servers');
+			$servers = \OC::$server->get(SystemConfig::class)->getValue('memcached_servers');
 			if (!$servers) {
-				$server = \OC::$server->getSystemConfig()->getValue('memcached_server');
+				$server = \OC::$server->get(SystemConfig::class)->getValue('memcached_server');
 				if ($server) {
 					$servers = [$server];
 				} else {

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -63,7 +63,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	 */
 	public function getCache() {
 		if (is_null(self::$cache)) {
-			self::$cache = \OC::$server->getGetRedisFactory()->getInstance();
+			self::$cache = \OC::$server->get('RedisFactory')->getInstance();
 		}
 		return self::$cache;
 	}
@@ -182,7 +182,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public static function isAvailable(): bool {
-		return \OC::$server->getGetRedisFactory()->isAvailable();
+		return \OC::$server->get('RedisFactory')->isAvailable();
 	}
 
 	protected function evalLua(string $scriptName, array $keys, array $args) {

--- a/lib/private/OCS/Provider.php
+++ b/lib/private/OCS/Provider.php
@@ -24,7 +24,12 @@
  */
 namespace OC\OCS;
 
-class Provider extends \OCP\AppFramework\Controller {
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\App\IAppManager;
+use OCP\IRequest;
+
+class Provider extends Controller {
 	/** @var \OCP\App\IAppManager */
 	private $appManager;
 
@@ -34,8 +39,8 @@ class Provider extends \OCP\AppFramework\Controller {
 	 * @param \OCP\App\IAppManager $appManager
 	 */
 	public function __construct($appName,
-								\OCP\IRequest $request,
-								\OCP\App\IAppManager $appManager) {
+								IRequest $request,
+								IAppManager $appManager) {
 		parent::__construct($appName, $request);
 		$this->appManager = $appManager;
 	}
@@ -108,7 +113,7 @@ class Provider extends \OCP\AppFramework\Controller {
 			];
 		}
 
-		return new \OCP\AppFramework\Http\JSONResponse([
+		return new JSONResponse([
 			'version' => 2,
 			'services' => $services,
 		]);

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -99,7 +99,7 @@ class BackgroundCleanupJob extends TimedJob {
 			$qb->setMaxResults(10);
 		}
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row['name'];
@@ -113,7 +113,7 @@ class BackgroundCleanupJob extends TimedJob {
 		$qb->select('path', 'mimetype')
 			->from('filecache')
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($this->previewFolder->getId())));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -162,7 +162,7 @@ class BackgroundCleanupJob extends TimedJob {
 			$qb->setMaxResults(10);
 		}
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row['name'];

--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -25,6 +25,7 @@ namespace OC\Preview;
 use OC\Archive\ZIP;
 use OCP\Files\File;
 use OCP\IImage;
+use OCP\ITempManager;
 
 /**
  * Extracts a preview from files that embed them in an ZIP archive
@@ -35,8 +36,8 @@ abstract class Bundled extends ProviderV2 {
 			return null;
 		}
 
-		$sourceTmp = \OC::$server->getTempManager()->getTemporaryFile();
-		$targetTmp = \OC::$server->getTempManager()->getTemporaryFile();
+		$sourceTmp = \OC::$server->get(ITempManager::class)->getTemporaryFile();
+		$targetTmp = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 		$this->tmpFiles[] = $sourceTmp;
 		$this->tmpFiles[] = $targetTmp;
 

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -29,6 +29,7 @@
  */
 namespace OC\Preview;
 
+use OC\AllConfig;
 use OCP\Files\File;
 use OCP\IImage;
 
@@ -37,7 +38,7 @@ abstract class Image extends ProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
-		$maxSizeForImages = \OC::$server->getConfig()->getSystemValueInt('preview_max_filesize_image', 50);
+		$maxSizeForImages = \OC::$server->get(AllConfig::class)->getSystemValueInt('preview_max_filesize_image', 50);
 		$size = $file->getSize();
 
 		if ($maxSizeForImages !== -1 && $size > ($maxSizeForImages * 1024 * 1024)) {

--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -30,6 +30,7 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\IImage;
+use OCP\Image;
 use Psr\Log\LoggerInterface;
 use wapmorgan\Mp3Info\Mp3Info;
 
@@ -62,7 +63,7 @@ class MP3 extends ProviderV2 {
 		}
 
 		if (is_string($picture)) {
-			$image = new \OCP\Image();
+			$image = new Image();
 			$image->loadFromData($picture);
 
 			if ($image->valid()) {

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -32,6 +32,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class Movie extends ProviderV2 {
@@ -120,7 +121,7 @@ class Movie extends ProviderV2 {
 	}
 
 	private function generateThumbNail(int $maxX, int $maxY, string $absPath, int $second): ?IImage {
-		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
+		$tmpPath = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
 

--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -31,6 +31,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 abstract class Office extends ProviderV2 {
@@ -51,10 +52,10 @@ abstract class Office extends ProviderV2 {
 
 		$absPath = $this->getLocalFile($file);
 
-		$tmpDir = \OC::$server->getTempManager()->getTempBaseDir();
+		$tmpDir = \OC::$server->get(ITempManager::class)->getTempBaseDir();
 
 		$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir . '/owncloud-' . \OC_Util::getInstanceId() . '/') . ' --headless --nologo --nofirststartwizard --invisible --norestore --convert-to png --outdir ';
-		$clParameters = \OC::$server->getConfig()->getSystemValue('preview_office_cl_parameters', $defaultParameters);
+		$clParameters = \OC::$server->get(\OC\AllConfig::class)->getSystemValue('preview_office_cl_parameters', $defaultParameters);
 
 		$cmd = $this->options['officeBinary'] . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath);
 

--- a/lib/private/Preview/ProviderV2.php
+++ b/lib/private/Preview/ProviderV2.php
@@ -28,6 +28,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use OCP\Preview\IProviderV2;
 
 abstract class ProviderV2 implements IProviderV2 {
@@ -85,7 +86,7 @@ abstract class ProviderV2 implements IProviderV2 {
 	 */
 	protected function getLocalFile(File $file, int $maxSize = null) {
 		if ($this->useTempFile($file)) {
-			$absPath = \OC::$server->getTempManager()->getTemporaryFile();
+			$absPath = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 
 			$content = $file->fopen('r');
 

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -32,6 +32,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\Image;
 
 class TXT extends ProviderV2 {
 	/**
@@ -103,7 +104,7 @@ class TXT extends ProviderV2 {
 			}
 		}
 
-		$imageObject = new \OCP\Image();
+		$imageObject = new Image();
 		$imageObject->setResource($image);
 
 		return $imageObject->valid() ? $imageObject : null;

--- a/lib/private/Repair/CleanTags.php
+++ b/lib/private/Repair/CleanTags.php
@@ -92,7 +92,7 @@ class CleanTags implements IRepairStep {
 			->orderBy('uid')
 			->setMaxResults(50)
 			->setFirstResult($offset);
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$users = [];
 		$hadResults = false;
@@ -113,7 +113,7 @@ class CleanTags implements IRepairStep {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete('vcategory')
 				->where($query->expr()->in('uid', $query->createNamedParameter($users, IQueryBuilder::PARAM_STR_ARRAY)));
-			$this->deletedTags += $query->execute();
+			$this->deletedTags += $query->executeStatement();
 		}
 		return true;
 	}
@@ -181,7 +181,7 @@ class CleanTags implements IRepairStep {
 			->andWhere(
 				$qb->expr()->isNull('s.' . $sourceNullColumn)
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 
 		$orphanItems = [];
 		while ($row = $result->fetch()) {
@@ -197,7 +197,7 @@ class CleanTags implements IRepairStep {
 					)
 					->andWhere($qb->expr()->in($deleteId, $qb->createParameter('ids')));
 				$qb->setParameter('ids', $items, IQueryBuilder::PARAM_INT_ARRAY);
-				$qb->execute();
+				$qb->executeStatement();
 			}
 		}
 

--- a/lib/private/Repair/NC11/FixMountStorages.php
+++ b/lib/private/Repair/NC11/FixMountStorages.php
@@ -58,12 +58,12 @@ class FixMountStorages implements IRepairStep {
 			->set('storage_id', $update->createParameter('storage'))
 			->where($query->expr()->eq('id', $update->createParameter('mount')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$entriesUpdated = 0;
 		while ($row = $result->fetch()) {
 			$update->setParameter('storage', $row['storage'], IQueryBuilder::PARAM_INT)
 				->setParameter('mount', $row['id'], IQueryBuilder::PARAM_INT);
-			$update->execute();
+			$update->executeStatement();
 			$entriesUpdated++;
 		}
 		$result->closeCursor();

--- a/lib/private/Repair/OldGroupMembershipShares.php
+++ b/lib/private/Repair/OldGroupMembershipShares.php
@@ -81,11 +81,11 @@ class OldGroupMembershipShares implements IRepairStep {
 		$deleteQuery->delete('share')
 			->where($query->expr()->eq('id', $deleteQuery->createParameter('share')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			if (!$this->isMember($row['group'], $row['user'])) {
 				$deletedEntries += $deleteQuery->setParameter('share', (int) $row['id'])
-					->execute();
+					->executeStatement();
 			}
 		}
 		$result->closeCursor();

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -139,7 +139,7 @@ class SaveAccountsTableData implements IRepairStep {
 			$query->setFirstResult($offset);
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$update = $this->db->getQueryBuilder();
 		$update->update('users')
@@ -193,7 +193,7 @@ class SaveAccountsTableData implements IRepairStep {
 		if ($userdata['display_name'] !== null) {
 			$update->setParameter('displayname', $userdata['display_name'])
 				->setParameter('userid', $userdata['user_id']);
-			$update->execute();
+			$update->executeStatement();
 		}
 	}
 }

--- a/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
+++ b/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
@@ -80,7 +80,7 @@ class UpdateLanguageCodes implements IRepairStep {
 				->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($oldCode), IQueryBuilder::PARAM_STR))
-				->execute();
+				->executeStatement();
 
 			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in preferences table.');
 		}

--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -95,7 +95,7 @@ class RemoveLinkShares implements IRepairStep {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -128,7 +128,7 @@ class RemoveLinkShares implements IRepairStep {
 			->from('share')
 			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$data = $result->fetch();
 		$result->closeCursor();
 
@@ -158,7 +158,7 @@ class RemoveLinkShares implements IRepairStep {
 			))
 			->andWhere($query->expr()->eq('s1.item_source', 's2.item_source'));
 		/** @var IResult $result */
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		return $result;
 	}
 

--- a/lib/private/Repair/RepairDavShares.php
+++ b/lib/private/Repair/RepairDavShares.php
@@ -81,7 +81,7 @@ class RepairDavShares implements IRepairStep {
 			->set('principaluri', $updateQuery->createParameter('updatedPrincipalUri'))
 			->where($updateQuery->expr()->eq('id', $updateQuery->createParameter('shareId')));
 
-		$statement = $qb->execute();
+		$statement = $qb->executeQuery();
 		while ($share = $statement->fetch()) {
 			$gid = substr($share['principaluri'], strlen(self::GROUP_PRINCIPAL_PREFIX));
 			$decodedGid = urldecode($gid);
@@ -110,7 +110,7 @@ class RepairDavShares implements IRepairStep {
 				$updateQuery
 					->setParameter('updatedPrincipalUri', $fixedPrincipal)
 					->setParameter('shareId', $share['id'])
-					->execute();
+					->executeStatement();
 				$this->logger->info('Repaired principal for dav share {id} from {old} to {new}', $logParameters);
 			} catch (Exception $e) {
 				$logParameters['message'] = $e->getMessage();

--- a/lib/private/Repair/RepairInvalidShares.php
+++ b/lib/private/Repair/RepairInvalidShares.php
@@ -67,7 +67,7 @@ class RepairInvalidShares implements IRepairStep {
 			->where($builder->expr()->eq('item_type', $builder->expr()->literal('file')))
 			->andWhere($builder->expr()->neq('permissions', $permsFunc));
 
-		$updatedEntries = $builder->execute();
+		$updatedEntries = $builder->executeStatement();
 		if ($updatedEntries > 0) {
 			$out->info('Fixed file share permissions for ' . $updatedEntries . ' shares');
 		}
@@ -95,11 +95,11 @@ class RepairInvalidShares implements IRepairStep {
 		$deletedInLastChunk = self::CHUNK_SIZE;
 		while ($deletedInLastChunk === self::CHUNK_SIZE) {
 			$deletedInLastChunk = 0;
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			while ($row = $result->fetch()) {
 				$deletedInLastChunk++;
 				$deletedEntries += $deleteQuery->setParameter('parent', (int) $row['parent'])
-					->execute();
+					->executeStatement();
 			}
 			$result->closeCursor();
 		}

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -69,7 +69,7 @@ class RepairMimeTypes implements IRepairStep {
 
 		if (empty($this->folderMimeTypeId)) {
 			$query->setParameter('mimetype', 'httpd/unix-directory');
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$this->folderMimeTypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 		}
@@ -86,21 +86,21 @@ class RepairMimeTypes implements IRepairStep {
 		foreach ($updatedMimetypes as $extension => $mimetype) {
 			// get target mimetype id
 			$query->setParameter('mimetype', $mimetype);
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$mimetypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 
 			if (!$mimetypeId) {
 				// insert mimetype
 				$insert->setParameter('mimetype', $mimetype);
-				$insert->execute();
+				$insert->executeStatement();
 				$mimetypeId = $insert->getLastInsertId();
 			}
 
 			// change mimetype for files with x extension
 			$update->setParameter('mimetype', $mimetypeId)
 				->setParameter('name', '%' . $this->connection->escapeLikeParameter('.' . $extension));
-			$count += $update->execute();
+			$count += $update->executeStatement();
 		}
 
 		return $count;

--- a/lib/private/Search.php
+++ b/lib/private/Search.php
@@ -30,6 +30,7 @@ namespace OC;
 use OCP\ISearch;
 use OCP\Search\PagedProvider;
 use OCP\Search\Provider;
+use Psr\Log\LoggerInterface;
 
 /**
  * Provide an interface to all search providers
@@ -65,7 +66,7 @@ class Search implements ISearch {
 					$results = array_merge($results, $providerResults);
 				}
 			} else {
-				\OC::$server->getLogger()->warning('Ignoring Unknown search provider', ['provider' => $provider]);
+				\OC::$server->get(LoggerInterface::class)->warning('Ignoring Unknown search provider', ['provider' => $provider]);
 			}
 		}
 		return $results;

--- a/lib/private/Search/Result/File.php
+++ b/lib/private/Search/Result/File.php
@@ -29,6 +29,7 @@ namespace OC\Search\Result;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\IPreview;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 
 /**
@@ -97,7 +98,7 @@ class File extends \OCP\Search\Result {
 
 		$this->id = $data->getId();
 		$this->name = $data->getName();
-		$this->link = \OC::$server->getURLGenerator()->linkToRoute(
+		$this->link = \OC::$server->get(IURLGenerator::class)->linkToRoute(
 			'files.view.index',
 			[
 				'dir' => dirname($path),

--- a/lib/private/Security/Bruteforce/CleanupJob.php
+++ b/lib/private/Security/Bruteforce/CleanupJob.php
@@ -51,6 +51,6 @@ class CleanupJob extends TimedJob {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('bruteforce_attempts')
 			->where($qb->expr()->lt('occurred', $qb->createNamedParameter($time), IQueryBuilder::PARAM_INT));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -92,7 +92,7 @@ class CredentialsManager implements ICredentialsManager {
 			$qb->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($userId)));
 		}
 
-		$qResult = $qb->execute();
+		$qResult = $qb->executeQuery();
 		$result = $qResult->fetch();
 		$qResult->closeCursor();
 
@@ -122,7 +122,7 @@ class CredentialsManager implements ICredentialsManager {
 			$qb->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($userId)));
 		}
 
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 
 	/**
@@ -136,6 +136,6 @@ class CredentialsManager implements ICredentialsManager {
 		$qb->delete(self::DB_TABLE)
 			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
 		;
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 }

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -41,8 +41,8 @@ use phpseclib\Crypt\Hash;
  * it will use the secret defined in config.php as key. Additionally the message will be HMAC'd.
  *
  * Usage:
- * $encryptWithDefaultPassword = \OC::$server->getCrypto()->encrypt('EncryptedText');
- * $encryptWithCustompassword = \OC::$server->getCrypto()->encrypt('EncryptedText', 'password');
+ * $encryptWithDefaultPassword = \OC::$server->get(\OCP\Security\ICrypto::class)->encrypt('EncryptedText');
+ * $encryptWithCustompassword = \OC::$server->get(\OCP\Security\ICrypto::class)->encrypt('EncryptedText', 'password');
  *
  * @package OC\Security
  */

--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -42,10 +42,10 @@ use OCP\Security\IHasher;
  *
  * Usage:
  * // Hashing a message
- * $hash = \OC::$server->getHasher()->hash('MessageToHash');
+ * $hash = \OC::$server->get(\OCP\Security\IHasher::class)->hash('MessageToHash');
  * // Verifying a message - $newHash will contain the newly calculated hash
  * $newHash = null;
- * var_dump(\OC::$server->getHasher()->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
+ * var_dump(\OC::$server->get(\OCP\Security\IHasher::class)->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
  * var_dump($newHash);
  *
  * @package OC\Security

--- a/lib/private/Security/SecureRandom.php
+++ b/lib/private/Security/SecureRandom.php
@@ -35,7 +35,7 @@ use OCP\Security\ISecureRandom;
  * use a fallback.
  *
  * Usage:
- * \OC::$server->getSecureRandom()->generate(10);
+ * \OC::$server->get(\OCP\Security\ISecureRandom::class)->generate(10);
  * @package OC\Security
  */
 class SecureRandom implements ISecureRandom {

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -122,14 +122,14 @@ class MySQL extends AbstractDatabase {
 
 			if ($connection->getDatabasePlatform() instanceof Mysql80Platform) {
 				$query = "CREATE USER '$name'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 				$query = "CREATE USER '$name'@'%' IDENTIFIED WITH mysql_native_password BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 			} else {
 				$query = "CREATE USER '$name'@'localhost' IDENTIFIED BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 				$query = "CREATE USER '$name'@'%' IDENTIFIED BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 			}
 		} catch (\Exception $ex) {
 			$this->logger->error('Database user creation failed.', [

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -25,13 +25,15 @@
  */
 namespace OC\Share;
 
+use OC\AllConfig;
+
 class Helper extends \OC\Share\Constants {
 	/**
 	 * get default expire settings defined by the admin
 	 * @return array contains 'defaultExpireDateSet', 'enforceExpireDate', 'expireAfterDays'
 	 */
 	public static function getDefaultExpireSetting() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 
 		$defaultExpireSettings = ['defaultExpireDateSet' => false];
 

--- a/lib/private/Share20/Hooks.php
+++ b/lib/private/Share20/Hooks.php
@@ -21,12 +21,14 @@
  */
 namespace OC\Share20;
 
+use OCP\Share\IManager;
+
 class Hooks {
 	public static function post_deleteUser($arguments) {
-		\OC::$server->getShareManager()->userDeleted($arguments['uid']);
+		\OC::$server->get(IManager::class)->userDeleted($arguments['uid']);
 	}
 
 	public static function post_deleteGroup($arguments) {
-		\OC::$server->getShareManager()->groupDeleted($arguments['gid']);
+		\OC::$server->get(IManager::class)->groupDeleted($arguments['gid']);
 	}
 }

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -32,6 +32,7 @@ use OC\Files\Filesystem;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\InvalidPathException;
+use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IRequest;
@@ -118,13 +119,13 @@ class Streamer {
 		// prevent absolute dirs
 		$internalDir = ltrim($internalDir, '/');
 
-		$userFolder = \OC::$server->getRootFolder()->get(Filesystem::getRoot());
+		$userFolder = \OC::$server->get(IRootFolder::class)->get(Filesystem::getRoot());
 		/** @var Folder $dirNode */
 		$dirNode = $userFolder->get($dir);
 		$files = $dirNode->getDirectoryListing();
 
 		/** @var LoggerInterface $logger */
-		$logger = \OC::$server->query(LoggerInterface::class);
+		$logger = \OC::$server->get(LoggerInterface::class);
 		foreach ($files as $file) {
 			if ($file instanceof File) {
 				try {

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -89,7 +89,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 				'gid' => $qb->createNamedParameter($group->getGID()),
 				'uid' => $qb->createNamedParameter($user->getUID())
 			])
-			->execute();
+			->executeStatement();
 
 		/** @deprecated 21.0.0 - use type SubAdminAddedEvent instead  */
 		$this->emit('\OC\SubAdmin', 'postCreateSubAdmin', [$user, $group]);
@@ -108,7 +108,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeStatement();
 
 		/** @deprecated 21.0.0 - use type SubAdminRemovedEvent instead  */
 		$this->emit('\OC\SubAdmin', 'postDeleteSubAdmin', [$user, $group]);
@@ -146,7 +146,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$result = $qb->select('gid')
 			->from('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeQuery();
 
 		$groups = [];
 		while ($row = $result->fetch()) {
@@ -179,7 +179,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$result = $qb->select('uid')
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
-			->execute();
+			->executeQuery();
 
 		$users = [];
 		while ($row = $result->fetch()) {
@@ -202,7 +202,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$result = $qb->select('*')
 			->from('group_admin')
-			->execute();
+			->executeQuery();
 
 		$subadmins = [];
 		while ($row = $result->fetch()) {
@@ -236,7 +236,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeQuery();
 
 		$fetch = $result->fetch();
 		$result->closeCursor();
@@ -262,7 +262,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->from('group_admin')
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->setMaxResults(1)
-			->execute();
+			->executeQuery();
 
 		$isSubAdmin = $result->fetch();
 		$result->closeCursor();
@@ -299,7 +299,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -311,6 +311,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
-			->execute();
+			->executeStatement();
 	}
 }

--- a/lib/private/SystemTag/ManagerFactory.php
+++ b/lib/private/SystemTag/ManagerFactory.php
@@ -27,10 +27,13 @@ declare(strict_types=1);
 namespace OC\SystemTag;
 
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagManagerFactory;
 use OCP\SystemTag\ISystemTagObjectMapper;
+use Psr\Container\ContainerInterface;
 
 /**
  * Default factory class for system tag managers
@@ -42,16 +45,16 @@ class ManagerFactory implements ISystemTagManagerFactory {
 	/**
 	 * Server container
 	 *
-	 * @var IServerContainer
+	 * @var ContainerInterface
 	 */
 	private $serverContainer;
 
 	/**
 	 * Constructor for the system tag manager factory
 	 *
-	 * @param IServerContainer $serverContainer server container
+	 * @param ContainerInterface $serverContainer server container
 	 */
-	public function __construct(IServerContainer $serverContainer) {
+	public function __construct(ContainerInterface $serverContainer) {
 		$this->serverContainer = $serverContainer;
 	}
 
@@ -63,8 +66,8 @@ class ManagerFactory implements ISystemTagManagerFactory {
 	 */
 	public function getManager(): ISystemTagManager {
 		return new SystemTagManager(
-			$this->serverContainer->getDatabaseConnection(),
-			$this->serverContainer->getGroupManager(),
+			$this->serverContainer->get(IDBConnection::class),
+			$this->serverContainer->get(IGroupManager::class),
 			$this->serverContainer->get(IEventDispatcher::class),
 		);
 	}
@@ -78,7 +81,7 @@ class ManagerFactory implements ISystemTagManagerFactory {
 	 */
 	public function getObjectMapper(): ISystemTagObjectMapper {
 		return new SystemTagObjectMapper(
-			$this->serverContainer->getDatabaseConnection(),
+			$this->serverContainer->get(IDBConnection::class),
 			$this->getManager(),
 			$this->serverContainer->get(IEventDispatcher::class),
 		);

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -94,7 +94,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('editable', 'ASC')
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$tag = $this->createSystemTagFromRow($row);
 			if ($user && !$this->canUserSeeTag($tag, $user)) {
@@ -143,7 +143,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('visibility', 'ASC')
 			->addOrderBy('editable', 'ASC');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$tags[$row['id']] = $this->createSystemTagFromRow($row);
 		}
@@ -163,7 +163,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('name', $truncatedTagName)
 			->setParameter('visibility', $userVisible ? 1 : 0)
 			->setParameter('editable', $userAssignable ? 1 : 0)
-			->execute();
+			->executeQuery();
 
 		$row = $result->fetch();
 		$result->closeCursor();
@@ -191,7 +191,7 @@ class SystemTagManager implements ISystemTagManager {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
 				'Tag ("' . $truncatedTagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
@@ -250,7 +250,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('tagid', $tagId);
 
 		try {
-			if ($query->execute() === 0) {
+			if ($query->executeStatement() === 0) {
 				throw new TagNotFoundException(
 					'Tag does not exist', 0, null, [$tagId]
 				);
@@ -299,13 +299,13 @@ class SystemTagManager implements ISystemTagManager {
 		$query->delete(SystemTagObjectMapper::RELATION_TABLE)
 			->where($query->expr()->in('systemtagid', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TAG_TABLE)
 			->where($query->expr()->in('id', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		foreach ($tags as $tag) {
 			$this->dispatcher->dispatch(ManagerEvent::EVENT_DELETE, new ManagerEvent(
@@ -377,7 +377,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete(self::TAG_GROUP_TABLE)
 				->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
-				->execute();
+				->executeStatement();
 
 			// add each group id
 			$query = $this->connection->getQueryBuilder();
@@ -391,7 +391,7 @@ class SystemTagManager implements ISystemTagManager {
 					continue;
 				}
 				$query->setParameter('gid', $groupId);
-				$query->execute();
+				$query->executeStatement();
 			}
 
 			$this->connection->commit();
@@ -412,7 +412,7 @@ class SystemTagManager implements ISystemTagManager {
 			->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
 			->orderBy('gid');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$groupIds[] = $row['gid'];
 		}

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -116,7 +116,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$objectIds = [];
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$objectIds[] = $row['objectid'];
 		}
@@ -147,7 +147,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		foreach ($tagIds as $tagId) {
 			try {
 				$query->setParameter('tagid', $tagId);
-				$query->execute();
+				$query->executeStatement();
 				$tagsAssigned[] = $tagId;
 			} catch (UniqueConstraintViolationException $e) {
 				// ignore existing relations
@@ -184,7 +184,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('objectid', $objId)
 			->setParameter('objecttype', $objectType)
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		$this->dispatcher->dispatch(MapperEvent::EVENT_UNASSIGN, new MapperEvent(
 			MapperEvent::EVENT_UNASSIGN,
@@ -223,7 +223,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('tagid', $tagId)
 			->setParameter('objecttype', $objectType);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch(\PDO::FETCH_NUM);
 		$result->closeCursor();
 

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -95,7 +95,7 @@ class TagManager implements ITagManager, IEventListener {
 			->andWhere($query->expr()->eq('c.type', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('c.category', $query->createNamedParameter(ITags::TAG_FAVORITE)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$users = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -37,8 +37,10 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\ITags;
+use OCP\L10N\IFactory;
 use OCP\Share_Backend;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class Tags implements ITags {
 	/**
@@ -235,7 +237,7 @@ class Tags implements ITags {
 		}
 
 		if ($tagId === false) {
-			$l10n = \OC::$server->getL10N('core');
+			$l10n = \OC::$server->get(IFactory::class)->get('core');
 			throw new \Exception(
 				$l10n->t('Could not find category "%s"', [$tag])
 			);
@@ -486,10 +488,11 @@ class Tags implements ITags {
 		try {
 			return $this->getIdsForTag(ITags::TAG_FAVORITE);
 		} catch (\Exception $e) {
-			\OC::$server->getLogger()->logException($e, [
+			\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+				'exception' => $e,
 				'message' => __METHOD__,
-				'level' => ILogger::ERROR,
-				'app' => 'core',
+				'level' => LogLevel::ERROR,
+				'app' => 'core'
 			]);
 			return [];
 		}
@@ -549,7 +552,7 @@ class Tags implements ITags {
 		try {
 			$qb->executeStatement();
 		} catch (\Exception $e) {
-			\OC::$server->getLogger()->error($e->getMessage(), [
+			\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 				'app' => 'core',
 				'exception' => $e,
 			]);

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -49,6 +49,7 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\ILogger;
 use OCP\IUser;
+use OCP\Share\IManager;
 use OCP\User\Backend\IPasswordConfirmationBackend;
 use OCP\Util;
 
@@ -260,7 +261,7 @@ class JSConfigHelper {
 					'resharingAllowed' => Share::isResharingAllowed(),
 					'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
 					'federatedCloudShareDoc' => $this->urlGenerator->linkToDocs('user-sharing-federated'),
-					'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing(),
+					'allowGroupSharing' => \OC::$server->get(IManager::class)->allowGroupSharing(),
 					'defaultInternalExpireDateEnabled' => $defaultInternalExpireDateEnabled,
 					'defaultInternalExpireDate' => $defaultInternalExpireDate,
 					'defaultInternalExpireDateEnforced' => $defaultInternalExpireDateEnforced,

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -217,7 +217,7 @@ class URLGenerator implements IURLGenerator {
 		$themingEnabled = $this->config->getSystemValueBool('installed', false) && $this->getAppManager()->isEnabledForUser('theming');
 		$themingImagePath = false;
 		if ($themingEnabled) {
-			$themingDefaults = \OC::$server->getThemingDefaults();
+			$themingDefaults = \OC::$server->get('ThemingDefaults');
 			if ($themingDefaults instanceof ThemingDefaults) {
 				$themingImagePath = $themingDefaults->replaceImagePath($appName, $file);
 			}
@@ -290,7 +290,7 @@ class URLGenerator implements IURLGenerator {
 	 * @return string url to the online documentation
 	 */
 	public function linkToDocs(string $key): string {
-		$theme = \OC::$server->getThemingDefaults();
+		$theme = \OC::$server->get('ThemingDefaults');
 		return $theme->buildDocLinkToKey($key);
 	}
 

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -48,6 +48,7 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Util;
 use OC\App\AppManager;
+use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OC\DB\MigratorExecuteSqlEvent;
@@ -272,10 +273,10 @@ class Updater extends BasicEmitter {
 		$this->doAppUpgrade();
 
 		// Update the appfetchers version so it downloads the correct list from the appstore
-		\OC::$server->getAppFetcher()->setVersion($currentVersion);
+		\OC::$server->get(AppFetcher::class)->setVersion($currentVersion);
 
 		/** @var AppManager $appManager */
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 
 		// upgrade appstore apps
 		$this->upgradeAppStoreApps($appManager->getInstalledApps());
@@ -303,7 +304,7 @@ class Updater extends BasicEmitter {
 		$this->config->setAppValue('core', 'lastupdatedat', '0');
 
 		// Check for code integrity if not disabled
-		if (\OC::$server->getIntegrityCodeChecker()->isCodeCheckEnforced()) {
+		if (\OC::$server->get('IntegrityCodeChecker')->isCodeCheckEnforced()) {
 			$this->emit('\OC\Updater', 'startCheckCodeIntegrity');
 			$this->checker->runInstanceVerification();
 			$this->emit('\OC\Updater', 'finishedCheckCodeIntegrity');
@@ -382,7 +383,7 @@ class Updater extends BasicEmitter {
 		$isCoreUpgrade = $this->isCodeUpgrade();
 		$apps = OC_App::getEnabledApps();
 		$version = implode('.', Util::getVersion());
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		foreach ($apps as $app) {
 			// check if the app is compatible with this version of Nextcloud
 			$info = $appManager->getAppInfo($app);

--- a/lib/private/Updater/ChangesMapper.php
+++ b/lib/private/Updater/ChangesMapper.php
@@ -50,7 +50,7 @@ class ChangesMapper extends QBMapper {
 		$result = $qb->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('version', $qb->createNamedParameter($version)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();

--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -30,6 +30,7 @@
  */
 use OCP\API;
 use OCP\AppFramework\Http;
+use OCP\IRequest;
 
 class OC_API {
 	/**
@@ -44,7 +45,7 @@ class OC_API {
 	 * @psalm-taint-escape html
 	 */
 	public static function respond($result, $format = 'xml') {
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 
 		// Send 401 headers if unauthorised
 		if ($result->getStatusCode() === \OCP\AppFramework\OCSController::RESPOND_UNAUTHORISED) {

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -57,7 +57,7 @@ class OC_Defaults {
 	private $defaultProductName;
 
 	public function __construct() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(\OC\AllConfig::class);
 
 		$this->defaultEntity = 'Nextcloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'Nextcloud'; /* short name, used when referring to the software */
@@ -237,7 +237,7 @@ class OC_Defaults {
 			return $this->theme->getSlogan($lang);
 		} else {
 			if ($this->defaultSlogan === null) {
-				$l10n = \OC::$server->getL10N('lib', $lang);
+				$l10n = \OC::$server->get(\OCP\L10N\IFactory::class)->get('lib', $lang);
 				$this->defaultSlogan = $l10n->t('a safe home for all your data');
 			}
 			return $this->defaultSlogan;
@@ -325,9 +325,9 @@ class OC_Defaults {
 		}
 
 		if ($useSvg) {
-			$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo/logo.svg');
+			$logo = \OC::$server->get(\OCP\IURLGenerator::class)->imagePath('core', 'logo/logo.svg');
 		} else {
-			$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo/logo.png');
+			$logo = \OC::$server->get(\OCP\IURLGenerator::class)->imagePath('core', 'logo/logo.png');
 		}
 		return $logo . '?v=' . hash('sha1', implode('.', \OCP\Util::getVersion()));
 	}

--- a/lib/private/legacy/OC_EventSource.php
+++ b/lib/private/legacy/OC_EventSource.php
@@ -29,7 +29,10 @@ use OCP\IRequest;
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-class OC_EventSource implements \OCP\IEventSource {
+
+ use OCP\IEventSource;
+
+class OC_EventSource implements IEventSource {
 	/**
 	 * @var bool
 	 */

--- a/lib/private/legacy/OC_FileChunking.php
+++ b/lib/private/legacy/OC_FileChunking.php
@@ -49,7 +49,7 @@ class OC_FileChunking {
 	 */
 	public function __construct($info) {
 		$this->info = $info;
-		$this->ttl = \OC::$server->getConfig()->getSystemValueInt('cache_chunk_gc_ttl', 86400);
+		$this->ttl = \OC::$server->get(\OC\AllConfig::class)->getSystemValueInt('cache_chunk_gc_ttl', 86400);
 	}
 
 	public function getPrefix() {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -44,11 +44,14 @@
  *
  */
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\AllConfig;
 use OC\Files\Filesystem;
+use OC\SystemConfig;
 use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IBinaryFinder;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -484,7 +487,7 @@ class OC_Helper {
 
 		// return storage info without adding mount points
 		if (self::$quotaIncludeExternalStorage === null) {
-			self::$quotaIncludeExternalStorage = \OC::$server->getSystemConfig()->getValue('quota_include_external_storage', false);
+			self::$quotaIncludeExternalStorage = \OC::$server->get(SystemConfig::class)->getValue('quota_include_external_storage', false);
 		}
 
 		$view = Filesystem::getView();
@@ -526,7 +529,7 @@ class OC_Helper {
 				/** @var \OC\Files\Storage\Home $storage */
 				$user = $storage->getUser();
 			} else {
-				$user = \OC::$server->getUserSession()->getUser();
+				$user = \OC::$server->get(IUserSession::class)->getUser();
 			}
 			$quota = OC_Util::getUserQuota($user);
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
@@ -575,7 +578,7 @@ class OC_Helper {
 		$ownerId = $storage->getOwner($path);
 		$ownerDisplayName = '';
 		if ($ownerId) {
-			$ownerDisplayName = \OC::$server->getUserManager()->getDisplayName($ownerId) ?? '';
+			$ownerDisplayName = \OC::$server->get(IUserManager::class)->getDisplayName($ownerId) ?? '';
 		}
 
 		if (substr_count($mount->getMountPoint(), '/') < 3) {
@@ -662,6 +665,6 @@ class OC_Helper {
 	 * @return bool
 	 */
 	public static function isReadOnlyConfigEnabled() {
-		return \OC::$server->getConfig()->getSystemValueBool('config_is_read_only', false);
+		return \OC::$server->get(AllConfig::class)->getSystemValueBool('config_is_read_only', false);
 	}
 }

--- a/lib/private/legacy/OC_Hook.php
+++ b/lib/private/legacy/OC_Hook.php
@@ -28,6 +28,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use Psr\Log\LoggerInterface;
+
 class OC_Hook {
 	public static $thrownExceptions = [];
 
@@ -105,7 +108,9 @@ class OC_Hook {
 				call_user_func([ $i["class"], $i["name"] ], $params);
 			} catch (Exception $e) {
 				self::$thrownExceptions[] = $e;
-				\OC::$server->getLogger()->logException($e);
+				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+					'exception' => $e
+				]);
 				if ($e instanceof \OCP\HintException) {
 					throw $e;
 				}

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -43,12 +43,14 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+use OC\AllConfig;
 use OCP\IImage;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class for basic image manipulation
  */
-class OC_Image implements \OCP\IImage {
+class OC_Image implements IImage {
 	// Default memory limit for images to load (256 MBytes).
 	protected const DEFAULT_MEMORY_LIMIT = 256;
 
@@ -65,7 +67,7 @@ class OC_Image implements \OCP\IImage {
 	protected $filePath = null;
 	/** @var finfo */
 	private $fileInfo;
-	/** @var \OCP\ILogger */
+	/** @var \Psr\Log\LoggerInterface */
 	private $logger;
 	/** @var \OCP\IConfig */
 	private $config;
@@ -77,18 +79,18 @@ class OC_Image implements \OCP\IImage {
 	 *
 	 * @param resource|string|\GdImage $imageRef The path to a local file, a base64 encoded string or a resource created by
 	 * an imagecreate* function.
-	 * @param \OCP\ILogger $logger
+	 * @param \Psr\Log\LoggerInterface $logger
 	 * @param \OCP\IConfig $config
 	 * @throws \InvalidArgumentException in case the $imageRef parameter is not null
 	 */
-	public function __construct($imageRef = null, \OCP\ILogger $logger = null, \OCP\IConfig $config = null) {
+	public function __construct($imageRef = null, LoggerInterface $logger = null, \OCP\IConfig $config = null) {
 		$this->logger = $logger;
 		if ($logger === null) {
-			$this->logger = \OC::$server->getLogger();
+			$this->logger = \OC::$server->get(LoggerInterface::class);
 		}
 		$this->config = $config;
 		if ($config === null) {
-			$this->config = \OC::$server->getConfig();
+			$this->config = \OC::$server->get(AllConfig::class);
 		}
 
 		if (\OC_Util::fileInfoLoaded()) {

--- a/lib/private/legacy/OC_Response.php
+++ b/lib/private/legacy/OC_Response.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+ use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+
 class OC_Response {
 	/**
 	 * Sets the content disposition header (with possible workarounds)
@@ -34,7 +37,7 @@ class OC_Response {
 	 * @param string $type disposition type, either 'attachment' or 'inline'
 	 */
 	public static function setContentDispositionHeader($filename, $type = 'attachment') {
-		if (\OC::$server->getRequest()->isUserAgent(
+		if (\OC::$server->get(\OCP\IRequest::class)->isUserAgent(
 			[
 				\OC\AppFramework\Http\Request::USER_AGENT_IE,
 				\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME,
@@ -81,7 +84,7 @@ class OC_Response {
 		 * @see \OCP\AppFramework\Http\Response::getHeaders
 		 */
 		$policy = 'default-src \'self\'; '
-			. 'script-src \'self\' \'nonce-'.\OC::$server->getContentSecurityPolicyNonceManager()->getNonce().'\'; '
+			. 'script-src \'self\' \'nonce-'.\OC::$server->get(ContentSecurityPolicyNonceManager::class)->getNonce().'\'; '
 			. 'style-src \'self\' \'unsafe-inline\'; '
 			. 'frame-src *; '
 			. 'img-src * data: blob:; '

--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -1,5 +1,6 @@
 <?php
 
+use OCP\IURLGenerator;
 use OCP\Util;
 
 /**
@@ -226,7 +227,7 @@ function component($app, $file) {
  * For further information have a look at \OCP\IURLGenerator::linkTo
  */
 function link_to($app, $file, $args = []) {
-	return \OC::$server->getURLGenerator()->linkTo($app, $file, $args);
+	return \OC::$server->get(IURLGenerator::class)->linkTo($app, $file, $args);
 }
 
 /**
@@ -234,7 +235,7 @@ function link_to($app, $file, $args = []) {
  * @return string url to the online documentation
  */
 function link_to_docs($key) {
-	return \OC::$server->getURLGenerator()->linkToDocs($key);
+	return \OC::$server->get(IURLGenerator::class)->linkToDocs($key);
 }
 
 /**
@@ -246,7 +247,7 @@ function link_to_docs($key) {
  * For further information have a look at \OCP\IURLGenerator::imagePath
  */
 function image_path($app, $image) {
-	return \OC::$server->getURLGenerator()->imagePath($app, $image);
+	return \OC::$server->get(IURLGenerator::class)->imagePath($app, $image);
 }
 
 /**
@@ -265,7 +266,7 @@ function mimetype_icon($mimetype) {
  * @return string link to the preview
  */
 function preview_icon($path) {
-	return \OC::$server->getURLGenerator()->linkToRoute('core.Preview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path]);
+	return \OC::$server->get(IURLGenerator::class)->linkToRoute('core.Preview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path]);
 }
 
 /**
@@ -274,7 +275,7 @@ function preview_icon($path) {
  * @return string
  */
 function publicPreview_icon($path, $token) {
-	return \OC::$server->getURLGenerator()->linkToRoute('files_sharing.PublicPreview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path, 'token' => $token]);
+	return \OC::$server->get(IURLGenerator::class)->linkToRoute('files_sharing.PublicPreview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path, 'token' => $token]);
 }
 
 /**

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -52,7 +52,7 @@ class Defaults {
 	 */
 	public function __construct(\OC_Defaults $defaults = null) {
 		if ($defaults === null) {
-			$defaults = \OC::$server->getThemingDefaults();
+			$defaults = \OC::$server->get('ThemingDefaults');
 		}
 		$this->defaults = $defaults;
 	}

--- a/lib/public/Federation/Exceptions/ActionNotSupportedException.php
+++ b/lib/public/Federation/Exceptions/ActionNotSupportedException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ActionNotSupportedException
@@ -38,7 +39,7 @@ class ActionNotSupportedException extends HintException {
 	 *
 	 */
 	public function __construct($action) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Action "' . $action . '" not supported or implemented.';
 		$hint = $l->t('Action "%s" not supported or implemented.', [$action]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/AuthenticationFailedException.php
+++ b/lib/public/Federation/Exceptions/AuthenticationFailedException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class AuthenticationFailedException
@@ -38,7 +39,7 @@ class AuthenticationFailedException extends HintException {
 	 *
 	 */
 	public function __construct() {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Authentication failed, wrong token or provider ID given';
 		$hint = $l->t('Authentication failed, wrong token or provider ID given');
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/BadRequestException.php
+++ b/lib/public/Federation/Exceptions/BadRequestException.php
@@ -24,6 +24,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class BadRequestException
@@ -45,7 +46,7 @@ class BadRequestException extends HintException {
 	 * @param array $missingParameters
 	 */
 	public function __construct(array $missingParameters) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$this->parameterList = $missingParameters;
 		$parameterList = implode(',', $missingParameters);
 		$message = 'Parameters missing in order to complete the request. Missing Parameters: ' . $parameterList;

--- a/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
@@ -25,6 +25,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ProviderAlreadyExistsException
@@ -42,7 +43,7 @@ class ProviderAlreadyExistsException extends HintException {
 	 * @param string $existingProviderName name of cloud federation provider which already use the same ID
 	 */
 	public function __construct($newProviderId, $existingProviderName) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'ID "' . $newProviderId . '" already used by cloud federation provider "' . $existingProviderName . '"';
 		$hint = $l->t('ID "%1$s" already used by cloud federation provider "%2$s"', [$newProviderId, $existingProviderName]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ProviderDoesNotExistsException
@@ -39,7 +40,7 @@ class ProviderDoesNotExistsException extends HintException {
 	 * @param string $providerId cloud federation provider ID
 	 */
 	public function __construct($providerId) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Cloud Federation Provider with ID: "' . $providerId . '" does not exist.';
 		$hint = $l->t('Cloud Federation Provider with ID: "%s" does not exist.', [$providerId]);
 		parent::__construct($message, $hint);

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -35,6 +35,8 @@
 
 namespace OCP;
 
+use OCP\Files\IMimeTypeDetector;
+
 /**
  * This class provides access to the internal filesystem abstraction layer. Use
  * this class exclusively if you want to access files
@@ -61,7 +63,7 @@ class Files {
 	 * @deprecated 14.0.0
 	 */
 	public static function getMimeType($path) {
-		return \OC::$server->getMimeTypeDetector()->detect($path);
+		return \OC::$server->get(IMimeTypeDetector::class)->detect($path);
 	}
 
 	/**

--- a/lib/public/Files/LockNotAcquiredException.php
+++ b/lib/public/Files/LockNotAcquiredException.php
@@ -28,6 +28,8 @@
 
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Exception for a file that is locked
  * @since 7.0.0
@@ -43,7 +45,7 @@ class LockNotAcquiredException extends \Exception {
 	 * @since 7.0.0
 	 */
 	public function __construct($path, $lockType, $code = 0, \Exception $previous = null) {
-		$message = \OC::$server->getL10N('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
+		$message = \OC::$server->get(IFactory::class)->get('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
 		parent::__construct($message, $code, $previous);
 	}
 

--- a/lib/public/Files/StorageAuthException.php
+++ b/lib/public/Files/StorageAuthException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageAuthException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage unauthorized. %s', [$message]), self::STATUS_UNAUTHORIZED, $previous);
 	}
 }

--- a/lib/public/Files/StorageBadConfigException.php
+++ b/lib/public/Files/StorageBadConfigException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage has bad or missing config params
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageBadConfigException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage incomplete configuration. %s', [$message]), self::STATUS_INCOMPLETE_CONF, $previous);
 	}
 }

--- a/lib/public/Files/StorageConnectionException.php
+++ b/lib/public/Files/StorageConnectionException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageConnectionException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage connection error. %s', [$message]), self::STATUS_NETWORK_ERROR, $previous);
 	}
 }

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -33,6 +33,7 @@
 namespace OCP\Files;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Storage is temporarily not available
@@ -56,7 +57,7 @@ class StorageNotAvailableException extends HintException {
 	 * @since 6.0.0
 	 */
 	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}
 

--- a/lib/public/Files/StorageTimeoutException.php
+++ b/lib/public/Files/StorageTimeoutException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageTimeoutException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage connection timeout. %s', [$message]), self::STATUS_TIMEOUT, $previous);
 	}
 }

--- a/lib/public/Mail/IMailer.php
+++ b/lib/public/Mail/IMailer.php
@@ -33,7 +33,7 @@ namespace OCP\Mail;
  *
  * Example usage:
  *
- * 	$mailer = \OC::$server->getMailer();
+ * 	$mailer = \OC::$server->get(\OCP\Mail\IMailer::class);
  * 	$message = $mailer->createMessage();
  * 	$message->setSubject('Your Subject');
  * 	$message->setFrom(['cloud@domain.org' => 'Nextcloud Notifier']);

--- a/lib/public/Security/ICrypto.php
+++ b/lib/public/Security/ICrypto.php
@@ -31,8 +31,8 @@ namespace OCP\Security;
  * it will use the secret defined in config.php as key. Additionally the message will be HMAC'd.
  *
  * Usage:
- * $encryptWithDefaultPassword = \OC::$server->getCrypto()->encrypt('EncryptedText');
- * $encryptWithCustomPassword = \OC::$server->getCrypto()->encrypt('EncryptedText', 'password');
+ * $encryptWithDefaultPassword = \OC::$server->get(\OCP\Security\ICrypto::class)->encrypt('EncryptedText');
+ * $encryptWithCustomPassword = \OC::$server->get(\OCP\Security\ICrypto::class)->encrypt('EncryptedText', 'password');
  *
  * @since 8.0.0
  */

--- a/lib/public/Security/IHasher.php
+++ b/lib/public/Security/IHasher.php
@@ -37,10 +37,10 @@ namespace OCP\Security;
  *
  * Usage:
  * // Hashing a message
- * $hash = \OC::$server->getHasher()->hash('MessageToHash');
+ * $hash = \OC::$server->get(\OCP\Security\IHasher::class)->hash('MessageToHash');
  * // Verifying a message - $newHash will contain the newly calculated hash
  * $newHash = null;
- * var_dump(\OC::$server->getHasher()->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
+ * var_dump(\OC::$server->get(\OCP\Security\IHasher::class)->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
  * var_dump($newHash);
  *
  * @since 8.0.0

--- a/ocm-provider/index.php
+++ b/ocm-provider/index.php
@@ -22,16 +22,18 @@
 
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IURLGenerator;
+
 header('Content-Type: application/json');
 
 $server = \OC::$server;
 
-$isEnabled = $server->getAppManager()->isEnabledForUser('cloud_federation_api');
+$isEnabled = $server->get(\OCP\App\IAppManager::class)->isEnabledForUser('cloud_federation_api');
 
 if ($isEnabled) {
 	// Make sure the routes are loaded
 	\OC_App::loadApp('cloud_federation_api');
-	$capabilities = new OCA\CloudFederationAPI\Capabilities($server->getURLGenerator());
+	$capabilities = new OCA\CloudFederationAPI\Capabilities($server->get(IURLGenerator::class));
 	header('Content-Type: application/json');
 	echo json_encode($capabilities->getCapabilities()['ocm']);
 } else {

--- a/ocs-provider/index.php
+++ b/ocs-provider/index.php
@@ -27,7 +27,7 @@ $server = \OC::$server;
 
 $controller = new \OC\OCS\Provider(
 	'ocs_provider',
-	$server->getRequest(),
+	$server->get(\OCP\IRequest::class),
 	$server->getAppManager()
 );
 echo $controller->buildProviderList()->render();

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/../lib/base.php';
 
 header('Content-type: application/xml');
 
-$request = \OC::$server->getRequest();
+$request = \OC::$server->get(\OCP\IRequest::class);
 
 $url = $request->getServerProtocol() . '://' . substr($request->getServerHost() . $request->getRequestUri(), 0, -17).'ocs/v1.php/';
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -41,6 +41,8 @@ if (\OCP\Util::needUpgrade()
 	exit;
 }
 
+use OCP\IRequest;
+use OCP\IUserSession;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
@@ -57,15 +59,15 @@ try {
 	// side effects in existing apps
 	OC_App::loadApps();
 
-	if (!\OC::$server->getUserSession()->isLoggedIn()) {
-		OC::handleLogin(\OC::$server->getRequest());
+	if (!\OC::$server->get(IUserSession::class)->isLoggedIn()) {
+		OC::handleLogin(\OC::$server->get(IRequest::class));
 	}
 
-	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
+	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->get(IRequest::class)->getRawPathInfo());
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 
-	$format = \OC::$server->getRequest()->getParam('format', 'xml');
+	$format = \OC::$server->get(IRequest::class)->getParam('format', 'xml');
 	$txt = 'Invalid query, please check the syntax. API specifications are here:'
 		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.'."\n";
 	OC_API::respond(new \OC\OCS\Result(null, \OCP\AppFramework\OCSController::RESPOND_NOT_FOUND, $txt), $format);
@@ -80,10 +82,10 @@ try {
 	\OC::$server->getLogger()->logException($e);
 	OC_API::setContentType();
 
-	$format = \OC::$server->getRequest()->getParam('format', 'xml');
+	$format = \OC::$server->get(IRequest::class)->getParam('format', 'xml');
 	$txt = 'Internal Server Error'."\n";
 	try {
-		if (\OC::$server->getSystemConfig()->getValue('debug', false)) {
+		if (\OC::$server->get(\OC\SystemConfig::class)->getValue('debug', false)) {
 			$txt .= $e->getMessage();
 		}
 	} catch (\Throwable $e) {

--- a/public.php
+++ b/public.php
@@ -32,6 +32,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\App\IAppManager;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
@@ -54,7 +56,7 @@ try {
 		$pathInfo = trim($pathInfo, '/');
 		[$service] = explode('/', $pathInfo);
 	}
-	$file = \OC::$server->getConfig()->getAppValue('core', 'public_' . strip_tags($service));
+	$file = \OC::$server->get(\OC\AllConfig::class)->getAppValue('core', 'public_' . strip_tags($service));
 	if ($file === '') {
 		http_response_code(404);
 		exit;
@@ -69,7 +71,7 @@ try {
 	OC_App::loadApps(['extended_authentication']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
-	if (!\OC::$server->getAppManager()->isInstalled($app)) {
+	if (!\OC::$server->get(IAppManager::class)->isInstalled($app)) {
 		http_response_code(404);
 		exit;
 	}

--- a/remote.php
+++ b/remote.php
@@ -33,7 +33,10 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\AllConfig;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
+use OCP\App\IAppManager;
+use OCP\IRequest;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
 use Psr\Log\LoggerInterface;
@@ -51,7 +54,7 @@ class RemoteException extends Exception {
  */
 function handleException($e) {
 	try {
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 		// in case the request content type is text/xml - we assume it's a WebDAV request
 		$isXmlContentType = strpos($request->getHeader('Content-Type'), 'text/xml');
 		if ($isXmlContentType === 0) {
@@ -112,7 +115,7 @@ function resolveService($service) {
 		return $services[$service];
 	}
 
-	return \OC::$server->getConfig()->getAppValue('core', 'remote_' . $service);
+	return \OC::$server->get(AllConfig::class)->getAppValue('core', 'remote_' . $service);
 }
 
 try {
@@ -129,7 +132,7 @@ try {
 		throw new RemoteException('Service unavailable', 503);
 	}
 
-	$request = \OC::$server->getRequest();
+	$request = \OC::$server->get(IRequest::class);
 	$pathInfo = $request->getPathInfo();
 	if ($pathInfo === false || $pathInfo === '') {
 		throw new RemoteException('Path not found', 404);
@@ -161,7 +164,7 @@ try {
 			$file = OC::$SERVERROOT .'/'. $file;
 			break;
 		default:
-			if (!\OC::$server->getAppManager()->isInstalled($app)) {
+			if (!\OC::$server->get(IAppManager::class)->isInstalled($app)) {
 				throw new RemoteException('App not installed: ' . $app);
 			}
 			OC_App::loadApp($app);

--- a/status.php
+++ b/status.php
@@ -33,10 +33,12 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use Psr\Log\LoggerInterface;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
-	$systemConfig = \OC::$server->getSystemConfig();
+	$systemConfig = \OC::$server->get(\OC\SystemConfig::class);
 
 	$installed = (bool) $systemConfig->getValue('installed', false);
 	$maintenance = (bool) $systemConfig->getValue('maintenance', false);
@@ -62,5 +64,8 @@ try {
 	}
 } catch (Exception $ex) {
 	http_response_code(500);
-	\OC::$server->getLogger()->logException($ex, ['app' => 'remote']);
+	\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+		'exception' => $ex,
+		'app' => 'remote'
+	]);
 }

--- a/tests/lib/BackgroundJob/QueuedJobTest.php
+++ b/tests/lib/BackgroundJob/QueuedJobTest.php
@@ -51,7 +51,7 @@ class QueuedJobTest extends \Test\TestCase {
 	}
 
 	public function testJobShouldBeRemovedNew() {
-		$job = new TestQueuedJobNew(\OC::$server->query(ITimeFactory::class));
+		$job = new TestQueuedJobNew(\OC::$server->get(ITimeFactory::class));
 		$job->setId(42);
 		$this->jobList->add($job);
 

--- a/tests/lib/BackgroundJob/TimedJobTest.php
+++ b/tests/lib/BackgroundJob/TimedJobTest.php
@@ -48,7 +48,7 @@ class TimedJobTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->jobList = new DummyJobList();
-		$this->time = \OC::$server->query(ITimeFactory::class);
+		$this->time = \OC::$server->get(ITimeFactory::class);
 	}
 
 	public function testShouldRunAfterInterval() {

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -70,7 +70,7 @@ class EtagTest extends \Test\TestCase {
 		$files = ['/foo.txt', '/folder/bar.txt', '/folder/subfolder', '/folder/subfolder/qwerty.txt'];
 		$originalEtags = $this->getEtags($files);
 
-		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection(), \OC::$server->query(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection(), \OC::$server->get(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
 		$scanner->backgroundScan('/');
 
 		$newEtags = $this->getEtags($files);

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -77,7 +77,7 @@ class HookConnectorTest extends TestCase {
 			$this->createMock(IUserManager::class),
 			$this->createMock(IEventDispatcher::class)
 		);
-		$this->eventDispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 	}
 
 	protected function tearDown(): void {

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -132,7 +132,7 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new \OC\Files\Utils\Scanner($uid, \OC::$server->getDatabaseConnection(), \OC::$server->query(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$scanner = new \OC\Files\Utils\Scanner($uid, \OC::$server->getDatabaseConnection(), \OC::$server->get(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
 
 		$this->assertFalse($cache->inCache('folder/bar.txt'));
 		$scanner->scan('/' . $uid . '/files/foo');

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -26,6 +26,7 @@ use OC\Preview\BackgroundCleanupJob;
 use OC\Preview\Storage\Root;
 use OC\PreviewManager;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
@@ -190,20 +191,20 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 	}
 
 	public function testOldPreviews() {
-		$appdata = \OC::$server->getAppDataDir('preview');
+		$appdata = \OC::$server->get(IAppDataFactory::class)->get('preview');
 
 		$f1 = $appdata->newFolder('123456781');
 		$f1->newFile('foo.jpg', 'foo');
 		$f2 = $appdata->newFolder('123456782');
 		$f2->newFile('foo.jpg', 'foo');
 
-		$appdata = \OC::$server->getAppDataDir('preview');
+		$appdata = \OC::$server->get(IAppDataFactory::class)->get('preview');
 		$this->assertSame(2, count($appdata->getDirectoryListing()));
 
 		$job = new BackgroundCleanupJob($this->timeFactory, $this->connection, $this->getRoot(), $this->mimeTypeLoader, true);
 		$job->run([]);
 
-		$appdata = \OC::$server->getAppDataDir('preview');
+		$appdata = \OC::$server->get(IAppDataFactory::class)->get('preview');
 		$this->assertSame(0, count($appdata->getDirectoryListing()));
 	}
 }

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -38,7 +38,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$this->contentSecurityPolicyManager = new ContentSecurityPolicyManager($this->dispatcher);
 	}
 

--- a/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
+++ b/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
@@ -40,7 +40,7 @@ class FeaturePolicyManagerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$this->manager = new FeaturePolicyManager($this->dispatcher);
 	}
 

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -84,7 +84,7 @@ class ManagerTest extends TestCase {
 	public function testGetAdminSections() {
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);
@@ -97,7 +97,7 @@ class ManagerTest extends TestCase {
 	public function testGetPersonalSections() {
 		$this->manager->registerSection('personal', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);
@@ -227,7 +227,7 @@ class ManagerTest extends TestCase {
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -64,7 +64,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			return false;
 		}
 
-		$this->services[$name] = \OC::$server->query($name);
+		$this->services[$name] = \OC::$server->get($name);
 		$container = \OC::$server->getAppContainerForService($name);
 		$container = $container ?? \OC::$server;
 


### PR DESCRIPTION
* Resolves: # N/A for now <!-- related github issue -->

## Summary
There are thousands of deprecated functions, constants, and classes in the NC core. Some of them are actually noted to be removed in previous releases, yet they still persist.

I am a strong believer in [dogfooding](https://deviq.com/practices/dogfooding) your own code and APIs. Therefore, I took some time to clean up a good chunk of the deprecated code. Nothing in `3rdparty` or `apps` has been changed.

Since this is a HUGE commit (and I may find more instances to add - suggestions welcome), I am leaving it as a draft for the moment.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
