### PR TITLE
fix: reduce memory consumption of scans

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -599,9 +599,12 @@ class Cache implements ICache {
 			}
 
 			/** @var ICacheEntry[] $childFolders */
-			$childFolders = array_filter($children, function ($child) {
-				return $child->getMimeType() == FileInfo::MIMETYPE_FOLDER;
-			});
+			$childFolders = [];
+			foreach ($children as $child) {
+				if ($child->getMimeType() == FileInfo::MIMETYPE_FOLDER) {
+					$childFolders[] = $child;
+				}
+			}
 			foreach ($childFolders as $folder) {
 				$parentIds[] = $folder->getId();
 				$queue[] = $folder->getId();


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/40919

## Summary

`array_filter` is pretty memory intensive, specially in the context of `appdata_` folder where it can have thousands of folders. Construct the array in a loop instead.

The `array_filter` creates a new array and populates it with elements that meet the filter condition. This means it creates a new array in memory to hold the filtered elements, which can be memory-intensive, especially if the original array `$children` is large.

On the other hand, a foreach loop initializes an empty array `$childFolders` and then iterates through the `$children` array, only adding elements to `$childFolders` if they meet the filtering condition. This approach doesn't create an additional array for the filtered elements, so it consumes less memory.

### Before
![old](https://github.com/nextcloud/server/assets/12234510/2c7d9c1c-f8b0-499d-b0a2-1e7bfeaf8680)

### After
![new](https://github.com/nextcloud/server/assets/12234510/82fc03d2-a4cc-463c-973d-765e02a4154c)

### Test system
```
+---------+--------+--------------+
| Folders | Files  | Elapsed time |
+---------+--------+--------------+
| 217688  | 155452 | 00:09:46     |
+---------+--------+--------------+
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
