### PR TITLE
add method to create a node from cache entry + mountpoint

### DIFF
--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -22,7 +22,10 @@
  */
 namespace OC\Files\Node;
 
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node as INode;
 
 /**
  * Class LazyRoot
@@ -51,5 +54,9 @@ class LazyRoot extends LazyFolder implements IRootFolder {
 
 	public function getByIdInPath(int $id, string $path) {
 		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getNodeFromCacheEntryAndMount(ICacheEntry $cacheEntry, IMountPoint $mountPoint): INode {
+		return $this->getRootFolder()->getNodeFromCacheEntryAndMount($cacheEntry, $mountPoint);
 	}
 }

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -69,7 +69,7 @@ class Node implements INode {
 	 * @param string $path
 	 * @param FileInfo $fileInfo
 	 */
-	public function __construct(IRootFolder $root, $view, $path, $fileInfo = null, ?Node $parent = null, bool $infoHasSubMountsIncluded = true) {
+	public function __construct(IRootFolder $root, $view, $path, $fileInfo = null, ?INode $parent = null, bool $infoHasSubMountsIncluded = true) {
 		if (Filesystem::normalizePath($view->getRoot()) !== '/') {
 			throw new PreConditionNotMetException('The view passed to the node should not have any fake root set');
 		}

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -26,7 +26,9 @@ namespace OCP\Files;
 
 use OC\Hooks\Emitter;
 use OC\User\NoUserException;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node as INode;
 
 /**
  * Interface IRootFolder
@@ -63,6 +65,16 @@ interface IRootFolder extends Folder, Emitter {
 	 * @since 28.0.0
 	 */
 	public function getMountsIn(string $mountPoint): array;
+
+	/**
+	 * Create a `Node` for a file or folder from the cache entry and mountpoint
+	 *
+	 * @param ICacheEntry $cacheEntry
+	 * @param IMountPoint $mountPoint
+	 * @return Node
+	 * @since 28.0.0
+	 */
+	public function getNodeFromCacheEntryAndMount(ICacheEntry $cacheEntry, IMountPoint $mountPoint): INode;
 
 	/**
 	 * @since 28.0.0


### PR DESCRIPTION
There are cases[\[1\]](https://github.com/nextcloud/files_accesscontrol/pull/385) where we need an `INode` but we only have the cache entry and mountpoint.

We can construct the needed "higher" classes from that data but the process is somewhat involved and uses a number of internal APIs. By exposing the functionality in the public API we can make it easy for apps to do.