### PR TITLE
feat(events): Add typed event for filtering autocompletion sugges…

### DIFF
--- a/core/Controller/AutoCompleteController.php
+++ b/core/Controller/AutoCompleteController.php
@@ -35,6 +35,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\Collaboration\AutoComplete\AutoCompleteEvent;
+use OCP\Collaboration\AutoComplete\AutoCompleteFilterEvent;
 use OCP\Collaboration\AutoComplete\IManager;
 use OCP\Collaboration\Collaborators\ISearch;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -86,6 +87,18 @@ class AutoCompleteController extends OCSController {
 			'limit' => $limit,
 		]);
 		$this->dispatcher->dispatch(IManager::class . '::filterResults', $event);
+		$results = $event->getResults();
+
+		$event = new AutoCompleteFilterEvent(
+			$results,
+			$search,
+			$itemType,
+			$itemId,
+			$sorter,
+			$shareTypes,
+			$limit,
+		);
+		$this->dispatcher->dispatchTyped($event);
 		$results = $event->getResults();
 
 		$exactMatches = $results['exact'];

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -169,6 +169,7 @@ return array(
     'OCP\\Capabilities\\IInitialStateExcludedCapability' => $baseDir . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
     'OCP\\Capabilities\\IPublicCapability' => $baseDir . '/lib/public/Capabilities/IPublicCapability.php',
     'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => $baseDir . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',
+    'OCP\\Collaboration\\AutoComplete\\AutoCompleteFilterEvent' => $baseDir . '/lib/public/Collaboration/AutoComplete/AutoCompleteFilterEvent.php',
     'OCP\\Collaboration\\AutoComplete\\IManager' => $baseDir . '/lib/public/Collaboration/AutoComplete/IManager.php',
     'OCP\\Collaboration\\AutoComplete\\ISorter' => $baseDir . '/lib/public/Collaboration/AutoComplete/ISorter.php',
     'OCP\\Collaboration\\Collaborators\\ISearch' => $baseDir . '/lib/public/Collaboration/Collaborators/ISearch.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -202,6 +202,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Capabilities\\IInitialStateExcludedCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
         'OCP\\Capabilities\\IPublicCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IPublicCapability.php',
         'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',
+        'OCP\\Collaboration\\AutoComplete\\AutoCompleteFilterEvent' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/AutoCompleteFilterEvent.php',
         'OCP\\Collaboration\\AutoComplete\\IManager' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/IManager.php',
         'OCP\\Collaboration\\AutoComplete\\ISorter' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/ISorter.php',
         'OCP\\Collaboration\\Collaborators\\ISearch' => __DIR__ . '/../../..' . '/lib/public/Collaboration/Collaborators/ISearch.php',

--- a/lib/public/Collaboration/AutoComplete/AutoCompleteFilterEvent.php
+++ b/lib/public/Collaboration/AutoComplete/AutoCompleteFilterEvent.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2019 Joas Schilling <coding@schilljs.com>
+ * @copyright Copyright (c) 2023 Joas Schilling <coding@schilljs.com>
  *
  * @author Joas Schilling <coding@schilljs.com>
  *
@@ -25,76 +25,83 @@ declare(strict_types=1);
  */
 namespace OCP\Collaboration\AutoComplete;
 
-use OCP\EventDispatcher\GenericEvent;
+use OCP\EventDispatcher\Event;
 
 /**
- * @since 16.0.0
- * @deprecated Use {@see AutoCompleteFilterEvent} instead
+ * @since 28.0.0
  */
-class AutoCompleteEvent extends GenericEvent {
+class AutoCompleteFilterEvent extends Event {
 	/**
-	 * @param array $arguments
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
-	public function __construct(array $arguments) {
-		parent::__construct(null, $arguments);
+	public function __construct(
+		protected array $results,
+		protected string $search,
+		protected ?string $itemType,
+		protected ?string $itemId,
+		protected ?string $sorter,
+		protected array $shareTypes,
+		protected int $limit,
+	) {
+		parent::__construct();
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
 	public function getResults(): array {
-		return $this->getArgument('results');
+		return $this->results;
 	}
 
 	/**
 	 * @param array $results
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
 	public function setResults(array $results): void {
-		$this->setArgument('results', $results);
+		$this->results = $results;
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
 	public function getSearchTerm(): string {
-		return $this->getArgument('search');
+		return $this->search;
 	}
 
 	/**
-	 * @return int[]
-	 * @since 16.0.0
+	 * @return int[] List of `\OCP\Share\IShare::TYPE_*` constants
+	 * @since 28.0.0
 	 */
 	public function getShareTypes(): array {
-		return $this->getArgument('shareTypes');
+		return $this->shareTypes;
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
-	public function getItemType(): string {
-		return $this->getArgument('itemType');
+	public function getItemType(): ?string {
+		return $this->itemType;
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
-	public function getItemId(): string {
-		return $this->getArgument('itemId');
+	public function getItemId(): ?string {
+		return $this->itemId;
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @return ?string List of desired sort identifiers, top priority first. When multiple are given they are joined with a pipe: `commenters|share-recipients`
+	 * @since 28.0.0
 	 */
-	public function getSorter(): string {
-		return $this->getArgument('sorter');
+	public function getSorter(): ?string {
+		return $this->sorter;
 	}
 
 	/**
-	 * @since 16.0.0
+	 * @since 28.0.0
 	 */
 	public function getLimit(): int {
-		return $this->getArgument('limit');
+		return $this->limit;
 	}
 }


### PR DESCRIPTION
…tions


* The previous event is not a typed event and uses `OCP\EventDispatcher\GenericEvent` which is deprecated.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
