### PR TITLE
ci: skip cypress install

### DIFF
--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -23,7 +23,7 @@ jobs:
           require: write
 
       - name: Add reaction on start
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.1
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           repository: ${{ github.event.repository.full_name }}
@@ -53,8 +53,14 @@ jobs:
     needs: init
 
     steps:
+      - name: Restore cached git repository
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: .git
+          key: git-repo
+
       - name: Checkout ${{ needs.init.outputs.head_ref }}
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
@@ -66,11 +72,11 @@ jobs:
           git config --local user.name "nextcloud-command"
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.1
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
         id: package-engines-versions
         with:
-          fallbackNode: '^16'
-          fallbackNpm: '^7'
+          fallbackNode: '^20'
+          fallbackNpm: '^9'
 
       - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
@@ -82,6 +88,8 @@ jobs:
         run: npm i -g npm@"${{ steps.package-engines-versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present
@@ -108,7 +116,7 @@ jobs:
           git push --force origin ${{ needs.init.outputs.head_ref }}
 
       - name: Add reaction on failure
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.1
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
         if: failure()
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -55,6 +55,9 @@ jobs:
           npm ci
           TESTING=true npm run build --if-present
 
+      - name: Show cypress version
+        run: npm run cypress:version
+
       - name: Save context
         uses: buildjet/cache/save@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
         with:

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'src/**'
-      - 'apps/**/appinfo/info.xml'
+      - 'appinfo/info.xml'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
@@ -38,14 +38,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.1
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
         id: versions
         with:
-          fallbackNode: '^16'
-          fallbackNpm: '^7'
+          fallbackNode: '^20'
+          fallbackNpm: '^9'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
@@ -56,6 +56,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: npm ci
 
       - name: Lint

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -32,6 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: versions
 
+    env:
+      CYPRESS_INSTALL_BINARY: 0
+
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -47,9 +50,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Show cypress version
+        run: npm run cypress:version
+
       - name: Test and process coverage
         run: npm run test:coverage
-  
+
       - name: Collect coverage
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
@@ -59,6 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: versions
 
+    env:
+      CYPRESS_INSTALL_BINARY: 0
+
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -73,6 +82,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Show cypress version
+        run: npm run cypress:version
 
       - name: Test
         run: npm run test:jsunit
@@ -81,6 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: versions
 
+    env:
+      CYPRESS_INSTALL_BINARY: 0
+
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -95,6 +110,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Show cypress version
+        run: npm run cypress:version
 
       - name: Run compile
         run: ./build/compile-handlebars-templates.sh

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - '.github/workflows/**'
       - 'src/**'
-      - 'apps/**/appinfo/info.xml'
+      - 'appinfo/info.xml'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
@@ -37,14 +37,14 @@ jobs:
     name: node
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.1
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
         id: versions
         with:
-          fallbackNode: '^16'
-          fallbackNpm: '^7'
+          fallbackNode: '^20'
+          fallbackNpm: '^9'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
@@ -55,6 +55,8 @@ jobs:
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
       - name: Install dependencies & build
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ matrix.branches }}
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.1
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
         id: versions
         with:
-          fallbackNode: '^16'
-          fallbackNpm: '^7'
+          fallbackNode: '^20'
+          fallbackNpm: '^9'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3
@@ -49,6 +49,8 @@ jobs:
 
       - name: Run npm ci and npm run build
         if: always()
+        env:
+          CYPRESS_INSTALL_BINARY: 0
         run: |
           npm ci
           npm run build --if-present

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "cypress": "npm run cypress:component && npm run cypress:e2e",
     "cypress:component": "cypress run --component",
     "cypress:e2e": "cypress run --e2e",
-    "cypress:gui": "cypress open"
+    "cypress:gui": "cypress open",
+    "cypress:version": "cypress version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Unnecessary to download the cypress binary if we don't run cypress

Workflow eslint:

![image](https://github.com/nextcloud/server/assets/3902676/0a363930-4bab-4e7e-8bff-3d0942cd8571)

Workflow cypress:

![image](https://github.com/nextcloud/server/assets/3902676/a0c7f60d-16e5-49ed-8a1a-1577af9f480b)


## TODO

- [x] Does it work?
- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
