### PR TITLE
Refactor `OC\Server::query`

### DIFF
--- a/console.php
+++ b/console.php
@@ -94,7 +94,7 @@ try {
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getRequest(),
 		\OC::$server->get(\Psr\Log\LoggerInterface::class),
-		\OC::$server->query(\OC\MemoryInfo::class)
+		\OC::$server->get(\OC\MemoryInfo::class)
 	);
 	$application->loadCommands(new ArgvInput(), new ConsoleOutput());
 	$application->run();

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -101,7 +101,7 @@ class Enable extends Command implements CompletionAwareInterface {
 
 		try {
 			/** @var Installer $installer */
-			$installer = \OC::$server->query(Installer::class);
+			$installer = \OC::$server->get(Installer::class);
 
 			if (false === $installer->isDownloaded($appId)) {
 				$installer->downloadApp($appId);

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -77,7 +77,7 @@ class Install extends Command {
 
 		try {
 			/** @var Installer $installer */
-			$installer = \OC::$server->query(Installer::class);
+			$installer = \OC::$server->get(Installer::class);
 			$installer->downloadApp($appId, $input->getOption('allow-unstable'));
 			$result = $installer->installApp($appId, $forceEnable);
 		} catch (\Exception $e) {

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -78,10 +78,10 @@ class Install extends Command {
 			$this->config,
 			$this->iniGetWrapper,
 			$server->getL10N('lib'),
-			$server->query(Defaults::class),
+			$server->get(Defaults::class),
 			$server->get(LoggerInterface::class),
 			$server->getSecureRandom(),
-			\OC::$server->query(Installer::class)
+			\OC::$server->get(Installer::class)
 		);
 		$sysInfo = $setupHelper->getSystemInfo(true);
 		$errors = $sysInfo['errors'];

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -117,7 +117,7 @@ if (\OCP\Util::needUpgrade()) {
 		$config,
 		\OC::$server->getIntegrityCodeChecker(),
 		$logger,
-		\OC::$server->query(\OC\Installer::class)
+		\OC::$server->get(\OC\Installer::class)
 	);
 	$incompatibleApps = [];
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -77,14 +77,14 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Install());
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
-	$application->add(\OC::$server->query(\OC\Core\Command\App\Update::class));
+	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->get(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
+	$application->add(\OC::$server->get(\OC\Core\Command\App\Update::class));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Disable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\State::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Enforce::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Enable::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\Disable::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\TwoFactorAuth\State::class));
 
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
@@ -92,7 +92,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Broadcast\Test::class));
 
 	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));
@@ -169,18 +169,18 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->query(\OC\Installer::class)));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->get(\OC\Installer::class)));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair([], \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class)),
 		\OC::$server->getConfig(),
 		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getAppManager()
 	));
-	$application->add(\OC::$server->query(OC\Core\Command\Maintenance\RepairShareOwnership::class));
+	$application->add(\OC::$server->get(OC\Core\Command\Maintenance\RepairShareOwnership::class));
 
 	$application->add(\OC::$server->get(\OC\Core\Command\Preview\Generate::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\Repair::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\ResetRenderedTexts::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Preview\Repair::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\Preview\ResetRenderedTexts::class));
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));

--- a/core/routes.php
+++ b/core/routes.php
@@ -37,7 +37,7 @@ declare(strict_types=1);
 use OC\Core\Application;
 
 /** @var Application $application */
-$application = \OC::$server->query(Application::class);
+$application = \OC::$server->get(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'lost#email', 'url' => '/lostpassword/email', 'verb' => 'POST'],

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -130,7 +130,7 @@ class Coordinator {
 					$this->eventLogger->start("bootstrap:register_app:$appId:application", "Load `Application` instance for $appId");
 					try {
 						/** @var IBootstrap|App $application */
-						$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
+						$apps[$appId] = $application = $this->serverContainer->get($applicationClassName);
 					} catch (QueryException $e) {
 						// Weird, but ok
 						$this->eventLogger->end("bootstrap:register_app:$appId");
@@ -193,7 +193,7 @@ class Coordinator {
 		$this->eventLogger->start('bootstrap:boot_app:' . $appId, "Call `Application::boot` for $appId");
 		try {
 			/** @var App $application */
-			$application = $this->serverContainer->query($applicationClassName);
+			$application = $this->serverContainer->get($applicationClassName);
 			if ($application instanceof IBootstrap) {
 				/** @var BootContext $context */
 				$context = new BootContext($application->getContainer());

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -145,7 +145,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			);
 		});
 		$this->registerService(ILogger::class, function (ContainerInterface $c) {
-			return new OC\AppFramework\Logger($this->server->query(ILogger::class), $c->get('AppName'));
+			return new OC\AppFramework\Logger($this->server->get(ILogger::class), $c->get('AppName'));
 		});
 
 		$this->registerService(IServerContainer::class, function () {
@@ -253,7 +253,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$c->get('AppName'),
 				$server->getUserSession()->isLoggedIn(),
 				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
-				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
+				$server->getUserSession()->getUser() !== null && $server->get(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
 				$server->getAppManager(),
 				$server->getL10N('lib'),
 				$c->get(AuthorizedGroupMapper::class),
@@ -262,13 +262,13 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			$dispatcher->registerMiddleware($securityMiddleware);
 			$dispatcher->registerMiddleware(
 				new OC\AppFramework\Middleware\Security\CSPMiddleware(
-					$server->query(OC\Security\CSP\ContentSecurityPolicyManager::class),
-					$server->query(OC\Security\CSP\ContentSecurityPolicyNonceManager::class),
-					$server->query(OC\Security\CSRF\CsrfTokenManager::class)
+					$server->get(OC\Security\CSP\ContentSecurityPolicyManager::class),
+					$server->get(OC\Security\CSP\ContentSecurityPolicyNonceManager::class),
+					$server->get(OC\Security\CSRF\CsrfTokenManager::class)
 				)
 			);
 			$dispatcher->registerMiddleware(
-				$server->query(OC\AppFramework\Middleware\Security\FeaturePolicyMiddleware::class)
+				$server->get(OC\AppFramework\Middleware\Security\FeaturePolicyMiddleware::class)
 			);
 			$dispatcher->registerMiddleware(
 				new OC\AppFramework\Middleware\Security\PasswordConfirmationMiddleware(
@@ -459,14 +459,14 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$isServerClass = str_starts_with($name, 'OCP\\') || str_starts_with($name, 'OC\\');
 		if ($isServerClass && !$this->has($name)) {
-			return $this->getServer()->query($name, $autoload);
+			return $this->getServer()->get($name, $autoload);
 		}
 
 		try {
 			return $this->queryNoFallback($name);
 		} catch (QueryException $firstException) {
 			try {
-				return $this->getServer()->query($name, $autoload);
+				return $this->getServer()->get($name, $autoload);
 			} catch (QueryException $secondException) {
 				if ($firstException->getCode() === 1) {
 					throw $secondException;

--- a/lib/private/Calendar/Resource/Manager.php
+++ b/lib/private/Calendar/Resource/Manager.php
@@ -97,7 +97,7 @@ class Manager implements IManager {
 				continue;
 			}
 
-			$this->initializedBackends[$backend] = $this->server->query($backend);
+			$this->initializedBackends[$backend] = $this->server->get($backend);
 		}
 
 		return array_values($this->initializedBackends);

--- a/lib/private/Calendar/Room/Manager.php
+++ b/lib/private/Calendar/Room/Manager.php
@@ -104,7 +104,7 @@ class Manager implements IManager {
 			 * The backend might have services injected that can't be build from the
 			 * server container.
 			 */
-			$this->initializedBackends[$backend] = $this->server->query($backend);
+			$this->initializedBackends[$backend] = $this->server->get($backend);
 		}
 
 		return array_values($this->initializedBackends);

--- a/lib/private/Collaboration/Resources/ProviderManager.php
+++ b/lib/private/Collaboration/Resources/ProviderManager.php
@@ -54,7 +54,7 @@ class ProviderManager implements IProviderManager {
 		if ($this->providers !== []) {
 			foreach ($this->providers as $provider) {
 				try {
-					$this->providerInstances[] = $this->serverContainer->query($provider);
+					$this->providerInstances[] = $this->serverContainer->get($provider);
 				} catch (QueryException $e) {
 					$this->logger->error("Could not query resource provider $provider: " . $e->getMessage(), [
 						'exception' => $e,

--- a/lib/private/EventDispatcher/ServiceEventListener.php
+++ b/lib/private/EventDispatcher/ServiceEventListener.php
@@ -67,7 +67,7 @@ final class ServiceEventListener {
 				// TODO: fetch from the app containers, otherwise any custom services,
 				//       parameters and aliases won't be resolved.
 				//       See https://github.com/nextcloud/server/issues/27793 for details.
-				$this->service = $this->container->query($this->class);
+				$this->service = $this->container->get($this->class);
 			} catch (QueryException $e) {
 				$this->logger->error(
 					sprintf(

--- a/lib/private/InitialStateService.php
+++ b/lib/private/InitialStateService.php
@@ -118,7 +118,7 @@ class InitialStateService implements IInitialStateService {
 		$initialStates = $context->getInitialStates();
 		foreach ($initialStates as $initialState) {
 			try {
-				$provider = $this->container->query($initialState->getService());
+				$provider = $this->container->get($initialState->getService());
 			} catch (QueryException $e) {
 				// Log an continue. We can be fault tolerant here.
 				$this->logger->error('Could not load initial state provider dynamically: ' . $e->getMessage(), [

--- a/lib/private/Search/SearchComposer.php
+++ b/lib/private/Search/SearchComposer.php
@@ -93,7 +93,7 @@ class SearchComposer {
 		foreach ($registrations as $registration) {
 			try {
 				/** @var IProvider $provider */
-				$provider = $this->container->query($registration->getService());
+				$provider = $this->container->get($registration->getService());
 				$this->providers[$provider->getId()] = $provider;
 			} catch (QueryException $e) {
 				// Log an continue. We can be fault tolerant here.

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -101,7 +101,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getGroupManager(),
 				$this->serverContainer->getLazyRootFolder(),
 				$this->serverContainer->getMailer(),
-				$this->serverContainer->query(Defaults::class),
+				$this->serverContainer->get(Defaults::class),
 				$this->serverContainer->getL10NFactory(),
 				$this->serverContainer->getURLGenerator(),
 				$this->serverContainer->getConfig()
@@ -138,11 +138,11 @@ class ProviderFactory implements IProviderFactory {
 			$notifications = new Notifications(
 				$addressHandler,
 				$this->serverContainer->getHTTPClientService(),
-				$this->serverContainer->query(\OCP\OCS\IDiscoveryService::class),
+				$this->serverContainer->get(\OCP\OCS\IDiscoveryService::class),
 				$this->serverContainer->getJobList(),
 				\OC::$server->getCloudFederationProviderManager(),
 				\OC::$server->getCloudFederationFactory(),
-				$this->serverContainer->query(IEventDispatcher::class),
+				$this->serverContainer->get(IEventDispatcher::class),
 				$this->serverContainer->get(LoggerInterface::class),
 			);
 			$tokenHandler = new TokenHandler(
@@ -197,7 +197,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getURLGenerator(),
 				$this->serverContainer->getActivityManager(),
 				$settingsManager,
-				$this->serverContainer->query(Defaults::class),
+				$this->serverContainer->get(Defaults::class),
 				$this->serverContainer->getHasher(),
 				$this->serverContainer->get(IEventDispatcher::class),
 				$this->serverContainer->get(IManager::class)

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -124,7 +124,7 @@ class Streamer {
 		$files = $dirNode->getDirectoryListing();
 
 		/** @var LoggerInterface $logger */
-		$logger = \OC::$server->query(LoggerInterface::class);
+		$logger = \OC::$server->get(LoggerInterface::class);
 		foreach ($files as $file) {
 			if ($file instanceof File) {
 				try {

--- a/lib/private/Support/CrashReport/Registry.php
+++ b/lib/private/Support/CrashReport/Registry.php
@@ -119,7 +119,7 @@ class Registry implements IRegistry {
 		while (($class = array_shift($this->lazyReporters)) !== null) {
 			try {
 				/** @var IReporter $reporter */
-				$reporter = $this->serverContainer->query($class);
+				$reporter = $this->serverContainer->get($class);
 			} catch (QueryException $e) {
 				/*
 				 * There is a circular dependency between the logger and the registry, so

--- a/lib/private/Support/Subscription/Registry.php
+++ b/lib/private/Support/Subscription/Registry.php
@@ -76,7 +76,7 @@ class Registry implements IRegistry {
 	private function getSubscription(): ?ISubscription {
 		if ($this->subscription === null && $this->subscriptionService !== null) {
 			try {
-				$this->subscription = $this->container->query($this->subscriptionService);
+				$this->subscription = $this->container->get($this->subscriptionService);
 			} catch (QueryException $e) {
 				// Ignore this
 			}

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -167,8 +167,8 @@ class App {
 	 *			parent::__construct('tasks', $params);
 	 *
 	 *			$this->getContainer()->registerService('PageController', function(IAppContainer $c){
-	 *				$a = $c->query('API');
-	 *				$r = $c->query('Request');
+	 *				$a = $c->get('API');
+	 *				$r = $c->get('Request');
 	 *				return new PageController($a, $r);
 	 *			});
 	 *		}

--- a/tests/lib/BackgroundJob/QueuedJobTest.php
+++ b/tests/lib/BackgroundJob/QueuedJobTest.php
@@ -51,7 +51,7 @@ class QueuedJobTest extends \Test\TestCase {
 	}
 
 	public function testJobShouldBeRemovedNew() {
-		$job = new TestQueuedJobNew(\OC::$server->query(ITimeFactory::class));
+		$job = new TestQueuedJobNew(\OC::$server->get(ITimeFactory::class));
 		$job->setId(42);
 		$this->jobList->add($job);
 

--- a/tests/lib/BackgroundJob/TimedJobTest.php
+++ b/tests/lib/BackgroundJob/TimedJobTest.php
@@ -48,7 +48,7 @@ class TimedJobTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->jobList = new DummyJobList();
-		$this->time = \OC::$server->query(ITimeFactory::class);
+		$this->time = \OC::$server->get(ITimeFactory::class);
 	}
 
 	public function testShouldRunAfterInterval() {

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -70,7 +70,7 @@ class EtagTest extends \Test\TestCase {
 		$files = ['/foo.txt', '/folder/bar.txt', '/folder/subfolder', '/folder/subfolder/qwerty.txt'];
 		$originalEtags = $this->getEtags($files);
 
-		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection(), \OC::$server->query(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$scanner = new \OC\Files\Utils\Scanner($user1, \OC::$server->getDatabaseConnection(), \OC::$server->get(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
 		$scanner->backgroundScan('/');
 
 		$newEtags = $this->getEtags($files);

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -77,7 +77,7 @@ class HookConnectorTest extends TestCase {
 			$this->createMock(IUserManager::class),
 			$this->createMock(IEventDispatcher::class)
 		);
-		$this->eventDispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->eventDispatcher = \OC::$server->get(IEventDispatcher::class);
 	}
 
 	protected function tearDown(): void {

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -132,7 +132,7 @@ class ScannerTest extends \Test\TestCase {
 		$storage->file_put_contents('foo.txt', 'qwerty');
 		$storage->file_put_contents('folder/bar.txt', 'qwerty');
 
-		$scanner = new \OC\Files\Utils\Scanner($uid, \OC::$server->getDatabaseConnection(), \OC::$server->query(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$scanner = new \OC\Files\Utils\Scanner($uid, \OC::$server->getDatabaseConnection(), \OC::$server->get(IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
 
 		$this->assertFalse($cache->inCache('folder/bar.txt'));
 		$scanner->scan('/' . $uid . '/files/foo');

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -77,63 +77,63 @@ class InfoXmlTest extends TestCase {
 		if (isset($appInfo['background-jobs'])) {
 			foreach ($appInfo['background-jobs'] as $job) {
 				$this->assertTrue(class_exists($job), 'Asserting background job "' . $job . '" exists');
-				$this->assertInstanceOf($job, \OC::$server->query($job));
+				$this->assertInstanceOf($job, \OC::$server->get($job));
 			}
 		}
 
 		if (isset($appInfo['two-factor-providers'])) {
 			foreach ($appInfo['two-factor-providers'] as $provider) {
 				$this->assertTrue(class_exists($provider), 'Asserting two-factor providers "' . $provider . '" exists');
-				$this->assertInstanceOf($provider, \OC::$server->query($provider));
+				$this->assertInstanceOf($provider, \OC::$server->get($provider));
 			}
 		}
 
 		if (isset($appInfo['commands'])) {
 			foreach ($appInfo['commands'] as $command) {
 				$this->assertTrue(class_exists($command), 'Asserting command "' . $command . '" exists');
-				$this->assertInstanceOf($command, \OC::$server->query($command));
+				$this->assertInstanceOf($command, \OC::$server->get($command));
 			}
 		}
 
 		if (isset($appInfo['repair-steps']['pre-migration'])) {
 			foreach ($appInfo['repair-steps']['pre-migration'] as $migration) {
 				$this->assertTrue(class_exists($migration), 'Asserting pre-migration "' . $migration . '" exists');
-				$this->assertInstanceOf($migration, \OC::$server->query($migration));
+				$this->assertInstanceOf($migration, \OC::$server->get($migration));
 			}
 		}
 
 		if (isset($appInfo['repair-steps']['post-migration'])) {
 			foreach ($appInfo['repair-steps']['post-migration'] as $migration) {
 				$this->assertTrue(class_exists($migration), 'Asserting post-migration "' . $migration . '" exists');
-				$this->assertInstanceOf($migration, \OC::$server->query($migration));
+				$this->assertInstanceOf($migration, \OC::$server->get($migration));
 			}
 		}
 
 		if (isset($appInfo['repair-steps']['live-migration'])) {
 			foreach ($appInfo['repair-steps']['live-migration'] as $migration) {
 				$this->assertTrue(class_exists($migration), 'Asserting live-migration "' . $migration . '" exists');
-				$this->assertInstanceOf($migration, \OC::$server->query($migration));
+				$this->assertInstanceOf($migration, \OC::$server->get($migration));
 			}
 		}
 
 		if (isset($appInfo['repair-steps']['install'])) {
 			foreach ($appInfo['repair-steps']['install'] as $migration) {
 				$this->assertTrue(class_exists($migration), 'Asserting install-migration "' . $migration . '" exists');
-				$this->assertInstanceOf($migration, \OC::$server->query($migration));
+				$this->assertInstanceOf($migration, \OC::$server->get($migration));
 			}
 		}
 
 		if (isset($appInfo['repair-steps']['uninstall'])) {
 			foreach ($appInfo['repair-steps']['uninstall'] as $migration) {
 				$this->assertTrue(class_exists($migration), 'Asserting uninstall-migration "' . $migration . '" exists');
-				$this->assertInstanceOf($migration, \OC::$server->query($migration));
+				$this->assertInstanceOf($migration, \OC::$server->get($migration));
 			}
 		}
 
 		if (isset($appInfo['commands'])) {
 			foreach ($appInfo['commands'] as $command) {
 				$this->assertTrue(class_exists($command), 'Asserting command "'. $command . '"exists');
-				$this->assertInstanceOf($command, \OC::$server->query($command));
+				$this->assertInstanceOf($command, \OC::$server->get($command));
 			}
 		}
 	}

--- a/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyManagerTest.php
@@ -38,7 +38,7 @@ class ContentSecurityPolicyManagerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$this->contentSecurityPolicyManager = new ContentSecurityPolicyManager($this->dispatcher);
 	}
 

--- a/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
+++ b/tests/lib/Security/FeaturePolicy/FeaturePolicyManagerTest.php
@@ -40,7 +40,7 @@ class FeaturePolicyManagerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$this->dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$this->manager = new FeaturePolicyManager($this->dispatcher);
 	}
 

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -171,7 +171,7 @@ class ServerTest extends \Test\TestCase {
 	 * @param string $instanceOf
 	 */
 	public function testQuery($serviceName, $instanceOf) {
-		$this->assertInstanceOf($instanceOf, $this->server->query($serviceName), 'Service "' . $serviceName . '"" did not return the right class');
+		$this->assertInstanceOf($instanceOf, $this->server->get($serviceName), 'Service "' . $serviceName . '"" did not return the right class');
 	}
 
 	public function testGetCertificateManager() {

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -84,7 +84,7 @@ class ManagerTest extends TestCase {
 	public function testGetAdminSections() {
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);
@@ -97,7 +97,7 @@ class ManagerTest extends TestCase {
 	public function testGetPersonalSections() {
 		$this->manager->registerSection('personal', \OCA\WorkflowEngine\Settings\Section::class);
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);
@@ -227,7 +227,7 @@ class ManagerTest extends TestCase {
 		$this->manager->registerSection('admin', \OCA\WorkflowEngine\Settings\Section::class);
 
 
-		$section = \OC::$server->query(\OCA\WorkflowEngine\Settings\Section::class);
+		$section = \OC::$server->get(\OCA\WorkflowEngine\Settings\Section::class);
 		$this->container->method('get')
 			->with(\OCA\WorkflowEngine\Settings\Section::class)
 			->willReturn($section);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -64,7 +64,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 			return false;
 		}
 
-		$this->services[$name] = \OC::$server->query($name);
+		$this->services[$name] = \OC::$server->get($name);
 		$container = \OC::$server->getAppContainerForService($name);
 		$container = $container ?? \OC::$server;
 

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -70,11 +70,11 @@ trait EncryptionTrait {
 
 		$container = $this->encryptionApp->getContainer();
 		/** @var KeyManager $keyManager */
-		$keyManager = $container->query(KeyManager::class);
+		$keyManager = $container->get(KeyManager::class);
 		/** @var Setup $userSetup */
-		$userSetup = $container->query(Setup::class);
+		$userSetup = $container->get(Setup::class);
 		$userSetup->setupUser($name, $password);
-		$encryptionManager = $container->query(IManager::class);
+		$encryptionManager = $container->get(IManager::class);
 		$this->encryptionApp->setUp($encryptionManager);
 		$keyManager->init($name, $password);
 	}


### PR DESCRIPTION
This PR refactors the deprecated method `OC\Server::query` and replaces it with `OC\Server::get` throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).