### PR TITLE
Refactor `OC\Server::getRequest`

### DIFF
--- a/console.php
+++ b/console.php
@@ -34,6 +34,7 @@
 require_once __DIR__ . '/lib/versioncheck.php';
 
 use OC\Console\Application;
+use OCP\IRequest;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
@@ -92,7 +93,7 @@ try {
 	$application = new Application(
 		\OC::$server->getConfig(),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
-		\OC::$server->getRequest(),
+		\OC::$server->get(IRequest::class),
 		\OC::$server->get(\Psr\Log\LoggerInterface::class),
 		\OC::$server->query(\OC\MemoryInfo::class)
 	);

--- a/index.php
+++ b/index.php
@@ -29,6 +29,8 @@
  *
  */
 require_once __DIR__ . '/lib/versioncheck.php';
+
+use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 try {
@@ -64,7 +66,7 @@ try {
 		OC_Template::printExceptionErrorPage($ex, 500);
 	}
 } catch (\OC\User\LoginException $ex) {
-	$request = \OC::$server->getRequest();
+	$request = \OC::$server->get(IRequest::class);
 	/**
 	 * Routes with the @CORS annotation and other API endpoints should
 	 * not return a webpage, so we only print the error page when html is accepted,

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -216,7 +216,7 @@ class App {
 				$expireDate,
 				$container->getServer()->getWebRoot(),
 				null,
-				$container->getServer()->getRequest()->getServerProtocol() === 'https',
+				$container->getServer()->get(IRequest::class)->getServerProtocol() === 'https',
 				true,
 				$sameSite
 			);

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -179,7 +179,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerService('Protocol', function (ContainerInterface $c) {
 			/** @var \OC\Server $server */
 			$server = $c->get(IServerContainer::class);
-			$protocol = $server->getRequest()->getHttpProtocol();
+			$protocol = $server->get(IRequest::class)->getHttpProtocol();
 			return new Http($_SERVER, $protocol);
 		});
 

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -40,6 +40,7 @@ use Exception;
 use Nextcloud\LogNormalizer\Normalizer;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Log\BeforeMessageLoggedEvent;
 use OCP\Log\IDataLogger;
@@ -263,7 +264,7 @@ class Log implements ILogger, IDataLogger {
 			if (!empty($logCondition)) {
 				// check for secret token in the request
 				if (isset($logCondition['shared_secret'])) {
-					$request = \OC::$server->getRequest();
+					$request = \OC::$server->get(IRequest::class);
 
 					if ($request->getMethod() === 'PUT' &&
 						!str_contains($request->getHeader('Content-Type'), 'application/x-www-form-urlencoded') &&

--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -26,6 +26,7 @@
 namespace OC\Log;
 
 use OC\SystemConfig;
+use OCP\IRequest;
 
 abstract class LogDetails {
 	/** @var SystemConfig */
@@ -51,7 +52,7 @@ abstract class LogDetails {
 			// apply timezone if $time is created from UNIX timestamp
 			$time->setTimezone($timezone);
 		}
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 		$reqId = $request->getId();
 		$remoteAddr = $request->getRemoteAddress();
 		// remove username/passwords from URLs before writing the to the log file

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -627,7 +627,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(IFactory::class, function (Server $c) {
 			return new \OC\L10N\Factory(
 				$c->get(\OCP\IConfig::class),
-				$c->getRequest(),
+				$c->get(IRequest::class),
 				$c->get(IUserSession::class),
 				$c->get(ICacheFactory::class),
 				\OC::$SERVERROOT
@@ -707,7 +707,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(\OCP\Activity\IManager::class, function (Server $c) {
 			$l10n = $this->get(IFactory::class)->get('lib');
 			return new \OC\Activity\Manager(
-				$c->getRequest(),
+				$c->get(IRequest::class),
 				$c->get(IUserSession::class),
 				$c->get(\OCP\IConfig::class),
 				$c->get(IValidator::class),
@@ -1161,7 +1161,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$classExists = false;
 			}
 
-			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isInstalled('theming') && $c->getTrustedDomainHelper()->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
+			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isInstalled('theming') && $c->getTrustedDomainHelper()->isTrustedDomain($c->get(IRequest::class)->getInsecureServerHost())) {
 				$imageManager = new ImageManager(
 					$c->get(\OCP\IConfig::class),
 					$c->getAppDataDir('theming'),

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -60,6 +60,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -313,7 +314,7 @@ class Setup {
 			return $error;
 		}
 
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 
 		//no errors, good
 		if (isset($options['trusted_domains'])

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -52,6 +52,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\INavigationManager;
+use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
@@ -251,7 +252,7 @@ class TemplateLayout extends \OC_Template {
 		}
 
 		try {
-			$pathInfo = \OC::$server->getRequest()->getPathInfo();
+			$pathInfo = \OC::$server->get(IRequest::class)->getPathInfo();
 		} catch (\Exception $e) {
 			$pathInfo = '';
 		}

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -42,6 +42,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IGroup;
+use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
@@ -234,7 +235,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		$result = $this->checkPasswordNoLogging($loginName, $password);
 
 		if ($result === false) {
-			\OC::$server->getLogger()->warning('Login failed: \''. $loginName .'\' (Remote IP: \''. \OC::$server->getRequest()->getRemoteAddress(). '\')', ['app' => 'core']);
+			\OC::$server->getLogger()->warning('Login failed: \''. $loginName .'\' (Remote IP: \''. \OC::$server->get(IRequest::class)->getRemoteAddress(). '\')', ['app' => 'core']);
 		}
 
 		return $result;

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -954,7 +954,7 @@ class Session implements IUserSession, Emitter {
 	 * @param string $token
 	 */
 	public function setMagicInCookie($username, $token) {
-		$secureCookie = OC::$server->getRequest()->getServerProtocol() === 'https';
+		$secureCookie = OC::$server->get(IRequest::class)->getServerProtocol() === 'https';
 		$webRoot = \OC::$WEBROOT;
 		if ($webRoot === '') {
 			$webRoot = '/';
@@ -1002,7 +1002,7 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function unsetMagicInCookie() {
 		//TODO: DI for cookies and IRequest
-		$secureCookie = OC::$server->getRequest()->getServerProtocol() === 'https';
+		$secureCookie = OC::$server->get(IRequest::class)->getServerProtocol() === 'https';
 
 		unset($_COOKIE['nc_username']); //TODO: DI
 		unset($_COOKIE['nc_token']);

--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -30,6 +30,7 @@
  */
 use OCP\API;
 use OCP\AppFramework\Http;
+use OCP\IRequest;
 
 class OC_API {
 	/**
@@ -44,7 +45,7 @@ class OC_API {
 	 * @psalm-taint-escape html
 	 */
 	public static function respond($result, $format = 'xml') {
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 
 		// Send 401 headers if unauthorised
 		if ($result->getStatusCode() === \OCP\AppFramework\OCSController::RESPOND_UNAUTHORISED) {

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -57,6 +57,7 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IRequest;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -404,7 +405,7 @@ class OC_App {
 			return '';
 		}
 
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 		$script = substr($request->getScriptName(), strlen(OC::$WEBROOT) + 1);
 		$topFolder = substr($script, 0, strpos($script, '/') ?: 0);
 		if (empty($topFolder)) {

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -47,6 +47,7 @@ use OCP\Lock\ILockingProvider;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IRequest;
 
 /**
  * Class for file server access
@@ -174,7 +175,7 @@ class OC_Files {
 				throw new \OC\ForbiddenException($event->getErrorMessage());
 			}
 
-			$streamer = new Streamer(\OC::$server->getRequest(), $fileSize, $numberOfFiles);
+			$streamer = new Streamer(\OC::$server->get(IRequest::class), $fileSize, $numberOfFiles);
 			OC_Util::obEnd();
 
 			$streamer->sendHeaders($name);

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IRequest;
+
 class OC_JSON {
 	/**
 	 * Check if the app is enabled, send json error msg if not
@@ -64,12 +67,12 @@ class OC_JSON {
 	 * @suppress PhanDeprecatedFunction
 	 */
 	public static function callCheck() {
-		if (!\OC::$server->getRequest()->passesStrictCookieCheck()) {
+		if (!\OC::$server->get(IRequest::class)->passesStrictCookieCheck()) {
 			header('Location: '.\OC::$WEBROOT);
 			exit();
 		}
 
-		if (!\OC::$server->getRequest()->passesCSRFCheck()) {
+		if (!\OC::$server->get(IRequest::class)->passesCSRFCheck()) {
 			$l = \OC::$server->getL10N('lib');
 			self::error([ 'data' => [ 'message' => $l->t('Token expired. Please reload page.'), 'error' => 'token_expired' ]]);
 			exit();

--- a/lib/private/legacy/OC_Response.php
+++ b/lib/private/legacy/OC_Response.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IRequest;
+
 class OC_Response {
 	/**
 	 * Sets the content disposition header (with possible workarounds)
@@ -34,7 +37,7 @@ class OC_Response {
 	 * @param string $type disposition type, either 'attachment' or 'inline'
 	 */
 	public static function setContentDispositionHeader($filename, $type = 'attachment') {
-		if (\OC::$server->getRequest()->isUserAgent(
+		if (\OC::$server->get(IRequest::class)->isUserAgent(
 			[
 				\OC\AppFramework\Http\Request::USER_AGENT_IE,
 				\OC\AppFramework\Http\Request::USER_AGENT_ANDROID_MOBILE_CHROME,

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -39,6 +39,7 @@
  */
 use OC\TemplateLayout;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IRequest;
 
 require_once __DIR__.'/template/functions.php';
 
@@ -277,7 +278,7 @@ class OC_Template extends \OC\Template\Base {
 	public static function printExceptionErrorPage($exception, $statusCode = 503) {
 		http_response_code($statusCode);
 		try {
-			$request = \OC::$server->getRequest();
+			$request = \OC::$server->get(IRequest::class);
 			$content = new \OC_Template('', 'exception', 'error', false);
 			$content->assign('errorClass', get_class($exception));
 			$content->assign('errorMsg', $exception->getMessage());

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -39,6 +39,7 @@
 use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\UserLoggedInEvent;
@@ -182,7 +183,7 @@ class OC_User {
 					throw new LoginException($message);
 				}
 				$userSession->setLoginName($uid);
-				$request = OC::$server->getRequest();
+				$request = OC::$server->get(IRequest::class);
 				$password = null;
 				if ($backend instanceof \OCP\Authentication\IProvideUserSecretBackend) {
 					$password = $backend->getCurrentUserSecret();

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -69,6 +69,7 @@ use OC\Files\SetupManager;
 use OCP\Files\Template\ITemplateManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Share\IManager;
@@ -785,7 +786,7 @@ class OC_Util {
 			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
 				'core.login.showLoginForm',
 				[
-					'redirect_url' => \OC::$server->getRequest()->getRequestUri(),
+					'redirect_url' => \OC::$server->get(IRequest::class)->getRequestUri(),
 				]
 			)
 			);

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -48,6 +48,7 @@ namespace OCP;
 
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
+use OCP\IRequest;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -294,7 +295,7 @@ class Util {
 	 * @since 5.0.0
 	 */
 	public static function getServerHostName() {
-		$host_name = \OC::$server->getRequest()->getServerHost();
+		$host_name = \OC::$server->get(IRequest::class)->getServerHost();
 		// strip away port number (if existing)
 		$colon_pos = strpos($host_name, ':');
 		if ($colon_pos != false) {

--- a/ocs-provider/index.php
+++ b/ocs-provider/index.php
@@ -21,13 +21,15 @@
 
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IRequest;
+
 header('Content-Type: application/json');
 
 $server = \OC::$server;
 
 $controller = new \OC\OCS\Provider(
 	'ocs_provider',
-	$server->getRequest(),
+	$server->get(IRequest::class),
 	$server->getAppManager()
 );
 echo $controller->buildProviderList()->render();

--- a/ocs/providers.php
+++ b/ocs/providers.php
@@ -26,9 +26,11 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IRequest;
+
 header('Content-type: application/xml');
 
-$request = \OC::$server->getRequest();
+$request = \OC::$server->get(IRequest::class);
 
 $url = $request->getServerProtocol() . '://' . substr($request->getServerHost() . $request->getRequestUri(), 0, -17).'ocs/v1.php/';
 

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -30,6 +30,8 @@
 require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
+use OCP\IRequest;
+
 if (\OCP\Util::needUpgrade()
 	|| \OC::$server->getConfig()->getSystemValueBool('maintenance')) {
 	// since the behavior of apps or remotes are unpredictable during
@@ -58,14 +60,14 @@ try {
 	OC_App::loadApps();
 
 	if (!\OC::$server->getUserSession()->isLoggedIn()) {
-		OC::handleLogin(\OC::$server->getRequest());
+		OC::handleLogin(\OC::$server->get(IRequest::class));
 	}
 
-	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
+	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->get(IRequest::class)->getRawPathInfo());
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 
-	$format = \OC::$server->getRequest()->getParam('format', 'xml');
+	$format = \OC::$server->get(IRequest::class)->getParam('format', 'xml');
 	$txt = 'Invalid query, please check the syntax. API specifications are here:'
 		.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.'."\n";
 	OC_API::respond(new \OC\OCS\Result(null, \OCP\AppFramework\OCSController::RESPOND_NOT_FOUND, $txt), $format);
@@ -80,7 +82,7 @@ try {
 	\OC::$server->getLogger()->logException($e);
 	OC_API::setContentType();
 
-	$format = \OC::$server->getRequest()->getParam('format', 'xml');
+	$format = \OC::$server->get(IRequest::class)->getParam('format', 'xml');
 	$txt = 'Internal Server Error'."\n";
 	try {
 		if (\OC::$server->getSystemConfig()->getValue('debug', false)) {

--- a/public.php
+++ b/public.php
@@ -32,6 +32,8 @@
  */
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\IRequest;
+
 try {
 	require_once __DIR__ . '/lib/base.php';
 	if (\OCP\Util::needUpgrade()) {
@@ -42,7 +44,7 @@ try {
 	}
 
 	OC::checkMaintenanceMode(\OC::$server->get(\OC\SystemConfig::class));
-	$request = \OC::$server->getRequest();
+	$request = \OC::$server->get(IRequest::class);
 	$pathInfo = $request->getPathInfo();
 
 	if (!$pathInfo && $request->getParam('service', '') === '') {

--- a/remote.php
+++ b/remote.php
@@ -34,6 +34,7 @@
 require_once __DIR__ . '/lib/versioncheck.php';
 
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
+use OCP\IRequest;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\Server;
 use Psr\Log\LoggerInterface;
@@ -51,7 +52,7 @@ class RemoteException extends Exception {
  */
 function handleException($e) {
 	try {
-		$request = \OC::$server->getRequest();
+		$request = \OC::$server->get(IRequest::class);
 		// in case the request content type is text/xml - we assume it's a WebDAV request
 		$isXmlContentType = strpos($request->getHeader('Content-Type'), 'text/xml');
 		if ($isXmlContentType === 0) {
@@ -129,7 +130,7 @@ try {
 		throw new RemoteException('Service unavailable', 503);
 	}
 
-	$request = \OC::$server->getRequest();
+	$request = \OC::$server->get(IRequest::class);
 	$pathInfo = $request->getPathInfo();
 	if ($pathInfo === false || $pathInfo === '') {
 		throw new RemoteException('Path not found', 404);


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getRequest` and replaces it with `OC\Server::get(\OCP\IRequest::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IRequest` class is imported via the `use` directive.