### PR TITLE
fix(provisioning_api): Fix quota fields in OpenAPI

### DIFF
--- a/apps/provisioning_api/lib/ResponseDefinitions.php
+++ b/apps/provisioning_api/lib/ResponseDefinitions.php
@@ -27,11 +27,11 @@ namespace OCA\Provisioning_API;
 
 /**
  * @psalm-type ProvisioningApiUserDetailsQuota = array{
- *     free?: float,
+ *     free?: float|int,
  *     quota?: float|int|string,
- *     relative?: float,
- *     total?: float,
- *     used?: float,
+ *     relative?: float|int,
+ *     total?: float|int,
+ *     used?: float|int,
  * }
  *
  * @psalm-type ProvisioningApiUserDetails = array{

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -507,8 +507,16 @@
                 "type": "object",
                 "properties": {
                     "free": {
-                        "type": "number",
-                        "format": "float"
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        ]
                     },
                     "quota": {
                         "oneOf": [
@@ -526,16 +534,40 @@
                         ]
                     },
                     "relative": {
-                        "type": "number",
-                        "format": "float"
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        ]
                     },
                     "total": {
-                        "type": "number",
-                        "format": "float"
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        ]
                     },
                     "used": {
-                        "type": "number",
-                        "format": "float"
+                        "oneOf": [
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Should have been fixed in https://github.com/nextcloud/server/pull/40426.
All this storage code is very old and psalm doesn't understand most of it, so it doesn't show any errors. I manually verified that this is the correct way to type those fields.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
