### PR TITLE
fix(session): Log why session renewal failed

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -916,9 +916,10 @@ class Session implements IUserSession, Emitter {
 			]);
 			return false;
 		} catch (InvalidTokenException $ex) {
-			$this->logger->error('Renewing session token failed', [
+			$this->logger->error('Renewing session token failed: ' . $ex->getMessage(), [
 				'app' => 'core',
 				'user' => $uid,
+				'exception' => $ex,
 			]);
 			return false;
 		}


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/nextcloud/server/pull/40785, which logs

```json
{
  "reqId": "wEtQ6wYq1uWybvZebFcb",
  "level": 3,
  "time": "2023-10-11T06:18:27+00:00",
  "remoteAddr": "abc:def::",
  "user": "--",
  "app": "core",
  "method": "GET",
  "url": "/",
  "message": "Renewing session token failed",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
  "version": "27.1.2.1",
  "data": {
    "app": "core",
    "user": "user123"
  },
  "id": "65264067911b1"
}
```

but doesn't tell me the reason for the renewal error.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
