### PR TITLE
fix mimetype not being updated when changing file extention on objectstore

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -205,21 +205,25 @@ class Updater implements IUpdater {
 
 		$sourceInfo = $sourceCache->get($source);
 
+		$sourceExtension = pathinfo($source, PATHINFO_EXTENSION);
+		$targetExtension = pathinfo($target, PATHINFO_EXTENSION);
+		$targetIsTrash = preg_match("/^d\d+$/", $targetExtension);
+
 		if ($sourceInfo !== false) {
 			if (!$this->storage->instanceOfStorage(ObjectStoreStorage::class)) {
 				$operation($sourceCache, $sourceInfo);
 			}
 
-			$sourceExtension = pathinfo($source, PATHINFO_EXTENSION);
-			$targetExtension = pathinfo($target, PATHINFO_EXTENSION);
-			$targetIsTrash = preg_match("/d\d+/", $targetExtension);
+			$isDir = $sourceInfo->getMimeType() === FileInfo::MIMETYPE_FOLDER;
+		} else {
+			$isDir = $this->storage->is_dir($target);
+		}
 
-			if ($sourceExtension !== $targetExtension && $sourceInfo->getMimeType() !== FileInfo::MIMETYPE_FOLDER && !$targetIsTrash) {
-				// handle mime type change
-				$mimeType = $this->storage->getMimeType($target);
-				$fileId = $this->cache->getId($target);
-				$this->cache->update($fileId, ['mimetype' => $mimeType]);
-			}
+		if ($sourceExtension !== $targetExtension && !$isDir && !$targetIsTrash) {
+			// handle mime type change
+			$mimeType = $this->storage->getMimeType($target);
+			$fileId = $this->cache->getId($target);
+			$this->cache->update($fileId, ['mimetype' => $mimeType]);
 		}
 
 		if ($sourceCache instanceof Cache) {

--- a/tests/lib/Files/Cache/UpdaterTest.php
+++ b/tests/lib/Files/Cache/UpdaterTest.php
@@ -8,7 +8,10 @@
 namespace Test\Files\Cache;
 
 use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\ObjectStore\StorageObjectStore;
 use OC\Files\Storage\Temporary;
+use OCP\Files\Storage\IStorage;
 
 /**
  * Class UpdaterTest
@@ -300,5 +303,37 @@ class UpdaterTest extends \Test\TestCase {
 			$this->assertEquals($old['fileid'], $new['fileid']);
 			$this->assertEquals($old['mimetype'], $new['mimetype']);
 		}
+	}
+
+	public function changeExtensionProvider(): array {
+		return [
+			[new Temporary()],
+			[new ObjectStoreStorage(['objectstore' => new StorageObjectStore(new Temporary())])]
+		];
+	}
+
+	/**
+	 * @dataProvider changeExtensionProvider
+	 */
+	public function testChangeExtension(IStorage $storage) {
+		$updater = $storage->getUpdater();
+		$cache = $storage->getCache();
+		$storage->file_put_contents('foo', 'qwerty');
+		$updater->update('foo');
+
+		$bareCached = $cache->get('foo');
+		$this->assertEquals('application/octet-stream', $bareCached->getMimeType());
+
+		$storage->rename('foo', 'foo.txt');
+		$updater->renameFromStorage($storage, 'foo', 'foo.txt');
+
+		$cached = $cache->get('foo.txt');
+		$this->assertEquals('text/plain', $cached->getMimeType());
+
+		$storage->rename('foo.txt', 'foo.md');
+		$updater->renameFromStorage($storage, 'foo.txt', 'foo.md');
+
+		$cachedTarget = $cache->get('foo.md');
+		$this->assertEquals('text/markdown', $cachedTarget->getMimeType());
 	}
 }


### PR DESCRIPTION
With object store the source entry no longer exists once we hit the updater, so the old code path for changing the mimetype wasn't triggered.