### PR TITLE
fix(backupcodes): Remove old notifications before creating a new remi…

### DIFF
--- a/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
@@ -94,9 +94,11 @@ class RememberBackupCodesJob extends TimedJob {
 		$notification = $this->notificationManager->createNotification();
 		$notification->setApp('twofactor_backupcodes')
 			->setUser($user->getUID())
-			->setDateTime($date)
 			->setObject('create', 'codes')
 			->setSubject('create_backupcodes');
+		$this->notificationManager->markProcessed($notification);
+
+		$notification->setDateTime($date);
 		$this->notificationManager->notify($notification);
 	}
 }


### PR DESCRIPTION
…nder

## Summary

Currently a user will receive a new notification every 2 weeks. Previous notifications however did not get removed before, resulting in some users having multiple (record seen in the wild is 68 notifications => 952 days so over 2 years ignoring this).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
