### PR TITLE
Refactor `OC\Server::getSession`

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -39,6 +39,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\User\Session;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -54,7 +56,7 @@ try {
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 
-	\OC::$server->getSession()->close();
+	\OC::$server->get(Session::class)->getSession()->close();
 
 	// initialize a dummy memory session
 	$session = new \OC\Session\Memory('');

--- a/lib/base.php
+++ b/lib/base.php
@@ -68,6 +68,7 @@ declare(strict_types=1);
 
 use OC\Encryption\HookManager;
 use OC\Share20\Hooks;
+use OC\User\Session;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\ILogger;
@@ -754,7 +755,7 @@ class OC {
 
 		// User and Groups
 		if (!$systemConfig->getValue("installed", false)) {
-			self::$server->getSession()->set('user_id', '');
+			self::$server->get(Session::class)->getSession()->set('user_id', '');
 		}
 
 		OC_User::useBackend(new \OC\User\Database());
@@ -990,7 +991,7 @@ class OC {
 
 		// Check if Nextcloud is installed or in maintenance (update) mode
 		if (!$systemConfig->getValue('installed', false)) {
-			\OC::$server->getSession()->clear();
+			\OC::$server->get(Session::class)->getSession()->clear();
 			$setupHelper = new OC\Setup(
 				$systemConfig,
 				Server::get(\bantu\IniGetWrapper\IniGetWrapper::class),

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -50,6 +50,7 @@ use OC\Diagnostics\EventLogger;
 use OC\Log\PsrLoggerAdapter;
 use OC\ServerContainer;
 use OC\Settings\AuthorizedGroupMapper;
+use OC\User\Session;
 use OCA\WorkflowEngine\Manager;
 use OCP\AppFramework\Http\IOutput;
 use OCP\AppFramework\IAppContainer;
@@ -400,7 +401,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	}
 
 	private function getUserId() {
-		return $this->getServer()->getSession()->get('user_id');
+		return $this->getServer()->get(Session::class)->getSession()->get('user_id');
 	}
 
 	/**

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -47,6 +47,7 @@ use OC\Search\SearchQuery;
 use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;
 use OC\Template\JSResourceLocator;
+use OC\User\Session;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -228,7 +229,7 @@ class TemplateLayout extends \OC_Template {
 				\OC::$server->getL10N('lib'),
 				\OCP\Server::get(Defaults::class),
 				\OC::$server->getAppManager(),
-				\OC::$server->getSession(),
+				\OC::$server->get(Session::class)->getSession(),
 				\OC::$server->getUserSession()->getUser(),
 				$this->config,
 				\OC::$server->getGroupManager(),

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -38,6 +38,7 @@
  *
  */
 use OC\TemplateLayout;
+use OC\User\Session;
 use OCP\AppFramework\Http\TemplateResponse;
 
 require_once __DIR__.'/template/functions.php';
@@ -72,7 +73,7 @@ class OC_Template extends \OC\Template\Base {
 	public function __construct($app, $name, $renderAs = TemplateResponse::RENDER_AS_BLANK, $registerCall = true) {
 		$theme = OC_Util::getTheme();
 
-		$requestToken = (OC::$server->getSession() && $registerCall) ? \OCP\Util::callRegister() : '';
+		$requestToken = (OC::$server->get(Session::class)->getSession() && $registerCall) ? \OCP\Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = \OC::$server->getL10N($parts[0]);

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -37,6 +37,7 @@
  */
 
 use OC\User\LoginException;
+use OC\User\Session;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IUserManager;
@@ -258,7 +259,7 @@ class OC_User {
 		if ($user = $userManager->get($uid)) {
 			$userSession->setUser($user);
 		} else {
-			\OC::$server->getSession()->set('user_id', $uid);
+			\OC::$server->get(Session::class)->getSession()->set('user_id', $uid);
 		}
 	}
 
@@ -338,7 +339,7 @@ class OC_User {
 	 * @return string|false uid or false
 	 */
 	public static function getUser() {
-		$uid = \OC::$server->getSession() ? \OC::$server->getSession()->get('user_id') : null;
+		$uid = \OC::$server->get(Session::class)->getSession() ? \OC::$server->get(Session::class)->getSession()->get('user_id') : null;
 		if (!is_null($uid) && self::$incognitoMode === false) {
 			return $uid;
 		} else {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -66,6 +66,7 @@
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\SetupManager;
+use OC\User\Session;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -507,7 +508,7 @@ class OC_Util {
 		}
 
 		// Assume that if checkServer() succeeded before in this session, then all is fine.
-		if (\OC::$server->getSession()->exists('checkServer_succeeded') && \OC::$server->getSession()->get('checkServer_succeeded')) {
+		if (\OC::$server->get(Session::class)->getSession()->exists('checkServer_succeeded') && \OC::$server->get(Session::class)->getSession()->get('checkServer_succeeded')) {
 			return $errors;
 		}
 
@@ -715,7 +716,7 @@ class OC_Util {
 		}
 
 		// Cache the result of this function
-		\OC::$server->getSession()->set('checkServer_succeeded', count($errors) == 0);
+		\OC::$server->get(Session::class)->getSession()->set('checkServer_succeeded', count($errors) == 0);
 
 		return $errors;
 	}

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -8,6 +8,8 @@
 
 namespace Test;
 
+use OC\User\Session;
+
 /**
  * Tests for server check functions
  *
@@ -41,7 +43,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 		$this->datadir = \OC::$server->getTempManager()->getTemporaryFolder();
 
 		file_put_contents($this->datadir . '/.ocdata', '');
-		\OC::$server->getSession()->set('checkServer_succeeded', false);
+		\OC::$server->get(Session::class)->getSession()->set('checkServer_succeeded', false);
 	}
 
 	protected function tearDown(): void {
@@ -86,7 +88,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 		// simulate old version that didn't have it
 		unlink($this->datadir . '/.ocdata');
 
-		$session = \OC::$server->getSession();
+		$session = \OC::$server->get(Session::class)->getSession();
 		$oldCurrentVersion = $session->get('OC_Version');
 
 		// upgrade condition to simulate needUpgrade() === true

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\User\Session;
 use OC_Util;
 
 /**
@@ -186,18 +187,18 @@ class UtilTest extends \Test\TestCase {
 	public function testNeedUpgradeCore() {
 		$config = \OC::$server->getConfig();
 		$oldConfigVersion = $config->getSystemValue('version', '0.0.0');
-		$oldSessionVersion = \OC::$server->getSession()->get('OC_Version');
+		$oldSessionVersion = \OC::$server->get(Session::class)->getSession()->get('OC_Version');
 
 		$this->assertFalse(\OCP\Util::needUpgrade());
 
 		$config->setSystemValue('version', '7.0.0.0');
-		\OC::$server->getSession()->set('OC_Version', [7, 0, 0, 1]);
+		\OC::$server->get(Session::class)->getSession()->set('OC_Version', [7, 0, 0, 1]);
 		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', [null]);
 
 		$this->assertTrue(\OCP\Util::needUpgrade());
 
 		$config->setSystemValue('version', $oldConfigVersion);
-		\OC::$server->getSession()->set('OC_Version', $oldSessionVersion);
+		\OC::$server->get(Session::class)->getSession()->set('OC_Version', $oldSessionVersion);
 		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', [null]);
 
 		$this->assertFalse(\OCP\Util::needUpgrade());

--- a/tests/startsessionlistener.php
+++ b/tests/startsessionlistener.php
@@ -7,6 +7,7 @@
  */
 
 use OC\Session\Memory;
+use OC\User\Session;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestListenerDefaultImplementation;
@@ -19,9 +20,9 @@ class StartSessionListener implements TestListener {
 
 	public function endTest(Test $test, float $time): void {
 		// reopen the session - only allowed for memory session
-		if (\OC::$server->getSession() instanceof Memory) {
+		if (\OC::$server->get(Session::class)->getSession() instanceof Memory) {
 			/** @var $session Memory */
-			$session = \OC::$server->getSession();
+			$session = \OC::$server->get(Session::class)->getSession();
 			$session->reopen();
 		}
 	}


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getSession` and replaces it with `OC\Server::get(\OC\User\Session::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OC\User\Session` class is imported via the `use` directive.