### PR TITLE
fix(docs): Use PHP 8.1 for building the PHP API docs

### DIFF
--- a/build/phpDocumentor.sh
+++ b/build/phpDocumentor.sh
@@ -4,4 +4,5 @@ wget https://phpdoc.org/phpDocumentor.phar
 
 mkdir -p api/
 
-php7.4 phpDocumentor.phar -t "./api" -d "./lib/public" --title="Nextcloud PHP API ($BRANCH)"
+export PHP_VERSION=8.1
+php phpDocumentor.phar -t "./api" -d "./lib/public" --title="Nextcloud PHP API ($BRANCH)"


### PR DESCRIPTION
## Summary

PHP documentor required 8.1 as minimum PHP version, so we need to use php8.1 on Netlify.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
