### PR TITLE
don't return a 'sparse' array from getMountsForFileId

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -369,7 +369,7 @@ class UserMountCache implements IUserMountCache {
 		});
 
 		$filteredMounts = array_filter(array_map([$this, 'dbRowToMountInfo'], $filteredMounts));
-		return array_map(function (ICachedMountInfo $mount) use ($internalPath) {
+		$result = array_map(function (ICachedMountInfo $mount) use ($internalPath) {
 			return new CachedMountFileInfo(
 				$mount->getUser(),
 				$mount->getStorageId(),
@@ -381,6 +381,7 @@ class UserMountCache implements IUserMountCache {
 				$internalPath
 			);
 		}, $filteredMounts);
+		return array_values($result);
 	}
 
 	/**


### PR DESCRIPTION
Not all callers are setup to deal with non-continuous arrays here. Easier to fix it here than to verify all callers