### PR TITLE
fix: Hide set reminder action on public shares

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -721,7 +721,7 @@
 					icon: function(_filename, _context) {
 						return OC.imagePath('files_reminders', 'alarm.svg')
 					},
-					permissions: OC.PERMISSION_READ,
+					permissions: $('#isPublic').val() ? null : OC.PERMISSION_READ,
 					actionHandler: function(_filename, _context) {},
 				});
 			}


### PR DESCRIPTION
## Summary

Fix https://github.com/nextcloud/server/issues/40325

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)