### PR TITLE
fix(CalDAV): check birthday calendar owner

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php
+++ b/apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php
@@ -27,6 +27,7 @@ namespace OCA\DAV\CalDAV\BirthdayCalendar;
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalendarHome;
 use OCP\IConfig;
+use OCP\IUser;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
@@ -56,15 +57,20 @@ class EnablePlugin extends ServerPlugin {
 	 */
 	protected $server;
 
+	/** @var IUser */
+	private $user;
+
 	/**
 	 * PublishPlugin constructor.
 	 *
 	 * @param IConfig $config
 	 * @param BirthdayService $birthdayService
+	 * @param IUser $user
 	 */
-	public function __construct(IConfig $config, BirthdayService $birthdayService) {
+	public function __construct(IConfig $config, BirthdayService $birthdayService, IUser $user) {
 		$this->config = $config;
 		$this->birthdayService = $birthdayService;
+		$this->user = $user;
 	}
 
 	/**
@@ -127,11 +133,14 @@ class EnablePlugin extends ServerPlugin {
 			return;
 		}
 
-		$principalUri = $node->getOwner();
-		$userId = substr($principalUri, 17);
+		$owner = substr($node->getOwner(), 17);
+		if($owner !== $this->user->getUID()) {
+			$this->server->httpResponse->setStatus(403);
+			return false;
+		}
 
-		$this->config->setUserValue($userId, 'dav', 'generateBirthdayCalendar', 'yes');
-		$this->birthdayService->syncUser($userId);
+		$this->config->setUserValue($this->user->getUID(), 'dav', 'generateBirthdayCalendar', 'yes');
+		$this->birthdayService->syncUser($this->user->getUID());
 
 		$this->server->httpResponse->setStatus(204);
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -327,7 +327,8 @@ class Server {
 				}
 				$this->server->addPlugin(new \OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin(
 					\OC::$server->getConfig(),
-					\OC::$server->query(BirthdayService::class)
+					\OC::$server->query(BirthdayService::class),
+					$user
 				));
 				$this->server->addPlugin(new AppleProvisioningPlugin(
 					\OC::$server->getUserSession(),


### PR DESCRIPTION
## Summary
Add the correct 403 response for the DAV endpoint

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
