### PR TITLE
Add "no public GH Issues please" request, past advisories link, bounty mention, scope link to security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,62 @@
 # Security Policy
 
-## Supported Versions
+[Security](https://nextcloud.com/security/) is very important to us. 
 
-The latest three major release versions of Nextcloud are currently being supported with security updates.
-Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
+If you believe you have found a security vulnerability that meets our definition of a security 
+vulnerability, please report is as described below.
+
+## Context
+
+Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what 
+is currently considered a security vulnerability versus expected behavior. And review what is considered 
+[in scope or bounty eligible](https://hackerone.com/nextcloud/policy_scopes).
+
+You can expect a response within 24 hours in most cases.
 
 ## Reporting a Vulnerability
 
-Security is very important to us. If you have discovered a security issue with Nextcloud,
-please read our responsible disclosure guidelines and contact us at [hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+** **Please do _not_ report security vulnerabilities through public GitHub issues.** **
+
+If you have discovered a security matter with Nextcloud, please read our
+[responsible disclosure guidelines](https://nextcloud.com/security/) and contact us at
+[hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+
 Your report should include:
 
 - Product version
 - A vulnerability description
 - Reproduction steps
+- Any other details you think are likely to be important
 
-A member of the security team will confirm the vulnerability, determine its impact, and develop a fix.
-The fix will be applied to the master branch, tested, and packaged in the next security release.
+### What to Expect
+
+You should receive an initial acknowledgement within 24 hours in most cases.
+
+A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
+and coordinate a fix.
+
+The fix will be applied to the `master` branch, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
-to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud community. Note our 
-[threat model](https://nextcloud.com/security/threat-model) to know what is expected behavior.
+to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud 
+community. 
 
+### Bug Bounties
 
-Please visit https://nextcloud.com/security/ for further information about security.
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Details
+on past bounty ranges can be found at [hackerone.com/nextcloud](https://hackerone.com/nextcloud).
+
+## Existing Security Advisories
+
+Past advisories can be viewed at
+[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories
+).
+
+## Supported Versions
+
+The latest three major release versions of Nextcloud are currently being supported with security updates.
+Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
+
+## Additional Information
+
+Please visit [https://nextcloud.com/security/](https://nextcloud.com/security/) for further information about Nextcloud security.
+Please visit [https://nextcloud.com/security/threat-model](https://nextcloud.com/security/threat-model) for our threat model and accepted risks.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,6 @@ Please review our [threat model and accepted risks](https://nextcloud.com/securi
 is currently considered a security vulnerability versus expected behavior. And review what is considered 
 [in scope or bounty eligible](https://hackerone.com/nextcloud/policy_scopes).
 
-You can expect a response within 24 hours in most cases.
 
 ## Reporting a Vulnerability
 
@@ -33,9 +32,9 @@ Your report should include:
 You should receive an initial acknowledgement within 24 hours in most cases.
 
 A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
-and coordinate a fix.
+and coordinate the fix and publication.
 
-The fix will be applied to the `master` branch, tested, and packaged in the next security release.
+The fix will be applied to all applicable and still supported stable branches, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
 to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud 
 community. 
@@ -47,13 +46,13 @@ on past bounty ranges can be found at [hackerone.com/nextcloud](https://hackeron
 
 ## Existing Security Advisories
 
-Past advisories can be viewed at
+Published security advisories for the Nextcloud Server, Clients and Apps can be viewed at
 [https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories
 ).
 
 ## Supported Versions
 
-The latest three major release versions of Nextcloud are currently being supported with security updates.
+Nextcloud Server major release versions are being supported with security updates for 1 year after their initial release.
 Please visit https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule for further details.
 
 ## Additional Information


### PR DESCRIPTION
## Summary

* Added request to _not_ report vulnerabilities in public GH issues
* Added missing and/or deeper links to relevant pages { existing security advisories, scope }
* Mentioned bounty program
* Reorganized to keep focus on reporting while also adding context helpful to other audiences
* Added some new headings to keep things easy to access

I was tempted to add the "No BS" stuff from [the HackerOne page](https://hackerone.com/nextcloud), but ultimately opted to keep this the more formal of the two since that is how it's been historically.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
