### PR TITLE
Fix version number in ITimeFactory after it was delayed

### DIFF
--- a/lib/private/AppFramework/Utility/TimeFactory.php
+++ b/lib/private/AppFramework/Utility/TimeFactory.php
@@ -34,7 +34,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
  * Use this to get a timestamp or DateTime object in code to remain testable
  *
  * @since 8.0.0
- * @since 26.0.0 Extends the \Psr\Clock\ClockInterface interface
+ * @since 27.0.0 Implements the \Psr\Clock\ClockInterface interface
  * @ref https://www.php-fig.org/psr/psr-20/#21-clockinterface
  */
 class TimeFactory implements ITimeFactory {

--- a/lib/public/AppFramework/Utility/ITimeFactory.php
+++ b/lib/public/AppFramework/Utility/ITimeFactory.php
@@ -33,7 +33,7 @@ use Psr\Clock\ClockInterface;
  * Use this to get a timestamp or DateTime object in code to remain testable
  *
  * @since 8.0.0
- * @since 26.0.0 Extends the \Psr\Clock\ClockInterface interface
+ * @since 27.0.0 Extends the \Psr\Clock\ClockInterface interface
  * @ref https://www.php-fig.org/psr/psr-20/#21-clockinterface
  */
 


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/pull/35872#discussion_r1354485464


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
