### PR TITLE
load script and styles on setup page

### DIFF
--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -32,6 +32,7 @@
 namespace OC\Core\Controller;
 
 use OC\Setup;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class SetupController {
@@ -95,6 +96,13 @@ class SetupController {
 			'dbtype' => '',
 		];
 		$parameters = array_merge($defaults, $post);
+
+		Util::addStyle('server', null);
+
+		// include common nextcloud webpack bundle
+		Util::addScript('core', 'common');
+		Util::addScript('core', 'main');
+		Util::addTranslations('core');
 
 		\OC_Template::printGuestPage('', 'installation', $parameters);
 	}


### PR DESCRIPTION
`SetupController` is not a real controller so it doesn't get middleware.

Fixes regression from https://github.com/nextcloud/server/pull/39867