### PR TITLE
Refactor `OC\Server::getLazyRootFolder`

### DIFF
--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -44,6 +44,7 @@ use OCA\Talk\Share\RoomShareProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IRootFolder;
 use OCP\IServerContainer;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
@@ -100,7 +101,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getGroupManager(),
-				$this->serverContainer->getLazyRootFolder(),
+				$this->serverContainer->get(IRootFolder::class),
 				$this->serverContainer->getMailer(),
 				$this->serverContainer->query(Defaults::class),
 				$this->serverContainer->getL10NFactory(),
@@ -156,7 +157,7 @@ class ProviderFactory implements IProviderFactory {
 				$notifications,
 				$tokenHandler,
 				$l,
-				$this->serverContainer->getLazyRootFolder(),
+				$this->serverContainer->get(IRootFolder::class),
 				$this->serverContainer->getConfig(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getCloudIdManager(),
@@ -191,7 +192,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getSecureRandom(),
 				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getLazyRootFolder(),
+				$this->serverContainer->get(IRootFolder::class),
 				$this->serverContainer->getL10N('sharebymail'),
 				$this->serverContainer->get(LoggerInterface::class),
 				$this->serverContainer->getMailer(),
@@ -233,7 +234,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getSecureRandom(),
 				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getLazyRootFolder(),
+				$this->serverContainer->get(IRootFolder::class),
 				$this->serverContainer->getL10N('circles'),
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getURLGenerator()


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getLazyRootFolder` and replaces it with `OC\Server::get(\OCP\Files\IRootFolder::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Files\IRootFolder` class is imported via the `use` directive.