### PR TITLE
fix(files_external): on case insensitive system, block case change

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -59,6 +59,11 @@ class SMB extends Backend {
 				(new DefinitionParameter('show_hidden', $l->t('Show hidden files')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('case_sensitive', $l->t('Case sensitive file system')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL)
+					->setDefaultValue(true)
+					->setTooltip($l->t('Disabling it will allow to use a case insentive file system, but comes with a performance penalty')),
 				(new DefinitionParameter('check_acl', $l->t('Verify ACL access when listing files')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL)


### PR DESCRIPTION
* Ref: #40690 

## Summary

Add an option to declare a SMB share case-insensitive.

When a file/directory is renamed to the same name with only case change, the rename fail. We block this kind of rename.

The user will have to rename to another name first.