### PR TITLE
Migrate forwarded for headers check

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -78,6 +78,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\DefaultPhoneRegionSet' => $baseDir . '/../lib/SetupChecks/DefaultPhoneRegionSet.php',
     'OCA\\Settings\\SetupChecks\\EmailTestSuccessful' => $baseDir . '/../lib/SetupChecks/EmailTestSuccessful.php',
     'OCA\\Settings\\SetupChecks\\FileLocking' => $baseDir . '/../lib/SetupChecks/FileLocking.php',
+    'OCA\\Settings\\SetupChecks\\ForwardedForHeaders' => $baseDir . '/../lib/SetupChecks/ForwardedForHeaders.php',
     'OCA\\Settings\\SetupChecks\\InternetConnectivity' => $baseDir . '/../lib/SetupChecks/InternetConnectivity.php',
     'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => $baseDir . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
     'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => $baseDir . '/../lib/SetupChecks/MemcacheConfigured.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -93,6 +93,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\DefaultPhoneRegionSet' => __DIR__ . '/..' . '/../lib/SetupChecks/DefaultPhoneRegionSet.php',
         'OCA\\Settings\\SetupChecks\\EmailTestSuccessful' => __DIR__ . '/..' . '/../lib/SetupChecks/EmailTestSuccessful.php',
         'OCA\\Settings\\SetupChecks\\FileLocking' => __DIR__ . '/..' . '/../lib/SetupChecks/FileLocking.php',
+        'OCA\\Settings\\SetupChecks\\ForwardedForHeaders' => __DIR__ . '/..' . '/../lib/SetupChecks/ForwardedForHeaders.php',
         'OCA\\Settings\\SetupChecks\\InternetConnectivity' => __DIR__ . '/..' . '/../lib/SetupChecks/InternetConnectivity.php',
         'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => __DIR__ . '/..' . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
         'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => __DIR__ . '/..' . '/../lib/SetupChecks/MemcacheConfigured.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -53,6 +53,7 @@ use OCA\Settings\SetupChecks\CheckUserCertificates;
 use OCA\Settings\SetupChecks\DefaultPhoneRegionSet;
 use OCA\Settings\SetupChecks\EmailTestSuccessful;
 use OCA\Settings\SetupChecks\FileLocking;
+use OCA\Settings\SetupChecks\ForwardedForHeaders;
 use OCA\Settings\SetupChecks\InternetConnectivity;
 use OCA\Settings\SetupChecks\LegacySSEKeyFormat;
 use OCA\Settings\SetupChecks\MemcacheConfigured;
@@ -162,6 +163,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(DefaultPhoneRegionSet::class);
 		$context->registerSetupCheck(EmailTestSuccessful::class);
 		$context->registerSetupCheck(FileLocking::class);
+		$context->registerSetupCheck(ForwardedForHeaders::class);
 		$context->registerSetupCheck(InternetConnectivity::class);
 		$context->registerSetupCheck(LegacySSEKeyFormat::class);
 		$context->registerSetupCheck(MemcacheConfigured::class);

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -247,31 +247,6 @@ class CheckSetupController extends Controller {
 	}
 
 	/**
-	 * Check if the reverse proxy configuration is working as expected
-	 *
-	 * @return bool
-	 */
-	private function forwardedForHeadersWorking(): bool {
-		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
-		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
-
-		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host') !== '') {
-			return false;
-		}
-
-		if (\is_array($trustedProxies)) {
-			if (\in_array($remoteAddress, $trustedProxies, true) && $remoteAddress !== '127.0.0.1') {
-				return $remoteAddress !== $this->request->getRemoteAddress();
-			}
-		} else {
-			return false;
-		}
-
-		// either not enabled or working correctly
-		return true;
-	}
-
-	/**
 	 * Checks if the correct memcache module for PHP is installed. Only
 	 * fails if memcached is configured and the working module is not installed.
 	 *
@@ -721,7 +696,6 @@ Raw output
 				'cronErrors' => $this->getCronErrors(),
 				'isFairUseOfFreePushService' => $this->isFairUseOfFreePushService(),
 				'isUsedTlsLibOutdated' => $this->isUsedTlsLibOutdated(),
-				'forwardedForHeadersWorking' => $this->forwardedForHeadersWorking(),
 				'reverseProxyDocs' => $this->urlGenerator->linkToDocs('admin-reverse-proxy'),
 				'isCorrectMemcachedPHPModuleInstalled' => $this->isCorrectMemcachedPHPModuleInstalled(),
 				'hasPassedCodeIntegrityCheck' => $this->checker->hasPassedCheck(),

--- a/apps/settings/lib/SetupChecks/BruteForceThrottler.php
+++ b/apps/settings/lib/SetupChecks/BruteForceThrottler.php
@@ -53,9 +53,13 @@ class BruteForceThrottler implements ISetupCheck {
 	public function run(): SetupResult {
 		$address = $this->request->getRemoteAddress();
 		if ($address === '') {
-			return SetupResult::info(
-				$this->l10n->t('Your remote address could not be determined.')
-			);
+			if (\OC::$CLI) {
+				/* We were called from CLI */
+				return SetupResult::info('Your remote address could not be determined.');
+			} else {
+				/* Should never happen */
+				return SetupResult::error('Your remote address could not be determined.');
+			}
 		} elseif ($this->throttler->showBruteforceWarning($address)) {
 			return SetupResult::error(
 				$this->l10n->t('Your remote address was identified as "%s" and is bruteforce throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', $address),

--- a/apps/settings/lib/SetupChecks/BruteForceThrottler.php
+++ b/apps/settings/lib/SetupChecks/BruteForceThrottler.php
@@ -62,12 +62,12 @@ class BruteForceThrottler implements ISetupCheck {
 			}
 		} elseif ($this->throttler->showBruteforceWarning($address)) {
 			return SetupResult::error(
-				$this->l10n->t('Your remote address was identified as "%s" and is bruteforce throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', $address),
+				$this->l10n->t('Your remote address was identified as "%s" and is bruteforce throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
 				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
 			);
 		} else {
 			return SetupResult::success(
-				$this->l10n->t('Your remote address "%s" is not bruteforce throttled.', $address)
+				$this->l10n->t('Your remote address "%s" is not bruteforce throttled.', [$address])
 			);
 		}
 	}

--- a/apps/settings/lib/SetupChecks/BruteForceThrottler.php
+++ b/apps/settings/lib/SetupChecks/BruteForceThrottler.php
@@ -55,10 +55,10 @@ class BruteForceThrottler implements ISetupCheck {
 		if ($address === '') {
 			if (\OC::$CLI) {
 				/* We were called from CLI */
-				return SetupResult::info('Your remote address could not be determined.');
+				return SetupResult::info($this->l10n->t('Your remote address could not be determined.'));
 			} else {
 				/* Should never happen */
-				return SetupResult::error('Your remote address could not be determined.');
+				return SetupResult::error($this->l10n->t('Your remote address could not be determined.'));
 			}
 		} elseif ($this->throttler->showBruteforceWarning($address)) {
 			return SetupResult::error(

--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class ForwardedForHeaders implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private IURLGenerator $urlGenerator,
+		private IRequest $request,
+	) {
+	}
+
+	public function getCategory(): string {
+		return 'security';
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Forwared for headers');
+	}
+
+	public function run(): SetupResult {
+		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
+		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
+
+		if (!\is_array($trustedProxies)) {
+			return SetupResult::error($this->l10n->t('Your trusted_proxies setting is not correctly set, it should be an array.'));
+		}
+
+		if (($remoteAddress === '') && ($this->request->getRemoteAddress() === '')) {
+			/* Most likely we were called from CLI */
+			return SetupResult::info('Your remote address could not be determined.');
+		}
+
+		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host') !== '') {
+			return SetupResult::warning(
+				$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
+				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+			);
+		}
+
+		if (\in_array($remoteAddress, $trustedProxies, true) && ($remoteAddress !== '127.0.0.1')) {
+			if ($remoteAddress !== $this->request->getRemoteAddress()) {
+				/* Remote address was successfuly fixed */
+				return SetupResult::success('Working');
+			} else {
+				return SetupResult::warning(
+					$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
+					$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+				);
+			}
+		}
+
+		/* Either not enabled or working correctly */
+		return SetupResult::success();
+	}
+}

--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -64,8 +64,8 @@ class ForwardedForHeaders implements ISetupCheck {
 		}
 
 		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host') !== '') {
-			return SetupResult::warning(
-				$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
+			return SetupResult::error(
+				$this->l10n->t('The reverse proxy header configuration is incorrect. This is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
 				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
 			);
 		}

--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -59,8 +59,13 @@ class ForwardedForHeaders implements ISetupCheck {
 		}
 
 		if (($remoteAddress === '') && ($this->request->getRemoteAddress() === '')) {
-			/* Most likely we were called from CLI */
-			return SetupResult::info('Your remote address could not be determined.');
+			if (\OC::$CLI) {
+				/* We were called from CLI */
+				return SetupResult::info('Your remote address could not be determined.');
+			} else {
+				/* Should never happen */
+				return SetupResult::error('Your remote address could not be determined.');
+			}
 		}
 
 		if (empty($trustedProxies) && $this->request->getHeader('X-Forwarded-Host') !== '') {

--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -53,18 +53,19 @@ class ForwardedForHeaders implements ISetupCheck {
 	public function run(): SetupResult {
 		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
 		$remoteAddress = $this->request->getHeader('REMOTE_ADDR');
+		$detectedRemoteAddress = $this->request->getRemoteAddress();
 
 		if (!\is_array($trustedProxies)) {
 			return SetupResult::error($this->l10n->t('Your trusted_proxies setting is not correctly set, it should be an array.'));
 		}
 
-		if (($remoteAddress === '') && ($this->request->getRemoteAddress() === '')) {
+		if (($remoteAddress === '') && ($detectedRemoteAddress === '')) {
 			if (\OC::$CLI) {
 				/* We were called from CLI */
-				return SetupResult::info('Your remote address could not be determined.');
+				return SetupResult::info($this->l10n->t('Your remote address could not be determined.'));
 			} else {
 				/* Should never happen */
-				return SetupResult::error('Your remote address could not be determined.');
+				return SetupResult::error($this->l10n->t('Your remote address could not be determined.'));
 			}
 		}
 
@@ -76,9 +77,9 @@ class ForwardedForHeaders implements ISetupCheck {
 		}
 
 		if (\in_array($remoteAddress, $trustedProxies, true) && ($remoteAddress !== '127.0.0.1')) {
-			if ($remoteAddress !== $this->request->getRemoteAddress()) {
+			if ($remoteAddress !== $detectedRemoteAddress) {
 				/* Remote address was successfuly fixed */
-				return SetupResult::success('Working');
+				return SetupResult::success($this->l10n->t('Your IP address was resolved as %s', $detectedRemoteAddress));
 			} else {
 				return SetupResult::warning(
 					$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),

--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -79,7 +79,7 @@ class ForwardedForHeaders implements ISetupCheck {
 		if (\in_array($remoteAddress, $trustedProxies, true) && ($remoteAddress !== '127.0.0.1')) {
 			if ($remoteAddress !== $detectedRemoteAddress) {
 				/* Remote address was successfuly fixed */
-				return SetupResult::success($this->l10n->t('Your IP address was resolved as %s', $detectedRemoteAddress));
+				return SetupResult::success($this->l10n->t('Your IP address was resolved as %s', [$detectedRemoteAddress]));
 			} else {
 				return SetupResult::warning(
 					$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -415,7 +415,6 @@ class CheckSetupControllerTest extends TestCase {
 				],
 				'cronErrors' => [],
 				'isUsedTlsLibOutdated' => '',
-				'forwardedForHeadersWorking' => false,
 				'reverseProxyDocs' => 'reverse-proxy-doc-link',
 				'isCorrectMemcachedPHPModuleInstalled' => true,
 				'hasPassedCodeIntegrityCheck' => true,

--- a/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2021 Morris Jobke <hey@morrisjobke.de>
+ *
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Settings\Tests;
+
+use OCA\Settings\SetupChecks\ForwardedForHeaders;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\SetupResult;
+use Test\TestCase;
+
+class ForwardedForHeadersTest extends TestCase {
+	private IL10N $l10n;
+	private IConfig $config;
+	private IURLGenerator $urlGenerator;
+	private IRequest $request;
+	private ForwardedForHeaders $check;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->getMockBuilder(IL10N::class)
+			->disableOriginalConstructor()->getMock();
+		$this->l10n->expects($this->any())
+			->method('t')
+			->willReturnCallback(function ($message, array $replace) {
+				return vsprintf($message, $replace);
+			});
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->check = new ForwardedForHeaders(
+			$this->l10n,
+			$this->config,
+			$this->urlGenerator,
+			$this->request,
+		);
+	}
+
+	/**
+	 * @dataProvider dataForwardedForHeadersWorking
+	 */
+	public function testForwardedForHeadersWorking(array $trustedProxies, string $remoteAddrNotForwarded, string $remoteAddr, string $result): void {
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('trusted_proxies', [])
+			->willReturn($trustedProxies);
+		$this->request->expects($this->atLeastOnce())
+			->method('getHeader')
+			->willReturnMap([
+				['REMOTE_ADDR', $remoteAddrNotForwarded],
+				['X-Forwarded-Host', '']
+			]);
+		$this->request->expects($this->any())
+			->method('getRemoteAddress')
+			->willReturn($remoteAddr);
+
+		$this->assertEquals(
+			$result,
+			$this->check->run()->getSeverity()
+		);
+	}
+
+	public function dataForwardedForHeadersWorking(): array {
+		return [
+			// description => trusted proxies, getHeader('REMOTE_ADDR'), getRemoteAddr, expected result
+			'no trusted proxies' => [[], '2.2.2.2', '2.2.2.2', SetupResult::SUCCESS],
+			'trusted proxy, remote addr not trusted proxy' => [['1.1.1.1'], '2.2.2.2', '2.2.2.2', SetupResult::SUCCESS],
+			'trusted proxy, remote addr is trusted proxy, x-forwarded-for working' => [['1.1.1.1'], '1.1.1.1', '2.2.2.2', SetupResult::SUCCESS],
+			'trusted proxy, remote addr is trusted proxy, x-forwarded-for not set' => [['1.1.1.1'], '1.1.1.1', '1.1.1.1', SetupResult::WARNING],
+		];
+	}
+
+	public function testForwardedHostPresentButTrustedProxiesNotAnArray(): void {
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('trusted_proxies', [])
+			->willReturn('1.1.1.1');
+		$this->request->expects($this->atLeastOnce())
+			->method('getHeader')
+			->willReturnMap([
+				['REMOTE_ADDR', '1.1.1.1'],
+				['X-Forwarded-Host', 'nextcloud.test']
+			]);
+		$this->request->expects($this->any())
+			->method('getRemoteAddress')
+			->willReturn('1.1.1.1');
+
+		$this->assertEquals(
+			SetupResult::ERROR,
+			$this->check->run()->getSeverity()
+		);
+	}
+
+	public function testForwardedHostPresentButTrustedProxiesEmpty(): void {
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('trusted_proxies', [])
+			->willReturn([]);
+		$this->request->expects($this->atLeastOnce())
+			->method('getHeader')
+			->willReturnMap([
+				['REMOTE_ADDR', '1.1.1.1'],
+				['X-Forwarded-Host', 'nextcloud.test']
+			]);
+		$this->request->expects($this->any())
+			->method('getRemoteAddress')
+			->willReturn('1.1.1.1');
+
+		$this->assertEquals(
+			SetupResult::WARNING,
+			$this->check->run()->getSeverity()
+		);
+	}
+}

--- a/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
@@ -133,7 +133,7 @@ class ForwardedForHeadersTest extends TestCase {
 			->willReturn('1.1.1.1');
 
 		$this->assertEquals(
-			SetupResult::WARNING,
+			SetupResult::ERROR,
 			$this->check->run()->getSeverity()
 		);
 	}

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -222,14 +222,6 @@
 							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 						});
 					}
-					if(!data.forwardedForHeadersWorking) {
-						messages.push({
-							msg: t('core', 'The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud. Further information can be found in the {linkstart}documentation ↗{linkend}.')
-								.replace('{linkstart}', '<a target="_blank" rel="noreferrer noopener" class="external" href="' + data.reverseProxyDocs + '">')
-								.replace('{linkend}', '</a>'),
-							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-						});
-					}
 					if(!data.isCorrectMemcachedPHPModuleInstalled) {
 						messages.push({
 							msg: t('core', 'Memcached is configured as distributed cache, but the wrong PHP module "memcache" is installed. \\OC\\Memcache\\Memcached only supports "memcached" and not "memcache". See the {linkstart}memcached wiki about both modules ↗{linkend}.')

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -225,7 +225,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -279,7 +278,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -333,7 +331,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -387,7 +384,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: false,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -439,7 +435,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -482,59 +477,6 @@ describe('OC.SetupChecks tests', function() {
 			});
 		});
 
-		it('should return an error if the forwarded for headers are not working', function(done) {
-			var async = OC.SetupChecks.checkSetup();
-
-			suite.server.requests[0].respond(
-				200,
-				{
-					'Content-Type': 'application/json',
-				},
-				JSON.stringify({
-					suggestedOverwriteCliURL: '',
-					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: false,
-					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
-					isCorrectMemcachedPHPModuleInstalled: true,
-					hasPassedCodeIntegrityCheck: true,
-					OpcacheSetupRecommendations: [],
-					isSettimelimitAvailable: true,
-					missingIndexes: [],
-					missingPrimaryKeys: [],
-					missingColumns: [],
-					cronErrors: [],
-					cronInfo: {
-						diffInSeconds: 0
-					},
-					appDirsWithDifferentOwner: [],
-					isImagickEnabled: true,
-					areWebauthnExtensionsEnabled: true,
-					pendingBigIntConversionColumns: [],
-					isMysqlUsedWithoutUTF8MB4: false,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
-					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
-					generic: {
-						network: {
-							"Internet connectivity": {
-								severity: "success",
-								description: null,
-								linkToDoc: null
-							}
-						},
-					},
-				})
-			);
-
-			async.done(function( data, s, x ){
-				expect(data).toEqual([{
-					msg: 'The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud. Further information can be found in the <a target="_blank" rel="noreferrer noopener" class="external" href="https://docs.nextcloud.com/foo/bar.html">documentation ↗</a>.',
-					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-				}]);
-				done();
-			});
-		});
-
 		it('should return an error if set_time_limit is unavailable', function(done) {
 			var async = OC.SetupChecks.checkSetup();
 
@@ -546,7 +488,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
@@ -599,7 +540,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
@@ -684,7 +624,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -743,7 +682,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: ['recommendation1', 'recommendation2'],
@@ -795,7 +733,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -851,7 +788,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -904,7 +840,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -954,7 +889,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -1007,7 +941,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -1060,7 +993,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -1112,7 +1044,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],
@@ -1171,7 +1102,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					suggestedOverwriteCliURL: '',
 					isFairUseOfFreePushService: true,
-					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 					OpcacheSetupRecommendations: [],


### PR DESCRIPTION
* See https://github.com/nextcloud/server/issues/41364

## Summary

Migrate forwarded for headers check to new SetupCheck API.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
