### PR TITLE
fix(cypress): Also sync `3rdparty` directory for local cypress tests

### DIFF
--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -148,6 +148,7 @@ export const applyChangesToNextcloud = async function() {
 
 	const htmlPath = '/var/www/html'
 	const folderPaths = [
+		'./3rdparty',
 		'./apps',
 		'./core',
 		'./dist',


### PR DESCRIPTION
## Summary

We also need to sync the 3rdparty directory, otherwise there will be errors if a dependency was updated and used in `lib`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
