### PR TITLE
Enable caldav push notifications by default

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php
@@ -82,7 +82,7 @@ class PushProvider extends AbstractProvider {
 						 ?string $calendarDisplayName,
 						 array $principalEmailAddresses,
 						 array $users = []):void {
-		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'no') !== 'yes') {
+		if ($this->config->getAppValue('dav', 'sendEventRemindersPush', 'yes') !== 'yes') {
 			return;
 		}
 

--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -47,7 +47,7 @@ class CalDAVSettings implements IDelegatedSettings {
 		'generateBirthdayCalendar' => 'yes',
 		'sendEventReminders' => 'yes',
 		'sendEventRemindersToSharedUsers' => 'yes',
-		'sendEventRemindersPush' => 'no',
+		'sendEventRemindersPush' => 'yes',
 	];
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -66,7 +66,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 	public function testNotSend(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('dav', 'sendEventRemindersPush', 'no')
+			->with('dav', 'sendEventRemindersPush', 'yes')
 			->willReturn('no');
 
 		$this->manager->expects($this->never())
@@ -92,7 +92,7 @@ class PushProviderTest extends AbstractNotificationProviderTest {
 	public function testSend(): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('dav', 'sendEventRemindersPush', 'no')
+			->with('dav', 'sendEventRemindersPush', 'yes')
 			->willReturn('yes');
 
 		$user1 = $this->createMock(IUser::class);

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -62,7 +62,7 @@ class CalDAVSettingsTest extends TestCase {
 			   ['dav', 'generateBirthdayCalendar', 'yes'],
 			   ['dav', 'sendEventReminders', 'yes'],
 			   ['dav', 'sendEventRemindersToSharedUsers', 'yes'],
-			   ['dav', 'sendEventRemindersPush', 'no'],
+			   ['dav', 'sendEventRemindersPush', 'yes'],
 		   )
 		   ->will($this->onConsecutiveCalls('yes', 'no', 'yes', 'yes', 'yes'));
 		$this->urlGenerator


### PR DESCRIPTION
* Resolves: [#39862](https://github.com/nextcloud/server/issues/39862)

## Summary




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
