### PR TITLE
Add a message for app updates trough occ when no updates available

### DIFF
--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -77,6 +77,7 @@ class Update extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$singleAppId = $input->getArgument('app-id');
+		$updateFound = false;
 
 		if ($singleAppId) {
 			$apps = [$singleAppId];
@@ -97,6 +98,7 @@ class Update extends Command {
 		foreach ($apps as $appId) {
 			$newVersion = $this->installer->isUpdateAvailable($appId, $input->getOption('allow-unstable'));
 			if ($newVersion) {
+				$updateFound = true;
 				$output->writeln($appId . ' new version available: ' . $newVersion);
 
 				if (!$input->getOption('showonly')) {
@@ -119,6 +121,14 @@ class Update extends Command {
 						$output->writeln($appId . ' updated');
 					}
 				}
+			}
+		}
+
+		if (!$updateFound) {
+			if ($singleAppId) {
+				$output->writeln($singleAppId . ' is up-to-date or no updates could be found');
+			} else {
+				$output->writeln('All apps are up-to-date or no updates could be found');
 			}
 		}
 


### PR DESCRIPTION
## Summary

Return a message when no updates are available or have been found.

Can be useful to both inform the user that updates have been performed but none found and for scripting, instead of an empty output (and return 0).

```
# occ app:update contacts
contacts is up-to-date or no updates could be found

# occ app:update --all
All apps are up-to-date or no updates could be found
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
