### PR TITLE
Refactor `OC\Server::getAvatarManager`

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -576,7 +576,7 @@ class User implements IUser {
 	public function getAvatarImage($size) {
 		// delay the initialization
 		if (is_null($this->avatarManager)) {
-			$this->avatarManager = \OC::$server->getAvatarManager();
+			$this->avatarManager = \OC::$server->get(IAvatarManager::class);
 		}
 
 		$avatar = $this->avatarManager->getAvatar($this->uid);


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getAvatarManager` and replaces it with `OC\Server::get(\OCP\IAvatarManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IAvatarManager` class is imported via the `use` directive.