### PR TITLE
fix: Validate that we have a proper distributed cache configured

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -30,6 +30,8 @@ use InvalidArgumentException;
 use OC\Files\Filesystem;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\View;
+use OC\Memcache\Memcached;
+use OC\Memcache\Redis;
 use OC_Hook;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
@@ -40,6 +42,7 @@ use OCP\Files\Storage\IChunkedFileWrite;
 use OCP\Files\StorageInvalidException;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\Lock\ILockingProvider;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\InsufficientStorage;
@@ -272,6 +275,11 @@ class ChunkingV2Plugin extends ServerPlugin {
 	 * @throws StorageInvalidException
 	 */
 	private function checkPrerequisites(bool $checkUploadMetadata = true): void {
+		$distributedCacheConfig = \OCP\Server::get(IConfig::class)->getSystemValue('memcache.distributed', null);
+
+		if ($distributedCacheConfig === null || (!$this->cache instanceof Redis && !$this->cache instanceof Memcached)) {
+			throw new BadRequest('Skipping chunking v2 since no proper distributed cache is available');
+		}
 		if (!$this->uploadFolder instanceof UploadFolder || empty($this->server->httpRequest->getHeader(self::DESTINATION_HEADER))) {
 			throw new BadRequest('Skipping chunked file writing as the destination header was not passed');
 		}
@@ -284,7 +292,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 		if ($checkUploadMetadata) {
 			if ($this->uploadId === null || $this->uploadPath === null) {
-				throw new PreconditionFailed('Missing metadata for chunked upload');
+				throw new PreconditionFailed('Missing metadata for chunked upload. The distributed cache does not hold the information of previous requests.');
 			}
 		}
 	}


### PR DESCRIPTION
Properly handle instances where there is
- No distributed cache configured in which case we fall back to the old chunking
- The distributed cache factory method returns other caches than Redis/memcached

We cannot detect if there is a redis distributed cache configured but the cache is not shared, in this case an error like "Missing metadata for chunked upload" is still expected and points out an architectural issue of the instance setup. I extended the error message a bit there to be more clear.

Fixes https://github.com/nextcloud/server/issues/41198