### PR TITLE
fix(dav): assume utc as the default out-of-office time zone

### DIFF
--- a/apps/dav/lib/Controller/AvailabilitySettingsController.php
+++ b/apps/dav/lib/Controller/AvailabilitySettingsController.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Controller;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use OCA\DAV\AppInfo\Application;
 use OCA\DAV\Service\AbsenceService;
 use OCP\AppFramework\Controller;
@@ -46,6 +47,9 @@ class AvailabilitySettingsController extends Controller {
 	}
 
 	/**
+	 * @param string $firstDay Assume UTC as the time zone if none is specified
+	 * @param string $lastDay Assume UTC as the time zone if none is specified
+	 *
 	 * @throws \OCP\DB\Exception
 	 * @throws \Exception
 	 */
@@ -61,8 +65,9 @@ class AvailabilitySettingsController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$parsedFirstDay = new DateTimeImmutable($firstDay);
-		$parsedLastDay = new DateTimeImmutable($lastDay);
+		$utc = new DateTimeZone('UTC');
+		$parsedFirstDay = new DateTimeImmutable($firstDay, $utc);
+		$parsedLastDay = new DateTimeImmutable($lastDay, $utc);
 		if ($parsedFirstDay->getTimestamp() >= $parsedLastDay->getTimestamp()) {
 			throw new \Exception('First day is on or after last day');
 		}

--- a/apps/dav/lib/Db/Absence.php
+++ b/apps/dav/lib/Db/Absence.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Db;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use InvalidArgumentException;
 use JsonSerializable;
 use OC\User\OutOfOfficeData;
@@ -71,9 +72,9 @@ class Absence extends Entity implements JsonSerializable {
 			throw new InvalidArgumentException("The user doesn't match the user id of this absence! Expected " . $this->getUserId() . ", got " . $user->getUID());
 		}
 
-		//$user = $userManager->get($this->getUserId());
-		$startDate = new DateTimeImmutable($this->getFirstDay());
-		$endDate = new DateTimeImmutable($this->getLastDay());
+		$utc = new DateTimeZone('UTC');
+		$startDate = new DateTimeImmutable($this->getFirstDay(), $utc);
+		$endDate = new DateTimeImmutable($this->getLastDay(), $utc);
 		return new OutOfOfficeData(
 			(string)$this->getId(),
 			$user,


### PR DESCRIPTION
* Resolves: _none_

## Summary

The frontend always sends the start and end dates in UTC. However, the backend, or more specifically the `DateTimeImmutable` constructor, falls back to the local time zone (of the server).

Now, the time zone is assumed to be in UTC by default. If the frontend specifies a custom time zone and includes it in the date string it will continue to work. The second parameter `$timezone` of the constructor is ignored in this case.

Ref https://www.php.net/manual/de/datetimeimmutable.construct.php

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
