### PR TITLE
Refactor `OC\Server::getJobList`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\BackgroundJob\IJobList;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -89,8 +91,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
-	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
+	$application->add(new OC\Core\Command\Background\Job(\OC::$server->get(IJobList::class), \OC::$server->getLogger()));
+	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->get(IJobList::class)));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));
 

--- a/cron.php
+++ b/cron.php
@@ -39,6 +39,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\BackgroundJob\IJobList;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -134,7 +136,7 @@ try {
 		}
 
 		// Work
-		$jobList = \OC::$server->getJobList();
+		$jobList = \OC::$server->get(IJobList::class);
 
 		// We only ask for jobs for 14 minutes, because after 5 minutes the next
 		// system cron task should spawn and we want to have at most three
@@ -170,7 +172,7 @@ try {
 			OC_JSON::error(['data' => ['message' => 'Backgroundjobs are using system cron!']]);
 		} else {
 			// Work and success :-)
-			$jobList = \OC::$server->getJobList();
+			$jobList = \OC::$server->get(IJobList::class);
 			$job = $jobList->getNext();
 			if ($job != null) {
 				$logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -38,6 +38,7 @@ use OC\Repair\AddRemoveOldTasksBackgroundJob;
 use OC\Repair\CleanUpAbandonedApps;
 use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
 use OCP\Collaboration\Resources\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Migration\IOutput;
@@ -180,24 +181,24 @@ class Repair implements IOutput {
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new MoveUpdaterStepFile(\OC::$server->getConfig()),
 			new MoveAvatars(
-				\OC::$server->getJobList(),
+				\OC::$server->get(IJobList::class),
 				\OC::$server->getConfig()
 			),
 			new CleanPreviews(
-				\OC::$server->getJobList(),
+				\OC::$server->get(IJobList::class),
 				\OC::$server->getUserManager(),
 				\OC::$server->getConfig()
 			),
 			new MigrateOauthTables(\OC::$server->get(Connection::class)),
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
 			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
-			new AddLogRotateJob(\OC::$server->getJobList()),
+			new AddLogRotateJob(\OC::$server->get(IJobList::class)),
 			new ClearFrontendCaches(\OC::$server->getMemCacheFactory(), \OCP\Server::get(JSCombiner::class)),
 			\OCP\Server::get(ClearGeneratedAvatarCache::class),
-			new AddPreviewBackgroundCleanupJob(\OC::$server->getJobList()),
-			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
+			new AddPreviewBackgroundCleanupJob(\OC::$server->get(IJobList::class)),
+			new AddCleanupUpdaterBackupsJob(\OC::$server->get(IJobList::class)),
 			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->get(LoggerInterface::class)),
-			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->getJobList()),
+			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->get(IJobList::class)),
 			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OCP\Server::get(ITimeFactory::class)),
 			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OCP\Server::get(IManager::class)),
 			\OCP\Server::get(ResetGeneratedAvatarFlag::class),

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -57,6 +57,7 @@ use OC\TextProcessing\RemoveOldTasksBackgroundJob;
 use OC\Log\Rotate;
 use OC\Preview\BackgroundCleanupJob;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
 use OCP\Defaults;
 use OCP\IGroup;
 use OCP\IL10N;
@@ -450,7 +451,7 @@ class Setup {
 	}
 
 	public static function installBackgroundJobs() {
-		$jobList = \OC::$server->getJobList();
+		$jobList = \OC::$server->get(IJobList::class);
 		$jobList->add(TokenCleanupJob::class);
 		$jobList->add(Rotate::class);
 		$jobList->add(BackgroundCleanupJob::class);

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -41,6 +41,7 @@ use OCA\FederatedFileSharing\TokenHandler;
 use OCA\ShareByMail\Settings\SettingsManager;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCA\Talk\Share\RoomShareProvider;
+use OCP\BackgroundJob\IJobList;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
@@ -139,7 +140,7 @@ class ProviderFactory implements IProviderFactory {
 				$addressHandler,
 				$this->serverContainer->getHTTPClientService(),
 				$this->serverContainer->query(\OCP\OCS\IDiscoveryService::class),
-				$this->serverContainer->getJobList(),
+				$this->serverContainer->get(IJobList::class),
 				\OC::$server->getCloudFederationProviderManager(),
 				\OC::$server->getCloudFederationFactory(),
 				$this->serverContainer->query(IEventDispatcher::class),

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -55,6 +55,7 @@ use OCP\App\Events\AppUpdateEvent;
 use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
+use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OC\AppFramework\Bootstrap\Coordinator;
@@ -838,7 +839,7 @@ class OC_App {
 	}
 
 	public static function setupBackgroundJobs(array $jobs) {
-		$queue = \OC::$server->getJobList();
+		$queue = \OC::$server->get(IJobList::class);
 		foreach ($jobs as $job) {
 			$queue->add($job);
 		}
@@ -849,7 +850,7 @@ class OC_App {
 	 * @param string[] $steps
 	 */
 	private static function setupLiveMigrations(string $appId, array $steps) {
-		$queue = \OC::$server->getJobList();
+		$queue = \OC::$server->get(IJobList::class);
 		foreach ($steps as $step) {
 			$queue->add('OC\Migration\BackgroundRepair', [
 				'app' => $appId,


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getJobList` and replaces it with `OC\Server::get(\OCP\BackgroundJob\IJobList::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\BackgroundJob\IJobList` class is imported via the `use` directive.