### PR TITLE
fix(log): Log exception class when message is empty

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -344,7 +344,7 @@ class Log implements ILogger, IDataLogger {
 		unset($data['app']);
 		unset($data['level']);
 		$data = array_merge($serializer->serializeException($exception), $data);
-		$data = $this->interpolateMessage($data, $context['message'] ?? '--', 'CustomMessage');
+		$data = $this->interpolateMessage($data, isset($context['message']) && $context['message'] !== '' ? $context['message'] : ('Exception thrown: ' . get_class($exception)), 'CustomMessage');
 
 
 		array_walk($context, [$this->normalizer, 'format']);


### PR DESCRIPTION
* Resolves:
*  Before is first line
* After is last line

![grafik](https://github.com/nextcloud/server/assets/213943/c115cafc-c1a1-4b86-89d5-c8785c5ca0ec)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
