### PR TITLE
get children from dav node when preloading system tags

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -303,9 +303,11 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 			$fileIds = [$node->getId()];
 
 			// note: pre-fetching only supported for depth <= 1
-			$folderContent = $node->getNode()->getDirectoryListing();
+			$folderContent = $node->getChildren();
 			foreach ($folderContent as $info) {
-				$fileIds[] = $info->getId();
+				if ($info instanceof Node) {
+					$fileIds[] = $info->getId();
+				}
 			}
 
 			$tags = $this->tagMapper->getTagIdsForObjects($fileIds, 'files');


### PR DESCRIPTION
`Directory::getChildren` does internal caching so this prevents needlessly getting the children multiple times