### PR TITLE
fix(cypress): Do not install calendar app from app store for testing

### DIFF
--- a/cypress/e2e/theming/navigation-bar-settings.cy.ts
+++ b/cypress/e2e/theming/navigation-bar-settings.cy.ts
@@ -21,6 +21,7 @@
  */
 
 import { User } from '@nextcloud/cypress'
+import { installTestApp, uninstallTestApp } from '../../support/commonUtils'
 
 const admin = new User('admin', 'admin')
 
@@ -152,9 +153,9 @@ describe('User theming set app order with default app', () => {
 	before(() => {
 		cy.resetAdminTheming()
 		// install a third app
-		cy.runOccCommand('app:install --force --allow-unstable calendar')
-		// set calendar as default app
-		cy.runOccCommand('config:system:set --value "calendar,files" defaultapp')
+		installTestApp()
+		// set files as default app
+		cy.runOccCommand('config:system:set --value "files" defaultapp')
 
 		// Create random user for this test
 		cy.createRandomUser().then(($user) => {
@@ -165,55 +166,56 @@ describe('User theming set app order with default app', () => {
 
 	after(() => {
 		cy.deleteUser(user)
-		cy.runOccCommand('app:remove calendar')
+		uninstallTestApp()
 	})
 
-	it('See calendar is the default app', () => {
+	it('See files is the default app', () => {
 		cy.visit('/')
-		cy.url().should('match', /apps\/calendar/)
+		cy.url().should('match', /apps\/files/)
 
 		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'calendar')
+			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
 		})
 	})
 
-	it('See the app order settings: calendar is the first one', () => {
+	it('See the app order settings: files is the first one', () => {
 		cy.visit('/settings/user/theming')
 		cy.get('[data-cy-app-order]').scrollIntoView()
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').should('have.length', 3).each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'calendar')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').should('have.length', 4).each(($el, idx) => {
+			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
 			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
 		})
 	})
 
 	it('Can not change the default app', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="calendar"] [data-cy-app-order-button="up"]').should('not.be.visible')
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="calendar"] [data-cy-app-order-button="down"]').should('not.be.visible')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').should('not.be.visible')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="down"]').should('not.be.visible')
 
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="dashboard"] [data-cy-app-order-button="up"]').should('not.be.visible')
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="dashboard"] [data-cy-app-order-button="down"]').should('be.visible')
 
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').should('be.visible')
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="down"]').should('not.be.visible')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').should('be.visible')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="down"]').should('not.be.visible')
 	})
 
 	it('Change the order of the other apps', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').click()
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').should('not.be.visible')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').should('not.be.visible')
 
 		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'calendar')
-			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
+			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'testapp')
+			else if (idx === 2) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
 		})
 	})
 
 	it('See the app menu order is changed', () => {
 		cy.reload()
 		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'calendar')
-			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
-			else cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
+			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
+			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-app-id', 'testapp')
+			else if (idx === 2) cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
 		})
 	})
 })

--- a/cypress/fixtures/testapp/appinfo/info.xml
+++ b/cypress/fixtures/testapp/appinfo/info.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+    <!--
+    SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
+    SPDX-License-Identifier: CC0-1.0
+    -->
+    <id>testapp</id>
+    <name>Test App</name>
+    <summary>Test App</summary>
+    <description><![CDATA[A simple test app]]></description>
+    <version>0.0.1</version>
+    <licence>agpl</licence>
+    <author mail="opensource@fthiessen.de" >Ferdinand Thiessen</author>
+    <namespace>TestApp</namespace>
+    <category>games</category>
+    <bugs>https://github.com/nextcloud/server/issues</bugs>
+    <dependencies>
+        <nextcloud min-version="28" max-version="28"/>
+    </dependencies>
+    <navigations>
+        <navigation>
+            <name>Test App</name>
+            <route>testapp.page.index</route>
+        </navigation>
+        <navigation>
+            <name>Test App 2</name>
+            <route>testapp.page.index</route>
+        </navigation>
+    </navigations>
+</info>

--- a/cypress/fixtures/testapp/appinfo/routes.php
+++ b/cypress/fixtures/testapp/appinfo/routes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+// SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+return [
+	'routes' => [
+		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+	]
+];

--- a/cypress/fixtures/testapp/img/app.svg
+++ b/cypress/fixtures/testapp/img/app.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="32"
+   width="32"
+   version="1"
+   viewBox="0 0 32 32"
+   id="svg4"
+   sodipodi:docname="app.svg"
+   inkscape:version="0.92.1 r">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="789"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="7.375"
+     inkscape:cx="-8.3389831"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M13.733 0a.915.915 0 0 0-.933.934V3.6c-1.182.304-2.243.794-3.267 1.4L7.6 3.068a.93.93 0 0 0-1.334 0l-3.2 3.2a.93.93 0 0 0 0 1.334L5 9.535c-.607 1.024-1.097 2.085-1.4 3.267H.933a.915.915 0 0 0-.933.934v4.533c0 .53.403.934.933.934H3.6c.303 1.182.793 2.243 1.4 3.267l-1.934 1.935a.93.93 0 0 0 0 1.333l3.2 3.2a.93.93 0 0 0 1.333 0L9.532 27c1.024.61 2.085 1.097 3.266 1.4v2.667c0 .53.402.933.932.933h4.534c.53 0 .933-.403.933-.935V28.4c1.18-.305 2.24-.795 3.265-1.4L24.4 28.93a.93.93 0 0 0 1.332 0l3.2-3.2a.93.93 0 0 0 0-1.333L27 22.465c.607-1.024 1.096-2.085 1.4-3.266h2.665a.915.915 0 0 0 .935-.933v-4.534a.915.915 0 0 0-.934-.933H28.4c-.304-1.182-.792-2.243-1.4-3.267L28.932 7.6a.93.93 0 0 0 0-1.334l-3.2-3.2a.93.93 0 0 0-1.333 0L22.465 5c-1.024-.607-2.084-1.097-3.266-1.4V.933A.915.915 0 0 0 18.267 0zM16 8.87A7.134 7.134 0 0 1 23.13 16 7.134 7.134 0 0 1 16 23.133c-3.936 0-7.13-3.196-7.13-7.132S12.063 8.87 16 8.87z"
+     display="block"
+     fill="#fff"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/cypress/fixtures/testapp/lib/AppInfo/Application.php
+++ b/cypress/fixtures/testapp/lib/AppInfo/Application.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+// SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\TestApp\AppInfo;
+
+use OCP\AppFramework\App;
+
+class Application extends App {
+	public const APP_ID = 'testapp';
+
+	public function __construct() {
+		parent::__construct(self::APP_ID);
+	}
+}

--- a/cypress/fixtures/testapp/lib/Controller/PageController.php
+++ b/cypress/fixtures/testapp/lib/Controller/PageController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+// SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\TestApp\Controller;
+
+use OCA\TestApp\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IRequest;
+
+class PageController extends Controller {
+	public function __construct(IRequest $request) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function index(): TemplateResponse {
+		return new TemplateResponse(Application::APP_ID, 'main');
+	}
+}

--- a/cypress/fixtures/testapp/templates/main.php
+++ b/cypress/fixtures/testapp/templates/main.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+// SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+?>
+<div id="content"></div>

--- a/cypress/support/commonUtils.ts
+++ b/cypress/support/commonUtils.ts
@@ -35,3 +35,25 @@ export function clearState() {
 		users.forEach((userID) => cy.runOccCommand(`user:delete '${userID}'`))
 	})
 }
+
+/**
+ * Install the test app
+ */
+export function installTestApp() {
+	const testAppPath = 'cypress/fixtures/testapp'
+	cy.runOccCommand('-V').then((output) => {
+		const version = output.stdout.match(/(\d\d+)\.\d+\.\d+/)?.[1]
+		cy.wrap(version).should('not.be.undefined')
+		cy.exec(`docker cp '${testAppPath}' nextcloud-cypress-tests-server:/var/www/html/apps`, { log: true })
+		cy.exec(`docker exec nextcloud-cypress-tests-server sed -i 's|version="[0-9]+|version="${version}|' apps/testapp/appinfo/info.xml`)
+		cy.runOccCommand('app:enable testapp')
+	})
+}
+
+/**
+ * Remove the test app
+ */
+export function uninstallTestApp() {
+	cy.runOccCommand('app:remove testapp', { failOnNonZeroExit: false })
+	cy.exec('docker exec nextcloud-cypress-tests-server rm -fr apps/testapp/appinfo/info.xml')
+}


### PR DESCRIPTION
## Summary

Instead use locally provided test app for the navigation bar.

## TODO

- We might instead of provide the test app adjust the qa testing app to have navigation entries, not sure if that would be better? I do not know if it is ok to add stub navigation entries to that app?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
