### PR TITLE
Refactor `OC\Server::getCloudFederationFactory`

### DIFF
--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -44,6 +44,7 @@ use OCA\Talk\Share\RoomShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudFederationFactory;
 use OCP\IServerContainer;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
@@ -142,7 +143,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->query(\OCP\OCS\IDiscoveryService::class),
 				$this->serverContainer->getJobList(),
 				\OC::$server->getCloudFederationProviderManager(),
-				\OC::$server->getCloudFederationFactory(),
+				\OC::$server->get(ICloudFederationFactory::class),
 				$this->serverContainer->query(IEventDispatcher::class),
 				$this->serverContainer->get(LoggerInterface::class),
 			);


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getCloudFederationFactory` and replaces it with `OC\Server::get(\OCP\Federation\ICloudFederationFactory::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Federation\ICloudFederationFactory` class is imported via the `use` directive.