### PR TITLE
fix(federation): Fix type and docs on ICloudFederationNotification in…

### DIFF
--- a/lib/public/Federation/ICloudFederationNotification.php
+++ b/lib/public/Federation/ICloudFederationNotification.php
@@ -34,8 +34,8 @@ interface ICloudFederationNotification {
 	 *
 	 * @param string $notificationType (e.g. SHARE_ACCEPTED)
 	 * @param string $resourceType (e.g. file, calendar, contact,...)
-	 * @param $providerId id of the share
-	 * @param array $notification , payload of the notification
+	 * @param string $providerId id of the share
+	 * @param array $notification payload of the notification
 	 *
 	 * @since 14.0.0
 	 */


### PR DESCRIPTION
…terface

## Summary

- Check the type on `$providerId` and be confused what `OCP\Federation\id` might be referring to:

![grafik](https://github.com/nextcloud/server/assets/213943/ba9dc8be-8c3e-4bad-85c6-8d1a99739dc4)

## Todo

- [x] Copy the doc block from the actual implementation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
