### PR TITLE
[cypress] Use GitHub action service for Nextcloud server

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -110,10 +110,12 @@ jobs:
       - name: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }} cypress tests
         uses: cypress-io/github-action@ebe8b24c4428922d0f793a5c4c96853a633180e3 # v6.6.0
         with:
-          ci-build-id: ${{ github.sha }}-${{ github.run_number }}
+          # Unavailable without cypress cloud
+          # ci-build-id: ${{ github.sha }}-${{ github.run_number }}
           component: ${{ matrix.containers == 'component' }}
-          group: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
-          tag: ${{ github.event_name }}
+          # Unavailable without cypress cloud
+          # group: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
+          # tag: ${{ github.event_name }}
         env:
           # Use github service for server
           NEXTCLOUD_HOST: localhost

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -84,6 +84,13 @@ jobs:
 
     name: runner ${{ matrix.containers }}
 
+    services:
+      nextcloud:
+        image: ghcr.io/nextcloud/continuous-integration-shallow-server
+        options: --name nextcloud
+        ports:
+          - 80:80
+
     steps:
       - name: Restore context
         uses: buildjet/cache/restore@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
@@ -103,12 +110,14 @@ jobs:
       - name: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }} cypress tests
         uses: cypress-io/github-action@ebe8b24c4428922d0f793a5c4c96853a633180e3 # v6.6.0
         with:
+          ci-build-id: ${{ github.sha }}-${{ github.run_number }}
           component: ${{ matrix.containers == 'component' }}
-          group: ${{ matrix.use-cypress-cloud && matrix.containers == 'component' && 'Run component' || matrix.use-cypress-cloud && 'Run E2E' || '' }}
-          # cypress env
-          ci-build-id: ${{ matrix.use-cypress-cloud && format('{0}-{1}', github.sha, github.run_number) || '' }}
-          tag: ${{ matrix.use-cypress-cloud && github.event_name || '' }}
+          group: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
+          tag: ${{ github.event_name }}
         env:
+          # Use github service for server
+          NEXTCLOUD_HOST: localhost
+          NEXTCLOUD_CONTAINER: nextcloud
           # Needs to be prefixed with CYPRESS_
           CYPRESS_BRANCH: ${{ env.BRANCH }}
           # https://github.com/cypress-io/github-action/issues/124

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -85,7 +85,9 @@ export default defineConfig({
 			config.baseUrl = `http://${ip}/index.php`
 			await waitOnNextcloud(ip)
 			await configureNextcloud()
-			await applyChangesToNextcloud()
+			await applyChangesToNextcloud();
+
+			(config as any).NEXTCLOUD_CONTAINER = process.env.NEXTCLOUD_CONTAINER ?? 'nextcloud-cypress-tests-server'
 
 			// IMPORTANT: return the config otherwise cypress-split will not work
 			return config

--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -30,7 +30,7 @@ import { execSync } from 'child_process'
 
 export const docker = new Docker()
 
-const CONTAINER_NAME = 'nextcloud-cypress-tests-server'
+const CONTAINER_NAME = process.env.NEXTCLOUD_CONTAINER ?? 'nextcloud-cypress-tests-server'
 const SERVER_IMAGE = 'ghcr.io/nextcloud/continuous-integration-shallow-server'
 
 /**
@@ -39,6 +39,10 @@ const SERVER_IMAGE = 'ghcr.io/nextcloud/continuous-integration-shallow-server'
  * @param {string} branch the branch of your current work
  */
 export const startNextcloud = async function(branch: string = getCurrentGitBranch()): Promise<any> {
+	if (process.env.NEXTCLOUD_HOST) {
+		console.log('\nRunning on CI skipping pulling images')
+		return process.env.NEXTCLOUD_HOST
+	}
 
 	try {
 		try {
@@ -204,6 +208,11 @@ export const stopNextcloud = async function() {
 export const getContainerIP = async function(
 	container = docker.getContainer(CONTAINER_NAME),
 ): Promise<string> {
+
+	if (process.env.NEXTCLOUD_HOST) {
+		return process.env.NEXTCLOUD_HOST
+	}
+
 	let ip = ''
 	let tries = 0
 	while (ip === '' && tries < 10) {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -287,6 +287,7 @@ Cypress.Commands.add('resetUserTheming', (user?: User) => {
 })
 
 Cypress.Commands.add('runOccCommand', (command: string, options?: Partial<Cypress.ExecOptions>) => {
+	const container = (Cypress.config() as unknown as Record<string, string>).NEXTCLOUD_CONTAINER
 	const env = Object.entries(options?.env ?? {}).map(([name, value]) => `-e '${name}=${value}'`).join(' ')
-	return cy.exec(`docker exec --user www-data ${env} nextcloud-cypress-tests-server php ./occ ${command}`, options)
+	return cy.exec(`docker exec --user www-data ${env} ${container} php ./occ ${command}`, options)
 })


### PR DESCRIPTION
## Summary

Follow up on https://github.com/nextcloud/server/pull/41250 

This changes the Cypress workflow to not start a docker container from Cypress but use a GitHub workflow service as the Nextcloud container.
This saves ~2 minutes CI time per Cypress runner (currently 3).

Also the service is up when the workflow starts meaning cypress does not have to wait for it and should no longer time out.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits