### PR TITLE
Refactor `OC\Server::getLogger`

### DIFF
--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -35,7 +35,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IEventSource;
 use OCP\IEventSourceFactory;
 use OCP\IL10N;
-use OCP\ILogger;
 use OC\DB\MigratorExecuteSqlEvent;
 use OC\Repair\Events\RepairAdvanceEvent;
 use OC\Repair\Events\RepairErrorEvent;
@@ -45,6 +44,8 @@ use OC\Repair\Events\RepairStartEvent;
 use OC\Repair\Events\RepairStepEvent;
 use OC\Repair\Events\RepairWarningEvent;
 use OCP\L10N\IFactory;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
 	@set_time_limit(0);
@@ -186,9 +187,10 @@ if (\OCP\Util::needUpgrade()) {
 	try {
 		$updater->upgrade();
 	} catch (\Exception $e) {
-		\OC::$server->getLogger()->logException($e, [
-			'level' => ILogger::ERROR,
+		\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+			'level' => LogLevel::ERROR,
 			'app' => 'update',
+			'exception' => $e
 		]);
 		$eventSource->send('failure', get_class($e) . ': ' . $e->getMessage());
 		$eventSource->close();

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -89,7 +89,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
+	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->get(LoggerInterface::class)));
 	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
 
 	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));

--- a/cron.php
+++ b/cron.php
@@ -39,15 +39,17 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use Psr\Log\LoggerInterface;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
 	if (\OCP\Util::needUpgrade()) {
-		\OC::$server->getLogger()->debug('Update required, skipping cron', ['app' => 'cron']);
+		\OC::$server->get(LoggerInterface::class)->debug('Update required, skipping cron', ['app' => 'cron']);
 		exit;
 	}
 	if ((bool) \OC::$server->getSystemConfig()->getValue('maintenance', false)) {
-		\OC::$server->getLogger()->debug('We are in maintenance mode, skipping cron', ['app' => 'cron']);
+		\OC::$server->get(LoggerInterface::class)->debug('We are in maintenance mode, skipping cron', ['app' => 'cron']);
 		exit;
 	}
 
@@ -62,7 +64,7 @@ try {
 	$session = $cryptoWrapper->wrapSession($session);
 	\OC::$server->setSession($session);
 
-	$logger = \OC::$server->getLogger();
+	$logger = \OC::$server->get(LoggerInterface::class);
 	$config = \OC::$server->getConfig();
 	$tempManager = \OC::$server->getTempManager();
 
@@ -185,11 +187,17 @@ try {
 	$config->setAppValue('core', 'lastcron', time());
 	exit();
 } catch (Exception $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'cron',
+		'exception' => $ex
+	]);
 	echo $ex . PHP_EOL;
 	exit(1);
 } catch (Error $ex) {
-	\OC::$server->getLogger()->logException($ex, ['app' => 'cron']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'cron',
+		'exception' => $ex
+	]);
 	echo $ex . PHP_EOL;
 	exit(1);
 }

--- a/lib/private/BackgroundJob/Job.php
+++ b/lib/private/BackgroundJob/Job.php
@@ -28,6 +28,7 @@ namespace OC\BackgroundJob;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * @deprecated internal class, use \OCP\BackgroundJob\Job
@@ -45,7 +46,7 @@ abstract class Job implements IJob {
 	public function execute(IJobList $jobList, ILogger $logger = null) {
 		$jobList->setLastRun($this);
 		if ($logger === null) {
-			$logger = \OC::$server->getLogger();
+			$logger = \OC::$server->get(LoggerInterface::class);
 		}
 
 		try {

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -192,11 +192,11 @@ class File implements ICache {
 						}
 					} catch (\OCP\Lock\LockedException $e) {
 						// ignore locked chunks
-						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
 					} catch (\OCP\Files\ForbiddenException $e) {
-						\OC::$server->getLogger()->debug('Could not cleanup forbidden chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup forbidden chunk "' . $file . '"', ['app' => 'core']);
 					} catch (\OCP\Files\LockNotAcquiredException $e) {
-						\OC::$server->getLogger()->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
+						\OC::$server->get(LoggerInterface::class)->debug('Could not cleanup locked chunk "' . $file . '"', ['app' => 'core']);
 					}
 				}
 			}

--- a/lib/private/Collaboration/AutoComplete/Manager.php
+++ b/lib/private/Collaboration/AutoComplete/Manager.php
@@ -26,6 +26,7 @@ namespace OC\Collaboration\AutoComplete;
 use OCP\Collaboration\AutoComplete\IManager;
 use OCP\Collaboration\AutoComplete\ISorter;
 use OCP\IServerContainer;
+use Psr\Log\LoggerInterface;
 
 class Manager implements IManager {
 	/** @var string[] */
@@ -46,7 +47,7 @@ class Manager implements IManager {
 			if (isset($sorterInstances[$sorter])) {
 				$sorterInstances[$sorter]->sort($sortArray, $context);
 			} else {
-				$this->c->getLogger()->warning('No sorter for ID "{id}", skipping', [
+				$this->c->get(LoggerInterface::class)->warning('No sorter for ID "{id}", skipping', [
 					'app' => 'core', 'id' => $sorter
 				]);
 			}
@@ -63,13 +64,13 @@ class Manager implements IManager {
 				/** @var ISorter $instance */
 				$instance = $this->c->resolve($sorter);
 				if (!$instance instanceof ISorter) {
-					$this->c->getLogger()->notice('Skipping sorter which is not an instance of ISorter. Class name: {class}',
+					$this->c->get(LoggerInterface::class)->notice('Skipping sorter which is not an instance of ISorter. Class name: {class}',
 						['app' => 'core', 'class' => $sorter]);
 					continue;
 				}
 				$sorterId = trim($instance->getId());
 				if (trim($sorterId) === '') {
-					$this->c->getLogger()->notice('Skipping sorter with empty ID. Class name: {class}',
+					$this->c->get(LoggerInterface::class)->notice('Skipping sorter with empty ID. Class name: {class}',
 						['app' => 'core', 'class' => $sorter]);
 					continue;
 				}

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -48,6 +48,7 @@ use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 class Filesystem {
 	private static ?Mount\Manager $mounts = null;
@@ -200,7 +201,7 @@ class Filesystem {
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper, $priority = 50) {
 		if (self::$logWarningWhenAddingStorageWrapper) {
-			\OC::$server->getLogger()->warning("Storage wrapper '{wrapper}' was not registered via the 'OC_Filesystem - preSetup' hook which could cause potential problems.", [
+			\OC::$server->get(LoggerInterface::class)->warning("Storage wrapper '{wrapper}' was not registered via the 'OC_Filesystem - preSetup' hook which could cause potential problems.", [
 				'wrapper' => $wrapperName,
 				'app' => 'filesystem',
 			]);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -47,6 +47,7 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 use OCP\Files\Storage\IChunkedFileWrite;
 use OCP\Files\Storage\IStorage;
+use Psr\Log\LoggerInterface;
 
 class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFileWrite {
 	use CopyDirectory;
@@ -89,7 +90,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			$this->validateWrites = (bool)$params['validateWrites'];
 		}
 
-		$this->logger = \OC::$server->getLogger();
+		$this->logger = \OC::$server->get(LoggerInterface::class);
 	}
 
 	public function mkdir($path, bool $force = false) {

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -30,6 +30,7 @@ namespace OC\L10N;
 
 use OCP\IL10N;
 use OCP\L10N\IFactory;
+use Psr\Log\LoggerInterface;
 use Punic\Calendar;
 use Symfony\Component\Translation\IdentityTranslator;
 
@@ -234,7 +235,7 @@ class L10N implements IL10N {
 		$json = json_decode(file_get_contents($translationFile), true);
 		if (!\is_array($json)) {
 			$jsonError = json_last_error();
-			\OC::$server->getLogger()->warning("Failed to load $translationFile - json error code: $jsonError", ['app' => 'l10n']);
+			\OC::$server->get(LoggerInterface::class)->warning("Failed to load $translationFile - json error code: $jsonError", ['app' => 'l10n']);
 			return false;
 		}
 

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -25,6 +25,7 @@
 namespace OC\Log;
 
 use OCP\Log\RotationTrait;
+use Psr\Log\LoggerInterface;
 
 /**
  * This rotates the current logfile to a new name, this way the total log usage
@@ -43,7 +44,7 @@ class Rotate extends \OCP\BackgroundJob\Job {
 		if ($this->shouldRotateBySize()) {
 			$rotatedFile = $this->rotate();
 			$msg = 'Log file "'.$this->filePath.'" was over '.$this->maxSize.' bytes, moved to "'.$rotatedFile.'"';
-			\OC::$server->getLogger()->warning($msg, ['app' => Rotate::class]);
+			\OC::$server->get(LoggerInterface::class)->warning($msg, ['app' => Rotate::class]);
 		}
 	}
 }

--- a/lib/private/Search.php
+++ b/lib/private/Search.php
@@ -30,6 +30,7 @@ namespace OC;
 use OCP\ISearch;
 use OCP\Search\PagedProvider;
 use OCP\Search\Provider;
+use Psr\Log\LoggerInterface;
 
 /**
  * Provide an interface to all search providers
@@ -65,7 +66,7 @@ class Search implements ISearch {
 					$results = array_merge($results, $providerResults);
 				}
 			} else {
-				\OC::$server->getLogger()->warning('Ignoring Unknown search provider', ['provider' => $provider]);
+				\OC::$server->get(LoggerInterface::class)->warning('Ignoring Unknown search provider', ['provider' => $provider]);
 			}
 		}
 		return $results;

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -55,6 +55,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
+use Psr\Log\LoggerInterface;
 use function str_starts_with;
 
 /**
@@ -1247,7 +1248,9 @@ class DefaultShareProvider implements IShareProvider {
 				)
 			);
 		} else {
-			\OC::$server->getLogger()->logException(new \InvalidArgumentException('Default share provider tried to delete all shares for type: ' . $shareType));
+			\OC::$server->get(LoggerInterface::class)->error('Default share provider tried to delete all shares for type: ' . $shareType, [
+				'exception' => new \InvalidArgumentException('Default share provider tried to delete all shares for type: ' . $shareType)
+			]);
 			return;
 		}
 

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -192,7 +192,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getL10N('sharebymail'),
-				$this->serverContainer->getLogger(),
+				$this->serverContainer->get(LoggerInterface::class),
 				$this->serverContainer->getMailer(),
 				$this->serverContainer->getURLGenerator(),
 				$this->serverContainer->getActivityManager(),
@@ -234,7 +234,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getL10N('circles'),
-				$this->serverContainer->getLogger(),
+				$this->serverContainer->get(LoggerInterface::class),
 				$this->serverContainer->getURLGenerator()
 			);
 		}

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -39,6 +39,7 @@ use OCP\ILogger;
 use OCP\ITags;
 use OCP\Share_Backend;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class Tags implements ITags {
 	/**
@@ -486,10 +487,11 @@ class Tags implements ITags {
 		try {
 			return $this->getIdsForTag(ITags::TAG_FAVORITE);
 		} catch (\Exception $e) {
-			\OC::$server->getLogger()->logException($e, [
+			\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 				'message' => __METHOD__,
-				'level' => ILogger::ERROR,
+				'level' => LogLevel::ERROR,
 				'app' => 'core',
+				'exception' => $e
 			]);
 			return [];
 		}
@@ -549,7 +551,7 @@ class Tags implements ITags {
 		try {
 			$qb->executeStatement();
 		} catch (\Exception $e) {
-			\OC::$server->getLogger()->error($e->getMessage(), [
+			\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 				'app' => 'core',
 				'exception' => $e,
 			]);

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -55,6 +55,7 @@ use OCP\User\Backend\ICountUsersBackend;
 use OCP\User\Events\BeforeUserCreatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\UserInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Manager
@@ -234,7 +235,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		$result = $this->checkPasswordNoLogging($loginName, $password);
 
 		if ($result === false) {
-			\OC::$server->getLogger()->warning('Login failed: \''. $loginName .'\' (Remote IP: \''. \OC::$server->getRequest()->getRemoteAddress(). '\')', ['app' => 'core']);
+			\OC::$server->get(LoggerInterface::class)->warning('Login failed: \''. $loginName .'\' (Remote IP: \''. \OC::$server->getRequest()->getRemoteAddress(). '\')', ['app' => 'core']);
 		}
 
 		return $result;

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -454,7 +454,7 @@ class OC_App {
 	 * @deprecated 20.0.0 Please register your alternative login option using the registerAlternativeLogin() on the RegistrationContext in your Application class implementing the OCP\Authentication\IAlternativeLogin interface
 	 */
 	public static function registerLogIn(array $entry) {
-		\OC::$server->getLogger()->debug('OC_App::registerLogIn() is deprecated, please register your alternative login option using the registerAlternativeLogin() on the RegistrationContext in your Application class implementing the OCP\Authentication\IAlternativeLogin interface');
+		\OC::$server->get(LoggerInterface::class)->debug('OC_App::registerLogIn() is deprecated, please register your alternative login option using the registerAlternativeLogin() on the RegistrationContext in your Application class implementing the OCP\Authentication\IAlternativeLogin interface');
 		self::$altLogin[] = $entry;
 	}
 
@@ -467,7 +467,7 @@ class OC_App {
 
 		foreach ($bootstrapCoordinator->getRegistrationContext()->getAlternativeLogins() as $registration) {
 			if (!in_array(IAlternativeLogin::class, class_implements($registration->getService()), true)) {
-				\OC::$server->getLogger()->error('Alternative login option {option} does not implement {interface} and is therefore ignored.', [
+				\OC::$server->get(LoggerInterface::class)->error('Alternative login option {option} does not implement {interface} and is therefore ignored.', [
 					'option' => $registration->getService(),
 					'interface' => IAlternativeLogin::class,
 					'app' => $registration->getAppId(),
@@ -479,10 +479,11 @@ class OC_App {
 				/** @var IAlternativeLogin $provider */
 				$provider = \OCP\Server::get($registration->getService());
 			} catch (ContainerExceptionInterface $e) {
-				\OC::$server->getLogger()->logException($e, [
+				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 					'message' => 'Alternative login option {option} can not be initialised.',
 					'option' => $registration->getService(),
 					'app' => $registration->getAppId(),
+					'exception' => $e
 				]);
 			}
 
@@ -495,10 +496,11 @@ class OC_App {
 					'class' => $provider->getClass(),
 				];
 			} catch (Throwable $e) {
-				\OC::$server->getLogger()->logException($e, [
+				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 					'message' => 'Alternative login option {option} had an error while loading.',
 					'option' => $registration->getService(),
 					'app' => $registration->getAppId(),
+					'exception' => $e
 				]);
 			}
 		}
@@ -752,7 +754,7 @@ class OC_App {
 		}
 
 		if (is_file($appPath . '/appinfo/database.xml')) {
-			\OC::$server->getLogger()->error('The appinfo/database.xml file is not longer supported. Used in ' . $appId);
+			\OC::$server->get(LoggerInterface::class)->error('The appinfo/database.xml file is not longer supported. Used in ' . $appId);
 			return false;
 		}
 
@@ -830,7 +832,9 @@ class OC_App {
 				$r->addStep($step);
 			} catch (Exception $ex) {
 				$dispatcher->dispatchTyped(new RepairErrorEvent($ex->getMessage()));
-				\OC::$server->getLogger()->logException($ex);
+				\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+					'exception' => $ex
+				]);
 			}
 		}
 		// run the steps

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -47,6 +47,7 @@ use OCP\Lock\ILockingProvider;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class for file server access
@@ -200,7 +201,7 @@ class OC_Files {
 							$fileTime = $file->getMTime();
 						} else {
 							// File is not a file? …
-							\OC::$server->getLogger()->debug(
+							\OC::$server->get(LoggerInterface::class)->debug(
 								'File given, but no Node available. Name {file}',
 								[ 'app' => 'files', 'file' => $file ]
 							);
@@ -221,18 +222,24 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 		} catch (\OCP\Lock\LockedException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
-			OC::$server->getLogger()->logException($ex);
+			OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+				'exception' => $ex
+			]);
 			$l = \OC::$server->getL10N('lib');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
 			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint, 200);
 		} catch (\OCP\Files\ForbiddenException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
-			OC::$server->getLogger()->logException($ex);
+			OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+				'exception' => $ex
+			]);
 			$l = \OC::$server->getL10N('lib');
 			\OC_Template::printErrorPage($l->t('Cannot download file'), $ex->getMessage(), 200);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
-			OC::$server->getLogger()->logException($ex);
+			OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+				'exception' => $ex
+			]);
 			$l = \OC::$server->getL10N('lib');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
 			if ($event && $event->getErrorMessage() !== null) {

--- a/lib/private/legacy/OC_Hook.php
+++ b/lib/private/legacy/OC_Hook.php
@@ -28,6 +28,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use Psr\Log\LoggerInterface;
+
 class OC_Hook {
 	public static $thrownExceptions = [];
 
@@ -105,7 +108,9 @@ class OC_Hook {
 				call_user_func([ $i["class"], $i["name"] ], $params);
 			} catch (Exception $e) {
 				self::$thrownExceptions[] = $e;
-				\OC::$server->getLogger()->logException($e);
+				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+					'exception' => $e
+				]);
 				if ($e instanceof \OCP\HintException) {
 					throw $e;
 				}

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -44,6 +44,7 @@ declare(strict_types=1);
  *
  */
 use OCP\IImage;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class for basic image manipulation
@@ -84,7 +85,7 @@ class OC_Image implements \OCP\IImage {
 	public function __construct($imageRef = null, \OCP\ILogger $logger = null, \OCP\IConfig $config = null) {
 		$this->logger = $logger;
 		if ($logger === null) {
-			$this->logger = \OC::$server->getLogger();
+			$this->logger = \OC::$server->get(LoggerInterface::class);
 		}
 		$this->config = $config;
 		if ($config === null) {

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -39,6 +39,7 @@
  */
 use OC\TemplateLayout;
 use OCP\AppFramework\Http\TemplateResponse;
+use Psr\Log\LoggerInterface;
 
 require_once __DIR__.'/template/functions.php';
 
@@ -257,7 +258,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('errors', $errors);
 			$content->printPage();
 		} catch (\Exception $e) {
-			$logger = \OC::$server->getLogger();
+			$logger = \OC::$server->get(LoggerInterface::class);
 			$logger->error("$error_msg $hint", ['app' => 'core']);
 			$logger->logException($e, ['app' => 'core']);
 
@@ -291,7 +292,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->printPage();
 		} catch (\Exception $e) {
 			try {
-				$logger = \OC::$server->getLogger();
+				$logger = \OC::$server->get(LoggerInterface::class);
 				$logger->logException($exception, ['app' => 'core']);
 				$logger->logException($e, ['app' => 'core']);
 			} catch (Throwable $e) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -230,7 +230,7 @@ class OC_Util {
 	 * @return void
 	 */
 	public static function copyr($source, \OCP\Files\Folder $target) {
-		$logger = \OC::$server->getLogger();
+		$logger = \OC::$server->get(LoggerInterface::class);
 
 		// Verify if folder exists
 		$dir = opendir($source);
@@ -1077,7 +1077,7 @@ class OC_Util {
 
 		$normalizedValue = Normalizer::normalize($value);
 		if ($normalizedValue === null || $normalizedValue === false) {
-			\OC::$server->getLogger()->warning('normalizing failed for "' . $value . '"', ['app' => 'core']);
+			\OC::$server->get(LoggerInterface::class)->warning('normalizing failed for "' . $value . '"', ['app' => 'core']);
 			return $value;
 		}
 

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -38,6 +38,7 @@ use OC\AppFramework\Routing\RouteConfig;
 use OC\Route\Router;
 use OC\ServerContainer;
 use OCP\Route\IRouter;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class App
@@ -98,8 +99,9 @@ class App {
 			}
 
 			if (!$setUpViaQuery && $applicationClassName !== \OCP\AppFramework\App::class) {
-				\OC::$server->getLogger()->logException($e, [
+				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 					'app' => $appName,
+					'exception' => $e
 				]);
 			}
 		}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -50,6 +50,7 @@ use OC\AppScriptDependency;
 use OC\AppScriptSort;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * This class provides different helper functions to make the life of a developer easier
@@ -119,7 +120,7 @@ class Util {
 	 */
 	public static function writeLog($app, $message, $level) {
 		$context = ['app' => $app];
-		\OC::$server->getLogger()->log($level, $message, $context);
+		\OC::$server->get(LoggerInterface::class)->log($level, $message, $context);
 	}
 
 	/**

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,6 +30,8 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use Psr\Log\LoggerInterface;
+
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getConfig()->getSystemValueBool('maintenance')) {
 	// since the behavior of apps or remotes are unpredictable during
@@ -77,7 +79,9 @@ try {
 } catch (\OC\User\LoginException $e) {
 	OC_API::respond(new \OC\OCS\Result(null, \OCP\AppFramework\OCSController::RESPOND_UNAUTHORISED, 'Unauthorised'));
 } catch (\Exception $e) {
-	\OC::$server->getLogger()->logException($e);
+	\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
+		'exception' => $e
+	]);
 	OC_API::setContentType();
 
 	$format = \OC::$server->getRequest()->getParam('format', 'xml');

--- a/public.php
+++ b/public.php
@@ -32,6 +32,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use Psr\Log\LoggerInterface;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
@@ -85,10 +87,16 @@ try {
 		$status = 503;
 	}
 	//show the user a detailed error page
-	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'public',
+		'exception' => $ex
+	]);
 	OC_Template::printExceptionErrorPage($ex, $status);
 } catch (Error $ex) {
 	//show the user a detailed error page
-	\OC::$server->getLogger()->logException($ex, ['app' => 'public']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'public',
+		'exception' => $ex
+	]);
 	OC_Template::printExceptionErrorPage($ex, 500);
 }

--- a/status.php
+++ b/status.php
@@ -33,6 +33,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use Psr\Log\LoggerInterface;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 
@@ -62,5 +64,8 @@ try {
 	}
 } catch (Exception $ex) {
 	http_response_code(500);
-	\OC::$server->getLogger()->logException($ex, ['app' => 'remote']);
+	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		'app' => 'remote',
+		'exception' => $ex
+	]);
 }


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getLogger` and replaces it with `OC\Server::get(\Psr\Log\LoggerInterface::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `Psr\Log\LoggerInterface` class is imported via the `use` directive.