### PR TITLE
fix(files_versions): Explicitly use either user or owner to get path

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -354,14 +354,20 @@ class FileEventsListener implements IEventListener {
 	 * If no user is connected, use the node's owner.
 	 */
 	private function getPathForNode(Node $node): ?string {
-		try {
+		$user = \OC_User::getUser();
+		$owner = $node->getOwner()?->getUid();
+
+		if (!empty($user)) {
 			return $this->rootFolder
-				->getUserFolder(\OC_User::getUser())
-				->getRelativePath($node->getPath());
-		} catch (\Throwable $ex) {
-			return $this->rootFolder
-				->getUserFolder($node->getOwner()->getUid())
+				->getUserFolder($user)
 				->getRelativePath($node->getPath());
 		}
+		if (!empty($owner)) {
+			return $this->rootFolder
+				->getUserFolder($owner)
+				->getRelativePath($node->getPath());
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary

Don't rely on Throwable (catch `false` or `null` values)

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
