### PR TITLE
Refactor `OC\Server::getAppManager`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,7 +48,9 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-use Psr\Log\LoggerInterface;
+
+ use OCP\App\IAppManager;
+ use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
@@ -72,12 +74,12 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
-	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\App\Disable(\OC::$server->get(IAppManager::class)));
+	$application->add(new OC\Core\Command\App\Enable(\OC::$server->get(IAppManager::class), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
-	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
+	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->get(IAppManager::class)));
+	$application->add(new OC\Core\Command\App\Remove(\OC::$server->get(IAppManager::class), \OC::$server->query(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
 	$application->add(\OC::$server->query(\OC\Core\Command\App\Update::class));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
@@ -116,7 +118,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	if (\OC::$server->getConfig()->getSystemValueBool('debug', false)) {
 		$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->get(\OC\DB\Connection::class)));
 		$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->get(\OC\DB\Connection::class)));
-		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getAppManager()));
+		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->get(IAppManager::class)));
 		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getConfig()));
 	}
 
@@ -125,10 +127,10 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
+	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->get(IAppManager::class), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
 	$application->add(new OC\Core\Command\Encryption\DecryptAll(
 		\OC::$server->getEncryptionManager(),
-		\OC::$server->getAppManager(),
+		\OC::$server->get(IAppManager::class),
 		\OC::$server->getConfig(),
 		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
@@ -174,7 +176,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 		new \OC\Repair([], \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class)),
 		\OC::$server->getConfig(),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
-		\OC::$server->getAppManager()
+		\OC::$server->get(IAppManager::class)
 	));
 	$application->add(\OC::$server->query(OC\Core\Command\Maintenance\RepairShareOwnership::class));
 
@@ -188,7 +190,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
-	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
+	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->get(IAppManager::class)));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -51,6 +51,7 @@ use OC\Log\PsrLoggerAdapter;
 use OC\ServerContainer;
 use OC\Settings\AuthorizedGroupMapper;
 use OCA\WorkflowEngine\Manager;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\IOutput;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\QueryException;
@@ -255,7 +256,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$server->getUserSession()->isLoggedIn(),
 				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
 				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
-				$server->getAppManager(),
+				$server->get(IAppManager::class),
 				$server->getL10N('lib'),
 				$c->get(AuthorizedGroupMapper::class),
 				$server->get(IUserSession::class)

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -494,7 +494,7 @@ class Installer {
 	 */
 	public function removeApp($appId) {
 		if ($this->isDownloaded($appId)) {
-			if (\OC::$server->getAppManager()->isShipped($appId)) {
+			if (\OC::$server->get(IAppManager::class)->isShipped($appId)) {
 				return false;
 			}
 			$appDir = OC_App::getInstallPath() . '/' . $appId;
@@ -537,7 +537,7 @@ class Installer {
 	 * @return array Array of error messages (appid => Exception)
 	 */
 	public static function installShippedApps($softErrors = false) {
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		$config = \OC::$server->getConfig();
 		$errors = [];
 		foreach (\OC::$APPSROOTS as $app_dir) {

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -41,6 +41,7 @@ use OCA\FederatedFileSharing\TokenHandler;
 use OCA\ShareByMail\Settings\SettingsManager;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCA\Talk\Share\RoomShareProvider;
+use OCP\App\IAppManager;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
@@ -121,7 +122,7 @@ class ProviderFactory implements IProviderFactory {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
+			$appManager = $this->serverContainer->get(IAppManager::class);
 			if (!$appManager->isEnabledForUser('federatedfilesharing')) {
 				return null;
 			}
@@ -178,7 +179,7 @@ class ProviderFactory implements IProviderFactory {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
+			$appManager = $this->serverContainer->get(IAppManager::class);
 			if (!$appManager->isEnabledForUser('sharebymail')) {
 				return null;
 			}
@@ -220,7 +221,7 @@ class ProviderFactory implements IProviderFactory {
 			return null;
 		}
 
-		if (!$this->serverContainer->getAppManager()->isEnabledForUser('circles') ||
+		if (!$this->serverContainer->get(IAppManager::class)->isEnabledForUser('circles') ||
 			!class_exists('\OCA\Circles\ShareByCircleProvider')
 		) {
 			$this->circlesAreNotAvailable = true;
@@ -252,7 +253,7 @@ class ProviderFactory implements IProviderFactory {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
+			$appManager = $this->serverContainer->get(IAppManager::class);
 			if (!$appManager->isEnabledForUser('spreed')) {
 				return null;
 			}

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -47,6 +47,7 @@ use OC\Search\SearchQuery;
 use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;
 use OC\Template\JSResourceLocator;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -87,7 +88,7 @@ class TemplateLayout extends \OC_Template {
 
 		// Add fallback theming variables if theming is disabled
 		if ($renderAs !== TemplateResponse::RENDER_AS_USER
-			|| !\OC::$server->getAppManager()->isEnabledForUser('theming')) {
+			|| !\OC::$server->get(IAppManager::class)->isEnabledForUser('theming')) {
 			// TODO cache generated default theme if enabled for fallback if server is erroring ?
 			Util::addStyle('theming', 'default');
 		}
@@ -113,7 +114,7 @@ class TemplateLayout extends \OC_Template {
 
 			// Set body data-theme
 			$this->assign('enabledThemes', []);
-			if (\OC::$server->getAppManager()->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
+			if (\OC::$server->get(IAppManager::class)->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
 				/** @var \OCA\Theming\Service\ThemesService */
 				$themesService = \OC::$server->get(\OCA\Theming\Service\ThemesService::class);
 				$this->assign('enabledThemes', $themesService->getEnabledThemes());
@@ -124,8 +125,8 @@ class TemplateLayout extends \OC_Template {
 			$this->assign('logoUrl', $logoUrl);
 
 			// Set default app name
-			$defaultApp = \OC::$server->getAppManager()->getDefaultAppForUser();
-			$defaultAppInfo = \OC::$server->getAppManager()->getAppInfo($defaultApp);
+			$defaultApp = \OC::$server->get(IAppManager::class)->getDefaultAppForUser();
+			$defaultAppInfo = \OC::$server->get(IAppManager::class)->getAppInfo($defaultApp);
 			$l10n = \OC::$server->getL10NFactory()->get($defaultApp);
 			$this->assign('defaultAppName', $l10n->t($defaultAppInfo['name']));
 
@@ -227,7 +228,7 @@ class TemplateLayout extends \OC_Template {
 			$jsConfigHelper = new JSConfigHelper(
 				\OC::$server->getL10N('lib'),
 				\OCP\Server::get(Defaults::class),
-				\OC::$server->getAppManager(),
+				\OC::$server->get(IAppManager::class),
 				\OC::$server->getSession(),
 				\OC::$server->getUserSession()->getUser(),
 				$this->config,
@@ -312,7 +313,7 @@ class TemplateLayout extends \OC_Template {
 		$v = [];
 
 		if ($this->config->getSystemValueBool('installed', false)) {
-			if (\OC::$server->getAppManager()->isInstalled('theming')) {
+			if (\OC::$server->get(IAppManager::class)->isInstalled('theming')) {
 				$themingSuffix = '-' . $this->config->getAppValue('theming', 'cachebuster', '0');
 			}
 			$v = \OC_App::getAppVersions();

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -275,7 +275,7 @@ class Updater extends BasicEmitter {
 		\OC::$server->getAppFetcher()->setVersion($currentVersion);
 
 		/** @var AppManager $appManager */
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 
 		// upgrade appstore apps
 		$this->upgradeAppStoreApps($appManager->getInstalledApps());
@@ -382,7 +382,7 @@ class Updater extends BasicEmitter {
 		$isCoreUpgrade = $this->isCodeUpgrade();
 		$apps = OC_App::getEnabledApps();
 		$version = implode('.', Util::getVersion());
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		foreach ($apps as $app) {
 			// check if the app is compatible with this version of Nextcloud
 			$info = $appManager->getAppInfo($app);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -183,7 +183,7 @@ class OC_App {
 	 * read app types from info.xml and cache them in the database
 	 */
 	public static function setAppTypes(string $app) {
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		$appData = $appManager->getAppInfo($app);
 		if (!is_array($appData)) {
 			return;
@@ -221,7 +221,7 @@ class OC_App {
 		}
 		// in incognito mode or when logged out, $user will be false,
 		// which is also the case during an upgrade
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		if ($all) {
 			$user = null;
 		} else {
@@ -264,7 +264,7 @@ class OC_App {
 
 		$installer->installApp($appId);
 
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		if ($groups !== []) {
 			$groupManager = \OC::$server->getGroupManager();
 			$groupsList = [];
@@ -354,7 +354,7 @@ class OC_App {
 	 * @param string $appId
 	 * @param bool $refreshAppPath should be set to true only during install/upgrade
 	 * @return string|false
-	 * @deprecated 11.0.0 use \OC::$server->getAppManager()->getAppPath()
+	 * @deprecated 11.0.0 use \OC::$server->get(\OCP\App\IAppManager::class)->getAppPath()
 	 */
 	public static function getAppPath(string $appId, bool $refreshAppPath = false) {
 		if ($appId === null || trim($appId) === '') {
@@ -373,7 +373,7 @@ class OC_App {
 	 *
 	 * @param string $appId
 	 * @return string|false
-	 * @deprecated 18.0.0 use \OC::$server->getAppManager()->getAppWebPath()
+	 * @deprecated 18.0.0 use \OC::$server->get(\OCP\App\IAppManager::class)->getAppWebPath()
 	 */
 	public static function getAppWebPath(string $appId) {
 		if (($dir = self::findAppInDirectories($appId)) != false) {
@@ -390,7 +390,7 @@ class OC_App {
 	 */
 	public static function getAppVersionByPath(string $path): string {
 		$infoFile = $path . '/appinfo/info.xml';
-		$appData = \OC::$server->getAppManager()->getAppInfo($infoFile, true);
+		$appData = \OC::$server->get(IAppManager::class)->getAppInfo($infoFile, true);
 		return isset($appData['version']) ? $appData['version'] : '';
 	}
 
@@ -556,7 +556,7 @@ class OC_App {
 	public function listAllApps(): array {
 		$installedApps = OC_App::getAllApps();
 
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		//we don't want to show configuration for these
 		$blacklist = $appManager->getAlwaysEnabledApps();
 		$appList = [];
@@ -756,7 +756,7 @@ class OC_App {
 			return false;
 		}
 
-		\OC::$server->getAppManager()->clearAppsCache();
+		\OC::$server->get(IAppManager::class)->clearAppsCache();
 		$l = \OC::$server->getL10N('core');
 		$appData = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppInfo($appId, false, $l->getLanguageCode());
 
@@ -778,8 +778,8 @@ class OC_App {
 		self::executeRepairSteps($appId, $appData['repair-steps']['post-migration']);
 		self::setupLiveMigrations($appId, $appData['repair-steps']['live-migration']);
 		// update appversion in app manager
-		\OC::$server->getAppManager()->clearAppsCache();
-		\OC::$server->getAppManager()->getAppVersion($appId, false);
+		\OC::$server->get(IAppManager::class)->clearAppsCache();
+		\OC::$server->get(IAppManager::class)->getAppVersion($appId, false);
 
 		self::setupBackgroundJobs($appData['background-jobs']);
 
@@ -862,7 +862,7 @@ class OC_App {
 	 * @return \OC\Files\View|false
 	 */
 	public static function getStorage(string $appId) {
-		if (\OC::$server->getAppManager()->isEnabledForUser($appId)) { //sanity check
+		if (\OC::$server->get(IAppManager::class)->isEnabledForUser($appId)) { //sanity check
 			if (\OC::$server->getUserSession()->isLoggedIn()) {
 				$view = new \OC\Files\View('/' . OC_User::getUser());
 				if (!$view->file_exists($appId)) {

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+ use OCP\App\IAppManager;
+
 class OC_JSON {
 	/**
 	 * Check if the app is enabled, send json error msg if not
@@ -35,7 +38,7 @@ class OC_JSON {
 	 * @suppress PhanDeprecatedFunction
 	 */
 	public static function checkAppEnabled($app) {
-		if (!\OC::$server->getAppManager()->isEnabledForUser($app)) {
+		if (!\OC::$server->get(IAppManager::class)->isEnabledForUser($app)) {
 			$l = \OC::$server->getL10N('lib');
 			self::error([ 'data' => [ 'message' => $l->t('Application is not enabled'), 'error' => 'application_not_enabled' ]]);
 			exit();

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -38,6 +38,7 @@
  *
  */
 use OC\TemplateLayout;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 
 require_once __DIR__.'/template/functions.php';
@@ -240,7 +241,7 @@ class OC_Template extends \OC\Template\Base {
 	 * @suppress PhanAccessMethodInternal
 	 */
 	public static function printErrorPage($error_msg, $hint = '', $statusCode = 500) {
-		if (\OC::$server->getAppManager()->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
+		if (\OC::$server->get(IAppManager::class)->isEnabledForUser('theming') && !\OC_App::isAppLoaded('theming')) {
 			\OC_App::loadApp('theming');
 		}
 

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -66,6 +66,7 @@
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\SetupManager;
+use OCP\App\IAppManager;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -83,7 +84,7 @@ class OC_Util {
 	private static $versionCache = null;
 
 	protected static function getAppManager() {
-		return \OC::$server->getAppManager();
+		return \OC::$server->get(IAppManager::class);
 	}
 
 	/**

--- a/ocm-provider/index.php
+++ b/ocm-provider/index.php
@@ -22,11 +22,13 @@
 
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\App\IAppManager;
+
 header('Content-Type: application/json');
 
 $server = \OC::$server;
 
-$isEnabled = $server->getAppManager()->isEnabledForUser('cloud_federation_api');
+$isEnabled = $server->get(IAppManager::class)->isEnabledForUser('cloud_federation_api');
 
 if ($isEnabled) {
 	// Make sure the routes are loaded

--- a/ocs-provider/index.php
+++ b/ocs-provider/index.php
@@ -21,6 +21,8 @@
 
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\App\IAppManager;
+
 header('Content-Type: application/json');
 
 $server = \OC::$server;
@@ -28,6 +30,6 @@ $server = \OC::$server;
 $controller = new \OC\OCS\Provider(
 	'ocs_provider',
 	$server->getRequest(),
-	$server->getAppManager()
+	$server->get(IAppManager::class)
 );
 echo $controller->buildProviderList()->render();

--- a/public.php
+++ b/public.php
@@ -32,6 +32,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\App\IAppManager;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
@@ -69,7 +71,7 @@ try {
 	OC_App::loadApps(['extended_authentication']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
-	if (!\OC::$server->getAppManager()->isInstalled($app)) {
+	if (!\OC::$server->get(IAppManager::class)->isInstalled($app)) {
 		http_response_code(404);
 		exit;
 	}

--- a/remote.php
+++ b/remote.php
@@ -34,6 +34,7 @@
 require_once __DIR__ . '/lib/versioncheck.php';
 
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
+use OCP\App\IAppManager;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
 use Psr\Log\LoggerInterface;
@@ -161,7 +162,7 @@ try {
 			$file = OC::$SERVERROOT .'/'. $file;
 			break;
 		default:
-			if (!\OC::$server->getAppManager()->isInstalled($app)) {
+			if (!\OC::$server->get(IAppManager::class)->isInstalled($app)) {
 				throw new RemoteException('App not installed: ' . $app);
 			}
 			OC_App::loadApp($app);

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\Config;
 
 use OC\Core\Command\App\Disable;
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -40,13 +41,13 @@ class AppsDisableTest extends TestCase {
 		parent::setUp();
 
 		$command = new Disable(
-			\OC::$server->getAppManager()
+			\OC::$server->get(IAppManager::class)
 		);
 
 		$this->commandTester = new CommandTester($command);
 
-		\OC::$server->getAppManager()->enableApp('admin_audit');
-		\OC::$server->getAppManager()->enableApp('comments');
+		\OC::$server->get(IAppManager::class)->enableApp('admin_audit');
+		\OC::$server->get(IAppManager::class)->enableApp('comments');
 	}
 
 	/**

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\Config;
 
 use OC\Core\Command\App\Enable;
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -40,14 +41,14 @@ class AppsEnableTest extends TestCase {
 		parent::setUp();
 
 		$command = new Enable(
-			\OC::$server->getAppManager(),
+			\OC::$server->get(IAppManager::class),
 			\OC::$server->getGroupManager()
 		);
 
 		$this->commandTester = new CommandTester($command);
 
-		\OC::$server->getAppManager()->disableApp('admin_audit');
-		\OC::$server->getAppManager()->disableApp('comments');
+		\OC::$server->get(IAppManager::class)->disableApp('admin_audit');
+		\OC::$server->get(IAppManager::class)->disableApp('comments');
 	}
 
 	/**

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -25,6 +25,7 @@ namespace Test\Preview;
 use OC\Preview\BackgroundCleanupJob;
 use OC\Preview\Storage\Root;
 use OC\PreviewManager;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
@@ -78,7 +79,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$this->logout();
 		$this->loginAsUser($this->userId);
 
-		$appManager = \OC::$server->getAppManager();
+		$appManager = \OC::$server->get(IAppManager::class);
 		$this->trashEnabled = $appManager->isEnabledForUser('files_trashbin', $user);
 		$appManager->disableApp('files_trashbin');
 
@@ -91,7 +92,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		if ($this->trashEnabled) {
-			$appManager = \OC::$server->getAppManager();
+			$appManager = \OC::$server->get(IAppManager::class);
 			$appManager->enableApp('files_trashbin');
 		}
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getAppManager` and replaces it with `OC\Server::get(\OCP\App\IAppManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\App\IAppManager` class is imported via the `use` directive.