### PR TITLE
fix(userstatus): Sync migration version number with app version

### DIFF
--- a/apps/user_status/composer/composer/autoload_classmap.php
+++ b/apps/user_status/composer/composer/autoload_classmap.php
@@ -30,7 +30,7 @@ return array(
     'OCA\\UserStatus\\Migration\\Version0001Date20200602134824' => $baseDir . '/../lib/Migration/Version0001Date20200602134824.php',
     'OCA\\UserStatus\\Migration\\Version0002Date20200902144824' => $baseDir . '/../lib/Migration/Version0002Date20200902144824.php',
     'OCA\\UserStatus\\Migration\\Version1000Date20201111130204' => $baseDir . '/../lib/Migration/Version1000Date20201111130204.php',
-    'OCA\\UserStatus\\Migration\\Version2301Date20210809144824' => $baseDir . '/../lib/Migration/Version2301Date20210809144824.php',
+    'OCA\\UserStatus\\Migration\\Version1003Date20210809144824' => $baseDir . '/../lib/Migration/Version1003Date20210809144824.php',
     'OCA\\UserStatus\\ResponseDefinitions' => $baseDir . '/../lib/ResponseDefinitions.php',
     'OCA\\UserStatus\\Service\\JSDataService' => $baseDir . '/../lib/Service/JSDataService.php',
     'OCA\\UserStatus\\Service\\PredefinedStatusService' => $baseDir . '/../lib/Service/PredefinedStatusService.php',

--- a/apps/user_status/composer/composer/autoload_static.php
+++ b/apps/user_status/composer/composer/autoload_static.php
@@ -45,7 +45,7 @@ class ComposerStaticInitUserStatus
         'OCA\\UserStatus\\Migration\\Version0001Date20200602134824' => __DIR__ . '/..' . '/../lib/Migration/Version0001Date20200602134824.php',
         'OCA\\UserStatus\\Migration\\Version0002Date20200902144824' => __DIR__ . '/..' . '/../lib/Migration/Version0002Date20200902144824.php',
         'OCA\\UserStatus\\Migration\\Version1000Date20201111130204' => __DIR__ . '/..' . '/../lib/Migration/Version1000Date20201111130204.php',
-        'OCA\\UserStatus\\Migration\\Version2301Date20210809144824' => __DIR__ . '/..' . '/../lib/Migration/Version2301Date20210809144824.php',
+        'OCA\\UserStatus\\Migration\\Version1003Date20210809144824' => __DIR__ . '/..' . '/../lib/Migration/Version1003Date20210809144824.php',
         'OCA\\UserStatus\\ResponseDefinitions' => __DIR__ . '/..' . '/../lib/ResponseDefinitions.php',
         'OCA\\UserStatus\\Service\\JSDataService' => __DIR__ . '/..' . '/../lib/Service/JSDataService.php',
         'OCA\\UserStatus\\Service\\PredefinedStatusService' => __DIR__ . '/..' . '/../lib/Service/PredefinedStatusService.php',

--- a/apps/user_status/lib/Migration/Version1003Date20210809144824.php
+++ b/apps/user_status/lib/Migration/Version1003Date20210809144824.php
@@ -33,7 +33,7 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * @package OCA\UserStatus\Migration
  */
-class Version2301Date20210809144824 extends SimpleMigrationStep {
+class Version1003Date20210809144824 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
@@ -48,10 +48,12 @@ class Version2301Date20210809144824 extends SimpleMigrationStep {
 
 		$statusTable = $schema->getTable('user_status');
 
-		$statusTable->addColumn('is_backup', Types::BOOLEAN, [
-			'notnull' => false,
-			'default' => false,
-		]);
+		if (!$statusTable->hasColumn('is_backup')) {
+			$statusTable->addColumn('is_backup', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
 
 		return $schema;
 	}


### PR DESCRIPTION
## Summary

The migration version number was synced with server in https://github.com/nextcloud/server/pull/28403. The app was at 1.3.0. Now we are at 1.8.0 and it just feels wrong to continue the out-of-sync naming in https://github.com/nextcloud/server/pull/40564.

Renaming causes the migration to run again if it hasn't run already. It's adjusted to not cause an issue in that case.

I'm also open for other ideas that bring the versioning state into consistency.

## TODO

- [x] Adjust version number
- [x] Test an upgrade/migration

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
