### PR TITLE
fix(caldav): add webroot to objectid for activities

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -97,7 +97,7 @@ class Event extends Base {
 				// The calendar app needs to be manually loaded for the routes to be loaded
 				OC_App::loadApp('calendar');
 				$linkData = $eventData['link'];
-				$objectId = base64_encode('/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $linkData['calendar_uri'] . '/' . $linkData['object_uri']);
+				$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $linkData['calendar_uri'] . '/' . $linkData['object_uri']);
 				$link = [
 					'view' => 'dayGridMonth',
 					'timeRange' => 'now',

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -122,6 +122,8 @@ class EventTest extends TestCase {
 				->willReturn($calendarAppEnabled);
 			if ($calendarAppEnabled) {
 				$this->url->expects($this->once())
+					->method('getWebroot');
+				$this->url->expects($this->once())
 					->method('linkToRouteAbsolute')
 					->with('calendar.view.indexview.timerange.edit', $generatedLink)
 					->willReturn('fullLink');


### PR DESCRIPTION
## Summary

A calendar uri includes the webroot: example.com/cloud/remote.php/dav/calendars/alice/personal/ 
The calendar app uses base64(calendar uri) as identifier for calendar objects.

Without this patch the links from activity app to calendar app don't work for installations in a subdirectory.

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
