### PR TITLE
Remove last calls to deprecated at matcher in tests/Core

### DIFF
--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -159,9 +159,9 @@ class ChangeKeyStorageRootTest extends TestCase {
 				]
 			)->setMethods(['prepareNewRoot', 'moveSystemKeys', 'moveUserKeys'])->getMock();
 
-		$changeKeyStorageRoot->expects($this->at(0))->method('prepareNewRoot')->with('newRoot');
-		$changeKeyStorageRoot->expects($this->at(1))->method('moveSystemKeys')->with('oldRoot', 'newRoot');
-		$changeKeyStorageRoot->expects($this->at(2))->method('moveUserKeys')->with('oldRoot', 'newRoot', $this->outputInterface);
+		$changeKeyStorageRoot->expects($this->once())->method('prepareNewRoot')->with('newRoot');
+		$changeKeyStorageRoot->expects($this->once())->method('moveSystemKeys')->with('oldRoot', 'newRoot');
+		$changeKeyStorageRoot->expects($this->once())->method('moveUserKeys')->with('oldRoot', 'newRoot', $this->outputInterface);
 
 		$this->invokePrivate($changeKeyStorageRoot, 'moveAllKeys', ['oldRoot', 'newRoot', $this->outputInterface]);
 	}

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -86,17 +86,16 @@ class DecryptAllTest extends TestCase {
 
 	public function testMaintenanceAndTrashbin() {
 		// on construct we enable single-user-mode and disable the trash bin
-		$this->config->expects($this->at(1))
+		// on destruct we disable single-user-mode again and enable the trash bin
+		$this->config->expects($this->exactly(2))
 			->method('setSystemValue')
-			->with('maintenance', true);
+			->withConsecutive(
+				['maintenance', true],
+				['maintenance', false],
+			);
 		$this->appManager->expects($this->once())
 			->method('disableApp')
 			->with('files_trashbin');
-
-		// on destruct wi disable single-user-mode again and enable the trash bin
-		$this->config->expects($this->at(2))
-			->method('setSystemValue')
-			->with('maintenance', false);
 		$this->appManager->expects($this->once())
 			->method('enableApp')
 			->with('files_trashbin');
@@ -142,9 +141,12 @@ class DecryptAllTest extends TestCase {
 			->willReturn('user1');
 
 		if ($encryptionEnabled) {
-			$this->config->expects($this->at(1))
+			$this->config->expects($this->exactly(2))
 				->method('setAppValue')
-				->with('core', 'encryption_enabled', 'no');
+				->withConsecutive(
+					['core', 'encryption_enabled', 'no'],
+					['core', 'encryption_enabled', 'yes'],
+				);
 			$this->questionHelper->expects($this->once())
 				->method('ask')
 				->willReturn($continue);
@@ -154,9 +156,6 @@ class DecryptAllTest extends TestCase {
 					->with($this->consoleInput, $this->consoleOutput, 'user1');
 			} else {
 				$this->decryptAll->expects($this->never())->method('decryptAll');
-				$this->config->expects($this->at(2))
-					->method('setAppValue')
-					->with('core', 'encryption_enabled', 'yes');
 			}
 		} else {
 			$this->config->expects($this->never())->method('setAppValue');
@@ -188,14 +187,13 @@ class DecryptAllTest extends TestCase {
 			$this->questionHelper
 		);
 
-		$this->config->expects($this->at(1))
-			->method('setAppValue')
-			->with('core', 'encryption_enabled', 'no');
-
 		// make sure that we enable encryption again after a exception was thrown
-		$this->config->expects($this->at(4))
+		$this->config->expects($this->exactly(2))
 			->method('setAppValue')
-			->with('core', 'encryption_enabled', 'yes');
+			->withConsecutive(
+				['core', 'encryption_enabled', 'no'],
+				['core', 'encryption_enabled', 'yes'],
+			);
 
 		$this->encryptionManager->expects($this->once())
 			->method('isEnabled')

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -88,8 +88,12 @@ class EncryptAllTest extends TestCase {
 		// enable single user mode to avoid that other user login during encryption
 		// destructor should disable the single user mode again
 		$this->config->expects($this->once())->method('getSystemValueBool')->with('maintenance', false)->willReturn(false);
-		$this->config->expects($this->at(1))->method('setSystemValue')->with('maintenance', true);
-		$this->config->expects($this->at(2))->method('setSystemValue')->with('maintenance', false);
+		$this->config->expects($this->exactly(2))
+			->method('setSystemValue')
+			->withConsecutive(
+				['maintenance', true],
+				['maintenance', false],
+			);
 
 		$instance = new EncryptAll($this->encryptionManager, $this->appManager, $this->config, $this->questionHelper);
 		$this->invokePrivate($instance, 'forceMaintenanceAndTrashbin');

--- a/tests/Core/Command/Encryption/SetDefaultModuleTest.php
+++ b/tests/Core/Command/Encryption/SetDefaultModuleTest.php
@@ -127,13 +127,12 @@ class SetDefaultModuleTest extends TestCase {
 			->with('maintenance', false)
 			->willReturn(true);
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(2))
 			->method('writeln')
-			->with($this->stringContains('Maintenance mode must be disabled when setting default module,'));
-
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with($this->stringContains('in order to load the relevant encryption modules correctly.'));
+			->withConsecutive(
+				[$this->stringContains('Maintenance mode must be disabled when setting default module,')],
+				[$this->stringContains('in order to load the relevant encryption modules correctly.')],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/Log/FileTest.php
+++ b/tests/Core/Command/Log/FileTest.php
@@ -110,15 +110,13 @@ class FileTest extends TestCase {
 				['log_rotate_size', 100 * 1024 * 1024, 5 * 1024 * 1024],
 			]);
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(3))
 			->method('writeln')
-			->with('Log backend file: disabled');
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with('Log file: /var/log/nextcloud.log');
-		$this->consoleOutput->expects($this->at(2))
-			->method('writeln')
-			->with('Rotate at: 5 MB');
+			->withConsecutive(
+				['Log backend file: disabled'],
+				['Log file: /var/log/nextcloud.log'],
+				['Rotate at: 5 MB'],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -156,28 +156,25 @@ class ManageTest extends TestCase {
 	}
 
 	public function testGetConfiguration() {
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->exactly(3))
 			->method('getSystemValue')
-			->with('log_type', 'file')
-			->willReturn('log_type_value');
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('loglevel', 2)
-			->willReturn(0);
-		$this->config->expects($this->at(2))
-			->method('getSystemValue')
-			->with('logtimezone', 'UTC')
-			->willReturn('logtimezone_value');
+			->withConsecutive(
+				['log_type', 'file'],
+				['loglevel', 2],
+				['logtimezone', 'UTC'],
+			)->willReturnOnConsecutiveCalls(
+				'log_type_value',
+				0,
+				'logtimezone_value'
+			);
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(3))
 			->method('writeln')
-			->with('Enabled logging backend: log_type_value');
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with('Log level: Debug (0)');
-		$this->consoleOutput->expects($this->at(2))
-			->method('writeln')
-			->with('Log timezone: logtimezone_value');
+			->withConsecutive(
+				['Enabled logging backend: log_type_value'],
+				['Log level: Debug (0)'],
+				['Log timezone: logtimezone_value'],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
+++ b/tests/Core/Command/Maintenance/Mimetype/UpdateDBTest.php
@@ -78,12 +78,12 @@ class UpdateDBTest extends TestCase {
 		$this->loader->expects($this->never())
 			->method('updateFilecache');
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(2))
 			->method('writeln')
-			->with('Added 0 new mimetypes');
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with('Updated 0 filecache rows');
+			->withConsecutive(
+				['Added 0 new mimetypes'],
+				['Updated 0 filecache rows'],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -117,19 +117,14 @@ class UpdateDBTest extends TestCase {
 			->with('new', 2)
 			->willReturn(3);
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(4))
 			->method('writeln')
-			->with('Added mimetype "testing/newmimetype" to database');
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with('Updated 3 filecache rows for mimetype "testing/newmimetype"');
-
-		$this->consoleOutput->expects($this->at(2))
-			->method('writeln')
-			->with('Added 1 new mimetypes');
-		$this->consoleOutput->expects($this->at(3))
-			->method('writeln')
-			->with('Updated 3 filecache rows');
+			->withConsecutive(
+				['Added mimetype "testing/newmimetype" to database'],
+				['Updated 3 filecache rows for mimetype "testing/newmimetype"'],
+				['Added 1 new mimetypes'],
+				['Updated 3 filecache rows'],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -172,16 +167,13 @@ class UpdateDBTest extends TestCase {
 			->with('ext', 1)
 			->willReturn(3);
 
-		$this->consoleOutput->expects($this->at(0))
+		$this->consoleOutput->expects($this->exactly(3))
 			->method('writeln')
-			->with('Updated 3 filecache rows for mimetype "testing/existingmimetype"');
-
-		$this->consoleOutput->expects($this->at(1))
-			->method('writeln')
-			->with('Added 0 new mimetypes');
-		$this->consoleOutput->expects($this->at(2))
-			->method('writeln')
-			->with('Updated 3 filecache rows');
+			->withConsecutive(
+				['Updated 3 filecache rows for mimetype "testing/existingmimetype"'],
+				['Added 0 new mimetypes'],
+				['Updated 3 filecache rows'],
+			);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}

--- a/tests/Core/Command/Preview/RepairTest.php
+++ b/tests/Core/Command/Preview/RepairTest.php
@@ -142,7 +142,7 @@ class RepairTest extends TestCase {
 		$previewFolder->expects($this->once())
 			->method('getDirectoryListing')
 			->willReturn($directories);
-		$this->rootFolder->expects($this->at(0))
+		$this->rootFolder->expects($this->once())
 			->method('get')
 			->with("appdata_/preview")
 			->willReturn($previewFolder);


### PR DESCRIPTION
See #32316

## Summary

Get rid of deprecated at matcher in `tests/Core`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
