### PR TITLE
fix(s3): support SSE-C headers for the MultipartCopy call

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -191,6 +191,11 @@ trait S3ObjectTrait {
 	}
 
 	public function copyObject($from, $to, array $options = []) {
+		$sourceMetadata = $this->getConnection()->headObject([
+			'Bucket' => $this->getBucket(),
+			'Key' => $from,
+		] + $this->getSSECParameters());
+
 		$copy = new MultipartCopy($this->getConnection(), [
 			"source_bucket" => $this->getBucket(),
 			"source_key" => $from
@@ -198,7 +203,8 @@ trait S3ObjectTrait {
 			"bucket" => $this->getBucket(),
 			"key" => $to,
 			"acl" => "private",
-			"params" => $this->getSSECParameters() + $this->getSSECParameters(true)
+			"params" => $this->getSSECParameters() + $this->getSSECParameters(true),
+			"source_metadata" => $sourceMetadata
 		], $options));
 		$copy->copy();
 	}


### PR DESCRIPTION
Since a few weeks, I see a lot of HTTP 400 Bad Request errors on HeadObject calls in my Nextcloud logs.
Furthermore I realized, that it is no longer possible to copy a file using the Web-UI.
After further investigations I found out, that this problem is related to the switch to MultipartCopy for copyObject operations on S3 Object Storages.

Looking into the code of the AWS PHP SDK, MultipartCopy executes a headObject request to retrieve the metadata of the source object:
https://github.com/aws/aws-sdk-php/blob/master/src/S3/MultipartCopy.php#L193
Unfortunately, this request is executed without adding any additional Headers like SSE-C, so that this call fails on setups using SSE-C.

To fix this issue, the source object's metadata can be fetched by a separate headObject request and directly provided to the MultipartCopy object as an input argument, skipping the included headObject request (https://github.com/aws/aws-sdk-php/blob/master/src/S3/MultipartCopy.php#L196).

This Pull Requests fixes the broken copyObject function on Nextcloud setups using SSE-C for Primary S3 Object Storage.