### PR TITLE
fix(migration): Fix files metadata migration

### DIFF
--- a/core/Migrations/Version28000Date20231004103301.php
+++ b/core/Migrations/Version28000Date20231004103301.php
@@ -42,12 +42,16 @@ class Version28000Date20231004103301 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::BIGINT, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 15,
-				'unsigned' => true,
+				'length' => 20,
 			]);
-			$table->addColumn('file_id', Types::BIGINT, ['notnull' => false, 'length' => 15,]);
+			$table->addColumn('file_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
 			$table->addColumn('json', Types::TEXT);
-			$table->addColumn('sync_token', Types::STRING, ['length' => 15]);
+			$table->addColumn('sync_token', Types::STRING, [
+				'length' => 15,
+			]);
 			$table->addColumn('last_update', Types::DATETIME);
 
 			$table->setPrimaryKey(['id']);
@@ -60,13 +64,24 @@ class Version28000Date20231004103301 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::BIGINT, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 15,
-				'unsigned' => true,
+				'length' => 20,
 			]);
-			$table->addColumn('file_id', Types::BIGINT, ['notnull' => false, 'length' => 15]);
-			$table->addColumn('meta_key', Types::STRING, ['notnull' => false, 'length' => 31]);
-			$table->addColumn('meta_value_string', Types::STRING, ['notnull' => false, 'length' => 63]);
-			$table->addColumn('meta_value_int', Types::BIGINT, ['notnull' => false, 'length' => 11]);
+			$table->addColumn('file_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('meta_key', Types::STRING, [
+				'notnull' => false,
+				'length' => 31,
+			]);
+			$table->addColumn('meta_value_string', Types::STRING, [
+				'notnull' => false,
+				'length' => 63,
+			]);
+			$table->addColumn('meta_value_int', Types::BIGINT, [
+				'notnull' => false,
+				'length' => 11,
+			]);
 
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['file_id', 'meta_key', 'meta_value_string'], 'f_meta_index');

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [28, 0, 0, 3];
+$OC_Version = [28, 0, 0, 4];
 
 // The human-readable string
 $OC_VersionString = '28.0.0 beta 1';


### PR DESCRIPTION
* Follow up to #40761
* Otherwise the table can not hold all fileids from the filecache table
* And the migration never triggered

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
