### PR TITLE
Catch Imaginary processing errors

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -168,7 +168,7 @@ class Imaginary extends ProviderV2 {
 					'timeout' => 120,
 					'connect_timeout' => 3,
 				]);
-		} catch (\Exception $e) {
+		} catch (\GuzzleHttp\Exception\ClientException | \Exception $e) {
 			$this->logger->info('Imaginary preview generation failed: ' . $e->getMessage(), [
 				'exception' => $e,
 			]);

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -168,7 +168,7 @@ class Imaginary extends ProviderV2 {
 					'timeout' => 120,
 					'connect_timeout' => 3,
 				]);
-		} catch (\GuzzleHttp\Exception\ClientException | \Exception $e) {
+		} catch (\Throwable $e) {
 			$this->logger->info('Imaginary preview generation failed: ' . $e->getMessage(), [
 				'exception' => $e,
 			]);


### PR DESCRIPTION
## Summary

When Imaginary refuses to process images (unsupported, malformed...), resulting in errors 400/406, there is nothing the user/admin can do about it. Log them as info too.

```
"message": "Imaginary preview generation failed: Client error: `POST http://10.0.0.14:9000/pipeline?operations=%5B%7B%22operation%22%3A%22convert%22%2C%22params%22%3A%7B%22type%22%3A%22png%22%7D%7D%2C%7B%22operation%22%3A%22smartcrop%22%2C%22params%22%3A%7B%22width%22%3A256%2C%22height%22%3A256%2C%22stripmeta%22%3A%22true%22%2C%22type%22%3A%22png%22%2C%22norotation%22%3A%22true%22%2C%22quality%22%3A%2280%22%7D%7D%5D` resulted in a `406 Not Acceptable` response:\n{\"message\":\"Unsupported media type\",\"status\":406}\n",
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
