### PR TITLE
Fix typo in var

### DIFF
--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -58,7 +58,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			foreach ($matches['annotation'] as $key => $annotation) {
 				$annotation = strtolower($annotation);
 				$annotationValue = $matches['parameter'][$key];
-				if (isset($annotationValue[0]) && $annotationValue[0] === '(' && $annotationValue[\strlen($annotationValue) - 1] === ')') {
+				if (str_starts_with($annotationValue, '(') && str_ends_with($annotationValue, ')')) {
 					$cutString = substr($annotationValue, 1, -1);
 					$cutString = str_replace(' ', '', $cutString);
 					$splitArray = explode(',', $cutString);


### PR DESCRIPTION
## Summary
- `$annoNtation` to `$annotation`
- better readability of check the first and last characters in the string.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)