### PR TITLE
fix(OC_Template.php): ensure we throw all errors

### DIFF
--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -311,6 +311,9 @@ class OC_Template extends \OC\Template\Base {
 			print("The server encountered an internal error and was unable to complete your request.\n");
 			print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
 			print("More details can be found in the server log.\n");
+
+			// and then throw it again to log it at least to the web server error log
+			throw $e;
 		}
 		die();
 	}


### PR DESCRIPTION
## Summary

In one branch of the try/catch combination, in one specific path no error was thrown at all, thus the user ended up with a 500 error page online but absolutely no error anyway in the logs.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- ~~[ ] Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- ~~[ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~~
