### PR TITLE
fix(3rdparty): Don't use indirect dependency "Safe/" for functions

### DIFF
--- a/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Tests\integration\UserMigration;
 
-use function Safe\scandir;
+use function scandir;
 use OCA\DAV\AppInfo\Application;
 use OCA\DAV\UserMigration\CalendarMigrator;
 use OCP\AppFramework\App;

--- a/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Tests\integration\UserMigration;
 
-use function Safe\scandir;
+use function scandir;
 use OCA\DAV\AppInfo\Application;
 use OCA\DAV\UserMigration\ContactsMigrator;
 use OCP\AppFramework\App;

--- a/apps/dav/tests/unit/CalDAV/AppCalendar/AppCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/AppCalendar/AppCalendarTest.php
@@ -25,7 +25,7 @@ use OCP\Constants;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
-use function Safe\rewind;
+use function rewind;
 
 class AppCalendarTest extends TestCase {
 	private $principal = 'principals/users/foo';
@@ -35,7 +35,7 @@ class AppCalendarTest extends TestCase {
 
 	private ICalendar|MockObject $calendar;
 	private ICalendar|MockObject $writeableCalendar;
-	
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -115,7 +115,7 @@ class AppCalendarTest extends TestCase {
 			'principal' => $this->principal,
 			'protected' => true,
 		];
-		
+
 		// Check that the correct ACL is returned (default be only readable)
 		$this->assertEquals($expectedRO, $this->appCalendar->getACL());
 		$this->assertEquals($expectedRW, $this->writeableAppCalendar->getACL());

--- a/core/Db/ProfileConfig.php
+++ b/core/Db/ProfileConfig.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 
 namespace OC\Core\Db;
 
-use function Safe\json_decode;
-use function Safe\json_encode;
+use function json_decode;
+use function json_encode;
 use \JsonSerializable;
 use OCP\AppFramework\Db\Entity;
 use OCP\Profile\ParameterDoesNotExistException;

--- a/lib/private/Profile/Actions/FediverseAction.php
+++ b/lib/private/Profile/Actions/FediverseAction.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OC\Profile\Actions;
 
-use function Safe\substr;
+use function substr;
 use OCP\Accounts\IAccountManager;
 use OCP\IURLGenerator;
 use OCP\IUser;

--- a/lib/private/Profile/Actions/TwitterAction.php
+++ b/lib/private/Profile/Actions/TwitterAction.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace OC\Profile\Actions;
 
-use function Safe\substr;
+use function substr;
 use OCP\Accounts\IAccountManager;
 use OCP\IURLGenerator;
 use OCP\IUser;


### PR DESCRIPTION
* Ref https://github.com/nextcloud/server/pull/41055#discussion_r1368642331

@ChristophWurst there are more places in apps/dav/ that use functions from Safe, but also catch it's exceptions. Maybe you can clear that code with your team

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
