### PR TITLE
Refactor `OC\Server::getTrustedDomainHelper`

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1174,7 +1174,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$classExists = false;
 			}
 
-			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isInstalled('theming') && $c->getTrustedDomainHelper()->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
+			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isInstalled('theming') && $c->get(TrustedDomainHelper::class)->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
 				$imageManager = new ImageManager(
 					$c->get(\OCP\IConfig::class),
 					$c->getAppDataDir('theming'),


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getTrustedDomainHelper` and replaces it with `OC\Server::get(\OC\Security\TrustedDomainHelper::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OC\Security\TrustedDomainHelper` class is imported via the `use` directive.