### PR TITLE
feat: Adding the displayname to the output of occ group:list --info

### DIFF
--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -73,6 +73,7 @@ class ListCommand extends Base {
 		foreach ($groups as $group) {
 			if ($addInfo) {
 				$value = [
+					'displayName' => $group->getDisplayName(),
 					'backends' => $group->getBackendNames(),
 					'users' => $this->usersForGroup($group),
 				];


### PR DESCRIPTION
Adding the displayname to the output of occ group:list --info command


* Resolves: no bugs related

## Summary

When using `occ group:list --info`, the displayName is not returned. I then need to make a new  `occ group:info groupId` for every group to have a full and usable list.
This PR simply adds the `displayName` info to the info output.

Before :
```
# [...]occ group:list --info 
[...]

  - mygroup:
    - backends:
      - Database
    - users:
      - thibautplg
```
After :
```
# [...]occ group:list --info 
[...]

  - mygroup:
    - displayName: My Nextcloud group
    - backends:
      - Database
    - users:
      - thibautplg

```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
