### PR TITLE
fix: Only highlight profile entry when viewing own profile

### DIFF
--- a/core/Controller/ProfilePageController.php
+++ b/core/Controller/ProfilePageController.php
@@ -106,7 +106,9 @@ class ProfilePageController extends Controller {
 			$this->profileManager->getProfileFields($targetUser, $visitingUser),
 		);
 
-		$this->navigationManager->setActiveEntry('profile');
+		if ($targetUser === $visitingUser) {
+			$this->navigationManager->setActiveEntry('profile');
+		}
 
 		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($targetUserId));
 


### PR DESCRIPTION
## Summary

- Fix highlighting profile entry when viewing another user's profile

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)