### PR TITLE
dav: fix wrong decoding of pluses in URLs

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -921,7 +921,7 @@ class DAV extends Common {
 			}
 
 			foreach ($responses as $file => $response) {
-				$file = urldecode($file);
+				$file = rawurldecode($file);
 				$file = substr($file, strlen($this->root));
 				$file = $this->cleanPath($file);
 				$this->statCache->set($file, $response);


### PR DESCRIPTION
## Summary
PHP's urldecode function does not decode URLs according to RFC 3986, but according to the HTML 4.01 query parameter
encoding. This results in pluses being wrongly decoded to spaces even though they should not be decoded at all.

Use rawurldecode instead, which follows RFC 3986 properly.

This fixes an issue where files on DAV shares containing pluses were incorrectly decoded to spaces.

Fixes #15849
Fixes #40943

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
