### PR TITLE
[stable26] fix(cache): Remove displayname cache entry on delete

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -68,6 +68,7 @@ use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\IRootFolder;
 use OCP\Group\Events\GroupChangedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\IDBConnection;
 use OCP\IGroup;
@@ -76,6 +77,7 @@ use OCP\L10N\IFactory;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IManager;
 use OCP\User\Events\UserChangedEvent;
+use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -110,7 +112,9 @@ class Application extends App implements IBootstrap {
 
 		$context->registerNotifierService(Notifier::class);
 		$context->registerEventListener(UserChangedEvent::class, DisplayNameCache::class);
+		$context->registerEventListener(UserDeletedEvent::class, DisplayNameCache::class);
 		$context->registerEventListener(GroupChangedEvent::class, GroupDisplayNameCache::class);
+		$context->registerEventListener(GroupDeletedEvent::class, GroupDisplayNameCache::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/private/Group/DisplayNameCache.php
+++ b/lib/private/Group/DisplayNameCache.php
@@ -29,6 +29,7 @@ use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Events\GroupChangedEvent;
+use OCP\Group\Events\GroupDeletedEvent;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IGroupManager;
@@ -82,6 +83,11 @@ class DisplayNameCache implements IEventListener {
 			$newDisplayName = $event->getValue();
 			$this->cache[$groupId] = $newDisplayName;
 			$this->memCache->set($groupId, $newDisplayName, 60 * 10); // 10 minutes
+		}
+		if ($event instanceof GroupDeletedEvent) {
+			$groupId = $event->getGroup()->getGID();
+			unset($this->cache[$groupId]);
+			$this->memCache->remove($groupId);
 		}
 	}
 }

--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -29,6 +29,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IUserManager;
 use OCP\User\Events\UserChangedEvent;
+use OCP\User\Events\UserDeletedEvent;
 
 /**
  * Class that cache the relation UserId -> Display name
@@ -80,6 +81,11 @@ class DisplayNameCache implements IEventListener {
 			$newDisplayName = $event->getValue();
 			$this->cache[$userId] = $newDisplayName;
 			$this->memCache->set($userId, $newDisplayName, 60 * 10); // 10 minutes
+		}
+		if ($event instanceof UserDeletedEvent) {
+			$userId = $event->getUser()->getUID();
+			unset($this->cache[$userId]);
+			$this->memCache->remove($userId);
 		}
 	}
 }


### PR DESCRIPTION
Backport #40077 

Backport was clean, not sure why the bot tripped.