### PR TITLE
[stable26] Fix type in BeforeMessageLoggedEvent

### DIFF
--- a/lib/public/Log/BeforeMessageLoggedEvent.php
+++ b/lib/public/Log/BeforeMessageLoggedEvent.php
@@ -33,12 +33,12 @@ use OCP\EventDispatcher\Event;
 class BeforeMessageLoggedEvent extends Event {
 	private int $level;
 	private string $app;
-	private $message;
+	private array $message;
 
 	/**
 	 * @since 26.0.8
 	 */
-	public function __construct(string $app, int $level, $message) {
+	public function __construct(string $app, int $level, array $message) {
 		$this->level = $level;
 		$this->app = $app;
 		$this->message = $message;
@@ -54,7 +54,6 @@ class BeforeMessageLoggedEvent extends Event {
 		return $this->level;
 	}
 
-
 	/**
 	 * Get the app context of the log item
 	 *
@@ -65,14 +64,13 @@ class BeforeMessageLoggedEvent extends Event {
 		return $this->app;
 	}
 
-
 	/**
 	 * Get the message of the log item
 	 *
-	 * @return string
+	 * @return array
 	 * @since 26.0.8
 	 */
-	public function getMessage(): string {
+	public function getMessage(): array {
 		return $this->message;
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/38843

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
