### PR TITLE
Refactor `OC\Server::getEncryptionManager`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\Encryption\IManager as IEncryptionManager;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -121,16 +123,16 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	}
 
 	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
+	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->get(IEncryptionManager::class)));
+	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->get(IEncryptionManager::class), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->get(IEncryptionManager::class), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->get(IEncryptionManager::class)));
+	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->get(IEncryptionManager::class), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
 	$application->add(new OC\Core\Command\Encryption\DecryptAll(
-		\OC::$server->getEncryptionManager(),
+		\OC::$server->get(IEncryptionManager::class),
 		\OC::$server->getAppManager(),
 		\OC::$server->getConfig(),
-		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
+		new \OC\Encryption\DecryptAll(\OC::$server->get(IEncryptionManager::class), \OC::$server->getUserManager(), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
 	);
 

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -26,6 +26,7 @@ namespace OC\Encryption;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
+use OCP\Encryption\IManager as IEncryptionManager;
 use Psr\Log\LoggerInterface;
 
 class HookManager {
@@ -78,7 +79,7 @@ class HookManager {
 					\OC::$server->getGroupManager(),
 					\OC::$server->getConfig()),
 				Filesystem::getMountManager(),
-				\OC::$server->getEncryptionManager(),
+				\OC::$server->get(IEncryptionManager::class),
 				\OC::$server->getEncryptionFilesHelper(),
 				\OC::$server->get(LoggerInterface::class),
 				$uid

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -14,7 +14,7 @@ use OC\Memcache\ArrayCache;
 use OCA\Encryption\AppInfo\Application;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
-use OCP\Encryption\IManager;
+use OCP\Encryption\IManager as IEncryptionManager;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
@@ -74,7 +74,7 @@ trait EncryptionTrait {
 		/** @var Setup $userSetup */
 		$userSetup = $container->query(Setup::class);
 		$userSetup->setupUser($name, $password);
-		$encryptionManager = $container->query(IManager::class);
+		$encryptionManager = $container->query(IEncryptionManager::class);
 		$this->encryptionApp->setUp($encryptionManager);
 		$keyManager->init($name, $password);
 	}
@@ -82,7 +82,7 @@ trait EncryptionTrait {
 	protected function postLogin() {
 		$encryptionWrapper = new EncryptionWrapper(
 			new ArrayCache(),
-			\OC::$server->getEncryptionManager(),
+			\OC::$server->get(IEncryptionManager::class),
 			\OC::$server->get(LoggerInterface::class)
 		);
 
@@ -90,7 +90,7 @@ trait EncryptionTrait {
 	}
 
 	protected function setUpEncryptionTrait() {
-		$isReady = \OC::$server->getEncryptionManager()->isReady();
+		$isReady = \OC::$server->get(IEncryptionManager::class)->isReady();
 		if (!$isReady) {
 			$this->markTestSkipped('Encryption not ready');
 		}
@@ -107,7 +107,7 @@ trait EncryptionTrait {
 		$this->originalEncryptionModule = $this->config->getAppValue('core', 'default_encryption_module');
 		$this->config->setAppValue('core', 'default_encryption_module', \OCA\Encryption\Crypto\Encryption::ID);
 		$this->config->setAppValue('core', 'encryption_enabled', 'yes');
-		$this->assertTrue(\OC::$server->getEncryptionManager()->isEnabled());
+		$this->assertTrue(\OC::$server->get(IEncryptionManager::class)->isEnabled());
 	}
 
 	protected function tearDownEncryptionTrait() {


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getEncryptionManager` and replaces it with `OC\Server::get(\OCP\Encryption\IManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\Encryption\IManager` class is imported via the `use` directive.