### PR TITLE
Make logo in header clickable in the shared file view

### DIFF
--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -38,14 +38,22 @@ p($theme->getTitle());
 
 	<header id="header">
 		<div class="header-left">
-			<div class="logo logo-icon svg"></div>
-			<span id="nextcloud" class="header-appname">
+			<div id="nextcloud" class="header-appname">
+				<?php if ($_['logoUrl']): ?>
+					<a href="<?php print_unescaped($_['logoUrl']); ?>"
+					   aria-label="<?php p($l->t('Go to %s', [$_['logoUrl']])); ?>">
+						<div class="logo logo-icon"></div>
+					</a>
+				<?php else: ?>
+					<div class="logo logo-icon"></div>
+				<?php endif; ?>
+
 				<?php if (isset($template) && $template->getHeaderTitle() !== '') { ?>
 					<?php p($template->getHeaderTitle()); ?>
 				<?php } else { ?>
 					<?php	p($theme->getName()); ?>
 				<?php } ?>
-			</span>
+			</div>
 			<?php if (isset($template) && $template->getHeaderDetails() !== '') { ?>
 				<div class="header-shared-by">
 					<?php p($template->getHeaderDetails()); ?>

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -189,6 +189,10 @@ class TemplateLayout extends \OC_Template {
 			$this->assign('appid', $appId);
 			$this->assign('bodyid', 'body-public');
 
+			// Set logo link target
+			$logoUrl = $this->config->getSystemValueString('logo_url', '');
+			$this->assign('logoUrl', $logoUrl);
+
 			/** @var IRegistry $subscription */
 			$subscription = \OCP\Server::get(IRegistry::class);
 			$showSimpleSignup = $this->config->getSystemValueBool('simpleSignUpLink.shown', true);


### PR DESCRIPTION
## Summary
Now we use same `logo_url` settings for shared file view that are used for normal user view.

![image](https://github.com/nextcloud/server/assets/191082/a4805906-65e4-4cc5-a0bd-01eec7997f4e)

## Open questions
- How to deal if `logo_url` is not configured? Use home link (like now) or make logo non-clickable?

## How to test
1. update `config/config.php` with
    ```php
      'logo_url' => 'https://google.com',
    ```
1. share file by creating public link
1. open shared link
1. click on logo

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
