### PR TITLE
Remove last at matcher call in dav application tests

### DIFF
--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -36,7 +36,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class CalendarManagerTest extends \Test\TestCase {
-
 	/** @var CalDavBackend | MockObject */
 	private $backend;
 
@@ -77,22 +76,16 @@ class CalendarManagerTest extends \Test\TestCase {
 
 		/** @var IManager | MockObject $calendarManager */
 		$calendarManager = $this->createMock(Manager::class);
-		$calendarManager->expects($this->at(0))
+		$registeredIds = [];
+		$calendarManager->expects($this->exactly(2))
 			->method('registerCalendar')
-			->willReturnCallback(function (): void {
-				$parameter = func_get_arg(0);
+			->willReturnCallback(function ($parameter) use (&$registeredIds): void {
 				$this->assertInstanceOf(CalendarImpl::class, $parameter);
-				$this->assertEquals(123, $parameter->getKey());
-			});
-
-		$calendarManager->expects($this->at(1))
-			->method('registerCalendar')
-			->willReturnCallback(function (): void {
-				$parameter = func_get_arg(0);
-				$this->assertInstanceOf(CalendarImpl::class, $parameter);
-				$this->assertEquals(456, $parameter->getKey());
+				$registeredIds[] = $parameter->getKey();
 			});
 
 		$this->manager->setupCalendarProvider($calendarManager, 'user123');
+
+		$this->assertEquals(['123','456'], $registeredIds);
 	}
 }


### PR DESCRIPTION
See #32316 

## Summary

Remove last call to deprecated at matcher in dav application

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
