### PR TITLE
fix: don't use davtags for tag search

### DIFF
--- a/apps/systemtags/lib/Search/TagSearchProvider.php
+++ b/apps/systemtags/lib/Search/TagSearchProvider.php
@@ -120,10 +120,7 @@ class TagSearchProvider implements IProvider {
 
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 		$fileQuery = new SearchQuery(
-			new SearchBinaryOperator(SearchBinaryOperator::OPERATOR_OR, [
-				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'tagname', '%' . $query->getTerm() . '%'),
-				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'systemtag', '%' . $query->getTerm() . '%'),
-			]),
+			new SearchComparison(ISearchComparison::COMPARE_LIKE, 'systemtag', '%' . $query->getTerm() . '%'),
 			$query->getLimit(),
 			(int)$query->getCursor(),
 			$query->getSortOrder() === ISearchQuery::SORT_DATE_DESC ? [


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/pull/26813 Initial implementation with support for systemtags and davtags (vcategory)
https://github.com/nextcloud/server/pull/39062 Additional check if the given tag exists, though ISystemTagManager.getAllTags only looks for systemtags

Therefore, it's not possible anymore to search for davtags and unnecessary to join the other tables.



## TODO

- [x] CI
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
