### PR TITLE
fix(federation): Use `sharing.federation.allowSelfSignedCertificates` config for all OCM requests

### DIFF
--- a/apps/files_sharing/lib/Controller/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controller/ExternalSharesController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IRequest;
 
 /**
@@ -37,25 +38,14 @@ use OCP\IRequest;
  * @package OCA\Files_Sharing\Controller
  */
 class ExternalSharesController extends Controller {
-
-	/** @var \OCA\Files_Sharing\External\Manager */
-	private $externalManager;
-	/** @var IClientService */
-	private $clientService;
-
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param \OCA\Files_Sharing\External\Manager $externalManager
-	 * @param IClientService $clientService
-	 */
-	public function __construct($appName,
-								IRequest $request,
-								\OCA\Files_Sharing\External\Manager $externalManager,
-								IClientService $clientService) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private \OCA\Files_Sharing\External\Manager $externalManager,
+		private IClientService $clientService,
+		private IConfig $config,
+	) {
 		parent::__construct($appName, $request);
-		$this->externalManager = $externalManager;
-		$this->clientService = $clientService;
 	}
 
 	/**
@@ -107,6 +97,7 @@ class ExternalSharesController extends Controller {
 				[
 					'timeout' => 3,
 					'connect_timeout' => 3,
+					'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
 				]
 			)->getBody());
 

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -53,6 +53,7 @@ use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\LocalServerException;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMDiscoveryService;
@@ -67,6 +68,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 	private IClientService $httpClient;
 	private bool $updateChecked = false;
 	private ExternalShareManager $manager;
+	private IConfig $config;
 
 	/**
 	 * @param array{HttpClientService: IClientService, manager: ExternalShareManager, cloudId: ICloudId, mountpoint: string, token: string, password: ?string}|array $options
@@ -78,6 +80,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$this->cloudId = $options['cloudId'];
 		$this->logger = Server::get(LoggerInterface::class);
 		$discoveryService = Server::get(IOCMDiscoveryService::class);
+		$this->config = Server::get(IConfig::class);
 
 		// use default path to webdav if not found on discovery
 		try {
@@ -290,6 +293,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 			$result = $client->get($url, [
 				'timeout' => 10,
 				'connect_timeout' => 10,
+				'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
 			])->getBody();
 			$data = json_decode($result);
 			$returnValue = (is_object($data) && !empty($data->version));

--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\Http\Client\IResponse;
 use OCP\Http\Client\IClient;
@@ -50,6 +51,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->externalManager = $this->createMock(Manager::class);
 		$this->clientService = $this->createMock(IClientService::class);
+		$this->config = $this->createMock(IConfig::class);
 	}
 
 	/**
@@ -60,7 +62,8 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			'files_sharing',
 			$this->request,
 			$this->externalManager,
-			$this->clientService
+			$this->clientService,
+			$this->config,
 		);
 	}
 


### PR DESCRIPTION
## Summary

The config already existed in [many places](https://github.com/nextcloud/server/blob/8b9e7e235dd7711bba31441e9a8b09dc33f85d38/lib/private/Federation/CloudFederationProviderManager.php#L127), but was missed in these two, breaking it, because federation requests actually didn't work for self-signed certificates:

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
