### PR TITLE
[stable27] Clear progress bar text when hiding it

### DIFF
--- a/apps/files/js/operationprogressbar.js
+++ b/apps/files/js/operationprogressbar.js
@@ -29,6 +29,7 @@
 			$('#uploadprogressbar').fadeOut(function() {
 				self.$el.trigger(new $.Event('resized'));
 			});
+			this.setProgressBarText('', '');
 		},
 
 		hideCancelButton: function() {


### PR DESCRIPTION
When files are uploaded [the progress bar text is set accordingly](https://github.com/nextcloud/server/blob/eee7cbf5f2b285c33f08ac0139d3215ae45bd9eb/apps/files/js/file-upload.js#L1304-L1308). However, other operations that show the progress bar, like deleting files, [do not explicitly set any text](https://github.com/nextcloud/server/blob/cb5c1725d17aafbaf5686d86052538a281c6f222/apps/files/js/filelist.js#L2654-L2675). Due to that, when the progress bar was shown again after uploading files the text did not match the operation. To solve that now the text is cleared when the progress bar is hidden (it is not cleared when it is shown as in some cases [the text is set already before showing the progress bar](https://github.com/nextcloud/server/blob/eee7cbf5f2b285c33f08ac0139d3215ae45bd9eb/apps/files/js/file-upload.js#L1216-L1218)).

In Nextcloud 28 this issue no longer happens after moving the Files app to Vue, so the fix is only for Nextcloud 27 and below.

## How to test

- Open the Files app
- Upload one or more files
- Delete one or more files

### Result with this pull request

The progress bar shown while deleting the file does not have any text

### Result without this pull request

The progress bar shown while deleting the file has `Uploading...` or something similar (the last text shown when uploading the file)
