### PR TITLE
Fix sharing and around three errors related to Undefined array key "CLOUD"

### DIFF
--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -186,7 +186,7 @@ class MailPlugin implements ISearchPlugin {
 							return false;
 						}
 
-						if ($this->shareeEnumeration) {
+						if ($this->shareeEnumeration && isset($contact['CLOUD'])) {
 							try {
 								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0]);
 							} catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
## Summary
We try to access $contact['CLOUD'] when it might not be set. As a consequence of that 3 PHP errors are generated the last one being an uncaught exception that makes it impossible to share files locally.

This patch adds a simple check to ensure the value exists before using it.

Please backport this to stable 26 too as it also has the same issue.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
