### PR TITLE
enh(SpeechToText): Allow providers to declare a dynamic ID instead of using className

### DIFF
--- a/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
+++ b/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
@@ -31,6 +31,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
 use OCP\SpeechToText\ISpeechToTextManager;
+use OCP\SpeechToText\ISpeechToTextProviderWithId;
 use OCP\TextProcessing\IManager;
 use OCP\TextProcessing\IProvider;
 use OCP\TextProcessing\ITaskType;
@@ -69,7 +70,7 @@ class ArtificialIntelligence implements IDelegatedSettings {
 		$sttProviders = [];
 		foreach ($this->sttManager->getProviders() as $provider) {
 			$sttProviders[] = [
-				'class' => $provider::class,
+				'class' => $provider instanceof ISpeechToTextProviderWithId ? $provider->getId() : $provider::class,
 				'name' => $provider->getName(),
 			];
 		}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -658,6 +658,7 @@ return array(
     'OCP\\SpeechToText\\Events\\TranscriptionSuccessfulEvent' => $baseDir . '/lib/public/SpeechToText/Events/TranscriptionSuccessfulEvent.php',
     'OCP\\SpeechToText\\ISpeechToTextManager' => $baseDir . '/lib/public/SpeechToText/ISpeechToTextManager.php',
     'OCP\\SpeechToText\\ISpeechToTextProvider' => $baseDir . '/lib/public/SpeechToText/ISpeechToTextProvider.php',
+    'OCP\\SpeechToText\\ISpeechToTextProviderWithId' => $baseDir . '/lib/public/SpeechToText/ISpeechToTextProviderWithId.php',
     'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => $baseDir . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
     'OCP\\Support\\CrashReport\\IMessageReporter' => $baseDir . '/lib/public/Support/CrashReport/IMessageReporter.php',
     'OCP\\Support\\CrashReport\\IRegistry' => $baseDir . '/lib/public/Support/CrashReport/IRegistry.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -691,6 +691,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\SpeechToText\\Events\\TranscriptionSuccessfulEvent' => __DIR__ . '/../../..' . '/lib/public/SpeechToText/Events/TranscriptionSuccessfulEvent.php',
         'OCP\\SpeechToText\\ISpeechToTextManager' => __DIR__ . '/../../..' . '/lib/public/SpeechToText/ISpeechToTextManager.php',
         'OCP\\SpeechToText\\ISpeechToTextProvider' => __DIR__ . '/../../..' . '/lib/public/SpeechToText/ISpeechToTextProvider.php',
+        'OCP\\SpeechToText\\ISpeechToTextProviderWithId' => __DIR__ . '/../../..' . '/lib/public/SpeechToText/ISpeechToTextProviderWithId.php',
         'OCP\\Support\\CrashReport\\ICollectBreadcrumbs' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/ICollectBreadcrumbs.php',
         'OCP\\Support\\CrashReport\\IMessageReporter' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IMessageReporter.php',
         'OCP\\Support\\CrashReport\\IRegistry' => __DIR__ . '/../../..' . '/lib/public/Support/CrashReport/IRegistry.php',

--- a/lib/private/SpeechToText/SpeechToTextManager.php
+++ b/lib/private/SpeechToText/SpeechToTextManager.php
@@ -39,6 +39,7 @@ use OCP\IServerContainer;
 use OCP\PreConditionNotMetException;
 use OCP\SpeechToText\ISpeechToTextManager;
 use OCP\SpeechToText\ISpeechToTextProvider;
+use OCP\SpeechToText\ISpeechToTextProviderWithId;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
@@ -117,8 +118,13 @@ class SpeechToTextManager implements ISpeechToTextManager {
 
 		$json = $this->config->getAppValue('core', 'ai.stt_provider', '');
 		if ($json !== '') {
-			$className = json_decode($json, true);
-			$provider = current(array_filter($providers, fn ($provider) => $provider::class === $className));
+			$classNameOrId = json_decode($json, true);
+			$provider = current(array_filter($providers, function ($provider) use ($classNameOrId) {
+				if ($provider instanceof ISpeechToTextProviderWithId) {
+					return $provider->getId() === $classNameOrId;
+				}
+				return $provider::class === $classNameOrId;
+			}));
 			if ($provider !== false) {
 				$providers = [$provider];
 			}

--- a/lib/public/SpeechToText/ISpeechToTextProviderWithId.php
+++ b/lib/public/SpeechToText/ISpeechToTextProviderWithId.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OCP\SpeechToText;
+
+/**
+ * @since 28.0.0
+ */
+interface ISpeechToTextProviderWithId extends ISpeechToTextProvider {
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getId(): string;
+}


### PR DESCRIPTION
this allows AppAPI to register anonymous classes as SpeechToText providers

see [https://github.com/cloud-py-api/app_api/pull/60](https://github.com/cloud-py-api/app_api/pull/60)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
