### PR TITLE
test(cypress): only use the cypress cloud on pull requests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,6 +74,13 @@ jobs:
         # Run multiple copies of the current job in parallel
         # Please increase the number or runners as your tests suite grows
         containers: ["component", 1, 2]
+        # Only use cypress cloud for PRs
+        use-cypress-cloud:
+          - ${{ !!github.head_ref }}
+        # Only use one container if we are not using the cypress cloud.
+        exclude:
+          - use-cypress-cloud: false
+            containers: 2
 
     name: runner ${{ matrix.containers }}
 
@@ -96,14 +103,14 @@ jobs:
       - name: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }} cypress tests
         uses: cypress-io/github-action@59810ebfa5a5ac6fcfdcfdf036d1cd4d083a88f2 # v6.5.0
         with:
-          record: true
-          parallel: true
+          record: '${{ !!matrix.use-cypress-cloud }}'
+          parallel: '${{ !!matrix.use-cypress-cloud }}'
           # cypress run type
           component: ${{ matrix.containers == 'component' }}
-          group: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
+          group: ${{ matrix.use-cypress-cloud && matrix.containers == 'component' && 'Run component' || matrix.use-cypress-cloud || 'Run E2E' }}
           # cypress env
           ci-build-id: ${{ github.sha }}-${{ github.run_number }}
-          tag: ${{ github.event_name }}
+          tag: ${{ matrix.use-cypress-cloud && github.event_name }}
         env:
           # Needs to be prefixed with CYPRESS_
           CYPRESS_BRANCH: ${{ env.BRANCH }}


### PR DESCRIPTION
* Disable recording on integration branches.
* No parallelization on integration branches.

This will still run the cypress tests - but a bit slower and without recordings.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- tweaks the ci test setup - so no additional tests needed
- [x] not needed: Screenshots before/after for front-end changes
- [x] not needed: Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] not needed: [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
