### PR TITLE
fix ocm-provider rewrite rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -90,6 +90,7 @@
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
+  RewriteRule ^ocm-provider /index.php [QSA,L]
   RewriteRule ^(?:\.(?!well-known)|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -90,7 +90,7 @@
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
-  RewriteRule ^ocm-provider /index.php [QSA,L]
+  RewriteRule ^ocm-provider/?$ /index.php [QSA,L]
   RewriteRule ^(?:\.(?!well-known)|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -537,7 +537,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(cron|public|remote|status)\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v(1|2)\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/robots\\.txt";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(ocm-provider|ocs-provider|updater)/";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(ocs-provider|updater)/";
 			$content .= "\n  RewriteCond %{REQUEST_URI} !^/\\.well-known/(acme-challenge|pki-validation)/.*";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/richdocumentscode(_arm64)?/proxy.php$";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";


### PR DESCRIPTION
Fix the rewrite rules about `ocm-provider` in 2 locations:

- the default .htaccess, 
- the generated part of htaccess from `Setup.php`

I were only able to reproduce the issue in _some_ conditions, each time it seems that this patch fixed them.