### PR TITLE
feat(backgroundjob): Schedule job after <timestamp>

### DIFF
--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -58,6 +58,19 @@ interface IJobList {
 	public function add($job, $argument = null): void;
 
 	/**
+	 * Add a job to the list but only run it after the given timestamp
+	 *
+	 * For cron background jobs this means the job will likely run shortly after the timestamp
+	 * has been reached. For ajax background jobs the job might only run when users are active
+	 * on the instance again.
+	 *
+	 * @param class-string<IJob> $job
+	 * @param mixed $argument The serializable argument to be passed to $job->run() when the job is executed
+	 * @since 28.0.0
+	 */
+	public function scheduleAfter(string $job, int $runAfter, $argument = null): void;
+
+	/**
 	 * Remove a job from the list
 	 *
 	 * @param IJob|class-string<IJob> $job

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -35,7 +35,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	 * @param IJob|class-string<IJob> $job
 	 * @param mixed $argument
 	 */
-	public function add($job, $argument = null): void {
+	public function add($job, $argument = null, int $firstCheck = null): void {
 		if (is_string($job)) {
 			/** @var IJob $job */
 			$job = \OCP\Server::get($job);
@@ -44,6 +44,10 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 		if (!$this->has($job, null)) {
 			$this->jobs[] = $job;
 		}
+	}
+
+	public function scheduleAfter(string $job, int $runAfter, $argument = null): void {
+		$this->add($job, $argument, $runAfter);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

For a planned execution in the future. Avoids a job that picked up again and again until it's time has come.

Credits go to https://github.com/nextcloud/server/blob/f8f437072ac13a4556dea18219d55f11466497e5/apps/dav/lib/BackgroundJob/UserStatusAutomation.php#L174-L177 and @nickvergessen.

## TODO

- [x] Adjust API

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - https://github.com/nextcloud/documentation/pull/11157
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
