### PR TITLE
Remove deprectated ILogger uses from user_ldap application

### DIFF
--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -34,32 +34,22 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 class ConfigAPIController extends OCSController {
-
-	/** @var Helper */
-	private $ldapHelper;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var ConnectionFactory */
-	private $connectionFactory;
-
 	public function __construct(
-		$appName,
+		string $appName,
 		IRequest $request,
 		CapabilitiesManager $capabilitiesManager,
 		IUserSession $userSession,
 		IUserManager $userManager,
 		Manager $keyManager,
-		Helper $ldapHelper,
-		ILogger $logger,
-		ConnectionFactory $connectionFactory
+		private Helper $ldapHelper,
+		private LoggerInterface $logger,
+		private ConnectionFactory $connectionFactory
 	) {
 		parent::__construct(
 			$appName,
@@ -69,11 +59,6 @@ class ConfigAPIController extends OCSController {
 			$userManager,
 			$keyManager
 		);
-
-
-		$this->ldapHelper = $ldapHelper;
-		$this->logger = $logger;
-		$this->connectionFactory = $connectionFactory;
 	}
 
 	/**
@@ -90,7 +75,7 @@ class ConfigAPIController extends OCSController {
 			$configHolder->ldapConfigurationActive = false;
 			$configHolder->saveConfiguration();
 		} catch (\Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new OCSException('An issue occurred when creating the new config.');
 		}
 		return new DataResponse(['configID' => $configPrefix]);
@@ -116,7 +101,7 @@ class ConfigAPIController extends OCSController {
 		} catch (OCSException $e) {
 			throw $e;
 		} catch (\Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new OCSException('An issue occurred when deleting the config.');
 		}
 
@@ -158,7 +143,7 @@ class ConfigAPIController extends OCSController {
 		} catch (OCSException $e) {
 			throw $e;
 		} catch (\Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new OCSException('An issue occurred when modifying the config.');
 		}
 
@@ -258,7 +243,7 @@ class ConfigAPIController extends OCSController {
 		} catch (OCSException $e) {
 			throw $e;
 		} catch (\Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			throw new OCSException('An issue occurred when modifying the config.');
 		}
 
@@ -272,7 +257,7 @@ class ConfigAPIController extends OCSController {
 	 * @param string $configID
 	 * @throws OCSNotFoundException
 	 */
-	private function ensureConfigIDExists($configID) {
+	private function ensureConfigIDExists($configID): void {
 		$prefixes = $this->ldapHelper->getServerConfigurationPrefixes();
 		if (!in_array($configID, $prefixes, true)) {
 			throw new OCSNotFoundException('Config ID not found');


### PR DESCRIPTION
See #32127 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
