### PR TITLE
feat: Refined session handling

### DIFF
--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -113,7 +113,10 @@ class ChangePasswordController extends Controller {
 			]);
 		}
 
-		$this->userSession->updateSessionTokenPassword($newpassword);
+		$this->userSession->updateSessionTokenPassword(
+			$this->request->getCookie(Session::COOKIE_SESSION_ID),
+			$newpassword,
+		);
 
 		return new JSONResponse([
 			'status' => 'success',

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -90,10 +90,6 @@ class LoginController extends Controller {
 	 */
 	#[UseSession]
 	public function logout() {
-		$loginToken = $this->request->getCookie('nc_token');
-		if (!is_null($loginToken)) {
-			$this->config->deleteUserValue($this->userSession->getUser()->getUID(), 'login_token', $loginToken);
-		}
 		$this->userSession->logout();
 
 		$response = new RedirectResponse($this->urlGenerator->linkToRouteAbsolute(

--- a/lib/base.php
+++ b/lib/base.php
@@ -420,8 +420,8 @@ class OC {
 		// TODO: See https://github.com/nextcloud/server/issues/37277#issuecomment-1476366147 and the other comments
 		// TODO: for further information.
 		// $isDavRequest = strpos($request->getRequestUri(), '/remote.php/dav') === 0 || strpos($request->getRequestUri(), '/remote.php/webdav') === 0;
-		// if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie('cookie_test')) && $isDavRequest && !isset($_COOKIE['nc_session_id'])) {
-		// setcookie('cookie_test', 'test', time() + 3600);
+		// if ($request->getHeader('Authorization') !== '' && is_null($request->getCookie(\OC\User\Session::COOKIE_TEST)) && $isDavRequest)) {
+		// setcookie(\OC\User\Session::COOKIE_TEST, 'test', time() + 3600);
 		// // Do not initialize the session if a request is authenticated directly
 		// // unless there is a session cookie already sent along
 		// return;
@@ -1142,9 +1142,11 @@ class OC {
 			return true;
 		}
 		if (isset($_COOKIE['nc_username'])
-			&& isset($_COOKIE['nc_token'])
-			&& isset($_COOKIE['nc_session_id'])
-			&& $userSession->loginWithCookie($_COOKIE['nc_username'], $_COOKIE['nc_token'], $_COOKIE['nc_session_id'])) {
+			&& isset($_COOKIE[\OC\User\Session::COOKIE_SESSION_ID])
+			&& $userSession->loginWithCookie(
+				$_COOKIE['nc_username'],
+				$_COOKIE[\OC\User\Session::COOKIE_SESSION_ID])
+			) {
 			return true;
 		}
 		if ($userSession->tryBasicAuthLogin($request, Server::get(IThrottler::class))) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -490,7 +490,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		if ($this->getHeader('OCS-APIREQUEST')) {
 			return false;
 		}
-		if ($this->getCookie(session_name()) === null && $this->getCookie('nc_token') === null) {
+		if ($this->getCookie(session_name()) === null) {
 			return false;
 		}
 

--- a/lib/private/Authentication/Login/FinishRememberedLoginCommand.php
+++ b/lib/private/Authentication/Login/FinishRememberedLoginCommand.php
@@ -42,7 +42,7 @@ class FinishRememberedLoginCommand extends ALoginCommand {
 
 	public function process(LoginData $loginData): LoginResult {
 		if ($loginData->isRememberLogin() && !$this->config->getSystemValueBool('auto_logout', false)) {
-			$this->userSession->createRememberMeToken($loginData->getUser());
+			// TODO: finish login here? don't set cookies earlier
 		}
 
 		return $this->processNextOrFinishSuccessfully($loginData);

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -79,17 +79,6 @@ interface IProvider {
 	public function getTokenById(int $tokenId): IToken;
 
 	/**
-	 * Duplicate an existing session token
-	 *
-	 * @param string $oldSessionId
-	 * @param string $sessionId
-	 * @throws InvalidTokenException
-	 * @throws \RuntimeException when OpenSSL reports a problem
-	 * @return IToken The new token
-	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken;
-
-	/**
 	 * Invalidate (delete) the given session token
 	 *
 	 * @param string $token

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -160,22 +160,6 @@ class Manager implements IProvider, OCPIProvider {
 	}
 
 	/**
-	 * @param string $oldSessionId
-	 * @param string $sessionId
-	 * @throws InvalidTokenException
-	 * @return IToken
-	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
-		try {
-			return $this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
-		} catch (ExpiredTokenException $e) {
-			throw $e;
-		} catch (InvalidTokenException $e) {
-			throw $e;
-		}
-	}
-
-	/**
 	 * @param IToken $savedToken
 	 * @param string $tokenId session token
 	 * @throws InvalidTokenException

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -218,37 +218,6 @@ class PublicKeyTokenProvider implements IProvider {
 		return $token;
 	}
 
-	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
-		$this->cache->clear();
-
-		return $this->atomic(function () use ($oldSessionId, $sessionId) {
-			$token = $this->getToken($oldSessionId);
-
-			if (!($token instanceof PublicKeyToken)) {
-				throw new InvalidTokenException("Invalid token type");
-			}
-
-			$password = null;
-			if (!is_null($token->getPassword())) {
-				$privateKey = $this->decrypt($token->getPrivateKey(), $oldSessionId);
-				$password = $this->decryptPassword($token->getPassword(), $privateKey);
-			}
-			$newToken = $this->generateToken(
-				$sessionId,
-				$token->getUID(),
-				$token->getLoginName(),
-				$password,
-				$token->getName(),
-				IToken::TEMPORARY_TOKEN,
-				$token->getRemember()
-			);
-
-			$this->mapper->delete($token);
-
-			return $newToken;
-		}, $this->db);
-	}
-
 	public function invalidateToken(string $token) {
 		$this->cache->clear();
 

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -256,8 +256,7 @@ class Manager {
 		$passed = $provider->verifyChallenge($user, $challenge);
 		if ($passed) {
 			if ($this->session->get(self::REMEMBER_LOGIN) === true) {
-				// TODO: resolve cyclic dependency and use DI
-				\OC::$server->getUserSession()->createRememberMeToken($user);
+				// TODO: finish login here? don't set cookies earlier
 			}
 			$this->session->remove(self::SESSION_UID_KEY);
 			$this->session->remove(self::REMEMBER_LOGIN);

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -148,14 +148,7 @@ class Internal extends Session {
 			// Get the new id to update the token
 			$newId = $this->getId();
 
-			/** @var IProvider $tokenProvider */
-			$tokenProvider = \OCP\Server::get(IProvider::class);
-
-			try {
-				$tokenProvider->renewSessionToken($oldId, $newId);
-			} catch (InvalidTokenException $e) {
-				// Just ignore
-			}
+			// TODO: refresh cookie?!
 		}
 	}
 

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -192,7 +192,6 @@ class OC_User {
 				$dispatcher->dispatchTyped(new BeforeUserLoggedInEvent($uid, $password, $backend));
 
 				$userSession->createSessionToken($request, $uid, $uid, $password);
-				$userSession->createRememberMeToken($userSession->getUser());
 				// setup the filesystem
 				OC_Util::setupFS($uid);
 				// first call the post_login hooks, the login-process needs to be


### PR DESCRIPTION
* Remove secondary persistent remember me tokens
* Decouple session ID and session token
* Resolves: https://github.com/nextcloud/server/issues/37492

## Summary

### Before

Remember me is handled with persisted tokens stored in preferences. At cookie login (session expired, cookie is still alive), the token is compared with the database values, token is replaced on success. The session id is also the password/token of the session token in the password. This process is falling apart with concurrency. First, only one process can win the token race. Rarely there are two, because tokens are not read and replaced in a transaction. But then there are also two new PHP sessions and the database can only be updated once.

```mermaid
sequenceDiagram
    Browser->>+Server: session1, token1
    Server-->>-Browser: OK: session1, token1
    Note over Browser,Server: No activity. PHP session expires.
    Browser->>+Server: session1, token1
    Server-->>-Browser: OK: session2, token2   
    Note over Browser,Server: No activity. PHP session expires.
    par
        Browser->>+Server: session2, token2
        Server-->>-Browser: OK: session3, token3
    and
        Browser->>+Server: session2, token2
        Server-->>-Browser: ERROR: session4, logout
    end
```

### After

Remember me is still handled by a persisted token, but the token is a random one and it doesn't change throughout the session.

```mermaid
sequenceDiagram
    Browser->>+Server: session1, token1
    Server-->>-Browser: OK: session1, token1    
    Note over Browser,Server: No activity. PHP session expires.
    Browser->>+Server: session1, token1
    Server-->>-Browser: OK: session2, token1   
    Note over Browser,Server: No activity. PHP session expires.
    par
        Browser->>+Server: session2, token1
        Server-->>-Browser: OK: session3, token1
    and
        Browser->>+Server: session2, token1
        Server-->>-Browser: OK: session4, token1
    end
```

### Transition

The session id can be used as the "random" token at migration. The logic will keep that session alive as well. New sessions will use a real random token.

## TODO

- [x] Do
- [ ] Testing
- [ ] Testing
- [ ] Testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
