### PR TITLE
Ensure no description changes are lost

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -162,6 +162,11 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 		if (!$this->pathOfCalendarObjectChange) {
 			$this->pathOfCalendarObjectChange = $request->getPath();
 		}
+		
+		// Ensure description consistency
+		if (!$isNew) {
+		    $this->ensureDescriptionConsistency($request, $vCal, $modified);
+		}
 
 		parent::calendarObjectChange($request, $response, $vCal, $calendarPath, $modified, $isNew);
 	}
@@ -631,5 +636,39 @@ EOF;
 		$calendarHome->getCalDAVBackend()->createCalendar($principalUri, $uri, [
 			'{DAV:}displayname' => $displayName,
 		]);
+	}
+	
+	private function ensureDescriptionConsistency(RequestInterface $request, VCalendar $vCal, &$modified) {
+	    $xAltDescPropName = "X-ALT-DESC";
+	    
+	    // Obtain previous version
+	    $node = $this->server->tree->getNodeForPath($request->getPath());
+	    $oldObj = Reader::read($node->get());
+	    
+	    // Get presence of description fields
+	    $hasOldDescription = isset($oldObj->VTODO) && isset($oldObj->VTODO->DESCRIPTION);
+	    $hasNewDescription = isset($vCal->VTODO) && isset($vCal->VTODO->DESCRIPTION);
+	    $hasOldXAltDesc = isset($oldObj->VTODO) && isset($oldObj->VTODO->{$xAltDescPropName});
+	    $hasNewXAltDesc = isset($vCal->VTODO) && isset($vCal->VTODO->{$xAltDescPropName});
+	    $hasAllDesc = $hasOldDescription && $hasNewDescription && $hasOldXAltDesc && $hasNewXAltDesc;
+	    
+	    // If all description fields are present, then verify consistency
+	    if ($hasAllDesc) {
+	        // Get descriptions
+	        $oldDescription = (string) $oldObj->VTODO->DESCRIPTION;
+	        $newDescription = (string) $vCal->VTODO->DESCRIPTION;
+	        $oldXAltDesc = (string) $oldObj->VTODO->{$xAltDescPropName};
+	        $newXAltDesc = (string) $vCal->VTODO->{$xAltDescPropName};
+	        
+	        // Compare descriptions
+	        $isSameDescription = $oldDescription === $newDescription;
+	        $isSameXAltDesc = $oldXAltDesc === $newXAltDesc;
+	        
+	        // If the description changed, but not the alternate one, then delete the latest
+	        if (!$isSameDescription && $isSameXAltDesc) {
+	            unset($vCal->VTODO->{$xAltDescPropName});
+	            $modified = true;
+	        }
+	    }
 	}
 }

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -638,7 +638,7 @@ EOF;
 		]);
 	}
 	
-	private function ensureDescriptionConsistency(RequestInterface $request, VCalendar $vCal, &$modified) {
+	private function ensureDescriptionConsistency(RequestInterface $request, VCalendar $vCal, &$modified): void {
 	    $xAltDescPropName = "X-ALT-DESC";
 	    
 	    // Obtain previous version


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/tasks/issues/2239

## Summary
The first resolution was fixing it when using the NextCloud web interface, but not when using an application like OpenTasks on Android. This ensures that the alternate description is deleted if the description is modified alone. So, it better supports application only supporting textual description used in conjonction with others supporting also HTML.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included ==> No, as I'm new to modifying your software and as such I am not familiar with your structure, but if someone tells me where to add tests, I will.
- [ ] Screenshots before/after for front-end changes ==> No screenshot.
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required ==> Not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

I am joining the previous person who solved the issue (@max65482)  and the original issue requester (@Gorendal).