### PR TITLE
fix(theming): Stop leaking user theme into capabilities

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -86,23 +86,26 @@ class Capabilities implements IPublicCapability {
 	 * }
 	 */
 	public function getCapabilities() {
+		$color = $this->theming->getDefaultColorPrimary();
+		$colorText = $this->theming->getDefaultTextColorPrimary();
+
 		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime', '');
-		$color = $this->theming->getColorPrimary();
+		$backgroundPlain = $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $color !== '#0082c9');
+		$background = $backgroundPlain ? $color : $this->url->getAbsoluteURL($this->theming->getBackground());
+
 		return [
 			'theming' => [
 				'name' => $this->theming->getName(),
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $color,
-				'color-text' => $this->theming->getTextColorPrimary(),
+				'color-text' => $colorText,
 				'color-element' => $this->util->elementColor($color),
 				'color-element-bright' => $this->util->elementColor($color),
 				'color-element-dark' => $this->util->elementColor($color, false),
 				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
-				'background' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9') ?
-					$this->theming->getColorPrimary() :
-					$this->url->getAbsoluteURL($this->theming->getBackground()),
-				'background-plain' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9'),
+				'background' => $background,
+				'background-plain' => $backgroundPlain,
 				'background-default' => !$this->util->isBackgroundThemed(),
 				'logoheader' => $this->url->getAbsoluteURL($this->theming->getLogo()),
 				'favicon' => $this->url->getAbsoluteURL($this->theming->getLogo()),

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -165,13 +165,13 @@ class CapabilitiesTest extends TestCase {
 			->method('getSlogan')
 			->willReturn($slogan);
 		$this->theming->expects($this->atLeast(1))
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn($color);
 		$this->theming->expects($this->exactly(3))
 			->method('getLogo')
 			->willReturn($logo);
 		$this->theming->expects($this->once())
-			->method('getTextColorPrimary')
+			->method('getDefaultTextColorPrimary')
 			->willReturn($textColor);
 
 		$util = new Util($this->config, $this->createMock(IAppManager::class), $this->createMock(IAppData::class), $this->createMock(ImageManager::class));


### PR DESCRIPTION
## Summary

The capabilities were mixing the admin theme and the user theme. For now I set to only use the admin theming, but I intend to submit a second fix that uses the user theme if a the request came from a logged in user.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
