### PR TITLE
fix(user): Log affected user of app token login name mismatch

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -794,6 +794,8 @@ class Session implements IUserSession, Emitter {
 			$this->logger->error('App token login name does not match', [
 				'tokenLoginName' => $dbToken->getLoginName(),
 				'sessionLoginName' => $user,
+				'app' => 'core',
+				'user' => $dbToken->getUID(),
 			]);
 
 			return false;


### PR DESCRIPTION
Fixes

```json
{
  "reqId": "NvLwX40hHD9ntL777fNz",
  "level": 3,
  "time": "2023-10-06T06:15:00+00:00",
  "remoteAddr": "abcd:1234::",
  "user": "--",
  "app": "no app in context",
  "method": "REPORT",
  "url": "/remote.php/dav/principals/users/usr/",
  "message": "App token login name does not match",
  "userAgent": "iOS/17.0.2 (21A351) dataaccessd/1.0",
  "version": "27.1.2.1",
  "data": {
    "tokenLoginName": "usr",
    "sessionLoginName": "usr@domain.tld"
  },
  "id": "651faa6e0d771"
}
```

* app: *no app in context*
* user: *--* (none)

Which is not easy to process with tools like Sentry because the error can not be associated with the affected user.

## Summary

* Set app
* Set user

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
