### PR TITLE
feat(dependencyinjection): Allow optional (nullable) services

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -105,6 +105,11 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 					try {
 						return $this->query($resolveName);
 					} catch (QueryException $e2) {
+						// Pass null if typed and nullable
+						if ($parameter->allowsNull() && ($parameterType instanceof ReflectionNamedType)) {
+							return null;
+						}
+
 						// don't lose the error we got while trying to query by type
 						throw new QueryException($e->getMessage(), (int) $e->getCode(), $e);
 					}

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -50,6 +50,17 @@ class ClassComplexConstructor {
 	}
 }
 
+class ClassNullableUntypedConstructorArg {
+	public function __construct($class) {
+	}
+}
+class ClassNullableTypedConstructorArg {
+	public $class;
+	public function __construct(?\Some\Class $class) {
+		$this->class = $class;
+	}
+}
+
 interface IInterfaceConstructor {
 }
 class ClassInterfaceConstructor {
@@ -242,5 +253,18 @@ class SimpleContainerTest extends \Test\TestCase {
 			$this->container->query('test1'), $this->container->query('test1'));
 		$this->assertNotSame(
 			$this->container->query('test'), $this->container->query('test1'));
+	}
+
+	public function testQueryUntypedNullable(): void {
+		$this->expectException(\OCP\AppFramework\QueryException::class);
+
+		$this->container->query(ClassNullableUntypedConstructorArg::class);
+	}
+
+	public function testQueryTypedNullable(): void {
+		/** @var ClassNullableTypedConstructorArg $service */
+		$service = $this->container->query(ClassNullableTypedConstructorArg::class);
+
+		self::assertNull($service->class);
 	}
 }


### PR DESCRIPTION
## Summary

Allows working with classes that might or might not be available. For safety I chose to only allow this if a constructor argument is typed.

I need this for a cross-app dependency inside of server in https://github.com/nextcloud/server/issues/40559.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - https://github.com/nextcloud/documentation/pull/11262
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
