### PR TITLE
Add single status code descriptions for OpenAPI

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -104,6 +104,8 @@ class DashboardApiController extends OCSController {
 	 * @param int $limit Limit number of result items per widget
 	 * @param string[] $widgets Limit results to specific widgets
 	 * @return DataResponse<Http::STATUS_OK, array<string, DashboardWidgetItem[]>, array{}>
+	 *
+	 * 200: Widget items returned
 	 */
 	public function getWidgetItems(array $sinceIds = [], int $limit = 7, array $widgets = []): DataResponse {
 		$items = [];
@@ -129,6 +131,8 @@ class DashboardApiController extends OCSController {
 	 * @param int $limit Limit number of result items per widget
 	 * @param string[] $widgets Limit results to specific widgets
 	 * @return DataResponse<Http::STATUS_OK, array<string, DashboardWidgetItems>, array{}>
+	 *
+	 * 200: Widget items returned
 	 */
 	public function getWidgetItemsV2(array $sinceIds = [], int $limit = 7, array $widgets = []): DataResponse {
 		$items = [];
@@ -151,6 +155,8 @@ class DashboardApiController extends OCSController {
 	 * @NoCSRFRequired
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array<string, DashboardWidget>, array{}>
+	 *
+	 * 200: Widgets returned
 	 */
 	public function getWidgets(): DataResponse {
 		$widgets = $this->dashboardManager->getWidgets();

--- a/apps/dashboard/openapi.json
+++ b/apps/dashboard/openapi.json
@@ -200,7 +200,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Widgets returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -293,7 +293,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Widget items returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -389,7 +389,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Widget items returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -134,6 +134,8 @@ class RequestHandlerController extends OCSController {
 	 * @param string|null $ownerFederatedId Federated ID of the receiver
 	 * @return Http\DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Share created successfully
 	 */
 	public function createShare(
 		?string $remote = null,
@@ -284,6 +286,8 @@ class RequestHandlerController extends OCSController {
 	 * @param string|null $token Shared secret between servers
 	 * @return Http\DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Share declined successfully
 	 */
 	public function declineShare(int $id, ?string $token = null) {
 		$notification = [
@@ -316,6 +320,8 @@ class RequestHandlerController extends OCSController {
 	 * @param string|null $token Shared secret between servers
 	 * @return Http\DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Share unshared successfully
 	 */
 	public function unshare(int $id, ?string $token = null) {
 		if (!$this->isS2SEnabled()) {

--- a/apps/federatedfilesharing/openapi.json
+++ b/apps/federatedfilesharing/openapi.json
@@ -243,7 +243,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Share created successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -629,7 +629,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Share declined successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -707,7 +707,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Share unshared successfully",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -43,6 +43,7 @@ use OCA\Files\Service\UserConfig;
 use OCA\Files\Service\ViewConfig;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\IgnoreOpenAPI;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
@@ -389,13 +390,8 @@ class ApiController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
-	 *
-	 * Get the service-worker Javascript for previews
-	 *
-	 * @psalm-suppress MoreSpecificReturnType The value of Service-Worker-Allowed is not relevant
-	 * @psalm-suppress LessSpecificReturnStatement The value of Service-Worker-Allowed is not relevant
-	 * @return StreamResponse<Http::STATUS_OK, array{Content-Type: 'application/javascript', Service-Worker-Allowed: string}>
 	 */
+	#[IgnoreOpenAPI]
 	public function serviceWorker(): StreamResponse {
 		$response = new StreamResponse(__DIR__ . '/../../../../dist/preview-service-worker.js');
 		$response->setHeaders([

--- a/apps/files/lib/Controller/DirectEditingController.php
+++ b/apps/files/lib/Controller/DirectEditingController.php
@@ -55,6 +55,8 @@ class DirectEditingController extends OCSController {
 	 *
 	 * Get the direct editing capabilities
 	 * @return DataResponse<Http::STATUS_OK, array{editors: array<string, array{id: string, name: string, mimetypes: string[], optionalMimetypes: string[], secure: bool}>, creators: array<string, array{id: string, editor: string, name: string, extension: string, templates: bool, mimetypes: string[]}>}, array{}>
+	 *
+	 * 200: Direct editing capabilities returned
 	 */
 	public function info(): DataResponse {
 		$response = new DataResponse($this->directEditingService->getDirectEditingCapabilitites());

--- a/apps/files/lib/Controller/TemplateController.php
+++ b/apps/files/lib/Controller/TemplateController.php
@@ -55,6 +55,8 @@ class TemplateController extends OCSController {
 	 * List the available templates
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array<FilesTemplateFileCreator>, array{}>
+	 *
+	 * 200: Available templates returned
 	 */
 	public function list(): DataResponse {
 		return new DataResponse($this->templateManager->listTemplates());

--- a/apps/files/openapi.json
+++ b/apps/files/openapi.json
@@ -332,44 +332,6 @@
                 }
             }
         },
-        "/index.php/apps/files/preview-service-worker.js": {
-            "get": {
-                "operationId": "api-service-worker",
-                "summary": "Get the service-worker Javascript for previews",
-                "tags": [
-                    "api"
-                ],
-                "security": [
-                    {},
-                    {
-                        "bearer_auth": []
-                    },
-                    {
-                        "basic_auth": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "",
-                        "headers": {
-                            "Service-Worker-Allowed": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/javascript": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "binary"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/ocs/v2.php/apps/files/api/v1/directEditing": {
             "get": {
                 "operationId": "direct_editing-info",
@@ -398,7 +360,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Direct editing capabilities returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1041,7 +1003,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Available templates returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/files_external/lib/Controller/ApiController.php
+++ b/apps/files_external/lib/Controller/ApiController.php
@@ -101,6 +101,8 @@ class ApiController extends OCSController {
 	 * Get the mount points visible for this user
 	 *
 	 * @return DataResponse<Http::STATUS_OK, FilesExternalMount[], array{}>
+	 *
+	 * 200: User mounts returned
 	 */
 	public function getUserMounts(): DataResponse {
 		$entries = [];

--- a/apps/files_external/openapi.json
+++ b/apps/files_external/openapi.json
@@ -198,7 +198,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User mounts returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -188,6 +188,8 @@ class DeletedShareAPIController extends OCSController {
 	 * Get a list of all deleted shares
 	 *
 	 * @return DataResponse<Http::STATUS_OK, FilesSharingDeletedShare[], array{}>
+	 *
+	 * 200: Deleted shares returned
 	 */
 	public function index(): DataResponse {
 		$groupShares = $this->shareManager->getDeletedSharedWith($this->userId, IShare::TYPE_GROUP, null, -1, 0);

--- a/apps/files_sharing/lib/Controller/RemoteController.php
+++ b/apps/files_sharing/lib/Controller/RemoteController.php
@@ -62,6 +62,8 @@ class RemoteController extends OCSController {
 	 * Get list of pending remote shares
 	 *
 	 * @return DataResponse<Http::STATUS_OK, FilesSharingRemoteShare[], array{}>
+	 *
+	 * 200: Pending remote shares returned
 	 */
 	public function getOpenShares() {
 		return new DataResponse($this->externalManager->getOpenShares());
@@ -138,6 +140,8 @@ class RemoteController extends OCSController {
 	 * Get a list of accepted remote shares
 	 *
 	 * @return DataResponse<Http::STATUS_OK, FilesSharingRemoteShare[], array{}>
+	 *
+	 * 200: Accepted remote shares returned
 	 */
 	public function getShares() {
 		$shares = $this->externalManager->getAcceptedShares();

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1410,6 +1410,8 @@ class ShareAPIController extends OCSController {
 	 * Get all shares that are still pending
 	 *
 	 * @return DataResponse<Http::STATUS_OK, FilesSharingShare[], array{}>
+	 *
+	 * 200: Pending shares returned
 	 */
 	public function pendingShares(): DataResponse {
 		$pendingShares = [];

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -348,6 +348,8 @@ class ShareesAPIController extends OCSController {
 	 * @param string $itemType Limit to specific item types
 	 * @param int|int[]|null $shareType Limit to specific share types
 	 * @return DataResponse<Http::STATUS_OK, FilesSharingShareesRecommendedResult, array{}>
+	 *
+	 * 200: Recommended sharees returned
 	 */
 	public function findRecommended(string $itemType, $shareType = null): DataResponse {
 		$shareTypes = [

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -2107,7 +2107,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Pending shares returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2609,7 +2609,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Deleted shares returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2900,7 +2900,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Recommended sharees returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2960,7 +2960,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Accepted remote shares returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3023,7 +3023,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Pending remote shares returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -88,6 +88,8 @@ class AppConfigController extends OCSController {
 	 * Get a list of apps
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{data: string[]}, array{}>
+	 *
+	 * 200: Apps returned
 	 */
 	public function getApps(): DataResponse {
 		return new DataResponse([

--- a/apps/provisioning_api/lib/Controller/AppsController.php
+++ b/apps/provisioning_api/lib/Controller/AppsController.php
@@ -62,6 +62,8 @@ class AppsController extends OCSController {
 	 * @param ?string $filter Filter for enabled or disabled apps
 	 * @return DataResponse<Http::STATUS_OK, array{apps: string[]}, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Installed apps returned
 	 */
 	public function getApps(?string $filter = null): DataResponse {
 		$apps = (new OC_App())->listAllApps();
@@ -94,6 +96,8 @@ class AppsController extends OCSController {
 	 * @param string $app ID of the app
 	 * @return DataResponse<Http::STATUS_OK, ProvisioningApiAppInfo, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: App info returned
 	 */
 	public function getAppInfo(string $app): DataResponse {
 		$info = $this->appManager->getAppInfo($app);
@@ -112,6 +116,8 @@ class AppsController extends OCSController {
 	 * @param string $app ID of the app
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: App enabled successfully
 	 */
 	public function enable(string $app): DataResponse {
 		try {
@@ -129,6 +135,8 @@ class AppsController extends OCSController {
 	 *
 	 * @param string $app ID of the app
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
+	 *
+	 * 200: App disabled successfully
 	 */
 	public function disable(string $app): DataResponse {
 		$this->appManager->disableApp($app);

--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -91,6 +91,8 @@ class GroupsController extends AUserData {
 	 * @param ?int $limit Limit the amount of groups returned
 	 * @param int $offset Offset for searching for groups
 	 * @return DataResponse<Http::STATUS_OK, array{groups: string[]}, array{}>
+	 *
+	 * 200: Groups returned
 	 */
 	public function getGroups(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
@@ -112,6 +114,8 @@ class GroupsController extends AUserData {
 	 * @param ?int $limit Limit the amount of groups returned
 	 * @param int $offset Offset for searching for groups
 	 * @return DataResponse<Http::STATUS_OK, array{groups: ProvisioningApiGroupDetails[]}, array{}>
+	 *
+	 * 200: Groups details returned
 	 */
 	public function getGroupsDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
@@ -140,6 +144,8 @@ class GroupsController extends AUserData {
 	 * @throws OCSException
 	 *
 	 * @deprecated 14 Use getGroupUsers
+	 *
+	 * 200: Group users returned
 	 */
 	public function getGroup(string $groupId): DataResponse {
 		return $this->getGroupUsers($groupId);
@@ -200,6 +206,8 @@ class GroupsController extends AUserData {
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{users: array<string, ProvisioningApiUserDetails|array{id: string}>}, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Group users details returned
 	 */
 	public function getGroupUsersDetails(string $groupId, string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$groupId = urldecode($groupId);
@@ -251,6 +259,8 @@ class GroupsController extends AUserData {
 	 * @param string $displayname Display name of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Group created successfully
 	 */
 	public function addGroup(string $groupid, string $displayname = ''): DataResponse {
 		// Validate name
@@ -282,6 +292,8 @@ class GroupsController extends AUserData {
 	 * @param string $value New value for the key
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Group updated successfully
 	 */
 	public function updateGroup(string $groupId, string $key, string $value): DataResponse {
 		$groupId = urldecode($groupId);
@@ -309,6 +321,8 @@ class GroupsController extends AUserData {
 	 * @param string $groupId ID of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Group deleted successfully
 	 */
 	public function deleteGroup(string $groupId): DataResponse {
 		$groupId = urldecode($groupId);
@@ -330,6 +344,8 @@ class GroupsController extends AUserData {
 	 * @param string $groupId ID of the group
 	 * @return DataResponse<Http::STATUS_OK, string[], array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Sub admins returned
 	 */
 	public function getSubAdminsOfGroup(string $groupId): DataResponse {
 		// Check group exists

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -144,6 +144,8 @@ class UsersController extends AUserData {
 	 * @param int|null $limit Limit the amount of groups returned
 	 * @param int $offset Offset for searching for groups
 	 * @return DataResponse<Http::STATUS_OK, array{users: string[]}, array{}>
+	 *
+	 * 200: Users returned
 	 */
 	public function getUsers(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$user = $this->userSession->getUser();
@@ -183,6 +185,8 @@ class UsersController extends AUserData {
 	 * @param int|null $limit Limit the amount of groups returned
 	 * @param int $offset Offset for searching for groups
 	 * @return DataResponse<Http::STATUS_OK, array{users: array<string, ProvisioningApiUserDetails|array{id: string}>}, array{}>
+	 *
+	 * 200: Users details returned
 	 */
 	public function getUsersDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
 		$currentUser = $this->userSession->getUser();
@@ -537,6 +541,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, ProvisioningApiUserDetails, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User returned
 	 */
 	public function getUser(string $userId): DataResponse {
 		$includeScopes = false;
@@ -561,6 +567,8 @@ class UsersController extends AUserData {
 	 *
 	 * @return DataResponse<Http::STATUS_OK, ProvisioningApiUserDetails, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Current user returned
 	 */
 	public function getCurrentUser(): DataResponse {
 		$user = $this->userSession->getUser();
@@ -581,6 +589,8 @@ class UsersController extends AUserData {
 	 *
 	 * @return DataResponse<Http::STATUS_OK, string[], array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Editable fields returned
 	 */
 	public function getEditableFields(): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
@@ -600,6 +610,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, string[], array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Editable fields for user returned
 	 */
 	public function getEditableFieldsForUser(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
@@ -666,6 +678,8 @@ class UsersController extends AUserData {
 	 * @param string $value New value for the key
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User values edited successfully
 	 */
 	public function editUserMultiValue(
 		string $userId,
@@ -765,6 +779,8 @@ class UsersController extends AUserData {
 	 * @param string $value New value for the key
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User value edited successfully
 	 */
 	public function editUser(string $userId, string $key, string $value): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
@@ -1076,6 +1092,8 @@ class UsersController extends AUserData {
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 *
 	 * @throws OCSException
+	 *
+	 * 200: Wiped all user devices successfully
 	 */
 	public function wipeUserDevices(string $userId): DataResponse {
 		/** @var IUser $currentLoggedInUser */
@@ -1111,6 +1129,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User deleted successfully
 	 */
 	public function deleteUser(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
@@ -1148,6 +1168,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User disabled successfully
 	 */
 	public function disableUser(string $userId): DataResponse {
 		return $this->setEnabled($userId, false);
@@ -1162,6 +1184,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User enabled successfully
 	 */
 	public function enableUser(string $userId): DataResponse {
 		return $this->setEnabled($userId, true);
@@ -1201,6 +1225,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID of the user
 	 * @return DataResponse<Http::STATUS_OK, array{groups: string[]}, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Users groups returned
 	 */
 	public function getUsersGroups(string $userId): DataResponse {
 		$loggedInUser = $this->userSession->getUser();
@@ -1249,6 +1275,8 @@ class UsersController extends AUserData {
 	 * @param string $groupid ID of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User added to group successfully
 	 */
 	public function addToGroup(string $userId, string $groupid = ''): DataResponse {
 		if ($groupid === '') {
@@ -1286,6 +1314,8 @@ class UsersController extends AUserData {
 	 * @param string $groupid ID of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User removed from group successfully
 	 */
 	public function removeFromGroup(string $userId, string $groupid): DataResponse {
 		$loggedInUser = $this->userSession->getUser();
@@ -1349,6 +1379,8 @@ class UsersController extends AUserData {
 	 * @param string $groupid ID of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User added as group subadmin successfully
 	 */
 	public function addSubAdmin(string $userId, string $groupid): DataResponse {
 		$group = $this->groupManager->get($groupid);
@@ -1387,6 +1419,8 @@ class UsersController extends AUserData {
 	 * @param string $groupid ID of the group
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User removed as group subadmin successfully
 	 */
 	public function removeSubAdmin(string $userId, string $groupid): DataResponse {
 		$group = $this->groupManager->get($groupid);
@@ -1417,6 +1451,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID if the user
 	 * @return DataResponse<Http::STATUS_OK, string[], array{}>
 	 * @throws OCSException
+	 *
+	 * 200: User subadmin groups returned
 	 */
 	public function getUserSubAdminGroups(string $userId): DataResponse {
 		$groups = $this->getUserSubAdminGroupsData($userId);
@@ -1432,6 +1468,8 @@ class UsersController extends AUserData {
 	 * @param string $userId ID if the user
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Resent welcome message successfully
 	 */
 	public function resendWelcomeMessage(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -580,7 +580,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Installed apps returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -661,7 +661,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "App info returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -729,7 +729,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "App enabled successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -795,7 +795,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "App disabled successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -882,7 +882,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Groups returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -970,7 +970,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Group created successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1057,7 +1057,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Groups details returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1268,7 +1268,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Group users details returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1365,7 +1365,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Sub admins returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1439,7 +1439,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Group users returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1537,7 +1537,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Group updated successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1604,7 +1604,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Group deleted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1691,7 +1691,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Users returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1954,7 +1954,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Users details returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2158,7 +2158,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2243,7 +2243,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User value edited successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2308,7 +2308,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User deleted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2366,7 +2366,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Current user returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2426,7 +2426,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Editable fields returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2498,7 +2498,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Editable fields for user returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2598,7 +2598,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User values edited successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2665,7 +2665,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Wiped all user devices successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2732,7 +2732,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User enabled successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2799,7 +2799,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User disabled successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2866,7 +2866,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Users groups returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2953,7 +2953,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User added to group successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3027,7 +3027,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User removed from group successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3095,7 +3095,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User subadmin groups returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3175,7 +3175,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User added as group subadmin successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3250,7 +3250,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "User removed as group subadmin successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3317,7 +3317,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Resent welcome message successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3376,7 +3376,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Apps returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/settings/lib/Controller/LogSettingsController.php
+++ b/apps/settings/lib/Controller/LogSettingsController.php
@@ -51,6 +51,8 @@ class LogSettingsController extends Controller {
 	 * @psalm-suppress MoreSpecificReturnType The value of Content-Disposition is not relevant
 	 * @psalm-suppress LessSpecificReturnStatement The value of Content-Disposition is not relevant
 	 * @return StreamResponse<Http::STATUS_OK, array{Content-Type: 'application/octet-stream', 'Content-Disposition': string}>
+	 *
+	 * 200: Logfile returned
 	 */
 	public function download() {
 		if (!$this->log instanceof Log) {

--- a/apps/settings/openapi.json
+++ b/apps/settings/openapi.json
@@ -40,7 +40,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Logfile returned",
                         "headers": {
                             "Content-Disposition": {
                                 "schema": {

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -407,6 +407,8 @@ class ThemingController extends Controller {
 	 * @param string $app ID of the app
 	 * @psalm-suppress LessSpecificReturnStatement The content of the Manifest doesn't need to be described in the return type
 	 * @return JSONResponse<Http::STATUS_OK, array{name: string, short_name: string, start_url: string, theme_color: string, background_color: string, description: string, icons: array{src: non-empty-string, type: string, sizes: string}[], display: string}, array{}>
+	 *
+	 * 200: Manifest returned
 	 */
 	public function getManifest(string $app) {
 		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');

--- a/apps/theming/lib/Controller/UserThemeController.php
+++ b/apps/theming/lib/Controller/UserThemeController.php
@@ -178,6 +178,8 @@ class UserThemeController extends OCSController {
 	 * Delete the background
 	 *
 	 * @return JSONResponse<Http::STATUS_OK, ThemingBackground, array{}>
+	 *
+	 * 200: Background deleted successfully
 	 */
 	public function deleteBackground(): JSONResponse {
 		$currentVersion = (int)$this->config->getUserValue($this->userId, Application::APP_ID, 'userCacheBuster', '0');

--- a/apps/theming/openapi.json
+++ b/apps/theming/openapi.json
@@ -309,7 +309,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Manifest returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -763,7 +763,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Background deleted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/updatenotification/appinfo/routes.php
+++ b/apps/updatenotification/appinfo/routes.php
@@ -29,6 +29,6 @@ return [
 		['name' => 'Admin#setChannel', 'url' => '/channel', 'verb' => 'POST'],
 	],
 	'ocs' => [
-		['name' => 'API#getAppList', 'url' => '/api/{apiVersion}/applist/{newVersion}', 'verb' => 'GET', 'requirements' => ['apiVersion' => 'v1']],
+		['name' => 'API#getAppList', 'url' => '/api/{apiVersion}/applist/{newVersion}', 'verb' => 'GET', 'requirements' => ['apiVersion' => '(v1)']],
 	],
 ];

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -67,6 +67,8 @@ class ConfigAPIController extends OCSController {
 	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @return DataResponse<Http::STATUS_OK, array{configID: string}, array{}>
 	 * @throws OCSException
+	 *
+	 * 200: Config created successfully
 	 */
 	public function create() {
 		try {

--- a/apps/user_ldap/openapi.json
+++ b/apps/user_ldap/openapi.json
@@ -76,7 +76,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Config created successfully",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/user_status/lib/Controller/PredefinedStatusController.php
+++ b/apps/user_status/lib/Controller/PredefinedStatusController.php
@@ -63,6 +63,8 @@ class PredefinedStatusController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @return DataResponse<Http::STATUS_OK, UserStatusPredefined[], array{}>
+	 *
+	 * 200: Predefined statuses returned
 	 */
 	public function findAll():DataResponse {
 		// Filtering out the invisible one, that should only be set by API

--- a/apps/user_status/lib/Controller/StatusesController.php
+++ b/apps/user_status/lib/Controller/StatusesController.php
@@ -68,6 +68,8 @@ class StatusesController extends OCSController {
 	 * @param int|null $limit Maximum number of statuses to find
 	 * @param int|null $offset Offset for finding statuses
 	 * @return DataResponse<Http::STATUS_OK, UserStatusPublic[], array{}>
+	 *
+	 * 200: Statuses returned
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null): DataResponse {
 		$allStatuses = $this->service->findAll($limit, $offset);
@@ -86,7 +88,7 @@ class StatusesController extends OCSController {
 	 * @return DataResponse<Http::STATUS_OK, UserStatusPublic, array{}>
 	 * @throws OCSNotFoundException The user was not found
 	 *
-	 * 200: The status was found successfully
+	 * 200: Status returned
 	 */
 	public function find(string $userId): DataResponse {
 		try {

--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -172,6 +172,8 @@ class UserStatusController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
+	 *
+	 * 200: Message cleared successfully
 	 */
 	public function clearMessage(): DataResponse {
 		$this->service->clearMessage($this->userId);

--- a/apps/user_status/openapi.json
+++ b/apps/user_status/openapi.json
@@ -243,7 +243,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Statuses returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -315,7 +315,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "The status was found successfully",
+                        "description": "Status returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -721,7 +721,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Message cleared successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -853,7 +853,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Predefined statuses returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/apps/weather_status/lib/Controller/WeatherStatusController.php
+++ b/apps/weather_status/lib/Controller/WeatherStatusController.php
@@ -51,6 +51,8 @@ class WeatherStatusController extends OCSController {
 	 * Try to use the address set in user personal settings as weather location
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{success: bool, lat: ?float, lon: ?float, address: ?string}, array{}>
+	 *
+	 * 200: Address updated
 	 */
 	public function usePersonalAddress(): DataResponse {
 		return new DataResponse($this->service->usePersonalAddress());
@@ -65,6 +67,8 @@ class WeatherStatusController extends OCSController {
 	 *
 	 * @param int $mode New mode
 	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>
+	 *
+	 * 200: Weather status mode updated
 	 */
 	public function setMode(int $mode): DataResponse {
 		return new DataResponse($this->service->setMode($mode));
@@ -80,6 +84,8 @@ class WeatherStatusController extends OCSController {
 	 * @param float|null $lat Latitude in decimal degree format
 	 * @param float|null $lon Longitude in decimal degree format
 	 * @return DataResponse<Http::STATUS_OK, array{success: bool, lat: ?float, lon: ?float, address: ?string}, array{}>
+	 *
+	 * 200: Location updated
 	 */
 	public function setLocation(?string $address, ?float $lat, ?float $lon): DataResponse {
 		$currentWeather = $this->service->setLocation($address, $lat, $lon);
@@ -92,6 +98,8 @@ class WeatherStatusController extends OCSController {
 	 * Get stored user location
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{lat: float, lon: float, address: string, mode: int}, array{}>
+	 *
+	 * 200: Location returned
 	 */
 	public function getLocation(): DataResponse {
 		$location = $this->service->getLocation();
@@ -123,6 +131,8 @@ class WeatherStatusController extends OCSController {
 	 * Get favorites list
 	 *
 	 * @return DataResponse<Http::STATUS_OK, string[], array{}>
+	 *
+	 * 200: Favorites returned
 	 */
 	public function getFavorites(): DataResponse {
 		return new DataResponse($this->service->getFavorites());
@@ -135,6 +145,8 @@ class WeatherStatusController extends OCSController {
 	 *
 	 * @param string[] $favorites Favorite addresses
 	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>
+	 *
+	 * 200: Favorites updated
 	 */
 	public function setFavorites(array $favorites): DataResponse {
 		return new DataResponse($this->service->setFavorites($favorites));

--- a/apps/weather_status/openapi.json
+++ b/apps/weather_status/openapi.json
@@ -348,7 +348,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Weather status mode updated",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -416,7 +416,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Address updated",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -501,7 +501,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Location returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -611,7 +611,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Location updated",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -797,7 +797,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Favorites returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -870,7 +870,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Favorites updated",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -68,6 +68,8 @@ class AutoCompleteController extends OCSController {
 	 * @param int $limit Maximum number of results to return
 	 *
 	 * @return DataResponse<Http::STATUS_OK, CoreAutocompleteResult[], array{}>
+	 *
+	 * 200: Autocomplete results returned
 	 */
 	public function get(string $search, ?string $itemType, ?string $itemId, ?string $sorter = null, array $shareTypes = [IShare::TYPE_USER], int $limit = 10): DataResponse {
 		// if enumeration/user listings are disabled, we'll receive an empty

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -288,6 +288,8 @@ class ClientFlowLoginV2Controller extends Controller {
 	 * Init a login flow
 	 *
 	 * @return JSONResponse<Http::STATUS_OK, CoreLoginFlowV2, array{}>
+	 *
+	 * 200: Login flow init returned
 	 */
 	public function init(): JSONResponse {
 		// Get client user agent

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -71,6 +71,8 @@ class OCSController extends \OCP\AppFramework\OCSController {
 	 * Get the capabilities
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{version: array{major: int, minor: int, micro: int, string: string, edition: '', extendedSupport: bool}, capabilities: array<string, mixed>}, array{}>
+	 *
+	 * 200: Capabilities returned
 	 */
 	public function getCapabilities(): DataResponse {
 		$result = [];

--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -56,6 +56,8 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 * @param bool $resolve Resolve the references
 	 * @param int $limit Maximum amount of references to extract
 	 * @return DataResponse<Http::STATUS_OK, array{references: array<string, CoreReference|null>}, array{}>
+	 *
+	 * 200: References returned
 	 */
 	public function extract(string $text, bool $resolve = false, int $limit = 1): DataResponse {
 		$references = $this->referenceManager->extractReferences($text);
@@ -82,6 +84,8 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 *
 	 * @param string $reference Reference to resolve
 	 * @return DataResponse<Http::STATUS_OK, array{references: array<string, ?CoreReference>}, array{}>
+	 *
+	 * 200: Reference returned
 	 */
 	public function resolveOne(string $reference): DataResponse {
 		/** @var ?CoreReference $resolvedReference */
@@ -100,6 +104,8 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 * @param string[] $references References to resolve
 	 * @param int $limit Maximum amount of references to resolve
 	 * @return DataResponse<Http::STATUS_OK, array{references: array<string, CoreReference|null>}, array{}>
+	 *
+	 * 200: References returned
 	 */
 	public function resolve(array $references, int $limit = 1): DataResponse {
 		$result = [];
@@ -123,6 +129,8 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 * Get the providers
 	 *
 	 * @return DataResponse<Http::STATUS_OK, CoreReferenceProvider[], array{}>
+	 *
+	 * 200: Providers returned
 	 */
 	public function getProvidersInfo(): DataResponse {
 		$providers = $this->referenceManager->getDiscoverableProviders();
@@ -140,6 +148,8 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 * @param string $providerId ID of the provider
 	 * @param int|null $timestamp Timestamp of the last usage
 	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>
+	 *
+	 * 200: Provider touched
 	 */
 	public function touchProvider(string $providerId, ?int $timestamp = null): DataResponse {
 		if ($this->userId !== null) {

--- a/core/Controller/TextProcessingApiController.php
+++ b/core/Controller/TextProcessingApiController.php
@@ -66,6 +66,8 @@ class TextProcessingApiController extends \OCP\AppFramework\OCSController {
 	 * This endpoint returns all available LanguageModel task types
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{types: array{id: string, name: string, description: string}[]}, array{}>
+	 *
+	 * 200: Task types returned
 	 */
 	#[PublicPage]
 	public function taskTypes(): DataResponse {

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -52,6 +52,8 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 	 * Get the list of supported languages
 	 *
 	 * @return DataResponse<Http::STATUS_OK, array{languages: array{from: string, fromLabel: string, to: string, toLabel: string}[], languageDetection: bool}, array{}>
+	 *
+	 * 200: Supported languages returned
 	 */
 	public function languages(): DataResponse {
 		return new DataResponse([

--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -64,6 +64,8 @@ class UnifiedSearchController extends OCSController {
 	 *
 	 * @param string $from the url the user is currently at
 	 * @return DataResponse<Http::STATUS_OK, CoreUnifiedSearchProvider[], array{}>
+	 *
+	 * 200: Providers returned
 	 */
 	public function getProviders(string $from = ''): DataResponse {
 		[$route, $parameters] = $this->getRouteInformation($from);

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -858,7 +858,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Login flow init returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1423,7 +1423,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Capabilities returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1787,7 +1787,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Autocomplete results returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3322,7 +3322,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Reference returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3414,7 +3414,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "References returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3514,7 +3514,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "References returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3586,7 +3586,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Providers returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3668,7 +3668,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Provider touched",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3860,7 +3860,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Providers returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4070,7 +4070,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Supported languages returned",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -4393,7 +4393,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "Task types returned",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/vendor-bin/openapi-extractor/composer.json
+++ b/vendor-bin/openapi-extractor/composer.json
@@ -11,6 +11,6 @@
         }
     },
 	"require": {
-		"nextcloud/openapi-extractor": "dev-main#85b552a0c82ac71e1f5660109113b6235156e92e"
+		"nextcloud/openapi-extractor": "dev-main#8ba3b777239436ea71aa92fcef279db71e1f2ac9"
 	}
 }

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2658d66eab85e31914ebf538c8705ae0",
+    "content-hash": "e61826fae9fde663e18702f8f0b8db35",
     "packages": [
         {
             "name": "adhocore/cli",
@@ -82,12 +82,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/openapi-extractor.git",
-                "reference": "85b552a0c82ac71e1f5660109113b6235156e92e"
+                "reference": "8ba3b777239436ea71aa92fcef279db71e1f2ac9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/85b552a0c82ac71e1f5660109113b6235156e92e",
-                "reference": "85b552a0c82ac71e1f5660109113b6235156e92e",
+                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/8ba3b777239436ea71aa92fcef279db71e1f2ac9",
+                "reference": "8ba3b777239436ea71aa92fcef279db71e1f2ac9",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
                 "source": "https://github.com/nextcloud/openapi-extractor/tree/main",
                 "issues": "https://github.com/nextcloud/openapi-extractor/issues"
             },
-            "time": "2023-08-22T17:56:05+00:00"
+            "time": "2023-09-19T10:05:15+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -172,16 +172,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.23.1",
+            "version": "1.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26"
+                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/846ae76eef31c6d7790fac9bc399ecee45160b26",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
+                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
                 "shasum": ""
             },
             "require": {
@@ -213,9 +213,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.1"
             },
-            "time": "2023-08-03T16:32:59+00:00"
+            "time": "2023-09-18T12:18:02+00:00"
         }
     ],
     "packages-dev": [],
@@ -231,5 +231,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

Previously endpoints with only a single returned status code weren't required to set a description for them. This is now enforced.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
