### PR TITLE
fix: prevent sharing permissions on user root folder

### DIFF
--- a/lib/private/Files/Node/LazyUserFolder.php
+++ b/lib/private/Files/Node/LazyUserFolder.php
@@ -63,7 +63,8 @@ class LazyUserFolder extends LazyFolder {
 			}
 		}, [
 			'path' => $this->path,
-			'permissions' => Constants::PERMISSION_ALL,
+			// Sharing user root folder is not allowed
+			'permissions' => Constants::PERMISSION_ALL ^ Constants::PERMISSION_SHARE,
 			'type' => FileInfo::TYPE_FOLDER,
 			'mimetype' => FileInfo::MIMETYPE_FOLDER,
 		]);


### PR DESCRIPTION
A user root folder is not shareable.

https://github.com/nextcloud/server/blob/825b65e2efe958888380caebbfe8a7ec94b02943/lib/private/Share20/Manager.php#L274-L282