### PR TITLE
No prefetch in "stream_open()" [SFTP]

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -112,8 +112,6 @@ class SFTPReadStream implements File {
 				return false;
 		}
 
-		$this->request_chunk(256 * 1024);
-
 		return true;
 	}
 
@@ -126,12 +124,10 @@ class SFTPReadStream implements File {
 	}
 
 	public function stream_read($count) {
-		if (!$this->eof && strlen($this->buffer) < $count) {
+		while (strlen($this->buffer) < $count && !$this->eof) {
+			$this->request_chunk(256 * 1024);
 			$chunk = $this->read_chunk();
 			$this->buffer .= $chunk;
-			if (!$this->eof) {
-				$this->request_chunk(256 * 1024);
-			}
 		}
 
 		$data = substr($this->buffer, 0, $count);


### PR DESCRIPTION
* Resolves: #25788 <!-- related github issue -->

## Summary
`$this->request_chunk(256 * 1024)` at the end of `stream_open()` fetches a chunk of file contents. But when `stream_close()` is called without calling `stream_read()`, it tries to read status code from `request_chunk()`. Which lead to `stream_close()` to return `false`.

After this, regular files are displayed as folders. Previews are not generated.

Instead of fetching chunk in `stream_open()`, make the `stream_read()` call both `request_chunk()` and `read_chunk()` it it.


## TODO

- [ ] Discuss

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
