### PR TITLE
fix semaphore unguarding

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3075,14 +3075,7 @@
   <file src="lib/private/Preview/Generator.php">
     <InvalidArgument>
       <code>$maxPreviewImage</code>
-      <code>$semId</code>
     </InvalidArgument>
-    <InvalidReturnStatement>
-      <code>$sem</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>false|resource</code>
-    </InvalidReturnType>
     <LessSpecificReturnType>
       <code>null|string</code>
     </LessSpecificReturnType>

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -221,7 +221,7 @@ class Generator {
 	 *
 	 * @param int $semId
 	 * @param int $concurrency
-	 * @return false|resource the semaphore on success or false on failure
+	 * @return false|\SysvSemaphore the semaphore on success or false on failure
 	 */
 	public static function guardWithSemaphore(int $semId, int $concurrency) {
 		if (!extension_loaded('sysvsem')) {
@@ -240,11 +240,11 @@ class Generator {
 	/**
 	 * Releases the semaphore acquired from {@see Generator::guardWithSemaphore()}.
 	 *
-	 * @param resource|bool $semId the semaphore identifier returned by guardWithSemaphore
+	 * @param false|\SysvSemaphore $semId the semaphore identifier returned by guardWithSemaphore
 	 * @return bool
 	 */
-	public static function unguardWithSemaphore($semId): bool {
-		if ($semId === false || get_class($semId) !== 'SysvSemaphore' || !extension_loaded('sysvsem')) {
+	public static function unguardWithSemaphore(false|\SysvSemaphore $semId): bool {
+		if ($semId === false || !($semId instanceof \SysvSemaphore)) {
 			return false;
 		}
 		return sem_release($semId);

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -244,7 +244,7 @@ class Generator {
 	 * @return bool
 	 */
 	public static function unguardWithSemaphore($semId): bool {
-		if (!is_resource($semId) || !extension_loaded('sysvsem')) {
+		if ($semId === false || get_class($semId) !== 'SysvSemaphore' || !extension_loaded('sysvsem')) {
 			return false;
 		}
 		return sem_release($semId);


### PR DESCRIPTION
Apparently sem_get returns a SysvSemaphore class and not a resource anymore. See https://www.php.net/manual/en/function.sem-get.php