### PR TITLE
Fix: #41005 Resend welcome email

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2023, Ezhil Shanmugham <ezhil930@gmail.com>
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bjoern Schiessle <bjoern@schiessle.org>
@@ -25,6 +26,7 @@ declare(strict_types=1);
  * @author Tom Needham <tom@owncloud.com>
  * @author Vincent Petry <vincent@nextcloud.com>
  * @author Kate Döen <kate.doeen@nextcloud.com>
+ * @author Ezhil Shanmugham <ezhil930@gmail.com>
  *
  * @license AGPL-3.0
  *
@@ -1546,7 +1548,12 @@ class UsersController extends AUserData {
 		}
 
 		try {
-			$emailTemplate = $this->newUserMailHelper->generateTemplate($targetUser, false);
+			if ($this->config->getUserValue($targetUser->getUID(), 'core', 'lostpassword')) {
+				$emailTemplate = $this->newUserMailHelper->generateTemplate($targetUser, true);
+			} else {
+				$emailTemplate = $this->newUserMailHelper->generateTemplate($targetUser, false);
+			}
+
 			$this->newUserMailHelper->sendMail($targetUser, $emailTemplate);
 		} catch (\Exception $e) {
 			$this->logger->error(


### PR DESCRIPTION
Resolves: #41005

## Summary
- Fixed the bug reported on Issue #41005
- Resend welcome email does not send password reset token in the email template when password is not provided at the time to creating new users
- This has been fixed now. Password reset token will be sent in the email template when the password is not provided by the admin  

| Before Fix (Resend welcome email) | After Fix (Resend welcome email) |
|----------|----------|
| ![image](https://github.com/nextcloud/server/assets/103899034/4d2b27d2-0227-4375-afdc-3890245ff4db) | ![image](https://github.com/nextcloud/server/assets/103899034/aa1db3b4-2d5d-4949-89cb-c85290cfe978) |


## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
