### PR TITLE
[stable27] fix(isLegitimatedForUserId): Setup mountpoints to check file access

### DIFF
--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Jonas Meurer <jonas@freesources.org>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -27,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\WorkflowEngine\Entity;
 
 use OC\Files\Config\UserMountCache;
+use OC\Files\Mount\Manager as MountManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\Files\InvalidPathException;
@@ -77,6 +79,8 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 	private $userManager;
 	/** @var UserMountCache */
 	private $userMountCache;
+	/** @var MountManager */
+	private $mountManager;
 
 	public function __construct(
 		IL10N $l10n,
@@ -86,7 +90,8 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 		IUserSession $userSession,
 		ISystemTagManager $tagManager,
 		IUserManager $userManager,
-		UserMountCache $userMountCache
+		UserMountCache $userMountCache,
+		MountManager $mountManager
 	) {
 		$this->l10n = $l10n;
 		$this->urlGenerator = $urlGenerator;
@@ -96,6 +101,7 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 		$this->tagManager = $tagManager;
 		$this->userManager = $userManager;
 		$this->userMountCache = $userMountCache;
+		$this->mountManager = $mountManager;
 	}
 
 	public function getName(): string {
@@ -148,10 +154,10 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 				$fileId = $node->getId();
 			}
 
-			$mounts = $this->userMountCache->getMountsForFileId($fileId, $uid);
-			foreach ($mounts as $mount) {
-				$userFolder = $this->root->getUserFolder($uid);
-				if (!empty($userFolder->getById($fileId))) {
+			$mountInfos = $this->userMountCache->getMountsForFileId($fileId, $uid);
+			foreach ($mountInfos as $mountInfo) {
+				$mount = $this->mountManager->getMountFromMountInfo($mountInfo);
+				if ($mount && $mount->getStorage() && !empty($mount->getStorage()->getCache()->get($fileId))) {
 					return true;
 				}
 			}

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -27,6 +27,7 @@
 namespace OCA\WorkflowEngine\Tests;
 
 use OC\Files\Config\UserMountCache;
+use OC\Files\Mount\Manager as MountManager;
 use OC\L10N\L10N;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowEngine\Helper\ScopeContext;
@@ -413,6 +414,7 @@ class ManagerTest extends TestCase {
 							$this->createMock(ISystemTagManager::class),
 							$this->createMock(IUserManager::class),
 							$this->createMock(UserMountCache::class),
+							$this->createMock(MountManager::class),
 						])
 						->setMethodsExcept(['getEvents'])
 						->getMock();

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -26,6 +26,7 @@
  */
 namespace OCA\WorkflowEngine\Tests;
 
+use OC\Files\Config\UserMountCache;
 use OC\L10N\L10N;
 use OCA\WorkflowEngine\Entity\File;
 use OCA\WorkflowEngine\Helper\ScopeContext;
@@ -408,10 +409,10 @@ class ManagerTest extends TestCase {
 							$this->createMock(IURLGenerator::class),
 							$this->createMock(IRootFolder::class),
 							$this->createMock(ILogger::class),
-							$this->createMock(\OCP\Share\IManager::class),
 							$this->createMock(IUserSession::class),
 							$this->createMock(ISystemTagManager::class),
 							$this->createMock(IUserManager::class),
+							$this->createMock(UserMountCache::class),
 						])
 						->setMethodsExcept(['getEvents'])
 						->getMock();

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -463,7 +463,7 @@ class UserMountCache implements IUserMountCache {
 		}, $mounts);
 		$mounts = array_combine($mountPoints, $mounts);
 
-		$current = $path;
+		$current = rtrim($path, '/');
 		// walk up the directory tree until we find a path that has a mountpoint set
 		// the loop will return if a mountpoint is found or break if none are found
 		while (true) {

--- a/lib/private/Files/Mount/Manager.php
+++ b/lib/private/Files/Mount/Manager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Robin Appelman <robin@icewind.nl>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Jonas <jonas@freesources.org>
  *
  * @license AGPL-3.0
  *
@@ -33,6 +34,7 @@ use OCP\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OC\Files\SetupManager;
 use OC\Files\SetupManagerFactory;
+use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
@@ -225,5 +227,22 @@ class Manager implements IMountManager {
 				return in_array($mount->getMountProvider(), $mountProviders);
 			});
 		}
+	}
+
+	/**
+	 * Return the mount matching a cached mount info (or mount file info)
+	 *
+	 * @param ICachedMountInfo $info
+	 *
+	 * @return IMountPoint|null
+	 */
+	public function getMountFromMountInfo(ICachedMountInfo $info): ?IMountPoint {
+		$this->setupManager->setupForPath($info->getMountPoint());
+		foreach ($this->mounts as $mount) {
+			if ($mount->getMountPoint() === $info->getMountPoint()) {
+				return $mount;
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Manual backport of #40482

This fixes workflows on groupfolders, as it will consider access to files in groupfolders.

It also fixes false positives where access to files was limited by other means not taken into account before, e.g. access control.

For postDelete events, check for permissions of the parent folder instead, as the file itself no longer exists.

Fixes: https://github.com/nextcloud/flow_notifications/issues/71

Idea taken from https://github.com/nextcloud/server/pull/38946