### PR TITLE
fix(sharing): set name to target name in sharing cache

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -162,6 +162,10 @@ class Cache extends CacheJail {
 			} else {
 				$entry['permissions'] = $this->storage->getPermissions($entry['path']);
 			}
+
+			if ($this->share->getNodeId() === $entry['fileid']) {
+				$entry['name'] = basename($this->share->getTarget());
+			}
 		} catch (StorageNotAvailableException $e) {
 			// thrown by FailedStorage e.g. when the sharer does not exist anymore
 			// (IDE may say the exception is never thrown – false negative)

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -88,6 +88,7 @@ class CacheTest extends TestCase {
 		$this->view->file_put_contents('container/shareddir/subdir/another.txt', $textData);
 		$this->view->file_put_contents('container/shareddir/subdir/another too.txt', $textData);
 		$this->view->file_put_contents('container/shareddir/subdir/not a text file.xml', '<xml></xml>');
+		$this->view->file_put_contents('simplefile.txt', $textData);
 
 		[$this->ownerStorage,] = $this->view->resolvePath('');
 		$this->ownerCache = $this->ownerStorage->getCache();
@@ -300,6 +301,42 @@ class CacheTest extends TestCase {
 			],
 			$results
 		);
+	}
+
+	/**
+	 * This covers a bug where the share owners name was propagated
+	 * to the recipient in the recent files API response where the
+	 * share recipient has a different target set
+	 *
+	 * https://github.com/nextcloud/server/issues/39879
+	 */
+	public function testShareRenameOriginalFileInRecentResults() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('simplefile.txt');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(IShare::TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_READ);
+		$share = $this->shareManager->createShare($share);
+		$share->setStatus(IShare::STATUS_ACCEPTED);
+		$this->shareManager->updateShare($share);
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		$node->move(self::TEST_FILES_SHARING_API_USER1 . '/files/simplefile2.txt');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER3);
+		$recents = $rootFolder->getRecent(10);
+		self::assertEquals([
+			'welcome.txt',
+			'simplefile.txt'
+		], array_map(function($node) {
+			return $node->getFileInfo()['name'];
+		}, $recents));
 	}
 
 	public function testGetFolderContentsWhenSubSubdirShared() {


### PR DESCRIPTION
Fixes #39879.

Recent pages now also show the name the file has for the recipient.

After the files2vue rework we are using a different endpoint for recent pages which also fixes the user facing bug. However I think the underlying bug remains.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
