### PR TITLE
fix(mimetype): Fix aborted transaction on PostgreSQL when storing mimetype

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -117,13 +117,15 @@ class Loader implements IMimeTypeLoader {
 	 */
 	protected function store($mimetype) {
 		try {
-			$insert = $this->dbConnection->getQueryBuilder();
-			$insert->insert('mimetypes')
-				->values([
-					'mimetype' => $insert->createNamedParameter($mimetype)
-				])
-				->executeStatement();
-			$mimetypeId = $insert->getLastInsertId();
+			$mimetypeId = $this->atomic(function () use ($mimetype) {
+				$insert = $this->dbConnection->getQueryBuilder();
+				$insert->insert('mimetypes')
+					->values([
+						'mimetype' => $insert->createNamedParameter($mimetype)
+					])
+					->executeStatement();
+				return $insert->getLastInsertId();
+			}, $this->dbConnection);
 		} catch (DbalException $e) {
 			if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 				throw $e;


### PR DESCRIPTION
* Resolves #40064.

## Summary

In `OC\Files\Type\Loader::store()` we're executing a `SELECT` query after an expected failed mimetype `INSERT` in the same transaction. MySQL implicitly rollbacks[^1][^2] the transaction after the unique constraint violation error, but PostgreSQL does not[^3] and expects a explicit rollback. That's why we getting the `ERROR: current transaction is aborted, commands ignored until end of transaction block` error. 

A possible fix is to rollback before the SELECT statement. We also need to restart the transaction as `atomic()` will try to commit the results after calling our callback and PostgreSQL will complain if there isn't one active (MySQL won't).

```php
$mimetypeId = $this->atomic(function () use ($mimetype) {
	try {
		$insert = $this->dbConnection->getQueryBuilder();
		$insert->insert('mimetypes')
		// (...)
		return $insert->getLastInsertId();
	} catch (DbalException $e) {   
		if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
			throw $e;
		}

		// If we got here, then a unique constraint
		// violation happened. and we need to rollback. 
		$this->dbConnection->rollBack();
		// Restart the transaction for atomic() to commit.
		$this->dbConnection->beginTransaction();

		$qb = $this->dbConnection->getQueryBuilder();
		$qb->select('id')
		// (...)
	}
}, $this->dbConnection);
```

While this works, we're now executing a single statement in each transaction and this is what the db does by default (see autocommit [^4][^5]), so we might as well not use the transaction at all and this is what I did. @tcitworld I haven't found a good reason to keep this transaction, but I still don't know the codebase in depth so would you mind checking if my proposal is correct?

Lastly, a valid concern would be the case where another connection erases the mimetype between the `INSERT` attempt and the `SELECT` query. Unfortunately transactions alone won't be enough (on MySQL at least, see isolation levels [^6][^7]). This should be extremely rare, so the exception thrown at the end of the method looks like a good enough solution for me.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- ~Screenshots before/after for front-end changes~
- ~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

[^1]: https://dev.mysql.com/doc/refman/8.0/en/innodb-error-handling.html   
[^2]: https://www.burnison.ca/notes/fun-mysql-fact-of-the-day-implicit-rollbacks
[^3]: https://www.postgresql.org/docs/current/tutorial-transactions.html
[^4]: https://dev.mysql.com/doc/refman/8.0/en/innodb-autocommit-commit-rollback.html
[^5]: https://www.postgresql.org/docs/7.1/sql-begin.html#R1-SQL-BEGIN-1
[^6]: https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
[^7]: https://www.postgresql.org/docs/current/transaction-iso.html
