### PR TITLE
#37978: Remove duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "eslint-plugin-es": "^4.1.0",
     "exports-loader": "^4.0.0",
     "file-loader": "^6.2.0",
-    "handlebars": "^4.7.7",
     "handlebars-loader": "^1.7.3",
     "jasmine-core": "~2.5.2",
     "jasmine-sinon": "^0.4.0",


### PR DESCRIPTION


* Resolves: #37978

## Summary
I believe it's appropriate to include handlebars in dependencies rather than devDependencies, because it's imported by multiple js files inside the core directory. However, handlebars-loader is only referenced inside webpack.common.js, so I think it's ok to keep that one inside devDependencies.


## TODO

N/A

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- N/A Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- N/A Screenshots before/after for front-end changes
- N/A Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
