### PR TITLE
Use OCP\Util::getL10N instead of OC::$server->getL10N

### DIFF
--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -48,7 +48,7 @@ class Helper {
 	public static function buildFileStorageStatistics($dir) {
 		// information about storage capacities
 		$storageInfo = \OC_Helper::getStorageInfo($dir);
-		$l = \OC::$server->getL10N('files');
+		$l = \OCP\Util::getL10N('files');
 		$maxUploadFileSize = \OCP\Util::maxUploadFilesize($dir, $storageInfo['free']);
 		$maxHumanFileSize = \OCP\Util::humanFileSize($maxUploadFileSize);
 		$maxHumanFileSize = $l->t('Upload (max. %s)', [$maxHumanFileSize]);

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -152,7 +152,7 @@ class MountConfig {
 	 * @param Backend[] $backends
 	 */
 	public static function dependencyMessage(array $backends): string {
-		$l = \OC::$server->getL10N('files_external');
+		$l = \OCP\Util::getL10N('files_external');
 		$message = '';
 		$dependencyGroups = [];
 

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -1069,7 +1069,7 @@ class Trashbin {
 	private static function getUniqueFilename($location, $filename, View $view) {
 		$ext = pathinfo($filename, PATHINFO_EXTENSION);
 		$name = pathinfo($filename, PATHINFO_FILENAME);
-		$l = \OC::$server->getL10N('files_trashbin');
+		$l = \OCP\Util::getL10N('files_trashbin');
 
 		$location = '/' . trim($location, '/');
 

--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -50,7 +50,7 @@ try {
 	}
 
 	if ($mapping === null || !$result) {
-		$l = \OC::$server->getL10N('user_ldap');
+		$l = \OCP\Util::getL10N('user_ldap');
 		throw new \Exception($l->t('Failed to clear the mappings.'));
 	}
 	\OC_JSON::success();

--- a/apps/user_ldap/ajax/deleteConfiguration.php
+++ b/apps/user_ldap/ajax/deleteConfiguration.php
@@ -35,6 +35,6 @@ $helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig(), \OC::$server->get
 if ($helper->deleteServerConfiguration($prefix)) {
 	\OC_JSON::success();
 } else {
-	$l = \OC::$server->getL10N('user_ldap');
+	$l = \OCP\Util::getL10N('user_ldap');
 	\OC_JSON::error(['message' => $l->t('Failed to delete the server configuration')]);
 }

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -30,7 +30,7 @@
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$l = \OC::$server->getL10N('user_ldap');
+$l = \OCP\Util::getL10N('user_ldap');
 
 $ldapWrapper = new OCA\User_LDAP\LDAP();
 $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $_POST['ldap_serverconfig_chooser']);

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -31,7 +31,7 @@
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$l = \OC::$server->getL10N('user_ldap');
+$l = \OCP\Util::getL10N('user_ldap');
 
 if (!isset($_POST['action'])) {
 	\OC_JSON::error(['message' => $l->t('No action specified')]);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -354,7 +354,7 @@ class Access extends LDAPUtility {
 			return @$this->invokeLDAPMethod('exopPasswd', $userDN, '', $password) ||
 				@$this->invokeLDAPMethod('modReplace', $userDN, $password);
 		} catch (ConstraintViolationException $e) {
-			throw new HintException('Password change rejected.', \OC::$server->getL10N('user_ldap')->t('Password change rejected. Hint: ') . $e->getMessage(), (int)$e->getCode());
+			throw new HintException('Password change rejected.', \OCP\Util::getL10N('user_ldap')->t('Password change rejected. Hint: ') . $e->getMessage(), (int)$e->getCode());
 		}
 	}
 

--- a/core/strings.php
+++ b/core/strings.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
  *
  */
 //some strings that are used in /lib but won't be translatable unless they are in /core too
-$l = \OC::$server->getL10N('core');
+$l = \OCP\Util::getL10N('core');
 $l->t("Personal");
 $l->t("Users");
 $l->t("Apps");

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1846,19 +1846,19 @@ class View {
 			[$storage, $internalPath] = $this->resolvePath($path);
 			$storage->verifyPath($internalPath, $fileName);
 		} catch (ReservedWordException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OCP\Util::getL10N('lib');
 			throw new InvalidPathException($l->t('File name is a reserved word'));
 		} catch (InvalidCharacterInPathException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OCP\Util::getL10N('lib');
 			throw new InvalidPathException($l->t('File name contains at least one invalid character'));
 		} catch (FileNameTooLongException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OCP\Util::getL10N('lib');
 			throw new InvalidPathException($l->t('File name is too long'));
 		} catch (InvalidDirectoryException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OCP\Util::getL10N('lib');
 			throw new InvalidPathException($l->t('Dot files are not allowed'));
 		} catch (EmptyFileNameException $ex) {
-			$l = \OC::$server->getL10N('lib');
+			$l = \OCP\Util::getL10N('lib');
 			throw new InvalidPathException($l->t('Empty filename is not allowed'));
 		}
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1724,7 +1724,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @param string $app appid
 	 * @param string $lang
 	 * @return IL10N
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 use \OCP\Util::getL10N instead
 	 */
 	public function getL10N($app, $lang = null) {
 		return $this->get(IFactory::class)->get($app, $lang);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1724,7 +1724,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @param string $app appid
 	 * @param string $lang
 	 * @return IL10N
-	 * @deprecated 20.0.0 use \OCP\Util::getL10N instead
+	 * @deprecated 20.0.0 use DI of IL10N instead, or \OCP\Util::getL10N as a last resort
 	 */
 	public function getL10N($app, $lang = null) {
 		return $this->get(IFactory::class)->get($app, $lang);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1724,7 +1724,7 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @param string $app appid
 	 * @param string $lang
 	 * @return IL10N
-	 * @deprecated 20.0.0 use DI of IL10N instead, or \OCP\Util::getL10N as a last resort
+	 * @deprecated 20.0.0 use DI of {@see IL10N} or {@see IFactory} instead, or {@see \OCP\Util::getL10N()} as a last resort
 	 */
 	public function getL10N($app, $lang = null) {
 		return $this->get(IFactory::class)->get($app, $lang);

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -256,8 +256,8 @@ class Share extends Constants {
 	 * @throws \Exception
 	 */
 	public static function getBackend($itemType) {
-		$l = \OC::$server->getL10N('lib');
-		$logger = \OC::$server->get(LoggerInterface::class);
+		$l = \OCP\Util::getL10N('lib');
+		$logger = \OCP\Server::get(LoggerInterface::class);
 		if (isset(self::$backends[$itemType])) {
 			return self::$backends[$itemType];
 		} elseif (isset(self::$backendTypes[$itemType]['class'])) {

--- a/lib/private/Tags.php
+++ b/lib/private/Tags.php
@@ -235,7 +235,7 @@ class Tags implements ITags {
 		}
 
 		if ($tagId === false) {
-			$l10n = \OC::$server->getL10N('core');
+			$l10n = \OCP\Util::getL10N('core');
 			throw new \Exception(
 				$l10n->t('Could not find category "%s"', [$tag])
 			);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -249,7 +249,7 @@ class TemplateLayout extends \OC_Template {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)
 			// see https://github.com/nextcloud/server/pull/22636 for details
 			$jsConfigHelper = new JSConfigHelper(
-				\OC::$server->getL10N('lib'),
+				\OCP\Util::getL10N('lib'),
 				\OCP\Server::get(Defaults::class),
 				\OC::$server->getAppManager(),
 				\OC::$server->getSession(),

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -445,7 +445,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @throws \InvalidArgumentException
 	 */
 	public function createUserFromBackend($uid, $password, UserInterface $backend) {
-		$l = \OC::$server->getL10N('lib');
+		$l = \OCP\Util::getL10N('lib');
 
 		$this->validateUserId($uid, true);
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -367,7 +367,7 @@ class Session implements IUserSession, Emitter {
 		if (!$user->isEnabled()) {
 			// disabled users can not log in
 			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-			$message = \OC::$server->getL10N('lib')->t('User disabled');
+			$message = \OCP\Util::getL10N('lib')->t('User disabled');
 			throw new LoginException($message);
 		}
 
@@ -406,7 +406,7 @@ class Session implements IUserSession, Emitter {
 			return true;
 		}
 
-		$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
+		$message = \OCP\Util::getL10N('lib')->t('Login canceled by app');
 		throw new LoginException($message);
 	}
 

--- a/lib/public/Federation/Exceptions/ActionNotSupportedException.php
+++ b/lib/public/Federation/Exceptions/ActionNotSupportedException.php
@@ -38,7 +38,7 @@ class ActionNotSupportedException extends HintException {
 	 *
 	 */
 	public function __construct($action) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OCP\Util::getL10N('federation');
 		$message = 'Action "' . $action . '" not supported or implemented.';
 		$hint = $l->t('Action "%s" not supported or implemented.', [$action]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/AuthenticationFailedException.php
+++ b/lib/public/Federation/Exceptions/AuthenticationFailedException.php
@@ -38,7 +38,7 @@ class AuthenticationFailedException extends HintException {
 	 *
 	 */
 	public function __construct() {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OCP\Util::getL10N('federation');
 		$message = 'Authentication failed, wrong token or provider ID given';
 		$hint = $l->t('Authentication failed, wrong token or provider ID given');
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/BadRequestException.php
+++ b/lib/public/Federation/Exceptions/BadRequestException.php
@@ -45,7 +45,7 @@ class BadRequestException extends HintException {
 	 * @param array $missingParameters
 	 */
 	public function __construct(array $missingParameters) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OCP\Util::getL10N('federation');
 		$this->parameterList = $missingParameters;
 		$parameterList = implode(',', $missingParameters);
 		$message = 'Parameters missing in order to complete the request. Missing Parameters: ' . $parameterList;

--- a/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderAlreadyExistsException.php
@@ -42,7 +42,7 @@ class ProviderAlreadyExistsException extends HintException {
 	 * @param string $existingProviderName name of cloud federation provider which already use the same ID
 	 */
 	public function __construct($newProviderId, $existingProviderName) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OCP\Util::getL10N('federation');
 		$message = 'ID "' . $newProviderId . '" already used by cloud federation provider "' . $existingProviderName . '"';
 		$hint = $l->t('ID "%1$s" already used by cloud federation provider "%2$s"', [$newProviderId, $existingProviderName]);
 		parent::__construct($message, $hint);

--- a/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
+++ b/lib/public/Federation/Exceptions/ProviderDoesNotExistsException.php
@@ -39,7 +39,7 @@ class ProviderDoesNotExistsException extends HintException {
 	 * @param string $providerId cloud federation provider ID
 	 */
 	public function __construct($providerId) {
-		$l = \OC::$server->getL10N('federation');
+		$l = \OCP\Util::getL10N('federation');
 		$message = 'Cloud Federation Provider with ID: "' . $providerId . '" does not exist.';
 		$hint = $l->t('Cloud Federation Provider with ID: "%s" does not exist.', [$providerId]);
 		parent::__construct($message, $hint);

--- a/lib/public/Files/LockNotAcquiredException.php
+++ b/lib/public/Files/LockNotAcquiredException.php
@@ -43,7 +43,7 @@ class LockNotAcquiredException extends \Exception {
 	 * @since 7.0.0
 	 */
 	public function __construct($path, $lockType, $code = 0, \Exception $previous = null) {
-		$message = \OC::$server->getL10N('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
+		$message = \OCP\Util::getL10N('core')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
 		parent::__construct($message, $code, $previous);
 	}
 

--- a/lib/public/Files/StorageAuthException.php
+++ b/lib/public/Files/StorageAuthException.php
@@ -36,7 +36,7 @@ class StorageAuthException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OCP\Util::getL10N('core');
 		parent::__construct($l->t('Storage unauthorized. %s', [$message]), self::STATUS_UNAUTHORIZED, $previous);
 	}
 }

--- a/lib/public/Files/StorageBadConfigException.php
+++ b/lib/public/Files/StorageBadConfigException.php
@@ -36,7 +36,7 @@ class StorageBadConfigException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OCP\Util::getL10N('core');
 		parent::__construct($l->t('Storage incomplete configuration. %s', [$message]), self::STATUS_INCOMPLETE_CONF, $previous);
 	}
 }

--- a/lib/public/Files/StorageConnectionException.php
+++ b/lib/public/Files/StorageConnectionException.php
@@ -36,7 +36,7 @@ class StorageConnectionException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OCP\Util::getL10N('core');
 		parent::__construct($l->t('Storage connection error. %s', [$message]), self::STATUS_NETWORK_ERROR, $previous);
 	}
 }

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -56,7 +56,7 @@ class StorageNotAvailableException extends HintException {
 	 * @since 6.0.0
 	 */
 	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OCP\Util::getL10N('core');
 		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}
 

--- a/lib/public/Files/StorageTimeoutException.php
+++ b/lib/public/Files/StorageTimeoutException.php
@@ -36,7 +36,7 @@ class StorageTimeoutException extends StorageNotAvailableException {
 	 * @since 9.0.0
 	 */
 	public function __construct($message = '', \Exception $previous = null) {
-		$l = \OC::$server->getL10N('core');
+		$l = \OCP\Util::getL10N('core');
 		parent::__construct($l->t('Storage connection timeout. %s', [$message]), self::STATUS_TIMEOUT, $previous);
 	}
 }

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -126,13 +126,10 @@ class Util {
 
 	/**
 	 * get l10n object
-	 * @param string $application
-	 * @param string|null $language
-	 * @return \OCP\IL10N
 	 * @since 6.0.0 - parameter $language was added in 8.0.0
 	 */
-	public static function getL10N($application, $language = null) {
-		return \OC::$server->getL10N($application, $language);
+	public static function getL10N(string $application, ?string $language = null): IL10N {
+		return Server::get(\OCP\L10N\IFactory::class)->get($application, $language);
 	}
 
 	/**

--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -34,7 +34,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->formatter = new \OC\DateTimeFormatter(new \DateTimeZone('UTC'), \OC::$server->getL10N('lib', 'en'));
+		$this->formatter = new \OC\DateTimeFormatter(new \DateTimeZone('UTC'), \OCP\Util::getL10N('lib', 'en'));
 	}
 
 	protected function getTimestampAgo($time, $seconds = 0, $minutes = 0, $hours = 0, $days = 0, $years = 0) {
@@ -43,7 +43,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	public function formatTimeSpanData() {
 		$time = 1416916800; // Use a fixed timestamp so we don't switch days/years with the getTimestampAgo
-		$deL10N = \OC::$server->getL10N('lib', 'de');
+		$deL10N = \OCP\Util::getL10N('lib', 'de');
 		return [
 			['seconds ago',	$time, $time],
 			['in a few seconds', $time + 5 , $time],
@@ -84,7 +84,7 @@ class DateTimeFormatterTest extends TestCase {
 
 	public function formatDateSpanData() {
 		$time = 1416916800; // Use a fixed timestamp so we don't switch days/years with the getTimestampAgo
-		$deL10N = \OC::$server->getL10N('lib', 'de');
+		$deL10N = \OCP\Util::getL10N('lib', 'de');
 		return [
 			// Normal testing
 			['today',			$this->getTimestampAgo($time, 30, 15), $time],

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -201,12 +201,12 @@ class L10nTest extends TestCase {
 	}
 
 	public function testServiceGetLanguageCode() {
-		$l = \OC::$server->getL10N('lib', 'de');
+		$l = \OCP\Util::getL10N('lib', 'de');
 		$this->assertEquals('de', $l->getLanguageCode());
 	}
 
 	public function testWeekdayName() {
-		$l = \OC::$server->getL10N('lib', 'de');
+		$l = \OCP\Util::getL10N('lib', 'de');
 		$this->assertEquals('Mo.', $l->l('weekdayName', new \DateTime('2017-11-6'), ['width' => 'abbreviated']));
 	}
 


### PR DESCRIPTION
## Summary

`OCP` should not refer to private `OC` namespace, ever.
`$server->getL10N` is deprecated.
As there already was a helper in `OCP\Util`, I am using that instead of having to call tedious `\OCP\Server::get(OCP\L10N\IFactory::class)->get('appname')` each time.

## TODO

- [x] Do the same change in `core/` and `lib/private`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
