### PR TITLE
fix(autocomplete): Fix missing user status on autocomplete endpoint

### DIFF
--- a/build/integration/collaboration_features/autocomplete.feature
+++ b/build/integration/collaboration_features/autocomplete.feature
@@ -15,12 +15,13 @@ Feature: autocomplete
       | auto | users |
       | autocomplete | users |
       | autocomplete2 | users |
+    And user "autocomplete" has status "dnd"
     When parameter "shareapi_restrict_user_enumeration_full_match" of app "core" is set to "no"
     Then get autocomplete for "auto"
-      | id | source |
-      | auto | users |
-      | autocomplete | users |
-      | autocomplete2 | users |
+      | id            | source | status |
+      | auto          | users  | ""     |
+      | autocomplete  | users  | {"status":"dnd","message":null,"icon":null,"clearAt":null} |
+      | autocomplete2 | users  | ""     |
 
 
   Scenario: getting autocomplete without enumeration

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -1,6 +1,10 @@
 default:
   autoload:
     '': "%paths.base%/../features/bootstrap"
+  formatters:
+    pretty:
+      output_styles:
+        comment: [ 'bright-blue' ]
   suites:
     default:
       paths:

--- a/build/integration/features/bootstrap/CollaborationContext.php
+++ b/build/integration/features/bootstrap/CollaborationContext.php
@@ -73,6 +73,9 @@ class CollaborationContext implements Context {
 			if (isset($expected['source'])) {
 				$data['source'] = $suggestion['source'];
 			}
+			if (isset($expected['status'])) {
+				$data['status'] = json_encode($suggestion['status']);
+			}
 			return $data;
 		}, $suggestions, $formData->getHash()));
 	}

--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -123,8 +123,8 @@ class AutoCompleteController extends OCSController {
 				/** @var ?string $subline */
 				$subline = array_key_exists('subline', $result) ? $result['subline'] : null;
 
-				/** @var ?string $status */
-				$status = array_key_exists('status', $result) && is_string($result['status']) ? $result['status'] : null;
+				/** @var ?array{status: string, message: ?string, icon: ?string, clearAt: ?int} $status */
+				$status = array_key_exists('status', $result) && is_array($result['status']) && !empty($result['status']) ? $result['status'] : null;
 
 				/** @var ?string $shareWithDisplayNameUnique */
 				$shareWithDisplayNameUnique = array_key_exists('shareWithDisplayNameUnique', $result) ? $result['shareWithDisplayNameUnique'] : null;

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -124,7 +124,12 @@ namespace OCA\Core;
  *     label: string,
  *     icon: string,
  *     source: string,
- *     status: string,
+ *     status: array{
+ *       status: string,
+ *       message: ?string,
+ *       icon: ?string,
+ *       clearAt: ?int,
+ *     }|string,
  *     subline: string,
  *     shareWithDisplayNameUnique: string,
  * }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -45,7 +45,38 @@
                         "type": "string"
                     },
                     "status": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "required": [
+                                    "status",
+                                    "message",
+                                    "icon",
+                                    "clearAt"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "icon": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "clearAt": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true
+                                    }
+                                }
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "subline": {
                         "type": "string"


### PR DESCRIPTION
* Discovered by @Antreesy when working with participant suggestions in Talk

## Summary

Regression from https://github.com/nextcloud/server/commit/1be836273ddba6e0ddb3509a1d898535df9fd169#diff-8a51ce62a02e28659acaa3f84252600107a22d2eb093d950f2c9c16fe6b96c8e 
It seems the "empty string" default had confused @provokateurin but the status value was actually always an array, as per: https://github.com/nextcloud/server/blob/6427863443883c434ed39a16ec0531abd746fad6/lib/private/Collaboration/Collaborators/UserPlugin.php#L155-L162

I now added an integration test to confirm it's working and stays working. I left the default/empty value untouched as empty string and basically restored the array data when a status is present.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
