### PR TITLE
fix(cypress): Adjust admin theming tests for new `@nextcloud/vue` release

### DIFF
--- a/cypress/e2e/theming/admin-settings.cy.ts
+++ b/cypress/e2e/theming/admin-settings.cy.ts
@@ -270,19 +270,19 @@ describe('Change the login fields then reset them', function() {
 	})
 
 	it('Ensure undo button presence', function() {
-		cy.get('[data-admin-theming-setting-field="name"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="name"] .input-field__trailing-button')
 			.scrollIntoView()
-		cy.get('[data-admin-theming-setting-field="name"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="name"] .input-field__trailing-button')
 			.should('be.visible')
 
-		cy.get('[data-admin-theming-setting-field="url"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="url"] .input-field__trailing-button')
 			.scrollIntoView()
-		cy.get('[data-admin-theming-setting-field="url"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="url"] .input-field__trailing-button')
 			.should('be.visible')
 
-		cy.get('[data-admin-theming-setting-field="slogan"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="slogan"] .input-field__trailing-button')
 			.scrollIntoView()
-		cy.get('[data-admin-theming-setting-field="slogan"] .input-field__clear-button')
+		cy.get('[data-admin-theming-setting-field="slogan"] .input-field__trailing-button')
 			.should('be.visible')
 	})
 

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,6 +2,6 @@
 	"extends": "../tsconfig.json",
 	"include": ["./**/*.ts"],
 	"compilerOptions": {
-		"types": ["cypress", "dockerode", "cypress-wait-until"],
+		"types": ["cypress", "cypress-axe", "cypress-wait-until", "dockerode"],
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@vue/tsconfig/tsconfig.json",
 	"include": ["./apps/**/*.ts", "./core/**/*.ts", "./*.d.ts"],
 	"compilerOptions": {
-		"types": ["cypress", "cypress-axe", "jest", "node", "vue"],
+		"types": ["jest", "node", "vue"],
 		"outDir": "./dist/",
 		"target": "ESNext",
 		"module": "esnext",


### PR DESCRIPTION
## Summary

Fix cypress test as the trailing button selector has changed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
