### PR TITLE
Refactor `OC\Server::getLockdownManager`

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -546,7 +546,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$provider,
 				$c->get(\OCP\IConfig::class),
 				$c->get(ISecureRandom::class),
-				$c->getLockdownManager(),
+				$c->get('LockdownManager'),
 				$c->get(LoggerInterface::class),
 				$c->get(IEventDispatcher::class)
 			);

--- a/tests/lib/Lockdown/Filesystem/NoFSTest.php
+++ b/tests/lib/Lockdown/Filesystem/NoFSTest.php
@@ -39,7 +39,7 @@ class NoFSTest extends \Test\TestCase {
 		$token->setScope([
 			'filesystem' => true
 		]);
-		\OC::$server->getLockdownManager()->setToken($token);
+		\OC::$server->get('LockdownManager')->setToken($token);
 		parent::tearDown();
 	}
 
@@ -50,7 +50,7 @@ class NoFSTest extends \Test\TestCase {
 			'filesystem' => false
 		]);
 
-		\OC::$server->getLockdownManager()->setToken($token);
+		\OC::$server->get('LockdownManager')->setToken($token);
 		$this->createUser('foo', 'var');
 	}
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getLockdownManager` and replaces it with `OC\Server::get('LockdownManager')` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).