### PR TITLE
fix: add index on migration only if needed

### DIFF
--- a/core/Migrations/Version28000Date20230803221055.php
+++ b/core/Migrations/Version28000Date20230803221055.php
@@ -52,7 +52,9 @@ class Version28000Date20230803221055 extends SimpleMigrationStep {
 			$column = $table->getColumn('user_id');
 			$column->setNotnull(false);
 
-			$table->addIndex(['user_id', 'app_id', 'identifier'], 'tp_tasks_uid_appid_ident');
+			if (!$table->hasIndex('tp_tasks_uid_appid_ident')) {
+				$table->addIndex(['user_id', 'app_id', 'identifier'], 'tp_tasks_uid_appid_ident');
+			}
 
 			$changed = true;
 		}

--- a/core/Migrations/Version28000Date20230803221055.php
+++ b/core/Migrations/Version28000Date20230803221055.php
@@ -54,9 +54,8 @@ class Version28000Date20230803221055 extends SimpleMigrationStep {
 
 			if (!$table->hasIndex('tp_tasks_uid_appid_ident')) {
 				$table->addIndex(['user_id', 'app_id', 'identifier'], 'tp_tasks_uid_appid_ident');
+				$changed = true;
 			}
-
-			$changed = true;
 		}
 
 		if ($changed) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/41227

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
