### PR TITLE
fix(cypress): Make new-users test less flaky by using test isolation

### DIFF
--- a/cypress/e2e/settings/users.cy.ts
+++ b/cypress/e2e/settings/users.cy.ts
@@ -27,23 +27,16 @@ const admin = new User('admin', 'admin')
 const john = new User('john', '123456')
 
 describe('Settings: Create and delete users', function() {
-	before(function() {
+	beforeEach(function() {
+		cy.listUsers().then((users) => {
+			if ((users as string[]).includes(john.userId)) {
+				// ensure created user is deleted
+				cy.deleteUser(john)
+			}
+		})
 		cy.login(admin)
 		// open the User settings
 		cy.visit('/settings/users')
-	})
-
-	beforeEach(function() {
-		cy.login(admin)
-		cy.listUsers().then((users) => {
-			cy.login(admin)
-			if ((users as string[]).includes(john.userId)) {
-				// ensure created user is deleted
-				cy.deleteUser(john).login(admin)
-				// ensure deleted user is not present
-				cy.reload().login(admin)
-			}
-		})
 	})
 
 	it('Can create a user', function() {
@@ -64,7 +57,7 @@ describe('Settings: Create and delete users', function() {
 			// see that the password is 123456
 			cy.get('input[type="password"]').should('have.value', john.password)
 			// submit the new user form
-			cy.get('button[type="submit"]').click()
+			cy.get('button[type="submit"]').click({ force: true })
 		})
 
 		// Make sure no confirmation modal is shown
@@ -98,7 +91,7 @@ describe('Settings: Create and delete users', function() {
 			cy.get('input[type="password"]').type(john.password)
 			cy.get('input[type="password"]').should('have.value', john.password)
 			// submit the new user form
-			cy.get('button[type="submit"]').click()
+			cy.get('button[type="submit"]').click({ force: true })
 		})
 
 		// Make sure no confirmation modal is shown


### PR DESCRIPTION
## Summary

Use test isolation which should make the tests less flaky and also force click the buttons so we can ignore the scrolled state of the new users modal.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
