### PR TITLE
fix(theming): Correctly expose user and admin theming

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -27,9 +27,14 @@
  */
 namespace OCA\Theming;
 
+use Exception;
+use OCA\Theming\AppInfo\Application;
+use OCA\Theming\Service\BackgroundService;
 use OCP\Capabilities\IPublicCapability;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
 
 /**
  * Class Capabilities
@@ -50,17 +55,20 @@ class Capabilities implements IPublicCapability {
 	/** @var IConfig */
 	protected $config;
 
+	protected IUserSession $userSession;
+
 	/**
 	 * @param ThemingDefaults $theming
 	 * @param Util $util
 	 * @param IURLGenerator $url
 	 * @param IConfig $config
 	 */
-	public function __construct(ThemingDefaults $theming, Util $util, IURLGenerator $url, IConfig $config) {
+	public function __construct(ThemingDefaults $theming, Util $util, IURLGenerator $url, IConfig $config, IUserSession $userSession) {
 		$this->theming = $theming;
 		$this->util = $util;
 		$this->url = $url;
 		$this->config = $config;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -86,23 +94,49 @@ class Capabilities implements IPublicCapability {
 	 * }
 	 */
 	public function getCapabilities() {
+		$color = $this->theming->getDefaultColorPrimary();
+		$colorText = $this->theming->getDefaultTextColorPrimary();
+
 		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime', '');
-		$color = $this->theming->getColorPrimary();
+		$backgroundPlain = $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $color !== '#0082c9');
+		$background = $backgroundPlain ? $color : $this->url->getAbsoluteURL($this->theming->getBackground());
+
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser) {
+			/**
+			 * Mimics the logic of generateUserBackgroundVariables() that generates the CSS variables.
+			 * Also needs to be updated if the logic changes.
+			 * @see \OCA\Theming\Themes\CommonThemeTrait::generateUserBackgroundVariables()
+			 */
+			$color = $this->theming->getColorPrimary();
+			$colorText = $this->theming->getTextColorPrimary();
+
+			$backgroundImage = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background_image', BackgroundService::BACKGROUND_DEFAULT);
+			if ($backgroundImage === BackgroundService::BACKGROUND_CUSTOM) {
+				$backgroundPlain = false;
+				$background = $this->url->linkToRouteAbsolute('theming.userTheme.getBackground');
+			} else if (isset(BackgroundService::SHIPPED_BACKGROUNDS[$backgroundImage])) {
+				$backgroundPlain = false;
+				$background = $this->url->linkTo(Application::APP_ID, "img/background/$backgroundImage");
+			} else if ($backgroundImage !== BackgroundService::BACKGROUND_DEFAULT) {
+				$backgroundPlain = true;
+				$background = $color;
+			}
+		}
+
 		return [
 			'theming' => [
 				'name' => $this->theming->getName(),
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $color,
-				'color-text' => $this->theming->getTextColorPrimary(),
+				'color-text' => $colorText,
 				'color-element' => $this->util->elementColor($color),
 				'color-element-bright' => $this->util->elementColor($color),
 				'color-element-dark' => $this->util->elementColor($color, false),
 				'logo' => $this->url->getAbsoluteURL($this->theming->getLogo()),
-				'background' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9') ?
-					$this->theming->getColorPrimary() :
-					$this->url->getAbsoluteURL($this->theming->getBackground()),
-				'background-plain' => $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $this->theming->getColorPrimary() !== '#0082c9'),
+				'background' => $background,
+				'background-plain' => $backgroundPlain,
 				'background-default' => !$this->util->isBackgroundThemed(),
 				'logoheader' => $this->url->getAbsoluteURL($this->theming->getLogo()),
 				'favicon' => $this->url->getAbsoluteURL($this->theming->getLogo()),

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -36,6 +36,7 @@ use OCP\App\IAppManager;
 use OCP\Files\IAppData;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\IUserSession;
 use Test\TestCase;
 
 /**
@@ -56,6 +57,8 @@ class CapabilitiesTest extends TestCase {
 	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
 	protected $util;
 
+	protected IUserSession $userSession;
+
 	/** @var Capabilities */
 	protected $capabilities;
 
@@ -66,7 +69,8 @@ class CapabilitiesTest extends TestCase {
 		$this->url = $this->getMockBuilder(IURLGenerator::class)->getMock();
 		$this->config = $this->createMock(IConfig::class);
 		$this->util = $this->createMock(Util::class);
-		$this->capabilities = new Capabilities($this->theming, $this->util, $this->url, $this->config);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->capabilities = new Capabilities($this->theming, $this->util, $this->url, $this->config, $this->userSession);
 	}
 
 	public function dataGetCapabilities() {
@@ -165,13 +169,13 @@ class CapabilitiesTest extends TestCase {
 			->method('getSlogan')
 			->willReturn($slogan);
 		$this->theming->expects($this->atLeast(1))
-			->method('getColorPrimary')
+			->method('getDefaultColorPrimary')
 			->willReturn($color);
 		$this->theming->expects($this->exactly(3))
 			->method('getLogo')
 			->willReturn($logo);
 		$this->theming->expects($this->once())
-			->method('getTextColorPrimary')
+			->method('getDefaultTextColorPrimary')
 			->willReturn($textColor);
 
 		$util = new Util($this->config, $this->createMock(IAppManager::class), $this->createMock(IAppData::class), $this->createMock(ImageManager::class));


### PR DESCRIPTION
Supersedes https://github.com/nextcloud/server/pull/40877

## Summary

The capabilities were mixing the admin theme and the user theme.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
