### PR TITLE
fix(events): Make sure all `\OCP\Files::…` events are emitted with th…

### DIFF
--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -132,7 +132,14 @@ class Node implements INode {
 			if (method_exists($this->root, 'emit')) {
 				$this->root->emit('\OC\Files', $hook, $args);
 			}
-			$dispatcher->dispatch('\OCP\Files::' . $hook, new GenericEvent($args));
+
+			if (in_array($hook, ['preWrite', 'postWrite', 'preCreate', 'postCreate', 'preTouch', 'postTouch', 'preDelete', 'postDelete'], true)) {
+				$event = new GenericEvent($args[0]);
+			} else {
+				$event = new GenericEvent($args);
+			}
+
+			$dispatcher->dispatch('\OCP\Files::' . $hook, $event);
 		}
 	}
 


### PR DESCRIPTION
…e same data


* Resolves: #41360 

## Summary

* Make sure the events in appdata match the ones for normal files https://github.com/nextcloud/server/blob/44a0a621075962fecd9a3c94e724e2b544f7ce38/lib/private/Files/Node/HookConnector.php#L122-L126
* This was always misaligned, but in 27 etc the event was dispatched with 2 different classes and therefore the type check at https://github.com/nextcloud/server/blob/efb7448cd271f7f0cd21fd284fd1d3f9d729f20f/apps/workflowengine/lib/AppInfo/Application.php#L103-L114 checked a wrong event so it was actually never handled and did not error:
    - HookConnector used `OCP\EventDispatcher\GenericEvent`
    - https://github.com/nextcloud/server/blob/6034cc6893eba6e294970966ad9a6389488948d1/lib/private/Files/Node/HookConnector.php#L31
    - Node::sendHooks used `Symfony\Component\EventDispatcher\GenericEvent`
    - https://github.com/nextcloud/server/blob/f724760f67bbd8c177dd716fa3b95e990a787bda/lib/private/Files/Node/Node.php#L43
* So the same event was emitted with 2 different event classes and 2 different sets of parameters.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
