### PR TITLE
feat: add switch to disable dns pinning

### DIFF
--- a/lib/private/Http/Client/ClientService.php
+++ b/lib/private/Http/Client/ClientService.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 namespace OC\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use OCP\Diagnostics\IEventLogger;
 use OCP\Http\Client\IClient;
@@ -75,7 +75,9 @@ class ClientService implements IClientService {
 	public function newClient(): IClient {
 		$handler = new CurlHandler();
 		$stack = HandlerStack::create($handler);
-		$stack->push($this->dnsPinMiddleware->addDnsPinning());
+		if ($this->config->getSystemValueBool('dns_pinning', true)) {
+			$stack->push($this->dnsPinMiddleware->addDnsPinning());
+		}
 		$stack->push(Middleware::tap(function (RequestInterface $request) {
 			$this->eventLogger->start('http:request', $request->getMethod() . " request to " . $request->getRequestTarget());
 		}, function () {

--- a/tests/lib/Http/Client/ClientServiceTest.php
+++ b/tests/lib/Http/Client/ClientServiceTest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace Test\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use OC\Http\Client\Client;
 use OC\Http\Client\ClientService;
@@ -32,6 +32,9 @@ class ClientServiceTest extends \Test\TestCase {
 	public function testNewClient(): void {
 		/** @var IConfig $config */
 		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueBool')
+			->with('dns_pinning', true)
+			->willReturn(true);
 		/** @var ICertificateManager $certificateManager */
 		$certificateManager = $this->createMock(ICertificateManager::class);
 		$dnsPinMiddleware = $this->createMock(DnsPinMiddleware::class);
@@ -56,6 +59,54 @@ class ClientServiceTest extends \Test\TestCase {
 		$handler = new CurlHandler();
 		$stack = HandlerStack::create($handler);
 		$stack->push($dnsPinMiddleware->addDnsPinning());
+		$stack->push(Middleware::tap(function (RequestInterface $request) use ($eventLogger) {
+			$eventLogger->start('http:request', $request->getMethod() . " request to " . $request->getRequestTarget());
+		}, function () use ($eventLogger) {
+			$eventLogger->end('http:request');
+		}), 'event logger');
+		$guzzleClient = new GuzzleClient(['handler' => $stack]);
+
+		$this->assertEquals(
+			new Client(
+				$config,
+				$certificateManager,
+				$guzzleClient,
+				$remoteHostValidator,
+				$logger,
+			),
+			$clientService->newClient()
+		);
+	}
+
+	public function testDisableDnsPinning(): void {
+		/** @var IConfig $config */
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValueBool')
+			->with('dns_pinning', true)
+			->willReturn(false);
+		/** @var ICertificateManager $certificateManager */
+		$certificateManager = $this->createMock(ICertificateManager::class);
+		$dnsPinMiddleware = $this->createMock(DnsPinMiddleware::class);
+		$dnsPinMiddleware
+			->expects($this->never())
+			->method('addDnsPinning')
+			->willReturn(function () {
+			});
+		$remoteHostValidator = $this->createMock(IRemoteHostValidator::class);
+		$eventLogger = $this->createMock(IEventLogger::class);
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$clientService = new ClientService(
+			$config,
+			$certificateManager,
+			$dnsPinMiddleware,
+			$remoteHostValidator,
+			$eventLogger,
+			$logger,
+		);
+
+		$handler = new CurlHandler();
+		$stack = HandlerStack::create($handler);
 		$stack->push(Middleware::tap(function (RequestInterface $request) use ($eventLogger) {
 			$eventLogger->start('http:request', $request->getMethod() . " request to " . $request->getRequestTarget());
 		}, function () use ($eventLogger) {


### PR DESCRIPTION
## Summary

:warning: One should not disable DNS pinning unless they know what they are doing

A hard requirement for DNS pinning is the ability to resolve DNS records.
If resolving DNS records is not possible, DNS pinning cannot work. 

HTTP proxy => DNS names are resolved via proxy (c.f. ~https://everything.curl.dev/libcurl/proxies#local-or-proxy-name-lookup~ https://everything.curl.dev/transfers/conn/proxies.html#proxy-types). That explains, why outgoing connections work without the possibility to resolve DNS records locally.

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
