### PR TITLE
ci: skip puppeteer chrome download

### DIFF
--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Install dependencies & build
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           npm ci
           npm run build --if-present

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,6 +19,9 @@ jobs:
       nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
 
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: true
+
     steps:
       - name: Checkout server
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install dependencies
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: npm ci
 
       - name: Lint

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -65,6 +65,7 @@ jobs:
 
     env:
       CYPRESS_INSTALL_BINARY: 0
+      PUPPETEER_SKIP_DOWNLOAD: true
 
     steps:
       - name: Checkout
@@ -130,6 +131,7 @@ jobs:
 
     env:
       CYPRESS_INSTALL_BINARY: 0
+      PUPPETEER_SKIP_DOWNLOAD: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Install dependencies & build
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           npm ci
           npm run build --if-present

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         branches: ["main", "master", "stable27", "stable26", "stable25", "stable24"]
-  
+
     name: npm-audit-fix-${{ matrix.branches }}
 
     steps:
@@ -51,6 +51,7 @@ jobs:
         if: always()
         env:
           CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
         run: |
           npm ci
           npm run build --if-present


### PR DESCRIPTION
## Summary

A eslint job failed last week with:

```
npm ERR! path /home/runner/actions-runner/_work/server/server/node_modules/puppeteer
npm ERR! command failed
npm ERR! command sh -c node install.js
npm ERR! ERROR: Failed to set up Chrome r115.0.5790.170! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
```

Similar to [cypress](https://github.com/nextcloud/server/pull/40589) there is no need to download chrome to run eslint / cypress / etc. 

## TODO

- [x] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
