### PR TITLE
remove leading slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -90,7 +90,7 @@
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
   RewriteRule ^\.well-known/(?!acme-challenge|pki-validation) /index.php [QSA,L]
-  RewriteRule ^ocm-provider/?$ /index.php [QSA,L]
+  RewriteRule ^ocm-provider/?$ index.php [QSA,L]
   RewriteRule ^(?:\.(?!well-known)|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 


### PR DESCRIPTION
follow up of https://github.com/nextcloud/server/issues/40794

This will make the redirection works also on nextcloud installed in a subfolder.
Tested on 2 subfolder instances. Can confirm federated sharing works the same _pre-ocm-rewrite_ way