### PR TITLE
Add a command to run the setup checks from CLI

### DIFF
--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -64,6 +64,7 @@ class SetupChecks extends Base {
 						$emoji = match ($check->getSeverity()) {
 							'success' => '✓',
 							'error' => '❌',
+							'warning' => '⚠',
 							default => 'ℹ',
 						};
 						$verbosity = ($check->getSeverity() === 'error' ? OutputInterface::VERBOSITY_QUIET : OutputInterface::VERBOSITY_NORMAL);

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -66,12 +66,15 @@ class SetupChecks extends Base {
 							'error' => '❌',
 							default => 'ℹ',
 						};
+						$verbosity = ($check->getSeverity() === 'error' ? OutputInterface::VERBOSITY_QUIET : OutputInterface::VERBOSITY_NORMAL);
+						$description = $check->getDescription();
 						$output->writeln(
 							"\t\t<{$styleTag}>".
 							"{$emoji} ".
 							$title.
-							($check->getDescription() !== null ? ': '.$check->getDescription() : '').
-							"</{$styleTag}>"
+							($description !== null ? ': '.$description : '').
+							"</{$styleTag}>",
+							$verbosity
 						);
 					}
 				}
@@ -79,10 +82,10 @@ class SetupChecks extends Base {
 		foreach ($results as $category => $checks) {
 			foreach ($checks as $title => $check) {
 				if ($check->getSeverity() !== 'success') {
-					return 1;
+					return self::FAILURE;
 				}
 			}
 		}
-		return 0;
+		return self::SUCCESS;
 	}
 }

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -59,7 +59,8 @@ class SetupChecks extends Base {
 						$styleTag = match ($check->getSeverity()) {
 							'success' => 'info',
 							'error' => 'error',
-							default => 'comment',
+							'warning' => 'comment',
+							default => null,
 						};
 						$emoji = match ($check->getSeverity()) {
 							'success' => '✓',
@@ -70,11 +71,12 @@ class SetupChecks extends Base {
 						$verbosity = ($check->getSeverity() === 'error' ? OutputInterface::VERBOSITY_QUIET : OutputInterface::VERBOSITY_NORMAL);
 						$description = $check->getDescription();
 						$output->writeln(
-							"\t\t<{$styleTag}>".
+							"\t\t".
+							($styleTag !== null ? "<{$styleTag}>" : '').
 							"{$emoji} ".
 							$title.
 							($description !== null ? ': '.$description : '').
-							"</{$styleTag}>",
+							($styleTag !== null ? "</{$styleTag}>" : ''),
 							$verbosity
 						);
 					}

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command;
+
+use OCP\SetupCheck\ISetupCheckManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SetupChecks extends Base {
+	public function __construct(
+		private ISetupCheckManager $setupCheckManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+
+		$this
+			->setName('setupchecks')
+			->setDescription('Run setup checks and output the results')
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$results = $this->setupCheckManager->runAll();
+		switch ($input->getOption('output')) {
+			case self::OUTPUT_FORMAT_JSON:
+			case self::OUTPUT_FORMAT_JSON_PRETTY:
+				$this->writeArrayInOutputFormat($input, $output, $results);
+				break;
+			default:
+				foreach ($results as $category => $checks) {
+					$output->writeln("\t{$category}:");
+					foreach ($checks as $title => $check) {
+						$styleTag = match ($check->getSeverity()) {
+							'success' => 'info',
+							'error' => 'error',
+							default => 'comment',
+						};
+						$emoji = match ($check->getSeverity()) {
+							'success' => '✓',
+							'error' => '❌',
+							default => 'ℹ',
+						};
+						$output->writeln(
+							"\t\t<{$styleTag}>".
+							"{$emoji} ".
+							$title.
+							($check->getDescription() !== null ? ': '.$check->getDescription() : '').
+							"</{$styleTag}>"
+						);
+					}
+				}
+		}
+		foreach ($results as $category => $checks) {
+			foreach ($checks as $title => $check) {
+				if ($check->getSeverity() !== 'success') {
+					return 1;
+				}
+			}
+		}
+		return 0;
+	}
+}

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -63,7 +63,7 @@ class SetupChecks extends Base {
 						};
 						$emoji = match ($check->getSeverity()) {
 							'success' => '✓',
-							'error' => '❌',
+							'error' => '✗',
 							'warning' => '⚠',
 							default => 'ℹ',
 						};

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -214,6 +214,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager()));
 	$application->add(\OC::$server->get(\OC\Core\Command\Security\BruteforceAttempts::class));
 	$application->add(\OC::$server->get(\OC\Core\Command\Security\BruteforceResetAttempts::class));
+	$application->add(\OC::$server->get(\OC\Core\Command\SetupChecks::class));
 } else {
 	$application->add(\OC::$server->get(\OC\Core\Command\Maintenance\Install::class));
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1059,6 +1059,7 @@ return array(
     'OC\\Core\\Command\\Security\\ImportCertificate' => $baseDir . '/core/Command/Security/ImportCertificate.php',
     'OC\\Core\\Command\\Security\\ListCertificates' => $baseDir . '/core/Command/Security/ListCertificates.php',
     'OC\\Core\\Command\\Security\\RemoveCertificate' => $baseDir . '/core/Command/Security/RemoveCertificate.php',
+    'OC\\Core\\Command\\SetupChecks' => $baseDir . '/core/Command/SetupChecks.php',
     'OC\\Core\\Command\\Status' => $baseDir . '/core/Command/Status.php',
     'OC\\Core\\Command\\SystemTag\\Add' => $baseDir . '/core/Command/SystemTag/Add.php',
     'OC\\Core\\Command\\SystemTag\\Delete' => $baseDir . '/core/Command/SystemTag/Delete.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1092,6 +1092,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Security\\ImportCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/ImportCertificate.php',
         'OC\\Core\\Command\\Security\\ListCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ListCertificates.php',
         'OC\\Core\\Command\\Security\\RemoveCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/RemoveCertificate.php',
+        'OC\\Core\\Command\\SetupChecks' => __DIR__ . '/../../..' . '/core/Command/SetupChecks.php',
         'OC\\Core\\Command\\Status' => __DIR__ . '/../../..' . '/core/Command/Status.php',
         'OC\\Core\\Command\\SystemTag\\Add' => __DIR__ . '/../../..' . '/core/Command/SystemTag/Add.php',
         'OC\\Core\\Command\\SystemTag\\Delete' => __DIR__ . '/../../..' . '/core/Command/SystemTag/Delete.php',


### PR DESCRIPTION
## Summary

Add a command to run the setup checks from the cli.
This will help setup checks development by having an easy way to test setup checks and see their names&descriptions.
This will also be useful for admins who want to check their server problems from cli.

Screenshot:
![Screenshot_20231026_120306](https://github.com/nextcloud/server/assets/91878298/8b35e222-c985-4989-a9a4-f2cf3da010a3)

Note that names, categories and descriptions are not finals. The point of this command is also to be able to see all of them easily and adapt what looks wrong.

## TODO

- [x] Only failure by default and success with --verbose?
- [x] Improve warning/info differences
- [x] Fix descriptions and categories (not in this PR) https://github.com/nextcloud/server/pull/41083
- [x] Decide on naming: is setupchecks the right command name? Should this replace check? Some other name?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
