### PR TITLE
fix(cypress): Fix selector for the user menu button

### DIFF
--- a/cypress/e2e/login/login.cy.ts
+++ b/cypress/e2e/login/login.cy.ts
@@ -137,7 +137,7 @@ describe('Login', () => {
 		cy.url().should('match', /apps\/dashboard(\/|$)/)
 
 		// When click logout
-		cy.get('#user-menu button').should('exist').click()
+		cy.get('#user-menu > button').should('exist').click()
 		cy.get('#logout a').should('contain.text', 'Log out').click()
 
 		// Then I see that the current page is the Login page


### PR DESCRIPTION
## Summary

Adjusted the selector for the user menu toggle (upper right menu containing the logout button).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
