### PR TITLE
chore(deps): remove @nextcloud/vue-dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@nextcloud/sharing": "^0.1.0",
         "@nextcloud/upload": "^1.0.0-beta.17",
         "@nextcloud/vue": "^8.0.0-beta.5",
-        "@nextcloud/vue-dashboard": "^2.0.1",
         "@skjnldsv/sanitize-svg": "^1.0.2",
         "@vueuse/components": "^10.4.1",
         "autosize": "^6.0.1",
@@ -1721,28 +1720,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
-    },
-    "node_modules/@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dependencies": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/@babel/polyfill/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
-    },
-    "node_modules/@babel/polyfill/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "node_modules/@babel/preset-env": {
       "version": "7.22.9",
@@ -4164,289 +4141,6 @@
         "npm": "^9.0.0"
       }
     },
-    "node_modules/@nextcloud/vue-dashboard": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-2.0.1.tgz",
-      "integrity": "sha512-eLzdK8Ey5rrs3D6i2OAA5jkZ6lklrAbfnRgL40tZLIJ+MEKvRuPOjwrzhJKxHgVp3rU1rEgkaaPvSNXRVGS1mQ==",
-      "deprecated": "This library is deprecated as the components are now part of @nextcloud/vue starting with version 6.0.0.",
-      "dependencies": {
-        "@nextcloud/vue": "^3.1.1",
-        "core-js": "^3.6.4",
-        "vue": "^2.6.11"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@nextcloud/vue": "^3.1.1",
-        "vue": "^2.6.11"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@babel/runtime": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-      "dependencies": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/auth": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-      "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-      "dependencies": {
-        "@nextcloud/event-bus": "^1.1.3",
-        "@nextcloud/typings": "^0.2.2",
-        "core-js": "^3.6.4"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/auth/node_modules/@nextcloud/typings": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-0.2.4.tgz",
-      "integrity": "sha512-49M8XUDQH27VIQE+13KrqSOYcyOsDUk6Yfw17jbBVtXFoDJ3YBSYYq8YaKeAM3Lz2JVbEpqQW9suAT+EyYSb6g==",
-      "dependencies": {
-        "@types/jquery": "2.0.54"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/axios": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.8.0.tgz",
-      "integrity": "sha512-ni29rhouV6aWIeVG5aSv89fS5UIBN3ZADhFsbFKLO+xKuukDQlIwlWWViS3ZuPW6TR5FlK2dF84xnYnfKnHa5w==",
-      "dependencies": {
-        "@babel/cli": "^7.8.4",
-        "@babel/core": "^7.9.0",
-        "@babel/preset-env": "^7.9.0",
-        "@babel/preset-typescript": "^7.9.0",
-        "@nextcloud/auth": "^1.2.2",
-        "axios": "^0.24.0",
-        "core-js": "^3.6.4"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/browser-storage": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.1.1.tgz",
-      "integrity": "sha512-bWzs/A44rEK8b3CMOFw0ZhsenagrWdsB902LOEwmlMCcFysiFgWiOPbF4/0/ODlOYjvPrO02wf6RigWtb8P+gA==",
-      "dependencies": {
-        "core-js": "3.6.1"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/browser-storage/node_modules/core-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
-      "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/dialogs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-3.1.2.tgz",
-      "integrity": "sha512-hVgpr/CF0F+cE7tRZHJDVpB1S05K/pDcUMrfDpoxMKhux5SXlpwLXUaWM7iAbHEKYm6ArWdpUyhxBTTAo9yrvg==",
-      "dependencies": {
-        "@nextcloud/l10n": "^1.3.0",
-        "@nextcloud/typings": "^1.0.0",
-        "core-js": "^3.6.4",
-        "toastify-js": "^1.10.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/event-bus": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-      "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-      "dependencies": {
-        "@types/semver": "^7.3.5",
-        "core-js": "^3.11.2",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/l10n": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
-      "integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
-      "dependencies": {
-        "core-js": "^3.6.4",
-        "node-gettext": "^3.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/router": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-1.2.0.tgz",
-      "integrity": "sha512-kn9QsL9LuhkIMaSSgdiqRL3SZ6PatuAjXUiyq343BbSnI99Oc5eJH8kU6cT2AHije7wKy/tK8Xe3VQuVO32SZQ==",
-      "dependencies": {
-        "core-js": "^3.6.4"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@nextcloud/vue": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-3.10.2.tgz",
-      "integrity": "sha512-/8r2fE8V7nw9erjm06x3nCALC+6o9q2CzNSL0eDRfsKXCVySFoZ4bYX+zziQUStienisKDRXRhxh7RUAwkS2+w==",
-      "dependencies": {
-        "@nextcloud/auth": "^1.2.3",
-        "@nextcloud/axios": "^1.3.2",
-        "@nextcloud/browser-storage": "^0.1.1",
-        "@nextcloud/capabilities": "^1.0.2",
-        "@nextcloud/dialogs": "^3.0.0",
-        "@nextcloud/event-bus": "^1.1.4",
-        "@nextcloud/l10n": "^1.2.3",
-        "@nextcloud/router": "^1.0.2",
-        "core-js": "^3.6.5",
-        "debounce": "1.2.1",
-        "emoji-mart-vue-fast": "^7.0.7",
-        "escape-html": "^1.0.3",
-        "hammerjs": "^2.0.8",
-        "linkifyjs": "~2.1.9",
-        "md5": "^2.2.1",
-        "regenerator-runtime": "^0.13.5",
-        "string-length": "^4.0.1",
-        "striptags": "^3.1.1",
-        "style-loader": "^2.0.0",
-        "tributejs": "^5.1.3",
-        "v-click-outside": "^3.0.1",
-        "v-tooltip": "^2.0.3",
-        "vue": "^2.6.11",
-        "vue-color": "^2.7.1",
-        "vue-multiselect": "^2.1.6",
-        "vue-visible": "^1.0.2",
-        "vue2-datepicker": "^3.6.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/@types/jquery": {
-      "version": "2.0.54",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
-      "integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg=="
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/emoji-mart-vue-fast": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.7.tgz",
-      "integrity": "sha512-Nrk4IOjKcKKYyMnRm4lreEiPpvDX+h3FKI86SYs05dCFZ0WZIMTGok26dtWvJqseTThS1UghsNEjM4HrfDjIJg==",
-      "dependencies": {
-        "@babel/polyfill": "7.2.5",
-        "@babel/runtime": "7.3.4",
-        "vue-virtual-scroller": "^1.0.0-rc.2"
-      },
-      "peerDependencies": {
-        "vue": "^2.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/linkifyjs": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.9.tgz",
-      "integrity": "sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==",
-      "peerDependencies": {
-        "jquery": ">= 1.11.0",
-        "react": ">= 0.14.0",
-        "react-dom": ">= 0.14.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/style-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
-      "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-dashboard/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/@nextcloud/vue-select": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.23.0.tgz",
@@ -5701,7 +5395,9 @@
     "node_modules/@types/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -7869,6 +7565,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -10661,6 +10358,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -17671,6 +17369,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -21143,31 +20842,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -22057,15 +21731,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -25590,11 +25255,6 @@
       "peerDependencies": {
         "vue": "^2.3.0"
       }
-    },
-    "node_modules/vue-visible": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vue-visible/-/vue-visible-1.0.2.tgz",
-      "integrity": "sha512-yaX2its9XAJKGuQqf7LsiZHHSkxsIK8rmCOQOvEGEoF41blKRK8qr9my4qYoD6ikdLss4n8tKqYBecmaY0+WJg=="
     },
     "node_modules/vue2-datepicker": {
       "version": "3.11.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@nextcloud/sharing": "^0.1.0",
     "@nextcloud/upload": "^1.0.0-beta.17",
     "@nextcloud/vue": "^8.0.0-beta.5",
-    "@nextcloud/vue-dashboard": "^2.0.1",
     "@skjnldsv/sanitize-svg": "^1.0.2",
     "@vueuse/components": "^10.4.1",
     "autosize": "^6.0.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -109,7 +109,6 @@ module.exports = {
 				exclude: BabelLoaderExcludeNodeModulesExcept([
 					'@nextcloud/dialogs',
 					'@nextcloud/event-bus',
-					'@nextcloud/vue-dashboard',
 					'davclient.js',
 					'nextcloud-vue-collections',
 					'p-finally',


### PR DESCRIPTION
## Summary

`@nextcloud/vue-dashboard` is deprecated and actually not used in `server` anymore.
But it has some dependencies, including a very old `@nextcloud/vue@3`.

Removed 🧹

No `dist` changes after `build`.

## TODO

- [x] Uninstall `@nextcloud/vue-dashboard`
- [x] Remove the only `@nextcloud/vue-dashboard` mention - in the webpack config

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
