### PR TITLE
Remove deprecated at matcher in tests/lib/InstallerTest.php

### DIFF
--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -576,30 +576,30 @@ MPLX6f5V9tCJtlH6ztmEcDROfvuVc0U3rEhqx2hphoyo+MZrPFpdcJL8KkIdMKbY
 			],
 		];
 		$this->appFetcher
-			->expects($this->atLeastOnce())
+			->expects($this->once())
 			->method('get')
-			->willReturnOnConsecutiveCalls($appArray);
+			->willReturn($appArray);
 		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp.tar.gz', $realTmpFile);
 		$this->tempManager
-			->expects($this->atLeastOnce())
+			->expects($this->once())
 			->method('getTemporaryFile')
 			->with('.tar.gz')
-			->willReturnOnConsecutiveCalls($realTmpFile);
+			->willReturn($realTmpFile);
 		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->tempManager
-			->expects($this->atLeastOnce())
+			->expects($this->once())
 			->method('getTemporaryFolder')
-			->willReturnOnConsecutiveCalls($realTmpFolder);
+			->willReturn($realTmpFolder);
 		$client = $this->createMock(IClient::class);
 		$client
 			->expects($this->once())
 			->method('get')
 			->with('https://example.com', ['sink' => $realTmpFile, 'timeout' => 120]);
 		$this->clientService
-			->expects($this->atLeastOnce())
+			->expects($this->once())
 			->method('newClient')
-			->willReturnOnConsecutiveCalls($client);
+			->willReturn($client);
 
 		$installer = $this->getInstaller();
 		$installer->downloadApp('testapp');
@@ -610,6 +610,14 @@ MPLX6f5V9tCJtlH6ztmEcDROfvuVc0U3rEhqx2hphoyo+MZrPFpdcJL8KkIdMKbY
 
 
 	public function testDownloadAppWithDowngrade() {
+		// Use previous test to download the application in version 0.9
+		$this->testDownloadAppSuccessful();
+
+		// Reset mocks
+		$this->appFetcher = $this->createMock(AppFetcher::class);
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->tempManager = $this->createMock(ITempManager::class);
+
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('App for id testapp has version 0.9 and tried to update to lower version 0.8');
 
@@ -662,19 +670,19 @@ JXhrdaWDZ8fzpUjugrtC3qslsqL0dzgU37anS3HwrT8=',
 			],
 		];
 		$this->appFetcher
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('get')
 			->willReturn($appArray);
 		$realTmpFile = \OC::$server->getTempManager()->getTemporaryFile('.tar.gz');
 		copy(__DIR__ . '/../data/testapp.0.8.tar.gz', $realTmpFile);
 		$this->tempManager
-			->expects($this->at(2))
+			->expects($this->once())
 			->method('getTemporaryFile')
 			->with('.tar.gz')
 			->willReturn($realTmpFile);
 		$realTmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 		$this->tempManager
-			->expects($this->at(3))
+			->expects($this->once())
 			->method('getTemporaryFolder')
 			->willReturn($realTmpFolder);
 		$client = $this->createMock(IClient::class);
@@ -683,10 +691,9 @@ JXhrdaWDZ8fzpUjugrtC3qslsqL0dzgU37anS3HwrT8=',
 			->method('get')
 			->with('https://example.com', ['sink' => $realTmpFile, 'timeout' => 120]);
 		$this->clientService
-			->expects($this->at(1))
+			->expects($this->once())
 			->method('newClient')
 			->willReturn($client);
-		$this->testDownloadAppSuccessful();
 		$this->assertTrue(file_exists(__DIR__ . '/../../apps/testapp/appinfo/info.xml'));
 		$this->assertEquals('0.9', \OC_App::getAppVersionByPath(__DIR__ . '/../../apps/testapp/'));
 


### PR DESCRIPTION
See #32127

## Summary

Removes last usage of deprecated at matcher in `tests/lib` folder.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
