### PR TITLE
fix: Use proper fileInfo when trying to preview versions

### DIFF
--- a/apps/files_versions/src/views/VersionTab.vue
+++ b/apps/files_versions/src/views/VersionTab.vue
@@ -256,7 +256,7 @@ export default {
 			// We also point to the original filename if the version is the current one.
 			const versions = this.versions.map(version => ({
 				...version,
-				filename: version.mtime === this.fileInfo.mtime ? path.join('files', getCurrentUser()?.uid ?? '', fileInfo.path, fileInfo.name) : version.filename,
+				filename: version.mtime === this.fileInfo.mtime ? path.join('files', getCurrentUser()?.uid ?? '', this.fileInfo.path, this.fileInfo.name) : version.filename,
 				hasPreview: false,
 				previewUrl: undefined,
 			}))


### PR DESCRIPTION
Fix the regression from https://github.com/nextcloud/server/pull/40296/files#r1319816091 which broke opening version previews with viewer.

Catched by text cypress tests