### PR TITLE
style: Fix editorconfig indent for config/*config.php

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,7 @@ indent_style = space
 [build/psalm-baseline.xml]
 indent_size = 2
 indent_style = space
+
+[config/*config.php]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
*config.php is created with var_export, which indents lines with two spaces.

## How to test

1) Open config/config.php with a decent IDE
2) Add a new line

master: new line is indented with one tab (like other php code is)
here: new line is indented with two spaces (like the rest of the file)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
