### PR TITLE
Fix dashboard widgets api

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -150,7 +150,7 @@ class DashboardApiController extends OCSController {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * @return DataResponse<Http::STATUS_OK, DashboardWidget[], array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, DashboardWidget>, array{}>
 	 */
 	public function getWidgets(): DataResponse {
 		$widgets = $this->dashboardManager->getWidgets();

--- a/apps/dashboard/openapi.json
+++ b/apps/dashboard/openapi.json
@@ -220,8 +220,8 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "array",
-                                                    "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
                                                         "$ref": "#/components/schemas/Widget"
                                                     }
                                                 }

--- a/lib/private/Dashboard/Manager.php
+++ b/lib/private/Dashboard/Manager.php
@@ -40,8 +40,8 @@ class Manager implements IManager {
 	/** @var array */
 	private $lazyWidgets = [];
 
-	/** @var IWidget[] */
-	private $widgets = [];
+	/** @var array<string, IWidget> */
+	private array $widgets = [];
 
 	private ContainerInterface $serverContainer;
 	private ?IAppManager $appManager = null;
@@ -134,6 +134,9 @@ class Manager implements IManager {
 		$this->lazyWidgets = [];
 	}
 
+	/**
+	 * @return array<string, IWidget>
+	 */
 	public function getWidgets(): array {
 		$this->loadLazyPanels();
 		return $this->widgets;

--- a/lib/public/Dashboard/IManager.php
+++ b/lib/public/Dashboard/IManager.php
@@ -40,7 +40,7 @@ interface IManager {
 	/**
 	 * @since 20.0.0
 	 *
-	 * @return IWidget[]
+	 * @return array<string, IWidget>
 	 */
 	public function getWidgets(): array;
 }


### PR DESCRIPTION
## Summary

The interface was wrong since the implementation always used an associative array with the app id:
https://github.com/nextcloud/server/blob/e15d9999110a183a29d81542a6f8ac81d06d07d6/lib/private/Dashboard/Manager.php#L58

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
