### PR TITLE
Lower log level about invalid session token

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -783,7 +783,7 @@ class Session implements IUserSession, Emitter {
 		try {
 			$dbToken = $this->tokenProvider->getToken($token);
 		} catch (InvalidTokenException $ex) {
-			$this->logger->warning('Session token is invalid because it does not exist', [
+			$this->logger->debug('Session token is invalid because it does not exist', [
 				'app' => 'core',
 				'user' => $user,
 				'exception' => $ex,


### PR DESCRIPTION
* Resolves: #41156

## Summary

Lower log level severity as suggested by @ChristophWurst 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
