### PR TITLE
fix(autoloader): clear apcu with app management

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -543,6 +543,11 @@ class AppManager implements IAppManager {
 			ManagerEvent::EVENT_APP_ENABLE, $appId
 		));
 		$this->clearAppsCache();
+
+		if (function_exists('apcu_delete') && class_exists(\APCUIterator::class)) {
+			$apcuPrefix = 'composer_autoload_' . md5(\OC::$SERVERROOT . '_' . \OC::$VERSION_MTIME);
+			apcu_delete(new \APCUIterator('#^' . $apcuPrefix . '#'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/groupfolders/issues/2478 and likely others

## Summary

Composer uses apcu to store its results, if available. This includes misses: if a looked up class does not exist, it will be stored as such.

Now some apps may have – although highly discouraged – (optiona) inter-app dependencies.  So if a class of an app is requested, but not found, it may lead to autoloading problems once the app is actually enabled – as described in https://github.com/nextcloud/groupfolders/issues/2478#issuecomment-1702379910

This will probably also work vice versa: when disabling and app, its classes my still appear available.

In this draft I only add logic to delete autoloading values when enabling an app. This succeeds as a poc to solve mentioned issue.  I think it it also reasonable to reset the opcache in enabling/disabling scenarios, but also in for updates. Perhaps it can be done more cleverer to treat bulk operations just once, but it might not be necessary as it does not happen often, does not take long, and would make it unnecessary complex (even if not that much in total).

Any other thoughts about this? @icewind1991 @juliushaertl @ChristophWurst 