### PR TITLE
fix(update): Allow updating from 27.1 to 28

### DIFF
--- a/version.php
+++ b/version.php
@@ -38,6 +38,7 @@ $OC_VersionString = '28.0.0 dev';
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
 		'27.0' => true,
+		'27.1' => true,
 		'28.0' => true,
 	],
 	'owncloud' => [


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
