### PR TITLE
Fix unit tests on PHP 8.3

### DIFF
--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -32,6 +32,7 @@ use OCP\IRequest;
 use OCP\Http\Client\IResponse;
 use OCP\Http\Client\IClient;
 use OCA\Files_Sharing\External\Manager;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class ExternalShareControllerTest
@@ -43,6 +44,8 @@ class ExternalShareControllerTest extends \Test\TestCase {
 	private $request;
 	/** @var \OCA\Files_Sharing\External\Manager */
 	private $externalManager;
+	/** @var IConfig|MockObject */
+	private $config;
 	/** @var IClientService */
 	private $clientService;
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -401,8 +401,8 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
-	echo "$PHPUNIT" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	"$PHPUNIT" --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	echo "$PHPUNIT" --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"$PHPUNIT" --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
 	RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -8,7 +8,7 @@
 		 timeoutForLargeTests="900"
 		 convertDeprecationsToExceptions="true"
 		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
-	<testsuite name="ownCloud">
+	<testsuite name="Nextcloud Server">
 		<directory suffix=".php">lib/</directory>
 		<directory suffix=".php">Core/</directory>
 		<directory suffix=".php">Test/</directory>


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/actions/runs/6527898442/job/17723367127

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
