### PR TITLE
fix(cypress): Add timeout for waiting on Nextcloud server

### DIFF
--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -233,7 +233,15 @@ export const getContainerIP = async function(
 // https://github.com/cypress-io/cypress/issues/22676
 export const waitOnNextcloud = async function(ip: string) {
 	console.log('├─ Waiting for Nextcloud to be ready... ⏳')
-	await waitOn({ resources: [`http://${ip}/index.php`] })
+	await waitOn({
+		resources: [`http://${ip}/index.php`],
+		// wait for nextcloud to  be up and return any non error status
+		validateStatus: (status) => status >= 200 && status < 400,
+		// timout in ms
+		timeout: 5 * 60 * 1000,
+		// timeout for a single HTTP request
+		httpTimeout: 60 * 1000,
+	})
 	console.log('└─ Done')
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "@testing-library/vue": "^5.8.3",
         "@types/dockerode": "^3.3.21",
         "@types/jest": "^29.5.2",
+        "@types/wait-on": "^5.3.3",
         "@vue/test-utils": "^1.3.5",
         "@vue/tsconfig": "^0.4.0",
         "@vue/vue2-jest": "^29.2.6",
@@ -6159,6 +6160,15 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
       "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
+    },
+    "node_modules/@types/wait-on": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.3.tgz",
+      "integrity": "sha512-I8EnhU/DuvV2LODzBcLw85FPFFZ9mBvtgqfsgXbhkbo5IZYfIne5qxPTv4PGbD8d5uDQJG5g/pGwGdpM8lQ6Lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@testing-library/vue": "^5.8.3",
     "@types/dockerode": "^3.3.21",
     "@types/jest": "^29.5.2",
+    "@types/wait-on": "^5.3.3",
     "@vue/test-utils": "^1.3.5",
     "@vue/tsconfig": "^0.4.0",
     "@vue/vue2-jest": "^29.2.6",


### PR DESCRIPTION
## Summary

Do not wast CI time if docker setup of the Nextcloud server went wrong.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
