### PR TITLE
Remove unneeded `tabindex="0"` from sidebar and app content

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -2,7 +2,7 @@
 /** @var \OCP\IL10N $l */
 /** @var array $_ */
 ?>
-<div id="app-content" tabindex="0">
+<div id="app-content">
 <?php if ($_['previewSupported']): /* This enables preview images for links (e.g. on Facebook, Google+, ...)*/?>
 	<link rel="image_src" href="<?php p($_['previewImage']); ?>" />
 <?php endif; ?>

--- a/apps/settings/templates/settings/frame.php
+++ b/apps/settings/templates/settings/frame.php
@@ -34,7 +34,7 @@ script('files', 'jquery.fileupload');
 		<div id="app-navigation-caption-personal" class="app-navigation-caption"><?php p($l->t('Personal')); ?></div>
 	<?php endif; ?>
 	<nav class="app-navigation-personal" aria-labelledby="app-navigation-caption-personal">
-		<ul tabindex="0">
+		<ul>
 			<?php foreach ($_['forms']['personal'] as $form) {
 				if (isset($form['anchor'])) {
 					$anchor = \OC::$server->getURLGenerator()->linkToRoute('settings.PersonalSettings.index', ['section' => $form['anchor']]);
@@ -61,7 +61,7 @@ script('files', 'jquery.fileupload');
 		<div id="app-navigation-caption-administration" class="app-navigation-caption"><?php p($l->t('Administration')); ?></div>
 	<?php endif; ?>
 	<nav class="app-navigation-administration" aria-labelledby="app-navigation-caption-administration">
-		<ul tabindex="0">
+		<ul>
 			<?php foreach ($_['forms']['admin'] as $form) {
 				if (isset($form['anchor'])) {
 					$anchor = \OC::$server->getURLGenerator()->linkToRoute('settings.AdminSettings.index', ['section' => $form['anchor']]);
@@ -84,6 +84,6 @@ script('files', 'jquery.fileupload');
 		</ul>
 	</nav>
 </div>
-<div id="app-content" tabindex="0" data-active-section-id="<?php print_unescaped($_['activeSectionId']) ?>">
+<div id="app-content" data-active-section-id="<?php print_unescaped($_['activeSectionId']) ?>">
 	<?php print_unescaped($_['content']); ?>
 </div>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/40708

## Summary

Remove unneeded `tabindex="0"` from sidebar and app content. No visual changes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
