### PR TITLE
Explicitly close the directory stream

### DIFF
--- a/apps/encryption/lib/Command/FixKeyLocation.php
+++ b/apps/encryption/lib/Command/FixKeyLocation.php
@@ -366,6 +366,7 @@ class FixKeyLocation extends Command {
 					}
 				}
 			}
+			closedir($dh);
 		}
 	}
 

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -1119,6 +1119,7 @@ class Trashbin {
 					return false;
 				}
 			}
+			closedir($dh);
 		}
 		return true;
 	}

--- a/lib/private/Archive/Archive.php
+++ b/lib/private/Archive/Archive.php
@@ -120,6 +120,7 @@ abstract class Archive {
 					$this->addFile($path.'/'.$file, $source.'/'.$file);
 				}
 			}
+			closedir($dh);
 		}
 	}
 }

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -156,14 +156,15 @@ class File implements ICache {
 	 */
 	public function clear($prefix = '') {
 		$storage = $this->getStorage();
-		if ($storage and $storage->is_dir('/')) {
+		if ($storage && $storage->is_dir('/')) {
 			$dh = $storage->opendir('/');
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if ($file != '.' and $file != '..' and ($prefix === '' || str_starts_with($file, $prefix))) {
+					if ($file != '.' && $file != '..' && ($prefix === '' || str_starts_with($file, $prefix))) {
 						$storage->unlink('/' . $file);
 					}
 				}
+				closedir($dh);
 			}
 		}
 		return true;
@@ -184,7 +185,7 @@ class File implements ICache {
 				return null;
 			}
 			while (($file = readdir($dh)) !== false) {
-				if ($file != '.' and $file != '..') {
+				if ($file != '.' && $file != '..') {
 					try {
 						$mtime = $storage->filemtime('/' . $file);
 						if ($mtime < $now) {
@@ -200,6 +201,7 @@ class File implements ICache {
 					}
 				}
 			}
+			closedir($dh);
 		}
 	}
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -294,6 +294,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 					}
 				}
 			}
+			closedir($dh);
 		}
 	}
 
@@ -317,8 +318,8 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 					$files = array_merge($files, $this->searchInDir($query, $dir . '/' . $item));
 				}
 			}
+			closedir($dh);
 		}
-		closedir($dh);
 		return $files;
 	}
 
@@ -626,6 +627,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);
 					}
 				}
+				closedir($dh);
 			}
 		} else {
 			$source = $sourceStorage->fopen($sourceInternalPath, 'r');
@@ -905,6 +907,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 					}
 				}
 			}
+			closedir($dh);
 		}
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -824,11 +824,12 @@ class Encryption extends Wrapper {
 				$result = true;
 			}
 			if (is_resource($dh)) {
-				while ($result and ($file = readdir($dh)) !== false) {
+				while ($result && ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {
 						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, false, $isRename);
 					}
 				}
+				closedir($dh);
 			}
 		} else {
 			try {

--- a/lib/private/TempManager.php
+++ b/lib/private/TempManager.php
@@ -189,7 +189,7 @@ class TempManager implements ITempManager {
 		$cutOfTime = time() - 3600;
 		$files = [];
 		$dh = opendir($this->tmpBaseDir);
-		if ($dh) {
+		if (is_resource($dh)) {
 			while (($file = readdir($dh)) !== false) {
 				if (substr($file, 0, 7) === self::TMP_PREFIX) {
 					$path = $this->tmpBaseDir . '/' . $file;
@@ -199,6 +199,7 @@ class TempManager implements ITempManager {
 					}
 				}
 			}
+			closedir($dh);
 		}
 		return $files;
 	}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -523,10 +523,11 @@ class OC_App {
 
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
-					if ($file[0] != '.' and is_dir($apps_dir['path'] . '/' . $file) and is_file($apps_dir['path'] . '/' . $file . '/appinfo/info.xml')) {
+					if ($file[0] != '.' && is_dir($apps_dir['path'] . '/' . $file) && is_file($apps_dir['path'] . '/' . $file . '/appinfo/info.xml')) {
 						$apps[] = $file;
 					}
 				}
+				closedir($dh);
 			}
 		}
 

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -31,6 +31,7 @@ function loadDirectory($path): void {
 			require_once $file;
 		}
 	}
+	closedir($dh);
 }
 
 function getSubclasses($parentClassName): array {

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -82,10 +82,11 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('/');
 		$content = [];
 		while ($file = readdir($dh)) {
-			if ($file != '.' and $file != '..') {
+			if ($file != '.' && $file != '..') {
 				$content[] = $file;
 			}
 		}
+		closedir($dh);
 		$this->assertEquals([$directory], $content);
 
 		$content = iterator_to_array($this->instance->getDirectoryContent('/'));
@@ -114,10 +115,11 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('/');
 		$content = [];
 		while ($file = readdir($dh)) {
-			if ($file != '.' and $file != '..') {
+			if ($file != '.' && $file != '..') {
 				$content[] = $file;
 			}
 		}
+		closedir($dh);
 		$this->assertEquals([], $content);
 	}
 
@@ -455,10 +457,11 @@ abstract class Storage extends \Test\TestCase {
 		$dh = $this->instance->opendir('#foo');
 		$content = [];
 		while ($file = readdir($dh)) {
-			if ($file != '.' and $file != '..') {
+			if ($file != '.' && $file != '..') {
 				$content[] = $file;
 			}
 		}
+		closedir($dh);
 
 		$this->assertEquals(['test.txt'], $content);
 	}

--- a/tests/lib/Files/Storage/Wrapper/JailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/JailTest.php
@@ -33,6 +33,7 @@ class JailTest extends \Test\Files\Storage\Storage {
 				$contents[] = $file;
 			}
 		}
+		closedir($dh);
 		$this->assertEquals(['foo'], $contents);
 		$this->sourceStorage->cleanUp();
 		parent::tearDown();


### PR DESCRIPTION
## Summary

The directory handle `$dh` is explicitly closed using `closedir($dh)` to release resources after iterating through the directory.
This ensures proper resource management.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)