### PR TITLE
fix(external): Get storage before update it

### DIFF
--- a/apps/files_external/lib/Service/UserStoragesService.php
+++ b/apps/files_external/lib/Service/UserStoragesService.php
@@ -127,6 +127,9 @@ class UserStoragesService extends StoragesService {
 	 * @throws NotFoundException if the given storage does not exist in the config
 	 */
 	public function updateStorage(StorageConfig $updatedStorage) {
+		// verify ownership through $this->isApplicable() and otherwise throws an exception
+		$this->getStorage($updatedStorage->getId());
+
 		$updatedStorage->setApplicableUsers([$this->getUser()->getUID()]);
 		return parent::updateStorage($updatedStorage);
 	}


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
