### PR TITLE
Refactor `OC\Server::getGetRedisFactory`

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -70,7 +70,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	 */
 	public function getCache() {
 		if (is_null(self::$cache)) {
-			self::$cache = \OC::$server->getGetRedisFactory()->getInstance();
+			self::$cache = \OC::$server->get('RedisFactory')->getInstance();
 		}
 		return self::$cache;
 	}
@@ -209,7 +209,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public static function isAvailable(): bool {
-		return \OC::$server->getGetRedisFactory()->isAvailable();
+		return \OC::$server->get('RedisFactory')->isAvailable();
 	}
 
 	protected function evalLua(string $scriptName, array $keys, array $args) {


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getGetRedisFactory` and replaces it with `OC\Server::get('RedisFactory')` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).