### PR TITLE
fix(docs): Use PHP 8.1 for building the PHP API docs

### DIFF
--- a/build/phpDocumentor.sh
+++ b/build/phpDocumentor.sh
@@ -4,4 +4,4 @@ wget https://phpdoc.org/phpDocumentor.phar
 
 mkdir -p api/
 
-php phpDocumentor.phar --target=./api --directory=./lib/public --title="Nextcloud PHP API ($BRANCH)"
+php phpDocumentor.phar run -t "./api" -d "./lib/public" --title="Nextcloud PHP API ($BRANCH)"


### PR DESCRIPTION
We still need the additional `run`