### PR TITLE
[stable26] Show proper warning on 0 quota

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -25,7 +25,7 @@
 				state.call.abort();
 			}
 			state.dir = currentDir;
-			state.call = $.getJSON(OC.generateUrl('apps/files/ajax/getstoragestats?dir={dir}', {
+			state.call = $.getJSON(OC.generateUrl('apps/files/api/v1/stats?dir={dir}', {
 				dir: currentDir,
 			}), function(response) {
 				state.dir = null;
@@ -39,7 +39,7 @@
 		},
 		_updateStorageQuotas: function() {
 			var state = Files.updateStorageQuotas;
-			state.call = $.getJSON(OC.generateUrl('apps/files/ajax/getstoragestats'), function(response) {
+			state.call = $.getJSON(OC.generateUrl('apps/files/api/v1/stats'), function(response) {
 				Files.updateQuota(response);
 			});
 		},

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -70,8 +70,13 @@
 			if (response === undefined) {
 				return;
 			}
+
+			if (response.data !== undefined && response.data.free !== undefined) {
+				$('#free_space').val(response.data.free);
+				OCA.Files.App.fileList._updateDirectoryPermissions();
+			}
+
 			if (response.data !== undefined && response.data.uploadMaxFilesize !== undefined) {
-				$('#free_space').val(response.data.freeSpace);
 				$('#upload.button').attr('title', response.data.maxHumanFilesize);
 				$('#usedSpacePercent').val(response.data.usedSpacePercent);
 				$('#usedSpacePercent').data('mount-type', response.data.mountType);


### PR DESCRIPTION
- fix(files): url used to retrive storage stats (backport of https://github.com/nextcloud/server/pull/39588)
- fix: Apply directory permissions for new api response

## Steps to reproduce

- Have 0 quota configured
- Open the file list

## before

The file create menu was shown

## After

A proper info is shown as it was on Nextcloud 25

![Screenshot 2023-11-03 at 11 57 28](https://github.com/nextcloud/server/assets/3404133/eade7553-c45e-47b2-8073-cbbbe37c8a5d)

