### PR TITLE
Refactor `OC\Server::getMimeTypeDetector`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\Files\IMimeTypeDetector;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -163,11 +165,11 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 
 	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
-	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
-	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
+	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->get(IMimeTypeDetector::class), \OC::$server->getMimeTypeLoader()));
+	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->get(IMimeTypeDetector::class)));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
-	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
+	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->get(IMimeTypeDetector::class), \OC::$server->getMemCacheFactory()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -42,6 +42,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
@@ -436,7 +437,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 				//create a empty file, need to have at least on char to make it
 				// work with all object storage implementations
 				$this->file_put_contents($path, ' ');
-				$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($path);
+				$mimeType = \OC::$server->get(IMimeTypeDetector::class)->detectPath($path);
 				$stat = [
 					'etag' => $this->getETag($path),
 					'mimetype' => $mimeType,
@@ -501,7 +502,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$stat['mtime'] = $mTime;
 		$stat['storage_mtime'] = $mTime;
 
-		$mimetypeDetector = \OC::$server->getMimeTypeDetector();
+		$mimetypeDetector = \OC::$server->get(IMimeTypeDetector::class);
 		$mimetype = $mimetypeDetector->detectPath($path);
 
 		$stat['mimetype'] = $mimetype;

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -54,6 +54,7 @@ use OCP\Files\EmptyFileNameException;
 use OCP\Files\FileNameTooLongException;
 use OCP\Files\ForbiddenException;
 use OCP\Files\GenericFileException;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidDirectoryException;
 use OCP\Files\InvalidPathException;
@@ -254,7 +255,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		if ($this->is_dir($path)) {
 			return 'httpd/unix-directory';
 		} elseif ($this->file_exists($path)) {
-			return \OC::$server->getMimeTypeDetector()->detectPath($path);
+			return \OC::$server->get(IMimeTypeDetector::class)->detectPath($path);
 		} else {
 			return false;
 		}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -154,7 +154,7 @@ class DAV extends Common {
 		$this->eventLogger = \OC::$server->get(IEventLogger::class);
 		// This timeout value will be used for the download and upload of files
 		$this->timeout = \OC::$server->get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', 30);
-		$this->mimeTypeDetector = \OC::$server->getMimeTypeDetector();
+		$this->mimeTypeDetector = \OC::$server->get(IMimeTypeDetector::class);
 	}
 
 	protected function init() {

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -44,6 +44,7 @@ use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Files\View;
 use OC\Streamer;
 use OCP\Lock\ILockingProvider;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -80,7 +81,7 @@ class OC_Files {
 		header('Expires: 0');
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		$fileSize = \OC\Files\Filesystem::filesize($filename);
-		$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
+		$type = \OC::$server->get(IMimeTypeDetector::class)->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
 		if ($fileSize > -1) {
 			if (!empty($rangeArray)) {
 				http_response_code(206);
@@ -361,7 +362,7 @@ class OC_Files {
 					// we have to check it before body contents
 					$view->readfilePart($filename, $rangeArray[0]['size'], $rangeArray[0]['size']);
 
-					$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
+					$type = \OC::$server->get(IMimeTypeDetector::class)->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
 
 					foreach ($rangeArray as $range) {
 						echo "\r\n--".self::getBoundary()."\r\n".

--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -34,6 +34,9 @@ use OCP\Util;
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\Files\IMimeTypeDetector;
+
 function p($string) {
 	print(\OCP\Util::sanitizeHTML($string));
 }
@@ -255,7 +258,7 @@ function image_path($app, $image) {
  * @return string link to the image
  */
 function mimetype_icon($mimetype) {
-	return \OC::$server->getMimeTypeDetector()->mimeTypeIcon($mimetype);
+	return \OC::$server->get(IMimeTypeDetector::class)->mimeTypeIcon($mimetype);
 }
 
 /**

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -35,6 +35,8 @@
 
 namespace OCP;
 
+use OCP\Files\IMimeTypeDetector;
+
 /**
  * This class provides access to the internal filesystem abstraction layer. Use
  * this class exclusively if you want to access files
@@ -61,7 +63,7 @@ class Files {
 	 * @deprecated 14.0.0
 	 */
 	public static function getMimeType($path) {
-		return \OC::$server->getMimeTypeDetector()->detect($path);
+		return \OC::$server->get(IMimeTypeDetector::class)->detect($path);
 	}
 
 	/**


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getMimeTypeDetector` and replaces it with `OC\Server::get(\OCP\Files\IMimeTypeDetector::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\Files\IMimeTypeDetector` class is imported via the `use` directive.