### PR TITLE
Add timezone getter to ITimeFactory

### DIFF
--- a/lib/private/AppFramework/Utility/TimeFactory.php
+++ b/lib/private/AppFramework/Utility/TimeFactory.php
@@ -73,4 +73,11 @@ class TimeFactory implements ITimeFactory {
 
 		return $clone;
 	}
+
+	public function getTimeZone(?string $timezone = null): \DateTimeZone {
+		if ($timezone !== null) {
+			return new \DateTimeZone($timezone);
+		}
+		return $this->timezone;
+	}
 }

--- a/lib/public/AppFramework/Utility/ITimeFactory.php
+++ b/lib/public/AppFramework/Utility/ITimeFactory.php
@@ -58,4 +58,12 @@ interface ITimeFactory extends ClockInterface {
 	 * @since 26.0.0
 	 */
 	public function withTimeZone(\DateTimeZone $timezone): static;
+
+	/**
+	 * @param string|null $timezone
+	 * @return \DateTimeZone Requested timezone if provided, UTC otherwise
+	 * @throws \Exception
+	 * @since 29.0.0
+	 */
+	public function getTimeZone(?string $timezone = null): \DateTimeZone;
 }

--- a/tests/lib/AppFramework/Utility/TimeFactoryTest.php
+++ b/tests/lib/AppFramework/Utility/TimeFactoryTest.php
@@ -46,4 +46,21 @@ class TimeFactoryTest extends \Test\TestCase {
 		$now = $withTimeZone->now();
 		self::assertSame('Europe/Berlin', $now->getTimezone()->getName());
 	}
+
+	public function testGetTimeZone(): void {
+		$expected = new \DateTimeZone('Europe/Berlin');
+		$actual = $this->timeFactory->getTimeZone('Europe/Berlin');
+		self::assertEquals($expected, $actual);
+	}
+
+	public function testGetTimeZoneUTC(): void {
+		$expected = new \DateTimeZone('UTC');
+		$actual = $this->timeFactory->getTimeZone();
+		self::assertEquals($expected, $actual);
+	}
+
+	public function testGetTimeZoneInvalid(): void {
+		$this->expectException(\Exception::class);
+		$this->timeFactory->getTimeZone('blubblub');
+	}
 }


### PR DESCRIPTION
## Summary
Add factory method to generate a \DateTimeZone object

Better testability

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
