### PR TITLE
refactor: Unify running a dev server (for automated testing)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,10 @@
 		"psalm": "psalm --no-cache --threads=$(nproc)",
 		"psalm:ci": "psalm --no-cache --threads=1",
 		"psalm:update-baseline": "psalm --no-cache --threads=$(nproc) --update-baseline",
+		"serve": [
+			"Composer\\Config::disableProcessTimeout",
+			"PHP_CLI_SERVER_WORKERS=${NEXTCLOUD_WORKERS:=4} php -S ${NEXTCLOUD_HOST:=localhost}:${NEXTCLOUD_PORT:=8080} -t ./"
+		],
 		"test": "phpunit --configuration tests/phpunit-autotest.xml",
 		"test:db": "@composer run test -- --group DB,SLOWDB",
 		"test:files_external": "phpunit --configuration tests/phpunit-autotest-external.xml"


### PR DESCRIPTION
## Summary

Makes it quite easy to spin up a dev web server:

```bash
composer serve
```

It's possible to influence hostname, port and number of worker processes:

```bash
NEXTCLOUD_HOST=127.0.0.1 NEXTCLOUD_PORT=8081 NEXTCLOUD_WORKERS=10 composer serve
```

Ref https://github.com/php-pds/composer-script-names_research for the naming convention.

## TODO

- [x] Add new composer script
- [x] Set PHP_CLI_SERVER_WORKERS and make it overridable to have a bit of concurrency

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
