### PR TITLE
Refactor `OC\Server::getCommentsManager`

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -40,6 +40,7 @@ use OC\Avatar\AvatarManager;
 use OC\Hooks\Emitter;
 use OC_Helper;
 use OCP\Accounts\IAccountManager;
+use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\UserRemovedEvent;
@@ -290,8 +291,8 @@ class User implements IUser {
 			// Delete the user's keys in preferences
 			\OC::$server->getConfig()->deleteAllUserValues($this->uid);
 
-			\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->uid);
-			\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
+			\OC::$server->get(ICommentsManager::class)->deleteReferencesOfActor('users', $this->uid);
+			\OC::$server->get(ICommentsManager::class)->deleteReadMarksFromUser($this);
 
 			/** @var AvatarManager $avatarManager */
 			$avatarManager = \OCP\Server::get(AvatarManager::class);

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -668,7 +668,7 @@ class ManagerTest extends TestCase {
 		$user = \OC::$server->getUserManager()->createUser('xenia', '123456');
 		$this->assertTrue($user instanceof IUser);
 
-		$manager = \OC::$server->getCommentsManager();
+		$manager = \OC::$server->get(ICommentsManager::class);
 		$comment = $manager->create('users', $user->getUID(), 'files', 'file64');
 		$comment
 			->setMessage('Most important comment I ever left on the Internet.')

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -26,6 +26,7 @@ namespace Test;
 
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\App\AppStore\Fetcher\CategoryFetcher;
+use OCP\Comments\ICommentsManager;
 
 /**
  * Class Server
@@ -185,7 +186,7 @@ class ServerTest extends \Test\TestCase {
 
 		$config->setSystemValue('comments.managerFactory', '\Test\Comments\FakeFactory');
 
-		$manager = $this->server->getCommentsManager();
+		$manager = $this->server->get(ICommentsManager::class);
 		$this->assertInstanceOf('\OCP\Comments\ICommentsManager', $manager);
 
 		$config->setSystemValue('comments.managerFactory', $defaultManagerFactory);


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getCommentsManager` and replaces it with `OC\Server::get(\OCP\Comments\ICommentsManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\Comments\ICommentsManager` class is imported via the `use` directive.