### PR TITLE
Refactor `OC\Server::getURLGenerator`

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -33,6 +33,7 @@ namespace OC\Core\Controller;
 
 use OC\Setup;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 
 class SetupController {
 	private string $autoConfigFile;
@@ -108,7 +109,7 @@ class SetupController {
 			\OC_Template::printGuestPage('', 'installation_incomplete');
 		}
 
-		header('Location: ' . \OC::$server->getURLGenerator()->getAbsoluteURL('index.php/core/apps/recommended'));
+		header('Location: ' . \OC::$server->get(IURLGenerator::class)->getAbsoluteURL('index.php/core/apps/recommended'));
 		exit();
 	}
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -57,7 +59,7 @@ $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(
 	\OC::$server->getIntegrityCodeChecker(),
 	new \OC\IntegrityCheck\Helpers\FileAccessHelper(),
-	\OC::$server->getURLGenerator()
+	\OC::$server->get(IURLGenerator::class)
 ));
 $application->add(new \OC\Core\Command\Integrity\SignCore(
 	\OC::$server->getIntegrityCodeChecker(),
@@ -107,7 +109,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
 
 	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
-	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
+	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->get(IURLGenerator::class), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingColumns::class));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingIndices::class));

--- a/core/templates/403.php
+++ b/core/templates/403.php
@@ -1,9 +1,12 @@
 <?php
+
+use OCP\IURLGenerator;
+
 // @codeCoverageIgnoreStart
 if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }

--- a/core/templates/404-profile.php
+++ b/core/templates/404-profile.php
@@ -1,5 +1,7 @@
 <?php
 
+use OCP\IURLGenerator;
+
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
 /** @var \OCP\Defaults $theme */
@@ -7,7 +9,7 @@
 if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }
@@ -20,7 +22,7 @@ if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 		<div class="icon-big icon-error"></div>
 		<h2><?php p($l->t('Profile not found')); ?></h2>
 		<p class="infogroup"><?php p($l->t('The profile does not exist.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
+		<p><a class="button primary" href="<?php p(\OC::$server->get(IURLGenerator::class)->linkTo('', 'index.php')) ?>">
 				<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 			</a></p>
 	</div>

--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -1,4 +1,7 @@
 <?php
+
+use OCP\IURLGenerator;
+
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
 /** @var \OCP\Defaults $theme */
@@ -6,7 +9,7 @@
 if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OC::$server->get(IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }
@@ -19,7 +22,7 @@ if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 		<div class="icon-big icon-search"></div>
 		<h2><?php p($l->t('Page not found')); ?></h2>
 		<p class="infogroup"><?php p($l->t('The page could not be found on the server or you may not be allowed to view it.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
+		<p><a class="button primary" href="<?php p(\OC::$server->get(IURLGenerator::class)->linkTo('', 'index.php')) ?>">
 			<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 		</a></p>
 	</div>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -1,11 +1,14 @@
 <?php
+
+use OCP\IURLGenerator;
+
 /**
  * @var \OC_Defaults $theme
  * @var array $_
  */
 
 $getUserAvatar = static function (int $size) use ($_): string {
-	return \OC::$server->getURLGenerator()->linkToRoute('core.avatar.getAvatar', [
+	return \OC::$server->get(IURLGenerator::class)->linkToRoute('core.avatar.getAvatar', [
 		'userId' => $_['user_uid'],
 		'size' => $size,
 		'v' => $_['userAvatarVersion']

--- a/core/templates/twofactorselectchallenge.php
+++ b/core/templates/twofactorselectchallenge.php
@@ -1,4 +1,7 @@
 <?php
+
+use OCP\IURLGenerator;
+
 $noProviders = empty($_['providers']);
 ?>
 <div class="body-login-container update two-factor">
@@ -19,7 +22,7 @@ $noProviders = empty($_['providers']);
 				<strong><?php p($l->t('Two-factor authentication is enforced but has not been configured on your account. Contact your admin for assistance.')) ?></strong>
 			<?php } else { ?>
 				<strong><?php p($l->t('Two-factor authentication is enforced but has not been configured on your account. Please continue to setup two-factor authentication.')) ?></strong>
-				<a class="button primary two-factor-primary" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.setupProviders',
+				<a class="button primary two-factor-primary" href="<?php p(\OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.setupProviders',
 					[
 						'redirect_url' => $_['redirect_url'],
 					]
@@ -36,7 +39,7 @@ $noProviders = empty($_['providers']);
 	<?php foreach ($_['providers'] as $provider): ?>
 		<li>
 			<a class="two-factor-provider"
-			   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+			   href="<?php p(\OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			   	[
 			   		'challengeProviderId' => $provider->getId(),
 			   		'redirect_url' => $_['redirect_url'],
@@ -61,7 +64,7 @@ $noProviders = empty($_['providers']);
 	<?php endif ?>
 	<?php if (!is_null($_['backupProvider'])): ?>
 	<p>
-		<a class="<?php if ($noProviders): ?>button primary two-factor-primary<?php else: ?>two-factor-secondary<?php endif ?>" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="<?php if ($noProviders): ?>button primary two-factor-primary<?php else: ?>two-factor-secondary<?php endif ?>" href="<?php p(\OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			[
 				'challengeProviderId' => $_['backupProvider']->getId(),
 				'redirect_url' => $_['redirect_url'],

--- a/core/templates/twofactorsetupselection.php
+++ b/core/templates/twofactorsetupselection.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
  *
  */
 
+use OCP\IURLGenerator;
+
 ?>
 <div class="body-login-container update">
 	<h2 class="two-factor-header"><?php p($l->t('Set up two-factor authentication')) ?></h2>
@@ -30,7 +32,7 @@ declare(strict_types=1);
 	<?php foreach ($_['providers'] as $provider): ?>
 		<li>
 			<a class="two-factor-provider"
-			   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.setupProvider',
+			   href="<?php p(\OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.setupProvider',
 			   	[
 			   		'providerId' => $provider->getId(),
 			   	]

--- a/core/templates/twofactorshowchallenge.php
+++ b/core/templates/twofactorshowchallenge.php
@@ -1,4 +1,7 @@
 <?php
+
+use OCP\IURLGenerator;
+
 /** @var \OCP\IL10N $l */
 /** @var array $_*/
 /** @var boolean $error */
@@ -23,7 +26,7 @@ $template = $_['template'];
 	<?php print_unescaped($template); ?>
 	<?php if (!is_null($_['backupProvider'])): ?>
 	<p>
-		<a class="two-factor-secondary" href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.showChallenge',
+		<a class="two-factor-secondary" href="<?php p(\OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.showChallenge',
 			[
 				'challengeProviderId' => $_['backupProvider']->getId(),
 				'redirect_url' => $_['redirect_url'],

--- a/cron.php
+++ b/cron.php
@@ -39,6 +39,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\ITempManager;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -64,7 +66,7 @@ try {
 
 	$logger = \OC::$server->getLogger();
 	$config = \OC::$server->getConfig();
-	$tempManager = \OC::$server->getTempManager();
+	$tempManager = \OC::$server->get(ITempManager::class);
 
 	// Don't do anything if Nextcloud has not been installed
 	if (!$config->getSystemValue('installed', false)) {

--- a/lib/private/Archive/TAR.php
+++ b/lib/private/Archive/TAR.php
@@ -33,6 +33,7 @@
 namespace OC\Archive;
 
 use Icewind\Streams\CallbackWrapper;
+use OCP\ITempManager;
 
 class TAR extends Archive {
 	public const PLAIN = 0;
@@ -91,7 +92,7 @@ class TAR extends Archive {
 	 * add an empty folder to the archive
 	 */
 	public function addFolder(string $path): bool {
-		$tmpBase = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpBase = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$path = rtrim($path, '/') . '/';
 		if ($this->fileExists($path)) {
 			return false;
@@ -134,7 +135,7 @@ class TAR extends Archive {
 	 */
 	public function rename(string $source, string $dest): bool {
 		//no proper way to delete, rename entire archive, rename file and remake archive
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tar->extract($tmp);
 		rename($tmp . $source, $tmp . $dest);
 		$this->tar = null;
@@ -241,7 +242,7 @@ class TAR extends Archive {
 	 * extract a single file from the archive
 	 */
 	public function extractFile(string $path, string $dest): bool {
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		if (!$this->fileExists($path)) {
 			return false;
 		}
@@ -297,7 +298,7 @@ class TAR extends Archive {
 		$this->fileList = false;
 		$this->cachedHeaders = false;
 		//no proper way to delete, extract entire archive, delete file and remake archive
-		$tmp = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmp = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tar->extract($tmp);
 		\OCP\Files::rmdirr($tmp . $path);
 		$this->tar = null;
@@ -319,7 +320,7 @@ class TAR extends Archive {
 		} else {
 			$ext = '';
 		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 		if ($this->fileExists($path)) {
 			$this->extractFile($path, $tmpFile);
 		} elseif ($mode == 'r' or $mode == 'rb') {

--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -32,6 +32,7 @@
 namespace OC\Archive;
 
 use Icewind\Streams\CallbackWrapper;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class ZIP extends Archive {
@@ -224,7 +225,7 @@ class ZIP extends Archive {
 			} else {
 				$ext = '';
 			}
-			$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+			$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 			if ($this->fileExists($path)) {
 				$this->extractFile($path, $tmpFile);
 			}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -47,6 +47,7 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 use OCP\Files\Storage\IChunkedFileWrite;
 use OCP\Files\Storage\IStorage;
+use OCP\ITempManager;
 
 class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFileWrite {
 	use CopyDirectory;
@@ -367,7 +368,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 					return false;
 				}
 
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+				$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 				$handle = fopen($tmpFile, $mode);
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
 					$this->writeBack($tmpFile, $path);
@@ -381,7 +382,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			case 'x+':
 			case 'c':
 			case 'c+':
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+				$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($ext);
 				if ($this->file_exists($path)) {
 					$source = $this->fopen($path, 'r');
 					file_put_contents($tmpFile, $source);

--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -32,6 +32,7 @@ use Icewind\Streams\RetryWrapper;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\StorageAuthException;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 const SWIFT_SEGMENT_SIZE = 1073741824; // 1GB
@@ -75,7 +76,7 @@ class Swift implements IObjectStore {
 	}
 
 	public function writeObject($urn, $stream, string $mimetype = null) {
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('swiftwrite');
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('swiftwrite');
 		file_put_contents($tmpFile, $stream);
 		$handle = fopen($tmpFile, 'rb');
 

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -53,6 +53,7 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
 use OCP\IConfig;
+use OCP\ITempManager;
 use OCP\Util;
 use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV\Client;
@@ -400,7 +401,7 @@ class DAV extends Common {
 			case 'c':
 			case 'c+':
 				//emulate these
-				$tempManager = \OC::$server->getTempManager();
+				$tempManager = \OC::$server->get(ITempManager::class);
 				if (strrpos($path, '.') !== false) {
 					$ext = substr($path, strrpos($path, '.'));
 				} else {

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -23,6 +23,8 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\ITempManager;
+
 /**
  * Storage backend class for providing common filesystem operation methods
  * which are not storage-backend specific.
@@ -62,7 +64,7 @@ trait LocalTempFileTrait {
 		} else {
 			$extension = '';
 		}
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($extension);
 		$target = fopen($tmpFile, 'w');
 		\OC_Helper::streamCopy($source, $target);
 		fclose($target);

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -25,12 +25,14 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\ITempManager;
+
 /**
  * local storage backend in temporary folder for testing purpose
  */
 class Temporary extends Local {
 	public function __construct($arguments = null) {
-		parent::__construct(['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]);
+		parent::__construct(['datadir' => \OC::$server->get(ITempManager::class)->getTemporaryFolder()]);
 	}
 
 	public function cleanUp() {

--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OC\Files\Type;
 
 use OCP\Files\IMimeTypeDetector;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -311,7 +312,7 @@ class Detection implements IMimeTypeDetector {
 			return str_contains($info, ';') ? substr($info, 0, strpos($info, ';')) : $info;
 		}
 
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 		$fh = fopen($tmpFile, 'wb');
 		fwrite($fh, $data, 8024);
 		fclose($fh);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -65,6 +65,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\IStorage;
+use OCP\ITempManager;
 use OCP\IUser;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
@@ -997,7 +998,7 @@ class View {
 			$source = $this->fopen($path, 'r');
 			if ($source) {
 				$extension = pathinfo($path, PATHINFO_EXTENSION);
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($extension);
+				$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile($extension);
 				file_put_contents($tmpFile, $source);
 				return $tmpFile;
 			} else {

--- a/lib/private/Preview/Bundled.php
+++ b/lib/private/Preview/Bundled.php
@@ -25,6 +25,7 @@ namespace OC\Preview;
 use OC\Archive\ZIP;
 use OCP\Files\File;
 use OCP\IImage;
+use OCP\ITempManager;
 
 /**
  * Extracts a preview from files that embed them in an ZIP archive
@@ -35,8 +36,8 @@ abstract class Bundled extends ProviderV2 {
 			return null;
 		}
 
-		$sourceTmp = \OC::$server->getTempManager()->getTemporaryFile();
-		$targetTmp = \OC::$server->getTempManager()->getTemporaryFile();
+		$sourceTmp = \OC::$server->get(ITempManager::class)->getTemporaryFile();
+		$targetTmp = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 		$this->tmpFiles[] = $sourceTmp;
 		$this->tmpFiles[] = $targetTmp;
 

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -32,6 +32,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class Movie extends ProviderV2 {
@@ -120,7 +121,7 @@ class Movie extends ProviderV2 {
 	}
 
 	private function generateThumbNail(int $maxX, int $maxY, string $absPath, int $second): ?IImage {
-		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
+		$tmpPath = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
 

--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -31,6 +31,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 abstract class Office extends ProviderV2 {
@@ -51,7 +52,7 @@ abstract class Office extends ProviderV2 {
 
 		$absPath = $this->getLocalFile($file);
 
-		$tmpDir = \OC::$server->getTempManager()->getTempBaseDir();
+		$tmpDir = \OC::$server->get(ITempManager::class)->getTempBaseDir();
 
 		$defaultParameters = ' -env:UserInstallation=file://' . escapeshellarg($tmpDir . '/owncloud-' . \OC_Util::getInstanceId() . '/') . ' --headless --nologo --nofirststartwizard --invisible --norestore --convert-to png --outdir ';
 		$clParameters = \OC::$server->getConfig()->getSystemValue('preview_office_cl_parameters', $defaultParameters);

--- a/lib/private/Preview/ProviderV2.php
+++ b/lib/private/Preview/ProviderV2.php
@@ -28,6 +28,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\ITempManager;
 use OCP\Preview\IProviderV2;
 
 abstract class ProviderV2 implements IProviderV2 {
@@ -85,7 +86,7 @@ abstract class ProviderV2 implements IProviderV2 {
 	 */
 	protected function getLocalFile(File $file, int $maxSize = null) {
 		if ($this->useTempFile($file)) {
-			$absPath = \OC::$server->getTempManager()->getTemporaryFile();
+			$absPath = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 
 			$content = $file->fopen('r');
 

--- a/lib/private/Search/Result/File.php
+++ b/lib/private/Search/Result/File.php
@@ -29,6 +29,7 @@ namespace OC\Search\Result;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\IPreview;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 
 /**
@@ -97,7 +98,7 @@ class File extends \OCP\Search\Result {
 
 		$this->id = $data->getId();
 		$this->name = $data->getName();
-		$this->link = \OC::$server->getURLGenerator()->linkToRoute(
+		$this->link = \OC::$server->get(IURLGenerator::class)->linkToRoute(
 			'files.view.index',
 			[
 				'dir' => dirname($path),

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -44,6 +44,7 @@ use OCA\Talk\Share\RoomShareProvider;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
+use OCP\IURLGenerator;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
@@ -103,7 +104,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getMailer(),
 				$this->serverContainer->query(Defaults::class),
 				$this->serverContainer->getL10NFactory(),
-				$this->serverContainer->getURLGenerator(),
+				$this->serverContainer->get(IURLGenerator::class),
 				$this->serverContainer->getConfig()
 			);
 		}
@@ -131,7 +132,7 @@ class ProviderFactory implements IProviderFactory {
 			 */
 			$l = $this->serverContainer->getL10N('federatedfilesharing');
 			$addressHandler = new AddressHandler(
-				$this->serverContainer->getURLGenerator(),
+				$this->serverContainer->get(IURLGenerator::class),
 				$l,
 				$this->serverContainer->getCloudIdManager()
 			);
@@ -194,7 +195,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getL10N('sharebymail'),
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getMailer(),
-				$this->serverContainer->getURLGenerator(),
+				$this->serverContainer->get(IURLGenerator::class),
 				$this->serverContainer->getActivityManager(),
 				$settingsManager,
 				$this->serverContainer->query(Defaults::class),
@@ -235,7 +236,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getL10N('circles'),
 				$this->serverContainer->getLogger(),
-				$this->serverContainer->getURLGenerator()
+				$this->serverContainer->get(IURLGenerator::class)
 			);
 		}
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -52,6 +52,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\INavigationManager;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
@@ -233,7 +234,7 @@ class TemplateLayout extends \OC_Template {
 				$this->config,
 				\OC::$server->getGroupManager(),
 				\OC::$server->get(IniGetWrapper::class),
-				\OC::$server->getURLGenerator(),
+				\OC::$server->get(IURLGenerator::class),
 				\OC::$server->getCapabilitiesManager(),
 				\OCP\Server::get(IInitialStateService::class)
 			);
@@ -241,7 +242,7 @@ class TemplateLayout extends \OC_Template {
 			if (\OC::$server->getContentSecurityPolicyNonceManager()->browserSupportsCspV3()) {
 				$this->assign('inline_ocjs', $config);
 			} else {
-				$this->append('jsfiles', \OC::$server->getURLGenerator()->linkToRoute('core.OCJS.getConfig', ['v' => self::$versionHash]));
+				$this->append('jsfiles', \OC::$server->get(IURLGenerator::class)->linkToRoute('core.OCJS.getConfig', ['v' => self::$versionHash]));
 			}
 		}
 		foreach ($jsFiles as $info) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -112,7 +112,7 @@ class User implements IUser {
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
 		if (is_null($this->urlGenerator)) {
-			$this->urlGenerator = \OC::$server->getURLGenerator();
+			$this->urlGenerator = \OC::$server->get(IURLGenerator::class);
 		}
 		$this->dispatcher = $dispatcher;
 	}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -57,6 +57,7 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IURLGenerator;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -561,7 +562,7 @@ class OC_App {
 		$blacklist = $appManager->getAlwaysEnabledApps();
 		$appList = [];
 		$langCode = \OC::$server->getL10N('core')->getLanguageCode();
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OC::$server->get(IURLGenerator::class);
 		$supportedApps = $this->getSupportedApps();
 
 		foreach ($installedApps as $app) {

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -37,6 +37,8 @@
  *
  */
 
+use OCP\IURLGenerator;
+
 class OC_Defaults {
 	private $theme;
 
@@ -325,9 +327,9 @@ class OC_Defaults {
 		}
 
 		if ($useSvg) {
-			$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo/logo.svg');
+			$logo = \OC::$server->get(IURLGenerator::class)->imagePath('core', 'logo/logo.svg');
 		} else {
-			$logo = \OC::$server->getURLGenerator()->imagePath('core', 'logo/logo.png');
+			$logo = \OC::$server->get(IURLGenerator::class)->imagePath('core', 'logo/logo.png');
 		}
 		return $logo . '?v=' . hash('sha1', implode('.', \OCP\Util::getVersion()));
 	}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -522,7 +522,7 @@ class OC_Util {
 			\OC::$server->get(\OC\Installer::class)
 		);
 
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OC::$server->get(IURLGenerator::class);
 
 		$availableDatabases = $setup->getSupportedDatabases();
 		if (empty($availableDatabases)) {
@@ -782,7 +782,7 @@ class OC_Util {
 	public static function checkLoggedIn() {
 		// Check if we are a user
 		if (!\OC::$server->getUserSession()->isLoggedIn()) {
-			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
+			header('Location: ' . \OC::$server->get(IURLGenerator::class)->linkToRoute(
 				'core.login.showLoginForm',
 				[
 					'redirect_url' => \OC::$server->getRequest()->getRequestUri(),
@@ -793,7 +793,7 @@ class OC_Util {
 		}
 		// Redirect to 2FA challenge selection if 2FA challenge was not solved yet
 		if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
-			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.selectChallenge'));
+			header('Location: ' . \OC::$server->get(IURLGenerator::class)->linkToRoute('core.TwoFactorChallenge.selectChallenge'));
 			exit();
 		}
 	}
@@ -940,7 +940,7 @@ class OC_Util {
 		$testFile = $config->getSystemValueString('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
 
 		// accessing the file via http
-		$url = \OC::$server->getURLGenerator()->getAbsoluteURL(OC::$WEBROOT . '/data' . $fileName);
+		$url = \OC::$server->get(IURLGenerator::class)->getAbsoluteURL(OC::$WEBROOT . '/data' . $fileName);
 		try {
 			$content = \OC::$server->getHTTPClientService()->newClient()->get($url)->getBody();
 		} catch (\Exception $e) {

--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -34,6 +34,9 @@ use OCP\Util;
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IURLGenerator;
+
 function p($string) {
 	print(\OCP\Util::sanitizeHTML($string));
 }
@@ -226,7 +229,7 @@ function component($app, $file) {
  * For further information have a look at \OCP\IURLGenerator::linkTo
  */
 function link_to($app, $file, $args = []) {
-	return \OC::$server->getURLGenerator()->linkTo($app, $file, $args);
+	return \OC::$server->get(IURLGenerator::class)->linkTo($app, $file, $args);
 }
 
 /**
@@ -234,7 +237,7 @@ function link_to($app, $file, $args = []) {
  * @return string url to the online documentation
  */
 function link_to_docs($key) {
-	return \OC::$server->getURLGenerator()->linkToDocs($key);
+	return \OC::$server->get(IURLGenerator::class)->linkToDocs($key);
 }
 
 /**
@@ -246,7 +249,7 @@ function link_to_docs($key) {
  * For further information have a look at \OCP\IURLGenerator::imagePath
  */
 function image_path($app, $image) {
-	return \OC::$server->getURLGenerator()->imagePath($app, $image);
+	return \OC::$server->get(IURLGenerator::class)->imagePath($app, $image);
 }
 
 /**
@@ -265,7 +268,7 @@ function mimetype_icon($mimetype) {
  * @return string link to the preview
  */
 function preview_icon($path) {
-	return \OC::$server->getURLGenerator()->linkToRoute('core.Preview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path]);
+	return \OC::$server->get(IURLGenerator::class)->linkToRoute('core.Preview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path]);
 }
 
 /**
@@ -274,7 +277,7 @@ function preview_icon($path) {
  * @return string
  */
 function publicPreview_icon($path, $token) {
-	return \OC::$server->getURLGenerator()->linkToRoute('files_sharing.PublicPreview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path, 'token' => $token]);
+	return \OC::$server->get(IURLGenerator::class)->linkToRoute('files_sharing.PublicPreview.getPreview', ['x' => 32, 'y' => 32, 'file' => $path, 'token' => $token]);
 }
 
 /**

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -48,6 +48,7 @@ namespace OCP;
 
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
+use OCP\IURLGenerator;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -268,7 +269,7 @@ class Util {
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 */
 	public static function linkToAbsolute($app, $file, $args = []) {
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OC::$server->get(IURLGenerator::class);
 		return $urlGenerator->getAbsoluteURL(
 			$urlGenerator->linkTo($app, $file, $args)
 		);
@@ -281,7 +282,7 @@ class Util {
 	 * @since 4.0.0
 	 */
 	public static function linkToRemote($service) {
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OC::$server->get(IURLGenerator::class);
 		$remoteBase = $urlGenerator->linkTo('', 'remote.php') . '/' . $service;
 		return $urlGenerator->getAbsoluteURL(
 			$remoteBase . (($service[strlen($service) - 1] != '/') ? '/' : '')

--- a/ocm-provider/index.php
+++ b/ocm-provider/index.php
@@ -22,6 +22,8 @@
 
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IURLGenerator;
+
 header('Content-Type: application/json');
 
 $server = \OC::$server;
@@ -31,7 +33,7 @@ $isEnabled = $server->getAppManager()->isEnabledForUser('cloud_federation_api');
 if ($isEnabled) {
 	// Make sure the routes are loaded
 	\OC_App::loadApp('cloud_federation_api');
-	$capabilities = new OCA\CloudFederationAPI\Capabilities($server->getURLGenerator());
+	$capabilities = new OCA\CloudFederationAPI\Capabilities($server->get(IURLGenerator::class));
 	header('Content-Type: application/json');
 	echo json_encode($capabilities->getCapabilities()['ocm']);
 } else {

--- a/tests/lib/Archive/TARTest.php
+++ b/tests/lib/Archive/TARTest.php
@@ -9,6 +9,7 @@
 namespace Test\Archive;
 
 use OC\Archive\TAR;
+use OCP\ITempManager;
 
 class TARTest extends TestBase {
 	protected function getExisting() {
@@ -17,6 +18,6 @@ class TARTest extends TestBase {
 	}
 
 	protected function getNew() {
-		return new TAR(\OC::$server->getTempManager()->getTemporaryFile('.tar.gz'));
+		return new TAR(\OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz'));
 	}
 }

--- a/tests/lib/Archive/TestBase.php
+++ b/tests/lib/Archive/TestBase.php
@@ -8,6 +8,8 @@
 
 namespace Test\Archive;
 
+use OCP\ITempManager;
+
 abstract class TestBase extends \Test\TestCase {
 	/**
 	 * @var \OC\Archive\Archive
@@ -57,7 +59,7 @@ abstract class TestBase extends \Test\TestCase {
 		$textFile = $dir.'/lorem.txt';
 		$this->assertEquals(file_get_contents($textFile), $this->instance->getFile('lorem.txt'));
 
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('.txt');
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.txt');
 		$this->instance->extractFile('lorem.txt', $tmpFile);
 		$this->assertEquals(file_get_contents($textFile), file_get_contents($tmpFile));
 	}
@@ -111,7 +113,7 @@ abstract class TestBase extends \Test\TestCase {
 	public function testExtract() {
 		$dir = \OC::$SERVERROOT.'/tests/data';
 		$this->instance = $this->getExisting();
-		$tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->instance->extract($tmpDir);
 		$this->assertEquals(true, file_exists($tmpDir.'lorem.txt'));
 		$this->assertEquals(true, file_exists($tmpDir.'dir/lorem.txt'));

--- a/tests/lib/Archive/ZIPTest.php
+++ b/tests/lib/Archive/ZIPTest.php
@@ -9,6 +9,7 @@
 namespace Test\Archive;
 
 use OC\Archive\ZIP;
+use OCP\ITempManager;
 
 class ZIPTest extends TestBase {
 	protected function getExisting() {
@@ -17,6 +18,6 @@ class ZIPTest extends TestBase {
 	}
 
 	protected function getNew() {
-		return new ZIP(\OC::$server->getTempManager()->getTempBaseDir().'/newArchive.zip');
+		return new ZIP(\OC::$server->get(ITempManager::class)->getTempBaseDir().'/newArchive.zip');
 	}
 }

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -24,6 +24,7 @@ namespace Test\Cache;
 
 use OC\Files\Storage\Local;
 use OCP\Files\Mount\IMountManager;
+use OCP\ITempManager;
 use Test\Traits\UserTrait;
 
 /**
@@ -104,7 +105,7 @@ class FileCacheTest extends TestCache {
 	private function setupMockStorage() {
 		$mockStorage = $this->getMockBuilder(Local::class)
 			->setMethods(['filemtime', 'unlink'])
-			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
+			->setConstructorArgs([['datadir' => \OC::$server->get(ITempManager::class)->getTemporaryFolder()]])
 			->getMock();
 
 		\OC\Files\Filesystem::mount($mockStorage, [], '/test/cache');

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OC\Config;
+use OCP\ITempManager;
 
 class ConfigTest extends TestCase {
 	public const TESTCONTENT = '<?php $CONFIG=array("foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
@@ -23,7 +24,7 @@ class ConfigTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->randomTmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->randomTmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->configFile = $this->randomTmpDir.'testconfig.php';
 		file_put_contents($this->configFile, self::TESTCONTENT);
 	}

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -8,6 +8,8 @@
 
 namespace Test\Files\Cache;
 
+use OCP\ITempManager;
+
 class DummyUser extends \OC\User\User {
 	/**
 	 * @var string $home
@@ -69,7 +71,7 @@ class HomeCacheTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->user = new DummyUser('foo', \OC::$server->getTempManager()->getTemporaryFolder());
+		$this->user = new DummyUser('foo', \OC::$server->get(ITempManager::class)->getTemporaryFolder());
 		$this->storage = new \OC\Files\Storage\Home(['user' => $this->user]);
 		$this->cache = $this->storage->getCache();
 	}

--- a/tests/lib/Files/Cache/LocalRootScannerTest.php
+++ b/tests/lib/Files/Cache/LocalRootScannerTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Test\Files\Cache;
 
 use OC\Files\Storage\LocalRootStorage;
+use OCP\ITempManager;
 use Test\TestCase;
 
 /**
@@ -36,7 +37,7 @@ class LocalRootScannerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$folder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$folder = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->storage = new LocalRootStorage(['datadir' => $folder]);
 	}
 

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -10,6 +10,7 @@ namespace Test\Files;
 
 use OC\Files\Filesystem;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ITempManager;
 use OCA\Files_Sharing\AppInfo\Application;
 use Psr\Log\LoggerInterface;
 
@@ -42,7 +43,7 @@ class EtagTest extends \Test\TestCase {
 
 		$config = \OC::$server->getConfig();
 		$this->datadir = $config->getSystemValueString('datadirectory');
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$config->setSystemValue('datadirectory', $this->tmpDir);
 
 		$this->userBackend = new \Test\Util\User\Dummy();

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -27,6 +27,7 @@ use OC\Files\Storage\Temporary;
 use OC\User\NoUserException;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\ITempManager;
 use OCP\IUser;
 
 class DummyMountProvider implements IMountProvider {
@@ -71,7 +72,7 @@ class FilesystemTest extends \Test\TestCase {
 	 * @return array
 	 */
 	private function getStorageData() {
-		$dir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$dir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tmpDirs[] = $dir;
 		return ['datadir' => $dir];
 	}
@@ -329,7 +330,7 @@ class FilesystemTest extends \Test\TestCase {
 		\OC\Files\Filesystem::mkdir('/bar');
 //		\OC\Files\Filesystem::file_put_contents('/bar//foo', 'foo');
 
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile();
 		file_put_contents($tmpFile, 'foo');
 		$fh = fopen($tmpFile, 'r');
 //		\OC\Files\Filesystem::file_put_contents('/bar//foo', $fh);
@@ -459,7 +460,7 @@ class FilesystemTest extends \Test\TestCase {
 		$config = \OC::$server->getConfig();
 		$oldCachePath = $config->getSystemValueString('cache_path', '');
 		// set cache path to temp dir
-		$cachePath = \OC::$server->getTempManager()->getTemporaryFolder() . '/extcache';
+		$cachePath = \OC::$server->get(ITempManager::class)->getTemporaryFolder() . '/extcache';
 		$config->setSystemValue('cache_path', $cachePath);
 
 		\OC::$server->getUserManager()->createUser($userId, $userId);

--- a/tests/lib/Files/Storage/CommonTest.php
+++ b/tests/lib/Files/Storage/CommonTest.php
@@ -24,6 +24,7 @@ namespace Test\Files\Storage;
 
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\ITempManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -42,7 +43,7 @@ class CommonTest extends Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->instance = new \OC\Files\Storage\CommonTest(['datadir' => $this->tmpDir]);
 	}
 

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -23,6 +23,7 @@
 namespace Test\Files\Storage;
 
 use OC\User\User;
+use OCP\ITempManager;
 
 class DummyUser extends User {
 	private $home;
@@ -70,7 +71,7 @@ class HomeTest extends Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->userId = $this->getUniqueID('user_');
 		$this->user = new DummyUser($this->userId, $this->tmpDir);
 		$this->instance = new \OC\Files\Storage\Home(['user' => $this->user]);

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -22,6 +22,8 @@
 
 namespace Test\Files\Storage;
 
+use OCP\ITempManager;
+
 /**
  * Class LocalTest
  *
@@ -38,7 +40,7 @@ class LocalTest extends Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->instance = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir]);
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -19,6 +19,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 use Test\Files\Storage\Storage;
 
@@ -758,7 +759,7 @@ class EncryptionTest extends Storage {
 		$storage2->expects($this->any())
 			->method('fopen')
 			->willReturnCallback(function ($path, $mode) {
-				$temp = \OC::$server->getTempManager();
+				$temp = \OC::$server->get(ITempManager::class);
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
 		$storage2->method('getId')
@@ -807,7 +808,7 @@ class EncryptionTest extends Storage {
 		$storage2->expects($this->any())
 			->method('fopen')
 			->willReturnCallback(function ($path, $mode) {
-				$temp = \OC::$server->getTempManager();
+				$temp = \OC::$server->get(ITempManager::class);
 				return fopen($temp->getTemporaryFile(), $mode);
 			});
 		$storage2->method('getId')

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -11,6 +11,7 @@ namespace Test\Files\Storage\Wrapper;
 //ensure the constants are loaded
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
+use OCP\ITempManager;
 
 \OC::$loader->load('\OC\Files\Filesystem');
 
@@ -30,7 +31,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$storage = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir]);
 		$this->instance = new \OC\Files\Storage\Wrapper\Quota(['storage' => $storage, 'quota' => 10000000]);
 	}

--- a/tests/lib/Files/Storage/Wrapper/WrapperTest.php
+++ b/tests/lib/Files/Storage/Wrapper/WrapperTest.php
@@ -8,6 +8,8 @@
 
 namespace Test\Files\Storage\Wrapper;
 
+use OCP\ITempManager;
+
 class WrapperTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var string tmpDir
@@ -17,7 +19,7 @@ class WrapperTest extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->tmpDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$storage = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir]);
 		$this->instance = new \OC\Files\Storage\Wrapper\Wrapper(['storage' => $storage]);
 	}

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -32,7 +32,7 @@ class DetectionTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->detection = new Detection(
-			\OC::$server->getURLGenerator(),
+			\OC::$server->get(IURLGenerator::class),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$SERVERROOT . '/config/',
 			\OC::$SERVERROOT . '/resources/config/'

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -23,6 +23,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
+use OCP\ITempManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share\IShare;
@@ -826,7 +827,7 @@ class ViewTest extends \Test\TestCase {
 		 * 1024 is the max path length in mac
 		 */
 		$folderName = 'abcdefghijklmnopqrstuvwxyz012345678901234567890123456789';
-		$tmpdirLength = strlen(\OC::$server->getTempManager()->getTemporaryFolder());
+		$tmpdirLength = strlen(\OC::$server->get(ITempManager::class)->getTemporaryFolder());
 		if (\OC_Util::runningOnMac()) {
 			$depth = ((1024 - $tmpdirLength) / 57);
 		} else {

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -53,7 +53,7 @@ class InstallerTest extends TestCase {
 		$installer = new Installer(
 			\OC::$server->getAppFetcher(),
 			\OC::$server->getHTTPClientService(),
-			\OC::$server->getTempManager(),
+			\OC::$server->get(ITempManager::class),
 			\OC::$server->get(LoggerInterface::class),
 			$config,
 			false
@@ -76,7 +76,7 @@ class InstallerTest extends TestCase {
 		$installer = new Installer(
 			\OC::$server->getAppFetcher(),
 			\OC::$server->getHTTPClientService(),
-			\OC::$server->getTempManager(),
+			\OC::$server->get(ITempManager::class),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->getConfig(),
 			false
@@ -100,7 +100,7 @@ class InstallerTest extends TestCase {
 		$installer = new Installer(
 			\OC::$server->getAppFetcher(),
 			\OC::$server->getHTTPClientService(),
-			\OC::$server->getTempManager(),
+			\OC::$server->get(ITempManager::class),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->getConfig(),
 			false
@@ -338,7 +338,7 @@ u/spPSSVhaun5BA1FlphB2TkgnzlCmxJa63nFY045e/Jq+IKMcqqZl/092gbI2EQ
 			->expects($this->once())
 			->method('get')
 			->willReturn($appArray);
-		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
+		$realTmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp.tar.gz', $realTmpFile);
 		$this->tempManager
 			->expects($this->once())
@@ -416,14 +416,14 @@ YwDVP+QmNRzx72jtqAN/Kc3CvQ9nkgYhU65B95aX0xA=',
 			->expects($this->once())
 			->method('get')
 			->willReturn($appArray);
-		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
+		$realTmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp1.tar.gz', $realTmpFile);
 		$this->tempManager
 			->expects($this->once())
 			->method('getTemporaryFile')
 			->with('.tar.gz')
 			->willReturn($realTmpFile);
-		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$realTmpFolder = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		mkdir($realTmpFolder . '/testfolder');
 		$this->tempManager
 			->expects($this->once())
@@ -500,14 +500,14 @@ YwDVP+QmNRzx72jtqAN/Kc3CvQ9nkgYhU65B95aX0xA=',
 			->expects($this->once())
 			->method('get')
 			->willReturn($appArray);
-		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
+		$realTmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp1.tar.gz', $realTmpFile);
 		$this->tempManager
 			->expects($this->once())
 			->method('getTemporaryFile')
 			->with('.tar.gz')
 			->willReturn($realTmpFile);
-		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$realTmpFolder = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tempManager
 			->expects($this->once())
 			->method('getTemporaryFolder')
@@ -579,14 +579,14 @@ MPLX6f5V9tCJtlH6ztmEcDROfvuVc0U3rEhqx2hphoyo+MZrPFpdcJL8KkIdMKbY
 			->expects($this->atLeastOnce())
 			->method('get')
 			->willReturnOnConsecutiveCalls($appArray);
-		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
+		$realTmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp.tar.gz', $realTmpFile);
 		$this->tempManager
 			->expects($this->atLeastOnce())
 			->method('getTemporaryFile')
 			->with('.tar.gz')
 			->willReturnOnConsecutiveCalls($realTmpFile);
-		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$realTmpFolder = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tempManager
 			->expects($this->atLeastOnce())
 			->method('getTemporaryFolder')
@@ -665,14 +665,14 @@ JXhrdaWDZ8fzpUjugrtC3qslsqL0dzgU37anS3HwrT8=',
 			->expects($this->at(1))
 			->method('get')
 			->willReturn($appArray);
-		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
+		$realTmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp.0.8.tar.gz', $realTmpFile);
 		$this->tempManager
 			->expects($this->at(2))
 			->method('getTemporaryFile')
 			->with('.tar.gz')
 			->willReturn($realTmpFile);
-		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$realTmpFolder = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		$this->tempManager
 			->expects($this->at(3))
 			->method('getTemporaryFolder')

--- a/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
+++ b/tests/lib/IntegrityCheck/Helpers/FileAccessHelperTest.php
@@ -22,6 +22,7 @@
 namespace Test\IntegrityCheck\Helpers;
 
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OCP\ITempManager;
 use Test\TestCase;
 
 class FileAccessHelperTest extends TestCase {
@@ -34,7 +35,7 @@ class FileAccessHelperTest extends TestCase {
 	}
 
 	public function testReadAndWrite() {
-		$tempManager = \OC::$server->getTempManager();
+		$tempManager = \OC::$server->get(ITempManager::class);
 		$filePath = $tempManager->getTemporaryFile();
 		$data = 'SomeDataGeneratedByIntegrityCheck';
 
@@ -52,7 +53,7 @@ class FileAccessHelperTest extends TestCase {
 
 	public function testIs_writable() {
 		$this->assertFalse($this->fileAccessHelper->is_writable('/anabsolutelynotexistingfolder/on/the/system.txt'));
-		$this->assertTrue($this->fileAccessHelper->is_writable(\OC::$server->getTempManager()->getTemporaryFile('MyFile')));
+		$this->assertTrue($this->fileAccessHelper->is_writable(\OC::$server->get(ITempManager::class)->getTemporaryFile('MyFile')));
 	}
 
 	
@@ -64,7 +65,7 @@ class FileAccessHelperTest extends TestCase {
 	}
 
 	public function testAssertDirectoryExists() {
-		$this->fileAccessHelper->assertDirectoryExists(\OC::$server->getTempManager()->getTemporaryFolder('/testfolder/'));
+		$this->fileAccessHelper->assertDirectoryExists(\OC::$server->get(ITempManager::class)->getTemporaryFolder('/testfolder/'));
 		$this->addToAssertionCount(1);
 	}
 }

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\Files\View;
 use OC_Helper;
+use OCP\ITempManager;
 
 class LegacyHelperTest extends \Test\TestCase {
 	/** @var string */
@@ -241,7 +242,7 @@ class LegacyHelperTest extends \Test\TestCase {
 	 * Tests recursive folder deletion with rmdirr()
 	 */
 	public function testRecursiveFolderDeletion() {
-		$baseDir = \OC::$server->getTempManager()->getTemporaryFolder() . '/';
+		$baseDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder() . '/';
 		mkdir($baseDir . 'a/b/c/d/e', 0777, true);
 		mkdir($baseDir . 'a/b/c1/d/e', 0777, true);
 		mkdir($baseDir . 'a/b/c2/d/e', 0777, true);

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -32,6 +32,7 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
@@ -529,7 +530,7 @@ var b = \'world\';
 
 	public function testGetContent() {
 		// Create temporary file with some content
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('JSCombinerTest');
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('JSCombinerTest');
 		$pathInfo = pathinfo($tmpFile);
 		file_put_contents($tmpFile, json_encode(['/foo/bar/test', $pathInfo['dirname'] . '/js/mytest.js']));
 		$tmpFilePathArray = explode('/', $pathInfo['basename']);
@@ -544,7 +545,7 @@ var b = \'world\';
 
 	public function testGetContentInvalidJson() {
 		// Create temporary file with some content
-		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('JSCombinerTest');
+		$tmpFile = \OC::$server->get(ITempManager::class)->getTemporaryFile('JSCombinerTest');
 		$pathInfo = pathinfo($tmpFile);
 		file_put_contents($tmpFile, 'CertainlyNotJson');
 		$expected = [];

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -8,6 +8,8 @@
 
 namespace Test;
 
+use OCP\ITempManager;
+
 /**
  * Tests for server check functions
  *
@@ -38,7 +40,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->datadir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->datadir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 
 		file_put_contents($this->datadir . '/.ocdata', '');
 		\OC::$server->getSession()->set('checkServer_succeeded', false);

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OC_Util;
+use OCP\ITempManager;
 
 /**
  * Class UtilTest
@@ -204,13 +205,13 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testCheckDataDirectoryValidity() {
-		$dataDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$dataDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		touch($dataDir . '/.ocdata');
 		$errors = \OC_Util::checkDataDirectoryValidity($dataDir);
 		$this->assertEmpty($errors);
 		\OCP\Files::rmdirr($dataDir);
 
-		$dataDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$dataDir = \OC::$server->get(ITempManager::class)->getTemporaryFolder();
 		// no touch
 		$errors = \OC_Util::checkDataDirectoryValidity($dataDir);
 		$this->assertNotEmpty($errors);


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getURLGenerator` and replaces it with `OC\Server::get(\OCP\IURLGenerator::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IURLGenerator` class is imported via the `use` directive.