### PR TITLE
fix(cypress): Also clone 3rdparty submodule to keep in sync for cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,8 +22,11 @@ jobs:
       npmVersion: ${{ steps.versions.outputs.npmVersion }}
 
     steps:
-      - name: Checkout app
+      - name: Checkout server
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # We need to checkout submodules for 3rdparty
+          submodules: true
 
       - name: Check composer.json
         id: check_composer


### PR DESCRIPTION
## Summary

If `lib` uses updated `3rdparty` libraries but the shallow server is outdated (like now the server is 28 days old -> dependencies have been changed) it might lead to error 500 as the Nextcloud server can not find that changed dependencies.

So we need to also pull submodules on Cypress init.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
