### PR TITLE
feat: Allow specifying app version to install

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -45,6 +45,11 @@ class Install extends Command {
 				InputArgument::REQUIRED,
 				'install the specified app'
 			)
+			->addArgument(
+				'app-version',
+				InputArgument::OPTIONAL,
+				'version of the app to install'
+			)
 			->addOption(
 				'keep-disabled',
 				null,
@@ -68,6 +73,7 @@ class Install extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
+		$appVersion = $input->getArgument('app-version');
 		$forceEnable = (bool) $input->getOption('force');
 
 		if (\OC_App::getAppPath($appId)) {
@@ -78,7 +84,7 @@ class Install extends Command {
 		try {
 			/** @var Installer $installer */
 			$installer = \OC::$server->query(Installer::class);
-			$installer->downloadApp($appId, $input->getOption('allow-unstable'));
+			$installer->downloadApp($appId, $input->getOption('allow-unstable'), $appVersion);
 			$result = $installer->installApp($appId, $forceEnable);
 		} catch (\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -142,26 +142,6 @@ class AppFetcher extends Fetcher {
 			if (empty($releases)) {
 				// Remove apps that don't have a matching release
 				$response['data'][$dataKey] = [];
-				continue;
-			}
-
-			// Get the highest version
-			$versions = [];
-			foreach ($releases as $release) {
-				$versions[] = $release['version'];
-			}
-			usort($versions, function ($version1, $version2) {
-				return version_compare($version1, $version2);
-			});
-			$versions = array_reverse($versions);
-			if (isset($versions[0])) {
-				$highestVersion = $versions[0];
-				foreach ($releases as $release) {
-					if ((string)$release['version'] === (string)$highestVersion) {
-						$response['data'][$dataKey]['releases'] = [$release];
-						break;
-					}
-				}
 			}
 		}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36940

## Summary

Allows to specify the version of an app to install with `occ app:install`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
