### PR TITLE
Add OpenAPI attribute to allow multiple scopes

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -44,6 +44,7 @@ return array(
     'OCP\\AppFramework\\Http\\Attribute\\IgnoreOpenAPI' => $baseDir . '/lib/public/AppFramework/Http/Attribute/IgnoreOpenAPI.php',
     'OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired' => $baseDir . '/lib/public/AppFramework/Http/Attribute/NoAdminRequired.php',
     'OCP\\AppFramework\\Http\\Attribute\\NoCSRFRequired' => $baseDir . '/lib/public/AppFramework/Http/Attribute/NoCSRFRequired.php',
+    'OCP\\AppFramework\\Http\\Attribute\\OpenAPI' => $baseDir . '/lib/public/AppFramework/Http/Attribute/OpenAPI.php',
     'OCP\\AppFramework\\Http\\Attribute\\PasswordConfirmationRequired' => $baseDir . '/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php',
     'OCP\\AppFramework\\Http\\Attribute\\PublicPage' => $baseDir . '/lib/public/AppFramework/Http/Attribute/PublicPage.php',
     'OCP\\AppFramework\\Http\\Attribute\\StrictCookiesRequired' => $baseDir . '/lib/public/AppFramework/Http/Attribute/StrictCookiesRequired.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -77,6 +77,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\AppFramework\\Http\\Attribute\\IgnoreOpenAPI' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/IgnoreOpenAPI.php',
         'OCP\\AppFramework\\Http\\Attribute\\NoAdminRequired' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/NoAdminRequired.php',
         'OCP\\AppFramework\\Http\\Attribute\\NoCSRFRequired' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/NoCSRFRequired.php',
+        'OCP\\AppFramework\\Http\\Attribute\\OpenAPI' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/OpenAPI.php',
         'OCP\\AppFramework\\Http\\Attribute\\PasswordConfirmationRequired' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/PasswordConfirmationRequired.php',
         'OCP\\AppFramework\\Http\\Attribute\\PublicPage' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/PublicPage.php',
         'OCP\\AppFramework\\Http\\Attribute\\StrictCookiesRequired' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/StrictCookiesRequired.php',

--- a/lib/public/AppFramework/Http/Attribute/IgnoreOpenAPI.php
+++ b/lib/public/AppFramework/Http/Attribute/IgnoreOpenAPI.php
@@ -31,6 +31,7 @@ use Attribute;
  * Attribute for controller methods that should be ignored when generating OpenAPI documentation
  *
  * @since 28.0.0
+ * @deprecated 28.0.0 Use {@see OpenAPI} with {@see OpenAPI::SCOPE_IGNORE} instead: `#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]`
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class IgnoreOpenAPI {

--- a/lib/public/AppFramework/Http/Attribute/OpenAPI.php
+++ b/lib/public/AppFramework/Http/Attribute/OpenAPI.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\AppFramework\Http\Attribute;
+
+use Attribute;
+
+/**
+ * With this attribute a controller or a method can be moved into a different
+ * scope or tag. Scopes should be seen as API consumers, tags can be used to group
+ * different routes inside the same scope.
+ *
+ * @since 28.0.0
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class OpenAPI {
+	/**
+	 * APIs used for normal user facing interaction with your app,
+	 * e.g. when you would implement a mobile client or standalone frontend.
+	 *
+	 * @since 28.0.0
+	 */
+	public const SCOPE_DEFAULT = 'default';
+
+	/**
+	 * APIs used to administrate your app's configuration on an administrative level.
+	 * Will be set automatically when admin permissions are required to access the route.
+	 *
+	 * @since 28.0.0
+	 */
+	public const SCOPE_ADMINISTRATION = 'administration';
+
+	/**
+	 * APIs used by servers to federate with each other.
+	 *
+	 * @since 28.0.0
+	 */
+	public const SCOPE_FEDERATION = 'federation';
+
+	/**
+	 * Ignore this controller or method in all generated OpenAPI specifications.
+	 *
+	 * @since 28.0.0
+	 */
+	public const SCOPE_IGNORE = 'ignore';
+
+	/**
+	 * @param self::SCOPE_*|string $scope Scopes are used to define different clients.
+	 *   It is recommended to go with the scopes available as self::SCOPE_* constants,
+	 *   but in exotic cases other APIs might need documentation as well,
+	 *   then a free string can be provided (but it should be `a-z` only).
+	 * @param ?list<string> $tags Tags can be used to group routes inside a scope
+	 *   for easier implementation and reviewing of the API specification.
+	 *   It defaults to the controller name in snake_case (should be `a-z` and underscore only).
+	 * @since 28.0.0
+	 */
+	public function __construct(
+		protected string $scope = self::SCOPE_DEFAULT,
+		protected ?array $tags = null,
+	) {
+	}
+
+	/**
+	 * @since 28.0.0
+	 */
+	public function getScope(): string {
+		return $this->scope;
+	}
+
+	/**
+	 * @return ?list<string>
+	 * @since 28.0.0
+	 */
+	public function getTags(): ?array {
+		return $this->tags;
+	}
+}


### PR DESCRIPTION
* Ref https://github.com/nextcloud/openapi-extractor/issues/20

## 🚧  Todo
- [x] Add `OpenAPI`attribute
- [x] Fix the extractor to handle the new attribute
- [x] Deprecate `IgnoreOpenAPI` attribute
- [ ] Replace existing `IgnoreOpenAPI` attributes

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
