### PR TITLE
Refactor `OC\Server::getSystemConfig`

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -44,6 +44,7 @@ use OC\Repair\Events\RepairInfoEvent;
 use OC\Repair\Events\RepairStartEvent;
 use OC\Repair\Events\RepairStepEvent;
 use OC\Repair\Events\RepairWarningEvent;
+use OC\SystemConfig;
 use OCP\L10N\IFactory;
 
 if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
@@ -100,7 +101,7 @@ class FeedBackHandler {
 }
 
 if (\OCP\Util::needUpgrade()) {
-	$config = \OC::$server->getSystemConfig();
+	$config = \OC::$server->get(SystemConfig::class);
 	if ($config->getValue('upgrade.disable-web', false)) {
 		$eventSource->send('failure', $l->t('Please use the command line updater because updating via browser is disabled in your config.php.'));
 		$eventSource->close();

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,11 +48,13 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\SystemConfig;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
 $application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
-$application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
+$application->add(new OC\Core\Command\Check(\OC::$server->get(SystemConfig::class)));
 $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(
 	\OC::$server->getIntegrityCodeChecker(),
@@ -98,15 +100,15 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\App\SetConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\Import(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->getSystemConfig(), \OC::$server->getAppConfig()));
-	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
+	$application->add(new OC\Core\Command\Config\ListConfigs(\OC::$server->get(SystemConfig::class), \OC::$server->getAppConfig()));
+	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->get(SystemConfig::class)));
+	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->get(SystemConfig::class)));
+	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->get(SystemConfig::class)));
 
 	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
 	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
 
-	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
+	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->get(SystemConfig::class))));
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));
 	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingColumns::class));

--- a/cron.php
+++ b/cron.php
@@ -39,6 +39,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\SystemConfig;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -46,7 +48,7 @@ try {
 		\OC::$server->getLogger()->debug('Update required, skipping cron', ['app' => 'cron']);
 		exit;
 	}
-	if ((bool) \OC::$server->getSystemConfig()->getValue('maintenance', false)) {
+	if ((bool) \OC::$server->get(SystemConfig::class)->getValue('maintenance', false)) {
 		\OC::$server->getLogger()->debug('We are in maintenance mode, skipping cron', ['app' => 'cron']);
 		exit;
 	}

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -32,6 +32,7 @@ namespace OC\Console;
 
 use OC\MemoryInfo;
 use OC\NeedsUpdateException;
+use OC\SystemConfig;
 use OC_App;
 use OCP\App\IAppManager;
 use OCP\Console\ConsoleEvent;
@@ -157,7 +158,7 @@ class Application {
 		}
 
 		if ($input->getFirstArgument() !== 'check') {
-			$errors = \OC_Util::checkServer(\OC::$server->getSystemConfig());
+			$errors = \OC_Util::checkServer(\OC::$server->get(SystemConfig::class));
 			if (!empty($errors)) {
 				foreach ($errors as $error) {
 					$output->writeln((string)$error['error']);

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -103,7 +103,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 		$this->adapter = new $params['adapter']($this);
 		$this->tablePrefix = $params['tablePrefix'];
 
-		$this->systemConfig = \OC::$server->getSystemConfig();
+		$this->systemConfig = \OC::$server->get(SystemConfig::class);
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 
 		/** @var \OCP\Profiler\IProfiler */

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -44,6 +44,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Encryption;
+use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\CacheEntryInsertedEvent;
@@ -131,7 +132,7 @@ class Cache implements ICache {
 	protected function getQueryBuilder() {
 		return new CacheQueryBuilder(
 			$this->connection,
-			\OC::$server->getSystemConfig(),
+			\OC::$server->get(SystemConfig::class),
 			\OC::$server->get(LoggerInterface::class)
 		);
 	}

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -50,6 +50,7 @@ use OC\Files\Cache\Watcher;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\Wrapper;
+use OC\SystemConfig;
 use OCP\Files\EmptyFileNameException;
 use OCP\Files\FileNameTooLongException;
 use OCP\Files\ForbiddenException;
@@ -381,7 +382,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			$storage = $this;
 		}
 		if (!isset($storage->propagator)) {
-			$config = \OC::$server->getSystemConfig();
+			$config = \OC::$server->get(SystemConfig::class);
 			$storage->propagator = new Propagator($storage, \OC::$server->getDatabaseConnection(), ['appdata_' . $config->getValue('instanceid')]);
 		}
 		return $storage->propagator;

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -48,6 +48,7 @@ use OCP\Log\IWriter;
 use OCP\Support\CrashReport\IRegistry;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Log\ExceptionSerializer;
+use OC\SystemConfig;
 use Throwable;
 use function array_merge;
 use function strtr;
@@ -83,7 +84,7 @@ class Log implements ILogger, IDataLogger {
 	) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {
-			$config = \OC::$server->getSystemConfig();
+			$config = \OC::$server->get(SystemConfig::class);
 		}
 
 		$this->config = $config;

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -24,6 +24,7 @@
  */
 namespace OC\Log;
 
+use OC\SystemConfig;
 use OCP\Log\RotationTrait;
 
 /**
@@ -36,7 +37,7 @@ class Rotate extends \OCP\BackgroundJob\Job {
 	use RotationTrait;
 
 	public function run($dummy) {
-		$systemConfig = \OC::$server->getSystemConfig();
+		$systemConfig = \OC::$server->get(SystemConfig::class);
 		$this->filePath = $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/nextcloud.log');
 
 		$this->maxSize = \OC::$server->getConfig()->getSystemValueInt('log_rotate_size', 100 * 1024 * 1024);

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Memcache;
 
+use OC\SystemConfig;
 use OCP\HintException;
 use OCP\IMemcache;
 
@@ -84,9 +85,9 @@ class Memcached extends Cache implements IMemcache {
 				throw new HintException("Expected 'memcached_options' config to be an array, got $options");
 			}
 
-			$servers = \OC::$server->getSystemConfig()->getValue('memcached_servers');
+			$servers = \OC::$server->get(SystemConfig::class)->getValue('memcached_servers');
 			if (!$servers) {
-				$server = \OC::$server->getSystemConfig()->getValue('memcached_server');
+				$server = \OC::$server->get(SystemConfig::class)->getValue('memcached_server');
 				if ($server) {
 					$servers = [$server];
 				} else {

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -56,6 +56,7 @@ use OC\Authentication\Token\TokenCleanupJob;
 use OC\TextProcessing\RemoveOldTasksBackgroundJob;
 use OC\Log\Rotate;
 use OC\Preview\BackgroundCleanupJob;
+use OC\SystemConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
@@ -496,7 +497,7 @@ class Setup {
 	 * @throws \OCP\AppFramework\QueryException
 	 */
 	public static function updateHtaccess() {
-		$config = \OC::$server->getSystemConfig();
+		$config = \OC::$server->get(SystemConfig::class);
 
 		try {
 			$webRoot = self::findWebRoot($config);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -44,6 +44,7 @@ namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Search\SearchQuery;
+use OC\SystemConfig;
 use OC\Template\CSSResourceLocator;
 use OC\Template\JSConfigHelper;
 use OC\Template\JSResourceLocator;
@@ -207,7 +208,7 @@ class TemplateLayout extends \OC_Template {
 		$this->assign('language', $lang);
 		$this->assign('locale', $locale);
 
-		if (\OC::$server->getSystemConfig()->getValue('installed', false)) {
+		if (\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {
 			if (empty(self::$versionHash)) {
 				$v = \OC_App::getAppVersions();
 				$v['core'] = implode('.', \OCP\Util::getVersion());
@@ -258,7 +259,7 @@ class TemplateLayout extends \OC_Template {
 
 		// Do not initialise scss appdata until we have a fully installed instance
 		// Do not load scss for update, errors, installation or login page
-		if (\OC::$server->getSystemConfig()->getValue('installed', false)
+		if (\OC::$server->get(SystemConfig::class)->getValue('installed', false)
 			&& !\OCP\Util::needUpgrade()
 			&& $pathInfo !== ''
 			&& !preg_match('/^\/login/', $pathInfo)

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -64,6 +64,7 @@ use OC\DB\MigrationService;
 use OC\Installer;
 use OC\Repair;
 use OC\Repair\Events\RepairErrorEvent;
+use OC\SystemConfig;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
 
@@ -119,7 +120,7 @@ class OC_App {
 	 * if $types is set to non-empty array, only apps of those types will be loaded
 	 */
 	public static function loadApps(array $types = []): bool {
-		if (!\OC::$server->getSystemConfig()->getValue('installed', false)) {
+		if (!\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {
 			// This should be done before calling this method so that appmanager can be used
 			return false;
 		}
@@ -216,7 +217,7 @@ class OC_App {
 	 * @return string[]
 	 */
 	public static function getEnabledApps(bool $forceRefresh = false, bool $all = false): array {
-		if (!\OC::$server->getSystemConfig()->getValue('installed', false)) {
+		if (!\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {
 			return [];
 		}
 		// in incognito mode or when logged out, $user will be false,

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -45,6 +45,7 @@
  */
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\Filesystem;
+use OC\SystemConfig;
 use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IBinaryFinder;
@@ -484,7 +485,7 @@ class OC_Helper {
 
 		// return storage info without adding mount points
 		if (self::$quotaIncludeExternalStorage === null) {
-			self::$quotaIncludeExternalStorage = \OC::$server->getSystemConfig()->getValue('quota_include_external_storage', false);
+			self::$quotaIncludeExternalStorage = \OC::$server->get(SystemConfig::class)->getValue('quota_include_external_storage', false);
 		}
 
 		$view = Filesystem::getView();

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -37,6 +37,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\SystemConfig;
 use OC\TemplateLayout;
 use OCP\AppFramework\Http\TemplateResponse;
 
@@ -285,7 +287,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('file', $exception->getFile());
 			$content->assign('line', $exception->getLine());
 			$content->assign('exception', $exception);
-			$content->assign('debugMode', \OC::$server->getSystemConfig()->getValue('debug', false));
+			$content->assign('debugMode', \OC::$server->get(SystemConfig::class)->getValue('debug', false));
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());
 			$content->printPage();

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -36,6 +36,7 @@
  *
  */
 
+use OC\SystemConfig;
 use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
@@ -126,7 +127,7 @@ class OC_User {
 	 */
 	public static function setupBackends() {
 		OC_App::loadApps(['prelogin']);
-		$backends = \OC::$server->getSystemConfig()->getValue('user_backends', []);
+		$backends = \OC::$server->get(SystemConfig::class)->getValue('user_backends', []);
 		if (isset($backends['default']) && !$backends['default']) {
 			// clear default backends
 			self::clearBackends();
@@ -377,7 +378,7 @@ class OC_User {
 		if ($user) {
 			return $user->getHome();
 		} else {
-			return \OC::$server->getSystemConfig()->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $uid;
+			return \OC::$server->get(SystemConfig::class)->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $uid;
 		}
 	}
 

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -66,6 +66,7 @@
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\SetupManager;
+use OC\SystemConfig;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -842,11 +843,11 @@ class OC_Util {
 	 * @return string
 	 */
 	public static function getInstanceId() {
-		$id = \OC::$server->getSystemConfig()->getValue('instanceid', null);
+		$id = \OC::$server->get(SystemConfig::class)->getValue('instanceid', null);
 		if (is_null($id)) {
 			// We need to guarantee at least one letter in instanceid so it can be used as the session_name
 			$id = 'oc' . \OC::$server->getSecureRandom()->generate(10, \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
-			\OC::$server->getSystemConfig()->setValue('instanceid', $id);
+			\OC::$server->get(SystemConfig::class)->setValue('instanceid', $id);
 		}
 		return $id;
 	}
@@ -1053,7 +1054,7 @@ class OC_Util {
 	 * @return string the theme
 	 */
 	public static function getTheme() {
-		$theme = \OC::$server->getSystemConfig()->getValue("theme", '');
+		$theme = \OC::$server->get(SystemConfig::class)->getValue("theme", '');
 
 		if ($theme === '') {
 			if (is_dir(OC::$SERVERROOT . '/themes/default')) {

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -48,6 +48,7 @@ namespace OCP;
 
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
+use OC\SystemConfig;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -563,7 +564,7 @@ class Util {
 	 */
 	public static function needUpgrade() {
 		if (!isset(self::$needUpgradeCache)) {
-			self::$needUpgradeCache = \OC_Util::needUpgrade(\OC::$server->getSystemConfig());
+			self::$needUpgradeCache = \OC_Util::needUpgrade(\OC::$server->get(SystemConfig::class));
 		}
 		return self::$needUpgradeCache;
 	}

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,6 +30,8 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use OC\SystemConfig;
+
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getConfig()->getSystemValueBool('maintenance')) {
 	// since the behavior of apps or remotes are unpredictable during
@@ -83,7 +85,7 @@ try {
 	$format = \OC::$server->getRequest()->getParam('format', 'xml');
 	$txt = 'Internal Server Error'."\n";
 	try {
-		if (\OC::$server->getSystemConfig()->getValue('debug', false)) {
+		if (\OC::$server->get(SystemConfig::class)->getValue('debug', false)) {
 			$txt .= $e->getMessage();
 		}
 	} catch (\Throwable $e) {

--- a/status.php
+++ b/status.php
@@ -33,10 +33,12 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\SystemConfig;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
-	$systemConfig = \OC::$server->getSystemConfig();
+	$systemConfig = \OC::$server->get(SystemConfig::class);
 
 	$installed = (bool) $systemConfig->getValue('installed', false);
 	$maintenance = (bool) $systemConfig->getValue('maintenance', false);

--- a/tests/lib/Log/FileTest.php
+++ b/tests/lib/Log/FileTest.php
@@ -20,6 +20,7 @@
 namespace Test\Log;
 
 use OC\Log\File;
+use OC\SystemConfig;
 use OCP\IConfig;
 use OCP\ILogger;
 use Test\TestCase;
@@ -36,7 +37,7 @@ class FileTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$config = \OC::$server->getSystemConfig();
+		$config = \OC::$server->get(SystemConfig::class);
 		$this->restore_logfile = $config->getValue("logfile");
 		$this->restore_logdateformat = $config->getValue('logdateformat');
 
@@ -44,7 +45,7 @@ class FileTest extends TestCase {
 		$this->logFile = new File($config->getValue('datadirectory') . '/logtest.log', '', $config);
 	}
 	protected function tearDown(): void {
-		$config = \OC::$server->getSystemConfig();
+		$config = \OC::$server->get(SystemConfig::class);
 		if (isset($this->restore_logfile)) {
 			$config->getValue("logfile", $this->restore_logfile);
 		} else {

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -25,6 +25,7 @@ namespace Test\Preview;
 use OC\Preview\BackgroundCleanupJob;
 use OC\Preview\Storage\Root;
 use OC\PreviewManager;
+use OC\SystemConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
@@ -103,7 +104,7 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 	private function getRoot(): Root {
 		return new Root(
 			\OC::$server->getRootFolder(),
-			\OC::$server->getSystemConfig()
+			\OC::$server->get(SystemConfig::class)
 		);
 	}
 

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -22,6 +22,7 @@
 namespace Test\Share;
 
 use OC\Share\Share;
+use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IGroup;
@@ -94,7 +95,7 @@ class ShareTest extends \Test\TestCase {
 
 		Share::registerBackend('test', 'Test\Share\Backend');
 		\OC_Hook::clear('OCP\\Share');
-		\OC::registerShareHooks(\OC::$server->getSystemConfig());
+		\OC::registerShareHooks(\OC::$server->get(SystemConfig::class));
 		$this->resharing = \OC::$server->getConfig()->getAppValue('core', 'shareapi_allow_resharing', 'yes');
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_allow_resharing', 'yes');
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getSystemConfig` and replaces it with `OC\Server::get(\OC\SystemConfig::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OC\SystemConfig` class is imported via the `use` directive.