### PR TITLE
fix(caldav): add property for status service test

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
@@ -52,6 +52,7 @@ class StatusServiceTest extends TestCase {
 	private InvitationResponseServer|MockObject $server;
 	private IL10N|MockObject $l10n;
 	private FreeBusyGenerator|MockObject $generator;
+	private StatusService $service;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
