### PR TITLE
[stable27] fix(files): prevent redirect on heading column sort

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1228,6 +1228,10 @@
 			if (this.$table.hasClass('multiselect')) {
 				return;
 			}
+
+			// Ensure the url does not change
+			e.preventDefault();
+	
 			var $target = $(e.target);
 			var sort;
 			if (!$target.is('a')) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/38884

Seems like the old inline `onclick="event.preventDefault()"` isn't working after all