### PR TITLE
chore: Drop unused \OC\Memcache\Factory::createLowLatency

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -185,15 +185,6 @@ class Factory implements ICacheFactory {
 	}
 
 	/**
-	 * @see \OC\Memcache\Factory::createLocal()
-	 * @param string $prefix
-	 * @return ICache
-	 */
-	public function createLowLatency(string $prefix = ''): ICache {
-		return $this->createLocal($prefix);
-	}
-
-	/**
 	 * Check if a local memory cache backend is available
 	 *
 	 * @return bool


### PR DESCRIPTION
## Summary

The method is private API and unused.

## TODO

- [x] Remove method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
