### PR TITLE
fix(L10N): Support "Accept-Language: zh-Hans-CN" and alike

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -490,9 +490,13 @@ class Factory implements IFactory {
 				[$preferred_language] = explode(';', $preference);
 				$preferred_language = str_replace('-', '_', $preferred_language);
 
+				$preferred_language_parts = explode('_', $preferred_language);
 				foreach ($available as $available_language) {
 					if ($preferred_language === strtolower($available_language)) {
 						return $this->respectDefaultLanguage($app, $available_language);
+					}
+					if ($preferred_language_parts[0].'_'.$preferred_language_parts[count($preferred_language_parts) - 1] === strtolower($available_language)) {
+						return $available_language;
 					}
 				}
 

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -495,7 +495,7 @@ class Factory implements IFactory {
 					if ($preferred_language === strtolower($available_language)) {
 						return $this->respectDefaultLanguage($app, $available_language);
 					}
-					if ($preferred_language_parts[0].'_'.$preferred_language_parts[count($preferred_language_parts) - 1] === strtolower($available_language)) {
+					if ($preferred_language_parts[0].'_'.end($preferred_language_parts) === strtolower($available_language)) {
 						return $available_language;
 					}
 				}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary
Fall back for language codes like `zh-Hans-CN` if unsupported to `zh_CN`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
