### PR TITLE
fix: don't pass invalid streams to Imaginary

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -78,6 +78,9 @@ class Imaginary extends ProviderV2 {
 
 		// Object store
 		$stream = $file->fopen('r');
+		if (!$stream || !is_resource($stream) || feof($stream)) {
+			return null;
+		}
 
 		$httpClient = $this->service->newClient();
 


### PR DESCRIPTION
## Summary
Don't pass invalid streams to Imaginary to avoid "empty" errors.

https://github.com/h2non/imaginary/blob/7efb66c243056e5b3b65215e101be7915983e364/error.go#L19

```
GuzzleHttp\Exception\ClientException: Client error: `POST http://10.0.0.14:9000/pipeline?operations=%5B%7B%22operation%22%3A%22autorotate%22%7D%2C%7B%22operation%22%3A%22fit%22%2C%22params%22%3A%7B%22width%22%3A1024%2C%22height%22%3A1024%2C%22stripmeta%22%3A%22true%22%2C%22type%22%3A%22png%22%2C%22norotation%22%3A%22true%22%2C%22quality%22%3A%2280%22%7D%7D%5D` resulted in a `400 Bad Request` response: {"message":"Empty or unreadable image","status":400}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)