### PR TITLE
use multipart copy for s3

### DIFF
--- a/.github/workflows/smb-kerberos.yml
+++ b/.github/workflows/smb-kerberos.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Setup AD-DC
         run: |
           DC_IP=$(apps/files_external/tests/sso-setup/start-dc.sh)
+          sleep 1
           apps/files_external/tests/sso-setup/start-apache.sh $DC_IP $PWD
           echo "DC_IP=$DC_IP" >> $GITHUB_ENV
       - name: Set up Nextcloud

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -580,10 +580,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 		if ($isFile === true || $this->is_file($source)) {
 			try {
-				$this->getConnection()->copyObject([
-					'Bucket' => $this->bucket,
-					'Key' => $this->cleanKey($target),
-					'CopySource' => S3Client::encodeKey($this->bucket . '/' . $source),
+				$this->copyObject($source, $target, [
 					'StorageClass' => $this->storageClass,
 				]);
 				$this->testTimeout();

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -27,6 +27,7 @@
 namespace OC\Files\ObjectStore;
 
 use Aws\S3\Exception\S3MultipartUploadException;
+use Aws\S3\MultipartCopy;
 use Aws\S3\MultipartUploader;
 use Aws\S3\S3Client;
 use GuzzleHttp\Psr7;
@@ -189,9 +190,16 @@ trait S3ObjectTrait {
 		return $this->getConnection()->doesObjectExist($this->bucket, $urn, $this->getSSECParameters());
 	}
 
-	public function copyObject($from, $to) {
-		$this->getConnection()->copy($this->getBucket(), $from, $this->getBucket(), $to, 'private', [
-			'params' => $this->getSSECParameters() + $this->getSSECParameters(true)
-		]);
+	public function copyObject($from, $to, array $options = []) {
+		$copy = new MultipartCopy($this->getConnection(), [
+			"source_bucket" => $this->getBucket(),
+			"source_key" => $from
+		], array_merge([
+			"bucket" => $this->getBucket(),
+			"key" => $to,
+			"acl" => "private",
+			"params" => $this->getSSECParameters() + $this->getSSECParameters(true)
+		], $options));
+		$copy->copy();
 	}
 }


### PR DESCRIPTION
Switches to the multi part copies to support copying files >5GB (rename uses copy under the hood for ext s3)

Fixes https://github.com/nextcloud/server/issues/24540

Unfortunately my testing is limited by minio seemingly not having the 5GB limit on normal copy.