### PR TITLE
[stable27] fix: Hide set reminder action on public shares

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -721,7 +721,7 @@
 					icon: function(_filename, _context) {
 						return OC.imagePath('files_reminders', 'alarm.svg')
 					},
-					permissions: OC.PERMISSION_READ,
+					permissions: $('#isPublic').val() ? null : OC.PERMISSION_READ,
 					actionHandler: function(_filename, _context) {},
 				});
 			}


### PR DESCRIPTION
Backport https://github.com/nextcloud/server/pull/40341