### PR TITLE
fix(workflow): Fix "Call to a member function getUID() on null" with …

### DIFF
--- a/apps/workflowengine/lib/Entity/File.php
+++ b/apps/workflowengine/lib/Entity/File.php
@@ -135,10 +135,10 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 		}
 	}
 
-	public function isLegitimatedForUserId(string $uid): bool {
+	public function isLegitimatedForUserId(string $userId): bool {
 		try {
 			$node = $this->getNode();
-			if ($node->getOwner()->getUID() === $uid) {
+			if ($node->getOwner()?->getUID() === $userId) {
 				return true;
 			}
 
@@ -149,7 +149,7 @@ class File implements IEntity, IDisplayText, IUrl, IIcon, IContextPortation {
 				$fileId = $node->getId();
 			}
 
-			$mountInfos = $this->userMountCache->getMountsForFileId($fileId, $uid);
+			$mountInfos = $this->userMountCache->getMountsForFileId($fileId, $userId);
 			foreach ($mountInfos as $mountInfo) {
 				$mount = $this->mountManager->getMountFromMountInfo($mountInfo);
 				if ($mount && $mount->getStorage() && !empty($mount->getStorage()->getCache()->get($fileId))) {


### PR DESCRIPTION
…appdata


* Resolves: 

```json
{
  "reqId": "Afvi2xALJe0iSM0rND3i",
  "level": 3,
  "time": "2023-11-13T07:50:36+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "core",
  "method": "",
  "url": "--",
  "message": "Error while running background job (class: OCA\\Theming\\Jobs\\MigrateBackgroundImages, arguments: Array\n(\n    [stage] => prepare\n)\n)",
  "userAgent": "--",
  "version": "28.0.0.4",
  "exception": {
    "Exception": "Error",
    "Message": "Call to a member function getUID() on null",
    "Code": 0,
    "Trace": [
      {
        "file": "…/apps/workflowengine/lib/Service/RuleMatcher.php",
        "line": 157,
        "function": "isLegitimatedForUserId",
        "class": "OCA\\WorkflowEngine\\Entity\\File",
        "type": "->",
        "args": [
          "***REPLACED USER ID***"
        ]
      },
      {
        "file": "…/apps/workflowengine/lib/Service/RuleMatcher.php",
        "line": 128,
        "function": "getMatchingOperations",
        "class": "OCA\\WorkflowEngine\\Service\\RuleMatcher",
        "type": "->",
        "args": [
          "OCA\\Talk\\Flow\\Operation",
          false
        ]
      },
      {
        "file": "…/apps/spreed/lib/Flow/Operation.php",
        "line": 96,
        "function": "getFlows",
        "class": "OCA\\WorkflowEngine\\Service\\RuleMatcher",
        "type": "->",
        "args": [
          false
        ]
      },

```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
