### PR TITLE
Print log message when version could not be got from updater server

### DIFF
--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -31,6 +31,7 @@ use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 class VersionCheck {
 	public function __construct(
@@ -38,6 +39,7 @@ class VersionCheck {
 		private IConfig $config,
 		private IUserManager $userManager,
 		private IRegistry $registry,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -86,6 +88,8 @@ class VersionCheck {
 		try {
 			$xml = $this->getUrlContent($url);
 		} catch (\Exception $e) {
+			$this->logger->info('Version could not be fetched from updater server: ' . $url, ['exception' => $e]);
+
 			return false;
 		}
 

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -28,6 +28,7 @@ use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Support\Subscription\IRegistry;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 class VersionCheckTest extends \Test\TestCase {
 	/** @var IConfig| \PHPUnit\Framework\MockObject\MockObject */
@@ -36,6 +37,8 @@ class VersionCheckTest extends \Test\TestCase {
 	private $updater;
 	/** @var IRegistry | \PHPUnit\Framework\Mo2ckObject\MockObject*/
 	private $registry;
+	/** @var LoggerInterface | \PHPUnit\Framework\Mo2ckObject\MockObject*/
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -50,6 +53,7 @@ class VersionCheckTest extends \Test\TestCase {
 		$this->registry
 			->method('delegateHasValidSubscription')
 			->willReturn(false);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->updater = $this->getMockBuilder(VersionCheck::class)
 			->setMethods(['getUrlContent'])
 			->setConstructorArgs([
@@ -57,6 +61,7 @@ class VersionCheckTest extends \Test\TestCase {
 				$this->config,
 				$this->createMock(IUserManager::class),
 				$this->registry,
+				$this->logger,
 			])
 			->getMock();
 	}


### PR DESCRIPTION
## How to test

- Set log level to _DEBUG_ so everything is logged:
```
occ config:system:set --type integer --value 0 loglevel
```
- Set an invalid URL for the updater server:
```
occ config:system:set --value "https://invalid.url/" updater.server.url
```
- Ensure that _updatenotification_ app is enabled:
```
occ app:enable updatenotification
```
- Disable the _notifications_ app (as otherwise [the updater server is not checked when booting the _updatenotification_ app](https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/apps/updatenotification/lib/AppInfo/Application.php#L75)):
```
occ app:disable notifications
```
- Delete `lastupdatedat` setting to force getting the version from the updater server in the next version check (as otherwise [the value could be cached](https://github.com/nextcloud/server/blob/31f135477792902c3b7380fba6406202e7815ca1/lib/private/Updater/VersionCheck.php#L56-L59)):
```
occ config:app:delete core lastupdatedat
```
- Log in as an admin
- Check Nextcloud logs

### Result with this pull request

The log contains a message about not being able to get the version from the updater server, including the stack trace of the exception

### Result without this pull request

No message about the updater server is logged
