### PR TITLE
Refactor `OC\Server::getGroupManager`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -73,7 +75,7 @@ $application->add(new \OC\Core\Command\Integrity\CheckCore(
 
 if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->get(IGroupManager::class)));
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
@@ -141,7 +143,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$util = new \OC\Encryption\Util(
 		$view,
 		\OC::$server->getUserManager(),
-		\OC::$server->getGroupManager(),
+		\OC::$server->get(IGroupManager::class),
 		\OC::$server->getConfig()
 	);
 	$application->add(new OC\Core\Command\Encryption\ChangeKeyStorageRoot(
@@ -182,7 +184,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->query(\OC\Core\Command\Preview\Repair::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\Preview\ResetRenderedTexts::class));
 
-	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->get(IGroupManager::class)));
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
@@ -190,18 +192,18 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->get(IGroupManager::class)));
+	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->get(IGroupManager::class)));
 	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->getUserManager(), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Add::class));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\ListCommand::class));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Delete::class));
 
-	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\ListCommand(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\AddUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\Group\Add(\OC::$server->get(IGroupManager::class)));
+	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->get(IGroupManager::class)));
+	$application->add(new OC\Core\Command\Group\ListCommand(\OC::$server->get(IGroupManager::class)));
+	$application->add(new OC\Core\Command\Group\AddUser(\OC::$server->getUserManager(), \OC::$server->get(IGroupManager::class)));
+	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getUserManager(), \OC::$server->get(IGroupManager::class)));
 	$application->add(new OC\Core\Command\Group\Info(\OC::$server->get(\OCP\IGroupManager::class)));
 
 	$application->add(new OC\Core\Command\SystemTag\ListCommand(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -63,6 +63,7 @@ use OCP\Files\IAppData;
 use OCP\Group\ISubAdmin;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -253,7 +254,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$server->get(LoggerInterface::class),
 				$c->get('AppName'),
 				$server->getUserSession()->isLoggedIn(),
-				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
+				$this->getUserId() !== null && $server->get(IGroupManager::class)->isAdmin($this->getUserId()),
 				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
 				$server->getAppManager(),
 				$server->getL10N('lib'),

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -30,6 +30,7 @@ use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
+use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -85,7 +86,7 @@ class EncryptionWrapper {
 			$util = new Util(
 				new View(),
 				\OC::$server->getUserManager(),
-				\OC::$server->getGroupManager(),
+				\OC::$server->get(IGroupManager::class),
 				\OC::$server->getConfig()
 			);
 			$update = new Update(

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -26,6 +26,7 @@ namespace OC\Encryption;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
+use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 
 class HookManager {
@@ -75,7 +76,7 @@ class HookManager {
 				new Util(
 					new View(),
 					\OC::$server->getUserManager(),
-					\OC::$server->getGroupManager(),
+					\OC::$server->get(IGroupManager::class),
 					\OC::$server->getConfig()),
 				Filesystem::getMountManager(),
 				\OC::$server->getEncryptionManager(),

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Resources\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OC\DB\Connection;
@@ -198,7 +199,7 @@ class Repair implements IOutput {
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
 			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->get(LoggerInterface::class)),
 			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->getJobList()),
-			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->getNotificationManager(), \OCP\Server::get(ITimeFactory::class)),
+			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->get(IGroupManager::class), \OC::$server->getNotificationManager(), \OCP\Server::get(ITimeFactory::class)),
 			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OCP\Server::get(IManager::class)),
 			\OCP\Server::get(ResetGeneratedAvatarFlag::class),
 			\OCP\Server::get(EncryptionLegacyCipher::class),
@@ -223,7 +224,7 @@ class Repair implements IOutput {
 	 */
 	public static function getExpensiveRepairSteps() {
 		return [
-			new OldGroupMembershipShares(\OC::$server->getDatabaseConnection(), \OC::$server->getGroupManager()),
+			new OldGroupMembershipShares(\OC::$server->getDatabaseConnection(), \OC::$server->get(IGroupManager::class)),
 			\OC::$server->get(ValidatePhoneNumber::class),
 		];
 	}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -59,6 +59,7 @@ use OC\Preview\BackgroundCleanupJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
@@ -401,7 +402,7 @@ class Setup {
 				$config->setSystemValue('updater.release.channel', $vendorData['channel']);
 			}
 
-			$group = \OC::$server->getGroupManager()->createGroup('admin');
+			$group = \OC::$server->get(IGroupManager::class)->createGroup('admin');
 			if ($group instanceof IGroup) {
 				$group->addUser($user);
 			}

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -39,6 +39,7 @@ use OCA\Files_Sharing\ShareBackend\File;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
@@ -198,7 +199,7 @@ class Share extends Constants {
 			$userObject = \OC::$server->getUserManager()->get($user);
 			$groups = [];
 			if ($userObject) {
-				$groups = \OC::$server->getGroupManager()->getUserGroupIds($userObject);
+				$groups = \OC::$server->get(IGroupManager::class)->getUserGroupIds($userObject);
 			}
 
 			if (!empty($groups)) {
@@ -406,7 +407,7 @@ class Share extends Constants {
 				$user = \OC::$server->getUserManager()->get($shareWith);
 				$groups = [];
 				if ($user) {
-					$groups = \OC::$server->getGroupManager()->getUserGroupIds($user);
+					$groups = \OC::$server->get(IGroupManager::class)->getUserGroupIds($user);
 				}
 				if (!empty($groups)) {
 					$qb->orWhere($qb->expr()->andX(

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -43,6 +43,7 @@ use OCA\ShareByMail\ShareByMailProvider;
 use OCA\Talk\Share\RoomShareProvider;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
@@ -98,7 +99,7 @@ class ProviderFactory implements IProviderFactory {
 			$this->defaultProvider = new DefaultShareProvider(
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getGroupManager(),
+				$this->serverContainer->get(IGroupManager::class),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getMailer(),
 				$this->serverContainer->query(Defaults::class),

--- a/lib/private/SystemTag/ManagerFactory.php
+++ b/lib/private/SystemTag/ManagerFactory.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OC\SystemTag;
 
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagManagerFactory;
@@ -64,7 +65,7 @@ class ManagerFactory implements ISystemTagManagerFactory {
 	public function getManager(): ISystemTagManager {
 		return new SystemTagManager(
 			$this->serverContainer->getDatabaseConnection(),
-			$this->serverContainer->getGroupManager(),
+			$this->serverContainer->get(IGroupManager::class),
 			$this->serverContainer->get(IEventDispatcher::class),
 		);
 	}

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -50,6 +50,7 @@ use OC\Template\JSResourceLocator;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Defaults;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IInitialStateService;
 use OCP\INavigationManager;
 use OCP\IUserSession;
@@ -231,7 +232,7 @@ class TemplateLayout extends \OC_Template {
 				\OC::$server->getSession(),
 				\OC::$server->getUserSession()->getUser(),
 				$this->config,
-				\OC::$server->getGroupManager(),
+				\OC::$server->get(IGroupManager::class),
 				\OC::$server->get(IniGetWrapper::class),
 				\OC::$server->getURLGenerator(),
 				\OC::$server->getCapabilitiesManager(),

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -45,6 +45,7 @@ use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\IAvatarManager;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IImage;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -277,7 +278,7 @@ class User implements IUser {
 		if ($result) {
 			// FIXME: Feels like an hack - suggestions?
 
-			$groupManager = \OC::$server->getGroupManager();
+			$groupManager = \OC::$server->get(IGroupManager::class);
 			// We have to delete the user from all groups
 			foreach ($groupManager->getUserGroupIds($this) as $groupId) {
 				$group = $groupManager->get($groupId);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -56,6 +56,7 @@ use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
 use OCP\ILogger;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\App\DependencyAnalyzer;
@@ -266,7 +267,7 @@ class OC_App {
 
 		$appManager = \OC::$server->getAppManager();
 		if ($groups !== []) {
-			$groupManager = \OC::$server->getGroupManager();
+			$groupManager = \OC::$server->get(IGroupManager::class);
 			$groupsList = [];
 			foreach ($groups as $group) {
 				$groupItem = $groupManager->get($group);

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -38,6 +38,7 @@
 
 use OC\User\LoginException;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\User\Events\BeforeUserLoggedInEvent;
@@ -323,7 +324,7 @@ class OC_User {
 	 * @return bool
 	 */
 	public static function isAdminUser($uid) {
-		$group = \OC::$server->getGroupManager()->get('admin');
+		$group = \OC::$server->get(IGroupManager::class)->get('admin');
 		$user = \OC::$server->getUserManager()->get($uid);
 		if ($group && $user && $group->inGroup($user) && self::$incognitoMode === false) {
 			return true;

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\Config;
 
 use OC\Core\Command\App\Enable;
+use OCP\IGroupManager;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -41,7 +42,7 @@ class AppsEnableTest extends TestCase {
 
 		$command = new Enable(
 			\OC::$server->getAppManager(),
-			\OC::$server->getGroupManager()
+			\OC::$server->get(IGroupManager::class)
 		);
 
 		$this->commandTester = new CommandTester($command);

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -14,6 +14,7 @@ use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -459,7 +460,7 @@ class AppTest extends \Test\TestCase {
 	 */
 	public function testEnabledApps($user, $expectedApps, $forceAll) {
 		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = \OC::$server->get(IGroupManager::class);
 		$user1 = $userManager->createUser(self::TEST_USER1, self::TEST_USER1);
 		$user2 = $userManager->createUser(self::TEST_USER2, self::TEST_USER2);
 		$user3 = $userManager->createUser(self::TEST_USER3, self::TEST_USER3);
@@ -558,7 +559,7 @@ class AppTest extends \Test\TestCase {
 			\OC::$server->getUserSession(),
 			\OC::$server->getConfig(),
 			$appConfig,
-			\OC::$server->getGroupManager(),
+			\OC::$server->get(IGroupManager::class),
 			\OC::$server->getMemCacheFactory(),
 			\OC::$server->get(IEventDispatcher::class),
 			\OC::$server->get(LoggerInterface::class)

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -23,6 +23,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share\IShare;
@@ -99,7 +100,7 @@ class ViewTest extends \Test\TestCase {
 
 		//login
 		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = \OC::$server->get(IGroupManager::class);
 		$this->user = 'test';
 		$this->userObject = $userManager->createUser('test', 'test');
 

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -61,7 +61,7 @@ class ShareTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->groupManager = \OC::$server->getGroupManager();
+		$this->groupManager = \OC::$server->get(IGroupManager::class);
 		$this->userManager = \OC::$server->getUserManager();
 
 		$this->userManager->clearBackends();

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -2512,7 +2512,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 	public function testGetSharesInFolder() {
 		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = \OC::$server->get(IGroupManager::class);
 		$rootFolder = \OC::$server->getRootFolder();
 
 		$provider = new DefaultShareProvider(
@@ -2610,7 +2610,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 	public function testGetAccessListNoCurrentAccessRequired() {
 		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = \OC::$server->get(IGroupManager::class);
 		$rootFolder = \OC::$server->getRootFolder();
 
 		$provider = new DefaultShareProvider(
@@ -2706,7 +2706,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 
 	public function testGetAccessListCurrentAccessRequired() {
 		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = \OC::$server->get(IGroupManager::class);
 		$rootFolder = \OC::$server->getRootFolder();
 
 		$provider = new DefaultShareProvider(

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -24,6 +24,7 @@ namespace Test;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\SubAdminAddedEvent;
 use OCP\Group\Events\SubAdminRemovedEvent;
+use OCP\IGroupManager;
 
 /**
  * @group DB
@@ -54,7 +55,7 @@ class SubAdminTest extends \Test\TestCase {
 		$this->groups = [];
 
 		$this->userManager = \OC::$server->getUserManager();
-		$this->groupManager = \OC::$server->getGroupManager();
+		$this->groupManager = \OC::$server->get(IGroupManager::class);
 		$this->dbConn = \OC::$server->getDatabaseConnection();
 		$this->eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getGroupManager` and replaces it with `OC\Server::get(\OCP\IGroupManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IGroupManager` class is imported via the `use` directive.