### PR TITLE
provisioning_api: Fix quota constants in OpenAPI

### DIFF
--- a/apps/provisioning_api/lib/ResponseDefinitions.php
+++ b/apps/provisioning_api/lib/ResponseDefinitions.php
@@ -28,7 +28,7 @@ namespace OCA\Provisioning_API;
 /**
  * @psalm-type ProvisioningApiUserDetailsQuota = array{
  *     free?: float,
- *     quota?: float|string,
+ *     quota?: float|int|string,
  *     relative?: float,
  *     total?: float,
  *     used?: float,

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -517,6 +517,10 @@
                                 "format": "float"
                             },
                             {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            {
                                 "type": "string"
                             }
                         ]


### PR DESCRIPTION
## Summary

Quota can be -1 (not computed, -2 (unknown), and -3 (unlimited) as well.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
