### PR TITLE
chore(3rdparty): remove opis/closure

### DIFF
--- a/lib/private/Command/ClosureJob.php
+++ b/lib/private/Command/ClosureJob.php
@@ -24,11 +24,10 @@ namespace OC\Command;
 
 use OC\BackgroundJob\QueuedJob;
 use Laravel\SerializableClosure\SerializableClosure as LaravelClosure;
-use Opis\Closure\SerializableClosure as OpisClosure;
 
 class ClosureJob extends QueuedJob {
 	protected function run($serializedCallable) {
-		$callable = unserialize($serializedCallable, [LaravelClosure::class, OpisClosure::class]);
+		$callable = unserialize($serializedCallable, [LaravelClosure::class]);
 		$callable = $callable->getClosure();
 		if (is_callable($callable)) {
 			$callable();

--- a/tests/lib/Command/CronBusTest.php
+++ b/tests/lib/Command/CronBusTest.php
@@ -47,11 +47,4 @@ class CronBusTest extends AsyncBusTest {
 			$job->execute($this->jobList);
 		}
 	}
-
-	public function testClosureFromPreviousVersion() {
-		$serializedClosure = 'C:32:"Opis\\Closure\\SerializableClosure":217:{a:5:{s:3:"use";a:0:{}s:8:"function";s:64:"function () {\\Test\\Command\\AsyncBusTest::$lastCommand = \'opis\';}";s:5:"scope";s:24:"Test\\Command\\CronBusTest";s:4:"this";N;s:4:"self";s:32:"0000000027dcfe2f00000000407fa805";}}';
-		$this->jobList->add('OC\Command\ClosureJob', $serializedClosure);
-		$this->runJobs();
-		$this->assertEquals('opis', AsyncBusTest::$lastCommand);
-	}
 }


### PR DESCRIPTION
## Summary

- We are using laravel/serializable-closure for a while now.
- The package was there for compatibility reasons, but does not play nice with PHP 8.1.

## TODO

- [x] Review
- [x] CI
- [x] Merge https://github.com/nextcloud/3rdparty/pull/1580
- [x] Rebase
 
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
