### PR TITLE
FIX #38801: Missing metadata for chunked upload

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -144,7 +144,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	public function beforePut(RequestInterface $request, ResponseInterface $response): bool {
 		try {
-			$this->prepareUpload(dirname($request->getPath()));
+			$this->prepareUpload(basename(dirname($request->getPath())));
 			$this->checkPrerequisites();
 		} catch (StorageInvalidException|BadRequest|NotFound $e) {
 			return true;
@@ -189,7 +189,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	public function beforeMove($sourcePath, $destination): bool {
 		try {
-			$this->prepareUpload(dirname($sourcePath));
+			$this->prepareUpload(basename(dirname($sourcePath)));
 			$this->checkPrerequisites();
 		} catch (StorageInvalidException|BadRequest|NotFound|PreconditionFailed $e) {
 			return true;
@@ -255,7 +255,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	public function beforeDelete(RequestInterface $request, ResponseInterface $response) {
 		try {
-			$this->prepareUpload(dirname($request->getPath()));
+			$this->prepareUpload(basename(dirname($request->getPath())));
 			$this->checkPrerequisites();
 		} catch (StorageInvalidException|BadRequest|NotFound $e) {
 			return true;


### PR DESCRIPTION
* Resolves: #38801

## Summary

This commit fixes the problem with missing metadata for chunked uploads, reported in https://github.com/nextcloud/server/issues/38801.

The problem is caused because the directory name e.g. `web-file-upload-2802b0e2a4ef8eeea70f258257d03b7-1698172388825` is used as key for the cache entry that contains the upload id, the upload target path and the upload target id. Refer to: https://github.com/nextcloud/server/blob/ee1480cefc342578a2ee7539e4761abf59ac4a96/apps/dav/lib/Upload/ChunkingV2Plugin.php#L135-L139

In later calls, when the cache entry should be retrieved a relative path like `uploads/c.fiehe-local/web-file-upload-82802b0e2a4ef8eeea70f258257d03b7-1698172388825` gets used as key. Refer to: https://github.com/nextcloud/server/blob/ee1480cefc342578a2ee7539e4761abf59ac4a96/apps/dav/lib/Upload/ChunkingV2Plugin.php#L147

This retrieval results in a cache miss, that causes the upload to fail with files larger than the configured upload chunk size (defaults to 10 MB). When the log level was set to debug, the log contains the error message `Missing metadata for chunked upload`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
