### PR TITLE
Refactor `OC\Server::getIntegrityCodeChecker`

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -93,7 +93,7 @@ class Upgrade extends Command {
 			$self = $this;
 			$updater = new Updater(
 				$this->config,
-				\OC::$server->getIntegrityCodeChecker(),
+				\OC::$server->get('IntegrityCodeChecker'),
 				$this->logger,
 				$this->installer
 			);

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -102,7 +102,7 @@ class SetupController {
 		if (file_exists($this->autoConfigFile)) {
 			unlink($this->autoConfigFile);
 		}
-		\OC::$server->getIntegrityCodeChecker()->runInstanceVerification();
+		\OC::$server->get('IntegrityCodeChecker')->runInstanceVerification();
 
 		if ($this->setupHelper->shouldRemoveCanInstallFile()) {
 			\OC_Template::printGuestPage('', 'installation_incomplete');

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -115,7 +115,7 @@ if (\OCP\Util::needUpgrade()) {
 	$config = \OC::$server->getConfig();
 	$updater = new \OC\Updater(
 		$config,
-		\OC::$server->getIntegrityCodeChecker(),
+		\OC::$server->get('IntegrityCodeChecker'),
 		$logger,
 		\OC::$server->query(\OC\Installer::class)
 	);

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -55,19 +55,19 @@ $application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::cla
 $application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
 $application->add(new OC\Core\Command\L10n\CreateJs());
 $application->add(new \OC\Core\Command\Integrity\SignApp(
-	\OC::$server->getIntegrityCodeChecker(),
+	\OC::$server->get('IntegrityCodeChecker'),
 	new \OC\IntegrityCheck\Helpers\FileAccessHelper(),
 	\OC::$server->getURLGenerator()
 ));
 $application->add(new \OC\Core\Command\Integrity\SignCore(
-	\OC::$server->getIntegrityCodeChecker(),
+	\OC::$server->get('IntegrityCodeChecker'),
 	new \OC\IntegrityCheck\Helpers\FileAccessHelper()
 ));
 $application->add(new \OC\Core\Command\Integrity\CheckApp(
-	\OC::$server->getIntegrityCodeChecker()
+	\OC::$server->get('IntegrityCodeChecker')
 ));
 $application->add(new \OC\Core\Command\Integrity\CheckCore(
-	\OC::$server->getIntegrityCodeChecker()
+	\OC::$server->get('IntegrityCodeChecker')
 ));
 
 

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -303,7 +303,7 @@ class Updater extends BasicEmitter {
 		$this->config->setAppValue('core', 'lastupdatedat', '0');
 
 		// Check for code integrity if not disabled
-		if (\OC::$server->getIntegrityCodeChecker()->isCodeCheckEnforced()) {
+		if (\OC::$server->get('IntegrityCodeChecker')->isCodeCheckEnforced()) {
 			$this->emit('\OC\Updater', 'startCheckCodeIntegrity');
 			$this->checker->runInstanceVerification();
 			$this->emit('\OC\Updater', 'finishedCheckCodeIntegrity');


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getIntegrityCodeChecker` and replaces it with `OC\Server::get('IntegrityCodeChecker')` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).