### PR TITLE
feat: remove superfluous labels for email and phones

### DIFF
--- a/apps/dav/lib/CardDAV/Converter.php
+++ b/apps/dav/lib/CardDAV/Converter.php
@@ -87,7 +87,7 @@ class Converter {
 					break;
 				case IAccountManager::COLLECTION_EMAIL:
 				case IAccountManager::PROPERTY_EMAIL:
-					$vCard->add(new Text($vCard, 'EMAIL', $property->getValue(), ['TYPE' => 'OTHER', 'X-NC-SCOPE' => $scope]));
+					$vCard->add(new Text($vCard, 'EMAIL', $property->getValue(), ['X-NC-SCOPE' => $scope]));
 					break;
 				case IAccountManager::PROPERTY_WEBSITE:
 					$vCard->add(new Text($vCard, 'URL', $property->getValue(), ['X-NC-SCOPE' => $scope]));
@@ -108,7 +108,7 @@ class Converter {
 					}
 					break;
 				case IAccountManager::PROPERTY_PHONE:
-					$vCard->add(new Text($vCard, 'TEL', $property->getValue(), ['TYPE' => 'VOICE', 'X-NC-SCOPE' => $scope]));
+					$vCard->add(new Text($vCard, 'TEL', $property->getValue(), ['X-NC-SCOPE' => $scope]));
 					break;
 				case IAccountManager::PROPERTY_ADDRESS:
 					// structured prop: https://www.rfc-editor.org/rfc/rfc6350.html#section-6.3.1


### PR DESCRIPTION
## Summary

The information for the system address book comes from oc_accounts. 

Additional categorizations as available in vCard like the type (e.g., home or work) for a phone number or email address, are not available. VOICE (for phone numbers) and OTHER (for email addresses) are used as default labels.

This pull request will remove VOICE and OTHER as defaults because they don't provide any useful information.

| This PR | Main |
|--------|--------|
| ![Screenshot from 2023-10-11 17-23-33](https://github.com/nextcloud/server/assets/3902676/07be0642-71b7-4acc-8cd6-ddef1decaaa3) | ![Screenshot from 2023-10-11 17-13-51](https://github.com/nextcloud/server/assets/3902676/b702803a-4059-4adc-87bb-ca57435bfbc7) | 

(Screenshots from contacts app)



## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
