### PR TITLE
Refactor `OC\DB\QueryBuilder::execute`

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -298,7 +298,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		$query->automaticTablePrefix(false);
 		$query->select($query->func()->count('*', 'num_entries'))
 			->from($table->getName());
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -337,7 +337,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		for ($chunk = 0; $chunk < $numChunks; $chunk++) {
 			$query->setFirstResult($chunk * $chunkSize);
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 
 			try {
 				$toDB->beginTransaction();
@@ -359,7 +359,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 							$insertQuery->setParameter($key, $value);
 						}
 					}
-					$insertQuery->execute();
+					$insertQuery->executeStatement();
 				}
 				$result->closeCursor();
 

--- a/core/Command/Preview/ResetRenderedTexts.php
+++ b/core/Command/Preview/ResetRenderedTexts.php
@@ -137,7 +137,7 @@ class ResetRenderedTexts extends Command {
 		$qb->select('path', 'mimetype')
 			->from('filecache')
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($this->previewFolder->getId())));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -170,7 +170,7 @@ class ResetRenderedTexts extends Command {
 				)
 			);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row;

--- a/core/Db/LoginFlowV2Mapper.php
+++ b/core/Db/LoginFlowV2Mapper.php
@@ -88,7 +88,7 @@ class LoginFlowV2Mapper extends QBMapper {
 				$qb->expr()->lt('timestamp', $qb->createNamedParameter($this->timeFactory->getTime() - self::lifetime))
 			);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -273,7 +273,7 @@ class AccountManager implements IAccountManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete($this->table)
 			->where($query->expr()->eq('uid', $query->createNamedParameter($uid)))
-			->execute();
+			->executeStatement();
 
 		$this->deleteUserData($user);
 	}
@@ -286,7 +286,7 @@ class AccountManager implements IAccountManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete($this->dataTable)
 			->where($query->expr()->eq('uid', $query->createNamedParameter($uid)))
-			->execute();
+			->executeStatement();
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -306,7 +306,7 @@ class AppConfig implements IAppConfig {
 			}
 		}
 
-		$changedRow = (bool) $sql->execute();
+		$changedRow = (bool) $sql->executeStatement();
 
 		$this->cache[$app][$key] = $value;
 
@@ -329,7 +329,7 @@ class AppConfig implements IAppConfig {
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
 			->setParameter('app', $app)
 			->setParameter('configkey', $key);
-		$sql->execute();
+		$sql->executeStatement();
 
 		unset($this->cache[$app][$key]);
 		return false;
@@ -350,7 +350,7 @@ class AppConfig implements IAppConfig {
 		$sql->delete('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('app')))
 			->setParameter('app', $app);
-		$sql->execute();
+		$sql->executeStatement();
 
 		unset($this->cache[$app]);
 		return false;
@@ -415,7 +415,7 @@ class AppConfig implements IAppConfig {
 		$sql = $this->conn->getQueryBuilder();
 		$sql->select('*')
 			->from('appconfig');
-		$result = $sql->execute();
+		$result = $sql->executeQuery();
 
 		// we are going to store the result in memory anyway
 		$rows = $result->fetchAll();

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -51,7 +51,7 @@ class PublicKeyTokenMapper extends QBMapper {
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -66,7 +66,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('type', $qb->createNamedParameter(IToken::TEMPORARY_TOKEN, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('remember', $qb->createNamedParameter($remember, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeStatement();
 	}
 
 	public function invalidateLastUsedBefore(string $uid, int $before): int {
@@ -90,7 +90,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->from($this->tableName)
 			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -112,7 +112,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->from($this->tableName)
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();
@@ -139,7 +139,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)))
 			->setMaxResults(1000);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$data = $result->fetchAll();
 		$result->closeCursor();
 
@@ -157,7 +157,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -170,7 +170,7 @@ class PublicKeyTokenMapper extends QBMapper {
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('name', $qb->createNamedParameter($name), IQueryBuilder::PARAM_STR))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	public function deleteTempToken(PublicKeyToken $except) {
@@ -182,7 +182,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->neq('id', $qb->createNamedParameter($except->getId())))
 			->andWhere($qb->expr()->eq('version', $qb->createNamedParameter(PublicKeyToken::VERSION, IQueryBuilder::PARAM_INT)));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	public function hasExpiredTokens(string $uid): bool {
@@ -193,7 +193,7 @@ class PublicKeyTokenMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('password_invalid', $qb->createNamedParameter(true), IQueryBuilder::PARAM_BOOL))
 			->setMaxResults(1);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 

--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -56,7 +56,7 @@ class ProviderUserAssignmentDao {
 		$query = $qb->select('provider_id', 'enabled')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$providers = [];
 		foreach ($result->fetchAll() as $row) {
 			$providers[(string)$row['provider_id']] = 1 === (int)$row['enabled'];
@@ -80,14 +80,14 @@ class ProviderUserAssignmentDao {
 				'enabled' => $qb->createNamedParameter($enabled, IQueryBuilder::PARAM_INT),
 			]);
 
-			$insertQuery->execute();
+			$insertQuery->executeStatement();
 		} catch (UniqueConstraintViolationException $ex) {
 			// There is already an entry -> update it
 			$updateQuery = $qb->update(self::TABLE_NAME)
 				->set('enabled', $qb->createNamedParameter($enabled))
 				->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
 				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-			$updateQuery->execute();
+			$updateQuery->executeStatement();
 		}
 	}
 
@@ -103,7 +103,7 @@ class ProviderUserAssignmentDao {
 		$selectQuery = $qb1->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb1->expr()->eq('uid', $qb1->createNamedParameter($uid)));
-		$selectResult = $selectQuery->execute();
+		$selectResult = $selectQuery->executeQuery();
 		$rows = $selectResult->fetchAll();
 		$selectResult->closeCursor();
 
@@ -111,7 +111,7 @@ class ProviderUserAssignmentDao {
 		$deleteQuery = $qb2
 			->delete(self::TABLE_NAME)
 			->where($qb2->expr()->eq('uid', $qb2->createNamedParameter($uid)));
-		$deleteQuery->execute();
+		$deleteQuery->executeStatement();
 
 		return array_map(function (array $row) {
 			return [
@@ -128,6 +128,6 @@ class ProviderUserAssignmentDao {
 		$deleteQuery = $qb->delete(self::TABLE_NAME)
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)));
 
-		$deleteQuery->execute();
+		$deleteQuery->executeStatement();
 	}
 }

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -119,11 +119,11 @@ class JobList implements IJobList {
 			$query->setMaxResults($max);
 
 			do {
-				$deleted = $query->execute();
+				$deleted = $query->executeStatement();
 			} while ($deleted === $max);
 		} else {
 			// Dont use chunked delete - let the DB handle the large row count natively
-			$query->execute();
+			$query->executeStatement();
 		}
 	}
 

--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -100,7 +100,7 @@ class Collection implements ICollection {
 		$query->update(Manager::TABLE_COLLECTIONS)
 			->set('name', $query->createNamedParameter($name))
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->getId(), IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 
 		$this->name = $name;
 	}
@@ -142,7 +142,7 @@ class Collection implements ICollection {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (ConstraintViolationException $e) {
 			throw new ResourceException('Already part of the collection');
 		}
@@ -166,7 +166,7 @@ class Collection implements ICollection {
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($this->id, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('resource_type', $query->createNamedParameter($resource->getType())))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())));
-		$query->execute();
+		$query->executeStatement();
 
 		if (empty($this->resources)) {
 			$this->removeCollection();
@@ -222,7 +222,7 @@ class Collection implements ICollection {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(Manager::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->id, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 
 		$this->manager->invalidateAccessCacheForCollection($this);
 		$this->id = 0;

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -73,7 +73,7 @@ class Manager implements IManager {
 		$query->select('*')
 			->from(self::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -105,7 +105,7 @@ class Manager implements IManager {
 				)
 			)
 			->where($query->expr()->eq('c.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -151,7 +151,7 @@ class Manager implements IManager {
 			$query->andWhere($query->expr()->iLike('c.name', $query->createNamedParameter('%' . $this->connection->escapeLikeParameter($filter) . '%')));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$collections = [];
 
 		$foundResults = 0;
@@ -183,7 +183,7 @@ class Manager implements IManager {
 			->values([
 				'name' => $query->createNamedParameter($name),
 			]);
-		$query->execute();
+		$query->executeStatement();
 
 		return new Collection($this, $this->connection, $query->getLastInsertId(), $name);
 	}
@@ -222,7 +222,7 @@ class Manager implements IManager {
 			)
 			->where($query->expr()->eq('r.resource_type', $query->createNamedParameter($type, IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('r.resource_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -261,7 +261,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('r.collection_id', $query->createNamedParameter($collection->getId(), IQueryBuilder::PARAM_INT)));
 
 		$resources = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$access = $row['access'] === null ? null : (bool) $row['access'];
 			$resources[] = new Resource($this, $this->connection, $row['resource_type'], $row['resource_id'], $user, $access);
@@ -363,7 +363,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool) $row['access'];
 		}
@@ -383,7 +383,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool) $row['access'];
 		}
@@ -404,7 +404,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -420,7 +420,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -431,7 +431,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForResource(IResource $resource): void {
@@ -440,7 +440,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('resource_type', $query->createNamedParameter($resource->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeStatement();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollection($collection);
@@ -452,7 +452,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->neq('collection_id', $query->createNamedParameter(0)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForCollection(ICollection $collection): void {
@@ -460,7 +460,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForProvider(IProvider $provider): void {
@@ -468,7 +468,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForResourceByUser(IResource $resource, ?IUser $user): void {
@@ -478,7 +478,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollectionByUser($collection, $user);
@@ -492,7 +492,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForProviderByUser(IProvider $provider, ?IUser $user): void {
@@ -502,7 +502,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -150,7 +150,7 @@ class Resource implements IResource {
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($this->getType())))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($this->getId())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$collections[] = $this->manager->getCollection((int) $row['collection_id']);
 		}

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -200,7 +200,7 @@ class Manager implements ICommentsManager {
 			->where($qb->expr()->eq('parent_id', $qb->createParameter('id')))
 			->setParameter('id', $id);
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();
 		$children = (int)$data[0];
@@ -274,7 +274,7 @@ class Manager implements ICommentsManager {
 			->from('comments')
 			->where($qb->expr()->eq('id', $qb->createParameter('id')))
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -310,7 +310,7 @@ class Manager implements ICommentsManager {
 			$query->setFirstResult($offset);
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -369,7 +369,7 @@ class Manager implements ICommentsManager {
 				->setParameter('notOlderThan', $notOlderThan, 'datetime');
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -503,7 +503,7 @@ class Manager implements ICommentsManager {
 			}
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -529,7 +529,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
 			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -601,7 +601,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$comments = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($data = $result->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -640,7 +640,7 @@ class Manager implements ICommentsManager {
 			$query->andWhere($qb->expr()->eq('verb', $qb->createNamedParameter($verb)));
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();
 		return (int)$data[0];
@@ -755,7 +755,7 @@ class Manager implements ICommentsManager {
 			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$data = $result->fetch();
 		$result->closeCursor();
 
@@ -792,7 +792,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->in('actor_id', $query->createNamedParameter($actors, IQueryBuilder::PARAM_STR_ARRAY)))
 			->groupBy('actor_id');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$lastComments[$row['actor_id']] = $this->timeFactory->getDateTime($row['last_comment']);
 		}
@@ -844,7 +844,7 @@ class Manager implements ICommentsManager {
 				)
 			)->groupBy('f.fileid');
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 
 		$results = [];
 		while ($row = $resultStatement->fetch()) {
@@ -903,7 +903,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 			$this->uncache($id);
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
@@ -1173,7 +1173,7 @@ class Manager implements ICommentsManager {
 
 		$affectedRows = $qb->insert('comments')
 			->values($values)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			$comment->setId((string)$qb->getLastInsertId());
@@ -1311,7 +1311,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$affectedRows = $qb->where($qb->expr()->eq('id', $qb->createNamedParameter($comment->getId())))
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows === 0) {
 			throw new NotFoundException('Comment to update does ceased to exist');
@@ -1341,7 +1341,7 @@ class Manager implements ICommentsManager {
 			->andWhere($qb->expr()->eq('actor_id', $qb->createParameter('id')))
 			->setParameter('type', $actorType)
 			->setParameter('id', $actorId)
-			->execute();
+			->executeStatement();
 
 		$this->commentsCache = [];
 
@@ -1366,7 +1366,7 @@ class Manager implements ICommentsManager {
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('id')))
 			->setParameter('type', $objectType)
 			->setParameter('id', $objectId)
-			->execute();
+			->executeStatement();
 
 		$this->commentsCache = [];
 
@@ -1387,7 +1387,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID());
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,
@@ -1432,7 +1432,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			return;
@@ -1440,7 +1440,7 @@ class Manager implements ICommentsManager {
 
 		$qb->insert('comments_read_markers')
 			->values($values)
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -1464,7 +1464,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -1494,7 +1494,7 @@ class Manager implements ICommentsManager {
 			->setParameter('object_id', $objectId);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -270,7 +270,7 @@ class Connection extends \Doctrine\DBAL\Connection {
 		$sql = $this->adapter->fixupStatement($sql);
 		$this->queriesExecuted++;
 		$this->logQueryToFile($sql);
-		return parent::executeUpdate($sql, $params, $types);
+		return parent::executeStatement($sql, $params, $types);
 	}
 
 	/**

--- a/lib/private/DB/PreparedStatement.php
+++ b/lib/private/DB/PreparedStatement.php
@@ -83,7 +83,7 @@ class PreparedStatement implements IPreparedStatement {
 	}
 
 	public function execute($params = null): IResult {
-		return ($this->result = new ResultAdapter($this->statement->execute($params)));
+		return ($this->result = new ResultAdapter($this->statement->executeQuery($params)));
 	}
 
 	public function rowCount(): int {

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -277,7 +277,12 @@ class QueryBuilder implements IQueryBuilder {
 			]);
 		}
 
-		$result = $this->queryBuilder->execute();
+		if ($this->queryBuilder->getType() === $this->queryBuilder::SELECT) {
+			$result = $this->queryBuilder->executeQuery();
+		} else {
+			$result = $this->queryBuilder->executeStatement();
+		}
+
 		if (is_int($result)) {
 			return $result;
 		}

--- a/lib/private/DB/SQLiteSessionInit.php
+++ b/lib/private/DB/SQLiteSessionInit.php
@@ -57,8 +57,8 @@ class SQLiteSessionInit implements EventSubscriber {
 	 */
 	public function postConnect(ConnectionEventArgs $args) {
 		$sensitive = $this->caseSensitiveLike ? 'true' : 'false';
-		$args->getConnection()->executeUpdate('PRAGMA case_sensitive_like = ' . $sensitive);
-		$args->getConnection()->executeUpdate('PRAGMA journal_mode = ' . $this->journalMode);
+		$args->getConnection()->executeStatement('PRAGMA case_sensitive_like = ' . $sensitive);
+		$args->getConnection()->executeStatement('PRAGMA journal_mode = ' . $this->journalMode);
 		/** @var \Doctrine\DBAL\Driver\PDO\Connection $connection */
 		$connection = $args->getConnection()->getWrappedConnection();
 		$pdo = $connection->getWrappedConnection();

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -229,7 +229,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')->from(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($tokenRow = $result->fetch(FetchMode::ASSOCIATIVE)) {
 			return new Token($this, $tokenRow);
 		}
@@ -240,7 +240,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TABLE_TOKENS)
 			->where($query->expr()->lt('timestamp', $query->createNamedParameter(time() - self::TOKEN_CLEANUP_TIME)));
-		return $query->execute();
+		return $query->executeStatement();
 	}
 
 	public function refreshToken(string $token): bool {
@@ -248,7 +248,7 @@ class Manager implements IManager {
 		$query->update(self::TABLE_TOKENS)
 			->set('timestamp', $query->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -257,7 +257,7 @@ class Manager implements IManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TABLE_TOKENS)
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -267,7 +267,7 @@ class Manager implements IManager {
 			->set('accessed', $query->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
 			->set('timestamp', $query->createNamedParameter(time(), IQueryBuilder::PARAM_INT))
 			->where($query->expr()->eq('token', $query->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 		return $result !== 0;
 	}
 
@@ -294,7 +294,7 @@ class Manager implements IManager {
 				'share_id' => $query->createNamedParameter($share !== null ? $share->getId(): null),
 				'timestamp' => $query->createNamedParameter(time())
 			]);
-		$query->execute();
+		$query->executeStatement();
 		return $token;
 	}
 

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -312,7 +312,7 @@ class Cache implements ICache {
 				$builder->setValue($column, $builder->createNamedParameter($value));
 			}
 
-			if ($builder->execute()) {
+			if ($builder->executeStatement()) {
 				$fileId = $builder->getLastInsertId();
 
 				if (count($extensionValues)) {
@@ -709,7 +709,7 @@ class Cache implements ICache {
 				}
 
 				try {
-					$query->execute();
+					$query->executeStatement();
 				} catch (\OC\DatabaseException $e) {
 					$this->connection->rollBack();
 					throw $e;
@@ -761,7 +761,7 @@ class Cache implements ICache {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('storages')
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->storageId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**
@@ -1075,7 +1075,7 @@ class Cache implements ICache {
 			->from('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -217,13 +217,13 @@ class Propagator implements IPropagator {
 			$query->setParameter('time', $item['time'], IQueryBuilder::PARAM_INT);
 			$query->setParameter('hash', $item['hash']);
 
-			$query->execute();
+			$query->executeStatement();
 
 			if ($item['size']) {
 				$sizeQuery->setParameter('size', $item['size'], IQueryBuilder::PARAM_INT);
 				$sizeQuery->setParameter('hash', $item['hash']);
 
-				$sizeQuery->execute();
+				$sizeQuery->executeStatement();
 			}
 		}
 

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -179,7 +179,7 @@ class Storage {
 			->set('available', $query->createNamedParameter($available))
 			->set('last_checked', $query->createNamedParameter(time() + $delay))
 			->where($query->expr()->eq('id', $query->createNamedParameter($this->storageId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**
@@ -204,13 +204,13 @@ class Storage {
 		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->delete('storages')
 			->where($query->expr()->eq('id', $query->createNamedParameter($storageId)));
-		$query->execute();
+		$query->executeStatement();
 
 		if (!is_null($numericId)) {
 			$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 			$query->delete('filecache')
 				->where($query->expr()->eq('storage', $query->createNamedParameter($numericId)));
-			$query->execute();
+			$query->executeStatement();
 		}
 	}
 

--- a/lib/private/Files/Cache/StorageGlobal.php
+++ b/lib/private/Files/Cache/StorageGlobal.php
@@ -59,7 +59,7 @@ class StorageGlobal {
 			->from('storages')
 			->where($builder->expr()->in('id', $builder->createNamedParameter(array_values($storageIds), IQueryBuilder::PARAM_STR_ARRAY)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$this->cache[$row['id']] = $row;
 		}
@@ -77,7 +77,7 @@ class StorageGlobal {
 				->from('storages')
 				->where($builder->expr()->eq('id', $builder->createNamedParameter($storageId)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 
@@ -100,7 +100,7 @@ class StorageGlobal {
 				->from('storages')
 				->where($builder->expr()->eq('numeric_id', $builder->createNamedParameter($numericId)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -209,7 +209,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
 			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)));
 
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function removeFromCache(ICachedMountInfo $mount) {
@@ -219,7 +219,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($mount->getUser()->getUID())))
 			->andWhere($builder->expr()->eq('root_id', $builder->createNamedParameter($mount->getRootId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->eq('mount_point', $builder->createNamedParameter($mount->getMountPoint())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function dbRowToMountInfo(array $row) {
@@ -254,7 +254,7 @@ class UserMountCache implements IUserMountCache {
 				->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
 				->where($builder->expr()->eq('user_id', $builder->createPositionalParameter($user->getUID())));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$rows = $result->fetchAll();
 			$result->closeCursor();
 
@@ -279,7 +279,7 @@ class UserMountCache implements IUserMountCache {
 			$query->andWhere($builder->expr()->eq('user_id', $builder->createPositionalParameter($user)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 
@@ -297,7 +297,7 @@ class UserMountCache implements IUserMountCache {
 			->innerJoin('m', 'filecache', 'f', $builder->expr()->eq('m.root_id', 'f.fileid'))
 			->where($builder->expr()->eq('root_id', $builder->createPositionalParameter($rootFileId, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 
@@ -316,7 +316,7 @@ class UserMountCache implements IUserMountCache {
 				->from('filecache')
 				->where($builder->expr()->eq('fileid', $builder->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 
@@ -355,7 +355,7 @@ class UserMountCache implements IUserMountCache {
 			$query->andWhere($builder->expr()->eq('user_id', $builder->createPositionalParameter($user)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		// filter mounts that are from the same storage but a different directory
@@ -393,7 +393,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($user->getUID())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function removeUserStorageMount($storageId, $userId) {
@@ -402,7 +402,7 @@ class UserMountCache implements IUserMountCache {
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('user_id', $builder->createNamedParameter($userId)))
 			->andWhere($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function remoteStorageMounts($storageId) {
@@ -410,7 +410,7 @@ class UserMountCache implements IUserMountCache {
 
 		$query = $builder->delete('mounts')
 			->where($builder->expr()->eq('storage_id', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**
@@ -441,7 +441,7 @@ class UserMountCache implements IUserMountCache {
 			->where($builder->expr()->eq('m.mount_point', $mountPoint))
 			->andWhere($builder->expr()->in('m.user_id', $builder->createNamedParameter($userIds, IQueryBuilder::PARAM_STR_ARRAY)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$results = [];
 		while ($row = $result->fetch()) {

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -158,7 +158,7 @@ class Loader implements IMimeTypeLoader {
 		$qb->select('id', 'mimetype')
 			->from('mimetypes');
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$results = $result->fetchAll();
 		$result->closeCursor();
 
@@ -190,6 +190,6 @@ class Loader implements IMimeTypeLoader {
 				$update->func()->lower('name'),
 				$update->createNamedParameter('%' . $this->dbConnection->escapeLikeParameter('.' . $ext))
 			));
-		return $update->execute();
+		return $update->executeStatement();
 	}
 }

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -103,7 +103,7 @@ class Database extends ABackend implements
 			$result = $builder->insert('groups')
 				->setValue('gid', $builder->createNamedParameter($gid))
 				->setValue('displayname', $builder->createNamedParameter($gid))
-				->execute();
+				->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			$result = 0;
 		}
@@ -131,19 +131,19 @@ class Database extends ABackend implements
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete the group-user relation
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('group_user')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete the group-groupadmin relation
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		// Delete from cache
 		unset($this->groupCache[$gid]);
@@ -168,7 +168,7 @@ class Database extends ABackend implements
 			->from('group_user')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 
 		$result = $cursor->fetch();
 		$cursor->closeCursor();
@@ -193,7 +193,7 @@ class Database extends ABackend implements
 			$qb->insert('group_user')
 				->setValue('uid', $qb->createNamedParameter($uid))
 				->setValue('gid', $qb->createNamedParameter($gid))
-				->execute();
+				->executeStatement();
 			return true;
 		} else {
 			return false;
@@ -215,7 +215,7 @@ class Database extends ABackend implements
 		$qb->delete('group_user')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
 			->andWhere($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeStatement();
 
 		return true;
 	}
@@ -242,7 +242,7 @@ class Database extends ABackend implements
 			->from('group_user', 'gu')
 			->leftJoin('gu', 'groups', 'g', $qb->expr()->eq('gu.gid', 'g.gid'))
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($uid)))
-			->execute();
+			->executeQuery();
 
 		$groups = [];
 		while ($row = $cursor->fetch()) {
@@ -289,7 +289,7 @@ class Database extends ABackend implements
 		if ($offset > 0) {
 			$query->setFirstResult($offset);
 		}
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$groups = [];
 		while ($row = $result->fetch()) {
@@ -321,7 +321,7 @@ class Database extends ABackend implements
 		$cursor = $qb->select('gid', 'displayname')
 			->from('groups')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($gid)))
-			->execute();
+			->executeQuery();
 		$result = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -452,7 +452,7 @@ class Database extends ABackend implements
 			)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -484,7 +484,7 @@ class Database extends ABackend implements
 			->andWhere($query->expr()->eq('configvalue', $query->createNamedParameter('false'), IQueryBuilder::PARAM_STR))
 			->andWhere($query->expr()->eq('gid', $query->createNamedParameter($gid), IQueryBuilder::PARAM_STR));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -513,7 +513,7 @@ class Database extends ABackend implements
 			->from('groups')
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$displayName = $result->fetchOne();
 		$result->closeCursor();
 
@@ -582,7 +582,7 @@ class Database extends ABackend implements
 		$query->update('groups')
 			->set('displayname', $query->createNamedParameter($displayName))
 			->where($query->expr()->eq('gid', $query->createNamedParameter($gid)));
-		$query->execute();
+		$query->executeStatement();
 
 		return true;
 	}

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -99,7 +99,7 @@ class BackgroundCleanupJob extends TimedJob {
 			$qb->setMaxResults(10);
 		}
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row['name'];
@@ -113,7 +113,7 @@ class BackgroundCleanupJob extends TimedJob {
 		$qb->select('path', 'mimetype')
 			->from('filecache')
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($this->previewFolder->getId())));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -162,7 +162,7 @@ class BackgroundCleanupJob extends TimedJob {
 			$qb->setMaxResults(10);
 		}
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		while ($row = $cursor->fetch()) {
 			yield $row['name'];

--- a/lib/private/Repair/CleanTags.php
+++ b/lib/private/Repair/CleanTags.php
@@ -92,7 +92,7 @@ class CleanTags implements IRepairStep {
 			->orderBy('uid')
 			->setMaxResults(50)
 			->setFirstResult($offset);
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$users = [];
 		$hadResults = false;
@@ -113,7 +113,7 @@ class CleanTags implements IRepairStep {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete('vcategory')
 				->where($query->expr()->in('uid', $query->createNamedParameter($users, IQueryBuilder::PARAM_STR_ARRAY)));
-			$this->deletedTags += $query->execute();
+			$this->deletedTags += $query->executeStatement();
 		}
 		return true;
 	}
@@ -181,7 +181,7 @@ class CleanTags implements IRepairStep {
 			->andWhere(
 				$qb->expr()->isNull('s.' . $sourceNullColumn)
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 
 		$orphanItems = [];
 		while ($row = $result->fetch()) {
@@ -197,7 +197,7 @@ class CleanTags implements IRepairStep {
 					)
 					->andWhere($qb->expr()->in($deleteId, $qb->createParameter('ids')));
 				$qb->setParameter('ids', $items, IQueryBuilder::PARAM_INT_ARRAY);
-				$qb->execute();
+				$qb->executeStatement();
 			}
 		}
 

--- a/lib/private/Repair/NC11/FixMountStorages.php
+++ b/lib/private/Repair/NC11/FixMountStorages.php
@@ -58,12 +58,12 @@ class FixMountStorages implements IRepairStep {
 			->set('storage_id', $update->createParameter('storage'))
 			->where($query->expr()->eq('id', $update->createParameter('mount')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$entriesUpdated = 0;
 		while ($row = $result->fetch()) {
 			$update->setParameter('storage', $row['storage'], IQueryBuilder::PARAM_INT)
 				->setParameter('mount', $row['id'], IQueryBuilder::PARAM_INT);
-			$update->execute();
+			$update->executeStatement();
 			$entriesUpdated++;
 		}
 		$result->closeCursor();

--- a/lib/private/Repair/OldGroupMembershipShares.php
+++ b/lib/private/Repair/OldGroupMembershipShares.php
@@ -81,11 +81,11 @@ class OldGroupMembershipShares implements IRepairStep {
 		$deleteQuery->delete('share')
 			->where($query->expr()->eq('id', $deleteQuery->createParameter('share')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			if (!$this->isMember($row['group'], $row['user'])) {
 				$deletedEntries += $deleteQuery->setParameter('share', (int) $row['id'])
-					->execute();
+					->executeStatement();
 			}
 		}
 		$result->closeCursor();

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -139,7 +139,7 @@ class SaveAccountsTableData implements IRepairStep {
 			$query->setFirstResult($offset);
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$update = $this->db->getQueryBuilder();
 		$update->update('users')
@@ -193,7 +193,7 @@ class SaveAccountsTableData implements IRepairStep {
 		if ($userdata['display_name'] !== null) {
 			$update->setParameter('displayname', $userdata['display_name'])
 				->setParameter('userid', $userdata['user_id']);
-			$update->execute();
+			$update->executeStatement();
 		}
 	}
 }

--- a/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
+++ b/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
@@ -80,7 +80,7 @@ class UpdateLanguageCodes implements IRepairStep {
 				->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($oldCode), IQueryBuilder::PARAM_STR))
-				->execute();
+				->executeStatement();
 
 			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in preferences table.');
 		}

--- a/lib/private/Repair/RemoveLinkShares.php
+++ b/lib/private/Repair/RemoveLinkShares.php
@@ -95,7 +95,7 @@ class RemoveLinkShares implements IRepairStep {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -128,7 +128,7 @@ class RemoveLinkShares implements IRepairStep {
 			->from('share')
 			->where($query->expr()->in('id', $query->createFunction($subQuery->getSQL())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$data = $result->fetch();
 		$result->closeCursor();
 
@@ -158,7 +158,7 @@ class RemoveLinkShares implements IRepairStep {
 			))
 			->andWhere($query->expr()->eq('s1.item_source', 's2.item_source'));
 		/** @var IResult $result */
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		return $result;
 	}
 

--- a/lib/private/Repair/RepairDavShares.php
+++ b/lib/private/Repair/RepairDavShares.php
@@ -81,7 +81,7 @@ class RepairDavShares implements IRepairStep {
 			->set('principaluri', $updateQuery->createParameter('updatedPrincipalUri'))
 			->where($updateQuery->expr()->eq('id', $updateQuery->createParameter('shareId')));
 
-		$statement = $qb->execute();
+		$statement = $qb->executeQuery();
 		while ($share = $statement->fetch()) {
 			$gid = substr($share['principaluri'], strlen(self::GROUP_PRINCIPAL_PREFIX));
 			$decodedGid = urldecode($gid);
@@ -110,7 +110,7 @@ class RepairDavShares implements IRepairStep {
 				$updateQuery
 					->setParameter('updatedPrincipalUri', $fixedPrincipal)
 					->setParameter('shareId', $share['id'])
-					->execute();
+					->executeStatement();
 				$this->logger->info('Repaired principal for dav share {id} from {old} to {new}', $logParameters);
 			} catch (Exception $e) {
 				$logParameters['message'] = $e->getMessage();

--- a/lib/private/Repair/RepairInvalidShares.php
+++ b/lib/private/Repair/RepairInvalidShares.php
@@ -67,7 +67,7 @@ class RepairInvalidShares implements IRepairStep {
 			->where($builder->expr()->eq('item_type', $builder->expr()->literal('file')))
 			->andWhere($builder->expr()->neq('permissions', $permsFunc));
 
-		$updatedEntries = $builder->execute();
+		$updatedEntries = $builder->executeStatement();
 		if ($updatedEntries > 0) {
 			$out->info('Fixed file share permissions for ' . $updatedEntries . ' shares');
 		}
@@ -95,11 +95,11 @@ class RepairInvalidShares implements IRepairStep {
 		$deletedInLastChunk = self::CHUNK_SIZE;
 		while ($deletedInLastChunk === self::CHUNK_SIZE) {
 			$deletedInLastChunk = 0;
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			while ($row = $result->fetch()) {
 				$deletedInLastChunk++;
 				$deletedEntries += $deleteQuery->setParameter('parent', (int) $row['parent'])
-					->execute();
+					->executeStatement();
 			}
 			$result->closeCursor();
 		}

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -69,7 +69,7 @@ class RepairMimeTypes implements IRepairStep {
 
 		if (empty($this->folderMimeTypeId)) {
 			$query->setParameter('mimetype', 'httpd/unix-directory');
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$this->folderMimeTypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 		}
@@ -86,21 +86,21 @@ class RepairMimeTypes implements IRepairStep {
 		foreach ($updatedMimetypes as $extension => $mimetype) {
 			// get target mimetype id
 			$query->setParameter('mimetype', $mimetype);
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$mimetypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 
 			if (!$mimetypeId) {
 				// insert mimetype
 				$insert->setParameter('mimetype', $mimetype);
-				$insert->execute();
+				$insert->executeStatement();
 				$mimetypeId = $insert->getLastInsertId();
 			}
 
 			// change mimetype for files with x extension
 			$update->setParameter('mimetype', $mimetypeId)
 				->setParameter('name', '%' . $this->connection->escapeLikeParameter('.' . $extension));
-			$count += $update->execute();
+			$count += $update->executeStatement();
 		}
 
 		return $count;

--- a/lib/private/Security/Bruteforce/CleanupJob.php
+++ b/lib/private/Security/Bruteforce/CleanupJob.php
@@ -51,6 +51,6 @@ class CleanupJob extends TimedJob {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('bruteforce_attempts')
 			->where($qb->expr()->lt('occurred', $qb->createNamedParameter($time), IQueryBuilder::PARAM_INT));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/private/Security/CredentialsManager.php
+++ b/lib/private/Security/CredentialsManager.php
@@ -92,7 +92,7 @@ class CredentialsManager implements ICredentialsManager {
 			$qb->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($userId)));
 		}
 
-		$qResult = $qb->execute();
+		$qResult = $qb->executeQuery();
 		$result = $qResult->fetch();
 		$qResult->closeCursor();
 
@@ -122,7 +122,7 @@ class CredentialsManager implements ICredentialsManager {
 			$qb->andWhere($qb->expr()->eq('user', $qb->createNamedParameter($userId)));
 		}
 
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 
 	/**
@@ -136,6 +136,6 @@ class CredentialsManager implements ICredentialsManager {
 		$qb->delete(self::DB_TABLE)
 			->where($qb->expr()->eq('user', $qb->createNamedParameter($userId)))
 		;
-		return $qb->execute();
+		return $qb->executeStatement();
 	}
 }

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -122,14 +122,14 @@ class MySQL extends AbstractDatabase {
 
 			if ($connection->getDatabasePlatform() instanceof Mysql80Platform) {
 				$query = "CREATE USER '$name'@'localhost' IDENTIFIED WITH mysql_native_password BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 				$query = "CREATE USER '$name'@'%' IDENTIFIED WITH mysql_native_password BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 			} else {
 				$query = "CREATE USER '$name'@'localhost' IDENTIFIED BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 				$query = "CREATE USER '$name'@'%' IDENTIFIED BY '$password'";
-				$connection->executeUpdate($query);
+				$connection->executeStatement($query);
 			}
 		} catch (\Exception $ex) {
 			$this->logger->error('Database user creation failed.', [

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -56,7 +56,7 @@ class PostgreSQL extends AbstractDatabase {
 					->andWhere($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
 
 				try {
-					$result = $query->execute();
+					$result = $query->executeQuery();
 					$canCreateRoles = $result->rowCount() > 0;
 				} catch (DatabaseException $e) {
 					$canCreateRoles = false;
@@ -124,7 +124,7 @@ class PostgreSQL extends AbstractDatabase {
 			//The database does not exists... let's create it
 			$query = $connection->prepare("CREATE DATABASE " . addslashes($this->dbName) . " OWNER \"" . addslashes($this->dbUser) . '"');
 			try {
-				$query->execute();
+				$query->executeStatement();
 			} catch (DatabaseException $e) {
 				$this->logger->error('Error while trying to create database', [
 					'exception' => $e,
@@ -133,7 +133,7 @@ class PostgreSQL extends AbstractDatabase {
 		} else {
 			$query = $connection->prepare("REVOKE ALL PRIVILEGES ON DATABASE " . addslashes($this->dbName) . " FROM PUBLIC");
 			try {
-				$query->execute();
+				$query->executeStatement();
 			} catch (DatabaseException $e) {
 				$this->logger->error('Error while trying to restrict database permissions', [
 					'exception' => $e,
@@ -148,7 +148,7 @@ class PostgreSQL extends AbstractDatabase {
 		$query = $builder->select('*')
 			->from('pg_roles')
 			->where($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		return $result->rowCount() > 0;
 	}
 
@@ -158,7 +158,7 @@ class PostgreSQL extends AbstractDatabase {
 		$query = $builder->select('datname')
 			->from('pg_database')
 			->where($builder->expr()->eq('datname', $builder->createNamedParameter($this->dbName)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		return $result->rowCount() > 0;
 	}
 
@@ -173,10 +173,10 @@ class PostgreSQL extends AbstractDatabase {
 
 			// create the user
 			$query = $connection->prepare("CREATE USER \"" . addslashes($this->dbUser) . "\" CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
-			$query->execute();
+			$query->executeStatement();
 			if ($this->databaseExists($connection)) {
 				$query = $connection->prepare('GRANT CONNECT ON DATABASE ' . addslashes($this->dbName) . ' TO "' . addslashes($this->dbUser) . '"');
-				$query->execute();
+				$query->executeStatement();
 			}
 		} catch (DatabaseException $e) {
 			$this->logger->error('Error while trying to create database user', [

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -266,7 +266,7 @@ class DefaultShareProvider implements IShareProvider {
 				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 				->set('note', $qb->createNamedParameter($share->getNote()))
 				->set('accepted', $qb->createNamedParameter($share->getStatus()))
-				->execute();
+				->executeStatement();
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')
@@ -279,7 +279,7 @@ class DefaultShareProvider implements IShareProvider {
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 				->set('note', $qb->createNamedParameter($share->getNote()))
-				->execute();
+				->executeStatement();
 
 			/*
 			 * Update all user defined group shares
@@ -294,7 +294,7 @@ class DefaultShareProvider implements IShareProvider {
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 				->set('note', $qb->createNamedParameter($share->getNote()))
-				->execute();
+				->executeStatement();
 
 			/*
 			 * Now update the permissions for all children that have not set it to 0
@@ -305,7 +305,7 @@ class DefaultShareProvider implements IShareProvider {
 				->andWhere($qb->expr()->neq('permissions', $qb->createNamedParameter(0)))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
 				->set('attributes', $qb->createNamedParameter($shareAttributes))
-				->execute();
+				->executeStatement();
 		} elseif ($share->getShareType() === IShare::TYPE_LINK) {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')
@@ -323,7 +323,7 @@ class DefaultShareProvider implements IShareProvider {
 				->set('note', $qb->createNamedParameter($share->getNote()))
 				->set('label', $qb->createNamedParameter($share->getLabel()))
 				->set('hide_download', $qb->createNamedParameter($share->getHideDownload() ? 1 : 0), IQueryBuilder::PARAM_INT)
-				->execute();
+				->executeStatement();
 		}
 
 		if ($originalShare->getNote() !== $share->getNote() && $share->getNote() !== '') {
@@ -366,7 +366,7 @@ class DefaultShareProvider implements IShareProvider {
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 				))
-				->execute();
+				->executeQuery();
 
 			$data = $stmt->fetch();
 			$stmt->closeCursor();
@@ -394,7 +394,7 @@ class DefaultShareProvider implements IShareProvider {
 		$qb->update('share')
 			->set('accepted', $qb->createNamedParameter(IShare::STATUS_ACCEPTED))
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
-			->execute();
+			->executeStatement();
 
 		return $share;
 	}
@@ -429,7 +429,7 @@ class DefaultShareProvider implements IShareProvider {
 			))
 			->orderBy('id');
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$children[] = $this->createShare($data);
 		}
@@ -456,7 +456,7 @@ class DefaultShareProvider implements IShareProvider {
 			$qb->orWhere($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())));
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -493,7 +493,7 @@ class DefaultShareProvider implements IShareProvider {
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 				))
-				->execute();
+				->executeQuery();
 
 			$data = $stmt->fetch();
 
@@ -515,7 +515,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->update('share')
 					->set('permissions', $qb->createNamedParameter(0))
 					->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
-					->execute();
+					->executeStatement();
 			}
 		} elseif ($share->getShareType() === IShare::TYPE_USER) {
 			if ($share->getSharedWith() !== $recipient) {
@@ -546,7 +546,7 @@ class DefaultShareProvider implements IShareProvider {
 				'file_target' => $qb->createNamedParameter($share->getTarget()),
 				'permissions' => $qb->createNamedParameter($share->getPermissions()),
 				'stime' => $qb->createNamedParameter($share->getShareTime()->getTimestamp()),
-			])->execute();
+			])->executeStatement();
 
 		return $qb->getLastInsertId();
 	}
@@ -564,7 +564,7 @@ class DefaultShareProvider implements IShareProvider {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($share->getId()))
 			);
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -581,7 +581,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('share_with', $qb->createNamedParameter($recipient))
 			);
 
-		$qb->execute();
+		$qb->executeStatement();
 
 		return $this->getShareById($share->getId(), $recipient);
 	}
@@ -596,7 +596,7 @@ class DefaultShareProvider implements IShareProvider {
 			$qb->update('share')
 				->set('file_target', $qb->createNamedParameter($share->getTarget()))
 				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-				->execute();
+				->executeStatement();
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			// Check if there is a usergroup share
 			$qb = $this->dbConn->getQueryBuilder();
@@ -610,7 +610,7 @@ class DefaultShareProvider implements IShareProvider {
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 				))
 				->setMaxResults(1)
-				->execute();
+				->executeQuery();
 
 			$data = $stmt->fetch();
 			$stmt->closeCursor();
@@ -636,14 +636,14 @@ class DefaultShareProvider implements IShareProvider {
 						'permissions' => $qb->createNamedParameter($share->getPermissions()),
 						'attributes' => $qb->createNamedParameter($shareAttributes),
 						'stime' => $qb->createNamedParameter($share->getShareTime()->getTimestamp()),
-					])->execute();
+					])->executeStatement();
 			} else {
 				// Already a usergroup share. Update it.
 				$qb = $this->dbConn->getQueryBuilder();
 				$qb->update('share')
 					->set('file_target', $qb->createNamedParameter($share->getTarget()))
 					->where($qb->expr()->eq('id', $qb->createNamedParameter($data['id'])))
-					->execute();
+					->executeStatement();
 			}
 		}
 
@@ -771,7 +771,7 @@ class DefaultShareProvider implements IShareProvider {
 		$qb->setFirstResult($offset);
 		$qb->orderBy('id');
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$shares = [];
 		while ($data = $cursor->fetch()) {
 			$shares[] = $this->createShare($data);
@@ -805,7 +805,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			));
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -849,7 +849,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			))
-			->execute();
+			->executeQuery();
 
 		$shares = [];
 		while ($data = $cursor->fetch()) {
@@ -926,7 +926,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
 			}
 
-			$cursor = $qb->execute();
+			$cursor = $qb->executeQuery();
 
 			while ($data = $cursor->fetch()) {
 				if ($data['fileid'] && $data['path'] === null) {
@@ -990,7 +990,7 @@ class DefaultShareProvider implements IShareProvider {
 						$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 					));
 
-				$cursor = $qb->execute();
+				$cursor = $qb->executeQuery();
 				while ($data = $cursor->fetch()) {
 					if ($offset > 0) {
 						$offset--;
@@ -1034,7 +1034,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			))
-			->execute();
+			->executeQuery();
 
 		$data = $cursor->fetch();
 
@@ -1157,7 +1157,7 @@ class DefaultShareProvider implements IShareProvider {
 					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 				));
 
-			$stmt = $query->execute();
+			$stmt = $query->executeQuery();
 
 			while ($data = $stmt->fetch()) {
 				$shareMap[$data['parent']]->setPermissions((int)$data['permissions']);
@@ -1241,7 +1241,7 @@ class DefaultShareProvider implements IShareProvider {
 			return;
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -1260,7 +1260,7 @@ class DefaultShareProvider implements IShareProvider {
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
 			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($gid)));
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$ids = [];
 		while ($row = $cursor->fetch()) {
 			$ids[] = (int)$row['id'];
@@ -1273,7 +1273,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->delete('share')
 					->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USERGROUP)))
 					->andWhere($qb->expr()->in('parent', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
-				$qb->execute();
+				$qb->executeStatement();
 			}
 		}
 
@@ -1284,7 +1284,7 @@ class DefaultShareProvider implements IShareProvider {
 		$qb->delete('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
 			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($gid)));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -1303,7 +1303,7 @@ class DefaultShareProvider implements IShareProvider {
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
 			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($gid)));
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$ids = [];
 		while ($row = $cursor->fetch()) {
 			$ids[] = (int)$row['id'];
@@ -1320,7 +1320,7 @@ class DefaultShareProvider implements IShareProvider {
 					->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USERGROUP)))
 					->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($uid)))
 					->andWhere($qb->expr()->in('parent', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
-				$qb->execute();
+				$qb->executeStatement();
 			}
 		}
 	}
@@ -1356,7 +1356,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 
 		$users = [];
 		$link = false;
@@ -1548,7 +1548,7 @@ class DefaultShareProvider implements IShareProvider {
 				)
 			);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			try {
 				$share = $this->createShare($data);

--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -89,7 +89,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 				'gid' => $qb->createNamedParameter($group->getGID()),
 				'uid' => $qb->createNamedParameter($user->getUID())
 			])
-			->execute();
+			->executeStatement();
 
 		/** @deprecated 21.0.0 - use type SubAdminAddedEvent instead  */
 		$this->emit('\OC\SubAdmin', 'postCreateSubAdmin', [$user, $group]);
@@ -108,7 +108,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeStatement();
 
 		/** @deprecated 21.0.0 - use type SubAdminRemovedEvent instead  */
 		$this->emit('\OC\SubAdmin', 'postDeleteSubAdmin', [$user, $group]);
@@ -146,7 +146,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$result = $qb->select('gid')
 			->from('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeQuery();
 
 		$groups = [];
 		while ($row = $result->fetch()) {
@@ -179,7 +179,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 		$result = $qb->select('uid')
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
-			->execute();
+			->executeQuery();
 
 		$users = [];
 		while ($row = $result->fetch()) {
@@ -202,7 +202,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$result = $qb->select('*')
 			->from('group_admin')
-			->execute();
+			->executeQuery();
 
 		$subadmins = [];
 		while ($row = $result->fetch()) {
@@ -236,7 +236,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeQuery();
 
 		$fetch = $result->fetch();
 		$result->closeCursor();
@@ -262,7 +262,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 			->from('group_admin')
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
 			->setMaxResults(1)
-			->execute();
+			->executeQuery();
 
 		$isSubAdmin = $result->fetch();
 		$result->closeCursor();
@@ -299,7 +299,7 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter($user->getUID())))
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -311,6 +311,6 @@ class SubAdmin extends PublicEmitter implements ISubAdmin {
 
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($group->getGID())))
-			->execute();
+			->executeStatement();
 	}
 }

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -94,7 +94,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('editable', 'ASC')
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$tag = $this->createSystemTagFromRow($row);
 			if ($user && !$this->canUserSeeTag($tag, $user)) {
@@ -143,7 +143,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('visibility', 'ASC')
 			->addOrderBy('editable', 'ASC');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$tags[$row['id']] = $this->createSystemTagFromRow($row);
 		}
@@ -163,7 +163,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('name', $truncatedTagName)
 			->setParameter('visibility', $userVisible ? 1 : 0)
 			->setParameter('editable', $userAssignable ? 1 : 0)
-			->execute();
+			->executeQuery();
 
 		$row = $result->fetch();
 		$result->closeCursor();
@@ -191,7 +191,7 @@ class SystemTagManager implements ISystemTagManager {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
 				'Tag ("' . $truncatedTagName . '", '. $userVisible . ', ' . $userAssignable . ') already exists',
@@ -250,7 +250,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('tagid', $tagId);
 
 		try {
-			if ($query->execute() === 0) {
+			if ($query->executeStatement() === 0) {
 				throw new TagNotFoundException(
 					'Tag does not exist', 0, null, [$tagId]
 				);
@@ -299,13 +299,13 @@ class SystemTagManager implements ISystemTagManager {
 		$query->delete(SystemTagObjectMapper::RELATION_TABLE)
 			->where($query->expr()->in('systemtagid', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TAG_TABLE)
 			->where($query->expr()->in('id', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		foreach ($tags as $tag) {
 			$this->dispatcher->dispatch(ManagerEvent::EVENT_DELETE, new ManagerEvent(
@@ -377,7 +377,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete(self::TAG_GROUP_TABLE)
 				->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
-				->execute();
+				->executeStatement();
 
 			// add each group id
 			$query = $this->connection->getQueryBuilder();
@@ -391,7 +391,7 @@ class SystemTagManager implements ISystemTagManager {
 					continue;
 				}
 				$query->setParameter('gid', $groupId);
-				$query->execute();
+				$query->executeStatement();
 			}
 
 			$this->connection->commit();
@@ -412,7 +412,7 @@ class SystemTagManager implements ISystemTagManager {
 			->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
 			->orderBy('gid');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$groupIds[] = $row['gid'];
 		}

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -116,7 +116,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$objectIds = [];
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$objectIds[] = $row['objectid'];
 		}
@@ -147,7 +147,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		foreach ($tagIds as $tagId) {
 			try {
 				$query->setParameter('tagid', $tagId);
-				$query->execute();
+				$query->executeStatement();
 				$tagsAssigned[] = $tagId;
 			} catch (UniqueConstraintViolationException $e) {
 				// ignore existing relations
@@ -184,7 +184,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('objectid', $objId)
 			->setParameter('objecttype', $objectType)
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		$this->dispatcher->dispatch(MapperEvent::EVENT_UNASSIGN, new MapperEvent(
 			MapperEvent::EVENT_UNASSIGN,
@@ -223,7 +223,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->setParameter('tagid', $tagId)
 			->setParameter('objecttype', $objectType);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch(\PDO::FETCH_NUM);
 		$result->closeCursor();
 

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -95,7 +95,7 @@ class TagManager implements ITagManager, IEventListener {
 			->andWhere($query->expr()->eq('c.type', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('c.category', $query->createNamedParameter(ITags::TAG_FAVORITE)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$users = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 

--- a/lib/private/Updater/ChangesMapper.php
+++ b/lib/private/Updater/ChangesMapper.php
@@ -50,7 +50,7 @@ class ChangesMapper extends QBMapper {
 		$result = $qb->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('version', $qb->createNamedParameter($version)))
-			->execute();
+			->executeQuery();
 
 		$data = $result->fetch();
 		$result->closeCursor();

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -163,7 +163,7 @@ class Database extends ABackend implements
 		$query = $this->dbConn->getQueryBuilder();
 		$query->delete($this->table)
 			->where($query->expr()->eq('uid_lower', $query->createNamedParameter(mb_strtolower($uid))));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 
 		if (isset($this->cache[$uid])) {
 			unset($this->cache[$uid]);
@@ -177,7 +177,7 @@ class Database extends ABackend implements
 		$query->update($this->table)
 			->set('password', $query->createNamedParameter($passwordHash))
 			->where($query->expr()->eq('uid_lower', $query->createNamedParameter(mb_strtolower($uid))));
-		$result = $query->execute();
+		$result = $query->executeStatement();
 
 		return $result ? true : false;
 	}
@@ -235,7 +235,7 @@ class Database extends ABackend implements
 			$query->update($this->table)
 				->set('displayname', $query->createNamedParameter($displayName))
 				->where($query->expr()->eq('uid_lower', $query->createNamedParameter(mb_strtolower($uid))));
-			$query->execute();
+			$query->executeStatement();
 
 			$this->cache[$uid]['displayname'] = $displayName;
 
@@ -328,7 +328,7 @@ class Database extends ABackend implements
 			->setMaxResults($limit)
 			->setFirstResult($offset);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$displayNames = [];
 		while ($row = $result->fetch()) {
 			$displayNames[(string)$row['uid']] = (string)$row['displayname'];
@@ -389,7 +389,7 @@ class Database extends ABackend implements
 						'uid_lower', $qb->createNamedParameter(mb_strtolower($uid))
 					)
 				);
-			$result = $qb->execute();
+			$result = $qb->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -544,7 +544,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR));
 
 
-		$result = $queryBuilder->execute();
+		$result = $queryBuilder->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -574,7 +574,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR))
 			->andWhere($queryBuilder->expr()->in('gid', $queryBuilder->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));
 
-		$result = $queryBuilder->execute();
+		$result = $queryBuilder->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -600,7 +600,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('login')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('lastLogin')));
 
-		$query = $queryBuilder->execute();
+		$query = $queryBuilder->executeQuery();
 
 		$result = (int)$query->fetchOne();
 		$query->closeCursor();
@@ -662,7 +662,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		if ($offset !== null) {
 			$queryBuilder->setFirstResult($offset);
 		}
-		$query = $queryBuilder->execute();
+		$query = $queryBuilder->executeQuery();
 		$result = [];
 
 		while ($row = $query->fetch()) {

--- a/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
+++ b/tests/Test/Repair/Owncloud/UpdateLanguageCodesTest.php
@@ -77,7 +77,7 @@ class UpdateLanguageCodesTest extends TestCase {
 				'appid' => 'core',
 				'configkey' => 'lang',
 				'configvalue' => $user['configvalue'],
-			])->execute();
+			])->executeStatement();
 		}
 
 		// check if test data is written to DB
@@ -87,7 +87,7 @@ class UpdateLanguageCodesTest extends TestCase {
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 			->orderBy('userid')
-			->execute();
+			->executeQuery();
 
 		$rows = $result->fetchAll();
 		$result->closeCursor();
@@ -124,7 +124,7 @@ class UpdateLanguageCodesTest extends TestCase {
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 			->orderBy('userid')
-			->execute();
+			->executeQuery();
 
 		$rows = $result->fetchAll();
 		$result->closeCursor();
@@ -144,7 +144,7 @@ class UpdateLanguageCodesTest extends TestCase {
 				->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($user['configvalue']), IQueryBuilder::PARAM_STR))
-				->execute();
+				->executeStatement();
 		}
 	}
 

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -42,7 +42,7 @@ class AllConfigTest extends \Test\TestCase {
 		$config = $this->getConfig();
 
 		// preparation - add something to the database
-		$this->connection->executeUpdate(
+		$this->connection->executeStatement(
 			'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 			'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 			['userDelete', 'appDelete', 'keyDelete', 'valueDelete']
@@ -231,7 +231,7 @@ class AllConfigTest extends \Test\TestCase {
 		], $result[0]);
 
 		// drop data from database - but the config option should be cached in the config object
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences` WHERE `userid` = ?', ['userGet']);
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences` WHERE `userid` = ?', ['userGet']);
 
 		// testing the caching mechanism
 		$value = $config->getUserValue('userGet', 'appGet', 'keyGet');
@@ -260,7 +260,7 @@ class AllConfigTest extends \Test\TestCase {
 			['userFetch2', 'appFetch', 'keyFetch1', 'value7']
 		];
 		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
+			$this->connection->executeStatement(
 				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 				$entry
@@ -274,7 +274,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(['keyFetch1'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences`');
 	}
 
 	public function testGetUserValueDefault() {
@@ -299,7 +299,7 @@ class AllConfigTest extends \Test\TestCase {
 			['userFetch7', 'appFetch2', 'keyFetch1', 'value7']
 		];
 		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
+			$this->connection->executeStatement(
 				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 				$entry
@@ -323,7 +323,7 @@ class AllConfigTest extends \Test\TestCase {
 		], $value, 'userFetch9 is an non-existent user and should not be shown.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences`');
 	}
 
 	public function testDeleteAllUserValues() {
@@ -340,7 +340,7 @@ class AllConfigTest extends \Test\TestCase {
 			['userFetch4', 'appFetch2', 'keyFetch1', 'value7']
 		];
 		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
+			$this->connection->executeStatement(
 				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 				$entry
@@ -357,7 +357,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(1, $actualCount, 'After removing `userFetch3` there should be exactly 1 entry left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences`');
 	}
 
 	public function testDeleteAppFromAllUsers() {
@@ -374,7 +374,7 @@ class AllConfigTest extends \Test\TestCase {
 			['userFetch6', 'appFetch2', 'keyFetch1', 'value7']
 		];
 		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
+			$this->connection->executeStatement(
 				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 				$entry
@@ -400,7 +400,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(2, $actualCount, 'After removing `appFetch2` there should be exactly 2 entries left.');
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences`');
 	}
 
 	public function testGetUsersForUserValue() {
@@ -420,7 +420,7 @@ class AllConfigTest extends \Test\TestCase {
 			['user6', 'appFetch9', 'keyFetch9', 'value9'],
 		];
 		foreach ($data as $entry) {
-			$this->connection->executeUpdate(
+			$this->connection->executeStatement(
 				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
 				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
 				$entry
@@ -431,7 +431,7 @@ class AllConfigTest extends \Test\TestCase {
 		$this->assertEquals(['user1', 'user2', 'user6'], $value);
 
 		// cleanup
-		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+		$this->connection->executeStatement('DELETE FROM `*PREFIX*preferences`');
 	}
 
 	public function testGetUsersForUserValueCaseInsensitive() {

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -36,13 +36,13 @@ class AppConfigTest extends TestCase {
 		$sql = $this->connection->getQueryBuilder();
 		$sql->select('*')
 			->from('appconfig');
-		$result = $sql->execute();
+		$result = $sql->executeQuery();
 		$this->originalConfig = $result->fetchAll();
 		$result->closeCursor();
 
 		$sql = $this->connection->getQueryBuilder();
 		$sql->delete('appconfig');
-		$sql->execute();
+		$sql->executeStatement();
 
 		$this->overwriteService(AppConfig::class, new \OC\AppConfig($this->connection));
 
@@ -58,66 +58,66 @@ class AppConfigTest extends TestCase {
 			'appid' => 'testapp',
 			'configkey' => 'enabled',
 			'configvalue' => 'true',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'testapp',
 			'configkey' => 'installed_version',
 			'configvalue' => '1.2.3',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'testapp',
 			'configkey' => 'depends_on',
 			'configvalue' => 'someapp',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'testapp',
 			'configkey' => 'deletethis',
 			'configvalue' => 'deletethis',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'testapp',
 			'configkey' => 'key',
 			'configvalue' => 'value',
-		])->execute();
+		])->executeStatement();
 
 		$sql->setParameters([
 			'appid' => 'someapp',
 			'configkey' => 'key',
 			'configvalue' => 'value',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'someapp',
 			'configkey' => 'otherkey',
 			'configvalue' => 'othervalue',
-		])->execute();
+		])->executeStatement();
 
 		$sql->setParameters([
 			'appid' => '123456',
 			'configkey' => 'key',
 			'configvalue' => 'value',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => '123456',
 			'configkey' => 'enabled',
 			'configvalue' => 'false',
-		])->execute();
+		])->executeStatement();
 
 		$sql->setParameters([
 			'appid' => 'anotherapp',
 			'configkey' => 'key',
 			'configvalue' => 'value',
-		])->execute();
+		])->executeStatement();
 		$sql->setParameters([
 			'appid' => 'anotherapp',
 			'configkey' => 'enabled',
 			'configvalue' => 'false',
-		])->execute();
+		])->executeStatement();
 	}
 
 	protected function tearDown(): void {
 		$sql = $this->connection->getQueryBuilder();
 		$sql->delete('appconfig');
-		$sql->execute();
+		$sql->executeStatement();
 
 		$sql = $this->connection->getQueryBuilder();
 		$sql->insert('appconfig')
@@ -131,7 +131,7 @@ class AppConfigTest extends TestCase {
 			$sql->setParameter('appid', $configs['appid'])
 				->setParameter('configkey', $configs['configkey'])
 				->setParameter('configvalue', $configs['configvalue']);
-			$sql->execute();
+			$sql->executeStatement();
 		}
 
 		$this->restoreService(AppConfig::class);
@@ -241,7 +241,7 @@ class AppConfigTest extends TestCase {
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
 			->setParameter('appid', 'testapp')
 			->setParameter('configkey', 'deletethis');
-		$query = $sql->execute();
+		$query = $sql->executeQuery();
 		$result = $query->fetch();
 		$query->closeCursor();
 		$this->assertFalse($result);
@@ -261,7 +261,7 @@ class AppConfigTest extends TestCase {
 			->from('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('appid')))
 			->setParameter('appid', 'someapp');
-		$query = $sql->execute();
+		$query = $sql->executeQuery();
 		$result = $query->fetch();
 		$query->closeCursor();
 		$this->assertFalse($result);
@@ -283,7 +283,7 @@ class AppConfigTest extends TestCase {
 			->from('appconfig')
 			->where($sql->expr()->eq('appid', $sql->createParameter('appid')))
 			->setParameter('appid', 'testapp');
-		$query = $sql->execute();
+		$query = $sql->executeQuery();
 		$expected = [];
 		while ($row = $query->fetch()) {
 			$expected[$row['configkey']] = $row['configvalue'];
@@ -298,7 +298,7 @@ class AppConfigTest extends TestCase {
 			->from('appconfig')
 			->where($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
 			->setParameter('configkey', 'enabled');
-		$query = $sql->execute();
+		$query = $sql->executeQuery();
 		$expected = [];
 		while ($row = $query->fetch()) {
 			$expected[$row['appid']] = $row['configvalue'];
@@ -359,7 +359,7 @@ class AppConfigTest extends TestCase {
 			->andWhere($sql->expr()->eq('configkey', $sql->createParameter('configkey')))
 			->setParameter('appid', $app)
 			->setParameter('configkey', $key);
-		$query = $sql->execute();
+		$query = $sql->executeQuery();
 		$actual = $query->fetch();
 		$query->closeCursor();
 

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -59,7 +59,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 
 	private function resetDatabase() {
 		$qb = $this->dbConnection->getQueryBuilder();
-		$qb->delete('authtoken')->execute();
+		$qb->delete('authtoken')->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user1'),
 			'login_name' => $qb->createNamedParameter('User1'),
@@ -72,7 +72,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user2'),
 			'login_name' => $qb->createNamedParameter('User2'),
@@ -85,7 +85,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user1'),
 			'login_name' => $qb->createNamedParameter('User1'),
@@ -98,7 +98,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user3'),
 			'login_name' => $qb->createNamedParameter('User3'),
@@ -112,7 +112,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
 			'password_invalid' => $qb->createNamedParameter(1),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user3'),
 			'login_name' => $qb->createNamedParameter('User3'),
@@ -126,14 +126,14 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
 			'password_invalid' => $qb->createNamedParameter(1),
-		])->execute();
+		])->executeStatement();
 	}
 
 	private function getNumberOfTokens() {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$result = $qb->select($qb->func()->count('*', 'count'))
 			->from('authtoken')
-			->execute()
+			->executeQuery()
 			->fetch();
 		return (int) $result['count'];
 	}
@@ -256,7 +256,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 		$qb->select('id')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$id = $result->fetch()['id'];
 
 		$this->mapper->deleteById('user1', (int)$id);
@@ -277,7 +277,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 		$qb->select('name')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$name = $result->fetch()['name'];
 		$this->mapper->deleteByName($name);
 		$this->assertEquals(4, $this->getNumberOfTokens());

--- a/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
@@ -47,7 +47,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 		$this->dbConn = OC::$server->getDatabaseConnection();
 		$qb = $this->dbConn->getQueryBuilder();
 		$q = $qb->delete(ProviderUserAssignmentDao::TABLE_NAME);
-		$q->execute();
+		$q->executeStatement();
 
 		$this->dao = new ProviderUserAssignmentDao($this->dbConn);
 	}
@@ -59,13 +59,13 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			'uid' => $qb->createNamedParameter('user123'),
 			'enabled' => $qb->createNamedParameter(1),
 		]);
-		$q1->execute();
+		$q1->executeStatement();
 		$q2 = $qb->insert(ProviderUserAssignmentDao::TABLE_NAME)->values([
 			'provider_id' => $qb->createNamedParameter('twofactor_totp'),
 			'uid' => $qb->createNamedParameter('user123'),
 			'enabled' => $qb->createNamedParameter(0),
 		]);
-		$q2->execute();
+		$q2->executeStatement();
 		$expected = [
 			'twofactor_u2f' => true,
 			'twofactor_totp' => false,
@@ -87,7 +87,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(0)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 		$this->assertCount(1, $data);
@@ -105,7 +105,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 
@@ -124,7 +124,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -53,7 +53,7 @@ class JobListTest extends TestCase {
 	protected function clearJobsList() {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('jobs');
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	protected function getAllSorted() {
@@ -168,7 +168,7 @@ class JobListTest extends TestCase {
 				'last_checked' => $query->createNamedParameter($lastChecked, IQueryBuilder::PARAM_INT),
 				'reserved_at' => $query->createNamedParameter($reservedTime, IQueryBuilder::PARAM_INT),
 			]);
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function testGetNext() {

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -66,7 +66,7 @@ class ManagerTest extends TestCase {
 				'object_id' => $qb->createNamedParameter($objectId),
 				'expire_date' => $qb->createNamedParameter($expireDate, 'datetime'),
 			])
-			->execute();
+			->executeStatement();
 
 		return $qb->getLastInsertId();
 	}
@@ -120,7 +120,7 @@ class ManagerTest extends TestCase {
 				'object_type' => $qb->createNamedParameter('files'),
 				'object_id' => $qb->createNamedParameter('file64'),
 			])
-			->execute();
+			->executeStatement();
 
 		$id = strval($qb->getLastInsertId());
 
@@ -337,7 +337,7 @@ class ManagerTest extends TestCase {
 		$fileIds = [];
 		for ($i = 0; $i < 4; $i++) {
 			$query->setParameter('path', 'path_' . $i);
-			$query->execute();
+			$query->executeStatement();
 			$fileIds[] = $query->getLastInsertId();
 		}
 

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -68,7 +68,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('users')
 			->where($query->expr()->like($query->createNamedParameter($param1), $query->createNamedParameter($param2)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($match, $column);
@@ -105,7 +105,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('users')
 			->where($query->expr()->iLike($query->createNamedParameter($param1), $query->createNamedParameter($param2)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($match, $column);
@@ -158,6 +158,6 @@ class ExpressionBuilderDBTest extends TestCase {
 				'configkey' => $query->createNamedParameter((string) $key),
 				'configvalue' => $query->createNamedParameter((string) $value),
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -413,7 +413,7 @@ class ExpressionBuilderTest extends TestCase {
 			$query->andWhere(call_user_func([$query->expr(), $function], 'configkey', 'configvalue', IQueryBuilder::PARAM_STR));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$this->assertEquals(['count' => $expected], $result->fetch());
 		$result->closeCursor();
@@ -421,7 +421,7 @@ class ExpressionBuilderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
-			->execute();
+			->executeStatement();
 	}
 
 	protected function createConfig($appId, $key, $value) {
@@ -432,6 +432,6 @@ class ExpressionBuilderTest extends TestCase {
 				'configkey' => $query->createNamedParameter((string) $key),
 				'configvalue' => $query->createNamedParameter((string) $value),
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -56,7 +56,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($return, $column);
@@ -132,7 +132,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString(',', $column);
@@ -148,7 +148,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('#', $column);
@@ -164,7 +164,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString("'", $column);
@@ -180,7 +180,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('"', $column);
@@ -221,7 +221,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('systemtag')
 			->where($query->expr()->eq('name', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString(',', $column);
@@ -237,7 +237,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('systemtag')
 			->where($query->expr()->eq('name', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('#', $column);
@@ -252,7 +252,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(md5('foobar'), $column);
@@ -265,7 +265,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('oo', $column);
@@ -278,7 +278,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('oobar', $column);
@@ -291,7 +291,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('foobar', $column);
@@ -304,7 +304,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(3, $column);
@@ -317,7 +317,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(1, $column);
@@ -330,7 +330,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertGreaterThan(1, $column);
@@ -355,7 +355,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($bytes, $column);
@@ -380,7 +380,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($bytes, $column);
@@ -395,7 +395,7 @@ class FunctionBuilderTest extends TestCase {
 				'configkey' => $query->createNamedParameter(uniqid()),
 				'configvalue' => $query->createNamedParameter((string)$value),
 			]);
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function clearMinMax() {
@@ -403,7 +403,7 @@ class FunctionBuilderTest extends TestCase {
 
 		$query->delete('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function testMaxEmpty() {
@@ -416,7 +416,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(null, $row);
@@ -432,7 +432,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(null, $row);
@@ -451,7 +451,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(20, $row);
@@ -470,7 +470,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(10, $row);
@@ -483,7 +483,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(2, $row);
@@ -496,7 +496,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(1, $row);

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -70,7 +70,7 @@ class QueryBuilderTest extends \Test\TestCase {
 					'configkey' => $qB->expr()->literal('testing' . $i),
 					'configvalue' => $qB->expr()->literal(100 - $i),
 				])
-				->execute();
+				->executeStatement();
 		}
 	}
 
@@ -98,7 +98,7 @@ class QueryBuilderTest extends \Test\TestCase {
 
 		$qB->delete('*PREFIX*appconfig')
 			->where($qB->expr()->eq('appid', $qB->expr()->literal($appId)))
-			->execute();
+			->executeStatement();
 	}
 
 	public function dataFirstResult() {
@@ -1190,7 +1190,7 @@ class QueryBuilderTest extends \Test\TestCase {
 				'propertyname' => $qB->expr()->literal('testing'),
 				'propertyvalue' => $qB->expr()->literal('testing'),
 			])
-			->execute();
+			->executeStatement();
 
 		$actual = $qB->getLastInsertId();
 
@@ -1200,7 +1200,7 @@ class QueryBuilderTest extends \Test\TestCase {
 
 		$qB->delete('properties')
 			->where($qB->expr()->eq('userid', $qB->expr()->literal('testFirstResult')))
-			->execute();
+			->executeStatement();
 
 		try {
 			$qB->getLastInsertId();

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -341,7 +341,7 @@ class ScannerTest extends TestCase {
 		$query = OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->delete('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($oldFolderId)));
-		$query->execute();
+		$query->executeStatement();
 
 		$cachedData = $this->cache->get('folder/bar.txt');
 		$this->assertEquals($oldFolderId, $cachedData['parent']);
@@ -367,7 +367,7 @@ class ScannerTest extends TestCase {
 		$query = OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$query->delete('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($oldFolderId)));
-		$query->execute();
+		$query->executeStatement();
 
 		$cachedData = $this->cache->get('folder/bar.txt');
 		$this->assertEquals($oldFolderId, $cachedData['parent']);

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -91,7 +91,7 @@ class SearchBuilderTest extends TestCase {
 		$builder->delete('filecache')
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($this->numericStorageId, IQueryBuilder::PARAM_INT)));
 
-		$builder->execute();
+		$builder->executeStatement();
 	}
 
 	private function addCacheEntry(array $data) {
@@ -128,7 +128,7 @@ class SearchBuilderTest extends TestCase {
 
 		$builder->insert('filecache')
 			->values($values)
-			->execute();
+			->executeStatement();
 
 		return $builder->getLastInsertId();
 	}
@@ -137,7 +137,7 @@ class SearchBuilderTest extends TestCase {
 		$dbOperator = $this->searchBuilder->searchOperatorToDBExpr($this->builder, $operator);
 		$this->builder->andWhere($dbOperator);
 
-		$result = $this->builder->execute();
+		$result = $this->builder->executeQuery();
 		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -73,14 +73,14 @@ class UserMountCacheTest extends TestCase {
 	protected function tearDown(): void {
 		$builder = $this->connection->getQueryBuilder();
 
-		$builder->delete('mounts')->execute();
+		$builder->delete('mounts')->executeStatement();
 
 		$builder = $this->connection->getQueryBuilder();
 
 		foreach ($this->fileIds as $fileId) {
 			$builder->delete('filecache')
 				->where($builder->expr()->eq('fileid', new Literal($fileId)))
-				->execute();
+				->executeStatement();
 		}
 	}
 

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -41,7 +41,7 @@ class LoaderTest extends \Test\TestCase {
 			->where($deleteMimetypes->expr()->like(
 				'mimetype', $deleteMimetypes->createPositionalParameter('testing/%')
 			));
-		$deleteMimetypes->execute();
+		$deleteMimetypes->executeStatement();
 	}
 
 
@@ -51,7 +51,7 @@ class LoaderTest extends \Test\TestCase {
 			->values([
 				'mimetype' => $qb->createPositionalParameter('testing/mymimetype')
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$this->assertTrue($this->loader->exists('testing/mymimetype'));
 		$mimetypeId = $this->loader->getId('testing/mymimetype');
@@ -76,7 +76,7 @@ class LoaderTest extends \Test\TestCase {
 			->from('mimetypes')
 			->where($qb->expr()->eq('id', $qb->createPositionalParameter($mimetypeId)));
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$mimetype = $result->fetch();
 		$result->closeCursor();
 		$this->assertEquals('testing/mymimetype', $mimetype['mimetype']);

--- a/tests/lib/Lock/DBLockingProviderTest.php
+++ b/tests/lib/Lock/DBLockingProviderTest.php
@@ -103,7 +103,7 @@ class DBLockingProviderTest extends LockingProvider {
 			->from('file_locks')
 			->where($query->expr()->eq('key', $query->createNamedParameter($key)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$rows = $result->fetchOne();
 		$result->closeCursor();
 

--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -60,13 +60,13 @@ class CleanTagsTest extends \Test\TestCase {
 	protected function cleanUpTables() {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('vcategory')
-			->execute();
+			->executeStatement();
 
 		$qb->delete('vcategory_to_object')
-			->execute();
+			->executeStatement();
 
 		$qb->delete('filecache')
-			->execute();
+			->executeStatement();
 	}
 
 	public function testRun() {
@@ -119,7 +119,7 @@ class CleanTagsTest extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb->select($qb->func()->count('*'))
 			->from($tableName)
-			->execute();
+			->executeQuery();
 
 		$this->assertEquals($expected, $result->fetchOne(), $message);
 	}
@@ -140,7 +140,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'category' => $qb->createNamedParameter($category),
 				'type' => $qb->createNamedParameter($type),
 			])
-			->execute();
+			->executeStatement();
 
 		return (int) $this->getLastInsertID('vcategory', 'id');
 	}
@@ -159,7 +159,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'categoryid' => $qb->createNamedParameter($category, IQueryBuilder::PARAM_INT),
 				'type' => $qb->createNamedParameter($type),
 			])
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -180,14 +180,14 @@ class CleanTagsTest extends \Test\TestCase {
 				'path' => $qb->createNamedParameter($fileName),
 				'path_hash' => $qb->createNamedParameter(md5($fileName)),
 			])
-			->execute();
+			->executeStatement();
 		$fileName = $this->getUniqueID('TestRepairCleanTags', 12);
 		$qb->insert('filecache')
 			->values([
 				'path' => $qb->createNamedParameter($fileName),
 				'path_hash' => $qb->createNamedParameter(md5($fileName)),
 			])
-			->execute();
+			->executeStatement();
 
 		$this->createdFile = (int) $this->getLastInsertID('filecache', 'fileid');
 		return $this->createdFile;

--- a/tests/lib/Repair/NC11/FixMountStoragesTest.php
+++ b/tests/lib/Repair/NC11/FixMountStoragesTest.php
@@ -97,7 +97,7 @@ class FixMountStoragesTest extends TestCase {
 				'size' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 				'unencrypted_size' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 			]);
-		$query->execute();
+		$query->executeStatement();
 
 		return $query->getLastInsertId();
 	}
@@ -112,7 +112,7 @@ class FixMountStoragesTest extends TestCase {
 				'user_id' => $query->createNamedParameter(static::getUniqueID(), IQueryBuilder::PARAM_STR),
 				'mount_point' => $query->createNamedParameter(static::getUniqueID(), IQueryBuilder::PARAM_STR),
 			]);
-		$query->execute();
+		$query->executeStatement();
 
 		return $query->getLastInsertId();
 	}
@@ -122,7 +122,7 @@ class FixMountStoragesTest extends TestCase {
 		$query->select('storage_id')
 			->from('mounts')
 			->where($query->expr()->eq('id', $query->createNamedParameter($mount, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 

--- a/tests/lib/Repair/OldGroupMembershipSharesTest.php
+++ b/tests/lib/Repair/OldGroupMembershipSharesTest.php
@@ -49,7 +49,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 
 	protected function deleteAllShares() {
 		$qb = $this->connection->getQueryBuilder();
-		$qb->delete('share')->execute();
+		$qb->delete('share')->executeStatement();
 	}
 
 	public function testRun() {
@@ -77,7 +77,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member], ['id' => $notAMember]], $rows);
 		$result->closeCursor();
@@ -93,7 +93,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member]], $rows);
 		$result->closeCursor();
@@ -128,7 +128,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values($shareValues)
-			->execute();
+			->executeStatement();
 
 		return $this->connection->lastInsertId('*PREFIX*share');
 	}

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -152,7 +152,7 @@ class RepairDavSharesTest extends TestCase {
 			->method('where')
 			->willReturnSelf();
 		$selectMock->expects($this->once())
-			->method('execute')
+			->method('executeQuery')
 			->willReturn($shareResults);
 
 		$updateMock = $this->createMock(IQueryBuilder::class);
@@ -178,7 +178,7 @@ class RepairDavSharesTest extends TestCase {
 			)
 			->willReturnSelf();
 		$updateMock->expects($this->exactly(2))
-			->method('execute');
+			->method('executeStatement');
 
 		$this->dbc->expects($this->atLeast(2))
 			->method('getQueryBuilder')

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -55,7 +55,7 @@ class RepairInvalidSharesTest extends TestCase {
 
 	protected function deleteAllShares() {
 		$qb = $this->connection->getQueryBuilder();
-		$qb->delete('share')->execute();
+		$qb->delete('share')->executeStatement();
 	}
 
 	/**
@@ -81,7 +81,7 @@ class RepairInvalidSharesTest extends TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values($shareValues)
-			->execute();
+			->executeStatement();
 		$parent = $this->getLastShareId();
 
 		// share with existing parent
@@ -89,7 +89,7 @@ class RepairInvalidSharesTest extends TestCase {
 		$qb->insert('share')
 			->values(array_merge($shareValues, [
 				'parent' => $qb->expr()->literal($parent),
-			]))->execute();
+			]))->executeStatement();
 		$validChild = $this->getLastShareId();
 
 		// share with non-existing parent
@@ -97,14 +97,14 @@ class RepairInvalidSharesTest extends TestCase {
 		$qb->insert('share')
 			->values(array_merge($shareValues, [
 				'parent' => $qb->expr()->literal($parent + 100),
-			]))->execute();
+			]))->executeStatement();
 		$invalidChild = $this->getLastShareId();
 
 		$query = $this->connection->getQueryBuilder();
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild], ['id' => $invalidChild]], $rows);
 		$result->closeCursor();
@@ -120,7 +120,7 @@ class RepairInvalidSharesTest extends TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild]], $rows);
 		$result->closeCursor();
@@ -168,7 +168,7 @@ class RepairInvalidSharesTest extends TestCase {
 				'permissions' => $qb->expr()->literal($testPerms),
 				'stime' => $qb->expr()->literal(time()),
 			])
-			->execute();
+			->executeStatement();
 
 		$shareId = $this->getLastShareId();
 
@@ -183,7 +183,7 @@ class RepairInvalidSharesTest extends TestCase {
 			->select('*')
 			->from('share')
 			->orderBy('permissions', 'ASC')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(1, $results);

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -57,7 +57,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$qb->delete('storages')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($this->storage->getId())));
-		$qb->execute();
+		$qb->executeStatement();
 
 		$this->clearMimeTypes();
 
@@ -67,7 +67,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 	private function clearMimeTypes() {
 		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$qb->delete('mimetypes');
-		$qb->execute();
+		$qb->executeStatement();
 
 		$this->mimetypeLoader->reset();
 	}

--- a/tests/lib/Repair/RepairSqliteAutoincrementTest.php
+++ b/tests/lib/Repair/RepairSqliteAutoincrementTest.php
@@ -48,7 +48,7 @@ class RepairSqliteAutoincrementTest extends \Test\TestCase {
 
 		$dbPrefix = $this->config->getSystemValueString('dbtableprefix', 'oc_');
 		$this->tableName = $this->getUniqueID($dbPrefix . 'autoinc_test');
-		$this->connection->prepare('CREATE TABLE ' . $this->tableName . '("someid" INTEGER NOT NULL, "text" VARCHAR(16), PRIMARY KEY("someid"))')->execute();
+		$this->connection->prepare('CREATE TABLE ' . $this->tableName . '("someid" INTEGER NOT NULL, "text" VARCHAR(16), PRIMARY KEY("someid"))')->executeStatement();
 
 		$this->repair = new \OC\Repair\SqliteAutoincrement($this->connection);
 	}

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -98,7 +98,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->timeFactory->expects($this->any())->method('now')->willReturn(new \DateTimeImmutable("2023-05-04 00:00 Europe/Berlin"));
 
 		//Empty share table
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->provider = new DefaultShareProvider(
 			$this->dbConn,
@@ -114,9 +114,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
-		$this->dbConn->getQueryBuilder()->delete('filecache')->execute();
-		$this->dbConn->getQueryBuilder()->delete('storages')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('filecache')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
 	}
 
 	/**
@@ -172,7 +172,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$qb->setValue('parent', $qb->expr()->literal($parent));
 		}
 
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return$qb->getLastInsertId();
 	}
 
@@ -199,7 +199,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -246,7 +246,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -281,7 +281,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -325,7 +325,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		// Get the id
 		$id = $qb->getLastInsertId();
@@ -410,7 +410,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'token' => $qb->expr()->literal('token'),
 				'expiration' => $qb->expr()->literal('2000-01-02 00:00:00'),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -452,7 +452,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -501,7 +501,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -533,7 +533,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -548,7 +548,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(13),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getId')->willReturn($id);
@@ -596,7 +596,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		// Get the id
 		$id = $qb->getLastInsertId();
@@ -614,7 +614,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(2),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -629,7 +629,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(4),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$ownerPath = $this->createMock(Folder::class);
 		$ownerFolder = $this->createMock(Folder::class);
@@ -884,7 +884,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(13),
 				'token' => $qb->expr()->literal('secrettoken'),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 		$id = $qb->getLastInsertId();
 
 		$file = $this->createMock(File::class);
@@ -915,7 +915,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->values([
 				'id' => $qb->expr()->literal($storageStringId),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 
@@ -928,7 +928,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'path_hash' => $qb->expr()->literal(md5($path)),
 				'name' => $qb->expr()->literal(basename($path)),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 
@@ -962,7 +962,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -977,7 +977,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1013,7 +1013,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -1027,7 +1027,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$groups = [];
@@ -1084,7 +1084,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		/*
@@ -1103,7 +1103,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(31),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		/*
 		 * Correct share. should be taken by code path.
@@ -1121,7 +1121,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$groups = ['sharedWith'];
 
@@ -1272,7 +1272,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1316,7 +1316,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1332,7 +1332,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1365,7 +1365,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1381,7 +1381,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(42);
@@ -1415,7 +1415,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id1 = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1430,7 +1430,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('userTarget'),
 				'permissions' => $qb->expr()->literal(0),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id2 = $qb->getLastInsertId();
 
 		$file = $this->createMock(File::class);
@@ -1506,7 +1506,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 		$stmt->closeCursor();
@@ -1530,7 +1530,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1546,7 +1546,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2),
 				'parent' => $qb->expr()->literal($id),
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 
 		$user1 = $this->createMock(IUser::class);
@@ -1578,7 +1578,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 		$stmt->closeCursor();
@@ -1603,7 +1603,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1649,7 +1649,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1687,7 +1687,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1740,7 +1740,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1783,7 +1783,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2),
 				'token' => $qb->expr()->literal('token'),
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1930,7 +1930,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->update('share');
 		$qb->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 		$qb->set('password', $qb->createNamedParameter('password'));
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$users = [];
 		for ($i = 0; $i < 6; $i++) {
@@ -2271,7 +2271,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
-			->execute();
+			->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -2482,7 +2482,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42));
-		$qb->execute();
+		$qb->executeStatement();
 		$id1 = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -2495,7 +2495,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
 			->setValue('parent', $qb->createNamedParameter($id1));
-		$qb->execute();
+		$qb->executeStatement();
 		$id2 = $qb->getLastInsertId();
 
 		$this->provider->userDeletedFromGroup($user, $group);
@@ -2814,7 +2814,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id1 = $qb->getLastInsertId();
 
@@ -2829,7 +2829,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id2 = $qb->getLastInsertId();
 

--- a/tests/lib/Share20/ShareByMailProviderTest.php
+++ b/tests/lib/Share20/ShareByMailProviderTest.php
@@ -118,7 +118,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 
 		// Empty share table
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->provider = new ShareByMailProvider(
 			$this->config,
@@ -140,9 +140,9 @@ class ShareByMailProviderTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
-		$this->dbConn->getQueryBuilder()->delete('filecache')->execute();
-		$this->dbConn->getQueryBuilder()->delete('storages')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('filecache')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
 	}
 
 	/**
@@ -201,7 +201,7 @@ class ShareByMailProviderTest extends TestCase {
 			$qb->setValue('parent', $qb->expr()->literal($parent));
 		}
 
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -77,19 +77,19 @@ class SubAdminTest extends \Test\TestCase {
 				'gid' => $qb->createNamedParameter($this->groups[0]->getGID()),
 				'uid' => $qb->createNamedParameter('orphanedUser')
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('group_admin')
 			->values([
 				'gid' => $qb->createNamedParameter('orphanedGroup'),
 				'uid' => $qb->createNamedParameter('orphanedUser')
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('group_admin')
 			->values([
 				'gid' => $qb->createNamedParameter('orphanedGroup'),
 				'uid' => $qb->createNamedParameter($this->users[0]->getUID())
 			])
-			->execute();
+			->executeStatement();
 	}
 
 	protected function tearDown(): void {
@@ -105,7 +105,7 @@ class SubAdminTest extends \Test\TestCase {
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter('orphanedUser')))
 			->orWhere($qb->expr()->eq('gid', $qb->createNamedParameter('orphanedGroup')))
-			->execute();
+			->executeStatement();
 	}
 
 	public function testCreateSubAdmin() {
@@ -118,7 +118,7 @@ class SubAdminTest extends \Test\TestCase {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute()
+			->executeQuery()
 			->fetch();
 		$this->assertEquals(
 			[
@@ -130,7 +130,7 @@ class SubAdminTest extends \Test\TestCase {
 		$result = $qb->delete('*PREFIX*group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute();
+			->executeQuery();
 	}
 
 	public function testDeleteSubAdmin() {
@@ -144,7 +144,7 @@ class SubAdminTest extends \Test\TestCase {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute()
+			->executeQuery()
 			->fetch();
 		$this->assertEmpty($result);
 	}

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -70,8 +70,8 @@ class SystemTagManagerTest extends TestCase {
 
 	protected function pruneTagsTables() {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->execute();
-		$query->delete(SystemTagManager::TAG_TABLE)->execute();
+		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->executeStatement();
+		$query->delete(SystemTagManager::TAG_TABLE)->executeStatement();
 	}
 
 	public function getAllTagsDataProvider() {

--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -111,8 +111,8 @@ class SystemTagObjectMapperTest extends TestCase {
 
 	protected function pruneTagsTables() {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->execute();
-		$query->delete(SystemTagManager::TAG_TABLE)->execute();
+		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->executeStatement();
+		$query->delete(SystemTagManager::TAG_TABLE)->executeStatement();
 	}
 
 	public function testGetTagIdsForObjects() {

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -313,7 +313,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 */
 	protected static function tearDownAfterClassCleanShares(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('share')
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -323,7 +323,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 */
 	protected static function tearDownAfterClassCleanStorages(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('storages')
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -333,7 +333,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 */
 	protected static function tearDownAfterClassCleanFileCache(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('filecache')
-			->execute();
+			->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
This PR refactors the deprecated method `OC\DB\QueryBuilder::execute` and replaces it with either
- `OC\DB\QueryBuilder::executeQuery` (when actual results are desired) or
- `OC\DB\QueryBuilder::executeStatement` (when a count of rows is desired or the operation is an insert / update / delete)

throughout the entire NC codebase (excluding `./apps` and `./3rdparty`).

Care was taken to not change `execute` methods that are NOT deprecated such as:
- `OC\Files\Cache\CacheQueryBuilder::execute`
- `OC\DB\QueryBuilder\QueryBuilder::execute`
- `OCP\DB\IPreparedStatement::execute`

However, please be advised that since this PR is rather extensive, it is possible that a `query` method NOT part of the `OC\DB\QueryBuilder` could have been updated.