### PR TITLE
Refactor `OC\Server::getAvatarManager` in dav app

### DIFF
--- a/apps/dav/lib/Avatars/RootCollection.php
+++ b/apps/dav/lib/Avatars/RootCollection.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\DAV\Avatars;
 
+use OCP\IAvatarManager;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 
 class RootCollection extends AbstractPrincipalCollection {
@@ -21,7 +22,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * @return AvatarHome
 	 */
 	public function getChildForPrincipal(array $principalInfo) {
-		$avatarManager = \OC::$server->getAvatarManager();
+		$avatarManager = \OC::$server->get(IAvatarManager::class);
 		return new AvatarHome($principalInfo, $avatarManager);
 	}
 


### PR DESCRIPTION
This PR refactors the deprecated method OC\Server::getAvatarManager and replaces it with OC\Server::get(\OCP\IAvatarManager::class) in the `dav` app.

Additionally, where necessary, the \OCP\IAvatarManager class is imported via the use directive.

This PR will be submitted once https://github.com/nextcloud/server/pull/40114 is approved.