### PR TITLE
fix: Pass parent to NonExistingFile instances

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -297,10 +297,19 @@ class Node implements INode {
 				return $this->root;
 			}
 
+			// Manually fetch the parent if the current node doesn't have a file info yet
+			try {
+				$fileInfo = $this->getFileInfo();
+			} catch (NotFoundException) {
+				$this->parent = $this->root->get($newPath);
+				/** @var \OCP\Files\Folder $this->parent */
+				return $this->parent;
+			}
+
 			// gather the metadata we already know about our parent
 			$parentData = [
 				'path' => $newPath,
-				'fileid' => $this->getFileInfo()->getParentId(),
+				'fileid' => $fileInfo->getParentId(),
 			];
 
 			// and create lazy folder with it instead of always querying

--- a/tests/lib/Files/Node/NodeTest.php
+++ b/tests/lib/Files/Node/NodeTest.php
@@ -481,8 +481,7 @@ abstract class NodeTest extends \Test\TestCase {
 		$parentNode = new \OC\Files\Node\Folder($this->root, $this->view, '/bar');
 		$newNode = $this->createTestNode($this->root, $this->view, '/bar/asd');
 
-		$this->root->expects($this->exactly(2))
-			->method('get')
+		$this->root->method('get')
 			->willReturnMap([
 				['/bar/asd', $newNode],
 				['/bar', $parentNode]


### PR DESCRIPTION
## Summary

Fixes calls to getParent after #38150 when calling on NonExistingFile instances, e.g. within a BeforeNodeRenamedEvent.

Found in failing tests for moving files in text which has special handling. CI is passing with this branch again: https://github.com/nextcloud/text/pull/4779

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
