### PR TITLE
Refactor `OC\Server::getEncryptionKeyStorage`

### DIFF
--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -28,6 +28,7 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
+use OCP\Encryption\Keys\IStorage;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\Storage\IStorage;
@@ -82,7 +83,7 @@ class EncryptionWrapper {
 			$mountManager = Filesystem::getMountManager();
 			$uid = $user ? $user->getUID() : null;
 			$fileHelper = \OC::$server->getEncryptionFilesHelper();
-			$keyStorage = \OC::$server->getEncryptionKeyStorage();
+			$keyStorage = \OC::$server->get(IStorage::class);
 
 			$util = new Util(
 				new View(),

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -28,7 +28,7 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
-use OCP\Encryption\Keys\IStorage;
+use OCP\Encryption\Keys\IStorage as EncryptionKeysStorage;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\Storage\IStorage;
@@ -83,7 +83,7 @@ class EncryptionWrapper {
 			$mountManager = Filesystem::getMountManager();
 			$uid = $user ? $user->getUID() : null;
 			$fileHelper = \OC::$server->getEncryptionFilesHelper();
-			$keyStorage = \OC::$server->get(IStorage::class);
+			$keyStorage = \OC::$server->get(EncryptionKeysStorage::class);
 
 			$util = new Util(
 				new View(),


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getEncryptionKeyStorage` and replaces it with `OC\Server::get(\OCP\Encryption\Keys\IStorage::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Encryption\Keys\IStorage` class is imported via the `use` directive.