### PR TITLE
Make OAuth2 authorization code expire

### DIFF
--- a/apps/oauth2/appinfo/info.xml
+++ b/apps/oauth2/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>OAuth 2.0</name>
 	<summary>Allows OAuth2 compatible authentication from other web applications.</summary>
 	<description>The OAuth2 app allows administrators to configure the built-in authentication workflow to also allow OAuth2 compatible authentication from other web applications.</description>
-	<version>1.16.2</version>
+	<version>1.16.3</version>
 	<licence>agpl</licence>
 	<author>Lukas Reschke</author>
 	<namespace>OAuth2</namespace>
@@ -18,6 +18,10 @@
 	<dependencies>
 		<nextcloud min-version="28" max-version="28"/>
 	</dependencies>
+
+	<background-jobs>
+		<job>OCA\OAuth2\BackgroundJob\CleanupExpiredAuthorizationCode</job>
+	</background-jobs>
 
 	<repair-steps>
 		<post-migration>

--- a/apps/oauth2/composer/composer/autoload_classmap.php
+++ b/apps/oauth2/composer/composer/autoload_classmap.php
@@ -7,6 +7,7 @@ $baseDir = $vendorDir;
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'OCA\\OAuth2\\BackgroundJob\\CleanupExpiredAuthorizationCode' => $baseDir . '/../lib/BackgroundJob/CleanupExpiredAuthorizationCode.php',
     'OCA\\OAuth2\\Controller\\LoginRedirectorController' => $baseDir . '/../lib/Controller/LoginRedirectorController.php',
     'OCA\\OAuth2\\Controller\\OauthApiController' => $baseDir . '/../lib/Controller/OauthApiController.php',
     'OCA\\OAuth2\\Controller\\SettingsController' => $baseDir . '/../lib/Controller/SettingsController.php',

--- a/apps/oauth2/composer/composer/autoload_classmap.php
+++ b/apps/oauth2/composer/composer/autoload_classmap.php
@@ -21,5 +21,6 @@ return array(
     'OCA\\OAuth2\\Migration\\Version010402Date20190107124745' => $baseDir . '/../lib/Migration/Version010402Date20190107124745.php',
     'OCA\\OAuth2\\Migration\\Version011601Date20230522143227' => $baseDir . '/../lib/Migration/Version011601Date20230522143227.php',
     'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => $baseDir . '/../lib/Migration/Version011602Date20230613160650.php',
+    'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => $baseDir . '/../lib/Migration/Version011603Date20230620111039.php',
     'OCA\\OAuth2\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
 );

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -22,6 +22,7 @@ class ComposerStaticInitOAuth2
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'OCA\\OAuth2\\BackgroundJob\\CleanupExpiredAuthorizationCode' => __DIR__ . '/..' . '/../lib/BackgroundJob/CleanupExpiredAuthorizationCode.php',
         'OCA\\OAuth2\\Controller\\LoginRedirectorController' => __DIR__ . '/..' . '/../lib/Controller/LoginRedirectorController.php',
         'OCA\\OAuth2\\Controller\\OauthApiController' => __DIR__ . '/..' . '/../lib/Controller/OauthApiController.php',
         'OCA\\OAuth2\\Controller\\SettingsController' => __DIR__ . '/..' . '/../lib/Controller/SettingsController.php',

--- a/apps/oauth2/composer/composer/autoload_static.php
+++ b/apps/oauth2/composer/composer/autoload_static.php
@@ -36,6 +36,7 @@ class ComposerStaticInitOAuth2
         'OCA\\OAuth2\\Migration\\Version010402Date20190107124745' => __DIR__ . '/..' . '/../lib/Migration/Version010402Date20190107124745.php',
         'OCA\\OAuth2\\Migration\\Version011601Date20230522143227' => __DIR__ . '/..' . '/../lib/Migration/Version011601Date20230522143227.php',
         'OCA\\OAuth2\\Migration\\Version011602Date20230613160650' => __DIR__ . '/..' . '/../lib/Migration/Version011602Date20230613160650.php',
+        'OCA\\OAuth2\\Migration\\Version011603Date20230620111039' => __DIR__ . '/..' . '/../lib/Migration/Version011603Date20230620111039.php',
         'OCA\\OAuth2\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
     );
 

--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace OCA\OAuth2\BackgroundJob;
+
+use OCA\OAuth2\Db\AccessTokenMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\DB\Exception;
+use Psr\Log\LoggerInterface;
+
+class CleanupExpiredAuthorizationCode extends TimedJob {
+
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private AccessTokenMapper $accessTokenMapper,
+		private LoggerInterface $logger,
+
+	) {
+		parent::__construct($timeFactory);
+		// 30 days
+		$this->setInterval(60 * 60 * 24 * 30);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	/**
+	 * @param mixed $argument
+	 * @inheritDoc
+	 */
+	protected function run($argument) {
+		try {
+			$this->accessTokenMapper->cleanupExpiredAuthorizationCode();
+		} catch (Exception $e) {
+			$this->logger->warning('Failed to cleanup tokens with expired authorization code', ['exception' => $e]);
+		}
+	}
+}

--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -51,7 +51,7 @@ class CleanupExpiredAuthorizationCode extends TimedJob {
 	 * @param mixed $argument
 	 * @inheritDoc
 	 */
-	protected function run($argument) {
+	protected function run($argument): void {
 		try {
 			$this->accessTokenMapper->cleanupExpiredAuthorizationCode();
 		} catch (Exception $e) {

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -74,10 +74,10 @@ class OauthApiController extends Controller {
 	 * Get a token
 	 *
 	 * @param string $grant_type Token type that should be granted
-	 * @param string|null $code Code of the flow
-	 * @param string|null $refresh_token Refresh token
-	 * @param string|null $client_id Client ID
-	 * @param string|null $client_secret Client secret
+	 * @param ?string $code Code of the flow
+	 * @param ?string $refresh_token Refresh token
+	 * @param ?string $client_id Client ID
+	 * @param ?string $client_secret Client secret
 	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -194,6 +194,11 @@ class OauthApiController extends Controller {
 		$newCode = $this->secureRandom->generate(128, ISecureRandom::CHAR_ALPHANUMERIC);
 		$accessToken->setHashedCode(hash('sha512', $newCode));
 		$accessToken->setEncryptedToken($this->crypto->encrypt($newToken, $newCode));
+		// increase the number of delivered oauth token
+		// this helps with cleaning up DB access token when authorization code has expired
+		// and it never delivered any oauth token
+		$tokenCount = $accessToken->getTokenCount();
+		$accessToken->setTokenCount($tokenCount + 1);
 		$this->accessTokenMapper->update($accessToken);
 
 		$this->throttler->resetDelay($this->request->getRemoteAddress(), 'login', ['user' => $appToken->getUID()]);

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -128,6 +128,9 @@ class OauthApiController extends Controller {
 			$now = $this->timeFactory->now()->getTimestamp();
 			$tokenCreatedAt = $accessToken->getCreatedAt();
 			if ($tokenCreatedAt < $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER) {
+				// we know this token is not useful anymore
+				$this->accessTokenMapper->delete($accessToken);
+
 				$response = new JSONResponse([
 					'error' => 'invalid_request',
 				], Http::STATUS_BAD_REQUEST);

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\Exception;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ICrypto;
@@ -46,6 +47,8 @@ use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
 
 class OauthApiController extends Controller {
+	// the authorization code expires after 10 minutes
+	private const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
 
 	public function __construct(
 		string $appName,
@@ -57,7 +60,8 @@ class OauthApiController extends Controller {
 		private ISecureRandom $secureRandom,
 		private ITimeFactory $time,
 		private LoggerInterface $logger,
-		private IThrottler $throttler
+		private IThrottler $throttler,
+		private ITimeFactory $timeFactory,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -70,16 +74,20 @@ class OauthApiController extends Controller {
 	 * Get a token
 	 *
 	 * @param string $grant_type Token type that should be granted
-	 * @param string $code Code of the flow
-	 * @param string $refresh_token Refresh token
-	 * @param string $client_id Client ID
-	 * @param string $client_secret Client secret
+	 * @param string|null $code Code of the flow
+	 * @param string|null $refresh_token Refresh token
+	 * @param string|null $client_id Client ID
+	 * @param string|null $client_secret Client secret
+	 * @throws Exception
 	 * @return JSONResponse<Http::STATUS_OK, array{access_token: string, token_type: string, expires_in: int, refresh_token: string, user_id: string}, array{}>|JSONResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
 	 * 200: Token returned
 	 * 400: Getting token is not possible
 	 */
-	public function getToken($grant_type, $code, $refresh_token, $client_id, $client_secret): JSONResponse {
+	public function getToken(
+		string $grant_type, ?string $code, ?string $refresh_token,
+		?string $client_id, ?string $client_secret
+	): JSONResponse {
 
 		// We only handle two types
 		if ($grant_type !== 'authorization_code' && $grant_type !== 'refresh_token') {
@@ -103,6 +111,20 @@ class OauthApiController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 			$response->throttle(['invalid_request' => 'token not found', 'code' => $code]);
 			return $response;
+		}
+
+		// check authorization code expiration
+		if ($grant_type === 'authorization_code') {
+			$now = $this->timeFactory->now()->getTimestamp();
+			$tokenCreatedAt = $accessToken->getCreatedAt();
+			if ($tokenCreatedAt < $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER) {
+				$response = new JSONResponse([
+					'error' => 'invalid_request',
+				], Http::STATUS_BAD_REQUEST);
+				$expiredSince = $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER - $tokenCreatedAt;
+				$response->throttle(['invalid_request' => 'authorization_code_expired', 'expired_since' => $expiredSince]);
+				return $response;
+			}
 		}
 
 		try {

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -48,7 +48,7 @@ use Psr\Log\LoggerInterface;
 
 class OauthApiController extends Controller {
 	// the authorization code expires after 10 minutes
-	private const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
+	public const AUTHORIZATION_CODE_EXPIRES_AFTER = 10 * 60;
 
 	public function __construct(
 		string $appName,

--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -126,15 +126,15 @@ class OauthApiController extends Controller {
 
 			// check authorization code expiration
 			$now = $this->timeFactory->now()->getTimestamp();
-			$tokenCreatedAt = $accessToken->getCreatedAt();
-			if ($tokenCreatedAt < $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER) {
+			$codeCreatedAt = $accessToken->getCodeCreatedAt();
+			if ($codeCreatedAt < $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER) {
 				// we know this token is not useful anymore
 				$this->accessTokenMapper->delete($accessToken);
 
 				$response = new JSONResponse([
 					'error' => 'invalid_request',
 				], Http::STATUS_BAD_REQUEST);
-				$expiredSince = $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER - $tokenCreatedAt;
+				$expiredSince = $now - self::AUTHORIZATION_CODE_EXPIRES_AFTER - $codeCreatedAt;
 				$response->throttle(['invalid_request' => 'authorization_code_expired', 'expired_since' => $expiredSince]);
 				return $response;
 			}

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -34,6 +34,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEncryptedToken(string $token)
  * @method string getHashedCode()
  * @method void setHashedCode(string $token)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
  */
 class AccessToken extends Entity {
 	/** @var int */
@@ -44,6 +46,8 @@ class AccessToken extends Entity {
 	protected $hashedCode;
 	/** @var string */
 	protected $encryptedToken;
+	/** @var int */
+	protected $createdAt;
 
 	public function __construct() {
 		$this->addType('id', 'int');
@@ -51,5 +55,6 @@ class AccessToken extends Entity {
 		$this->addType('clientId', 'int');
 		$this->addType('hashedCode', 'string');
 		$this->addType('encryptedToken', 'string');
+		$this->addType('created_at', 'int');
 	}
 }

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -34,8 +34,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEncryptedToken(string $token)
  * @method string getHashedCode()
  * @method void setHashedCode(string $token)
- * @method int getCreatedAt()
- * @method void setCreatedAt(int $createdAt)
+ * @method int getCodeCreatedAt()
+ * @method void setCodeCreatedAt(int $createdAt)
  * @method int getTokenCount()
  * @method void setTokenCount(int $tokenCount)
  */
@@ -49,7 +49,7 @@ class AccessToken extends Entity {
 	/** @var string */
 	protected $encryptedToken;
 	/** @var int */
-	protected $createdAt;
+	protected $codeCreatedAt;
 	/** @var int */
 	protected $tokenCount;
 
@@ -59,7 +59,7 @@ class AccessToken extends Entity {
 		$this->addType('clientId', 'int');
 		$this->addType('hashedCode', 'string');
 		$this->addType('encryptedToken', 'string');
-		$this->addType('created_at', 'int');
+		$this->addType('code_created_at', 'int');
 		$this->addType('token_count', 'int');
 	}
 }

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -59,7 +59,7 @@ class AccessToken extends Entity {
 		$this->addType('clientId', 'int');
 		$this->addType('hashedCode', 'string');
 		$this->addType('encryptedToken', 'string');
-		$this->addType('code_created_at', 'int');
-		$this->addType('token_count', 'int');
+		$this->addType('codeCreatedAt', 'int');
+		$this->addType('tokenCount', 'int');
 	}
 }

--- a/apps/oauth2/lib/Db/AccessToken.php
+++ b/apps/oauth2/lib/Db/AccessToken.php
@@ -36,6 +36,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setHashedCode(string $token)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
+ * @method int getTokenCount()
+ * @method void setTokenCount(int $tokenCount)
  */
 class AccessToken extends Entity {
 	/** @var int */
@@ -48,6 +50,8 @@ class AccessToken extends Entity {
 	protected $encryptedToken;
 	/** @var int */
 	protected $createdAt;
+	/** @var int */
+	protected $tokenCount;
 
 	public function __construct() {
 		$this->addType('id', 'int');
@@ -56,5 +60,6 @@ class AccessToken extends Entity {
 		$this->addType('hashedCode', 'string');
 		$this->addType('encryptedToken', 'string');
 		$this->addType('created_at', 'int');
+		$this->addType('token_count', 'int');
 	}
 }

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -99,7 +99,7 @@ class AccessTokenMapper extends QBMapper {
 		$qb
 			->delete($this->tableName)
 			->where($qb->expr()->eq('token_count', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->lt('created_at', $qb->createNamedParameter($maxTokenCreationTs, IQueryBuilder::PARAM_INT)));
+			->andWhere($qb->expr()->lt('code_created_at', $qb->createNamedParameter($maxTokenCreationTs, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
 	}
 }

--- a/apps/oauth2/lib/Db/AccessTokenMapper.php
+++ b/apps/oauth2/lib/Db/AccessTokenMapper.php
@@ -28,9 +28,12 @@ declare(strict_types=1);
  */
 namespace OCA\OAuth2\Db;
 
+use OCA\OAuth2\Controller\OauthApiController;
 use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
 use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -39,10 +42,10 @@ use OCP\IDBConnection;
  */
 class AccessTokenMapper extends QBMapper {
 
-	/**
-	 * @param IDBConnection $db
-	 */
-	public function __construct(IDBConnection $db) {
+	public function __construct(
+		IDBConnection $db,
+		private ITimeFactory $timeFactory,
+	) {
 		parent::__construct($db, 'oauth2_access_tokens');
 	}
 
@@ -77,6 +80,26 @@ class AccessTokenMapper extends QBMapper {
 		$qb
 			->delete($this->tableName)
 			->where($qb->expr()->eq('client_id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Delete access tokens that have an expired authorization code
+	 * -> those that are old enough
+	 * and which never delivered any oauth token (still in authorization state)
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function cleanupExpiredAuthorizationCode(): void {
+		$now = $this->timeFactory->now()->getTimestamp();
+		$maxTokenCreationTs = $now - OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER;
+
+		$qb = $this->db->getQueryBuilder();
+		$qb
+			->delete($this->tableName)
+			->where($qb->expr()->eq('token_count', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->lt('created_at', $qb->createNamedParameter($maxTokenCreationTs, IQueryBuilder::PARAM_INT)));
 		$qb->executeStatement();
 	}
 }

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -47,8 +47,8 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 		if ($schema->hasTable('oauth2_access_tokens')) {
 			$table = $schema->getTable('oauth2_access_tokens');
 			$dbChanged = false;
-			if (!$table->hasColumn('created_at')) {
-				$table->addColumn('created_at', Types::BIGINT, [
+			if (!$table->hasColumn('code_created_at')) {
+				$table->addColumn('code_created_at', Types::BIGINT, [
 					'notnull' => true,
 					'default' => 0,
 				]);
@@ -62,7 +62,7 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 				$dbChanged = true;
 			}
 			if (!$table->hasIndex('oauth2_tk_c_created_idx')) {
-				$table->addIndex(['token_count', 'created_at'], 'oauth2_tk_c_created_idx');
+				$table->addIndex(['token_count', 'code_created_at'], 'oauth2_tk_c_created_idx');
 				$dbChanged = true;
 			}
 			if ($dbChanged) {

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -47,20 +47,23 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 		if ($schema->hasTable('oauth2_access_tokens')) {
 			$table = $schema->getTable('oauth2_access_tokens');
 			$dbChanged = false;
-			if (!$table->hasColumn('created_at') || !$table->hasColumn('token_count')) {
-				$dbChanged = true;
-			}
 			if (!$table->hasColumn('created_at')) {
 				$table->addColumn('created_at', Types::BIGINT, [
 					'notnull' => true,
 					'default' => 0,
 				]);
+				$dbChanged = true;
 			}
 			if (!$table->hasColumn('token_count')) {
 				$table->addColumn('token_count', Types::BIGINT, [
 					'notnull' => true,
 					'default' => 0,
 				]);
+				$dbChanged = true;
+			}
+			if (!$table->hasIndex('oauth2_tk_c_created_idx')) {
+				$table->addIndex(['token_count', 'created_at'], 'oauth2_tk_c_created_idx');
+				$dbChanged = true;
 			}
 			if ($dbChanged) {
 				return $schema;

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright 2023, Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\OAuth2\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version011603Date20230620111039 extends SimpleMigrationStep {
+
+	public function __construct(
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('oauth2_access_tokens')) {
+			$table = $schema->getTable('oauth2_access_tokens');
+			if (!$table->hasColumn('created_at')) {
+				$table->addColumn('created_at', Types::BIGINT, [
+					'notnull' => true,
+					'default' => 0,
+				]);
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
+++ b/apps/oauth2/lib/Migration/Version011603Date20230620111039.php
@@ -40,7 +40,7 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 	) {
 	}
 
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
@@ -51,6 +51,7 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 				$table->addColumn('code_created_at', Types::BIGINT, [
 					'notnull' => true,
 					'default' => 0,
+					'unsigned' => true,
 				]);
 				$dbChanged = true;
 			}
@@ -58,6 +59,7 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 				$table->addColumn('token_count', Types::BIGINT, [
 					'notnull' => true,
 					'default' => 0,
+					'unsigned' => true,
 				]);
 				$dbChanged = true;
 			}
@@ -73,7 +75,7 @@ class Version011603Date20230620111039 extends SimpleMigrationStep {
 		return null;
 	}
 
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
 		// we consider that existing access_tokens have already produced at least one oauth token
 		// which prevents cleaning them up
 		$qbUpdate = $this->connection->getQueryBuilder();

--- a/apps/oauth2/openapi.json
+++ b/apps/oauth2/openapi.json
@@ -121,40 +121,50 @@
                         "name": "code",
                         "in": "query",
                         "description": "Code of the flow",
-                        "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                         }
                     },
                     {
                         "name": "refresh_token",
                         "in": "query",
                         "description": "Refresh token",
-                        "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                         }
                     },
                     {
                         "name": "client_id",
                         "in": "query",
                         "description": "Client ID",
-                        "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                         }
                     },
                     {
                         "name": "client_secret",
                         "in": "query",
                         "description": "Client secret",
-                        "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "nullable": true
                         }
                     }
                 ],
                 "responses": {
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "200": {
                         "description": "Token returned",
                         "content": {

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -70,6 +70,8 @@ class OauthApiControllerTest extends TestCase {
 	private $throttler;
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
+	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
+	private $timeFactory;
 	/** @var OauthApiController */
 	private $oauthApiController;
 
@@ -85,6 +87,7 @@ class OauthApiControllerTest extends TestCase {
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->throttler = $this->createMock(IThrottler::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->oauthApiController = new OauthApiController(
 			'oauth2',
@@ -96,7 +99,8 @@ class OauthApiControllerTest extends TestCase {
 			$this->secureRandom,
 			$this->time,
 			$this->logger,
-			$this->throttler
+			$this->throttler,
+			$this->timeFactory
 		);
 	}
 

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -127,7 +127,7 @@ class OauthApiControllerTest extends TestCase {
 	}
 
 	public function testGetTokenExpiredCode() {
-		$tokenCreatedAt = 100;
+		$codeCreatedAt = 100;
 		$expiredSince = 123;
 
 		$expected = new JSONResponse([
@@ -137,13 +137,13 @@ class OauthApiControllerTest extends TestCase {
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
-		$accessToken->setCreatedAt($tokenCreatedAt);
+		$accessToken->setCodeCreatedAt($codeCreatedAt);
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
 			->willReturn($accessToken);
 
-		$tsNow = $tokenCreatedAt + OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER + $expiredSince;
+		$tsNow = $codeCreatedAt + OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER + $expiredSince;
 		$dateNow = (new \DateTimeImmutable())->setTimestamp($tsNow);
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
@@ -154,7 +154,7 @@ class OauthApiControllerTest extends TestCase {
 	public function testGetTokenWithCodeForActiveToken() {
 		// if a token has already delivered oauth tokens,
 		// it should not be possible to get a new oauth token from a valid authorization code
-		$tokenCreatedAt = 100;
+		$codeCreatedAt = 100;
 
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',
@@ -163,14 +163,14 @@ class OauthApiControllerTest extends TestCase {
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
-		$accessToken->setCreatedAt($tokenCreatedAt);
+		$accessToken->setCodeCreatedAt($codeCreatedAt);
 		$accessToken->setTokenCount(1);
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
 			->willReturn($accessToken);
 
-		$tsNow = $tokenCreatedAt + 1;
+		$tsNow = $codeCreatedAt + 1;
 		$dateNow = (new \DateTimeImmutable())->setTimestamp($tsNow);
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);
@@ -181,7 +181,7 @@ class OauthApiControllerTest extends TestCase {
 	public function testGetTokenClientDoesNotExist() {
 		// In this test, the token's authorization code is valid and has not expired
 		// and we check what happens when the associated Oauth client does not exist
-		$tokenCreatedAt = 100;
+		$codeCreatedAt = 100;
 
 		$expected = new JSONResponse([
 			'error' => 'invalid_request',
@@ -190,14 +190,14 @@ class OauthApiControllerTest extends TestCase {
 
 		$accessToken = new AccessToken();
 		$accessToken->setClientId(42);
-		$accessToken->setCreatedAt($tokenCreatedAt);
+		$accessToken->setCodeCreatedAt($codeCreatedAt);
 
 		$this->accessTokenMapper->method('getByCode')
 			->with('validcode')
 			->willReturn($accessToken);
 
 		// 'now' is before the token's authorization code expiration
-		$tsNow = $tokenCreatedAt + OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER - 1;
+		$tsNow = $codeCreatedAt + OauthApiController::AUTHORIZATION_CODE_EXPIRES_AFTER - 1;
 		$dateNow = (new \DateTimeImmutable())->setTimestamp($tsNow);
 		$this->timeFactory->method('now')
 			->willReturn($dateNow);

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -25,6 +25,7 @@ namespace OCA\OAuth2\Tests\Db;
 
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
 use Test\TestCase;
 
 /**
@@ -36,7 +37,7 @@ class AccessTokenMapperTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->accessTokenMapper = new AccessTokenMapper(\OC::$server->getDatabaseConnection());
+		$this->accessTokenMapper = new AccessTokenMapper(\OC::$server->getDatabaseConnection(), \OC::$server->get(ITimeFactory::class));
 	}
 
 	public function testGetByCode() {
@@ -54,7 +55,7 @@ class AccessTokenMapperTest extends TestCase {
 		$this->accessTokenMapper->delete($token);
 	}
 
-	
+
 	public function testDeleteByClientId() {
 		$this->expectException(\OCA\OAuth2\Exceptions\AccessTokenNotFoundException::class);
 

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -289,7 +289,7 @@ class ClientFlowLoginController extends Controller {
 			$accessToken->setEncryptedToken($this->crypto->encrypt($token, $code));
 			$accessToken->setHashedCode(hash('sha512', $code));
 			$accessToken->setTokenId($generatedToken->getId());
-			$accessToken->setCreatedAt($this->timeFactory->now()->getTimestamp());
+			$accessToken->setCodeCreatedAt($this->timeFactory->now()->getTimestamp());
 			$this->accessTokenMapper->insert($accessToken);
 
 			$redirectUri = $client->getRedirectUri();

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -46,6 +46,7 @@ use OCP\AppFramework\Http\Attribute\IgnoreOpenAPI;
 use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
@@ -76,6 +77,7 @@ class ClientFlowLoginController extends Controller {
 		private AccessTokenMapper $accessTokenMapper,
 		private ICrypto $crypto,
 		private IEventDispatcher $eventDispatcher,
+		private ITimeFactory $timeFactory,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -287,6 +289,7 @@ class ClientFlowLoginController extends Controller {
 			$accessToken->setEncryptedToken($this->crypto->encrypt($token, $code));
 			$accessToken->setHashedCode(hash('sha512', $code));
 			$accessToken->setTokenId($generatedToken->getId());
+			$accessToken->setCreatedAt($this->timeFactory->now()->getTimestamp());
 			$this->accessTokenMapper->insert($accessToken);
 
 			$redirectUri = $client->getRedirectUri();

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -31,6 +31,7 @@ use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
@@ -95,6 +96,7 @@ class ClientFlowLoginControllerTest extends TestCase {
 		$this->accessTokenMapper = $this->createMock(AccessTokenMapper::class);
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->clientFlowLoginController = new ClientFlowLoginController(
 			'core',
@@ -109,7 +111,8 @@ class ClientFlowLoginControllerTest extends TestCase {
 			$this->clientMapper,
 			$this->accessTokenMapper,
 			$this->crypto,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->timeFactory
 		);
 	}
 


### PR DESCRIPTION
Oauth authorization codes now expire 10 minutes after being created.
To know if a row in `oauth2_access_tokens` is an authorization code or an access token, we keep track of the number of delivered access tokens. If no token was delivered, it means the row still contains an authorization code (in the `encrypted_token` column).

* Refuse to deliver an access token from an expired authorization code (and immediately delete the related DB entry)
* Expired authorization codes are cleaned up every month
* Fix: A refresh token could be used as an authorization code (with the `authorization_code` grant type). This is no longer possible
* A few tests have been implemented

