### PR TITLE
Return correct status if touch failed

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -550,18 +550,20 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		];
 
 		try {
-			if (!$this->file_exists($path)) {
-				$mimeType = $this->mimeDetector->detectPath($path);
-				$this->getConnection()->putObject([
-					'Bucket' => $this->bucket,
-					'Key' => $this->cleanKey($path),
-					'Metadata' => $metadata,
-					'Body' => '',
-					'ContentType' => $mimeType,
-					'MetadataDirective' => 'REPLACE',
-				]);
-				$this->testTimeout();
+			if ($this->file_exists($path)) {
+				return false;
 			}
+
+			$mimeType = $this->mimeDetector->detectPath($path);
+			$this->getConnection()->putObject([
+				'Bucket' => $this->bucket,
+				'Key' => $this->cleanKey($path),
+				'Metadata' => $metadata,
+				'Body' => '',
+				'ContentType' => $mimeType,
+				'MetadataDirective' => 'REPLACE',
+			]);
+			$this->testTimeout();
 		} catch (S3Exception $e) {
 			$this->logger->error($e->getMessage(), [
 				'app' => 'files_external',


### PR DESCRIPTION
When uploading a file to an external s3 bucket, the original mtime is not kept. It boils down to the [touch operation being deactivated for existing file for s3 buckets](https://github.com/nextcloud/server/blob/834c9a209ebef7b8d5795b53a018577fe4e534ca/apps/files_external/lib/Lib/Storage/AmazonS3.php#L553). Limitation introduced here: https://github.com/nextcloud/server/pull/21734

This PR changes the return value of the `touch` method. Now this method returns `false` when the file already exists to trigger the following condition: https://github.com/nextcloud/server/blob/e66e8bad1a711ec3073e901e824edc3f92dbd107/lib/private/Files/View.php#L560-L571