### PR TITLE
Refactor `OC\Server::getCapabilitiesManager`

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -43,6 +43,7 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\CapabilitiesManager;
 use OC\Search\SearchQuery;
 use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;
@@ -258,7 +259,7 @@ class TemplateLayout extends \OC_Template {
 				\OC::$server->getGroupManager(),
 				\OC::$server->get(IniGetWrapper::class),
 				\OC::$server->getURLGenerator(),
-				\OC::$server->getCapabilitiesManager(),
+				\OC::$server->get(CapabilitiesManager::class),
 				\OCP\Server::get(IInitialStateService::class)
 			);
 			$config = $jsConfigHelper->getConfig();

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -43,7 +43,6 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
-use OC\CapabilitiesManager;
 use OC\Search\SearchQuery;
 use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getCapabilitiesManager` and replaces it with `OC\Server::get(\OC\CapabilitiesManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OC\CapabilitiesManager` class is imported via the `use` directive.