### PR TITLE
Allow PHP 8.3

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ "8.0", "8.1", "8.2" ]
+        php-versions: [ "8.0", "8.1", "8.2", "8.3" ]
 
     name: php-lint
 

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.0','8.3']
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install -y ffmpeg imagemagick libmagickcore-6.q16-3-extra
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@9c77701ae57b0c47f6732beebfbdec76e4e5c90a #debian bookworm fix
+        uses: shivammathur/setup-php@72ae4ccbe57f82bbe08411e84e2130bd4ba1c10f #v2.25.5
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ctype, curl, dom, fileinfo, gd, imagick, intl, json, mbstring, openssl, pdo_sqlite, posix, sqlite, xml, zip, apcu

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -48,8 +48,7 @@ jobs:
           coverage: none
           ini-file: development
           ini-values:
-            apc.enabled=on,
-            apc.enable_cli=on
+            apc.enabled=on, apc.enable_cli=on, disable_functions= # https://github.com/shivammathur/setup-php/discussions/573
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -46,6 +46,7 @@ jobs:
           extensions: ctype, curl, dom, fileinfo, gd, imagick, intl, json, mbstring, openssl, pdo_sqlite, posix, sqlite, xml, zip, apcu
           tools: phpunit:9
           coverage: none
+          ini-file: development
           ini-values:
             apc.enabled=on,
             apc.enable_cli=on

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -33,10 +33,10 @@ if (PHP_VERSION_ID < 80000) {
 	exit(1);
 }
 
-// Show warning if >= PHP 8.3 is used as Nextcloud is not compatible with >= PHP 8.3 for now
-if (PHP_VERSION_ID >= 80300) {
+// Show warning if >= PHP 8.4 is used as Nextcloud is not compatible with >= PHP 8.4 for now
+if (PHP_VERSION_ID >= 80400) {
 	http_response_code(500);
-	echo 'This version of Nextcloud is not compatible with PHP>=8.3.<br/>';
+	echo 'This version of Nextcloud is not compatible with PHP>=8.4.<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '.';
 	exit(1);
 }


### PR DESCRIPTION
* Resolves: #38828

## Summary

The test suites in https://github.com/nextcloud/server/pull/39796 are now passing on 8.3.
This PR allows PHP 8.3 in version check, and adds it to lint CI.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required https://github.com/nextcloud/documentation/pull/11195
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
