### PR TITLE
fix(build): Ignore `default-source.svg` from image optimization

### DIFF
--- a/build/image-optimization.sh
+++ b/build/image-optimization.sh
@@ -4,17 +4,17 @@ set -e
 
 OPTIPNG=$(which optipng)
 if ! [ -x "$OPTIPNG" ]; then
-	echo "optipng executable not found, please install" >&2
+	echo -e "\033[0;31moptipng executable not found, please install\033[0m" >&2
 	exit 1
 fi
 JPEGOPTIM=$(which jpegoptim)
 if ! [ -x "$JPEGOPTIM" ]; then
-	echo "jpegoptim executable not found, please install" >&2
+	echo -e "\033[0;31mjpegoptim executable not found, please install\033[0m" >&2
 	exit 2
 fi
 SCOUR=$(which scour)
 if ! [ -x "$SCOUR" ]; then
-	echo "scour executable not found, please install" >&2
+	echo -e "\033[0;31mscour executable not found, please install\033[0m" >&2
 	exit 3
 fi
 
@@ -37,25 +37,25 @@ function recursive_optimize_images() {
 	DIR_NAME=${PWD##*/}
 
 	if [[ "$DIR_NAME" == "3rdparty" ]]; then
-		echo "Ignoring 3rdparty for image optimization"
+		echo -e "\033[0;36mIgnoring 3rdparty for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "build" ]]; then
-		echo "Ignoring build for image optimization"
+		echo -e "\033[0;36mIgnoring build for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "cypress" ]]; then
-		echo "Ignoring cypress for image optimization"
+		echo -e "\033[0;36mIgnoring cypress for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "node_modules" ]]; then
-		echo "Ignoring node_modules for image optimization"
+		echo -e "\033[0;36mIgnoring node_modules for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "tests" ]]; then
-		echo "Ignoring tests for image optimization"
+		echo -e "\033[0;36mIgnoring tests for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "vendor" ]]; then
-		echo "Ignoring vendor for image optimization"
+		echo -e "\033[0;36mIgnoring vendor for image optimization\033[0m"
 		return
 	elif [[ "$DIR_NAME" == "vendor-bin" ]]; then
-		echo "Ignoring vendor-bin for image optimization"
+		echo -e "\033[0;36mIgnoring vendor-bin for image optimization\033[0m"
 		return
 	fi
 
@@ -80,6 +80,11 @@ function recursive_optimize_images() {
 	do
 		[[ -e "$svg" ]] || break
 
+		if [[ "$svg" == "default-source.svg" ]]; then
+			echo -e "\033[0;36mIgnoring $svg image optimization\033[0m"
+			continue
+		fi
+
 		mv $svg $svg.opttmp
 		$SCOUR --create-groups \
 			--enable-id-stripping \
@@ -100,7 +105,7 @@ function recursive_optimize_images() {
 
 		if [[ -d "$dir" ]]; then
 			if git check-ignore $dir -q ; then
-				echo "$dir is not shipped. Ignoring image optimization"
+				echo -e "\033[0;36m$dir is not shipped. Ignoring image optimization\033[0m"
 				continue
 			fi
 


### PR DESCRIPTION
* Resolves: #40410 

## Summary

![image](https://github.com/nextcloud/server/assets/213943/723b0d7f-8506-4dfc-b507-d391773e12b3)

- Added colors for the skipped entries to recognize them easier
- Added the intentional "broken" svg to the ignore list, otherwise #40329 will happen just again

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
