### PR TITLE
Refactor `OC\Server::getMemCacheFactory`

### DIFF
--- a/build/integration/features/bootstrap/RemoteContext.php
+++ b/build/integration/features/bootstrap/RemoteContext.php
@@ -23,6 +23,7 @@
  *
  */
 use Behat\Behat\Context\Context;
+use OCP\ICacheFactory;
 use PHPUnit\Framework\Assert;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -66,7 +67,7 @@ class RemoteContext implements Context {
 		}
 		$this->lastException = null;
 		try {
-			$this->remoteInstance = new \OC\Remote\Instance($baseUri, \OC::$server->getMemCacheFactory()->createLocal(), \OC::$server->getHTTPClientService());
+			$this->remoteInstance = new \OC\Remote\Instance($baseUri, \OC::$server->get(ICacheFactory::class)->createLocal(), \OC::$server->getHTTPClientService());
 			// trigger the status request
 			$this->remoteInstance->getProtocol();
 		} catch (\Exception $e) {

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -167,7 +169,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
-	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
+	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->get(ICacheFactory::class)));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(

--- a/lib/private/Files/ObjectStore/Swift.php
+++ b/lib/private/Files/ObjectStore/Swift.php
@@ -32,6 +32,7 @@ use Icewind\Streams\RetryWrapper;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\StorageAuthException;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 const SWIFT_SEGMENT_SIZE = 1073741824; // 1GB
@@ -47,7 +48,7 @@ class Swift implements IObjectStore {
 
 	public function __construct($params, SwiftFactory $connectionFactory = null) {
 		$this->swiftFactory = $connectionFactory ?: new SwiftFactory(
-			\OC::$server->getMemCacheFactory()->createDistributed('swift::'),
+			\OC::$server->get(ICacheFactory::class)->createDistributed('swift::'),
 			$params,
 			\OC::$server->get(LoggerInterface::class)
 		);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Resources\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ICacheFactory;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OC\DB\Connection;
@@ -192,7 +193,7 @@ class Repair implements IOutput {
 			new FixMountStorages(\OC::$server->getDatabaseConnection()),
 			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new AddLogRotateJob(\OC::$server->getJobList()),
-			new ClearFrontendCaches(\OC::$server->getMemCacheFactory(), \OCP\Server::get(JSCombiner::class)),
+			new ClearFrontendCaches(\OC::$server->get(ICacheFactory::class), \OCP\Server::get(JSCombiner::class)),
 			\OCP\Server::get(ClearGeneratedAvatarCache::class),
 			new AddPreviewBackgroundCleanupJob(\OC::$server->getJobList()),
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -14,6 +14,7 @@ use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -559,7 +560,7 @@ class AppTest extends \Test\TestCase {
 			\OC::$server->getConfig(),
 			$appConfig,
 			\OC::$server->getGroupManager(),
-			\OC::$server->getMemCacheFactory(),
+			\OC::$server->get(ICacheFactory::class),
 			\OC::$server->get(IEventDispatcher::class),
 			\OC::$server->get(LoggerInterface::class)
 		));


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getMemCacheFactory` and replaces it with `OC\Server::get(\OCP\ICacheFactory::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `OCP\ICacheFactory` class is imported via the `use` directive.