### PR TITLE
Refactor `OC\Server::getUserManager`

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -48,6 +48,8 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
@@ -130,7 +132,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 		\OC::$server->getEncryptionManager(),
 		\OC::$server->getAppManager(),
 		\OC::$server->getConfig(),
-		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
+		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->get(IUserManager::class), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
 	);
 
@@ -140,13 +142,13 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$view = new \OC\Files\View();
 	$util = new \OC\Encryption\Util(
 		$view,
-		\OC::$server->getUserManager(),
+		\OC::$server->get(IUserManager::class),
 		\OC::$server->getGroupManager(),
 		\OC::$server->getConfig()
 	);
 	$application->add(new OC\Core\Command\Encryption\ChangeKeyStorageRoot(
 		$view,
-		\OC::$server->getUserManager(),
+		\OC::$server->get(IUserManager::class),
 		\OC::$server->getConfig(),
 		$util,
 		new \Symfony\Component\Console\Helper\QuestionHelper()
@@ -155,7 +157,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
 	$application->add(new OC\Core\Command\Encryption\MigrateKeyStorage(
 		$view,
-		\OC::$server->getUserManager(),
+		\OC::$server->get(IUserManager::class),
 		\OC::$server->getConfig(),
 		$util,
 		\OC::$server->getCrypto()
@@ -182,26 +184,26 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(\OC::$server->query(\OC\Core\Command\Preview\Repair::class));
 	$application->add(\OC::$server->query(\OC\Core\Command\Preview\ResetRenderedTexts::class));
 
-	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\Add(\OC::$server->get(IUserManager::class), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\Delete(\OC::$server->get(IUserManager::class)));
+	$application->add(new OC\Core\Command\User\Disable(\OC::$server->get(IUserManager::class)));
+	$application->add(new OC\Core\Command\User\Enable(\OC::$server->get(IUserManager::class)));
+	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->get(IUserManager::class)));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
-	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->getUserManager(), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));
+	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->get(IUserManager::class), \OC::$server->getAppManager()));
+	$application->add(new OC\Core\Command\User\Setting(\OC::$server->get(IUserManager::class), \OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->get(IUserManager::class), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\Info(\OC::$server->get(IUserManager::class), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->get(IUserManager::class), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Add::class));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\ListCommand::class));
 	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Delete::class));
-
+	
 	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\ListCommand(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\AddUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\Group\AddUser(\OC::$server->get(IUserManager::class), \OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->get(IUserManager::class), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\Info(\OC::$server->get(\OCP\IGroupManager::class)));
 
 	$application->add(new OC\Core\Command\SystemTag\ListCommand(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));

--- a/lib/private/Encryption/EncryptionWrapper.php
+++ b/lib/private/Encryption/EncryptionWrapper.php
@@ -30,6 +30,7 @@ use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -84,7 +85,7 @@ class EncryptionWrapper {
 
 			$util = new Util(
 				new View(),
-				\OC::$server->getUserManager(),
+				\OC::$server->get(IUserManager::class),
 				\OC::$server->getGroupManager(),
 				\OC::$server->getConfig()
 			);

--- a/lib/private/Encryption/HookManager.php
+++ b/lib/private/Encryption/HookManager.php
@@ -26,6 +26,7 @@ namespace OC\Encryption;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Files\SetupManager;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class HookManager {
@@ -54,7 +55,7 @@ class HookManager {
 		if (is_null(self::$updater)) {
 			$user = \OC::$server->getUserSession()->getUser();
 			if (!$user && $owner) {
-				$user = \OC::$server->getUserManager()->get($owner);
+				$user = \OC::$server->get(IUserManager::class)->get($owner);
 			}
 			if (!$user) {
 				throw new \Exception("Inconsistent data, File unshared, but owner not found. Should not happen");
@@ -74,7 +75,7 @@ class HookManager {
 				new View(),
 				new Util(
 					new View(),
-					\OC::$server->getUserManager(),
+					\OC::$server->get(IUserManager::class),
 					\OC::$server->getGroupManager(),
 					\OC::$server->getConfig()),
 				Filesystem::getMountManager(),

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -473,7 +473,7 @@ class Root extends Folder implements IRootFolder {
 			$absolutePath = rtrim($mount->getMountPoint() . $pathRelativeToMount, '/');
 			return $this->createNode($absolutePath, new FileInfo(
 				$absolutePath, $mount->getStorage(), $cacheEntry->getPath(), $cacheEntry, $mount,
-				\OC::$server->getUserManager()->get($mount->getStorage()->getOwner($pathRelativeToMount))
+				\OC::$server->get(IUserManager::class)->get($mount->getStorage()->getOwner($pathRelativeToMount))
 			));
 		}, $mountsContainingFile);
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -66,6 +66,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
@@ -105,7 +106,7 @@ class View {
 		$this->fakeRoot = $root;
 		$this->lockingProvider = \OC::$server->getLockingProvider();
 		$this->lockingEnabled = !($this->lockingProvider instanceof \OC\Lock\NoopLockingProvider);
-		$this->userManager = \OC::$server->getUserManager();
+		$this->userManager = \OC::$server->get(IUserManager::class);
 		$this->logger = \OC::$server->get(LoggerInterface::class);
 	}
 
@@ -1626,7 +1627,7 @@ class View {
 		$mount = $this->getMount('');
 		$mountPoint = $mount->getMountPoint();
 		$storage = $mount->getStorage();
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		if ($storage) {
 			$cache = $storage->getCache('');
 
@@ -1803,7 +1804,7 @@ class View {
 		$mount = $this->getMount($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($this->getAbsolutePath($path));
-		$owner = \OC::$server->getUserManager()->get($storage->getOwner($internalPath));
+		$owner = \OC::$server->get(IUserManager::class)->get($storage->getOwner($internalPath));
 		return new FileInfo(
 			$this->getAbsolutePath($path),
 			$storage,

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Resources\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUserManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use OC\DB\Connection;
@@ -176,7 +177,7 @@ class Repair implements IOutput {
 		return [
 			new Collation(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->getDatabaseConnection(), false),
 			new RepairMimeTypes(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
-			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
+			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->get(IUserManager::class)),
 			new RepairInvalidShares(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()),
 			new MoveUpdaterStepFile(\OC::$server->getConfig()),
 			new MoveAvatars(
@@ -185,7 +186,7 @@ class Repair implements IOutput {
 			),
 			new CleanPreviews(
 				\OC::$server->getJobList(),
-				\OC::$server->getUserManager(),
+				\OC::$server->get(IUserManager::class),
 				\OC::$server->getConfig()
 			),
 			new MigrateOauthTables(\OC::$server->get(Connection::class)),

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -60,6 +60,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IGroup;
 use OCP\IL10N;
+use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -382,7 +383,7 @@ class Setup {
 		//create the user and group
 		$user = null;
 		try {
-			$user = \OC::$server->getUserManager()->createUser($username, $password);
+			$user = \OC::$server->get(IUserManager::class)->createUser($username, $password);
 			if (!$user) {
 				$error[] = "User <$username> could not be created.";
 			}

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -39,6 +39,7 @@ use OCA\Files_Sharing\ShareBackend\File;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
@@ -195,7 +196,7 @@ class Share extends Constants {
 
 		// if we didn't found a result then let's look for a group share.
 		if (empty($shares) && $user !== null) {
-			$userObject = \OC::$server->getUserManager()->get($user);
+			$userObject = \OC::$server->get(IUserManager::class)->get($user);
 			$groups = [];
 			if ($userObject) {
 				$groups = \OC::$server->getGroupManager()->getUserGroupIds($userObject);
@@ -403,7 +404,7 @@ class Share extends Constants {
 					$qb->expr()->eq('share_with', $qb->createNamedParameter($shareWith))
 				));
 
-				$user = \OC::$server->getUserManager()->get($shareWith);
+				$user = \OC::$server->get(IUserManager::class)->get($shareWith);
 				$groups = [];
 				if ($user) {
 					$groups = \OC::$server->getGroupManager()->getUserGroupIds($user);
@@ -592,7 +593,7 @@ class Share extends Constants {
 			$row['share_with_displayname'] = $row['share_with'];
 			if (isset($row['share_with']) && $row['share_with'] != '' &&
 				$row['share_type'] === IShare::TYPE_USER) {
-				$shareWithUser = \OC::$server->getUserManager()->get($row['share_with']);
+				$shareWithUser = \OC::$server->get(IUserManager::class)->get($row['share_with']);
 				$row['share_with_displayname'] = $shareWithUser === null ? $row['share_with'] : $shareWithUser->getDisplayName();
 			} elseif (isset($row['share_with']) && $row['share_with'] != '' &&
 				$row['share_type'] === IShare::TYPE_REMOTE) {
@@ -611,7 +612,7 @@ class Share extends Constants {
 				}
 			}
 			if (isset($row['uid_owner']) && $row['uid_owner'] != '') {
-				$ownerUser = \OC::$server->getUserManager()->get($row['uid_owner']);
+				$ownerUser = \OC::$server->get(IUserManager::class)->get($row['uid_owner']);
 				$row['displayname_owner'] = $ownerUser === null ? $row['uid_owner'] : $ownerUser->getDisplayName();
 			}
 

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -44,6 +44,7 @@ use OCA\Talk\Share\RoomShareProvider;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
+use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
@@ -97,7 +98,7 @@ class ProviderFactory implements IProviderFactory {
 		if ($this->defaultProvider === null) {
 			$this->defaultProvider = new DefaultShareProvider(
 				$this->serverContainer->getDatabaseConnection(),
-				$this->serverContainer->getUserManager(),
+				$this->serverContainer->get(IUserManager::class),
 				$this->serverContainer->getGroupManager(),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getMailer(),
@@ -157,7 +158,7 @@ class ProviderFactory implements IProviderFactory {
 				$l,
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getConfig(),
-				$this->serverContainer->getUserManager(),
+				$this->serverContainer->get(IUserManager::class),
 				$this->serverContainer->getCloudIdManager(),
 				$this->serverContainer->getGlobalScaleConfig(),
 				$this->serverContainer->getCloudFederationProviderManager(),
@@ -189,7 +190,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getConfig(),
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getSecureRandom(),
-				$this->serverContainer->getUserManager(),
+				$this->serverContainer->get(IUserManager::class),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getL10N('sharebymail'),
 				$this->serverContainer->getLogger(),
@@ -231,7 +232,7 @@ class ProviderFactory implements IProviderFactory {
 			$this->shareByCircleProvider = new \OCA\Circles\ShareByCircleProvider(
 				$this->serverContainer->getDatabaseConnection(),
 				$this->serverContainer->getSecureRandom(),
-				$this->serverContainer->getUserManager(),
+				$this->serverContainer->get(IUserManager::class),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getL10N('circles'),
 				$this->serverContainer->getLogger(),

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -49,6 +49,7 @@ use OCP\AppFramework\Db\TTransactional;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\ICheckPasswordBackend;
@@ -504,7 +505,7 @@ class Database extends ABackend implements
 			throw new \Exception('key uid is expected to be set in $param');
 		}
 
-		$backends = \OC::$server->getUserManager()->getBackends();
+		$backends = \OC::$server->get(IUserManager::class)->getBackends();
 		foreach ($backends as $backend) {
 			if ($backend instanceof Database) {
 				/** @var \OC\User\Database $backend */

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -49,6 +49,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\ICacheFactory;
 use OCP\IBinaryFinder;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -575,7 +576,7 @@ class OC_Helper {
 		$ownerId = $storage->getOwner($path);
 		$ownerDisplayName = '';
 		if ($ownerId) {
-			$ownerDisplayName = \OC::$server->getUserManager()->getDisplayName($ownerId) ?? '';
+			$ownerDisplayName = \OC::$server->get(IUserManager::class)->getDisplayName($ownerId) ?? '';
 		}
 
 		if (substr_count($mount->getMountPoint(), '/') < 3) {

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -81,7 +81,7 @@ class OC_User {
 	public static function useBackend($backend = 'database') {
 		if ($backend instanceof \OCP\UserInterface) {
 			self::$_usedBackends[get_class($backend)] = $backend;
-			\OC::$server->getUserManager()->registerBackend($backend);
+			\OC::$server->get(IUserManager::class)->registerBackend($backend);
 		} else {
 			// You'll never know what happens
 			if (null === $backend or !is_string($backend)) {
@@ -95,17 +95,17 @@ class OC_User {
 				case 'sqlite':
 					\OCP\Util::writeLog('core', 'Adding user backend ' . $backend . '.', ILogger::DEBUG);
 					self::$_usedBackends[$backend] = new \OC\User\Database();
-					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->get(IUserManager::class)->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				case 'dummy':
 					self::$_usedBackends[$backend] = new \Test\Util\User\Dummy();
-					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->get(IUserManager::class)->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				default:
 					\OCP\Util::writeLog('core', 'Adding default user backend ' . $backend . '.', ILogger::DEBUG);
 					$className = 'OC_USER_' . strtoupper($backend);
 					self::$_usedBackends[$backend] = new $className();
-					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
+					\OC::$server->get(IUserManager::class)->registerBackend(self::$_usedBackends[$backend]);
 					break;
 			}
 		}
@@ -117,7 +117,7 @@ class OC_User {
 	 */
 	public static function clearBackends() {
 		self::$_usedBackends = [];
-		\OC::$server->getUserManager()->clearBackends();
+		\OC::$server->get(IUserManager::class)->clearBackends();
 	}
 
 	/**
@@ -254,7 +254,7 @@ class OC_User {
 	 */
 	public static function setUserId($uid) {
 		$userSession = \OC::$server->getUserSession();
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		if ($user = $userManager->get($uid)) {
 			$userSession->setUser($user);
 		} else {
@@ -324,7 +324,7 @@ class OC_User {
 	 */
 	public static function isAdminUser($uid) {
 		$group = \OC::$server->getGroupManager()->get('admin');
-		$user = \OC::$server->getUserManager()->get($uid);
+		$user = \OC::$server->get(IUserManager::class)->get($uid);
 		if ($group && $user && $group->inGroup($user) && self::$incognitoMode === false) {
 			return true;
 		}
@@ -357,7 +357,7 @@ class OC_User {
 	 * Change the password of a user
 	 */
 	public static function setPassword($uid, $password, $recoveryPassword = null) {
-		$user = \OC::$server->getUserManager()->get($uid);
+		$user = \OC::$server->get(IUserManager::class)->get($uid);
 		if ($user) {
 			return $user->setPassword($password, $recoveryPassword);
 		} else {
@@ -373,7 +373,7 @@ class OC_User {
 	 * @deprecated Use \OC::$server->getUserManager->getHome()
 	 */
 	public static function getHome($uid) {
-		$user = \OC::$server->getUserManager()->get($uid);
+		$user = \OC::$server->get(IUserManager::class)->get($uid);
 		if ($user) {
 			return $user->getHome();
 		} else {
@@ -394,7 +394,7 @@ class OC_User {
 	 */
 	public static function getDisplayNames($search = '', $limit = null, $offset = null) {
 		$displayNames = [];
-		$users = \OC::$server->getUserManager()->searchDisplayName($search, $limit, $offset);
+		$users = \OC::$server->get(IUserManager::class)->searchDisplayName($search, $limit, $offset);
 		foreach ($users as $user) {
 			$displayNames[$user->getUID()] = $user->getDisplayName();
 		}

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -14,6 +14,7 @@ use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -458,7 +459,7 @@ class AppTest extends \Test\TestCase {
 	 * @dataProvider appConfigValuesProvider
 	 */
 	public function testEnabledApps($user, $expectedApps, $forceAll) {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$user1 = $userManager->createUser(self::TEST_USER1, self::TEST_USER1);
 		$user2 = $userManager->createUser(self::TEST_USER2, self::TEST_USER2);
@@ -507,7 +508,7 @@ class AppTest extends \Test\TestCase {
 	 * enabled apps more than once when a user is set.
 	 */
 	public function testEnabledAppsCache() {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$user1 = $userManager->createUser(self::TEST_USER1, self::TEST_USER1);
 
 		\OC_User::setUserId(self::TEST_USER1);

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -14,6 +14,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IInitialStateService;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -657,7 +658,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testDeleteReferencesOfActorWithUserManagement() {
-		$user = \OC::$server->getUserManager()->createUser('xenia', '123456');
+		$user = \OC::$server->get(IUserManager::class)->createUser('xenia', '123456');
 		$this->assertTrue($user instanceof IUser);
 
 		$manager = \OC::$server->getCommentsManager();

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -15,6 +15,7 @@ use OC\Files\Search\SearchQuery;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IUser;
+use OCP\IUserManager;
 
 class LongId extends \OC\Files\Storage\Temporary {
 	public function getId() {
@@ -353,7 +354,7 @@ class CacheTest extends \Test\TestCase {
 
 	public function testSearchQueryByTag() {
 		$userId = static::getUniqueID('user');
-		\OC::$server->getUserManager()->createUser($userId, $userId);
+		\OC::$server->get(IUserManager::class)->createUser($userId, $userId);
 		static::loginAsUser($userId);
 		$user = new \OC\User\User($userId, null, \OC::$server->get(IEventDispatcher::class));
 
@@ -400,7 +401,7 @@ class CacheTest extends \Test\TestCase {
 		$tagManager->delete('tag2');
 
 		static::logout();
-		$user = \OC::$server->getUserManager()->get($userId);
+		$user = \OC::$server->get(IUserManager::class)->get($userId);
 		if ($user !== null) {
 			try {
 				$user->delete();

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -11,6 +11,7 @@ namespace Test\Files\Cache;
 use OC\Files\Filesystem as Filesystem;
 use OC\Files\View;
 use OCP\Files\Mount\IMountManager;
+use OCP\IUserManager;
 
 /**
  * Class UpdaterLegacyTest
@@ -57,7 +58,7 @@ class UpdaterLegacyTest extends \Test\TestCase {
 			self::$user = $this->getUniqueID();
 		}
 
-		\OC::$server->getUserManager()->createUser(self::$user, 'password');
+		\OC::$server->get(IUserManager::class)->createUser(self::$user, 'password');
 		$this->loginAsUser(self::$user);
 
 		Filesystem::init(self::$user, '/' . self::$user . '/files');
@@ -77,7 +78,7 @@ class UpdaterLegacyTest extends \Test\TestCase {
 		}
 
 		$result = false;
-		$user = \OC::$server->getUserManager()->get(self::$user);
+		$user = \OC::$server->get(IUserManager::class)->get(self::$user);
 		if ($user !== null) {
 			$result = $user->delete();
 		}

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -28,6 +28,7 @@ use OC\User\NoUserException;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
+use OCP\IUserManager;
 
 class DummyMountProvider implements IMountProvider {
 	private $mounts = [];
@@ -81,7 +82,7 @@ class FilesystemTest extends \Test\TestCase {
 		$userBackend = new \Test\Util\User\Dummy();
 		$userBackend->createUser(self::TEST_FILESYSTEM_USER1, self::TEST_FILESYSTEM_USER1);
 		$userBackend->createUser(self::TEST_FILESYSTEM_USER2, self::TEST_FILESYSTEM_USER2);
-		\OC::$server->getUserManager()->registerBackend($userBackend);
+		\OC::$server->get(IUserManager::class)->registerBackend($userBackend);
 		$this->loginAsUser();
 	}
 
@@ -312,7 +313,7 @@ class FilesystemTest extends \Test\TestCase {
 			$backend = new \Test\Util\User\Dummy();
 			\OC_User::useBackend($backend);
 			$backend->createUser($user, $user);
-			$userObj = \OC::$server->getUserManager()->get($user);
+			$userObj = \OC::$server->get(IUserManager::class)->get($user);
 			\OC::$server->getUserSession()->setUser($userObj);
 			\OC\Files\Filesystem::init($user, '/' . $user . '/files');
 		}
@@ -397,7 +398,7 @@ class FilesystemTest extends \Test\TestCase {
 	public function testHomeMount() {
 		$userId = $this->getUniqueID('user_');
 
-		\OC::$server->getUserManager()->createUser($userId, $userId);
+		\OC::$server->get(IUserManager::class)->createUser($userId, $userId);
 
 		\OC\Files\Filesystem::initMountPoints($userId);
 
@@ -410,7 +411,7 @@ class FilesystemTest extends \Test\TestCase {
 			$this->assertEquals('home::' . $userId, $homeMount->getId());
 		}
 
-		$user = \OC::$server->getUserManager()->get($userId);
+		$user = \OC::$server->get(IUserManager::class)->get($userId);
 		if ($user !== null) {
 			$user->delete();
 		}
@@ -431,7 +432,7 @@ class FilesystemTest extends \Test\TestCase {
 		// no cache path configured
 		$config->setSystemValue('cache_path', '');
 
-		\OC::$server->getUserManager()->createUser($userId, $userId);
+		\OC::$server->get(IUserManager::class)->createUser($userId, $userId);
 		\OC\Files\Filesystem::initMountPoints($userId);
 
 		$this->assertEquals(
@@ -441,7 +442,7 @@ class FilesystemTest extends \Test\TestCase {
 		[$storage, $internalPath] = \OC\Files\Filesystem::resolvePath('/' . $userId . '/cache');
 		$this->assertTrue($storage->instanceOfStorage('\OCP\Files\IHomeStorage'));
 		$this->assertEquals('cache', $internalPath);
-		$user = \OC::$server->getUserManager()->get($userId);
+		$user = \OC::$server->get(IUserManager::class)->get($userId);
 		if ($user !== null) {
 			$user->delete();
 		}
@@ -462,7 +463,7 @@ class FilesystemTest extends \Test\TestCase {
 		$cachePath = \OC::$server->getTempManager()->getTemporaryFolder() . '/extcache';
 		$config->setSystemValue('cache_path', $cachePath);
 
-		\OC::$server->getUserManager()->createUser($userId, $userId);
+		\OC::$server->get(IUserManager::class)->createUser($userId, $userId);
 		\OC\Files\Filesystem::initMountPoints($userId);
 
 		$this->assertEquals(
@@ -472,7 +473,7 @@ class FilesystemTest extends \Test\TestCase {
 		[$storage, $internalPath] = \OC\Files\Filesystem::resolvePath('/' . $userId . '/cache');
 		$this->assertTrue($storage->instanceOfStorage('\OC\Files\Storage\Local'));
 		$this->assertEquals('', $internalPath);
-		$user = \OC::$server->getUserManager()->get($userId);
+		$user = \OC::$server->get(IUserManager::class)->get($userId);
 		if ($user !== null) {
 			$user->delete();
 		}

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -71,7 +71,7 @@ class HookConnectorTest extends TestCase {
 		$this->root = new Root(
 			Filesystem::getMountManager(),
 			$this->view,
-			\OC::$server->getUserManager()->get($this->userId),
+			\OC::$server->get(IUserManager::class)->get($this->userId),
 			\OC::$server->getUserMountCache(),
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(IUserManager::class),

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class TestScanner extends \OC\Files\Utils\Scanner {
@@ -52,13 +53,13 @@ class ScannerTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->userBackend = new \Test\Util\User\Dummy();
-		\OC::$server->getUserManager()->registerBackend($this->userBackend);
+		\OC::$server->get(IUserManager::class)->registerBackend($this->userBackend);
 		$this->loginAsUser();
 	}
 
 	protected function tearDown(): void {
 		$this->logout();
-		\OC::$server->getUserManager()->removeBackend($this->userBackend);
+		\OC::$server->get(IUserManager::class)->removeBackend($this->userBackend);
 		parent::tearDown();
 	}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -23,6 +23,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share\IShare;
@@ -98,7 +99,7 @@ class ViewTest extends \Test\TestCase {
 		\OC_User::useBackend(new \Test\Util\User\Dummy());
 
 		//login
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$this->user = 'test';
 		$this->userObject = $userManager->createUser('test', 'test');
@@ -1679,7 +1680,7 @@ class ViewTest extends \Test\TestCase {
 		$view->mkdir('shareddir/sub2');
 
 		$fileId = $view->getFileInfo('shareddir')->getId();
-		$userObject = \OC::$server->getUserManager()->createUser('test2', 'IHateNonMockableStaticClasses');
+		$userObject = \OC::$server->get(IUserManager::class)->createUser('test2', 'IHateNonMockableStaticClasses');
 
 		$userFolder = \OC::$server->getUserFolder($this->user);
 		$shareDir = $userFolder->get('shareddir');

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -12,6 +12,7 @@ namespace Test\Group;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
+use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class GroupTest extends \Test\TestCase {
@@ -65,7 +66,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend], $this->dispatcher, $userManager);
 
 		$backend->expects($this->once())
@@ -89,7 +90,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1, $backend2], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->once())
@@ -117,7 +118,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder('\OC\User\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -138,7 +139,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder(\OC\User\Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -161,7 +162,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder('\OC\User\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -186,7 +187,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder('\OC\User\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -210,7 +211,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder('\OC\User\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -235,7 +236,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder(\OC\User\Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -262,7 +263,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$userBackend = $this->getMockBuilder('\OC\User\Backend')
 			->disableOriginalConstructor()
 			->getMock();
@@ -299,7 +300,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend], $this->dispatcher, $userManager);
 
 		$backend->expects($this->once())
@@ -321,7 +322,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1, $backend2], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->once())
@@ -344,7 +345,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend], $this->dispatcher, $userManager);
 
 		$backend->expects($this->once())
@@ -366,7 +367,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1, $backend2], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->once())
@@ -391,7 +392,7 @@ class GroupTest extends \Test\TestCase {
 		$backend1 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->once())
@@ -415,7 +416,7 @@ class GroupTest extends \Test\TestCase {
 		$backend2 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1, $backend2], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->once())
@@ -443,7 +444,7 @@ class GroupTest extends \Test\TestCase {
 		$backend1 = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend1], $this->dispatcher, $userManager);
 
 		$backend1->expects($this->never())
@@ -461,7 +462,7 @@ class GroupTest extends \Test\TestCase {
 		$backend = $this->getMockBuilder('OC\Group\Database')
 			->disableOriginalConstructor()
 			->getMock();
-		$userManager = $this->getUserManager();
+		$userManager = $this->get(IUserManager::class);
 		$group = new \OC\Group\Group('group1', [$backend], $this->dispatcher, $userManager);
 
 		$backend->expects($this->once())

--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -22,6 +22,7 @@
 namespace Test\Preview;
 
 use OC\Files\Node\File;
+use OCP\IUserManager;
 
 abstract class Provider extends \Test\TestCase {
 	/** @var string */
@@ -48,7 +49,7 @@ abstract class Provider extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$userManager->clearBackends();
 		$backend = new \Test\Util\User\Dummy();
 		$userManager->registerBackend($backend);

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -14,6 +14,7 @@ namespace Test\Security;
 use OC\Files\View;
 use OC\Security\CertificateManager;
 use OCP\IConfig;
+use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -64,7 +65,7 @@ class CertificateManagerTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$user = \OC::$server->getUserManager()->get($this->username);
+		$user = \OC::$server->get(IUserManager::class)->get($this->username);
 		if ($user !== null) {
 			$user->delete();
 		}

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -62,7 +62,7 @@ class ShareTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->groupManager = \OC::$server->getGroupManager();
-		$this->userManager = \OC::$server->getUserManager();
+		$this->userManager = \OC::$server->get(IUserManager::class);
 
 		$this->userManager->clearBackends();
 		$this->userManager->registerBackend(new \Test\Util\User\Dummy());

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -2511,7 +2511,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharesInFolder() {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$rootFolder = \OC::$server->getRootFolder();
 
@@ -2609,7 +2609,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetAccessListNoCurrentAccessRequired() {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$rootFolder = \OC::$server->getRootFolder();
 
@@ -2705,7 +2705,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetAccessListCurrentAccessRequired() {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OC::$server->get(IUserManager::class);
 		$groupManager = \OC::$server->getGroupManager();
 		$rootFolder = \OC::$server->getRootFolder();
 

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -24,6 +24,7 @@ namespace Test;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\SubAdminAddedEvent;
 use OCP\Group\Events\SubAdminRemovedEvent;
+use OCP\IUserManager;
 
 /**
  * @group DB
@@ -53,7 +54,7 @@ class SubAdminTest extends \Test\TestCase {
 		$this->users = [];
 		$this->groups = [];
 
-		$this->userManager = \OC::$server->getUserManager();
+		$this->userManager = \OC::$server->get(IUserManager::class);
 		$this->groupManager = \OC::$server->getGroupManager();
 		$this->dbConn = \OC::$server->getDatabaseConnection();
 		$this->eventDispatcher = \OC::$server->get(IEventDispatcher::class);

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -24,6 +24,7 @@ namespace Test;
 
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -50,7 +51,7 @@ class TagsTest extends \Test\TestCase {
 		\OC_User::clearBackends();
 		\OC_User::useBackend('dummy');
 		$userId = $this->getUniqueID('user_');
-		\OC::$server->getUserManager()->createUser($userId, 'pass');
+		\OC::$server->get(IUserManager::class)->createUser($userId, 'pass');
 		\OC_User::setUserId($userId);
 		$this->user = $this->createMock(IUser::class);
 		$this->user->method('getUID')

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -38,6 +38,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
@@ -408,12 +409,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 		self::logout();
 		\OC\Files\Filesystem::tearDown();
 		\OC_User::setUserId($user);
-		$userObject = \OC::$server->getUserManager()->get($user);
+		$userObject = \OC::$server->get(IUserManager::class)->get($user);
 		if (!is_null($userObject)) {
 			$userObject->updateLastLoginTimestamp();
 		}
 		\OC_Util::setupFS($user);
-		if (\OC::$server->getUserManager()->userExists($user)) {
+		if (\OC::$server->get(IUserManager::class)->userExists($user)) {
 			\OC::$server->getUserFolder($user);
 		}
 	}

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -10,6 +10,7 @@ namespace Test\Traits;
 
 use OC\User\User;
 use OCP\IUser;
+use OCP\IUserManager;
 
 class DummyUser extends User {
 	private string $uid;
@@ -39,10 +40,10 @@ trait UserTrait {
 
 	protected function setUpUserTrait() {
 		$this->userBackend = new \Test\Util\User\Dummy();
-		\OC::$server->getUserManager()->registerBackend($this->userBackend);
+		\OC::$server->get(IUserManager::class)->registerBackend($this->userBackend);
 	}
 
 	protected function tearDownUserTrait() {
-		\OC::$server->getUserManager()->removeBackend($this->userBackend);
+		\OC::$server->get(IUserManager::class)->removeBackend($this->userBackend);
 	}
 }

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -17,6 +17,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
+use OCP\IUserManager;
 use Test\TestCase;
 
 /**
@@ -576,7 +577,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCountUsersOnlyDisabled() {
-		$manager = \OC::$server->getUserManager();
+		$manager = \OC::$server->get(IUserManager::class);
 		// count other users in the db before adding our own
 		$countBefore = $manager->countDisabledUsers();
 
@@ -601,7 +602,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCountUsersOnlySeen() {
-		$manager = \OC::$server->getUserManager();
+		$manager = \OC::$server->get(IUserManager::class);
 		// count other users in the db before adding our own
 		$countBefore = $manager->countSeenUsers();
 
@@ -627,7 +628,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testCallForSeenUsers() {
-		$manager = \OC::$server->getUserManager();
+		$manager = \OC::$server->get(IUserManager::class);
 		// count other users in the db before adding our own
 		$count = 0;
 		$function = function (IUser $user) use (&$count) {


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::getUserManager` and replaces it with `OC\Server::get(\OCP\IUserManager::class)` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Additionally, where necessary, the `\OCP\IUserManager` class is imported via the `use` directive.