### PR TITLE
Read apporder from configuration value

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -825,13 +825,26 @@ class AppManager implements IAppManager {
 	public function getDefaultAppForUser(?IUser $user = null): string {
 		// Set fallback to always-enabled files app
 		$appId = 'files';
-		$defaultApps = explode(',', $this->config->getSystemValueString('defaultapp', 'dashboard,files'));
+		$defaultApps = explode(',', $this->config->getSystemValueString('defaultapp', ''));
 
 		$user ??= $this->userSession->getUser();
 
 		if ($user !== null) {
 			$userDefaultApps = explode(',', $this->config->getUserValue($user->getUID(), 'core', 'defaultapp'));
 			$defaultApps = array_filter(array_merge($userDefaultApps, $defaultApps));
+			if (empty($defaultApps)) {
+				/* Fallback on user defined apporder */
+				$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
+				if (!empty($customOrders)) {
+					$customOrders = array_map('min', $customOrders);
+					asort($customOrders);
+					$defaultApps = array_keys($customOrders);
+				}
+			}
+		}
+
+		if (empty($defaultApps)) {
+			$defaultApps = ['dashboard','files'];
 		}
 
 		// Find the first app that is enabled for the current user

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -826,6 +826,7 @@ class AppManager implements IAppManager {
 		// Set fallback to always-enabled files app
 		$appId = 'files';
 		$defaultApps = explode(',', $this->config->getSystemValueString('defaultapp', ''));
+		$defaultApps = array_filter($defaultApps);
 
 		$user ??= $this->userSession->getUser();
 

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -284,16 +284,10 @@ class NavigationManager implements INavigationManager {
 			return;
 		}
 
-		$adminCustomOrders = json_decode($this->config->getSystemValueString('apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
-		$forceAdminOrder = $this->config->getSystemValueBool('apporderForce', false);
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();
 			$apps = $this->appManager->getEnabledAppsForUser($user);
-			if ($forceAdminOrder) {
-				$customOrders = [];
-			} else {
-				$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
-			}
+			$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
 		} else {
 			$apps = $this->appManager->getInstalledApps();
 			$customOrders = [];
@@ -325,7 +319,7 @@ class NavigationManager implements INavigationManager {
 				}
 				$l = $this->l10nFac->get($app);
 				$id = $nav['id'] ?? $app . ($key === 0 ? '' : $key);
-				$order = $customOrders[$app][$key] ?? $adminCustomOrders[$app][$key] ?? $nav['order'] ?? 100;
+				$order = $customOrders[$app][$key] ?? $nav['order'] ?? 100;
 				$type = $nav['type'];
 				$route = !empty($nav['route']) ? $this->urlGenerator->linkToRoute($nav['route']) : '';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -284,10 +284,16 @@ class NavigationManager implements INavigationManager {
 			return;
 		}
 
+		$adminCustomOrders = json_decode($this->config->getSystemValueString('apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
+		$forceAdminOrder = $this->config->getSystemValueBool('apporderForce', false);
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();
 			$apps = $this->appManager->getEnabledAppsForUser($user);
-			$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
+			if ($forceAdminOrder) {
+				$customOrders = [];
+			} else {
+				$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
+			}
 		} else {
 			$apps = $this->appManager->getInstalledApps();
 			$customOrders = [];
@@ -319,7 +325,7 @@ class NavigationManager implements INavigationManager {
 				}
 				$l = $this->l10nFac->get($app);
 				$id = $nav['id'] ?? $app . ($key === 0 ? '' : $key);
-				$order = $customOrders[$app][$key] ?? $nav['order'] ?? 100;
+				$order = $customOrders[$app][$key] ?? $adminCustomOrders[$app][$key] ?? $nav['order'] ?? 100;
 				$type = $nav['type'];
 				$route = !empty($nav['route']) ? $this->urlGenerator->linkToRoute($nav['route']) : '';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -285,10 +285,14 @@ class NavigationManager implements INavigationManager {
 		}
 
 		if ($this->userSession->isLoggedIn()) {
-			$apps = $this->appManager->getEnabledAppsForUser($this->userSession->getUser());
+			$user = $this->userSession->getUser();
+			$apps = $this->appManager->getEnabledAppsForUser($user);
+			$customOrders = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
 		} else {
 			$apps = $this->appManager->getInstalledApps();
+			$customOrders = [];
 		}
+
 
 		foreach ($apps as $app) {
 			if (!$this->userSession->isLoggedIn() && !$this->appManager->isEnabledForUser($app, $this->userSession->getUser())) {
@@ -315,7 +319,7 @@ class NavigationManager implements INavigationManager {
 				}
 				$l = $this->l10nFac->get($app);
 				$id = $nav['id'] ?? $app . ($key === 0 ? '' : $key);
-				$order = isset($nav['order']) ? $nav['order'] : 100;
+				$order = $customOrders[$app][$key] ?? $nav['order'] ?? 100;
 				$type = $nav['type'];
 				$route = !empty($nav['route']) ? $this->urlGenerator->linkToRoute($nav['route']) : '';
 				$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -607,21 +607,43 @@ class AppManagerTest extends TestCase {
 			// none specified, default to files
 			[
 				'',
+				'',
+				'{}',
 				'files',
 			],
 			// unexisting or inaccessible app specified, default to files
 			[
 				'unexist',
+				'',
+				'{}',
 				'files',
 			],
 			// non-standard app
 			[
 				'settings',
+				'',
+				'{}',
 				'settings',
 			],
 			// non-standard app with fallback
 			[
 				'unexist,settings',
+				'',
+				'{}',
+				'settings',
+			],
+			// user-customized defaultapp
+			[
+				'unexist,settings',
+				'files',
+				'{"settings":[1],"files":[2]}',
+				'files',
+			],
+			// user-customized apporder fallback
+			[
+				'',
+				'',
+				'{"settings":[1],"files":[2]}',
 				'settings',
 			],
 		];
@@ -630,7 +652,7 @@ class AppManagerTest extends TestCase {
 	/**
 	 * @dataProvider provideDefaultApps
 	 */
-	public function testGetDefaultAppForUser($defaultApps, $expectedApp) {
+	public function testGetDefaultAppForUser($defaultApps, $userDefaultApps, $userApporder, $expectedApp) {
 		$user = $this->newUser('user1');
 
 		$this->userSession->expects($this->once())
@@ -642,10 +664,12 @@ class AppManagerTest extends TestCase {
 			->with('defaultapp', $this->anything())
 			->willReturn($defaultApps);
 
-		$this->config->expects($this->once())
+		$this->config->expects($this->atLeastOnce())
 			->method('getUserValue')
-			->with('user1', 'core', 'defaultapp')
-			->willReturn('');
+			->willReturnMap([
+				['user1', 'core', 'defaultapp', '', $userDefaultApps],
+				['user1', 'core', 'apporder', '[]', $userApporder],
+			]);
 
 		$this->assertEquals($expectedApp, $this->manager->getDefaultAppForUser());
 	}


### PR DESCRIPTION
* Part of https://github.com/nextcloud/server/issues/40254

## Summary

Backend for allowing users to set apporder.

- [x] First application also be set as default app if no default app was set
- [x] ~Allow admin to provide default order~
- [x] ~Allow admin to force default order~

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
