### PR TITLE
fix(userstatus): Do not override message timestamp for default messages

### DIFF
--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -504,7 +504,6 @@ class StatusService {
 		if ($predefinedMessage !== null) {
 			$status->setCustomMessage($predefinedMessage['message']);
 			$status->setCustomIcon($predefinedMessage['icon']);
-			$status->setStatusMessageTimestamp($this->timeFactory->now()->getTimestamp());
 		}
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Deriving a default message doesn't mean the user changed their status. So we don't override the timestamp here.

## How to test

1) Set status to a predfined one as user A (e.g. *Working remotely*)
2) Wait 2 minutes
3) Open the dashboard as user B

master: user A shows with *Working remotely, seconds ago*
here: user A shows with *Working remotely, 2 minutes ago*

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
