### PR TITLE
Refactor `OC\Server::getConfig`

### DIFF
--- a/build/integration/features/bootstrap/RemoteContext.php
+++ b/build/integration/features/bootstrap/RemoteContext.php
@@ -23,6 +23,7 @@
  *
  */
 use Behat\Behat\Context\Context;
+use OC\AllConfig;
 use PHPUnit\Framework\Assert;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -80,7 +81,7 @@ class RemoteContext implements Context {
 	 */
 	public function theRemoteVersionShouldBe($version) {
 		if ($version === '__current_version__') {
-			$version = \OC::$server->getConfig()->getSystemValue('version', '0.0.0.0');
+			$version = \OC::$server->get(AllConfig::class)->getSystemValue('version', '0.0.0.0');
 		}
 
 		Assert::assertEquals($version, $this->remoteInstance->getVersion());

--- a/console.php
+++ b/console.php
@@ -33,6 +33,7 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\AllConfig;
 use OC\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -90,7 +91,7 @@ try {
 	}
 
 	$application = new Application(
-		\OC::$server->getConfig(),
+		\OC::$server->get(AllConfig::class),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getRequest(),
 		\OC::$server->get(\Psr\Log\LoggerInterface::class),

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -36,6 +36,7 @@ use OCP\IEventSource;
 use OCP\IEventSourceFactory;
 use OCP\IL10N;
 use OCP\ILogger;
+use OC\AllConfig;
 use OC\DB\MigratorExecuteSqlEvent;
 use OC\Repair\Events\RepairAdvanceEvent;
 use OC\Repair\Events\RepairErrorEvent;
@@ -112,7 +113,7 @@ if (\OCP\Util::needUpgrade()) {
 	\OC_User::setIncognitoMode(true);
 
 	$logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
-	$config = \OC::$server->getConfig();
+	$config = \OC::$server->get(AllConfig::class);
 	$updater = new \OC\Updater(
 		$config,
 		\OC::$server->getIntegrityCodeChecker(),

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,7 +48,9 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
-use Psr\Log\LoggerInterface;
+
+ use OC\AllConfig;
+ use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
@@ -71,7 +73,7 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 ));
 
 
-if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
+if (\OC::$server->get(AllConfig::class)->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\App\Install());
@@ -86,18 +88,18 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Disable::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\State::class));
 
-	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->get(AllConfig::class)));
 	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));
 
-	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\Import(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Config\Import(\OC::$server->get(AllConfig::class)));
 	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->getSystemConfig(), \OC::$server->getAppConfig()));
 	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->getSystemConfig()));
 	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
@@ -106,48 +108,48 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
 	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
 
-	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
-	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
+	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->get(AllConfig::class), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
+	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->get(AllConfig::class), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingColumns::class));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingIndices::class));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingPrimaryKeys::class));
 
-	if (\OC::$server->getConfig()->getSystemValueBool('debug', false)) {
+	if (\OC::$server->get(AllConfig::class)->getSystemValueBool('debug', false)) {
 		$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->get(\OC\DB\Connection::class)));
 		$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->get(\OC\DB\Connection::class)));
 		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getAppManager()));
-		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getConfig()));
+		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->get(AllConfig::class)));
 	}
 
-	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->get(AllConfig::class), \OC::$server->getEncryptionManager()));
+	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->get(AllConfig::class)));
 	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
+	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->get(AllConfig::class), new \Symfony\Component\Console\Helper\QuestionHelper()));
 	$application->add(new OC\Core\Command\Encryption\DecryptAll(
 		\OC::$server->getEncryptionManager(),
 		\OC::$server->getAppManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(AllConfig::class),
 		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
 	);
 
-	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Log\File(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->get(AllConfig::class)));
+	$application->add(new OC\Core\Command\Log\File(\OC::$server->get(AllConfig::class)));
 
 	$view = new \OC\Files\View();
 	$util = new \OC\Encryption\Util(
 		$view,
 		\OC::$server->getUserManager(),
 		\OC::$server->getGroupManager(),
-		\OC::$server->getConfig()
+		\OC::$server->get(AllConfig::class)
 	);
 	$application->add(new OC\Core\Command\Encryption\ChangeKeyStorageRoot(
 		$view,
 		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(AllConfig::class),
 		$util,
 		new \Symfony\Component\Console\Helper\QuestionHelper()
 	)
@@ -156,23 +158,23 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Encryption\MigrateKeyStorage(
 		$view,
 		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
+		\OC::$server->get(AllConfig::class),
 		$util,
 		\OC::$server->getCrypto()
 	)
 	);
 
-	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
+	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->get(AllConfig::class), new \OC\AppFramework\Utility\TimeFactory()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
-	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->get(AllConfig::class)));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->get(AllConfig::class), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair([], \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class)),
-		\OC::$server->getConfig(),
+		\OC::$server->get(AllConfig::class),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getAppManager()
 	));
@@ -189,7 +191,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->get(AllConfig::class)));
 	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->getUserManager(), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));

--- a/cron.php
+++ b/cron.php
@@ -39,6 +39,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\AllConfig;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -63,7 +65,7 @@ try {
 	\OC::$server->setSession($session);
 
 	$logger = \OC::$server->getLogger();
-	$config = \OC::$server->getConfig();
+	$config = \OC::$server->get(AllConfig::class);
 	$tempManager = \OC::$server->getTempManager();
 
 	// Don't do anything if Nextcloud has not been installed

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -53,6 +53,7 @@ use OCP\IRequestId;
 use OCP\PreConditionNotMetException;
 use OCP\Profiler\IProfiler;
 use OC\DB\QueryBuilder\QueryBuilder;
+use OC\AllConfig;
 use OC\SystemConfig;
 use Psr\Log\LoggerInterface;
 
@@ -594,7 +595,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 		// TODO properly inject those dependencies
 		$random = \OC::$server->getSecureRandom();
 		$platform = $this->getDatabasePlatform();
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$dispatcher = \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class);
 		if ($platform instanceof SqlitePlatform) {
 			return new SQLiteMigrator($this, $config, $dispatcher);

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -35,6 +35,7 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Sequence;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
+use OC\AllConfig;
 use OC\App\InfoParser;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\Migration\SimpleOutput;
@@ -116,7 +117,7 @@ class MigrationService {
 			return false;
 		}
 
-		if ($this->connection->tableExists('migrations') && \OC::$server->getConfig()->getAppValue('core', 'vendor', '') !== 'owncloud') {
+		if ($this->connection->tableExists('migrations') && \OC::$server->get(AllConfig::class)->getAppValue('core', 'vendor', '') !== 'owncloud') {
 			$this->migrationTableCreated = true;
 			return false;
 		}

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -24,6 +24,7 @@
  */
 namespace OC\Encryption;
 
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
@@ -86,7 +87,7 @@ class EncryptionWrapper {
 				new View(),
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager(),
-				\OC::$server->getConfig()
+				\OC::$server->get(AllConfig::class)
 			);
 			$update = new Update(
 				new View(),

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -23,6 +23,7 @@
  */
 namespace OC\Encryption;
 
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
@@ -76,7 +77,7 @@ class HookManager {
 					new View(),
 					\OC::$server->getUserManager(),
 					\OC::$server->getGroupManager(),
-					\OC::$server->getConfig()),
+					\OC::$server->get(AllConfig::class)),
 				Filesystem::getMountManager(),
 				\OC::$server->getEncryptionManager(),
 				\OC::$server->getEncryptionFilesHelper(),

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -43,6 +43,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IReliableEtagStorage;
 use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
+use OC\AllConfig;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Hooks\BasicEmitter;
 use Psr\Log\LoggerInterface;
@@ -95,7 +96,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		$this->storage = $storage;
 		$this->storageId = $this->storage->getId();
 		$this->cache = $storage->getCache();
-		$this->cacheActive = !\OC::$server->getConfig()->getSystemValueBool('filesystem_cache_readonly', false);
+		$this->cacheActive = !\OC::$server->get(AllConfig::class)->getSystemValueBool('filesystem_cache_readonly', false);
 		$this->lockingProvider = \OC::$server->getLockingProvider();
 		$this->connection = \OC::$server->get(IDBConnection::class);
 	}

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -38,6 +38,7 @@
 namespace OC\Files;
 
 use OCP\Cache\CappedMemoryCache;
+use OC\AllConfig;
 use OC\Files\Mount\MountPoint;
 use OC\User\NoUserException;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -465,7 +466,7 @@ class Filesystem {
 		$filename = self::normalizePath($filename);
 
 		if (self::$blacklist === null) {
-			self::$blacklist = \OC::$server->getConfig()->getSystemValue('blacklisted_files', ['.htaccess']);
+			self::$blacklist = \OC::$server->get(AllConfig::class)->getSystemValue('blacklisted_files', ['.htaccess']);
 		}
 
 		$filename = strtolower(basename($filename));

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Files\Node;
 
+use OC\AllConfig;
 use OC\Files\Cache\QuerySearchHelper;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
@@ -314,7 +315,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	}
 
 	protected function getAppDataDirectoryName(): string {
-		$instanceId = \OC::$server->getConfig()->getSystemValueString('instanceid');
+		$instanceId = \OC::$server->get(AllConfig::class)->getSystemValueString('instanceid');
 		return 'appdata_' . $instanceId;
 	}
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -42,6 +42,7 @@
  */
 namespace OC\Files\Storage;
 
+use OC\AllConfig;
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\Propagator;
 use OC\Files\Cache\Scanner;
@@ -364,7 +365,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		}
 		if (!isset($this->watcher)) {
 			$this->watcher = new Watcher($storage);
-			$globalPolicy = \OC::$server->getConfig()->getSystemValue('filesystem_check_changes', Watcher::CHECK_NEVER);
+			$globalPolicy = \OC::$server->get(AllConfig::class)->getSystemValue('filesystem_check_changes', Watcher::CHECK_NEVER);
 			$this->watcher->setPolicy((int)$this->getMountOption('filesystem_check_changes', $globalPolicy));
 		}
 		return $this->watcher;
@@ -840,7 +841,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 
 	private function getLockLogger(): ?LoggerInterface {
 		if (is_null($this->shouldLogLocks)) {
-			$this->shouldLogLocks = \OC::$server->getConfig()->getSystemValueBool('filelocking.debug', false);
+			$this->shouldLogLocks = \OC::$server->get(AllConfig::class)->getSystemValueBool('filelocking.debug', false);
 			$this->logger = $this->shouldLogLocks ? \OC::$server->get(LoggerInterface::class) : null;
 		}
 		return $this->logger;

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -40,6 +40,7 @@ namespace OC\Files\Storage;
 use Exception;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OC\MemCache\ArrayCache;
 use OCP\AppFramework\Http;
@@ -172,7 +173,7 @@ class DAV extends Common {
 			$settings['authType'] = $this->authType;
 		}
 
-		$proxy = \OC::$server->getConfig()->getSystemValueString('proxy', '');
+		$proxy = \OC::$server->get(AllConfig::class)->getSystemValueString('proxy', '');
 		if ($proxy !== '') {
 			$settings['proxy'] = $proxy;
 		}

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -26,6 +26,7 @@
  */
 namespace OC\Files\Storage\Wrapper;
 
+use OC\AllConfig;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageAuthException;
 use OCP\Files\StorageNotAvailableException;
@@ -43,7 +44,7 @@ class Availability extends Wrapper {
 	protected $config;
 
 	public function __construct($parameters) {
-		$this->config = $parameters['config'] ?? \OC::$server->getConfig();
+		$this->config = $parameters['config'] ?? \OC::$server->get(AllConfig::class);
 		parent::__construct($parameters);
 	}
 

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -40,6 +40,7 @@
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\AllConfig;
 use OC\App\AppStore\Bundles\Bundle;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\AppFramework\Bootstrap\Coordinator;
@@ -165,15 +166,15 @@ class Installer {
 		OC_App::executeRepairSteps($appId, $info['repair-steps']['install']);
 
 		//set the installed version
-		\OC::$server->getConfig()->setAppValue($info['id'], 'installed_version', \OCP\Server::get(IAppManager::class)->getAppVersion($info['id'], false));
-		\OC::$server->getConfig()->setAppValue($info['id'], 'enabled', 'no');
+		\OC::$server->get(AllConfig::class)->setAppValue($info['id'], 'installed_version', \OCP\Server::get(IAppManager::class)->getAppVersion($info['id'], false));
+		\OC::$server->get(AllConfig::class)->setAppValue($info['id'], 'enabled', 'no');
 
 		//set remote/public handlers
 		foreach ($info['remote'] as $name => $path) {
-			\OC::$server->getConfig()->setAppValue('core', 'remote_'.$name, $info['id'].'/'.$path);
+			\OC::$server->get(AllConfig::class)->setAppValue('core', 'remote_'.$name, $info['id'].'/'.$path);
 		}
 		foreach ($info['public'] as $name => $path) {
-			\OC::$server->getConfig()->setAppValue('core', 'public_'.$name, $info['id'].'/'.$path);
+			\OC::$server->get(AllConfig::class)->setAppValue('core', 'public_'.$name, $info['id'].'/'.$path);
 		}
 
 		OC_App::setAppTypes($info['id']);
@@ -538,7 +539,7 @@ class Installer {
 	 */
 	public static function installShippedApps($softErrors = false) {
 		$appManager = \OC::$server->getAppManager();
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$errors = [];
 		foreach (\OC::$APPSROOTS as $app_dir) {
 			if ($dir = opendir($app_dir['path'])) {
@@ -585,7 +586,7 @@ class Installer {
 		$appPath = OC_App::getAppPath($app);
 		\OC_App::registerAutoloading($app, $appPath);
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 
 		$ms = new MigrationService($app, \OC::$server->get(Connection::class));
 		$previousVersion = $config->getAppValue($app, 'installed_version', false);

--- a/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
+++ b/lib/private/IntegrityCheck/Iterator/ExcludeFoldersByPathFilterIterator.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
  */
 namespace OC\IntegrityCheck\Iterator;
 
+use OC\AllConfig;
+
 class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 	private $excludedFolders;
 
@@ -51,7 +53,7 @@ class ExcludeFoldersByPathFilterIterator extends \RecursiveFilterIterator {
 			rtrim($root . '/updater', '/'),
 			rtrim($root . '/_oc_upgrade', '/'),
 		];
-		$customDataDir = \OC::$server->getConfig()->getSystemValueString('datadirectory', '');
+		$customDataDir = \OC::$server->get(AllConfig::class)->getSystemValueString('datadirectory', '');
 		if ($customDataDir !== '') {
 			$excludedFolders[] = rtrim($customDataDir, '/');
 		}

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -24,6 +24,7 @@
  */
 namespace OC\Log;
 
+use OC\AllConfig;
 use OCP\Log\RotationTrait;
 
 /**
@@ -39,7 +40,7 @@ class Rotate extends \OCP\BackgroundJob\Job {
 		$systemConfig = \OC::$server->getSystemConfig();
 		$this->filePath = $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/nextcloud.log');
 
-		$this->maxSize = \OC::$server->getConfig()->getSystemValueInt('log_rotate_size', 100 * 1024 * 1024);
+		$this->maxSize = \OC::$server->get(AllConfig::class)->getSystemValueInt('log_rotate_size', 100 * 1024 * 1024);
 		if ($this->shouldRotateBySize()) {
 			$rotatedFile = $this->rotate();
 			$msg = 'Log file "'.$this->filePath.'" was over '.$this->maxSize.' bytes, moved to "'.$rotatedFile.'"';

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Memcache;
 
+use OC\AllConfig;
 use OCP\HintException;
 use OCP\IMemcache;
 
@@ -76,7 +77,7 @@ class Memcached extends Cache implements IMemcache {
 				$defaultOptions[\Memcached::OPT_SERIALIZER] =
 					\Memcached::SERIALIZER_IGBINARY;
 			}
-			$options = \OC::$server->getConfig()->getSystemValue('memcached_options', []);
+			$options = \OC::$server->get(AllConfig::class)->getSystemValue('memcached_options', []);
 			if (is_array($options)) {
 				$options = $options + $defaultOptions;
 				self::$cache->setOptions($options);

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -29,6 +29,7 @@
  */
 namespace OC\Preview;
 
+use OC\AllConfig;
 use OCP\Files\File;
 use OCP\IImage;
 
@@ -37,7 +38,7 @@ abstract class Image extends ProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
-		$maxSizeForImages = \OC::$server->getConfig()->getSystemValueInt('preview_max_filesize_image', 50);
+		$maxSizeForImages = \OC::$server->get(AllConfig::class)->getSystemValueInt('preview_max_filesize_image', 50);
 		$size = $file->getSize();
 
 		if ($maxSizeForImages !== -1 && $size > ($maxSizeForImages * 1024 * 1024)) {

--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -28,6 +28,7 @@
  */
 namespace OC\Preview;
 
+use OC\AllConfig;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
@@ -54,7 +55,7 @@ abstract class Office extends ProviderV2 {
 		$tmpDir = \OC::$server->getTempManager()->getTempBaseDir();
 
 		$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir . '/owncloud-' . \OC_Util::getInstanceId() . '/') . ' --headless --nologo --nofirststartwizard --invisible --norestore --convert-to png --outdir ';
-		$clParameters = \OC::$server->getConfig()->getSystemValue('preview_office_cl_parameters', $defaultParameters);
+		$clParameters = \OC::$server->get(AllConfig::class)->getSystemValue('preview_office_cl_parameters', $defaultParameters);
 
 		$cmd = $this->options['officeBinary'] . $clParameters . escapeshellarg($tmpDir) . ' ' . escapeshellarg($absPath);
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -34,6 +34,7 @@
  */
 namespace OC;
 
+use OC\AllConfig;
 use OC\Repair\AddRemoveOldTasksBackgroundJob;
 use OC\Repair\CleanUpAbandonedApps;
 use OCP\AppFramework\QueryException;
@@ -174,32 +175,32 @@ class Repair implements IOutput {
 	 */
 	public static function getRepairSteps(): array {
 		return [
-			new Collation(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->getDatabaseConnection(), false),
-			new RepairMimeTypes(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
+			new Collation(\OC::$server->get(AllConfig::class), \OC::$server->get(LoggerInterface::class), \OC::$server->getDatabaseConnection(), false),
+			new RepairMimeTypes(\OC::$server->get(AllConfig::class), \OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
-			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
-			new MoveUpdaterStepFile(\OC::$server->getConfig()),
+			new RepairInvalidShares(\OC::$server->get(AllConfig::class), \OC::$server->getDatabaseConnection()),
+			new MoveUpdaterStepFile(\OC::$server->get(AllConfig::class)),
 			new MoveAvatars(
 				\OC::$server->getJobList(),
-				\OC::$server->getConfig()
+				\OC::$server->get(AllConfig::class)
 			),
 			new CleanPreviews(
 				\OC::$server->getJobList(),
 				\OC::$server->getUserManager(),
-				\OC::$server->getConfig()
+				\OC::$server->get(AllConfig::class)
 			),
 			new MigrateOauthTables(\OC::$server->get(Connection::class)),
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
-			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
+			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->get(AllConfig::class)),
 			new AddLogRotateJob(\OC::$server->getJobList()),
 			new ClearFrontendCaches(\OC::$server->getMemCacheFactory(), \OCP\Server::get(JSCombiner::class)),
 			\OCP\Server::get(ClearGeneratedAvatarCache::class),
 			new AddPreviewBackgroundCleanupJob(\OC::$server->getJobList()),
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
-			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->get(LoggerInterface::class)),
+			new CleanupCardDAVPhotoCache(\OC::$server->get(AllConfig::class), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->get(LoggerInterface::class)),
 			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->getJobList()),
-			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OCP\Server::get(ITimeFactory::class)),
-			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OCP\Server::get(IManager::class)),
+			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->get(AllConfig::class), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OCP\Server::get(ITimeFactory::class)),
+			new ClearCollectionsAccessCache(\OC::$server->get(AllConfig::class), \OCP\Server::get(IManager::class)),
 			\OCP\Server::get(ResetGeneratedAvatarFlag::class),
 			\OCP\Server::get(EncryptionLegacyCipher::class),
 			\OCP\Server::get(EncryptionMigration::class),
@@ -239,9 +240,9 @@ class Repair implements IOutput {
 		$connection = \OC::$server->get(Connection::class);
 		/** @var ConnectionAdapter $connectionAdapter */
 		$connectionAdapter = \OC::$server->get(ConnectionAdapter::class);
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$steps = [
-			new Collation(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), $connectionAdapter, true),
+			new Collation(\OC::$server->get(AllConfig::class), \OC::$server->get(LoggerInterface::class), $connectionAdapter, true),
 			new SqliteAutoincrement($connection),
 			new SaveAccountsTableData($connectionAdapter, $config),
 			new DropAccountTermsTable($connectionAdapter),

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -51,6 +51,7 @@ namespace OC;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Exception;
 use InvalidArgumentException;
+use OC\AllConfig;
 use OC\Authentication\Token\PublicKeyTokenProvider;
 use OC\Authentication\Token\TokenCleanupJob;
 use OC\TextProcessing\RemoveOldTasksBackgroundJob;
@@ -226,7 +227,7 @@ class Setup {
 
 			try {
 				$util = new \OC_Util();
-				$htAccessWorking = $util->isHtaccessWorking(\OC::$server->getConfig());
+				$htAccessWorking = $util->isHtaccessWorking(\OC::$server->get(AllConfig::class));
 			} catch (\OCP\HintException $e) {
 				$errors[] = [
 					'error' => $e->getMessage(),
@@ -391,7 +392,7 @@ class Setup {
 		}
 
 		if (empty($error)) {
-			$config = \OC::$server->getConfig();
+			$config = \OC::$server->get(AllConfig::class);
 			$config->setAppValue('core', 'installedat', (string)microtime(true));
 			$config->setAppValue('core', 'lastupdatedat', (string)microtime(true));
 
@@ -587,7 +588,7 @@ class Setup {
 		$content .= "  IndexIgnore *\n";
 		$content .= "</IfModule>";
 
-		$baseDir = \OC::$server->getConfig()->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
+		$baseDir = \OC::$server->get(AllConfig::class)->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
 		file_put_contents($baseDir . '/.htaccess', $content);
 		file_put_contents($baseDir . '/index.html', '');
 	}

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -25,13 +25,15 @@
  */
 namespace OC\Share;
 
+use OC\AllConfig;
+
 class Helper extends \OC\Share\Constants {
 	/**
 	 * get default expire settings defined by the admin
 	 * @return array contains 'defaultExpireDateSet', 'enforceExpireDate', 'expireAfterDays'
 	 */
 	public static function getDefaultExpireSetting() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 
 		$defaultExpireSettings = ['defaultExpireDateSet' => false];
 

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -35,6 +35,7 @@
 
 namespace OC\Share;
 
+use OC\AllConfig;
 use OCA\Files_Sharing\ShareBackend\File;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -76,7 +77,7 @@ class Share extends Constants {
 	 * @return boolean true if backend is registered or false if error
 	 */
 	public static function registerBackend($itemType, $class, $collectionOf = null, $supportedFileExtensions = null) {
-		if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_enabled', 'yes') == 'yes') {
+		if (\OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_enabled', 'yes') == 'yes') {
 			if (!isset(self::$backendTypes[$itemType])) {
 				self::$backendTypes[$itemType] = [
 					'class' => $class,
@@ -293,7 +294,7 @@ class Share extends Constants {
 	 */
 	public static function isResharingAllowed() {
 		if (!isset(self::$isResharingAllowed)) {
-			if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_resharing', 'yes') == 'yes') {
+			if (\OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_allow_resharing', 'yes') == 'yes') {
 				self::$isResharingAllowed = true;
 			} else {
 				self::$isResharingAllowed = false;
@@ -351,7 +352,7 @@ class Share extends Constants {
 	public static function getItems($itemType, ?string $item = null, ?int $shareType = null, $shareWith = null,
 									$uidOwner = null, $format = self::FORMAT_NONE, $parameters = null, $limit = -1,
 									$includeCollections = false, $itemShareWithBySource = false, $checkExpireDate = true) {
-		if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_enabled', 'yes') != 'yes') {
+		if (\OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_enabled', 'yes') != 'yes') {
 			return [];
 		}
 		$fileDependent = $itemType == 'file' || $itemType == 'folder';
@@ -392,7 +393,7 @@ class Share extends Constants {
 				$qb->where($qb->expr()->eq('item_type', $qb->createNamedParameter($itemType)));
 			}
 		}
-		if (\OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
+		if (\OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_allow_links', 'yes') !== 'yes') {
 			$qb->andWhere($qb->expr()->neq('share_type', $qb->createNamedParameter(IShare::TYPE_LINK, IQueryBuilder::PARAM_INT)));
 		}
 		if (isset($shareType)) {
@@ -956,7 +957,7 @@ class Share extends Constants {
 	 * @return int
 	 */
 	public static function getExpireInterval() {
-		return (int)\OC::$server->getConfig()->getAppValue('core', 'shareapi_expire_after_n_days', '7');
+		return (int)\OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_expire_after_n_days', '7');
 	}
 
 	/**

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -33,6 +33,7 @@
  */
 namespace OC\Share20;
 
+use OC\AllConfig;
 use OC\Share20\Exception\ProviderException;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
@@ -104,7 +105,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->query(Defaults::class),
 				$this->serverContainer->getL10NFactory(),
 				$this->serverContainer->getURLGenerator(),
-				$this->serverContainer->getConfig()
+				$this->serverContainer->get(AllConfig::class)
 			);
 		}
 
@@ -156,7 +157,7 @@ class ProviderFactory implements IProviderFactory {
 				$tokenHandler,
 				$l,
 				$this->serverContainer->getLazyRootFolder(),
-				$this->serverContainer->getConfig(),
+				$this->serverContainer->get(AllConfig::class),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getCloudIdManager(),
 				$this->serverContainer->getGlobalScaleConfig(),
@@ -183,10 +184,10 @@ class ProviderFactory implements IProviderFactory {
 				return null;
 			}
 
-			$settingsManager = new SettingsManager($this->serverContainer->getConfig());
+			$settingsManager = new SettingsManager($this->serverContainer->get(AllConfig::class));
 
 			$this->shareByMailProvider = new ShareByMailProvider(
-				$this->serverContainer->getConfig(),
+				$this->serverContainer->get(AllConfig::class),
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getSecureRandom(),
 				$this->serverContainer->getUserManager(),

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -45,6 +45,7 @@ declare(strict_types=1);
  */
 namespace OC\User;
 
+use OC\AllConfig;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -447,7 +448,7 @@ class Database extends ABackend implements
 	 */
 	public function getHome(string $uid) {
 		if ($this->userExists($uid)) {
-			return \OC::$server->getConfig()->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
+			return \OC::$server->get(AllConfig::class)->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
 		}
 
 		return false;

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -36,6 +36,7 @@ namespace OC\User;
 
 use InvalidArgumentException;
 use OC\Accounts\AccountManager;
+use OC\AllConfig;
 use OC\Avatar\AvatarManager;
 use OC\Hooks\Emitter;
 use OC_Helper;
@@ -107,7 +108,7 @@ class User implements IUser {
 		$this->backend = $backend;
 		$this->emitter = $emitter;
 		if (is_null($config)) {
-			$config = \OC::$server->getConfig();
+			$config = \OC::$server->get(AllConfig::class);
 		}
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
@@ -288,7 +289,7 @@ class User implements IUser {
 				}
 			}
 			// Delete the user's keys in preferences
-			\OC::$server->getConfig()->deleteAllUserValues($this->uid);
+			\OC::$server->get(AllConfig::class)->deleteAllUserValues($this->uid);
 
 			\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->uid);
 			\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -57,6 +57,7 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OC\AllConfig;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -196,7 +197,7 @@ class OC_App {
 			$appData['types'] = [];
 		}
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$config->setAppValue($app, 'types', $appTypes);
 
 		if ($appManager->hasProtectedAppType($appData['types'])) {
@@ -577,7 +578,7 @@ class OC_App {
 					continue;
 				}
 
-				$enabled = \OC::$server->getConfig()->getAppValue($app, 'enabled', 'no');
+				$enabled = \OC::$server->get(AllConfig::class)->getAppValue($app, 'enabled', 'no');
 				$info['groups'] = null;
 				if ($enabled === 'yes') {
 					$active = true;
@@ -760,10 +761,10 @@ class OC_App {
 		$l = \OC::$server->getL10N('core');
 		$appData = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppInfo($appId, false, $l->getLanguageCode());
 
-		$ignoreMaxApps = \OC::$server->getConfig()->getSystemValue('app_install_overwrite', []);
+		$ignoreMaxApps = \OC::$server->get(AllConfig::class)->getSystemValue('app_install_overwrite', []);
 		$ignoreMax = in_array($appId, $ignoreMaxApps, true);
 		\OC_App::checkAppDependencies(
-			\OC::$server->getConfig(),
+			\OC::$server->get(AllConfig::class),
 			$l,
 			$appData,
 			$ignoreMax
@@ -785,21 +786,21 @@ class OC_App {
 
 		//set remote/public handlers
 		if (array_key_exists('ocsid', $appData)) {
-			\OC::$server->getConfig()->setAppValue($appId, 'ocsid', $appData['ocsid']);
-		} elseif (\OC::$server->getConfig()->getAppValue($appId, 'ocsid', null) !== null) {
-			\OC::$server->getConfig()->deleteAppValue($appId, 'ocsid');
+			\OC::$server->get(AllConfig::class)->setAppValue($appId, 'ocsid', $appData['ocsid']);
+		} elseif (\OC::$server->get(AllConfig::class)->getAppValue($appId, 'ocsid', null) !== null) {
+			\OC::$server->get(AllConfig::class)->deleteAppValue($appId, 'ocsid');
 		}
 		foreach ($appData['remote'] as $name => $path) {
-			\OC::$server->getConfig()->setAppValue('core', 'remote_' . $name, $appId . '/' . $path);
+			\OC::$server->get(AllConfig::class)->setAppValue('core', 'remote_' . $name, $appId . '/' . $path);
 		}
 		foreach ($appData['public'] as $name => $path) {
-			\OC::$server->getConfig()->setAppValue('core', 'public_' . $name, $appId . '/' . $path);
+			\OC::$server->get(AllConfig::class)->setAppValue('core', 'public_' . $name, $appId . '/' . $path);
 		}
 
 		self::setAppTypes($appId);
 
 		$version = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppVersion($appId);
-		\OC::$server->getConfig()->setAppValue($appId, 'installed_version', $version);
+		\OC::$server->get(AllConfig::class)->setAppValue($appId, 'installed_version', $version);
 
 		\OC::$server->get(IEventDispatcher::class)->dispatchTyped(new AppUpdateEvent($appId));
 		\OC::$server->get(IEventDispatcher::class)->dispatch(ManagerEvent::EVENT_APP_UPDATE, new ManagerEvent(

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -37,6 +37,8 @@
  *
  */
 
+ use OC\AllConfig;
+
 class OC_Defaults {
 	private $theme;
 
@@ -57,7 +59,7 @@ class OC_Defaults {
 	private $defaultProductName;
 
 	public function __construct() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 
 		$this->defaultEntity = 'Nextcloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'Nextcloud'; /* short name, used when referring to the software */

--- a/lib/private/legacy/OC_FileChunking.php
+++ b/lib/private/legacy/OC_FileChunking.php
@@ -28,6 +28,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+ use OC\AllConfig;
+
 class OC_FileChunking {
 	protected $info;
 	protected $cache;
@@ -49,7 +52,7 @@ class OC_FileChunking {
 	 */
 	public function __construct($info) {
 		$this->info = $info;
-		$this->ttl = \OC::$server->getConfig()->getSystemValueInt('cache_chunk_gc_ttl', 86400);
+		$this->ttl = \OC::$server->get(AllConfig::class)->getSystemValueInt('cache_chunk_gc_ttl', 86400);
 	}
 
 	public function getPrefix() {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -44,6 +44,7 @@
  *
  */
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
@@ -662,6 +663,6 @@ class OC_Helper {
 	 * @return bool
 	 */
 	public static function isReadOnlyConfigEnabled() {
-		return \OC::$server->getConfig()->getSystemValueBool('config_is_read_only', false);
+		return \OC::$server->get(AllConfig::class)->getSystemValueBool('config_is_read_only', false);
 	}
 }

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -43,6 +43,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\AllConfig;
 use OCP\IImage;
 
 /**
@@ -88,7 +90,7 @@ class OC_Image implements \OCP\IImage {
 		}
 		$this->config = $config;
 		if ($config === null) {
-			$this->config = \OC::$server->getConfig();
+			$this->config = \OC::$server->get(AllConfig::class);
 		}
 
 		if (\OC_Util::fileInfoLoaded()) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -65,6 +65,7 @@
  */
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\AllConfig;
 use OC\Files\SetupManager;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
@@ -183,7 +184,7 @@ class OC_Util {
 		/** @var LoggerInterface $logger */
 		$logger = \OC::$server->get(LoggerInterface::class);
 
-		$plainSkeletonDirectory = \OC::$server->getConfig()->getSystemValueString('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+		$plainSkeletonDirectory = \OC::$server->get(AllConfig::class)->getSystemValueString('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
 		$userLang = \OC::$server->getL10NFactory()->findLanguage();
 		$skeletonDirectory = str_replace('{lang}', $userLang, $plainSkeletonDirectory);
 
@@ -200,7 +201,7 @@ class OC_Util {
 			}
 		}
 
-		$instanceId = \OC::$server->getConfig()->getSystemValue('instanceid', '');
+		$instanceId = \OC::$server->get(AllConfig::class)->getSystemValue('instanceid', '');
 
 		if ($instanceId === null) {
 			throw new \RuntimeException('no instance id!');
@@ -304,7 +305,7 @@ class OC_Util {
 	 */
 	public static function getChannel() {
 		OC_Util::loadVersion();
-		return \OC::$server->getConfig()->getSystemValueString('updater.release.channel', self::$versionCache['OC_Channel']);
+		return \OC::$server->get(AllConfig::class)->getSystemValueString('updater.release.channel', self::$versionCache['OC_Channel']);
 	}
 
 	/**
@@ -727,7 +728,7 @@ class OC_Util {
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkDataDirectoryPermissions($dataDirectory) {
-		if (!\OC::$server->getConfig()->getSystemValueBool('check_data_directory_permissions', true)) {
+		if (!\OC::$server->get(AllConfig::class)->getSystemValueBool('check_data_directory_permissions', true)) {
 			return  [];
 		}
 

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
  */
 namespace OCP\AppFramework;
 
+use OC\AllConfig;
 use OC\AppFramework\Routing\RouteConfig;
 use OC\Route\Router;
 use OC\ServerContainer;
@@ -71,7 +72,7 @@ class App {
 	 * @since 6.0.0
 	 */
 	public function __construct(string $appName, array $urlParams = []) {
-		$runIsSetupDirectly = \OC::$server->getConfig()->getSystemValueBool('debug')
+		$runIsSetupDirectly = \OC::$server->get(AllConfig::class)->getSystemValueBool('debug')
 			&& (PHP_VERSION_ID < 70400 || (PHP_VERSION_ID >= 70400 && !ini_get('zend.exception_ignore_args')));
 
 		if ($runIsSetupDirectly) {

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -46,6 +46,7 @@
 
 namespace OCP;
 
+use OC\AllConfig;
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
 use bantu\IniGetWrapper\IniGetWrapper;
@@ -88,7 +89,7 @@ class Util {
 			return $subscriptionRegistry->delegateHasExtendedSupport();
 		} catch (ContainerExceptionInterface $e) {
 		}
-		return \OC::$server->getConfig()->getSystemValueBool('extendedSupport', false);
+		return \OC::$server->get(AllConfig::class)->getSystemValueBool('extendedSupport', false);
 	}
 
 	/**
@@ -97,7 +98,7 @@ class Util {
 	 * @since 8.1.0
 	 */
 	public static function setChannel($channel) {
-		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
+		\OC::$server->get(AllConfig::class)->setSystemValue('updater.release.channel', $channel);
 	}
 
 	/**
@@ -320,7 +321,7 @@ class Util {
 	 * @since 5.0.0
 	 */
 	public static function getDefaultEmailAddress(string $user_part): string {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$user_part = $config->getSystemValueString('mail_from_address', $user_part);
 		$host_name = self::getServerHostName();
 		$host_name = $config->getSystemValueString('mail_domain', $host_name);

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,8 +30,10 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use OC\AllConfig;
+
 if (\OCP\Util::needUpgrade()
-	|| \OC::$server->getConfig()->getSystemValueBool('maintenance')) {
+	|| \OC::$server->get(AllConfig::class)->getSystemValueBool('maintenance')) {
 	// since the behavior of apps or remotes are unpredictable during
 	// an upgrade, return a 503 directly
 	http_response_code(503);

--- a/public.php
+++ b/public.php
@@ -32,6 +32,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\AllConfig;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
@@ -54,7 +56,7 @@ try {
 		$pathInfo = trim($pathInfo, '/');
 		[$service] = explode('/', $pathInfo);
 	}
-	$file = \OC::$server->getConfig()->getAppValue('core', 'public_' . strip_tags($service));
+	$file = \OC::$server->get(AllConfig::class)->getAppValue('core', 'public_' . strip_tags($service));
 	if ($file === '') {
 		http_response_code(404);
 		exit;

--- a/remote.php
+++ b/remote.php
@@ -33,6 +33,7 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\AllConfig;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
@@ -112,7 +113,7 @@ function resolveService($service) {
 		return $services[$service];
 	}
 
-	return \OC::$server->getConfig()->getAppValue('core', 'remote_' . $service);
+	return \OC::$server->get(AllConfig::class)->getAppValue('core', 'remote_' . $service);
 }
 
 try {

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -9,6 +9,7 @@
 
 namespace Test;
 
+use OC\AllConfig;
 use OC\App\AppManager;
 use OC\App\InfoParser;
 use OC\AppConfig;
@@ -556,7 +557,7 @@ class AppTest extends \Test\TestCase {
 		$this->overwriteService(AppConfig::class, $appConfig);
 		$this->overwriteService(AppManager::class, new AppManager(
 			\OC::$server->getUserSession(),
-			\OC::$server->getConfig(),
+			\OC::$server->get(AllConfig::class),
 			$appConfig,
 			\OC::$server->getGroupManager(),
 			\OC::$server->getMemCacheFactory(),

--- a/tests/lib/Command/BackgroundJobsTest.php
+++ b/tests/lib/Command/BackgroundJobsTest.php
@@ -25,6 +25,7 @@
 
 namespace Test\Command;
 
+use OC\AllConfig;
 use OC\Core\Command\Background\Ajax;
 use OC\Core\Command\Background\Cron;
 use OC\Core\Command\Background\WebCron;
@@ -35,21 +36,21 @@ use Test\TestCase;
 
 class BackgroundJobsTest extends TestCase {
 	public function testCronCommand() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$job = new Cron($config);
 		$job->run(new StringInput(''), new NullOutput());
 		$this->assertEquals('cron', $config->getAppValue('core', 'backgroundjobs_mode'));
 	}
 
 	public function testAjaxCommand() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$job = new Ajax($config);
 		$job->run(new StringInput(''), new NullOutput());
 		$this->assertEquals('ajax', $config->getAppValue('core', 'backgroundjobs_mode'));
 	}
 
 	public function testWebCronCommand() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$job = new WebCron($config);
 		$job->run(new StringInput(''), new NullOutput());
 		$this->assertEquals('webcron', $config->getAppValue('core', 'backgroundjobs_mode'));

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
+use OC\AllConfig;
 use OC\DB\Migrator;
 use OC\DB\MySQLMigrator;
 use OC\DB\OracleMigrator;
@@ -52,7 +53,7 @@ class MigratorTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = \OC::$server->getConfig();
+		$this->config = \OC::$server->get(AllConfig::class);
 		$this->connection = \OC::$server->get(\OC\DB\Connection::class);
 
 		$this->tableName = $this->getUniqueTableName();

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files;
 
+use OC\AllConfig;
 use OC\Files\Filesystem;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCA\Files_Sharing\AppInfo\Application;
@@ -40,7 +41,7 @@ class EtagTest extends \Test\TestCase {
 		\OC\Share\Share::registerBackend('file', 'OCA\Files_Sharing\ShareBackend\File');
 		\OC\Share\Share::registerBackend('folder', 'OCA\Files_Sharing\ShareBackend\Folder', 'file');
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$this->datadir = $config->getSystemValueString('datadirectory');
 		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
 		$config->setSystemValue('datadirectory', $this->tmpDir);
@@ -50,7 +51,7 @@ class EtagTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		\OC::$server->getConfig()->setSystemValue('datadirectory', $this->datadir);
+		\OC::$server->get(AllConfig::class)->setSystemValue('datadirectory', $this->datadir);
 
 		$this->logout();
 		parent::tearDown();

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -22,6 +22,7 @@
 
 namespace Test\Files;
 
+use OC\AllConfig;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
 use OC\User\NoUserException;
@@ -426,7 +427,7 @@ class FilesystemTest extends \Test\TestCase {
 	 */
 	public function testMountDefaultCacheDir() {
 		$userId = $this->getUniqueID('user_');
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$oldCachePath = $config->getSystemValueString('cache_path', '');
 		// no cache path configured
 		$config->setSystemValue('cache_path', '');
@@ -456,7 +457,7 @@ class FilesystemTest extends \Test\TestCase {
 	public function testMountExternalCacheDir() {
 		$userId = $this->getUniqueID('user_');
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$oldCachePath = $config->getSystemValueString('cache_path', '');
 		// set cache path to temp dir
 		$cachePath = \OC::$server->getTempManager()->getTemporaryFolder() . '/extcache';

--- a/tests/lib/Files/ObjectStore/AzureTest.php
+++ b/tests/lib/Files/ObjectStore/AzureTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Files\ObjectStore;
 
+use OC\AllConfig;
 use OC\Files\ObjectStore\Azure;
 
 /**
@@ -28,7 +29,7 @@ use OC\Files\ObjectStore\Azure;
  */
 class AzureTest extends ObjectStoreTest {
 	protected function getInstance() {
-		$config = \OC::$server->getConfig()->getSystemValue('objectstore');
+		$config = \OC::$server->get(AllConfig::class)->getSystemValue('objectstore');
 		if (!is_array($config) || $config['class'] !== 'OC\\Files\\ObjectStore\\Azure') {
 			$this->markTestSkipped('objectstore not configured for azure');
 		}

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -22,6 +22,7 @@
 namespace Test\Files\ObjectStore;
 
 use Icewind\Streams\Wrapper;
+use OC\AllConfig;
 use OC\Files\ObjectStore\S3;
 
 class MultiPartUploadS3 extends S3 {
@@ -67,7 +68,7 @@ class S3Test extends ObjectStoreTest {
 	}
 
 	protected function getInstance() {
-		$config = \OC::$server->getConfig()->getSystemValue('objectstore');
+		$config = \OC::$server->get(AllConfig::class)->getSystemValue('objectstore');
 		if (!is_array($config) || $config['class'] !== S3::class) {
 			$this->markTestSkipped('objectstore not configured for s3');
 		}

--- a/tests/lib/Files/ObjectStore/SwiftTest.php
+++ b/tests/lib/Files/ObjectStore/SwiftTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Files\ObjectStore;
 
+use OC\AllConfig;
 use OC\Files\ObjectStore\Swift;
 
 /**
@@ -31,7 +32,7 @@ class SwiftTest extends ObjectStoreTest {
 	 * @return \OCP\Files\ObjectStore\IObjectStore
 	 */
 	protected function getInstance() {
-		$config = \OC::$server->getConfig()->getSystemValue('objectstore');
+		$config = \OC::$server->get(AllConfig::class)->getSystemValue('objectstore');
 		if (!is_array($config) || $config['class'] !== 'OC\\Files\\ObjectStore\\Swift') {
 			$this->markTestSkipped('objectstore not configured for swift');
 		}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files;
 
 use OCP\Cache\CappedMemoryCache;
+use OC\AllConfig;
 use OC\Files\Cache\Watcher;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
@@ -298,7 +299,7 @@ class ViewTest extends \Test\TestCase {
 		// Reset sharing disabled for users cache
 		self::invokePrivate(\OC::$server->getShareManager(), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$oldExcludeGroupsFlag = $config->getAppValue('core', 'shareapi_exclude_groups', 'no');
 		$oldExcludeGroupsList = $config->getAppValue('core', 'shareapi_exclude_groups_list', '');
 		$config->setAppValue('core', 'shareapi_exclude_groups', $excludeGroups);

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\AllConfig;
 use OC\Files\Storage\Temporary;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
@@ -58,7 +59,7 @@ class HelperStorageTest extends \Test\TestCase {
 		\OC\Files\Filesystem::tearDown();
 
 		\OC_User::setUserId('');
-		\OC::$server->getConfig()->deleteAllUserValues($this->user);
+		\OC::$server->get(AllConfig::class)->deleteAllUserValues($this->user);
 
 		parent::tearDown();
 	}
@@ -174,7 +175,7 @@ class HelperStorageTest extends \Test\TestCase {
 
 		\OC\Files\Filesystem::mount($extStorage, [], '/' . $this->user . '/files/ext');
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$this->setIncludeExternalStorage(true);
 
 		$storageInfo = \OC_Helper::getStorageInfo('');

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\AllConfig;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\Archive\ZIP;
 use OC\Installer;
@@ -47,7 +48,7 @@ class InstallerTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->config = $this->createMock(IConfig::class);
 
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$this->appstore = $config->setSystemValue('appstoreenabled', true);
 		$config->setSystemValue('appstoreenabled', true);
 		$installer = new Installer(
@@ -78,11 +79,11 @@ class InstallerTest extends TestCase {
 			\OC::$server->getHTTPClientService(),
 			\OC::$server->getTempManager(),
 			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->getConfig(),
+			\OC::$server->get(AllConfig::class),
 			false
 		);
 		$installer->removeApp(self::$appid);
-		\OC::$server->getConfig()->setSystemValue('appstoreenabled', $this->appstore);
+		\OC::$server->get(AllConfig::class)->setSystemValue('appstoreenabled', $this->appstore);
 
 		parent::tearDown();
 	}
@@ -102,13 +103,13 @@ class InstallerTest extends TestCase {
 			\OC::$server->getHTTPClientService(),
 			\OC::$server->getTempManager(),
 			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->getConfig(),
+			\OC::$server->get(AllConfig::class),
 			false
 		);
-		$this->assertNull(\OC::$server->getConfig()->getAppValue('testapp', 'enabled', null), 'Check that the app is not listed before installation');
+		$this->assertNull(\OC::$server->get(AllConfig::class)->getAppValue('testapp', 'enabled', null), 'Check that the app is not listed before installation');
 		$this->assertSame('testapp', $installer->installApp(self::$appid));
-		$this->assertSame('no', \OC::$server->getConfig()->getAppValue('testapp', 'enabled', null), 'Check that the app is listed after installation');
-		$this->assertSame('0.9', \OC::$server->getConfig()->getAppValue('testapp', 'installed_version'));
+		$this->assertSame('no', \OC::$server->get(AllConfig::class)->getAppValue('testapp', 'enabled', null), 'Check that the app is listed after installation');
+		$this->assertSame('0.9', \OC::$server->get(AllConfig::class)->getAppValue('testapp', 'installed_version'));
 		$installer->removeApp(self::$appid);
 	}
 

--- a/tests/lib/Log/FileTest.php
+++ b/tests/lib/Log/FileTest.php
@@ -19,6 +19,7 @@
 
 namespace Test\Log;
 
+use OC\AllConfig;
 use OC\Log\File;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -81,7 +82,7 @@ class FileTest extends TestCase {
 	}
 
 	public function testMicrosecondsLogTimestamp() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		# delete old logfile
 		unlink($config->getSystemValue('logfile'));
 

--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -9,6 +9,8 @@
 
 namespace Test\Memcache;
 
+use OC\AllConfig;
+
 /**
  * @group Memcache
  * @group Redis
@@ -21,7 +23,7 @@ class RedisTest extends Cache {
 			self::markTestSkipped('The redis extension is not available.');
 		}
 
-		if (\OC::$server->getConfig()->getSystemValue('redis', []) === []) {
+		if (\OC::$server->get(AllConfig::class)->getSystemValue('redis', []) === []) {
 			self::markTestSkipped('Redis not configured in config.php');
 		}
 

--- a/tests/lib/Repair/RepairCollationTest.php
+++ b/tests/lib/Repair/RepairCollationTest.php
@@ -9,6 +9,7 @@
 namespace Test\Repair;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\AllConfig;
 use OC\Repair\Collation;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -61,7 +62,7 @@ class RepairCollationTest extends TestCase {
 
 		$this->connection = \OC::$server->get(IDBConnection::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->config = \OC::$server->getConfig();
+		$this->config = \OC::$server->get(AllConfig::class);
 		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
 			$this->markTestSkipped("Test only relevant on MySql");
 		}

--- a/tests/lib/Repair/RepairSqliteAutoincrementTest.php
+++ b/tests/lib/Repair/RepairSqliteAutoincrementTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Repair;
 
+use OC\AllConfig;
 use OC\DB\Connection;
 use OCP\Migration\IOutput;
 
@@ -41,7 +42,7 @@ class RepairSqliteAutoincrementTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->connection = \OC::$server->get(\OC\DB\Connection::class);
-		$this->config = \OC::$server->getConfig();
+		$this->config = \OC::$server->get(AllConfig::class);
 		if (!$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {
 			$this->markTestSkipped("Test only relevant on Sqlite");
 		}

--- a/tests/lib/Security/CryptoTest.php
+++ b/tests/lib/Security/CryptoTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Test\Security;
 
+use OC\AllConfig;
 use OC\Security\Crypto;
 
 class CryptoTest extends \Test\TestCase {
@@ -27,7 +28,7 @@ class CryptoTest extends \Test\TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->crypto = new Crypto(\OC::$server->getConfig());
+		$this->crypto = new Crypto(\OC::$server->get(AllConfig::class));
 	}
 
 	/**

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -24,6 +24,7 @@
 
 namespace Test;
 
+use OC\AllConfig;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\App\AppStore\Fetcher\CategoryFetcher;
 
@@ -180,7 +181,7 @@ class ServerTest extends \Test\TestCase {
 	}
 
 	public function testOverwriteDefaultCommentsManager() {
-		$config = $this->server->getConfig();
+		$config = $this->server->get(AllConfig::class);
 		$defaultManagerFactory = $config->getSystemValue('comments.managerFactory', '\OC\Comments\ManagerFactory');
 
 		$config->setSystemValue('comments.managerFactory', '\Test\Comments\FakeFactory');

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Share;
 
+use OC\AllConfig;
 use OC\Share\Share;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -95,8 +96,8 @@ class ShareTest extends \Test\TestCase {
 		Share::registerBackend('test', 'Test\Share\Backend');
 		\OC_Hook::clear('OCP\\Share');
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
-		$this->resharing = \OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_resharing', 'yes');
-		\OC::$server->getConfig()->setAppValue('core', 'shareapi_allow_resharing', 'yes');
+		$this->resharing = \OC::$server->get(AllConfig::class)->getAppValue('core', 'shareapi_allow_resharing', 'yes');
+		\OC::$server->get(AllConfig::class)->setAppValue('core', 'shareapi_allow_resharing', 'yes');
 
 		// 20 Minutes in the past, 20 minutes in the future.
 		$now = time();
@@ -109,7 +110,7 @@ class ShareTest extends \Test\TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('share')->andWhere($query->expr()->eq('item_type', $query->createNamedParameter('test')));
 		$query->executeStatement();
-		\OC::$server->getConfig()->setAppValue('core', 'shareapi_allow_resharing', $this->resharing);
+		\OC::$server->get(AllConfig::class)->setAppValue('core', 'shareapi_allow_resharing', $this->resharing);
 
 		$this->user1->delete();
 		$this->user2->delete();

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -24,6 +24,7 @@ namespace Test;
 
 use DOMDocument;
 use DOMNode;
+use OC\AllConfig;
 use OC\Command\QueueBus;
 use OC\Files\Config\MountProviderCollection;
 use OC\Files\Filesystem;
@@ -270,7 +271,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 				return self::$realDatabase;
 			});
 		}
-		$dataDir = \OC::$server->getConfig()->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data-autotest');
+		$dataDir = \OC::$server->get(AllConfig::class)->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
 			$db = \OC::$server->getDatabaseConnection();
 			if ($db->inTransaction()) {

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -8,6 +8,7 @@
 
 namespace Test\Traits;
 
+use OC\AllConfig;
 use OC\Encryption\EncryptionWrapper;
 use OC\Files\SetupManager;
 use OC\Memcache\ArrayCache;
@@ -102,7 +103,7 @@ trait EncryptionTrait {
 
 		$this->encryptionApp = new Application([], $isReady);
 
-		$this->config = \OC::$server->getConfig();
+		$this->config = \OC::$server->get(AllConfig::class);
 		$this->encryptionWasEnabled = $this->config->getAppValue('core', 'encryption_enabled', 'no');
 		$this->originalEncryptionModule = $this->config->getAppValue('core', 'default_encryption_module');
 		$this->config->setAppValue('core', 'default_encryption_module', \OCA\Encryption\Crypto\Encryption::ID);

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\AllConfig;
 use OC_Util;
 
 /**
@@ -97,7 +98,7 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testGetDefaultEmailAddressFromConfig() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$config->setSystemValue('mail_domain', 'example.com');
 		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
 		$this->assertEquals('no-reply@example.com', $email);
@@ -105,7 +106,7 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testGetConfiguredEmailAddressFromConfig() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$config->setSystemValue('mail_domain', 'example.com');
 		$config->setSystemValue('mail_from_address', 'owncloud');
 		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
@@ -115,7 +116,7 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testGetInstanceIdGeneratesValidId() {
-		\OC::$server->getConfig()->deleteSystemValue('instanceid');
+		\OC::$server->get(AllConfig::class)->deleteSystemValue('instanceid');
 		$instanceId = OC_Util::getInstanceId();
 		$this->assertStringStartsWith('oc', $instanceId);
 		$matchesRegex = preg_match('/^[a-z0-9]+$/', $instanceId);
@@ -184,7 +185,7 @@ class UtilTest extends \Test\TestCase {
 	 * Test needUpgrade() when the core version is increased
 	 */
 	public function testNeedUpgradeCore() {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(AllConfig::class);
 		$oldConfigVersion = $config->getSystemValue('version', '0.0.0');
 		$oldSessionVersion = \OC::$server->getSession()->get('OC_Version');
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getConfig` and replaces it with `OC\Server::get(\OC\AllConfig::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OC\AllConfig` class is imported via the `use` directive.