### PR TITLE
Allow options to be provided to Doctrine

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1825,6 +1825,34 @@ $CONFIG = [
 ],
 
 /**
+ * Allows defining custom DB types and options as well as the ability to override
+ * the default connection parameters as defined by
+ * OC\DB\ConnectionFactory::defaultConnectionParams.
+ */
+'dbconnectionparams' => [
+	'dbtype' => [
+		'adapter' => AdapterMySQL::class,
+		'charset' => 'UTF8',
+		'driver' => 'pdo_dbtype',
+		'wrapperClass' => Doctrine\DBAL\Connection::class,
+	],
+],
+
+/**
+ * Allows additional configuration options to be provided for the database
+ * connection as defined by Doctrine\DBAL\Configuration::class. This is useful
+ * for specifying a custom logger, middlewares, etc.
+ */
+'dbconfigurationparams' => [
+	"sqllogger" => 'Doctrine\DBAL\Logging\SQLLogger',
+	"resultcache" => 'Psr\Cache\CacheItemPoolInterface',
+	"schemaassetsfilter" => 'callable',
+	"autocommit" => true,
+	"middlewares" => array(
+		'Doctrine\DBAL\Driver\Middleware',
+	),
+],
+/**
  * sqlite3 journal mode can be specified using this configuration parameter -
  * can be 'WAL' or 'DELETE' see for more details https://www.sqlite.org/wal.html
  */

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -302,7 +302,7 @@ class OC_App {
 	 *
 	 * @param string $appId
 	 * @param bool $ignoreCache ignore cache and rebuild it
-	 * @return false|string
+	 * @return false|array
 	 */
 	public static function findAppInDirectories(string $appId, bool $ignoreCache = false) {
 		$sanitizedAppId = self::cleanAppId($appId);


### PR DESCRIPTION
* Resolves: #40447
* Would also resolve #36572 by allowing for custom middlewares and driver wrappers

## Summary
This allows additional options, configurations, and middlewares to be provided to Doctrine when the DB connection is established.

#### NOTES
- Two new optional settings were created in `config.php`: `dbconnectionparams` and `dbconfigurationparams`. I had considered appending these to the existing `dbdriveroptions`, but these settings are distinctly different. So, I created new settings.
- In `OC\AppFramework\App`:
    - The method `getAppIdForClass()` was incomplete. The function isn't used by anything else, at present
    - The method `registerAppClass` was added to allow app classes to be registered prior to actually loading the apps. This is because custom classes must be provided when defining middlewares, custom loggers, etc, but any classes provided by an app aren't available when the DB connection is established. This allows an app's classes to be registered in an out-of-band way
    - A modified version of `OC\App\AppManager::getAppInfo` was added instead of using the existing class and method. This is because the DB connection must exist in order to load the `AppManager`, leading to a race condition.
    - Code was added to `OC\DB\ConnectionFactory` in order to load the options from `config.php`, ensure that any custom classes are loaded (using the previously-mentioned methods), and apply the options provided.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
