### PR TITLE
Improve setup checks API

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpModules.php
+++ b/apps/settings/lib/SetupChecks/PhpModules.php
@@ -75,12 +75,12 @@ class PhpModules implements ISetupCheck {
 		$missingRequiredModules = $this->getMissingModules(self::REQUIRED_MODULES);
 		if (!empty($missingRequiredModules)) {
 			return SetupResult::error(
-				$this->l10n->t('This instance is missing some required PHP modules. It is required to install them: %s', implode(', ', $missingRequiredModules)),
+				$this->l10n->t('This instance is missing some required PHP modules. It is required to install them: %s.', implode(', ', $missingRequiredModules)),
 				$this->urlGenerator->linkToDocs('admin-php-modules')
 			);
 		} elseif (!empty($missingRecommendedModules)) {
 			return SetupResult::info(
-				$this->l10n->t('This instance is missing some recommended PHP modules. For improved performance and better compatibility it is highly recommended to install them: %s', implode(', ', $missingRecommendedModules)),
+				$this->l10n->t('This instance is missing some recommended PHP modules. For improved performance and better compatibility it is highly recommended to install them: %s.', implode(', ', $missingRecommendedModules)),
 				$this->urlGenerator->linkToDocs('admin-php-modules')
 			);
 		} else {

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -55,7 +55,7 @@ class SetupChecks extends Base {
 			default:
 				foreach ($results as $category => $checks) {
 					$output->writeln("\t{$category}:");
-					foreach ($checks as $title => $check) {
+					foreach ($checks as $check) {
 						$styleTag = match ($check->getSeverity()) {
 							'success' => 'info',
 							'error' => 'error',
@@ -74,7 +74,7 @@ class SetupChecks extends Base {
 							"\t\t".
 							($styleTag !== null ? "<{$styleTag}>" : '').
 							"{$emoji} ".
-							$title.
+							($check->getName() ?? $check::class).
 							($description !== null ? ': '.$description : '').
 							($styleTag !== null ? "</{$styleTag}>" : ''),
 							$verbosity
@@ -83,7 +83,7 @@ class SetupChecks extends Base {
 				}
 		}
 		foreach ($results as $category => $checks) {
-			foreach ($checks as $title => $check) {
+			foreach ($checks as $check) {
 				if ($check->getSeverity() !== 'success') {
 					return self::FAILURE;
 				}

--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -47,9 +47,10 @@ class SetupCheckManager implements ISetupCheckManager {
 			$setupCheckObject = Server::get($setupCheck->getService());
 			$this->logger->debug('Running check '.get_class($setupCheckObject));
 			$setupResult = $setupCheckObject->run();
+			$setupResult->setName($setupCheckObject->getName());
 			$category = $setupCheckObject->getCategory();
 			$results[$category] ??= [];
-			$results[$category][$setupCheckObject->getName()] = $setupResult;
+			$results[$category][$setupCheckObject::class] = $setupResult;
 		}
 		return $results;
 	}

--- a/lib/public/SetupCheck/ISetupCheck.php
+++ b/lib/public/SetupCheck/ISetupCheck.php
@@ -36,11 +36,13 @@ namespace OCP\SetupCheck;
 interface ISetupCheck {
 	/**
 	 * @since 28.0.0
+	 * @return string Category id, one of security/system/accounts, or a custom one which will be merged in system
 	 */
 	public function getCategory(): string;
 
 	/**
 	 * @since 28.0.0
+	 * @return string Translated name to display to the user
 	 */
 	public function getName(): string;
 

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -38,6 +38,11 @@ class SetupResult implements \JsonSerializable {
 	public const ERROR = 'error';
 
 	/**
+	 * @param string $name Translated name to display to the user
+	 */
+	private ?string $name = null;
+
+	/**
 	 * @brief Private constructor, use success()/info()/warning()/error() instead
 	 * @param self::SUCCESS|self::INFO|self::WARNING|self::ERROR $severity
 	 * @since 28.0.0
@@ -51,6 +56,8 @@ class SetupResult implements \JsonSerializable {
 
 	/**
 	 * @brief Create a success result object
+	 * @param ?string $description Translated detailed description to display to the user
+	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
 	 */
 	public static function success(?string $description = null, ?string $linkToDoc = null): self {
@@ -59,6 +66,8 @@ class SetupResult implements \JsonSerializable {
 
 	/**
 	 * @brief Create an info result object
+	 * @param ?string $description Translated detailed description to display to the user
+	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
 	 */
 	public static function info(?string $description = null, ?string $linkToDoc = null): self {
@@ -67,6 +76,8 @@ class SetupResult implements \JsonSerializable {
 
 	/**
 	 * @brief Create a warning result object
+	 * @param ?string $description Translated detailed description to display to the user
+	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
 	 */
 	public static function warning(?string $description = null, ?string $linkToDoc = null): self {
@@ -75,6 +86,8 @@ class SetupResult implements \JsonSerializable {
 
 	/**
 	 * @brief Create an error result object
+	 * @param ?string $description Translated detailed description to display to the user
+	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
 	 */
 	public static function error(?string $description = null, ?string $linkToDoc = null): self {
@@ -101,6 +114,24 @@ class SetupResult implements \JsonSerializable {
 	}
 
 	/**
+	 * @brief Get the name for the setup check
+	 *
+	 * @since 28.0.0
+	 */
+	public function getName(): ?string {
+		return $this->name;
+	}
+
+	/**
+	 * @brief Set the name from the setup check
+	 *
+	 * @since 28.0.0
+	 */
+	public function setName(string $name): void {
+		$this->name = $name;
+	}
+
+	/**
 	 * @brief Get a link to the doc for the explanation.
 	 *
 	 * @since 28.0.0
@@ -116,6 +147,7 @@ class SetupResult implements \JsonSerializable {
 	 */
 	public function jsonSerialize(): array {
 		return [
+			'name' => $this->name,
 			'severity' => $this->severity,
 			'description' => $this->description,
 			'linkToDoc' => $this->linkToDoc,


### PR DESCRIPTION
## Summary

The idea here is to avoid using the name as a key in the array as the name of setup checks is translated.
Before:
```json
{
    "dav": {
        "Checking for DAV system address book": {
            "severity": "success",
            "description": "No outstanding DAV system address book sync.",
            "linkToDoc": null
        }
    },
    "security": {
        "Checking for old user imported certificate": {
            "severity": "success",
            "description": null,
            "linkToDoc": null
        },
        "Code integrity": {
            "severity": "info",
            "description": "Integrity checker has been disabled. Integrity cannot be verified.",
            "linkToDoc": null
        },
```
After:
```json
{
    "dav": {
        "OCA\\DAV\\SetupChecks\\NeedsSystemAddressBookSync": {
            "name": "Checking for DAV system address book",
            "severity": "success",
            "description": "No outstanding DAV system address book sync.",
            "linkToDoc": null
        }
    },
    "security": {
        "OCA\\Settings\\SetupChecks\\CheckUserCertificates": {
            "name": "Checking for old user imported certificate",
            "severity": "success",
            "description": null,
            "linkToDoc": null
        },
        "OCA\\Settings\\SetupChecks\\CodeIntegrity": {
            "name": "Code integrity",
            "severity": "info",
            "description": "Integrity checker has been disabled. Integrity cannot be verified.",
            "linkToDoc": null
        },
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
