### PR TITLE
Update version.php to owncloud 10.13

### DIFF
--- a/version.php
+++ b/version.php
@@ -41,7 +41,7 @@ $OC_VersionCanBeUpgradedFrom = [
 		'28.0' => true,
 	],
 	'owncloud' => [
-		'10.11' => true,
+		'10.13' => true,
 	],
 ];
 


### PR DESCRIPTION
ownCloud's current version is 10.13
migration was tested with a customer; 
documentation was adjusted
https://github.com/nextcloud/documentation/pull/11225




## Summary


## TODO



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
