### PR TITLE
fix(cypress): User groups test

### DIFF
--- a/cypress/e2e/settings/users_groups.cy.ts
+++ b/cypress/e2e/settings/users_groups.cy.ts
@@ -87,9 +87,9 @@ describe('Settings: Create and delete groups', () => {
 			expect(error.name).to.equal('AssertionError')
 			expect(error).to.have.property('node', '.modal-container')
 		})
-		// Make sure no confirmation modal is shown
+		// Make sure no confirmation modal is shown on top of the Remove group modal
 		cy.get('body').find('.modal-container').then(($modals) => {
-			if ($modals.length > 0) {
+			if ($modals.length > 1) {
 				cy.wrap($modals.first()).find('input[type="password"]').type(admin.password)
 				cy.wrap($modals.first()).find('button').contains('Confirm').click()
 			}


### PR DESCRIPTION
## Summary

- Fix `AssertionError: expected { Object (message, showDiff, ...) } to have property 'node' of '.modal-container', but got undefined` error which would occur occasionally when removing the group doesn't trigger the password confirmation modal

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
-  Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)