### PR TITLE
fix(autoloader): no apcu no side effects

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -114,8 +114,6 @@ class OC {
 
 	public static string $configDir;
 
-	public static int $VERSION_MTIME = 0;
-
 	/**
 	 * requested app
 	 */
@@ -610,10 +608,9 @@ class OC {
 
 		self::$CLI = (php_sapi_name() == 'cli');
 
-		// Add default composer PSR-4 autoloader
+		// Add default composer PSR-4 autoloader, ensure apcu to be disabled
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
-		OC::$VERSION_MTIME = filemtime(OC::$SERVERROOT . '/version.php');
-		self::$composerAutoloader->setApcuPrefix('composer_autoload_' . md5(OC::$SERVERROOT . '_' . OC::$VERSION_MTIME));
+		self::$composerAutoloader->setApcuPrefix(null);
 
 		try {
 			self::initPaths();

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -325,9 +325,10 @@ class OC_Util {
 			return;
 		}
 
+		$timestamp = filemtime(OC::$SERVERROOT . '/version.php');
 		require OC::$SERVERROOT . '/version.php';
 		/** @var int $timestamp */
-		self::$versionCache['OC_Version_Timestamp'] = \OC::$VERSION_MTIME;
+		self::$versionCache['OC_Version_Timestamp'] = $timestamp;
 		/** @var string $OC_Version */
 		self::$versionCache['OC_Version'] = $OC_Version;
 		/** @var string $OC_VersionString */


### PR DESCRIPTION
apcu lead to side effects especially with app management and (soft) inter-dependencies, and lead also to 500 server errors. While we could add management to clear apcu cache in many cases (may stil leave edge cases) the performance benefit is marginally as also class maps are already cached in opcache. Hence, the simple and effective way to go is to not use apcu for autoloading.

Resolves: https://github.com/nextcloud/groupfolders/issues/2478 and likely others

Obsoletes: #40191 

Also confer https://github.com/nextcloud/server/pull/40191#issuecomment-1702626445