### PR TITLE
Fix dynamic property in CalDav tests

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
@@ -52,6 +52,7 @@ class StatusServiceTest extends TestCase {
 	private InvitationResponseServer|MockObject $server;
 	private IL10N|MockObject $l10n;
 	private FreeBusyGenerator|MockObject $generator;
+	private StatusService $service;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
* Resolves: `Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$service is deprecated`

## Summary

Fix dynamic property from https://github.com/nextcloud/server/commit/f14a4f8fd73c71e76a9747ac51e657030f5bb835#r132396755

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
