### PR TITLE
Migrate applications away from deprecated ILogger

### DIFF
--- a/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
+++ b/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
@@ -38,7 +38,6 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class OCSAuthAPIControllerTest extends TestCase {
-
 	/** @var \PHPUnit\Framework\MockObject\MockObject|IRequest */
 	private $request;
 
@@ -54,7 +53,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject|DbHandler */
 	private $dbHandler;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject|ILogger */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface */
 	private $logger;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject|ITimeFactory */

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -41,7 +41,6 @@ use Test\TestCase;
 use Psr\Log\LoggerInterface;
 
 class TrustedServersTest extends TestCase {
-
 	/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers */
 	private $trustedServers;
 
@@ -57,7 +56,7 @@ class TrustedServersTest extends TestCase {
 	/** @var  \PHPUnit\Framework\MockObject\MockObject | IResponse */
 	private $response;
 
-	/** @var  \PHPUnit\Framework\MockObject\MockObject | ILogger */
+	/** @var  \PHPUnit\Framework\MockObject\MockObject | LoggerInterface */
 	private $logger;
 
 	/** @var  \PHPUnit\Framework\MockObject\MockObject | IJobList */
@@ -132,7 +131,7 @@ class TrustedServersTest extends TestCase {
 		$this->dbHandler->expects($this->once())->method('addToken')->with('https://url', 'token');
 		$this->jobList->expects($this->once())->method('add')
 			->with('OCA\Federation\BackgroundJob\RequestSharedSecret',
-					['url' => 'https://url', 'token' => 'token', 'created' => 1234567]);
+				['url' => 'https://url', 'token' => 'token', 'created' => 1234567]);
 
 		$this->assertSame(
 			$trustedServers->addServer('url'),

--- a/apps/files/lib/Controller/DirectEditingViewController.php
+++ b/apps/files/lib/Controller/DirectEditingViewController.php
@@ -30,27 +30,19 @@ use OCP\AppFramework\Http\Response;
 use OCP\DirectEditing\IManager;
 use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 #[IgnoreOpenAPI]
 class DirectEditingViewController extends Controller {
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
-
-	/** @var IManager */
-	private $directEditingManager;
-
-	/** @var ILogger */
-	private $logger;
-
-	public function __construct($appName, IRequest $request, IEventDispatcher $eventDispatcher, IManager $manager, ILogger $logger) {
+	public function __construct(
+		$appName,
+		IRequest $request,
+		private IEventDispatcher $eventDispatcher,
+		private IManager $directEditingManager,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($appName, $request);
-
-		$this->eventDispatcher = $eventDispatcher;
-		$this->directEditingManager = $manager;
-		$this->logger = $logger;
 	}
 
 	/**
@@ -66,7 +58,7 @@ class DirectEditingViewController extends Controller {
 		try {
 			return $this->directEditingManager->edit($token);
 		} catch (Exception $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return new NotFoundResponse();
 		}
 	}

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -35,16 +35,14 @@ use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
-use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
-use OCP\ILogger;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class Storage extends Wrapper {
 	private string $mountPoint;
-	private  IUserManager$userManager;
+	private IUserManager$userManager;
 	private LoggerInterface $logger;
 	private IEventDispatcher $eventDispatcher;
 	private IRootFolder $rootFolder;
@@ -218,7 +216,7 @@ class Storage extends Wrapper {
 					$rootFolder,
 				);
 			},
-		1);
+			1);
 	}
 
 	public function getMountPoint() {

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -47,7 +47,6 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
-use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Share\IShare;

--- a/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
+++ b/apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php
@@ -39,7 +39,6 @@ use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\Job;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
 

--- a/apps/settings/lib/Controller/WebAuthnController.php
+++ b/apps/settings/lib/Controller/WebAuthnController.php
@@ -33,37 +33,24 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\IgnoreOpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 use Webauthn\PublicKeyCredentialCreationOptions;
 
 #[IgnoreOpenAPI]
 class WebAuthnController extends Controller {
 	private const WEBAUTHN_REGISTRATION = 'webauthn_registration';
 
-	/** @var Manager */
-	private $manager;
-
-	/** @var IUserSession */
-	private $userSession;
-	/**
-	 * @var ISession
-	 */
-	private $session;
-	/**
-	 * @var ILogger
-	 */
-	private $logger;
-
-	public function __construct(IRequest $request, ILogger $logger, Manager $webAuthnManager, IUserSession $userSession, ISession $session) {
+	public function __construct(
+		IRequest $request,
+		private LoggerInterface $logger,
+		private Manager $manager,
+		private IUserSession $userSession,
+		private ISession $session,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-
-		$this->manager = $webAuthnManager;
-		$this->userSession = $userSession;
-		$this->session = $session;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -50,7 +50,6 @@ use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -74,8 +73,6 @@ class UsersControllerTest extends \Test\TestCase {
 	private $userSession;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
 	/** @var IMailer|\PHPUnit\Framework\MockObject\MockObject */
 	private $mailer;
 	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -42,38 +42,21 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\ICacheFactory;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class ImageManager {
 	public const SUPPORTED_IMAGE_KEYS = ['background', 'logo', 'logoheader', 'favicon'];
 
-	/** @var IConfig */
-	private $config;
-	/** @var IAppData */
-	private $appData;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-	/** @var ICacheFactory */
-	private $cacheFactory;
-	/** @var ILogger */
-	private $logger;
-	/** @var ITempManager */
-	private $tempManager;
-
-	public function __construct(IConfig $config,
-								IAppData $appData,
-								IURLGenerator $urlGenerator,
-								ICacheFactory $cacheFactory,
-								ILogger $logger,
-								ITempManager $tempManager) {
-		$this->config = $config;
-		$this->urlGenerator = $urlGenerator;
-		$this->cacheFactory = $cacheFactory;
-		$this->logger = $logger;
-		$this->tempManager = $tempManager;
-		$this->appData = $appData;
+	public function __construct(
+		private IConfig $config,
+		private IAppData $appData,
+		private IURLGenerator $urlGenerator,
+		private ICacheFactory $cacheFactory,
+		private LoggerInterface $logger,
+		private ITempManager $tempManager,
+	) {
 	}
 
 	/**

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -34,14 +34,13 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\ICacheFactory;
 use OCP\IConfig;
-use OCP\ILogger;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ImageManagerTest extends TestCase {
-
 	/** @var IConfig|MockObject */
 	protected $config;
 	/** @var IAppData|MockObject */
@@ -52,7 +51,7 @@ class ImageManagerTest extends TestCase {
 	private $urlGenerator;
 	/** @var ICacheFactory|MockObject */
 	private $cacheFactory;
-	/** @var ILogger|MockObject */
+	/** @var LoggerInterface|MockObject */
 	private $logger;
 	/** @var ITempManager|MockObject */
 	private $tempManager;
@@ -65,7 +64,7 @@ class ImageManagerTest extends TestCase {
 		$this->appData = $this->createMock(IAppData::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->tempManager = $this->createMock(ITempManager::class);
 		$this->rootFolder = $this->createMock(ISimpleFolder::class);
 		$this->imageManager = new ImageManager(
@@ -143,7 +142,7 @@ class ImageManagerTest extends TestCase {
 			->withConsecutive(
 				['theming', 'cachebuster', '0'],
 				['theming', 'logoMime', '']
-				)
+			)
 			->willReturn(0);
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
@@ -322,7 +321,7 @@ class ImageManagerTest extends TestCase {
 		$folders[2]->expects($this->never())->method('delete');
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('theming','cachebuster','0')
+			->with('theming', 'cachebuster', '0')
 			->willReturn('2');
 		$this->rootFolder->expects($this->once())
 			->method('getDirectoryListing')

--- a/apps/twofactor_backupcodes/lib/Listener/ActivityPublisher.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ActivityPublisher.php
@@ -30,20 +30,13 @@ use OCA\TwoFactorBackupCodes\Event\CodesGenerated;
 use OCP\Activity\IManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class ActivityPublisher implements IEventListener {
-
-	/** @var IManager */
-	private $activityManager;
-
-	/** @var ILogger */
-	private $logger;
-
-	public function __construct(IManager $activityManager,
-								ILogger $logger) {
-		$this->activityManager = $activityManager;
-		$this->logger = $logger;
+	public function __construct(
+		private IManager $activityManager,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**
@@ -60,8 +53,7 @@ class ActivityPublisher implements IEventListener {
 			try {
 				$this->activityManager->publish($activity);
 			} catch (BadMethodCallException $e) {
-				$this->logger->warning('could not publish backup code creation activity', ['app' => 'twofactor_backupcodes']);
-				$this->logger->logException($e, ['app' => 'twofactor_backupcodes']);
+				$this->logger->error('Could not publish backup code creation activity', ['exception' => $e]);
 			}
 		}
 	}

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ActivityPublisherTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ActivityPublisherTest.php
@@ -32,18 +32,16 @@ use OCA\TwoFactorBackupCodes\Listener\ActivityPublisher;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\EventDispatcher\Event;
-use OCP\ILogger;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ActivityPublisherTest extends TestCase {
-
 	/** @var IManager|MockObject */
 	private $activityManager;
 
-	/** @var ILogger */
-
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var ActivityPublisher */
@@ -53,7 +51,7 @@ class ActivityPublisherTest extends TestCase {
 		parent::setUp();
 
 		$this->activityManager = $this->createMock(IManager::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new ActivityPublisher($this->activityManager, $this->logger);
 	}

--- a/apps/updatenotification/lib/AppInfo/Application.php
+++ b/apps/updatenotification/lib/AppInfo/Application.php
@@ -40,10 +40,10 @@ use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\QueryException;
 use OCP\IConfig;
 use OCP\IGroupManager;
-use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 class Application extends App implements IBootstrap {
 	public function __construct() {
@@ -56,11 +56,11 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$context->injectFn(function (IConfig $config,
-									 IUserSession $userSession,
-									 IAppManager $appManager,
-									 IGroupManager $groupManager,
-									 IAppContainer $appContainer,
-									 ILogger $logger) {
+			IUserSession $userSession,
+			IAppManager $appManager,
+			IGroupManager $groupManager,
+			IAppContainer $appContainer,
+			LoggerInterface $logger) {
 			if ($config->getSystemValue('updatechecker', true) !== true) {
 				// Updater check is disabled
 				return;
@@ -77,7 +77,7 @@ class Application extends App implements IBootstrap {
 				try {
 					$updateChecker = $appContainer->get(UpdateChecker::class);
 				} catch (QueryException $e) {
-					$logger->logException($e);
+					$logger->error($e->getMessage(), ['exception' => $e]);
 					return;
 				}
 

--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -42,41 +42,21 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 /**
  * @psalm-import-type UserStatusPrivate from ResponseDefinitions
  */
 class UserStatusController extends OCSController {
-
-	/** @var string */
-	private $userId;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var StatusService */
-	private $service;
-
-	/**
-	 * StatusesController constructor.
-	 *
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param string $userId
-	 * @param ILogger $logger;
-	 * @param StatusService $service
-	 */
-	public function __construct(string $appName,
-								IRequest $request,
-								string $userId,
-								ILogger $logger,
-								StatusService $service) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private string $userId,
+		private LoggerInterface $logger,
+		private StatusService $service,
+	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
-		$this->logger = $logger;
-		$this->service = $service;
 	}
 
 	/**

--- a/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
+++ b/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
@@ -37,14 +37,13 @@ use OCA\UserStatus\Service\StatusService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use Throwable;
 
 class UserStatusControllerTest extends TestCase {
-
-	/** @var ILogger|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
 
 	/** @var StatusService|\PHPUnit\Framework\MockObject\MockObject */
@@ -58,7 +57,7 @@ class UserStatusControllerTest extends TestCase {
 
 		$request = $this->createMock(IRequest::class);
 		$userId = 'john.doe';
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = $this->createMock(StatusService::class);
 
 		$this->controller = new UserStatusController('user_status', $request, $userId, $this->logger, $this->service);

--- a/apps/weather_status/lib/Controller/WeatherStatusController.php
+++ b/apps/weather_status/lib/Controller/WeatherStatusController.php
@@ -30,32 +30,19 @@ use OCA\WeatherStatus\Service\WeatherStatusService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
-use OCP\ILogger;
 use OCP\IRequest;
 
 /**
  * @psalm-import-type WeatherStatusForecast from ResponseDefinitions
  */
 class WeatherStatusController extends OCSController {
-
-	/** @var string */
-	private $userId;
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var WeatherStatusService */
-	private $service;
-
-	public function __construct(string $appName,
-								IRequest $request,
-								ILogger $logger,
-								WeatherStatusService $service,
-								?string $userId) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private WeatherStatusService $service,
+		private ?string $userId,
+	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
-		$this->logger = $logger;
-		$this->service = $service;
 	}
 
 	/**

--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -33,7 +33,6 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -59,8 +58,6 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 	protected $urlGenerator;
 	/** @var IRootFolder */
 	protected $root;
-	/** @var ILogger */
-	protected $logger;
 	/** @var string */
 	protected $eventName;
 	/** @var Event */
@@ -82,7 +79,6 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 		IL10N $l10n,
 		IURLGenerator $urlGenerator,
 		IRootFolder $root,
-		ILogger $logger,
 		ShareManager $shareManager,
 		IUserSession $userSession,
 		ISystemTagManager $tagManager,
@@ -91,7 +87,6 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 		$this->l10n = $l10n;
 		$this->urlGenerator = $urlGenerator;
 		$this->root = $root;
-		$this->logger = $logger;
 		$this->shareManager = $shareManager;
 		$this->userSession = $userSession;
 		$this->tagManager = $tagManager;

--- a/apps/workflowengine/lib/Manager.php
+++ b/apps/workflowengine/lib/Manager.php
@@ -48,12 +48,10 @@ use OCA\WorkflowEngine\Service\RuleMatcher;
 use OCP\AppFramework\QueryException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Storage\IStorage;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IUserSession;
 use OCP\WorkflowEngine\Events\RegisterChecksEvent;
@@ -66,31 +64,14 @@ use OCP\WorkflowEngine\IEntityEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IOperation;
 use OCP\WorkflowEngine\IRuleMatcher;
+use Psr\Log\LoggerInterface;
 
 class Manager implements IManager {
-	/** @var IStorage */
-	protected $storage;
-
-	/** @var string */
-	protected $path;
-
-	/** @var object */
-	protected $entity;
-
 	/** @var array[] */
 	protected $operations = [];
 
 	/** @var array[] */
 	protected $checks = [];
-
-	/** @var IDBConnection */
-	protected $connection;
-
-	/** @var IServerContainer|\OC\Server */
-	protected $container;
-
-	/** @var IL10N */
-	protected $l;
 
 	/** @var IEntity[] */
 	protected $registeredEntities = [];
@@ -101,41 +82,20 @@ class Manager implements IManager {
 	/** @var ICheck[] */
 	protected $registeredChecks = [];
 
-	/** @var ILogger */
-	protected $logger;
-
 	/** @var CappedMemoryCache<int[]> */
 	protected CappedMemoryCache $operationsByScope;
 
-	/** @var IUserSession */
-	protected $session;
-
-	/** @var IEventDispatcher */
-	private $dispatcher;
-
-	/** @var IConfig */
-	private $config;
-	private ICacheFactory $cacheFactory;
-
 	public function __construct(
-		IDBConnection $connection,
-		IServerContainer $container,
-		IL10N $l,
-		ILogger $logger,
-		IUserSession $session,
-		IEventDispatcher $dispatcher,
-		IConfig $config,
-		ICacheFactory $cacheFactory,
+		protected IDBConnection $connection,
+		protected IServerContainer $container,
+		protected IL10N $l,
+		protected LoggerInterface $logger,
+		protected IUserSession $session,
+		private IEventDispatcher $dispatcher,
+		private IConfig $config,
+		private ICacheFactory $cacheFactory,
 	) {
-		$this->connection = $connection;
-		$this->container = $container;
-		$this->l = $l;
-		$this->logger = $logger;
 		$this->operationsByScope = new CappedMemoryCache(64);
-		$this->session = $session;
-		$this->dispatcher = $dispatcher;
-		$this->config = $config;
-		$this->cacheFactory = $cacheFactory;
 	}
 
 	public function getRuleMatcher(): IRuleMatcher {
@@ -730,7 +690,7 @@ class Manager implements IManager {
 				File::class => $this->container->query(File::class),
 			];
 		} catch (QueryException $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return [];
 		}
 	}
@@ -744,7 +704,7 @@ class Manager implements IManager {
 				// None yet
 			];
 		} catch (QueryException $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return [];
 		}
 	}
@@ -766,7 +726,7 @@ class Manager implements IManager {
 				$this->container->query(UserGroupMembership::class),
 			];
 		} catch (QueryException $e) {
-			$this->logger->logException($e);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			return [];
 		}
 	}

--- a/apps/workflowengine/lib/Service/Logger.php
+++ b/apps/workflowengine/lib/Service/Logger.php
@@ -36,24 +36,17 @@ use OCP\Log\ILogFactory;
 use Psr\Log\LoggerInterface;
 
 class Logger {
-	/** @var ILogger */
-	protected $generalLogger;
-	/** @var LoggerInterface */
-	protected $flowLogger;
-	/** @var IConfig */
-	private $config;
-	/** @var ILogFactory */
-	private $logFactory;
+	protected ?LoggerInterface $flowLogger = null;
 
-	public function __construct(ILogger $generalLogger, IConfig $config, ILogFactory $logFactory) {
-		$this->generalLogger = $generalLogger;
-		$this->config = $config;
-		$this->logFactory = $logFactory;
-
+	public function __construct(
+		protected LoggerInterface $generalLogger,
+		private IConfig $config,
+		private ILogFactory $logFactory,
+	) {
 		$this->initLogger();
 	}
 
-	protected function initLogger() {
+	protected function initLogger(): void {
 		$default = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/flow.log';
 		$logFile = trim((string)$this->config->getAppValue(Application::APP_ID, 'logfile', $default));
 		if ($logFile !== '') {

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -39,7 +39,6 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -52,6 +51,7 @@ use OCP\WorkflowEngine\IEntityEvent;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IOperation;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 /**
@@ -65,7 +65,7 @@ class ManagerTest extends TestCase {
 	protected $manager;
 	/** @var MockObject|IDBConnection */
 	protected $db;
-	/** @var \PHPUnit\Framework\MockObject\MockObject|ILogger */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface */
 	protected $logger;
 	/** @var MockObject|IServerContainer */
 	protected $container;
@@ -92,7 +92,7 @@ class ManagerTest extends TestCase {
 				return vsprintf($text, $parameters);
 			});
 
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->config = $this->createMock(IConfig::class);
@@ -403,7 +403,6 @@ class ManagerTest extends TestCase {
 							$this->l,
 							$this->createMock(IURLGenerator::class),
 							$this->createMock(IRootFolder::class),
-							$this->createMock(ILogger::class),
 							$this->createMock(\OCP\Share\IManager::class),
 							$this->createMock(IUserSession::class),
 							$this->createMock(ISystemTagManager::class),

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1168,7 +1168,7 @@ class Server extends ServerContainer implements IServerContainer {
 					$c->getAppDataDir('theming'),
 					$c->get(IURLGenerator::class),
 					$this->get(ICacheFactory::class),
-					$this->get(ILogger::class),
+					$this->get(LoggerInterface::class),
 					$this->get(ITempManager::class)
 				);
 				return new ThemingDefaults(


### PR DESCRIPTION
See #32127

## Summary

Migrate applications away from deprecated ILogger
Left alone jobs and a few other cases for now.
Also migrated to PHP8 promoted constructor properties modified classes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
