### PR TITLE
implements search on null/notnull metadata

### DIFF
--- a/apps/dav/lib/CalDAV/CachedSubscription.php
+++ b/apps/dav/lib/CalDAV/CachedSubscription.php
@@ -169,11 +169,11 @@ class CachedSubscription extends \Sabre\CalDAV\Calendar {
 
 	/**
 	 * @param string $name
-	 * @param null|resource|string $calendarData
+	 * @param null|resource|string $data
 	 * @return null|string
 	 * @throws MethodNotAllowed
 	 */
-	public function createFile($name, $calendarData = null) {
+	public function createFile($name, $data = null) {
 		throw new MethodNotAllowed('Creating objects in cached subscription is not allowed');
 	}
 

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -386,7 +386,7 @@ class FileSearchBackend implements ISearchBackend {
 				}
 
 				return new SearchComparison(
-					ISearchComparison::COMPARE_DEFINED,
+					$trimmedType,
 					$field,
 					$this->castValue($property, $value ?? ''),
 					$extra ?? ''

--- a/build/integration/features/bootstrap/CommentsContext.php
+++ b/build/integration/features/bootstrap/CommentsContext.php
@@ -49,6 +49,37 @@ class CommentsContext implements \Behat\Behat\Context\Context {
 		}
 	}
 
+
+
+	/**
+	 * get a named entry from response instead of picking a random entry from values
+	 *
+	 * @param string $path
+	 *
+	 * @return array|string
+	 * @throws Exception
+	 */
+	private function getValueFromNamedEntries(string $path, array $response): mixed {
+		$next = '';
+		if (str_contains($path, ' ')) {
+			[$key, $next] = explode(' ', $path, 2);
+		} else {
+			$key = $path;
+		}
+
+		foreach ($response as $entry) {
+			if ($entry['name'] === $key) {
+				if ($next !== '') {
+					return $this->getValueFromNamedEntries($next, $entry['value']);
+				} else {
+					return $entry['value'];
+				}
+			}
+		}
+
+		return null;
+	}
+
 	/** @AfterScenario */
 	public function teardownScenario() {
 		$client = new \GuzzleHttp\Client();
@@ -175,7 +206,7 @@ class CommentsContext implements \Behat\Behat\Context\Context {
 		if ($res->getStatusCode() === 207) {
 			$service = new Sabre\Xml\Service();
 			$this->response = $service->parse($res->getBody()->getContents());
-			$this->commentId = (int) ($this->response[0]['value'][2]['value'][0]['value'][0]['value'] ?? 0);
+			$this->commentId = (int) ($this->getValueFromNamedEntries('{DAV:}response {DAV:}propstat {DAV:}prop {http://owncloud.org/ns}id', $this->response ?? []) ?? 0);
 		}
 	}
 
@@ -238,7 +269,8 @@ class CommentsContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainAPropertyWithValue($key, $value) {
-		$keys = $this->response[0]['value'][2]['value'][0]['value'];
+//		$keys = $this->response[0]['value'][1]['value'][0]['value'];
+		$keys = $this->getValueFromNamedEntries('{DAV:}response {DAV:}propstat {DAV:}prop', $this->response);
 		$found = false;
 		foreach ($keys as $singleKey) {
 			if ($singleKey['name'] === '{http://owncloud.org/ns}' . substr($key, 3)) {

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -47,6 +47,7 @@ class SearchBuilder {
 		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'gte',
 		ISearchComparison::COMPARE_LESS_THAN => 'lt',
 		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'lte',
+		ISearchComparison::COMPARE_DEFINED => 'isNotNull',
 	];
 
 	protected static $searchOperatorNegativeMap = [
@@ -57,6 +58,7 @@ class SearchBuilder {
 		ISearchComparison::COMPARE_GREATER_THAN_EQUAL => 'lt',
 		ISearchComparison::COMPARE_LESS_THAN => 'gte',
 		ISearchComparison::COMPARE_LESS_THAN_EQUAL => 'gt',
+		ISearchComparison::COMPARE_DEFINED => 'isNull',
 	];
 
 	public const TAG_FAVORITE = '_$!<Favorite>!$_';

--- a/lib/public/Files/Search/ISearchComparison.php
+++ b/lib/public/Files/Search/ISearchComparison.php
@@ -35,6 +35,7 @@ interface ISearchComparison extends ISearchOperator {
 	public const COMPARE_LESS_THAN_EQUAL = 'lte';
 	public const COMPARE_LIKE = 'like';
 	public const COMPARE_LIKE_CASE_SENSITIVE = 'clike';
+	public const COMPARE_DEFINED = 'defined';
 
 	public const HINT_PATH_EQ_HASH = 'path_eq_hash'; // transform `path = "$path"` into `path_hash = md5("$path")`, on by default
 

--- a/lib/public/Files/Search/ISearchComparison.php
+++ b/lib/public/Files/Search/ISearchComparison.php
@@ -35,7 +35,7 @@ interface ISearchComparison extends ISearchOperator {
 	public const COMPARE_LESS_THAN_EQUAL = 'lte';
 	public const COMPARE_LIKE = 'like';
 	public const COMPARE_LIKE_CASE_SENSITIVE = 'clike';
-	public const COMPARE_DEFINED = 'defined';
+	public const COMPARE_DEFINED = 'is-defined';
 
 	public const HINT_PATH_EQ_HASH = 'path_eq_hash'; // transform `path = "$path"` into `path_hash = md5("$path")`, on by default
 


### PR DESCRIPTION
Add the possiblity to search on null/not null value on metadata.
This is a test-feature for the Photos App.

This PR requires to add this line
```
      '{DAV:}is-defined'    => Operator::class,
```
in https://github.com/nextcloud/3rdparty/blob/master/icewind/searchdav/src/DAV/QueryParser.php#L78


```
[...]
     <d:where>
        <d:and>
          <d:not>
          <d:is-defined>
            <d:prop><nc:metadata-test/></d:prop>
            </d:is-defined>
          </d:not>
        </d:and>
[...]
```

Need:
- [x] https://github.com/icewind1991/SearchDAV/pull/13
- [x] https://github.com/nextcloud/3rdparty/pull/1643