### PR TITLE
Expose metadata to sidebar tabs

### DIFF
--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -196,7 +196,7 @@ export default {
 				const shareUrl = generateOcsUrl('apps/files_sharing/api/v1/shares')
 				const format = 'json'
 				// TODO: replace with proper getFUllpath implementation of our own FileInfo model
-				const path = (this.fileInfo.path + '/' + this.fileInfo.name).replace('//', '/')
+				const path = (this.fileInfo.path).replace('//', '/')
 
 				// fetch shares
 				const fetchShares = axios.get(shareUrl, {

--- a/apps/files_versions/src/utils/versions.js
+++ b/apps/files_versions/src/utils/versions.js
@@ -108,7 +108,7 @@ function formatVersion(version, fileInfo) {
 		})
 	} else {
 		previewUrl = generateUrl('/apps/files_versions/preview?file={file}&version={fileVersion}', {
-			file: joinPaths(fileInfo.path, fileInfo.name),
+			file: fileInfo.path,
 			fileVersion: version.basename,
 		})
 	}


### PR DESCRIPTION
Currently, the sidebar makes a `PROPFIND` request when it is opened. But the result of this `PROPFIND` does not expose the request extra properties.