### PR TITLE
feat: Add factory method for in-memory caches

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Memcache;
 
+use OCP\Cache\CappedMemoryCache;
 use OCP\Profiler\IProfiler;
 use OCP\ICache;
 use OCP\ICacheFactory;
@@ -182,6 +183,10 @@ class Factory implements ICacheFactory {
 	 */
 	public function isAvailable(): bool {
 		return $this->distributedCacheClass !== self::NULL_CACHE;
+	}
+
+	public function createInMemory(int $capacity = 512): ICache {
+		return new CappedMemoryCache($capacity);
 	}
 
 	/**

--- a/lib/public/ICacheFactory.php
+++ b/lib/public/ICacheFactory.php
@@ -75,4 +75,20 @@ interface ICacheFactory {
 	 * @since 13.0.0
 	 */
 	public function createLocal(string $prefix = ''): ICache;
+
+	/**
+	 * Create an in-memory cache instance
+	 *
+	 * Useful for remembering values inside one process. Cache memory is cleared
+	 * when the object is garbage-collected. Implementation may also expire keys
+	 * earlier when the TTL is reached or too much memory is consumed.
+	 *
+	 * Cache keys are local to the cache object. When building two in-memory
+	 * caches, there is no data exchange between the instances.
+	 *
+	 * @param int $capacity maximum number of cache keys
+	 * @return ICache
+	 * @since 28.0.0
+	 */
+	public function createInMemory(int $capacity = 512): ICache;
 }

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -140,4 +140,15 @@ class FactoryTest extends \Test\TestCase {
 		$profiler = $this->getMockBuilder(IProfiler::class)->getMock();
 		new \OC\Memcache\Factory('abc', $logger, $profiler, $localCache, $distributedCache);
 	}
+
+	public function testCreateInMemory(): void {
+		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+		$profiler = $this->getMockBuilder(IProfiler::class)->getMock();
+		$factory = new \OC\Memcache\Factory('abc', $logger, $profiler, null, null, null);
+
+		$cache = $factory->createInMemory();
+		$cache->set('test', 48);
+
+		self::assertSame(48, $cache->get('test'));
+	}
 }


### PR DESCRIPTION
## Summary

This makes usage of in-memory caches mockable in unit tests.

This is a follow-up to https://github.com/nextcloud/server/pull/33064.

## TODO

- [x] Add factory method to cache factory

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  * https://github.com/nextcloud/documentation/pull/11198
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
