### PR TITLE
[stable23] fix(caching): suppress static analysis warning for memcaching

### DIFF
--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -66,7 +66,10 @@ class Memcached extends Cache implements IMemcache {
 				//\Memcached::OPT_BINARY_PROTOCOL =>      true,
 			];
 			// by default enable igbinary serializer if available
-			/** @psalm-suppress RedundantCondition */
+			/**
+			 * @psalm-suppress RedundantCondition
+			 * @psalm-suppress TypeDoesNotContainType
+			 */
 			if (\Memcached::HAVE_IGBINARY) {
 				$defaultOptions[\Memcached::OPT_SERIALIZER] =
 					\Memcached::SERIALIZER_IGBINARY;


### PR DESCRIPTION
As seen on https://github.com/nextcloud/server/pull/40318#issuecomment-1709575276