### PR TITLE
Read configuration from files during installation

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -30,6 +30,9 @@
  */
 namespace OC\Core\Command\Maintenance;
 
+require_once __DIR__ . '/../../../lib/base.php';
+
+use OC;
 use bantu\IniGetWrapper\IniGetWrapper;
 use InvalidArgumentException;
 use OC\Installer;
@@ -111,6 +114,26 @@ class Install extends Command {
 		return 0;
 	}
 
+	protected function getOption(InputInterface $input, string $name) {
+		$option_mapping = [
+			'database' => 'dbtype',
+			'database-user' => 'dbuser',
+			'database-pass' => 'dbpassword',
+			'database-name' => 'dbname',
+			'database-host' => 'dbhost',
+			'admin-user' => 'adminlogin',
+			'admin-pass' => 'adminpass',
+			'admin-email' => 'adminemail',
+			'data-dir' => 'datadirectory',
+		];
+		$option = $input->getOption($name);
+		if (is_null($option)) {
+			return OC::$config->getValue($option_mapping[$name]);
+		} else {
+			return $option;
+		}
+	}
+
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
@@ -118,33 +141,33 @@ class Install extends Command {
 	 * @return array
 	 */
 	protected function validateInput(InputInterface $input, OutputInterface $output, $supportedDatabases) {
-		$db = strtolower($input->getOption('database'));
+		$db = strtolower($this->getOption($input, 'database'));
 
 		if (!in_array($db, $supportedDatabases)) {
 			throw new InvalidArgumentException("Database <$db> is not supported. " . implode(", ", $supportedDatabases) . " are supported.");
 		}
 
-		$dbUser = $input->getOption('database-user');
-		$dbPass = $input->getOption('database-pass');
-		$dbName = $input->getOption('database-name');
-		$dbPort = $input->getOption('database-port');
+		$dbUser = $this->getOption($input, 'database-user');
+		$dbPass = $this->getOption($input, 'database-pass');
+		$dbName = $this->getOption($input, 'database-name');
+		$dbPort = $this->getOption($input, 'database-port');
 		if ($db === 'oci') {
 			// an empty hostname needs to be read from the raw parameters
 			$dbHost = $input->getParameterOption('--database-host', '');
 		} else {
-			$dbHost = $input->getOption('database-host');
+			$dbHost = $this->getOption($input, 'database-host');
 		}
 		if ($dbPort) {
 			// Append the port to the host so it is the same as in the config (there is no dbport config)
 			$dbHost .= ':' . $dbPort;
 		}
 		if ($input->hasParameterOption('--database-pass')) {
-			$dbPass = (string) $input->getOption('database-pass');
+			$dbPass = (string) $this->getOption($input, 'database-pass');
 		}
-		$adminLogin = $input->getOption('admin-user');
-		$adminPassword = $input->getOption('admin-pass');
-		$adminEmail = $input->getOption('admin-email');
-		$dataDir = $input->getOption('data-dir');
+		$adminLogin = $this->getOption($input, 'admin-user');
+		$adminPassword = $this->getOption($input, 'admin-pass');
+		$adminEmail = $this->getOption($input, 'admin-email');
+		$dataDir = $this->getOption($input, 'data-dir');
 
 		if ($db !== 'sqlite') {
 			if (is_null($dbUser)) {

--- a/lib/base.php
+++ b/lib/base.php
@@ -130,7 +130,7 @@ class OC {
 
 	public static \OC\Server $server;
 
-	private static \OC\Config $config;
+	public static \OC\Config $config;
 
 	/**
 	 * @throws \RuntimeException when the 3rdparty directory is missing or


### PR DESCRIPTION
## Summary

The installation script required users to either enter sensitive information in command line arguments, which was unsecure, or enter it interactively in the input, which prevented automated installation. This commit makes it possible to pre-configure the server in config.php so that automated installation can be performed safely.

I intentionally didn't add tests for now as I seek guidance on how to test CLI/installation and whether this approach is good.

## TODO

- [ ] add tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~ - doesn't apply
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
