### PR TITLE
Refactor `OC\Server::getLockingProvider`

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -96,7 +96,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		$this->storageId = $this->storage->getId();
 		$this->cache = $storage->getCache();
 		$this->cacheActive = !\OC::$server->getConfig()->getSystemValueBool('filesystem_cache_readonly', false);
-		$this->lockingProvider = \OC::$server->getLockingProvider();
+		$this->lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$this->connection = \OC::$server->get(IDBConnection::class);
 	}
 

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -50,6 +50,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
+use OCP\Lock\ILockingProvider;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -100,7 +101,7 @@ class Scanner extends PublicEmitter {
 		$this->dispatcher = $dispatcher;
 		$this->logger = $logger;
 		// when DB locking is used, no DB transactions will be used
-		$this->useTransaction = !(\OC::$server->getLockingProvider() instanceof DBLockingProvider);
+		$this->useTransaction = !(\OC::$server->get(ILockingProvider::class) instanceof DBLockingProvider);
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -106,7 +106,7 @@ class View {
 		}
 
 		$this->fakeRoot = $root;
-		$this->lockingProvider = \OC::$server->getLockingProvider();
+		$this->lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$this->lockingEnabled = !($this->lockingProvider instanceof \OC\Lock\NoopLockingProvider);
 		$this->userManager = \OC::$server->getUserManager();
 		$this->logger = \OC::$server->get(LoggerInterface::class);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1388,7 +1388,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test that locks are on mount point paths instead of mount root
 	 */
 	public function testLockLocalMountPointPathInsteadOfStorageRoot() {
-		$lockingProvider = \OC::$server->getLockingProvider();
+		$lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
 		Filesystem::mount($storage, [], '/');
@@ -1418,7 +1418,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test that locks are on mount point paths and also mount root when requested
 	 */
 	public function testLockStorageRootButNotLocalMountPoint() {
-		$lockingProvider = \OC::$server->getLockingProvider();
+		$lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
 		Filesystem::mount($storage, [], '/');
@@ -1448,7 +1448,7 @@ class ViewTest extends \Test\TestCase {
 	 * Test that locks are on mount point paths and also mount root when requested
 	 */
 	public function testLockMountPointPathFailReleasesBoth() {
-		$lockingProvider = \OC::$server->getLockingProvider();
+		$lockingProvider = \OC::$server->get(ILockingProvider::class);
 		$view = new View('/testuser/files/');
 		$storage = new Temporary([]);
 		Filesystem::mount($storage, [], '/');

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -38,6 +38,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\Lock\ILockingProvider;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -197,7 +198,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		// further cleanup
 		$hookExceptions = \OC_Hook::$thrownExceptions;
 		\OC_Hook::$thrownExceptions = [];
-		\OC::$server->getLockingProvider()->releaseAll();
+		\OC::$server->get(ILockingProvider::class)->releaseAll();
 		if (!empty($hookExceptions)) {
 			throw $hookExceptions[0];
 		}
@@ -418,7 +419,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 * Clean up the list of locks
 	 */
 	protected static function tearDownAfterClassCleanStrayLocks() {
-		\OC::$server->getLockingProvider()->releaseAll();
+		\OC::$server->get(ILockingProvider::class)->releaseAll();
 	}
 
 	/**


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getLockingProvider` and replaces it with `OC\Server::get(\OCP\Lock\ILockingProvider::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Lock\ILockingProvider` class is imported via the `use` directive.