### PR TITLE
fix(dav): report status

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -406,7 +406,6 @@ class FilesReportPlugin extends ServerPlugin {
 			$responses[] = new Response(
 				rtrim($this->server->getBaseUri(), '/') . $filesUri . $node->getPath(),
 				$result,
-				200
 			);
 		}
 		return $responses;


### PR DESCRIPTION
Fixed favorites and (incoming) tag view

### Context
If a status is defined on the response, it will be used and forced-rendered outside of `propstat`. Which is invalid according to the RFC and broke in the last webdav update (which is now compliant to the rfc too)

https://github.com/nextcloud/3rdparty/blob/1269091e96a2a550912db37c0d2b29ed5c0aa60f/sabre/dav/lib/DAV/Xml/Element/Response.php#L115-L117