### PR TITLE
Refactor `OC\Server::getL10N`

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -36,6 +36,7 @@ use OC\Installer;
 use OC\Setup;
 use OC\SystemConfig;
 use OCP\Defaults;
+use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -77,7 +78,7 @@ class Install extends Command {
 		$setupHelper = new Setup(
 			$this->config,
 			$this->iniGetWrapper,
-			$server->getL10N('lib'),
+			$server->get(IFactory::class)->get('lib'),
 			$server->query(Defaults::class),
 			$server->get(LoggerInterface::class),
 			$server->getSecureRandom(),

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -209,7 +211,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\SystemTag\Add(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
 	$application->add(new OC\Core\Command\SystemTag\Edit(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
 
-	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(), \OC::$server->getL10N('core')));
+	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(), \OC::$server->get(IFactory::class)->get('core')));
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager()));
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\Security\BruteforceAttempts::class));

--- a/core/strings.php
+++ b/core/strings.php
@@ -24,8 +24,11 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\L10N\IFactory;
+
 //some strings that are used in /lib but won't be translatable unless they are in /core too
-$l = \OC::$server->getL10N('core');
+$l = \OC::$server->get(IFactory::class)->get('core');
 $l->t("Personal");
 $l->t("Users");
 $l->t("Apps");

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -73,6 +73,7 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Security\Bruteforce\IThrottler;
+use OCP\L10N\IFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -135,7 +136,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 
 		$this->registerService(IL10N::class, function (ContainerInterface $c) {
-			return $this->getServer()->getL10N($c->get('AppName'));
+			return $this->getServer()->get(IFactory::class)->get($c->get('AppName'));
 		});
 
 		// Log wrappers
@@ -256,7 +257,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
 				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
 				$server->getAppManager(),
-				$server->getL10N('lib'),
+				$server->get(IFactory::class)->get('lib'),
 				$c->get(AuthorizedGroupMapper::class),
 				$server->get(IUserSession::class)
 			);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -66,6 +66,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
+use OCP\L10N\IFactory;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
@@ -1834,19 +1835,19 @@ class View {
 			[$storage, $internalPath] = $this->resolvePath($path);
 			$storage->verifyPath($internalPath, $fileName);
 		} catch (ReservedWordException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name is a reserved word'));
 		} catch (InvalidCharacterInPathException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name contains at least one invalid character'));
 		} catch (FileNameTooLongException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('File name is too long'));
 		} catch (InvalidDirectoryException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('Dot files are not allowed'));
 		} catch (EmptyFileNameException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			throw new InvalidPathException($l->t('Empty filename is not allowed'));
 		}
 	}

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -53,6 +53,7 @@ use OCP\HintException;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\ITempManager;
+use OCP\L10N\IFactory;
 use phpseclib\File\X509;
 use Psr\Log\LoggerInterface;
 
@@ -113,7 +114,7 @@ class Installer {
 			throw new \Exception('The appinfo/database.xml file is not longer supported. Used in ' . $appId);
 		}
 
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		$info = \OCP\Server::get(IAppManager::class)->getAppInfo($basedir . '/appinfo/info.xml', true, $l->getLanguageCode());
 
 		if (!is_array($info)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -365,7 +365,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new Encryption\Manager(
 				$c->get(\OCP\IConfig::class),
 				$c->get(LoggerInterface::class),
-				$c->getL10N('core'),
+				$c->get(IFactory::class)->get('core'),
 				new View(),
 				$util,
 				new ArrayCache()
@@ -719,7 +719,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService(\OCP\Activity\IEventMerger::class, function (Server $c) {
 			return new \OC\Activity\EventMerger(
-				$c->getL10N('lib')
+				$c->get(IFactory::class)->get('lib')
 			);
 		});
 		$this->registerAlias(IValidator::class, Validator::class);
@@ -729,7 +729,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IUserSession::class),
 				$c->get(\OC\User\Manager::class),
 				$c->getAppDataDir('avatar'),
-				$c->getL10N('lib'),
+				$c->get(IFactory::class)->get('lib'),
 				$c->get(LoggerInterface::class),
 				$c->get(\OCP\IConfig::class),
 				$c->get(IAccountManager::class),
@@ -890,7 +890,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 			return new DateTimeFormatter(
 				$c->get(IDateTimeZone::class)->getTimeZone(),
-				$c->getL10N('lib', $language)
+				$c->get(IFactory::class)->get('lib', $language)
 			);
 		});
 		/** @deprecated 19.0.0 */
@@ -1033,7 +1033,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(LoggerInterface::class),
 				$c->get(Defaults::class),
 				$c->get(IURLGenerator::class),
-				$c->getL10N('lib'),
+				$c->get(IFactory::class)->get('lib'),
 				$c->get(IEventDispatcher::class),
 				$c->get(IFactory::class)
 			);
@@ -1108,7 +1108,7 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('MimeTypeLoader', IMimeTypeLoader::class);
 		$this->registerService(BundleFetcher::class, function () {
-			return new BundleFetcher($this->getL10N('lib'));
+			return new BundleFetcher($this->get(IFactory::class)->get('lib'));
 		});
 		$this->registerAlias(\OCP\Notification\IManager::class, Manager::class);
 		/** @deprecated 19.0.0 */
@@ -1172,7 +1172,7 @@ class Server extends ServerContainer implements IServerContainer {
 				);
 				return new ThemingDefaults(
 					$c->get(\OCP\IConfig::class),
-					$c->getL10N('theming'),
+					$c->get(IFactory::class)->get('theming'),
 					$c->get(IUserSession::class),
 					$c->get(IURLGenerator::class),
 					$c->get(ICacheFactory::class),
@@ -1242,7 +1242,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IHasher::class),
 				$c->get(IMountManager::class),
 				$c->get(IGroupManager::class),
-				$c->getL10N('lib'),
+				$c->get(IFactory::class)->get('lib'),
 				$c->get(IFactory::class),
 				$factory,
 				$c->get(IUserManager::class),

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -60,6 +60,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
 use OCP\IL10N;
+use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -507,7 +508,7 @@ class Setup {
 		$setupHelper = new \OC\Setup(
 			$config,
 			\OC::$server->get(IniGetWrapper::class),
-			\OC::$server->getL10N('lib'),
+			\OC::$server->get(IFactory::class)->get('lib'),
 			\OCP\Server::get(Defaults::class),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->getSecureRandom(),

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -40,6 +40,7 @@ use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Share\IShare;
+use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -256,7 +257,7 @@ class Share extends Constants {
 	 * @throws \Exception
 	 */
 	public static function getBackend($itemType) {
-		$l = \OC::$server->getL10N('lib');
+		$l = \OC::$server->get(IFactory::class)->get('lib');
 		$logger = \OC::$server->get(LoggerInterface::class);
 		if (isset(self::$backends[$itemType])) {
 			return self::$backends[$itemType];

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -44,6 +44,7 @@ use OCA\Talk\Share\RoomShareProvider;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
+use OCP\L10N\IFactory;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
@@ -129,7 +130,7 @@ class ProviderFactory implements IProviderFactory {
 			/*
 			 * TODO: add factory to federated sharing app
 			 */
-			$l = $this->serverContainer->getL10N('federatedfilesharing');
+			$l = $this->serverContainer->get(IFactory::class)->get('federatedfilesharing');
 			$addressHandler = new AddressHandler(
 				$this->serverContainer->getURLGenerator(),
 				$l,
@@ -191,7 +192,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getSecureRandom(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getLazyRootFolder(),
-				$this->serverContainer->getL10N('sharebymail'),
+				$this->serverContainer->get(IFactory::class)->get('sharebymail'),
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getMailer(),
 				$this->serverContainer->getURLGenerator(),
@@ -233,7 +234,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getSecureRandom(),
 				$this->serverContainer->getUserManager(),
 				$this->serverContainer->getLazyRootFolder(),
-				$this->serverContainer->getL10N('circles'),
+				$this->serverContainer->get(IFactory::class)->get('circles'),
 				$this->serverContainer->getLogger(),
 				$this->serverContainer->getURLGenerator()
 			);

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -37,6 +37,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\ITags;
+use OCP\L10N\IFactory;
 use OCP\Share_Backend;
 use Psr\Log\LoggerInterface;
 
@@ -235,7 +236,7 @@ class Tags implements ITags {
 		}
 
 		if ($tagId === false) {
-			$l10n = \OC::$server->getL10N('core');
+			$l10n = \OC::$server->get(IFactory::class)->get('core');
 			throw new \Exception(
 				$l10n->t('Could not find category "%s"', [$tag])
 			);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -53,6 +53,7 @@ use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\INavigationManager;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
 
@@ -225,7 +226,7 @@ class TemplateLayout extends \OC_Template {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)
 			// see https://github.com/nextcloud/server/pull/22636 for details
 			$jsConfigHelper = new JSConfigHelper(
-				\OC::$server->getL10N('lib'),
+				\OC::$server->get(IFactory::class)->get('lib'),
 				\OCP\Server::get(Defaults::class),
 				\OC::$server->getAppManager(),
 				\OC::$server->getSession(),

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -415,7 +415,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @throws \InvalidArgumentException
 	 */
 	public function createUserFromBackend($uid, $password, UserInterface $backend) {
-		$l = \OC::$server->getL10N('lib');
+		$l = \OC::$server->get(IFactory::class)->get('lib');
 
 		$this->validateUserId($uid, true);
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -59,6 +59,7 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\Lockdown\ILockdownManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ISecureRandom;
@@ -367,7 +368,7 @@ class Session implements IUserSession, Emitter {
 		if (!$user->isEnabled()) {
 			// disabled users can not log in
 			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-			$message = \OC::$server->getL10N('lib')->t('User disabled');
+			$message = \OC::$server->get(IFactory::class)->get('lib')->t('User disabled');
 			throw new LoginException($message);
 		}
 
@@ -406,7 +407,7 @@ class Session implements IUserSession, Emitter {
 			return true;
 		}
 
-		$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
+		$message = \OC::$server->get(IFactory::class)->get('lib')->t('Login canceled by app');
 		throw new LoginException($message);
 	}
 

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -57,6 +57,7 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
+use OCP\L10N\IFactory;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
@@ -560,7 +561,7 @@ class OC_App {
 		//we don't want to show configuration for these
 		$blacklist = $appManager->getAlwaysEnabledApps();
 		$appList = [];
-		$langCode = \OC::$server->getL10N('core')->getLanguageCode();
+		$langCode = \OC::$server->get(IFactory::class)->get('core')->getLanguageCode();
 		$urlGenerator = \OC::$server->getURLGenerator();
 		$supportedApps = $this->getSupportedApps();
 
@@ -757,7 +758,7 @@ class OC_App {
 		}
 
 		\OC::$server->getAppManager()->clearAppsCache();
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		$appData = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppInfo($appId, false, $l->getLanguageCode());
 
 		$ignoreMaxApps = \OC::$server->getConfig()->getSystemValue('app_install_overwrite', []);

--- a/lib/private/legacy/OC_Defaults.php
+++ b/lib/private/legacy/OC_Defaults.php
@@ -37,6 +37,8 @@
  *
  */
 
+use OCP\L10N\IFactory;
+
 class OC_Defaults {
 	private $theme;
 
@@ -237,7 +239,7 @@ class OC_Defaults {
 			return $this->theme->getSlogan($lang);
 		} else {
 			if ($this->defaultSlogan === null) {
-				$l10n = \OC::$server->getL10N('lib', $lang);
+				$l10n = \OC::$server->get(IFactory::class)->get('lib', $lang);
 				$this->defaultSlogan = $l10n->t('a safe home for all your data');
 			}
 			return $this->defaultSlogan;

--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -47,6 +47,7 @@ use OCP\Lock\ILockingProvider;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\L10N\IFactory;
 
 /**
  * Class for file server access
@@ -222,18 +223,18 @@ class OC_Files {
 		} catch (\OCP\Lock\LockedException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
 			\OC_Template::printErrorPage($l->t('File is currently busy, please try again later'), $hint, 200);
 		} catch (\OCP\Files\ForbiddenException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			\OC_Template::printErrorPage($l->t('Cannot download file'), $ex->getMessage(), 200);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
 			if ($event && $event->getErrorMessage() !== null) {
 				$hint .= ' ' . $event->getErrorMessage();

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -27,6 +27,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\L10N\IFactory;
+
 class OC_JSON {
 	/**
 	 * Check if the app is enabled, send json error msg if not
@@ -36,7 +39,7 @@ class OC_JSON {
 	 */
 	public static function checkAppEnabled($app) {
 		if (!\OC::$server->getAppManager()->isEnabledForUser($app)) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			self::error([ 'data' => [ 'message' => $l->t('Application is not enabled'), 'error' => 'application_not_enabled' ]]);
 			exit();
 		}
@@ -51,7 +54,7 @@ class OC_JSON {
 		$twoFactorAuthManger = \OC::$server->getTwoFactorAuthManager();
 		if (!\OC::$server->getUserSession()->isLoggedIn()
 			|| $twoFactorAuthManger->needsSecondFactor(\OC::$server->getUserSession()->getUser())) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			http_response_code(\OCP\AppFramework\Http::STATUS_UNAUTHORIZED);
 			self::error([ 'data' => [ 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' ]]);
 			exit();
@@ -70,7 +73,7 @@ class OC_JSON {
 		}
 
 		if (!\OC::$server->getRequest()->passesCSRFCheck()) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			self::error([ 'data' => [ 'message' => $l->t('Token expired. Please reload page.'), 'error' => 'token_expired' ]]);
 			exit();
 		}
@@ -83,7 +86,7 @@ class OC_JSON {
 	 */
 	public static function checkAdminUser() {
 		if (!OC_User::isAdminUser(OC_User::getUser())) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OC::$server->get(IFactory::class)->get('lib');
 			self::error([ 'data' => [ 'message' => $l->t('Authentication error'), 'error' => 'authentication_error' ]]);
 			exit();
 		}

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -39,6 +39,7 @@
  */
 use OC\TemplateLayout;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\L10N\IFactory;
 
 require_once __DIR__.'/template/functions.php';
 
@@ -75,7 +76,7 @@ class OC_Template extends \OC\Template\Base {
 		$requestToken = (OC::$server->getSession() && $registerCall) ? \OCP\Util::callRegister() : '';
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
-		$l10n = \OC::$server->getL10N($parts[0]);
+		$l10n = \OC::$server->get(IFactory::class)->get($parts[0]);
 		/** @var \OCP\Defaults $themeDefaults */
 		$themeDefaults = \OCP\Server::get(\OCP\Defaults::class);
 

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -40,6 +40,7 @@ use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IUserManager;
+use OCP\L10N\IFactory;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\UserLoggedInEvent;
 
@@ -178,7 +179,7 @@ class OC_User {
 				$dispatcher = \OC::$server->get(IEventDispatcher::class);
 
 				if ($userSession->getUser() && !$userSession->getUser()->isEnabled()) {
-					$message = \OC::$server->getL10N('lib')->t('User disabled');
+					$message = \OC::$server->get(IFactory::class)->get('lib')->t('User disabled');
 					throw new LoginException($message);
 				}
 				$userSession->setLoginName($uid);

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -71,6 +71,7 @@ use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\L10N\IFactory;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 
@@ -497,7 +498,7 @@ class OC_Util {
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkServer(\OC\SystemConfig $config) {
-		$l = \OC::$server->getL10N('lib');
+		$l = \OC::$server->get(IFactory::class)->get('lib');
 		$errors = [];
 		$CONFIG_DATADIRECTORY = $config->getValue('datadirectory', OC::$SERVERROOT . '/data');
 
@@ -515,7 +516,7 @@ class OC_Util {
 		$setup = new \OC\Setup(
 			$config,
 			\OC::$server->get(IniGetWrapper::class),
-			\OC::$server->getL10N('lib'),
+			\OC::$server->get(IFactory::class)->get('lib'),
 			\OC::$server->get(\OCP\Defaults::class),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->getSecureRandom(),
@@ -737,7 +738,7 @@ class OC_Util {
 			clearstatcache();
 			$perms = substr(decoct(@fileperms($dataDirectory)), -3);
 			if ($perms[2] !== '0') {
-				$l = \OC::$server->getL10N('lib');
+				$l = \OC::$server->get(IFactory::class)->get('lib');
 				return [[
 					'error' => $l->t('Your data directory is readable by other users.'),
 					'hint' => $l->t('Please change the permissions to 0770 so that the directory cannot be listed by other users.'),
@@ -755,7 +756,7 @@ class OC_Util {
 	 * @return array errors found
 	 */
 	public static function checkDataDirectoryValidity($dataDirectory) {
-		$l = \OC::$server->getL10N('lib');
+		$l = \OC::$server->get(IFactory::class)->get('lib');
 		$errors = [];
 		if ($dataDirectory[0] !== '/') {
 			$errors[] = [

--- a/lib/public/Federation/Exceptions/ActionNotSupportedException.php
+++ b/lib/public/Federation/Exceptions/ActionNotSupportedException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ActionNotSupportedException
@@ -38,7 +39,7 @@ class ActionNotSupportedException extends HintException {
 	 *
 	 */
 	public function __construct($action) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Action "' . $action . '" not supported or implemented.';
 		$hint = $l->t('Action "%s" not supported or implemented.', [$action]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/AuthenticationFailedException.php
+++ b/lib/public/Federation/Exceptions/AuthenticationFailedException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class AuthenticationFailedException
@@ -38,7 +39,7 @@ class AuthenticationFailedException extends HintException {
 	 *
 	 */
 	public function __construct() {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Authentication failed, wrong token or provider ID given';
 		$hint = $l->t('Authentication failed, wrong token or provider ID given');
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/BadRequestException.php
+++ b/lib/public/Federation/Exceptions/BadRequestException.php
@@ -24,6 +24,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class BadRequestException
@@ -45,7 +46,7 @@ class BadRequestException extends HintException {
 	 * @param array $missingParameters
 	 */
 	public function __construct(array $missingParameters) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$this->parameterList = $missingParameters;
 		$parameterList = implode(',', $missingParameters);
 		$message = 'Parameters missing in order to complete the request. Missing Parameters: ' . $parameterList;

--- a/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
@@ -25,6 +25,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ProviderAlreadyExistsException
@@ -42,7 +43,7 @@ class ProviderAlreadyExistsException extends HintException {
 	 * @param string $existingProviderName name of cloud federation provider which already use the same ID
 	 */
 	public function __construct($newProviderId, $existingProviderName) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'ID "' . $newProviderId . '" already used by cloud federation provider "' . $existingProviderName . '"';
 		$hint = $l->t('ID "%1$s" already used by cloud federation provider "%2$s"', [$newProviderId, $existingProviderName]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
@@ -23,6 +23,7 @@
 namespace OCP\Federation\Exceptions;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Class ProviderDoesNotExistsException
@@ -39,7 +40,7 @@ class ProviderDoesNotExistsException extends HintException {
 	 * @param string $providerId cloud federation provider ID
 	 */
 	public function __construct($providerId) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OC::$server->get(IFactory::class)->get('federation');
 		$message = 'Cloud Federation Provider with ID: "' . $providerId . '" does not exist.';
 		$hint = $l->t('Cloud Federation Provider with ID: "%s" does not exist.', [$providerId]);
 		parent::__construct($message, $hint);

--- a/lib/public/Files/LockNotAcquiredException.php
+++ b/lib/public/Files/LockNotAcquiredException.php
@@ -28,6 +28,8 @@
 
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Exception for a file that is locked
  * @since 7.0.0
@@ -43,7 +45,7 @@ class LockNotAcquiredException extends \Exception {
 	 * @since 7.0.0
 	 */
 	public function __construct($path, $lockType, $code = 0, \Exception $previous = null) {
-		$message = \OC::$server->getL10N('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
+		$message = \OC::$server->get(IFactory::class)->get('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
 		parent::__construct($message, $code, $previous);
 	}
 

--- a/lib/public/Files/StorageAuthException.php
+++ b/lib/public/Files/StorageAuthException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageAuthException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage unauthorized. %s', [$message]), self::STATUS_UNAUTHORIZED, $previous);
 	}
 }

--- a/lib/public/Files/StorageBadConfigException.php
+++ b/lib/public/Files/StorageBadConfigException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage has bad or missing config params
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageBadConfigException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage incomplete configuration. %s', [$message]), self::STATUS_INCOMPLETE_CONF, $previous);
 	}
 }

--- a/lib/public/Files/StorageConnectionException.php
+++ b/lib/public/Files/StorageConnectionException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageConnectionException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage connection error. %s', [$message]), self::STATUS_NETWORK_ERROR, $previous);
 	}
 }

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -33,6 +33,7 @@
 namespace OCP\Files;
 
 use OCP\HintException;
+use OCP\L10N\IFactory;
 
 /**
  * Storage is temporarily not available
@@ -56,7 +57,7 @@ class StorageNotAvailableException extends HintException {
 	 * @since 6.0.0
 	 */
 	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}
 

--- a/lib/public/Files/StorageTimeoutException.php
+++ b/lib/public/Files/StorageTimeoutException.php
@@ -23,6 +23,8 @@
  */
 namespace OCP\Files;
 
+use OCP\L10N\IFactory;
+
 /**
  * Storage authentication exception
  * @since 9.0.0
@@ -36,7 +38,7 @@ class StorageTimeoutException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OC::$server->get(IFactory::class)->get('core');
 		parent::__construct($l->t('Storage connection timeout. %s', [$message]), self::STATUS_TIMEOUT, $previous);
 	}
 }

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -48,6 +48,7 @@ namespace OCP;
 
 use OC\AppScriptDependency;
 use OC\AppScriptSort;
+use OCP\L10N\IFactory;
 use bantu\IniGetWrapper\IniGetWrapper;
 use Psr\Container\ContainerExceptionInterface;
 
@@ -150,7 +151,7 @@ class Util {
 	 * @since 6.0.0 - parameter $language was added in 8.0.0
 	 */
 	public static function getL10N($application, $language = null) {
-		return \OC::$server->getL10N($application, $language);
+		return \OC::$server->get(IFactory::class)->get($application, $language);
 	}
 
 	/**

--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -8,6 +8,8 @@
 
 namespace Test;
 
+use OCP\L10N\IFactory;
+
 class DateTimeFormatterTest extends TestCase {
 	/** @var \OC\DateTimeFormatter */
 	protected $formatter;
@@ -34,7 +36,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->formatter = new \OC\DateTimeFormatter(new \DateTimeZone('UTC'), \OC::$server->getL10N('lib', 'en'));
+		$this->formatter = new \OC\DateTimeFormatter(new \DateTimeZone('UTC'), \OC::$server->get(IFactory::class)->get('lib', 'en'));
 	}
 
 	protected function getTimestampAgo($time, $seconds = 0, $minutes = 0, $hours = 0, $days = 0, $years = 0) {
@@ -43,7 +45,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	public function formatTimeSpanData() {
 		$time = 1416916800; // Use a fixed timestamp so we don't switch days/years with the getTimestampAgo
-		$deL10N = \OC::$server->getL10N('lib', 'de');
+		$deL10N = \OC::$server->get(IFactory::class)->get('lib', 'de');
 		return [
 			['seconds ago',	$time, $time],
 			['in a few seconds', $time + 5 , $time],
@@ -84,7 +86,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	public function formatDateSpanData() {
 		$time = 1416916800; // Use a fixed timestamp so we don't switch days/years with the getTimestampAgo
-		$deL10N = \OC::$server->getL10N('lib', 'de');
+		$deL10N = \OC::$server->get(IFactory::class)->get('lib', 'de');
 		return [
 			// Normal testing
 			['today',			$this->getTimestampAgo($time, 30, 15), $time],

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -15,6 +15,7 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use Test\TestCase;
 
 /**
@@ -201,12 +202,12 @@ class L10nTest extends TestCase {
 	}
 
 	public function testServiceGetLanguageCode() {
-		$l = \OC::$server->getL10N('lib', 'de');
+		$l = \OC::$server->get(IFactory::class)->get('lib', 'de');
 		$this->assertEquals('de', $l->getLanguageCode());
 	}
 
 	public function testWeekdayName() {
-		$l = \OC::$server->getL10N('lib', 'de');
+		$l = \OC::$server->get(IFactory::class)->get('lib', 'de');
 		$this->assertEquals('Mo.', $l->l('weekdayName', new \DateTime('2017-11-6'), ['width' => 'abbreviated']));
 	}
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getL10N` and replaces it with `OC\Server::get(\OCP\L10N\IFactory::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\L10N\IFactory` class is imported via the `use` directive.