### PR TITLE
Refactor `OC\Server::getUserSession`

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -53,6 +53,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Mail\IMailer;
 use OCP\Security\VerificationToken\IVerificationToken;
 use OCP\Security\VerificationToken\InvalidTokenException;
@@ -239,7 +240,7 @@ class LostController extends Controller {
 			$this->twoFactorManager->clearTwoFactorPending($userId);
 
 			$this->config->deleteUserValue($userId, 'core', 'lostpassword');
-			@\OC::$server->getUserSession()->unsetMagicInCookie();
+			@\OC::$server->get(IUserSession::class)->unsetMagicInCookie();
 		} catch (HintException $e) {
 			$response = new JSONResponse($this->error($e->getHint()));
 			$response->throttle();

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -252,9 +252,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c->get(IURLGenerator::class),
 				$server->get(LoggerInterface::class),
 				$c->get('AppName'),
-				$server->getUserSession()->isLoggedIn(),
+				$server->get(IUserSession::class)->isLoggedIn(),
 				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
-				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
+				$server->get(IUserSession::class)->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->get(IUserSession::class)->getUser()),
 				$server->getAppManager(),
 				$server->getL10N('lib'),
 				$c->get(AuthorizedGroupMapper::class),
@@ -387,7 +387,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @return boolean
 	 */
 	public function isLoggedIn() {
-		return \OC::$server->getUserSession()->isLoggedIn();
+		return \OC::$server->get(IUserSession::class)->isLoggedIn();
 	}
 
 	/**

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -44,6 +44,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use function array_diff;
@@ -257,7 +258,7 @@ class Manager {
 		if ($passed) {
 			if ($this->session->get(self::REMEMBER_LOGIN) === true) {
 				// TODO: resolve cyclic dependency and use DI
-				\OC::$server->getUserSession()->createRememberMeToken($user);
+				\OC::$server->get(IUserSession::class)->createRememberMeToken($user);
 			}
 			$this->session->remove(self::SESSION_UID_KEY);
 			$this->session->remove(self::REMEMBER_LOGIN);

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -32,6 +32,7 @@ namespace OC\Cache;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\ICache;
+use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -50,9 +51,9 @@ class File implements ICache {
 		if ($this->storage !== null) {
 			return $this->storage;
 		}
-		if (\OC::$server->getUserSession()->isLoggedIn()) {
+		if (\OC::$server->get(IUserSession::class)->isLoggedIn()) {
 			$rootView = new View();
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			Filesystem::initMountPoints($user->getUID());
 			if (!$rootView->file_exists('/' . $user->getUID() . '/cache')) {
 				$rootView->mkdir('/' . $user->getUID() . '/cache');

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -30,6 +30,7 @@ use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,7 +77,7 @@ class EncryptionWrapper {
 		];
 
 		if (!$storage->instanceOfStorage(Storage\IDisableEncryptionStorage::class) && $mountPoint !== '/') {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			$mountManager = Filesystem::getMountManager();
 			$uid = $user ? $user->getUID() : null;
 			$fileHelper = \OC::$server->getEncryptionFilesHelper();

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -26,6 +26,7 @@ namespace OC\Encryption;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class HookManager {
@@ -52,7 +53,7 @@ class HookManager {
 
 	private static function getUpdate(?string $owner = null): Update {
 		if (is_null(self::$updater)) {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 			if (!$user && $owner) {
 				$user = \OC::$server->getUserManager()->get($owner);
 			}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -60,6 +60,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
 use OCP\IL10N;
+use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -431,7 +432,7 @@ class Setup {
 			// Create a session token for the newly created user
 			// The token provider requires a working db, so it's not injected on setup
 			/* @var $userSession User\Session */
-			$userSession = \OC::$server->getUserSession();
+			$userSession = \OC::$server->get(IUserSession::class);
 			$provider = \OCP\Server::get(PublicKeyTokenProvider::class);
 			$userSession->setTokenProvider($provider);
 			$userSession->login($username, $password);

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -39,6 +39,7 @@ use OCA\Files_Sharing\ShareBackend\File;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IUserSession;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
@@ -918,7 +919,7 @@ class Share extends Constants {
 			$statuses = [];
 			foreach ($items as $item) {
 				if ($item['share_type'] === IShare::TYPE_LINK) {
-					if ($item['uid_initiator'] !== \OC::$server->getUserSession()->getUser()->getUID()) {
+					if ($item['uid_initiator'] !== \OC::$server->get(IUserSession::class)->getUser()->getUID()) {
 						continue;
 					}
 					$statuses[$item[$column]]['link'] = true;

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -229,7 +229,7 @@ class TemplateLayout extends \OC_Template {
 				\OCP\Server::get(Defaults::class),
 				\OC::$server->getAppManager(),
 				\OC::$server->getSession(),
-				\OC::$server->getUserSession()->getUser(),
+				\OC::$server->get(IUserSession::class)->getUser(),
 				$this->config,
 				\OC::$server->getGroupManager(),
 				\OC::$server->get(IniGetWrapper::class),

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -57,6 +57,7 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IUserSession;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -225,7 +226,7 @@ class OC_App {
 		if ($all) {
 			$user = null;
 		} else {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = \OC::$server->get(IUserSession::class)->getUser();
 		}
 
 		if (is_null($user)) {
@@ -863,7 +864,7 @@ class OC_App {
 	 */
 	public static function getStorage(string $appId) {
 		if (\OC::$server->getAppManager()->isEnabledForUser($appId)) { //sanity check
-			if (\OC::$server->getUserSession()->isLoggedIn()) {
+			if (\OC::$server->get(IUserSession::class)->isLoggedIn()) {
 				$view = new \OC\Files\View('/' . OC_User::getUser());
 				if (!$view->file_exists($appId)) {
 					$view->mkdir($appId);

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -49,6 +49,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IBinaryFinder;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -526,7 +527,7 @@ class OC_Helper {
 				/** @var \OC\Files\Storage\Home $storage */
 				$user = $storage->getUser();
 			} else {
-				$user = \OC::$server->getUserSession()->getUser();
+				$user = \OC::$server->get(IUserSession::class)->getUser();
 			}
 			$quota = OC_Util::getUserQuota($user);
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IUserSession;
+
 class OC_JSON {
 	/**
 	 * Check if the app is enabled, send json error msg if not
@@ -49,8 +52,8 @@ class OC_JSON {
 	 */
 	public static function checkLoggedIn() {
 		$twoFactorAuthManger = \OC::$server->getTwoFactorAuthManager();
-		if (!\OC::$server->getUserSession()->isLoggedIn()
-			|| $twoFactorAuthManger->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
+		if (!\OC::$server->get(IUserSession::class)->isLoggedIn()
+			|| $twoFactorAuthManger->needsSecondFactor(\OC::$server->get(IUserSession::class)->getUser())) {
 			$l = \OC::$server->getL10N('lib');
 			http_response_code(\OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
 			self::error([ 'data' => [ 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' ]]);

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -40,6 +40,7 @@ use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\UserLoggedInEvent;
 
@@ -172,7 +173,7 @@ class OC_User {
 		if ($uid) {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
-				$userSession = \OC::$server->getUserSession();
+				$userSession = \OC::$server->get(IUserSession::class);
 
 				/** @var IEventDispatcher $dispatcher */
 				$dispatcher = \OC::$server->get(IEventDispatcher::class);
@@ -238,7 +239,7 @@ class OC_User {
 
 			//setup extra user backends
 			self::setupBackends();
-			\OC::$server->getUserSession()->unsetMagicInCookie();
+			\OC::$server->get(IUserSession::class)->unsetMagicInCookie();
 
 			return self::loginWithApache($backend);
 		}
@@ -253,7 +254,7 @@ class OC_User {
 	 * @param string $uid
 	 */
 	public static function setUserId($uid) {
-		$userSession = \OC::$server->getUserSession();
+		$userSession = \OC::$server->get(IUserSession::class);
 		$userManager = \OC::$server->getUserManager();
 		if ($user = $userManager->get($uid)) {
 			$userSession->setUser($user);
@@ -265,11 +266,11 @@ class OC_User {
 	/**
 	 * Check if the user is logged in, considers also the HTTP basic credentials
 	 *
-	 * @deprecated use \OC::$server->getUserSession()->isLoggedIn()
+	 * @deprecated use \OC::$server->get(IUserSession::class)->isLoggedIn()
 	 * @return bool
 	 */
 	public static function isLoggedIn() {
-		return \OC::$server->getUserSession()->isLoggedIn();
+		return \OC::$server->get(IUserSession::class)->isLoggedIn();
 	}
 
 	/**
@@ -302,7 +303,7 @@ class OC_User {
 			return $backend->getLogoutUrl();
 		}
 
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = \OC::$server->get(IUserSession::class)->getUser();
 		if ($user instanceof \OCP\IUser) {
 			$backend = $user->getBackend();
 			if ($backend instanceof \OCP\User\Backend\ICustomLogout) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -71,6 +71,7 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 
@@ -781,7 +782,7 @@ class OC_Util {
 	 */
 	public static function checkLoggedIn() {
 		// Check if we are a user
-		if (!\OC::$server->getUserSession()->isLoggedIn()) {
+		if (!\OC::$server->get(IUserSession::class)->isLoggedIn()) {
 			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
 				'core.login.showLoginForm',
 				[
@@ -792,7 +793,7 @@ class OC_Util {
 			exit();
 		}
 		// Redirect to 2FA challenge selection if 2FA challenge was not solved yet
-		if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
+		if (\OC::$server->getTwoFactorAuthManager()->needsSecondFactor(\OC::$server->get(IUserSession::class)->getUser())) {
 			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.selectChallenge'));
 			exit();
 		}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -48,6 +48,7 @@ namespace OCP;
 
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
+use OCP\IUserSession;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -134,7 +135,7 @@ class Util {
 			self::$shareManager = \OC::$server->getShareManager();
 		}
 
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = \OC::$server->get(IUserSession::class)->getUser();
 		if ($user !== null) {
 			$user = $user->getUID();
 		}

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,6 +30,8 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IUserSession;
+
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getConfig()->getSystemValueBool('maintenance')) {
 	// since the behavior of apps or remotes are unpredictable during
@@ -57,7 +59,7 @@ try {
 	// side effects in existing apps
 	OC_App::loadApps();
 
-	if (!\OC::$server->getUserSession()->isLoggedIn()) {
+	if (!\OC::$server->get(IUserSession::class)->isLoggedIn()) {
 		OC::handleLogin(\OC::$server->getRequest());
 	}
 

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -14,6 +14,7 @@ use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -555,7 +556,7 @@ class AppTest extends \Test\TestCase {
 	private function registerAppConfig(AppConfig $appConfig) {
 		$this->overwriteService(AppConfig::class, $appConfig);
 		$this->overwriteService(AppManager::class, new AppManager(
-			\OC::$server->getUserSession(),
+			\OC::$server->get(IUserSession::class),
 			\OC::$server->getConfig(),
 			$appConfig,
 			\OC::$server->getGroupManager(),

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -28,6 +28,7 @@ use OC\User\NoUserException;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
+use OCP\IUserSession;
 
 class DummyMountProvider implements IMountProvider {
 	private $mounts = [];
@@ -313,7 +314,7 @@ class FilesystemTest extends \Test\TestCase {
 			\OC_User::useBackend($backend);
 			$backend->createUser($user, $user);
 			$userObj = \OC::$server->getUserManager()->get($user);
-			\OC::$server->getUserSession()->setUser($userObj);
+			\OC::$server->get(IUserSession::class)->setUser($userObj);
 			\OC\Files\Filesystem::init($user, '/' . $user . '/files');
 		}
 		\OC_Hook::clear('OC_Filesystem');

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -38,6 +38,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -425,7 +426,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		// needed for fully logout
-		\OC::$server->getUserSession()->setUser(null);
+		\OC::$server->get(IUserSession::class)->setUser(null);
 	}
 
 	/**

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -16,6 +16,7 @@ use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
 use OCP\Encryption\IManager;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -52,7 +53,7 @@ trait EncryptionTrait {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		// needed for fully logout
-		\OC::$server->getUserSession()->setUser(null);
+		\OC::$server->get(IUserSession::class)->setUser(null);
 
 		$this->setupManager->tearDown();
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getUserSession` and replaces it with `OC\Server::get(\OCP\IUserSession::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IUserSession` class is imported via the `use` directive.