### PR TITLE
delete filecache entries when the object doesn't exist

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -13,6 +13,7 @@ use Aws\S3\S3Client;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Utils;
 use OC\Files\Stream\SeekableHttpStream;
+use OCP\Files\NotFoundException;
 use Psr\Http\Message\StreamInterface;
 
 trait S3ObjectTrait {
@@ -69,7 +70,11 @@ trait S3ObjectTrait {
 			}
 
 			$context = stream_context_create($opts);
-			return fopen($request->getUri(), 'r', false, $context);
+			$fh = fopen($request->getUri(), 'r', false, $context);
+			if (!$fh && isset($http_response_header[0]) && str_contains($http_response_header[0], '404')) {
+				throw new NotFoundException("object $urn not found in object store bucket " . $this->getBucket());
+			}
+			return $fh;
 		});
 		if (!$fh) {
 			throw new \Exception("Failed to read object $urn");


### PR DESCRIPTION
If the cache and object store get out of sync for any reason we can have items in the cache for an object store with no matching objects. This changes it so the cache item is deleted automatically when such a file is being read.

It logs the full cache item to provide some breadcrumbs if these files ever need to be recovered.
I would like to have a more complete "trashbin" for these items to help with debugging/resolving the cache desync issues but I can't think of anything atm.