### PR TITLE
fix(OCM): Fix OCM provider discovery for servers without beautiful URLs

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -69,6 +69,9 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 	 */
 	public function discover(string $remote, bool $skipCache = false): IOCMProvider {
 		$remote = rtrim($remote, '/');
+		if (str_ends_with($remote, '/index.php')) {
+			$remote = substr($remote, 0, -10);
+		}
 
 		if (!$skipCache) {
 			try {
@@ -84,7 +87,7 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		$client = $this->clientService->newClient();
 		try {
 			$response = $client->get(
-				$remote . '/ocm-provider/',
+				$remote . '/index.php/ocm-provider/',
 				[
 					'timeout' => 10,
 					'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates'),


### PR DESCRIPTION
* Followup to https://github.com/nextcloud/server/pull/39574

## Resolves

* This allows to do federation with instances again that do not support "beautiful" URLs at all.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
