### PR TITLE
fix(isLegitimatedForUserId): Setup mountpoints to check file access

### DIFF
--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
  */
 namespace OCA\WorkflowEngine\Entity;
 
+use OC\Files\Config\UserMountCache;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\Files\InvalidPathException;
@@ -37,7 +38,6 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\Share\IManager as ShareManager;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\MapperEvent;
@@ -62,8 +62,6 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 	protected $eventName;
 	/** @var Event */
 	protected $event;
-	/** @var ShareManager */
-	private $shareManager;
 	/** @var IUserSession */
 	private $userSession;
 	/** @var ISystemTagManager */
@@ -74,23 +72,25 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 	private $actingUser = null;
 	/** @var IUserManager */
 	private $userManager;
+	/** @var UserMountCache */
+	private $userMountCache;
 
 	public function __construct(
 		IL10N $l10n,
 		IURLGenerator $urlGenerator,
 		IRootFolder $root,
-		ShareManager $shareManager,
 		IUserSession $userSession,
 		ISystemTagManager $tagManager,
-		IUserManager $userManager
+		IUserManager $userManager,
+		UserMountCache $userMountCache
 	) {
 		$this->l10n = $l10n;
 		$this->urlGenerator = $urlGenerator;
 		$this->root = $root;
-		$this->shareManager = $shareManager;
 		$this->userSession = $userSession;
 		$this->tagManager = $tagManager;
 		$this->userManager = $userManager;
+		$this->userMountCache = $userMountCache;
 	}
 
 	public function getName(): string {
@@ -135,8 +135,22 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 			if ($node->getOwner()->getUID() === $uid) {
 				return true;
 			}
-			$acl = $this->shareManager->getAccessList($node, true, true);
-			return isset($acl['users']) && array_key_exists($uid, $acl['users']);
+
+			if ($this->eventName === self::EVENT_NAMESPACE . 'postDelete') {
+				// At postDelete, the file no longer exists. Check for parent folder instead.
+				$fileId = $node->getParentId();
+			} else {
+				$fileId = $node->getId();
+			}
+
+			$mounts = $this->userMountCache->getMountsForFileId($fileId, $uid);
+			foreach ($mounts as $mount) {
+				$userFolder = $this->root->getUserFolder($uid);
+				if (!empty($userFolder->getById($fileId))) {
+					return true;
+				}
+			}
+			return false;
 		} catch (NotFoundException $e) {
 			return false;
 		}

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -26,6 +26,7 @@
  */
 namespace OCA\WorkflowEngine\Tests;
 
+use OC\Files\Config\UserMountCache;
 use OC\L10N\L10N;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowEngine\Helper\ScopeContext;
@@ -403,10 +404,10 @@ class ManagerTest extends TestCase {
 							$this->l,
 							$this->createMock(IURLGenerator::class),
 							$this->createMock(IRootFolder::class),
-							$this->createMock(\OCP\Share\IManager::class),
 							$this->createMock(IUserSession::class),
 							$this->createMock(ISystemTagManager::class),
 							$this->createMock(IUserManager::class),
+							$this->createMock(UserMountCache::class),
 						])
 						->setMethodsExcept(['getEvents'])
 						->getMock();

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -35,6 +35,7 @@ use OCP\AppFramework\QueryException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\NodeCreatedEvent;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -408,6 +409,7 @@ class ManagerTest extends TestCase {
 							$this->createMock(ISystemTagManager::class),
 							$this->createMock(IUserManager::class),
 							$this->createMock(UserMountCache::class),
+							$this->createMock(IMountManager::class),
 						])
 						->setMethodsExcept(['getEvents'])
 						->getMock();

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -463,7 +463,7 @@ class UserMountCache implements IUserMountCache {
 		}, $mounts);
 		$mounts = array_combine($mountPoints, $mounts);
 
-		$current = $path;
+		$current = rtrim($path, '/');
 		// walk up the directory tree until we find a path that has a mountpoint set
 		// the loop will return if a mountpoint is found or break if none are found
 		while (true) {

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Robin Appelman <robin@icewind.nl>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Jonas <jonas@freesources.org>
  *
  * @license AGPL-3.0
  *
@@ -33,6 +34,7 @@ use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\SetupManager;
 use OC\Files\SetupManagerFactory;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
@@ -225,5 +227,22 @@ class Manager implements IMountManager {
 				return in_array($mount->getMountProvider(), $mountProviders);
 			});
 		}
+	}
+
+	/**
+	 * Return the mount matching a cached mount info (or mount file info)
+	 *
+	 * @param ICachedMountInfo $info
+	 *
+	 * @return IMountPoint|null
+	 */
+	public function getMountFromMountInfo(ICachedMountInfo $info): ?IMountPoint {
+		$this->setupManager->setupForPath($info->getMountPoint());
+		foreach ($this->mounts as $mount) {
+			if ($mount->getMountPoint() === $info->getMountPoint()) {
+				return $mount;
+			}
+		}
+		return null;
 	}
 }

--- a/lib/public/Files/Mount/IMountManager.php
+++ b/lib/public/Files/Mount/IMountManager.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
  */
 namespace OCP\Files\Mount;
 
+use OCP\Files\Config\ICachedMountInfo;
+
 /**
  * Interface IMountManager
  *
@@ -106,4 +108,14 @@ interface IMountManager {
 	 * @since 8.2.0
 	 */
 	public function findByNumericId(int $id): array;
+
+	/**
+	 * Return the mount matching a cached mount info (or mount file info)
+	 *
+	 * @param ICachedMountInfo $info
+	 *
+	 * @return IMountPoint|null
+	 * @since 28.0.0
+	 */
+	public function getMountFromMountInfo(ICachedMountInfo $info): ?IMountPoint;
 }


### PR DESCRIPTION
This fixes workflows on groupfolders, as it will consider access to files in groupfolders.

It also fixes false positives where access to files was limited by other means not taken into account before, e.g. access control.

For postDelete events, check for permissions of the parent folder instead, as the file itself no longer exists.

Fixes: nextcloud/flow_notifications#71

Idea taken from https://github.com/nextcloud/server/pull/38946

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
