### PR TITLE
Update security policy to match new project-wide default one

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policy
 
-[Security](https://nextcloud.com/security/) is very important to us. 
+[Security](https://nextcloud.com/security/) is very important to us.
 
-If you believe you have found a security vulnerability that meets our definition of a security 
+If you believe you have found a security vulnerability that meets our definition of a security
 vulnerability, please report is as described below.
 
 ## Context
 
-Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what 
-is currently considered a security vulnerability versus expected behavior. And review what is considered 
+Please review our [threat model and accepted risks](https://nextcloud.com/security/threat-model) to learn what
+is currently considered a security vulnerability versus expected behavior. And review what is considered
 [in scope or bounty eligible](https://hackerone.com/nextcloud/policy_scopes).
 
 
@@ -31,13 +31,17 @@ Your report should include:
 
 You should receive an initial acknowledgement within 24 hours in most cases.
 
-A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions, 
+A member of the security team will confirm the vulnerability, determine its impact, follow-up with any questions,
 and coordinate the fix and publication.
 
 The fix will be applied to all applicable and still supported stable branches, tested, and packaged in the next security release.
 The vulnerability will be publicly announced after the release. Finally, your name will be added
-to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud 
-community. 
+to the [hall of fame](https://hackerone.com/nextcloud/thanks) as a thank you from the entire Nextcloud
+community.
+
+If the vulnerability involves an app that is not maintained by Nextcloud (i.e. hosted by the 
+Nextcloud project but community maintained, or hosted elsewhere), the security team will try to coordinate with the
+current maintainer and help to get the issue fixed in similar fashion.
 
 ### Bug Bounties
 
@@ -47,8 +51,7 @@ on past bounty ranges can be found at [hackerone.com/nextcloud](https://hackeron
 ## Existing Security Advisories
 
 Published security advisories for the Nextcloud Server, Clients and Apps can be viewed at
-[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories
-).
+[https://github.com/nextcloud/security-advisories/security/advisories](https://github.com/nextcloud/security-advisories/security/advisories).
 
 ## Supported Versions
 


### PR DESCRIPTION
## Summary

Just making it match the final version of the new global one in nextcloud/.github#241

- Adds community/third-party apps note to security policy

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
