### PR TITLE
feat(contactsmenu): Sort by user status

### DIFF
--- a/apps/user_status/lib/ContactsMenu/StatusProvider.php
+++ b/apps/user_status/lib/ContactsMenu/StatusProvider.php
@@ -44,6 +44,7 @@ class StatusProvider implements IBulkProvider {
 		);
 
 		$statuses = $this->statusService->findByUserIds($uids);
+		/** @var array<string, UserStatus> $indexed */
 		$indexed = array_combine(
 			array_map(fn(UserStatus $status) => $status->getUserId(), $statuses),
 			$statuses
@@ -56,6 +57,7 @@ class StatusProvider implements IBulkProvider {
 				$entry->setStatus(
 					$status->getStatus(),
 					$status->getCustomMessage(),
+					$status->getStatusMessageTimestamp(),
 					$status->getCustomIcon(),
 				);
 			}

--- a/lib/private/Contacts/ContactsMenu/Entry.php
+++ b/lib/private/Contacts/ContactsMenu/Entry.php
@@ -32,6 +32,8 @@ use OCP\Contacts\ContactsMenu\IEntry;
 use function array_merge;
 
 class Entry implements IEntry {
+	public const PROPERTY_STATUS_MESSAGE_TIMESTAMP = 'statusMessageTimestamp';
+
 	/** @var string|int|null */
 	private $id = null;
 
@@ -53,6 +55,7 @@ class Entry implements IEntry {
 
 	private ?string $status = null;
 	private ?string $statusMessage = null;
+	private ?int $statusMessageTimestamp = null;
 	private ?string $statusIcon = null;
 
 	public function setId(string $id): void {
@@ -109,9 +112,11 @@ class Entry implements IEntry {
 
 	public function setStatus(string $status,
 		string $statusMessage = null,
+		int $statusMessageTimestamp = null,
 		string $icon = null): void {
 		$this->status = $status;
 		$this->statusMessage = $statusMessage;
+		$this->statusMessageTimestamp = $statusMessageTimestamp;
 		$this->statusIcon = $icon;
 	}
 
@@ -159,7 +164,7 @@ class Entry implements IEntry {
 	}
 
 	/**
-	 * @return array{id: int|string|null, fullName: string, avatar: string|null, topAction: mixed, actions: array, lastMessage: '', emailAddresses: string[], profileTitle: string|null, profileUrl: string|null, status: string|null, statusMessage: null|string, statusIcon: null|string, isUser: bool, uid: mixed}
+	 * @return array{id: int|string|null, fullName: string, avatar: string|null, topAction: mixed, actions: array, lastMessage: '', emailAddresses: string[], profileTitle: string|null, profileUrl: string|null, status: string|null, statusMessage: null|string, statusMessageTimestamp: null|int, statusIcon: null|string, isUser: bool, uid: mixed}
 	 */
 	public function jsonSerialize(): array {
 		$topAction = !empty($this->actions) ? $this->actions[0]->jsonSerialize() : null;
@@ -179,9 +184,18 @@ class Entry implements IEntry {
 			'profileUrl' => $this->profileUrl,
 			'status' => $this->status,
 			'statusMessage' => $this->statusMessage,
+			'statusMessageTimestamp' => $this->statusMessageTimestamp,
 			'statusIcon' => $this->statusIcon,
 			'isUser' => $this->getProperty('isUser') === true,
 			'uid' => $this->getProperty('UID'),
 		];
+	}
+
+	public function getStatusMessage(): ?string {
+		return $this->statusMessage;
+	}
+
+	public function getStatusMessageTimestamp(): ?int {
+		return $this->statusMessageTimestamp;
 	}
 }

--- a/lib/private/Contacts/ContactsMenu/Manager.php
+++ b/lib/private/Contacts/ContactsMenu/Manager.php
@@ -82,8 +82,19 @@ class Manager {
 	 * @return IEntry[]
 	 */
 	private function sortEntries(array $entries): array {
-		usort($entries, function (IEntry $entryA, IEntry $entryB) {
-			return strcasecmp($entryA->getFullName(), $entryB->getFullName());
+		usort($entries, function (Entry $entryA, Entry $entryB) {
+			$aStatusTimestamp = $entryA->getProperty(Entry::PROPERTY_STATUS_MESSAGE_TIMESTAMP);
+			$bStatusTimestamp = $entryB->getProperty(Entry::PROPERTY_STATUS_MESSAGE_TIMESTAMP);
+			if (!$aStatusTimestamp && !$bStatusTimestamp) {
+				return strcasecmp($entryA->getFullName(), $entryB->getFullName());
+			}
+			if ($aStatusTimestamp === null) {
+				return 1;
+			}
+			if ($bStatusTimestamp === null) {
+				return -1;
+			}
+			return $bStatusTimestamp - $aStatusTimestamp;
 		});
 		return $entries;
 	}

--- a/lib/public/Contacts/ContactsMenu/IEntry.php
+++ b/lib/public/Contacts/ContactsMenu/IEntry.php
@@ -64,6 +64,7 @@ interface IEntry extends JsonSerializable {
 	 */
 	public function setStatus(string $status,
 		string $statusMessage = null,
+		int $statusMessageTimestamp = null,
 		string $icon = null): void;
 
 	/**

--- a/tests/lib/Contacts/ContactsMenu/EntryTest.php
+++ b/tests/lib/Contacts/ContactsMenu/EntryTest.php
@@ -105,6 +105,7 @@ class EntryTest extends TestCase {
 			'profileUrl' => null,
 			'status' => null,
 			'statusMessage' => null,
+			'statusMessageTimestamp' => null,
 			'statusIcon' => null,
 			'isUser' => false,
 			'uid' => null,

--- a/tests/lib/Contacts/ContactsMenu/ManagerTest.php
+++ b/tests/lib/Contacts/ContactsMenu/ManagerTest.php
@@ -26,10 +26,10 @@ namespace Tests\Contacts\ContactsMenu;
 
 use OC\Contacts\ContactsMenu\ActionProviderStore;
 use OC\Contacts\ContactsMenu\ContactsStore;
+use OC\Contacts\ContactsMenu\Entry;
 use OC\Contacts\ContactsMenu\Manager;
 use OCP\App\IAppManager;
 use OCP\Constants;
-use OCP\Contacts\ContactsMenu\IEntry;
 use OCP\Contacts\ContactsMenu\IProvider;
 use OCP\IConfig;
 use OCP\IUser;
@@ -65,7 +65,7 @@ class ManagerTest extends TestCase {
 	private function generateTestEntries(): array {
 		$entries = [];
 		foreach (range('Z', 'A') as $char) {
-			$entry = $this->createMock(IEntry::class);
+			$entry = $this->createMock(Entry::class);
 			$entry->expects($this->any())
 				->method('getFullName')
 				->willReturn('Contact ' . $char);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/40559

## Summary

List system contacts with a recent custom status message first sorted descending by the status change time, then all other contacts sorted ascending by their name.

If user_status is not enabled or nobody set their custom status recently, fall back to sorting by contact name ascending only.

## TODO

- [x] Make it work
- [x] ~~Fix usage of `\OCP\Contacts\ContactsMenu\IContactsStore::getContacts` with pagination~~ Not used anyway. API now falls back to old behavior if offset is supplied.

![image](https://github.com/nextcloud/server/assets/1374172/d7368d60-04d0-4891-b550-97ee2e7325dc)

(avatars are only broken because automated tests deleted them …)

## Follow-up

- Make it fast

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
