### PR TITLE
Refactor `OC\Server::getAvatarManager` in user_ldap app

### DIFF
--- a/apps/user_ldap/lib/Jobs/Sync.php
+++ b/apps/user_ldap/lib/Jobs/Sync.php
@@ -319,7 +319,7 @@ class Sync extends TimedJob {
 		if (isset($argument['avatarManager'])) {
 			$this->avatarManager = $argument['avatarManager'];
 		} else {
-			$this->avatarManager = \OC::$server->getAvatarManager();
+			$this->avatarManager = \OC::$server->get(IAvatarManager::class);
 		}
 
 		if (isset($argument['dbc'])) {

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -35,6 +35,7 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\IAvatarManager;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 
@@ -124,7 +125,7 @@ abstract class AbstractIntegrationTest {
 			\OC::$server->getConfig(),
 			new FilesystemHelper(),
 			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->getAvatarManager(),
+			\OC::$server->get(IAvatarManager::class),
 			new \OCP\Image(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getNotificationManager(),

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -35,6 +35,7 @@ use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\IAvatarManager;
 use OCP\Image;
 use Psr\Log\LoggerInterface;
 
@@ -78,8 +79,8 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		\OC_Util::setupFS($username);
 		\OC::$server->getUserFolder($username);
 		\OC::$server->getConfig()->deleteUserValue($username, 'user_ldap', User::USER_PREFKEY_LASTREFRESH);
-		if (\OC::$server->getAvatarManager()->getAvatar($username)->exists()) {
-			\OC::$server->getAvatarManager()->getAvatar($username)->remove();
+		if (\OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists()) {
+			\OC::$server->get(IAvatarManager::class)->getAvatar($username)->remove();
 		}
 
 		// finally attempt to get the avatar set
@@ -99,7 +100,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 
 		$this->execFetchTest($dn, $username, $image);
 
-		return \OC::$server->getAvatarManager()->getAvatar($username)->exists();
+		return \OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists();
 	}
 
 	/**
@@ -116,7 +117,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 
 		$this->execFetchTest($dn, $username, $image);
 
-		return !\OC::$server->getAvatarManager()->getAvatar($username)->exists();
+		return !\OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists();
 	}
 
 	/**
@@ -136,7 +137,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 			\OC::$server->getConfig(),
 			new FilesystemHelper(),
 			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->getAvatarManager(),
+			\OC::$server->get(IAvatarManager::class),
 			new Image(),
 			\OC::$server->getDatabaseConnection(),
 			\OC::$server->getUserManager(),


### PR DESCRIPTION
This PR refactors the deprecated method OC\Server::getAvatarManager and replaces it with OC\Server::get(\OCP\IAvatarManager::class)  in the `user_ldap` app.

Additionally, where necessary, the \OCP\IAvatarManager class is imported via the use directive.

This PR will be submitted once https://github.com/nextcloud/server/pull/40114 is approved.