### PR TITLE
Fix for previews not being generated sometimes

### DIFF
--- a/lib/private/Preview/Watcher.php
+++ b/lib/private/Preview/Watcher.php
@@ -61,6 +61,9 @@ class Watcher {
 		}
 
 		try {
+			if (is_null($node->getId())) {
+				return;
+			}
 			$folder = $this->appData->getFolder((string)$node->getId());
 			$folder->delete();
 		} catch (NotFoundException $e) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/36463

## Summary
- A lot of unnecessary `rmdir` calls are done on the preview directory

- After investigating, here are the findings to justify the fix:
  - As per https://github.com/nextcloud/server/blob/834c9a209ebef7b8d5795b53a018577fe4e534ca/lib/private/Files/FileInfo.php#L164 there is a return type of `int` or `null`
  - A `null` return by this method call over [here](https://github.com/nextcloud/server/blob/834c9a209ebef7b8d5795b53a018577fe4e534ca/lib/private/Preview/Watcher.php#L64) makes sure that an empty string is passed to `$this->appData->getFolder()`
  - As per the logic, for an empty string this will return the preview folder i.e. `appdata_*****/preview` in our case
  - There is then an attempt to delete this entire folder

- On our instance we did find logs that a delete is attempted on the entire preview folder as per https://github.com/nextcloud/server/issues/36463#issuecomment-1766963639
- Further, by logging I could confirm that `$node->getId()` is indeed null in one case leading to consistent triggering of this `rmdir`
- One case is the upload of a partial file (`.part` extension)
  - The Nextcloud clients avoid this but certain DAV clients allow to upload to nextcloud servers
  - This kind of file is ignored by [`isPartialFile`](https://github.com/nextcloud/server/blob/834c9a209ebef7b8d5795b53a018577fe4e534ca/lib/public/Files/Cache/IScanner.php#L75) 
  - In this example a file with the `.part` extension succesfully triggers an `rmdir` of the entire preview directory 

#### Stack trace of the bug
```json
{
	"reqId": "*****",
	"level": 3,
	"time": "2023-10-17T17:50:58+00:00",
	"remoteAddr": "***.***.***.***",
	"user": "*****",
	"app": "PHP",
	"method": "MOVE",
	"url": "/remote.php/dav/uploads/*****/*****/*****",
	"message": "rmdir(/var/www/data/appdata_*****/preview/1): Directory not empty at /var/www/html/lib/private/Files/Storage/Local.php#139",
	"version": "25.0.8.2",
	"exception": {
		"Exception": "Error",
		"Message": "rmdir(/var/www/data/appdata_*****/preview/1): Directory not empty at /var/www/html/lib/private/Files/Storage/Local.php#139",
		"Code": 0,
		"Trace": [
			{
				"function": "onError",
				"class": "OC\\Log\\ErrorHandler",
				"type": "::",
				"args": [
					2,
					"rmdir(/var/www/data/appdata_*****/preview/1): Directory not empty",
					"/var/www/html/lib/private/Files/Storage/Local.php",
					139
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Storage/Local.php",
				"line": 139,
				"function": "rmdir",
				"args": [
					"/var/www/data/appdata_*****/preview/1"
				]
			},
			{
				"function": "rmdir",
				"class": "OC\\Files\\Storage\\Local",
				"type": "->",
				"args": [
					"appdata_*****/preview"
				]
			},
			{
				"file": "/var/www/html/apps/files_trashbin/lib/Storage.php",
				"line": 193,
				"function": "call_user_func",
				"args": [
					[
						[
							"OC\\Files\\Storage\\LocalRootStorage"
						],
						"rmdir"
					],
					"appdata_*****/preview"
				]
			},
			{
				"file": "/var/www/html/apps/files_trashbin/lib/Storage.php",
				"line": 125,
				"function": "doDelete",
				"class": "OCA\\Files_Trashbin\\Storage",
				"type": "->",
				"args": [
					"appdata_*****/preview",
					"rmdir"
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/View.php",
				"line": 1181,
				"function": "rmdir",
				"class": "OCA\\Files_Trashbin\\Storage",
				"type": "->",
				"args": [
					"appdata_*****/preview"
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/View.php",
				"line": 349,
				"function": "basicOperation",
				"class": "OC\\Files\\View",
				"type": "->",
				"args": [
					"rmdir",
					"/appdata_*****/preview",
					[
						"delete"
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Node/Folder.php",
				"line": 363,
				"function": "rmdir",
				"class": "OC\\Files\\View",
				"type": "->",
				"args": [
					"/appdata_*****/preview"
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/SimpleFS/SimpleFolder.php",
				"line": 68,
				"function": "delete",
				"class": "OC\\Files\\Node\\Folder",
				"type": "->",
				"args": []
			},
			{
				"file": "/var/www/html/lib/private/Preview/Watcher.php",
				"line": 65,
				"function": "delete",
				"class": "OC\\Files\\SimpleFS\\SimpleFolder",
				"type": "->",
				"args": []
			},
			{
				"file": "/var/www/html/lib/private/Preview/Watcher.php",
				"line": 54,
				"function": "deleteNode",
				"class": "OC\\Preview\\Watcher",
				"type": "->",
				"args": [
					"*** sensitive parameters replaced ***"
				]
			},
			{
				"file": "/var/www/html/lib/private/Preview/WatcherConnector.php",
				"line": 63,
				"function": "postWrite",
				"class": "OC\\Preview\\Watcher",
				"type": "->",
				"args": [
					"*** sensitive parameters replaced ***"
				]
			},
			{
				"function": "OC\\Preview\\{closure}",
				"class": "OC\\Preview\\WatcherConnector",
				"type": "->",
				"args": [
					"*** sensitive parameters replaced ***"
				]
			},
			{
				"file": "/var/www/html/lib/private/Hooks/EmitterTrait.php",
				"line": 106,
				"function": "call_user_func_array",
				"args": [
					[
						"Closure"
					],
					[
						"*** sensitive parameters replaced ***"
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Hooks/PublicEmitter.php",
				"line": 40,
				"function": "emit",
				"class": "OC\\Hooks\\BasicEmitter",
				"type": "->",
				"args": [
					"\\OC\\Files",
					"postWrite",
					[
						"*** sensitive parameters replaced ***"
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Node/Root.php",
				"line": 143,
				"function": "emit",
				"class": "OC\\Hooks\\PublicEmitter",
				"type": "->",
				"args": [
					"\\OC\\Files",
					"postWrite",
					[
						"*** sensitive parameters replaced ***"
					]
				]
			},
			{
				"function": "emit",
				"class": "OC\\Files\\Node\\Root",
				"type": "->",
				"args": [
					"\\OC\\Files",
					"postWrite",
					[
						"*** sensitive parameters replaced ***"
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Node/LazyFolder.php",
				"line": 72,
				"function": "call_user_func_array",
				"args": [
					[
						[
							"OC\\Files\\Node\\Root"
						],
						"emit"
					],
					[
						"\\OC\\Files",
						"postWrite",
						[
							"*** sensitive parameters replaced ***"
						]
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Node/LazyFolder.php",
				"line": 100,
				"function": "__call",
				"class": "OC\\Files\\Node\\LazyFolder",
				"type": "->",
				"args": [
					"emit",
					[
						"\\OC\\Files",
						"postWrite",
						[
							"*** sensitive parameters replaced ***"
						]
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/Files/Node/HookConnector.php",
				"line": 117,
				"function": "emit",
				"class": "OC\\Files\\Node\\LazyFolder",
				"type": "->",
				"args": [
					"\\OC\\Files",
					"postWrite",
					[
						"*** sensitive parameters replaced ***"
					]
				]
			},
			{
				"file": "/var/www/html/lib/private/legacy/OC_Hook.php",
				"line": 106,
				"function": "postWrite",
				"class": "OC\\Files\\Node\\HookConnector",
				"type": "->",
				"args": [
					[
						"/****/*****/*****/*****.part"
					]
				]
			},
			{
				"file": "/var/www/html/apps/dav/lib/Connector/Sabre/File.php",
				"line": 473,
				"function": "emit",
				"class": "OC_Hook",
				"type": "::",
				"args": [
					"OC_Filesystem",
					"post_write",
					[
						"/****/*****/*****/*****.part"
					]
				]
			},
			{
				"file": "/var/www/html/apps/dav/lib/Connector/Sabre/File.php",
				"line": 398,
				"function": "emitPostHooks",
				"class": "OCA\\DAV\\Connector\\Sabre\\File",
				"type": "->",
				"args": [
					true
				]
			},
			{
				"file": "/var/www/html/apps/dav/lib/Connector/Sabre/Directory.php",
				"line": 151,
				"function": "put",
				"class": "OCA\\DAV\\Connector\\Sabre\\File",
				"type": "->",
				"args": [
					null
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php",
				"line": 307,
				"function": "createFile",
				"class": "OCA\\DAV\\Connector\\Sabre\\Directory",
				"type": "->",
				"args": [
					"*****",
					null
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php",
				"line": 133,
				"function": "copyNode",
				"class": "Sabre\\DAV\\Tree",
				"type": "->",
				"args": [
					[
						"OCA\\DAV\\Upload\\FutureFile"
					],
					[
						"OCA\\DAV\\Connector\\Sabre\\Directory"
					],
					"*****"
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Tree.php",
				"line": 163,
				"function": "copy",
				"class": "Sabre\\DAV\\Tree",
				"type": "->",
				"args": [
					"uploads/*****/*****/*****",
					"files/*****/****/*****/*****/*****.part"
				]
			},
			{
				"file": "/var/www/html/apps/dav/lib/Upload/ChunkingPlugin.php",
				"line": 94,
				"function": "move",
				"class": "Sabre\\DAV\\Tree",
				"type": "->",
				"args": [
					"uploads/*****/*****/*****",
					"files/*****/****/*****/*****/*****.part"
				]
			},
			{
				"file": "/var/www/html/apps/dav/lib/Upload/ChunkingPlugin.php",
				"line": 76,
				"function": "performMove",
				"class": "OCA\\DAV\\Upload\\ChunkingPlugin",
				"type": "->",
				"args": [
					"uploads/*****/*****/*****",
					"files/*****/****/*****/*****/*****.part"
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
				"line": 89,
				"function": "beforeMove",
				"class": "OCA\\DAV\\Upload\\ChunkingPlugin",
				"type": "->",
				"args": [
					"uploads/*****/*****/*****",
					"files/*****/****/*****/*****/*****.part"
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
				"line": 603,
				"function": "emit",
				"class": "Sabre\\DAV\\Server",
				"type": "->",
				"args": [
					"beforeMove",
					[
						"uploads/*****/*****/*****",
						"files/*****/****/*****/*****/*****.part"
					]
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
				"line": 89,
				"function": "httpMove",
				"class": "Sabre\\DAV\\CorePlugin",
				"type": "->",
				"args": [
					[
						"Sabre\\HTTP\\Request"
					],
					[
						"Sabre\\HTTP\\Response"
					]
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
				"line": 472,
				"function": "emit",
				"class": "Sabre\\DAV\\Server",
				"type": "->",
				"args": [
					"method:MOVE",
					[
						[
							"Sabre\\HTTP\\Request"
						],
						[
							"Sabre\\HTTP\\Response"
						]
					]
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
				"line": 253,
				"function": "invokeMethod",
				"class": "Sabre\\DAV\\Server",
				"type": "->",
				"args": [
					[
						"Sabre\\HTTP\\Request"
					],
					[
						"Sabre\\HTTP\\Response"
					]
				]
			},
			{
				"file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
				"line": 321,
				"function": "start",
				"class": "Sabre\\DAV\\Server",
				"type": "->",
				"args": []
			},
			{
				"file": "/var/www/html/apps/dav/lib/Server.php",
				"line": 360,
				"function": "exec",
				"class": "Sabre\\DAV\\Server",
				"type": "->",
				"args": []
			},
			{
				"file": "/var/www/html/apps/dav/appinfo/v2/remote.php",
				"line": 35,
				"function": "exec",
				"class": "OCA\\DAV\\Server",
				"type": "->",
				"args": []
			},
			{
				"file": "/var/www/html/remote.php",
				"line": 172,
				"args": [
					"/var/www/html/apps/dav/appinfo/v2/remote.php"
				],
				"function": "require_once"
			}
		],
		"File": "/var/www/html/lib/private/Log/ErrorHandler.php",
		"Line": 92,
		"CustomMessage": "--"
	}
}
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
