### PR TITLE
Refactor `OC\Server::getAppFetcher`

### DIFF
--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
 namespace OC;
 
 use OC\App\AppManager;
+use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\DB\Connection;
 use OC\DB\MigrationService;
 use OC\DB\MigratorExecuteSqlEvent;
@@ -273,7 +274,7 @@ class Updater extends BasicEmitter {
 		$this->doAppUpgrade();
 
 		// Update the appfetchers version so it downloads the correct list from the appstore
-		\OC::$server->getAppFetcher()->setVersion($currentVersion);
+		\OC::$server->get(AppFetcher::class)->setVersion($currentVersion);
 
 		/** @var AppManager $appManager */
 		$appManager = \OC::$server->getAppManager();

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -51,7 +51,7 @@ class InstallerTest extends TestCase {
 		$this->appstore = $config->setSystemValue('appstoreenabled', true);
 		$config->setSystemValue('appstoreenabled', true);
 		$installer = new Installer(
-			\OC::$server->getAppFetcher(),
+			\OC::$server->get(AppFetcher::class),
 			\OC::$server->getHTTPClientService(),
 			\OC::$server->getTempManager(),
 			\OC::$server->get(LoggerInterface::class),
@@ -74,7 +74,7 @@ class InstallerTest extends TestCase {
 
 	protected function tearDown(): void {
 		$installer = new Installer(
-			\OC::$server->getAppFetcher(),
+			\OC::$server->get(AppFetcher::class),
 			\OC::$server->getHTTPClientService(),
 			\OC::$server->getTempManager(),
 			\OC::$server->get(LoggerInterface::class),
@@ -98,7 +98,7 @@ class InstallerTest extends TestCase {
 
 		// Install app
 		$installer = new Installer(
-			\OC::$server->getAppFetcher(),
+			\OC::$server->get(AppFetcher::class),
 			\OC::$server->getHTTPClientService(),
 			\OC::$server->getTempManager(),
 			\OC::$server->get(LoggerInterface::class),


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getAppFetcher` and replaces it with `OC\Server::get(\OC\App\AppStore\Fetcher\AppFetcher::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OC\App\AppStore\Fetcher\AppFetcher` class is imported via the `use` directive.