### PR TITLE
Do not send Clear-Site-Data header to Chrome-like browsers

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -106,7 +106,8 @@ class LoginController extends Controller {
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
 
-		if (!$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
+		if ($this->request->getServerProtocol() === 'https' 
+			&& !$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
 			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
 		}
 

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
+use OC\AppFramework\Http\Request;
 use OC\Authentication\Login\Chain;
 use OC\Authentication\Login\LoginData;
 use OC\Authentication\WebAuthn\Manager as WebAuthnManager;
@@ -105,8 +106,7 @@ class LoginController extends Controller {
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
 
-		if ($this->request->getServerProtocol() === 'https') {
-			// This feature is available only in secure contexts
+		if (!$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
 			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
 		}
 

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -106,7 +106,7 @@ class LoginController extends Controller {
 		$this->session->set('clearingExecutionContexts', '1');
 		$this->session->close();
 
-		if ($this->request->getServerProtocol() === 'https' 
+		if ($this->request->getServerProtocol() === 'https'
 			&& !$this->request->isUserAgent([Request::USER_AGENT_CHROME, Request::USER_AGENT_ANDROID_MOBILE_CHROME])) {
 			$response->addHeader('Clear-Site-Data', '"cache", "storage"');
 		}

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -143,8 +143,9 @@ class LoginControllerTest extends TestCase {
 			->with('nc_token')
 			->willReturn(null);
 		$this->request
-			->method('getServerProtocol')
-			->willReturn('https');
+			->expects($this->once())
+			->method('isUserAgent')
+			->willReturn(false);
 		$this->config
 			->expects($this->never())
 			->method('deleteUserValue');
@@ -159,6 +160,26 @@ class LoginControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->loginController->logout());
 	}
 
+	public function testLogoutNoClearSiteData() {
+		$this->request
+			->expects($this->once())
+			->method('getCookie')
+			->with('nc_token')
+			->willReturn(null);
+		$this->request
+			->expects($this->once())
+			->method('isUserAgent')
+			->willReturn(true);
+		$this->urlGenerator
+			->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('core.login.showLoginForm')
+			->willReturn('/login');
+
+		$expected = new RedirectResponse('/login');
+		$this->assertEquals($expected, $this->loginController->logout());
+	}
+	
 	public function testLogoutWithToken() {
 		$this->request
 			->expects($this->once())
@@ -167,8 +188,8 @@ class LoginControllerTest extends TestCase {
 			->willReturn('MyLoginToken');
 		$this->request
 			->expects($this->once())
-			->method('getServerProtocol')
-			->willReturn('https');
+			->method('isUserAgent')
+			->willReturn(false);
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())


### PR DESCRIPTION
* Resolves: #41196

## Summary

Cancels https://github.com/nextcloud/server/pull/37405 regression.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
