### PR TITLE
chore: enable dependabot for cs-fixer, openapi-extractor and psalm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,49 @@ updates:
   reviewers:
     - "nextcloud/server-dependabot"
 
+# cs-fixer
+- package-ecosystem: composer
+  directory: "/vendor-bin/cs-fixer"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "04:10"
+    timezone: Europe/Copenhagen
+  labels:
+    - "3. to review"
+    - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
+
+# openapi-extractor
+- package-ecosystem: composer
+  directory: "/vendor-bin/openapi-extractor"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "04:20"
+    timezone: Europe/Brussels
+  labels:
+    - "3. to review"
+    - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
+    - "provokateurin"
+
+# psalm
+- package-ecosystem: composer
+  directory: "/vendor-bin/psalm"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "04:30"
+    timezone: Europe/Madrid
+  labels:
+    - "3. to review"
+    - "feature: dependencies"
+  reviewers:
+    - "nextcloud/server-dependabot"
+
 # Main master npm
 - package-ecosystem: npm
   directory: "/"


### PR DESCRIPTION
## Summary

Enable dependabot for cs-fixer, openapi-extractor and psalm.

Each vendor-bin directory is an independent composer project, and therefore we need a dependabot configuration.


I wondered why cs:fixer did not support PHP 8.2 already. 

```
composer run cs:fix
> php-cs-fixer fix
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.2.9.
To ignore this requirement please set `PHP_CS_FIXER_IGNORE_ENV`.
If you use PHP version higher than supported, you may experience code modified in a wrong way.
```




## TODO

- [x] Merge
- [ ] Expect a couple of bumps next week

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
