### PR TITLE
fix(twofactor): avoid DB error on Twofactor (en/dis)abled event

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -25,8 +25,6 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\TwoFactorAuth\Db;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use function array_map;
 
@@ -70,25 +68,24 @@ class ProviderUserAssignmentDao {
 	 * Persist a new/updated (provider_id, uid, enabled) tuple
 	 */
 	public function persist(string $providerId, string $uid, int $enabled): void {
-		$qb = $this->conn->getQueryBuilder();
+		$conn = $this->conn;
 
-		try {
-			// Insert a new entry
-			$insertQuery = $qb->insert(self::TABLE_NAME)->values([
-				'provider_id' => $qb->createNamedParameter($providerId),
-				'uid' => $qb->createNamedParameter($uid),
-				'enabled' => $qb->createNamedParameter($enabled, IQueryBuilder::PARAM_INT),
-			]);
-
-			$insertQuery->execute();
-		} catch (UniqueConstraintViolationException $ex) {
-			// There is already an entry -> update it
-			$updateQuery = $qb->update(self::TABLE_NAME)
-				->set('enabled', $qb->createNamedParameter($enabled))
-				->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
-				->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
-			$updateQuery->execute();
+		// Insert a new entry
+		if ($conn->insertIgnoreConflict(self::TABLE_NAME, [
+			'provider_id' => $providerId,
+			'uid' => $uid,
+			'enabled' => $enabled,
+		])) {
+			return;
 		}
+
+		// There is already an entry -> update it
+		$qb = $conn->getQueryBuilder();
+		$updateQuery = $qb->update(self::TABLE_NAME)
+			->set('enabled', $qb->createNamedParameter($enabled))
+			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId)))
+			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter($uid)));
+		$updateQuery->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
* Required for: nextcloud/twofactor_admin#35

## Summary
With PostgreSQL, a transaction is aborted each time an error happen with the following message:
```
ERROR:  current transaction is aborted, commands ignored until end of transaction block
```
This PR avoid the error so the transaction can continue as expected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
