### PR TITLE
fix(session): Log when crypto session data is lost

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -32,6 +32,7 @@ namespace OC\Session;
 use OCP\ISession;
 use OCP\Security\ICrypto;
 use OCP\Session\Exceptions\SessionNotAvailableException;
+use function OCP\Log\logger;
 
 /**
  * Class CryptoSessionData
@@ -82,9 +83,14 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 		try {
 			$this->sessionValues = json_decode(
 				$this->crypto->decrypt($encryptedSessionData, $this->passphrase),
-				true
+				true,
+				512,
+				JSON_THROW_ON_ERROR,
 			);
 		} catch (\Exception $e) {
+			logger('core')->critical('Could not decrypt or decode encrypted session data', [
+				'exception' => $e,
+			]);
 			$this->sessionValues = [];
 			$this->regenerateId(true, false);
 		}


### PR DESCRIPTION
## Summary

I don't know if this ever happens, but logging it wouldn't be a bad idea, I guess?

The code then calls session_regenerate_id(true), which is known to cause lost sessions: https://www.php.net/manual/en/function.session-regenerate-id.php

Ref https://github.com/nextcloud/server/pull/24550

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
