### PR TITLE
refactor: Use DBAL's executeQuery instead of query (deprecated)

### DIFF
--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -159,7 +159,7 @@ class Migrator {
 		$step = 0;
 		foreach ($sqls as $sql) {
 			$this->emit($sql, $step++, count($sqls));
-			$connection->query($sql);
+			$connection->executeQuery($sql);
 		}
 		if (!$connection->getDatabasePlatform() instanceof MySQLPlatform) {
 			$connection->commit();

--- a/lib/private/Repair/SqliteAutoincrement.php
+++ b/lib/private/Repair/SqliteAutoincrement.php
@@ -93,7 +93,7 @@ class SqliteAutoincrement implements IRepairStep {
 
 		$this->connection->beginTransaction();
 		foreach ($schemaDiff->toSql($this->connection->getDatabasePlatform()) as $sql) {
-			$this->connection->query($sql);
+			$this->connection->executeQuery($sql);
 		}
 		$this->connection->commit();
 	}


### PR DESCRIPTION
## Summary

Non-exhaustive clean-up of DBAL usage found reading related code.

## TODO

- [x] Fix code

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
