### PR TITLE
Refactor `OC\Server::getAppConfig`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -98,7 +100,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\Import(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->getSystemConfig(), \OC::$server->getAppConfig()));
+	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->getSystemConfig(), \OC::$server->get(IAppConfig::class)));
 	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->getSystemConfig()));
 	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
 	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -56,6 +56,7 @@ use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\ILogger;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
@@ -731,7 +732,7 @@ class OC_App {
 		static $versions;
 
 		if (!$versions) {
-			$appConfig = \OC::$server->getAppConfig();
+			$appConfig = \OC::$server->get(IAppConfig::class);
 			$versions = $appConfig->getValues(false, 'installed_version');
 		}
 		return $versions;


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getAppConfig` and replaces it with `OC\Server::get(\OCP\IAppConfig::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IAppConfig` class is imported via the `use` directive.