### PR TITLE
fix(unifiedsearch): Allow searching for "0"

### DIFF
--- a/core/Controller/UnifiedSearchController.php
+++ b/core/Controller/UnifiedSearchController.php
@@ -100,7 +100,7 @@ class UnifiedSearchController extends OCSController {
 						   ?int $limit = null,
 						   $cursor = null,
 						   string $from = ''): DataResponse {
-		if (empty(trim($term))) {
+		if (trim($term) === "") {
 			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
 		}
 		[$route, $routeParameters] = $this->getRouteInformation($from);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36664
## Summary

empty("0") evaluates to true

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
