### PR TITLE
Improve setup checks naming and improve database version check

### DIFF
--- a/apps/dav/lib/SetupChecks/NeedsSystemAddressBookSync.php
+++ b/apps/dav/lib/SetupChecks/NeedsSystemAddressBookSync.php
@@ -40,7 +40,7 @@ class NeedsSystemAddressBookSync implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for DAV system address book');
+		return $this->l10n->t('DAV system address book');
 	}
 
 	public function getCategory(): string {

--- a/apps/settings/lib/SetupChecks/CheckUserCertificates.php
+++ b/apps/settings/lib/SetupChecks/CheckUserCertificates.php
@@ -46,7 +46,7 @@ class CheckUserCertificates implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for old user imported certificate');
+		return $this->l10n->t('Old user imported certificates');
 	}
 
 	public function run(): SetupResult {

--- a/apps/settings/lib/SetupChecks/DefaultPhoneRegionSet.php
+++ b/apps/settings/lib/SetupChecks/DefaultPhoneRegionSet.php
@@ -38,7 +38,7 @@ class DefaultPhoneRegionSet implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for default phone region');
+		return $this->l10n->t('Default phone region');
 	}
 
 	public function getCategory(): string {

--- a/apps/settings/lib/SetupChecks/LegacySSEKeyFormat.php
+++ b/apps/settings/lib/SetupChecks/LegacySSEKeyFormat.php
@@ -44,12 +44,12 @@ class LegacySSEKeyFormat implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for old server-side-encryption being disabled');
+		return $this->l10n->t('Old server-side-encryption');
 	}
 
 	public function run(): SetupResult {
 		if ($this->config->getSystemValueBool('encryption.legacy_format_support', false) === false) {
-			return SetupResult::success();
+			return SetupResult::success($this->l10n->t('Disabled'));
 		}
 		return SetupResult::warning($this->l10n->t('The old server-side-encryption format is enabled. We recommend disabling this.'), $this->urlGenerator->linkToDocs('admin-sse-legacy-format'));
 	}

--- a/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
+++ b/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
@@ -36,7 +36,7 @@ class PhpDefaultCharset implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for PHP default charset');
+		return $this->l10n->t('PHP default charset');
 	}
 
 	public function getCategory(): string {
@@ -45,7 +45,7 @@ class PhpDefaultCharset implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if (strtoupper(trim(ini_get('default_charset'))) === 'UTF-8') {
-			return SetupResult::success();
+			return SetupResult::success('UTF-8');
 		} else {
 			return SetupResult::warning($this->l10n->t('PHP configuration option default_charset should be UTF-8'));
 		}

--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -42,7 +42,7 @@ class PhpOutdated implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for PHP version');
+		return $this->l10n->t('PHP version');
 	}
 
 	public function run(): SetupResult {

--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -40,13 +40,13 @@ class PhpOutputBuffering implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for PHP output_buffering option');
+		return $this->l10n->t('PHP output_buffering option');
 	}
 
 	public function run(): SetupResult {
 		$value = trim(ini_get('output_buffering'));
 		if ($value === '' || $value === '0') {
-			return SetupResult::success();
+			return SetupResult::success($this->l10n->t('Disabled'));
 		} else {
 			return SetupResult::error($this->l10n->t('PHP configuration option output_buffering must be disabled'));
 		}

--- a/apps/settings/lib/SetupChecks/ReadOnlyConfig.php
+++ b/apps/settings/lib/SetupChecks/ReadOnlyConfig.php
@@ -38,7 +38,7 @@ class ReadOnlyConfig implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for configuration file access rights');
+		return $this->l10n->t('Configuration file access rights');
 	}
 
 	public function getCategory(): string {

--- a/apps/user_ldap/lib/SetupChecks/LdapInvalidUuids.php
+++ b/apps/user_ldap/lib/SetupChecks/LdapInvalidUuids.php
@@ -46,13 +46,13 @@ class LdapInvalidUuids implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Checking for invalid LDAP UUIDs');
+		return $this->l10n->t('Invalid LDAP UUIDs');
 	}
 
 	public function run(): SetupResult {
 		if (count($this->userMapping->getList(0, 1, true)) === 0
 			&& count($this->groupMapping->getList(0, 1, true)) === 0) {
-			return SetupResult::success();
+			return SetupResult::success($this->l10n->t('None found'));
 		} else {
 			return SetupResult::warning($this->l10n->t('Invalid UUIDs of LDAP users or groups have been found. Please review your "Override UUID detection" settings in the Expert part of the LDAP configuration and use "occ ldap:update-uuid" to update them.'));
 		}


### PR DESCRIPTION
* See: #40160 

## Summary

Improve setup checks naming so that output of the checks feel more natural.
Also fix and improves database version checking.

Using #41081 , before:
![Screenshot_20231024_114419](https://github.com/nextcloud/server/assets/91878298/3b08c4e9-03de-451a-9a6b-ae4a22532c63)

current state:
![Screenshot_20231024_114513](https://github.com/nextcloud/server/assets/91878298/659f187d-b903-4c44-8972-f5a016267838)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
