### PR TITLE
feat(settings): Add setup check for too much caching

### DIFF
--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -66,6 +66,7 @@ return [
 		['name' => 'LogSettings#getEntries', 'url' => '/settings/admin/log/entries', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'LogSettings#download', 'url' => '/settings/admin/log/download', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'CheckSetup#check', 'url' => '/settings/ajax/checksetup', 'verb' => 'GET' , 'root' => ''],
+		['name' => 'CheckSetup#checkCookies', 'url' => '/settings/ajax/checksetupcookies.png', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'CheckSetup#getFailedIntegrityCheckFiles', 'url' => '/settings/integrity/failed', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'CheckSetup#rescanFailedIntegrityCheck', 'url' => '/settings/integrity/rescan', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'PersonalSettings#index', 'url' => '/settings/user/{section}', 'verb' => 'GET', 'defaults' => ['section' => 'personal-info'] , 'root' => ''],

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -74,6 +74,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\IgnoreOpenAPI;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\DB\Events\AddMissingColumnsEvent;
 use OCP\DB\Events\AddMissingIndicesEvent;
@@ -94,6 +95,8 @@ use OCP\Notification\IManager;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\ISecureRandom;
 use Psr\Log\LoggerInterface;
+use function setcookie;
+use function time;
 
 #[IgnoreOpenAPI]
 class CheckSetupController extends Controller {
@@ -971,5 +974,20 @@ Raw output
 				NeedsSystemAddressBookSync::class => ['pass' => $needsSystemAddressBookSync->run(), 'description' => $needsSystemAddressBookSync->description(), 'severity' => $needsSystemAddressBookSync->severity()],
 			]
 		);
+	}
+
+	/**
+	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
+	 */
+	public function checkCookies(): JSONResponse {
+		$rand = $this->secureRandom->generate(32);
+		setcookie(
+			'nc_setup_check',
+			$rand,
+			time() + 60
+		);
+		return new JSONResponse([
+			'rand' => $rand,
+		]);
 	}
 }

--- a/apps/settings/src/admin.js
+++ b/apps/settings/src/admin.js
@@ -243,8 +243,9 @@ window.addEventListener('DOMContentLoaded', () => {
 			OC.SetupChecks.checkGeneric(),
 			OC.SetupChecks.checkWOFF2Loading(OC.filePath('core', '', 'fonts/NotoSans-Regular-latin.woff2'), OC.theme.docPlaceholderUrl),
 			OC.SetupChecks.checkDataProtected(),
-		).then((check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11) => {
-			const messages = [].concat(check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11)
+			OC.SetupChecks.checkCaching(),
+		).then((check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11, check12) => {
+			const messages = [].concat(check1, check2, check3, check4, check5, check6, check7, check8, check9, check10, check11, check12)
 			const $el = $('#postsetupchecks')
 			$('#security-warning-state-loading').addClass('hidden')
 

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -47,6 +47,27 @@
 			return deferred.promise();
 		},
 
+		checkCaching: function() {
+			return Promise.all([
+				$.get(OC.generateUrl('settings/ajax/checksetupcookies.png')),
+				$.get(OC.generateUrl('settings/ajax/checksetupcookies.png')),
+			]).then(function(responses) {
+				if (responses[0].rand === responses[1].rand) {
+					console.error('Two unique requests returned the same response', {
+						rand1: responses[0].rand,
+						rand2: responses[1].rand,
+					});
+					return [
+						{
+							msg: t('core', 'Your web server is caching too aggressively. This could lead to leaked cookies and sessions.'),
+							type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+						}
+					];
+				}
+				return [];
+			})
+		},
+
 		/**
 		 * Check whether the .well-known URLs works.
 		 *


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/40863 (or at least would help detect this type of configuration mishap and various others)

## Summary

Warn admins if their server caching is caching responses that should not be cached.

The approach is simple:
* Two requests with the same URL
* Make sure there is a `Set-Cookie` response header
* Return something unique, so uniqueness of the responses can be checked

If the two responses are identical, then the server didn't process the requests individually.

## TODO

- [x] Code
- [ ] Testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
