### PR TITLE
fix(objectstorage): cleanup HomeObjectStoreStorage

### DIFF
--- a/lib/private/Files/ObjectStore/AppdataPreviewObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/AppdataPreviewObjectStoreStorage.php
@@ -26,9 +26,12 @@ declare(strict_types=1);
 namespace OC\Files\ObjectStore;
 
 class AppdataPreviewObjectStoreStorage extends ObjectStoreStorage {
-	/** @var string */
-	private $internalId;
+	private string $internalId;
 
+	/**
+	 * @param array $params
+	 * @throws \Exception
+	 */
 	public function __construct($params) {
 		if (!isset($params['internal-id'])) {
 			throw new \Exception('missing id in parameters');
@@ -37,7 +40,7 @@ class AppdataPreviewObjectStoreStorage extends ObjectStoreStorage {
 		parent::__construct($params);
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'object::appdata::preview:' . $this->internalId;
 	}
 }

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -7,6 +7,7 @@
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Thomas Citharel <nextcloud@tcit.fr>
  *
  * @license AGPL-3.0
  *
@@ -29,6 +30,8 @@ use OCP\Files\IHomeStorage;
 use OCP\IUser;
 
 class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage {
+	protected IUser $user;
+
 	/**
 	 * The home user storage requires a user object to create a unique storage id
 	 * @param array $params

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -25,16 +25,16 @@
  */
 namespace OC\Files\ObjectStore;
 
-use OC\User\User;
+use OCP\Files\IHomeStorage;
 use OCP\IUser;
 
-class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IHomeStorage {
+class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage {
 	/**
 	 * The home user storage requires a user object to create a unique storage id
 	 * @param array $params
 	 */
 	public function __construct($params) {
-		if (! isset($params['user']) || ! $params['user'] instanceof User) {
+		if (! isset($params['user']) || ! $params['user'] instanceof IUser) {
 			throw new \Exception('missing user object in parameters');
 		}
 		$this->user = $params['user'];
@@ -58,11 +58,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 		return false;
 	}
 
-	/**
-	 * @param string $path, optional
-	 * @return \OC\User\User
-	 */
-	public function getUser($path = null): IUser {
+	public function getUser(): IUser {
 		return $this->user;
 	}
 }

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -26,6 +26,7 @@
  */
 namespace OC\Files\ObjectStore;
 
+use Exception;
 use OCP\Files\IHomeStorage;
 use OCP\IUser;
 
@@ -34,17 +35,19 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage 
 
 	/**
 	 * The home user storage requires a user object to create a unique storage id
+	 *
 	 * @param array $params
+	 * @throws Exception
 	 */
 	public function __construct($params) {
 		if (! isset($params['user']) || ! $params['user'] instanceof IUser) {
-			throw new \Exception('missing user object in parameters');
+			throw new Exception('missing user object in parameters');
 		}
 		$this->user = $params['user'];
 		parent::__construct($params);
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'object::user:' . $this->user->getUID();
 	}
 
@@ -52,13 +55,10 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage 
 	 * get the owner of a path
 	 *
 	 * @param string $path The path to get the owner
-	 * @return false|string uid
+	 * @return string uid
 	 */
-	public function getOwner($path) {
-		if (is_object($this->user)) {
-			return $this->user->getUID();
-		}
-		return false;
+	public function getOwner($path): string {
+		return $this->user->getUID();
 	}
 
 	public function getUser(): IUser {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -51,20 +51,9 @@ use OCP\Files\Storage\IStorage;
 class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFileWrite {
 	use CopyDirectory;
 
-	/**
-	 * @var \OCP\Files\ObjectStore\IObjectStore $objectStore
-	 */
-	protected $objectStore;
-	/**
-	 * @var string $id
-	 */
-	protected $id;
-	/**
-	 * @var \OC\User\User $user
-	 */
-	protected $user;
-
-	private $objectPrefix = 'urn:oid:';
+	protected IObjectStore $objectStore;
+	protected string $id;
+	private string $objectPrefix = 'urn:oid:';
 
 	private $logger;
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -47,6 +47,7 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 use OCP\Files\Storage\IChunkedFileWrite;
 use OCP\Files\Storage\IStorage;
+use OCP\ILogger;
 
 class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFileWrite {
 	use CopyDirectory;
@@ -55,13 +56,15 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	protected string $id;
 	private string $objectPrefix = 'urn:oid:';
 
-	private $logger;
+	private ILogger $logger;
 
 	private bool $handleCopiesAsOwned;
+	protected bool $validateWrites = true;
 
-	/** @var bool */
-	protected $validateWrites = true;
-
+	/**
+	 * @param array $params
+	 * @throws \Exception
+	 */
 	public function __construct($params) {
 		if (isset($params['objectstore']) && $params['objectstore'] instanceof IObjectStore) {
 			$this->objectStore = $params['objectstore'];

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageOverwrite.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageOverwrite.php
@@ -30,7 +30,7 @@ use OCP\Files\ObjectStore\IObjectStore;
  * Allow overwriting the object store instance for test purposes
  */
 class ObjectStoreStorageOverwrite extends ObjectStoreStorage {
-	public function setObjectStore(IObjectStore $objectStore) {
+	public function setObjectStore(IObjectStore $objectStore): void {
 		$this->objectStore = $objectStore;
 	}
 
@@ -38,7 +38,7 @@ class ObjectStoreStorageOverwrite extends ObjectStoreStorage {
 		return $this->objectStore;
 	}
 
-	public function setValidateWrites(bool $validate) {
+	public function setValidateWrites(bool $validate): void {
 		$this->validateWrites = $validate;
 	}
 }


### PR DESCRIPTION
## Summary

Fix invalid signature for `getUser()` method and change occurrences of `OC\User\User` for `OCP\IUser` (unless there's a good reason for that?)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
