### PR TITLE
Refactor `OC\Server::getEventLogger`

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -716,7 +716,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService('RedisFactory', function (Server $c) {
 			$systemConfig = $c->get(SystemConfig::class);
-			return new RedisFactory($systemConfig, $c->getEventLogger());
+			return new RedisFactory($systemConfig, $c->get(IEventLogger::class));
 		});
 
 		$this->registerService(\OCP\Activity\IManager::class, function (Server $c) {


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getEventLogger` and replaces it with `OC\Server::get(\OCP\Diagnostics\IEventLogger::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Diagnostics\IEventLogger` class is imported via the `use` directive.