### PR TITLE
[stable27] ci(cypress) force run on Github runner

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
@@ -62,7 +62,7 @@ jobs:
           path: ./
 
   cypress:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: init
 
     strategy:
@@ -141,7 +141,7 @@ jobs:
           path: data.tar
 
   summary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [init, cypress]
 
     if: always()


### PR DESCRIPTION
It seems they only fail on the privater runners … to unblock 27.1.2 RC1 at least.