### PR TITLE
Fix OCM provider public API and handling to allow apps to register

### DIFF
--- a/apps/cloud_federation_api/appinfo/info.xml
+++ b/apps/cloud_federation_api/appinfo/info.xml
@@ -12,8 +12,8 @@
 	<types>
 		<filesystem/>
 	</types>
-	<category>files</category>
-	<bugs>https://github.com/nextcloud/cloud_federation/issues</bugs>
+	<category>integration</category>
+	<bugs>https://github.com/nextcloud/server/issues</bugs>
 	<dependencies>
 		<nextcloud min-version="28" max-version="28"/>
 	</dependencies>

--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -28,14 +28,12 @@ declare(strict_types=1);
 
 namespace OCA\CloudFederationAPI;
 
-use OC\OCM\Model\OCMResource;
 use OCP\Capabilities\ICapability;
 use OCP\IURLGenerator;
 use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\IOCMProvider;
 
 class Capabilities implements ICapability {
-
 	public const API_VERSION = '1.0-proposal1';
 
 	public function __construct(
@@ -74,12 +72,12 @@ class Capabilities implements ICapability {
 
 		$this->provider->setEndPoint(substr($url, 0, $pos));
 
-		$resource = new OCMResource();
+		$resource = $this->provider->createNewResourceType();
 		$resource->setName('file')
 				 ->setShareTypes(['user', 'group'])
 				 ->setProtocols(['webdav' => '/public.php/webdav/']);
 
-		$this->provider->setResourceTypes([$resource]);
+		$this->provider->addResourceType($resource);
 
 		return ['ocm' => $this->provider->jsonSerialize()];
 	}

--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -28,11 +28,11 @@ declare(strict_types=1);
 
 namespace OCA\CloudFederationAPI;
 
-use OC\OCM\Model\OCMProvider;
 use OC\OCM\Model\OCMResource;
 use OCP\Capabilities\ICapability;
 use OCP\IURLGenerator;
 use OCP\OCM\Exceptions\OCMArgumentException;
+use OCP\OCM\IOCMProvider;
 
 class Capabilities implements ICapability {
 
@@ -40,6 +40,7 @@ class Capabilities implements ICapability {
 
 	public function __construct(
 		private IURLGenerator $urlGenerator,
+		private IOCMProvider $provider,
 	) {
 	}
 
@@ -63,24 +64,23 @@ class Capabilities implements ICapability {
 	public function getCapabilities() {
 		$url = $this->urlGenerator->linkToRouteAbsolute('cloud_federation_api.requesthandlercontroller.addShare');
 
-		$provider = new OCMProvider();
-		$provider->setEnabled(true);
-		$provider->setApiVersion(self::API_VERSION);
+		$this->provider->setEnabled(true);
+		$this->provider->setApiVersion(self::API_VERSION);
 
 		$pos = strrpos($url, '/');
 		if (false === $pos) {
 			throw new OCMArgumentException('generated route should contains a slash character');
 		}
 
-		$provider->setEndPoint(substr($url, 0, $pos));
+		$this->provider->setEndPoint(substr($url, 0, $pos));
 
 		$resource = new OCMResource();
 		$resource->setName('file')
 				 ->setShareTypes(['user', 'group'])
 				 ->setProtocols(['webdav' => '/public.php/webdav/']);
 
-		$provider->setResourceTypes([$resource]);
+		$this->provider->setResourceTypes([$resource]);
 
-		return ['ocm' => $provider->jsonSerialize()];
+		return ['ocm' => $this->provider->jsonSerialize()];
 	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -537,6 +537,7 @@ return array(
     'OCP\\Notification\\IManager' => $baseDir . '/lib/public/Notification/IManager.php',
     'OCP\\Notification\\INotification' => $baseDir . '/lib/public/Notification/INotification.php',
     'OCP\\Notification\\INotifier' => $baseDir . '/lib/public/Notification/INotifier.php',
+    'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => $baseDir . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
     'OCP\\OCM\\Exceptions\\OCMArgumentException' => $baseDir . '/lib/public/OCM/Exceptions/OCMArgumentException.php',
     'OCP\\OCM\\Exceptions\\OCMProviderException' => $baseDir . '/lib/public/OCM/Exceptions/OCMProviderException.php',
     'OCP\\OCM\\IOCMDiscoveryService' => $baseDir . '/lib/public/OCM/IOCMDiscoveryService.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -570,6 +570,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Notification\\IManager' => __DIR__ . '/../../..' . '/lib/public/Notification/IManager.php',
         'OCP\\Notification\\INotification' => __DIR__ . '/../../..' . '/lib/public/Notification/INotification.php',
         'OCP\\Notification\\INotifier' => __DIR__ . '/../../..' . '/lib/public/Notification/INotifier.php',
+        'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
         'OCP\\OCM\\Exceptions\\OCMArgumentException' => __DIR__ . '/../../..' . '/lib/public/OCM/Exceptions/OCMArgumentException.php',
         'OCP\\OCM\\Exceptions\\OCMProviderException' => __DIR__ . '/../../..' . '/lib/public/OCM/Exceptions/OCMProviderException.php',
         'OCP\\OCM\\IOCMDiscoveryService' => __DIR__ . '/../../..' . '/lib/public/OCM/IOCMDiscoveryService.php',

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -26,27 +26,27 @@ declare(strict_types=1);
 
 namespace OC\OCM\Model;
 
-use JsonSerializable;
 use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMProvider;
+use OCP\OCM\IOCMResource;
 
 /**
  * @since 28.0.0
  */
-class OCMProvider implements IOCMProvider, JsonSerializable {
+class OCMProvider implements IOCMProvider {
 	private bool $enabled = false;
 	private string $apiVersion = '';
 	private string $endPoint = '';
-	/** @var OCMResource[] */
+	/** @var IOCMResource[] */
 	private array $resourceTypes = [];
 
 	/**
 	 * @param bool $enabled
 	 *
-	 * @return OCMProvider
+	 * @return $this
 	 */
-	public function setEnabled(bool $enabled): self {
+	public function setEnabled(bool $enabled): static {
 		$this->enabled = $enabled;
 
 		return $this;
@@ -62,9 +62,9 @@ class OCMProvider implements IOCMProvider, JsonSerializable {
 	/**
 	 * @param string $apiVersion
 	 *
-	 * @return OCMProvider
+	 * @return $this
 	 */
-	public function setApiVersion(string $apiVersion): self {
+	public function setApiVersion(string $apiVersion): static {
 		$this->apiVersion = $apiVersion;
 
 		return $this;
@@ -80,9 +80,9 @@ class OCMProvider implements IOCMProvider, JsonSerializable {
 	/**
 	 * @param string $endPoint
 	 *
-	 * @return OCMProvider
+	 * @return $this
 	 */
-	public function setEndPoint(string $endPoint): self {
+	public function setEndPoint(string $endPoint): static {
 		$this->endPoint = $endPoint;
 
 		return $this;
@@ -96,29 +96,29 @@ class OCMProvider implements IOCMProvider, JsonSerializable {
 	}
 
 	/**
-	 * @param OCMResource $resource
+	 * @param IOCMResource $resource
 	 *
 	 * @return $this
 	 */
-	public function addResourceType(OCMResource $resource): self {
+	public function addResourceType(IOCMResource $resource): static {
 		$this->resourceTypes[] = $resource;
 
 		return $this;
 	}
 
 	/**
-	 * @param OCMResource[] $resourceTypes
+	 * @param IOCMResource[] $resourceTypes
 	 *
-	 * @return OCMProvider
+	 * @return $this
 	 */
-	public function setResourceTypes(array $resourceTypes): self {
+	public function setResourceTypes(array $resourceTypes): static {
 		$this->resourceTypes = $resourceTypes;
 
 		return $this;
 	}
 
 	/**
-	 * @return OCMResource[]
+	 * @return IOCMResource[]
 	 */
 	public function getResourceTypes(): array {
 		return $this->resourceTypes;
@@ -151,11 +151,11 @@ class OCMProvider implements IOCMProvider, JsonSerializable {
 	 *
 	 * @param array $data
 	 *
-	 * @return self
+	 * @return $this
 	 * @throws OCMProviderException in case a descent provider cannot be generated from data
 	 * @see self::jsonSerialize()
 	 */
-	public function import(array $data): self {
+	public function import(array $data): static {
 		$this->setEnabled(is_bool($data['enabled'] ?? '') ? $data['enabled'] : false)
 			 ->setApiVersion((string)($data['apiVersion'] ?? ''))
 			 ->setEndPoint($data['endPoint'] ?? '');

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -96,6 +96,14 @@ class OCMProvider implements IOCMProvider {
 	}
 
 	/**
+	 * create a new resource to later add it with {@see IOCMProvider::addResourceType()}
+	 * @return IOCMResource
+	 */
+	public function createNewResourceType(): IOCMResource {
+		return new OCMResource();
+	}
+
+	/**
 	 * @param IOCMResource $resource
 	 *
 	 * @return $this

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 
 namespace OC\OCM\Model;
 
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\OCM\Events\ResourceTypeRegisterEvent;
 use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMProvider;
@@ -40,6 +42,13 @@ class OCMProvider implements IOCMProvider {
 	private string $endPoint = '';
 	/** @var IOCMResource[] */
 	private array $resourceTypes = [];
+
+	private bool $emittedEvent = false;
+
+	public function __construct(
+		protected IEventDispatcher $dispatcher,
+	) {
+	}
 
 	/**
 	 * @param bool $enabled
@@ -129,6 +138,12 @@ class OCMProvider implements IOCMProvider {
 	 * @return IOCMResource[]
 	 */
 	public function getResourceTypes(): array {
+		if (!$this->emittedEvent) {
+			$this->emittedEvent = true;
+			$event = new ResourceTypeRegisterEvent($this);
+			$this->dispatcher->dispatchTyped($event);
+		}
+
 		return $this->resourceTypes;
 	}
 

--- a/lib/private/OCM/Model/OCMResource.php
+++ b/lib/private/OCM/Model/OCMResource.php
@@ -26,13 +26,12 @@ declare(strict_types=1);
 
 namespace OC\OCM\Model;
 
-use JsonSerializable;
 use OCP\OCM\IOCMResource;
 
 /**
  * @since 28.0.0
  */
-class OCMResource implements IOCMResource, JsonSerializable {
+class OCMResource implements IOCMResource {
 	private string $name = '';
 	/** @var string[] */
 	private array $shareTypes = [];
@@ -42,9 +41,9 @@ class OCMResource implements IOCMResource, JsonSerializable {
 	/**
 	 * @param string $name
 	 *
-	 * @return OCMResource
+	 * @return $this
 	 */
-	public function setName(string $name): self {
+	public function setName(string $name): static {
 		$this->name = $name;
 
 		return $this;
@@ -60,9 +59,9 @@ class OCMResource implements IOCMResource, JsonSerializable {
 	/**
 	 * @param string[] $shareTypes
 	 *
-	 * @return OCMResource
+	 * @return $this
 	 */
-	public function setShareTypes(array $shareTypes): self {
+	public function setShareTypes(array $shareTypes): static {
 		$this->shareTypes = $shareTypes;
 
 		return $this;
@@ -80,7 +79,7 @@ class OCMResource implements IOCMResource, JsonSerializable {
 	 *
 	 * @return $this
 	 */
-	public function setProtocols(array $protocols): self {
+	public function setProtocols(array $protocols): static {
 		$this->protocols = $protocols;
 
 		return $this;
@@ -98,17 +97,16 @@ class OCMResource implements IOCMResource, JsonSerializable {
 	 *
 	 * @param array $data
 	 *
-	 * @return self
+	 * @return $this
 	 * @see self::jsonSerialize()
 	 */
-	public function import(array $data): self {
+	public function import(array $data): static {
 		return $this->setName((string)($data['name'] ?? ''))
 					->setShareTypes($data['shareTypes'] ?? [])
 					->setProtocols($data['protocols'] ?? []);
 	}
 
 	/**
-	 *
 	 * @return array{
 	 *     name: string,
 	 *     shareTypes: string[],

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -124,6 +124,7 @@ use OC\Metadata\Capabilities as MetadataCapabilities;
 use OC\Metadata\IMetadataManager;
 use OC\Metadata\MetadataManager;
 use OC\Notification\Manager;
+use OC\OCM\Model\OCMProvider;
 use OC\OCM\OCMDiscoveryService;
 use OC\OCS\DiscoveryService;
 use OC\Preview\GeneratorHelper;
@@ -232,6 +233,7 @@ use OCP\Lockdown\ILockdownManager;
 use OCP\Log\ILogFactory;
 use OCP\Mail\IMailer;
 use OCP\OCM\IOCMDiscoveryService;
+use OCP\OCM\IOCMProvider;
 use OCP\Remote\Api\IApiFactory;
 use OCP\Remote\IInstanceFactory;
 use OCP\RichObjectStrings\IValidator;
@@ -1425,6 +1427,8 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerAlias(ILimiter::class, Limiter::class);
 
 		$this->registerAlias(IPhoneNumberUtil::class, PhoneNumberUtil::class);
+
+		$this->registerAlias(IOCMProvider::class, OCMProvider::class);
 
 		$this->connectDispatcher();
 	}

--- a/lib/public/OCM/Events/ResourceTypeRegisterEvent.php
+++ b/lib/public/OCM/Events/ResourceTypeRegisterEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCP\OCM\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\OCM\IOCMProvider;
+
+/**
+ * Use this event to register additional OCM resources before the API returns
+ * them in the OCM provider list and capability
+ *
+ * @since 28.0.0
+ */
+class ResourceTypeRegisterEvent extends Event {
+	/**
+	 * @param IOCMProvider $provider
+	 * @since 28.0.0
+	 */
+	public function __construct(
+		protected IOCMProvider $provider,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @param string $name
+	 * @param list<string> $shareTypes List of supported share recipients, e.g. 'user', 'group', …
+	 * @param array<string, string> $protocols List of supported protocols and their location,
+	 * 	e.g. ['webdav' => '/remote.php/webdav/']
+	 * @since 28.0.0
+	 */
+	public function registerResourceType(string $name, array $shareTypes, array $protocols): void {
+		$resourceType = $this->provider->createNewResourceType();
+		$resourceType->setName($name)
+			->setShareTypes($shareTypes)
+			->setProtocols($protocols);
+		$this->provider->addResourceType($resourceType);
+	}
+}

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCP\OCM;
 
-use OC\OCM\Model\OCMResource;
+use JsonSerializable;
 use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 
@@ -35,16 +35,16 @@ use OCP\OCM\Exceptions\OCMProviderException;
  * @link https://github.com/cs3org/OCM-API/
  * @since 28.0.0
  */
-interface IOCMProvider {
+interface IOCMProvider extends JsonSerializable {
 	/**
 	 * enable OCM
 	 *
 	 * @param bool $enabled
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setEnabled(bool $enabled): self;
+	public function setEnabled(bool $enabled): static;
 
 	/**
 	 * is set as enabled ?
@@ -59,10 +59,10 @@ interface IOCMProvider {
 	 *
 	 * @param string $apiVersion
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setApiVersion(string $apiVersion): self;
+	public function setApiVersion(string $apiVersion): static;
 
 	/**
 	 * returns API version
@@ -77,10 +77,10 @@ interface IOCMProvider {
 	 *
 	 * @param string $endPoint
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setEndPoint(string $endPoint): self;
+	public function setEndPoint(string $endPoint): static;
 
 	/**
 	 * get configured endpoint
@@ -93,22 +93,22 @@ interface IOCMProvider {
 	/**
 	 * add a single resource to the object
 	 *
-	 * @param OCMResource $resource
+	 * @param IOCMResource $resource
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function addResourceType(OCMResource $resource): self;
+	public function addResourceType(IOCMResource $resource): static;
 
 	/**
 	 * set resources
 	 *
-	 * @param OCMResource[] $resourceTypes
+	 * @param IOCMResource[] $resourceTypes
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setResourceTypes(array $resourceTypes): self;
+	public function setResourceTypes(array $resourceTypes): static;
 
 	/**
 	 * get all set resources
@@ -135,9 +135,24 @@ interface IOCMProvider {
 	 *
 	 * @param array<string, int|string|bool|array> $data
 	 *
-	 * @return self
+	 * @return $this
 	 * @throws OCMProviderException in case a descent provider cannot be generated from data
 	 * @since 28.0.0
 	 */
-	public function import(array $data): self;
+	public function import(array $data): static;
+
+	/**
+	 * @return array{
+	 *     enabled: bool,
+	 *     apiVersion: string,
+	 *     endPoint: string,
+	 *     resourceTypes: array{
+	 *         name: string,
+	 *         shareTypes: string[],
+	 *         protocols: array<string, string>
+	 *     }[]
+	 * }
+	 * @since 28.0.0
+	 */
+	public function jsonSerialize(): array;
 }

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -91,6 +91,13 @@ interface IOCMProvider extends JsonSerializable {
 	public function getEndPoint(): string;
 
 	/**
+	 * create a new resource to later add it with {@see addResourceType()}
+	 * @return IOCMResource
+	 * @since 28.0.0
+	 */
+	public function createNewResourceType(): IOCMResource;
+
+	/**
 	 * add a single resource to the object
 	 *
 	 * @param IOCMResource $resource

--- a/lib/public/OCM/IOCMResource.php
+++ b/lib/public/OCM/IOCMResource.php
@@ -26,22 +26,24 @@ declare(strict_types=1);
 
 namespace OCP\OCM;
 
+use JsonSerializable;
+
 /**
  * Model based on the Open Cloud Mesh Discovery API
  *
  * @link https://github.com/cs3org/OCM-API/
  * @since 28.0.0
  */
-interface IOCMResource {
+interface IOCMResource extends JsonSerializable {
 	/**
 	 * set name of the resource
 	 *
 	 * @param string $name
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setName(string $name): self;
+	public function setName(string $name): static;
 
 	/**
 	 * get name of the resource
@@ -56,10 +58,10 @@ interface IOCMResource {
 	 *
 	 * @param string[] $shareTypes
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setShareTypes(array $shareTypes): self;
+	public function setShareTypes(array $shareTypes): static;
 
 	/**
 	 * get share types
@@ -74,10 +76,10 @@ interface IOCMResource {
 	 *
 	 * @param array<string, string> $protocols
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function setProtocols(array $protocols): self;
+	public function setProtocols(array $protocols): static;
 
 	/**
 	 * get configured protocols
@@ -92,8 +94,18 @@ interface IOCMResource {
 	 *
 	 * @param array $data
 	 *
-	 * @return self
+	 * @return $this
 	 * @since 28.0.0
 	 */
-	public function import(array $data): self;
+	public function import(array $data): static;
+
+	/**
+	 * @return array{
+	 *     name: string,
+	 *     shareTypes: string[],
+	 *     protocols: array<string, string>
+	 * }
+	 * @since 28.0.0
+	 */
+	public function jsonSerialize(): array;
 }


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/39574

## TODO

- [x] Make the public API only rely on OCP
- [x] Make the OCM provider stateful so apps can add resources
- [x] Allow apps to register OCM resources

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
