### PR TITLE
perf: switch file list to vue-virtual-scroller

### DIFF
--- a/apps/files/src/components/FileEntry.vue
+++ b/apps/files/src/components/FileEntry.vue
@@ -50,9 +50,9 @@
 			<!-- Icon or preview -->
 			<span class="files-list__row-icon" @click="execDefaultAction">
 				<template v-if="source.type === 'folder'">
-					<FolderOpenIcon v-if="dragover" />
+					<FolderOpenIcon v-once v-if="dragover" />
 					<template v-else>
-						<FolderIcon />
+						<FolderIcon v-once />
 						<OverlayIcon :is="folderOverlay"
 							v-if="folderOverlay"
 							class="files-list__row-icon-overlay" />
@@ -69,13 +69,13 @@
 					@error="backgroundFailed = true"
 					@load="backgroundFailed = false">
 
-				<FileIcon v-else />
+				<FileIcon v-once v-else />
 
 				<!-- Favorite icon -->
 				<span v-if="isFavorite"
 					class="files-list__row-icon-favorite"
 					:aria-label="t('files', 'Favorite')">
-					<FavoriteIcon />
+					<FavoriteIcon v-once />
 				</span>
 			</span>
 

--- a/apps/files/src/components/FilesListTableFooter.vue
+++ b/apps/files/src/components/FilesListTableFooter.vue
@@ -159,7 +159,6 @@ export default Vue.extend({
 <style scoped lang="scss">
 // Scoped row
 tr {
-	padding-bottom: 300px;
 	border-top: 1px solid var(--color-border);
 	// Prevent hover effect on the whole row
 	background-color: transparent !important;

--- a/apps/files/src/components/FilesListVirtual.vue
+++ b/apps/files/src/components/FilesListVirtual.vue
@@ -278,20 +278,9 @@ export default Vue.extend({
 	--clickable-area: 44px;
 	--icon-preview-size: 32px;
 
-	display: block;
-	overflow: auto;
 	height: 100%;
 
 	&::v-deep {
-		// Table head, body and footer
-		tbody {
-			display: flex;
-			flex-direction: column;
-			width: 100%;
-			// Necessary for virtual scrolling absolute
-			position: relative;
-		}
-
 		// Before table and thead
 		.files-list__before {
 			display: flex;
@@ -310,7 +299,6 @@ export default Vue.extend({
 		// Table header
 		.files-list__thead {
 			// Pinned on top when scrolling
-			position: sticky;
 			z-index: 10;
 			top: 0;
 		}


### PR DESCRIPTION
This patch significantly improves the performance of the file list by using `vue-virtual-scroller` over the current simplistic implementation. `vue-virtual-scroller` has excellent performance since it uses CSS transforms to place the virtual elements and has very good component reuse.

The implementation isn't complete yet but I wanted to get some early feedback / thoughts.

It's somewhat hard to capture the improvement in a video, so here's a before and after with a 4x simulated slowdown:

Before:
https://github.com/nextcloud/server/assets/10709794/0d769798-3d85-44ea-a2b8-cd3fba0aeb53

After:
https://github.com/nextcloud/server/assets/10709794/1d2a2a83-0180-4a23-833b-12d6f69099fa

