### PR TITLE
dont reuse etag for folders marked explicitly unscanned

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -203,7 +203,8 @@ class Scanner extends BasicEmitter implements IScanner {
 						$fileId = $cacheData['fileid'];
 						$data['fileid'] = $fileId;
 						// only reuse data if the file hasn't explicitly changed
-						if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
+						$mtimeUnchanged = isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime'];
+						if ($mtimeUnchanged && $cacheData['size'] !== -1) {
 							$data['mtime'] = $cacheData['mtime'];
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
 								$data['size'] = $cacheData['size'];

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -204,6 +204,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						$data['fileid'] = $fileId;
 						// only reuse data if the file hasn't explicitly changed
 						$mtimeUnchanged = isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime'];
+						// if the folder is marked as unscanned, never reuse etags
 						if ($mtimeUnchanged && $cacheData['size'] !== -1) {
 							$data['mtime'] = $cacheData['mtime'];
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
@@ -221,6 +222,11 @@ class Scanner extends BasicEmitter implements IScanner {
 
 						// Only update metadata that has changed
 						$newData = array_diff_assoc($data, $cacheData->getData());
+
+						// make it known to the caller that etag has been changed and needs propagation
+						if (isset($newData['etag'])) {
+							$data['etag_changed'] = true;
+						}
 					} else {
 						// we only updated unencrypted_size if it's already set
 						unset($data['unencrypted_size']);
@@ -389,16 +395,20 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param int|float $oldSize the size of the folder before (re)scanning the children
 	 * @return int|float the size of the scanned folder or -1 if the size is unknown at this stage
 	 */
-	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize) {
+	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize, &$etagChanged = false) {
 		if ($reuse === -1) {
 			$reuse = ($recursive === self::SCAN_SHALLOW) ? self::REUSE_ETAG | self::REUSE_SIZE : self::REUSE_ETAG;
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'scanFolder', [$path, $this->storageId]);
 		$size = 0;
-		$childQueue = $this->handleChildren($path, $recursive, $reuse, $folderId, $lock, $size);
+		$childQueue = $this->handleChildren($path, $recursive, $reuse, $folderId, $lock, $size, $etagChanged);
 
 		foreach ($childQueue as $child => [$childId, $childSize]) {
-			$childSize = $this->scanChildren($child, $recursive, $reuse, $childId, $lock, $childSize);
+			// "etag changed" propagates up, but not down, so we pass `false` to the children even if we already know that the etag of the current folder changed
+			$childEtagChanged = false;
+			$childSize = $this->scanChildren($child, $recursive, $reuse, $childId, $lock, $childSize, $childEtagChanged);
+			$etagChanged |= $childEtagChanged;
+
 			if ($childSize === -1) {
 				$size = -1;
 			} elseif ($size !== -1) {
@@ -411,8 +421,17 @@ class Scanner extends BasicEmitter implements IScanner {
 		if ($this->storage->instanceOfStorage(Encryption::class)) {
 			$this->cache->calculateFolderSize($path);
 		} else {
-			if ($this->cacheActive && $oldSize !== $size) {
-				$this->cache->update($folderId, ['size' => $size]);
+			if ($this->cacheActive) {
+				$updatedData = [];
+				if ($oldSize !== $size) {
+					$updatedData['size'] = $size;
+				}
+				if ($etagChanged) {
+					$updatedData['etag'] = uniqid();
+				}
+				if ($updatedData) {
+					$this->cache->update($folderId, $updatedData);
+				}
 			}
 		}
 		$this->emit('\OC\Files\Cache\Scanner', 'postScanFolder', [$path, $this->storageId]);
@@ -422,7 +441,7 @@ class Scanner extends BasicEmitter implements IScanner {
 	/**
 	 * @param bool|IScanner::SCAN_RECURSIVE_INCOMPLETE $recursive
 	 */
-	private function handleChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float &$size): array {
+	private function handleChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float &$size, bool &$etagChanged): array {
 		// we put this in it's own function so it cleans up the memory before we start recursing
 		$existingChildren = $this->getExistingChildren($folderId);
 		$newChildren = iterator_to_array($this->storage->getDirectoryContent($path));
@@ -469,6 +488,10 @@ class Scanner extends BasicEmitter implements IScanner {
 						$size = -1;
 					} elseif ($size !== -1) {
 						$size += $data['size'];
+					}
+
+					if (isset($data['etag_changed']) && $data['etag_changed']) {
+						$etagChanged = true;
 					}
 				}
 			} catch (Exception $ex) {

--- a/lib/private/Files/ObjectStore/ObjectStoreScanner.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreScanner.php
@@ -39,7 +39,7 @@ class ObjectStoreScanner extends Scanner {
 		return [];
 	}
 
-	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize) {
+	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize, &$etagChanged = false) {
 		return 0;
 	}
 


### PR DESCRIPTION
Speculated issue:

- An external smb storage is setup where the folder mtime doesn't change when new files get created
- `files_external:notify` is running marking the parent folder of any created file with a size of -1
- the background scanner triggers for the parent folder, finding the new file
- because the mtime of the folder didn't change, the old etag for the parent folder is reused
- the sync client doesn't pickup the change because the etag of the parent folder didn't change.

A use case that might trigger this is an external smb storage where the underlying fs doesn't change folder mtime as we expect but "files_external:notify" is being used to process external file changes.

I was able to reproduce this with manual `touch`ing to "unchange" the folder mtime a few times but then *something* changed and I can't anymore...