### PR TITLE
Updated visible 'Twitter' name to 'X' in Personal info

### DIFF
--- a/apps/settings/src/components/PersonalInfo/TwitterSection.vue
+++ b/apps/settings/src/components/PersonalInfo/TwitterSection.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<AccountPropertySection v-bind.sync="twitter"
-		:placeholder="t('settings', 'Your Twitter handle')" />
+		:placeholder="t('settings', 'Your X handle')" />
 </template>
 
 <script>

--- a/apps/settings/src/components/PersonalInfo/TwitterSection.vue
+++ b/apps/settings/src/components/PersonalInfo/TwitterSection.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<AccountPropertySection v-bind.sync="twitter"
-		:placeholder="t('settings', 'Your X handle')" />
+		:placeholder="t('settings', 'Your X (formerly Twitter) handle')" />
 </template>
 
 <script>

--- a/apps/settings/src/constants/AccountPropertyConstants.js
+++ b/apps/settings/src/constants/AccountPropertyConstants.js
@@ -58,7 +58,7 @@ export const ACCOUNT_PROPERTY_READABLE_ENUM = Object.freeze({
 	PHONE: t('settings', 'Phone number'),
 	PROFILE_ENABLED: t('settings', 'Profile'),
 	ROLE: t('settings', 'Role'),
-	TWITTER: t('settings', 'X (Formerly Twitter)'),
+	TWITTER: t('settings', 'X (formerly Twitter)'),
 	FEDIVERSE: t('settings', 'Fediverse (e.g. Mastodon)'),
 	WEBSITE: t('settings', 'Website'),
 })

--- a/apps/settings/src/constants/AccountPropertyConstants.js
+++ b/apps/settings/src/constants/AccountPropertyConstants.js
@@ -58,7 +58,7 @@ export const ACCOUNT_PROPERTY_READABLE_ENUM = Object.freeze({
 	PHONE: t('settings', 'Phone number'),
 	PROFILE_ENABLED: t('settings', 'Profile'),
 	ROLE: t('settings', 'Role'),
-	TWITTER: t('settings', 'Twitter'),
+	TWITTER: t('settings', 'X (Formerly Twitter)'),
 	FEDIVERSE: t('settings', 'Fediverse (e.g. Mastodon)'),
 	WEBSITE: t('settings', 'Website'),
 })


### PR DESCRIPTION
* Resolves:[ #40648](https://github.com/nextcloud/server/issues/40648)

## Summary

- Updated the visual instances of 'Twitter' to 'X' in the setting's Personal Info tab

## Before:
![image](https://github.com/nextcloud/server/assets/14002597/60a6527a-4a34-418a-b000-238af39be01a)


## After:
![image](https://github.com/nextcloud/server/assets/14002597/1c1225dd-7e59-4dc9-9a90-9f33c56ff7d6)


## TODO

- [x] Read through the checklist

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
