### PR TITLE
chore(codecov): Do not run project status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,9 @@ codecov:
   - '!scrutinizer-ci.com'
 
 comment: false
+
+# Ignore project status check as our CI only runs PHP tests for PHP PRs and JS tests for JS PRs
+# Otherwise it will warn about project coverage drops
+coverage:
+  status:
+    project: off


### PR DESCRIPTION
## Summary

Fixes the currently always red  codecov project check.