### PR TITLE
Add label for input field and select and adjust styles

### DIFF
--- a/apps/systemtags/css/settings.css
+++ b/apps/systemtags/css/settings.css
@@ -1,6 +1,20 @@
 .systemtag-input {
 	display: flex;
 	flex-wrap: wrap;
+	align-items: center;
+}
+.systemtag-input--name {
+	margin-right: 3px;
+}
+.systemtag-input--name,
+.systemtag-input--level {
+	display: flex;
+	flex-direction: column;
+}
+.systemtag-input--actions {
+	margin-top: 25px;
+	display: flex;
+	flex-direction: row;
 }
 #systemtags .select2-container {
 	width: 100%;

--- a/apps/systemtags/templates/admin.php
+++ b/apps/systemtags/templates/admin.php
@@ -36,17 +36,25 @@ style('systemtags', 'settings');
 	<h3 id="systemtag_create"><?php p($l->t('Create a new tag')); ?></h3>
 
 	<div class="systemtag-input">
-		<input type="text" id="systemtag_name" name="systemtag_name" placeholder="<?php p($l->t('Name')); ?>">
+		<div class="systemtag-input--name">
+			<label for="systemtag_name"><?php p($l->t('Tag name')); ?></label>
+			<input type="text" id="systemtag_name" name="systemtag_name" placeholder="<?php p($l->t('Name')); ?>">
+		</div>
 
-		<select id="systemtag_level">
-			<option value="3"><?php p($l->t('Public')); ?></option>
-			<option value="2"><?php p($l->t('Restricted')); ?></option>
-			<option value="0"><?php p($l->t('Invisible')); ?></option>
-		</select>
+		<div class="systemtag-input--level">
+			<label for="systemtag_level"><?php p($l->t('Tag level')); ?></label>
+			<select id="systemtag_level">
+				<option value="3"><?php p($l->t('Public')); ?></option>
+				<option value="2"><?php p($l->t('Restricted')); ?></option>
+				<option value="0"><?php p($l->t('Invisible')); ?></option>
+			</select>
+		</div>
 
-		<a id="systemtag_delete" class="hidden button"><span><?php p($l->t('Delete')); ?></span></a>
-		<a id="systemtag_reset" class="button"><span><?php p($l->t('Reset')); ?></span></a>
-		<a id="systemtag_submit" class="button"><span><?php p($l->t('Create')); ?></span></a>
+		<div class="systemtag-input--actions">
+			<a id="systemtag_delete" class="hidden button systemtag-input--actions-button"><span><?php p($l->t('Delete')); ?></span></a>
+			<a id="systemtag_reset" class="button systemtag-input--actions-button"><span><?php p($l->t('Reset')); ?></span></a>
+			<a id="systemtag_submit" class="button systemtag-input--actions-button"><span><?php p($l->t('Create')); ?></span></a>
+		</div>
 	</div>
 
 </form>


### PR DESCRIPTION
* Part of https://github.com/nextcloud/server/issues/37082

## Summary

Add label for input field and select and adjust styles

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-08-28 18-45-16](https://github.com/nextcloud/server/assets/6078378/d3755120-4e70-4ea2-b6bd-34203402d6ce) | ![Screenshot from 2023-09-21 10-57-28](https://github.com/nextcloud/server/assets/6078378/ab4f6973-edef-4ca9-b403-06071fc46e51)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
