### PR TITLE
ignore metadata if migration to 28 is not done

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -178,7 +178,7 @@ class Cache implements ICache {
 		} elseif (!$data) {
 			return $data;
 		} else {
-			$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();
+			$data['metadata'] = $metadataQuery?->extractMetadata($data)->asArray() ?? [];
 			return self::cacheEntryFromData($data, $this->mimetypeLoader);
 		}
 	}
@@ -250,7 +250,7 @@ class Cache implements ICache {
 			$result->closeCursor();
 
 			return array_map(function (array $data) use ($metadataQuery) {
-				$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();
+				$data['metadata'] = $metadataQuery?->extractMetadata($data)->asArray() ?? [];
 				return self::cacheEntryFromData($data, $this->mimetypeLoader);
 			}, $files);
 		}

--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -135,9 +135,14 @@ class CacheQueryBuilder extends QueryBuilder {
 		return $this;
 	}
 
-	public function selectMetadata(): IMetadataQuery {
+	/**
+	 * join metadata to current query builder and returns an helper
+	 *
+	 * @return IMetadataQuery|null NULL if no metadata have never been generated
+	 */
+	public function selectMetadata(): ?IMetadataQuery {
 		$metadataQuery = $this->filesMetadataManager->getMetadataQuery($this, $this->alias, 'fileid');
-		$metadataQuery->retrieveMetadata();
+		$metadataQuery?->retrieveMetadata();
 		return $metadataQuery;
 	}
 }

--- a/lib/private/Files/Cache/QuerySearchHelper.php
+++ b/lib/private/Files/Cache/QuerySearchHelper.php
@@ -67,6 +67,12 @@ class QuerySearchHelper {
 		);
 	}
 
+	/**
+	 * @param CacheQueryBuilder $query
+	 * @param ISearchQuery $searchQuery
+	 * @param array $caches
+	 * @param IMetadataQuery|null $metadataQuery
+	 */
 	protected function applySearchConstraints(
 		CacheQueryBuilder $query,
 		ISearchQuery $searchQuery,
@@ -189,7 +195,12 @@ class QuerySearchHelper {
 		$files = $result->fetchAll();
 
 		$rawEntries = array_map(function (array $data) use ($metadataQuery) {
-			$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();
+			// migrate to null safe ...
+			if ($metadataQuery === null) {
+				$data['metadata'] = [];
+			} else {
+				$data['metadata'] = $metadataQuery->extractMetadata($data)->asArray();
+			}
 			return Cache::cacheEntryFromData($data, $this->mimetypeLoader);
 		}, $files);
 

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -243,11 +243,7 @@ class SearchBuilder {
 	}
 
 
-	private function getExtraOperatorField(ISearchComparison $operator, ?IMetadataQuery $metadataQuery): array {
-		if (null === $metadataQuery) {
-			throw new \InvalidArgumentException('IMetadataQuery is null while calling getExtraOperatorField');
-		}
-
+	private function getExtraOperatorField(ISearchComparison $operator, IMetadataQuery $metadataQuery): array {
 		$field = $operator->getField();
 		$value = $operator->getValue();
 		$type = $operator->getType();

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -243,7 +243,11 @@ class SearchBuilder {
 	}
 
 
-	private function getExtraOperatorField(ISearchComparison $operator, IMetadataQuery $metadataQuery): array {
+	private function getExtraOperatorField(ISearchComparison $operator, ?IMetadataQuery $metadataQuery): array {
+		if (null === $metadataQuery) {
+			throw new \InvalidArgumentException('IMetadataQuery is null while calling getExtraOperatorField');
+		}
+
 		$field = $operator->getField();
 		$value = $operator->getValue();
 		$type = $operator->getType();

--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -213,7 +213,7 @@ class FilesMetadataManager implements IFilesMetadataManager {
 	 * @param string $fileIdField alias of the field that contains file ids
 	 *
 	 * @inheritDoc
-	 * @return IMetadataQuery
+	 * @return IMetadataQuery|null
 	 * @see IMetadataQuery
 	 * @since 28.0.0
 	 */
@@ -221,7 +221,11 @@ class FilesMetadataManager implements IFilesMetadataManager {
 		IQueryBuilder $qb,
 		string $fileTableAlias,
 		string $fileIdField
-	): IMetadataQuery {
+	): ?IMetadataQuery {
+		// we don't want to join metadata table if never filled
+		if ($this->config->getAppValue('core', self::CONFIG_KEY, '') === '') {
+			return null;
+		}
 		return new MetadataQuery($qb, $this->getKnownMetadata(), $fileTableAlias, $fileIdField);
 	}
 

--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -105,7 +105,7 @@ interface IFilesMetadataManager {
 	 * @param string $fileTableAlias alias of the table that contains data about files
 	 * @param string $fileIdField alias of the field that contains file ids
 	 *
-	 * @return IMetadataQuery
+	 * @return IMetadataQuery|null NULL if table are not set yet or never used
 	 * @see IMetadataQuery
 	 * @since 28.0.0
 	 */
@@ -113,7 +113,7 @@ interface IFilesMetadataManager {
 		IQueryBuilder $qb,
 		string $fileTableAlias,
 		string $fileIdField
-	): IMetadataQuery;
+	): ?IMetadataQuery;
 
 	/**
 	 * returns all type of metadata currently available.


### PR DESCRIPTION
since we join the metadata table on `Cache::get()`, expect error between upgrade and migration.

This fix makes not joining the metadata table until the migration is done