### PR TITLE
Enhancements for advanced search API

### DIFF
--- a/lib/private/Search/FilterFactory.php
+++ b/lib/private/Search/FilterFactory.php
@@ -32,6 +32,8 @@ use OCP\IUserManager;
 use RuntimeException;
 
 final class FilterFactory {
+	private const PERSON_TYPE_SEPARATOR = '/';
+
 	public static function get(string $type, string|array $filter): IFilter {
 		return match ($type) {
 			FilterDefinition::TYPE_BOOL => new Filter\BooleanFilter($filter),
@@ -48,7 +50,7 @@ final class FilterFactory {
 	}
 
 	private static function getPerson(string $person): IFilter {
-		$parts = explode('_', $person, 2);
+		$parts = explode(self::PERSON_TYPE_SEPARATOR, $person, 2);
 
 		return match (count($parts)) {
 			1 => self::get(FilterDefinition::TYPE_NC_USER, $person),

--- a/lib/private/Search/SearchComposer.php
+++ b/lib/private/Search/SearchComposer.php
@@ -81,13 +81,13 @@ class SearchComposer {
 		private LoggerInterface $logger
 	) {
 		$this->commonFilters = [
-			'term' => new FilterDefinition('term', FilterDefinition::TYPE_STRING),
-			'since' => new FilterDefinition('since', FilterDefinition::TYPE_DATETIME),
-			'until' => new FilterDefinition('until', FilterDefinition::TYPE_DATETIME),
-			'title-only' => new FilterDefinition('title-only', FilterDefinition::TYPE_BOOL, false),
-			'person' => new FilterDefinition('person', FilterDefinition::TYPE_PERSON),
-			'places' => new FilterDefinition('places', FilterDefinition::TYPE_STRINGS, false),
-			'provider' => new FilterDefinition('provider', FilterDefinition::TYPE_STRING, false),
+			IFilter::BUILTIN_TERM => new FilterDefinition(IFilter::BUILTIN_TERM, FilterDefinition::TYPE_STRING),
+			IFilter::BUILTIN_SINCE => new FilterDefinition(IFilter::BUILTIN_SINCE, FilterDefinition::TYPE_DATETIME),
+			IFilter::BUILTIN_UNTIL => new FilterDefinition(IFilter::BUILTIN_UNTIL, FilterDefinition::TYPE_DATETIME),
+			IFilter::BUILTIN_TITLE_ONLY => new FilterDefinition(IFilter::BUILTIN_TITLE_ONLY, FilterDefinition::TYPE_BOOL, false),
+			IFilter::BUILTIN_PERSON => new FilterDefinition(IFilter::BUILTIN_PERSON, FilterDefinition::TYPE_PERSON),
+			IFilter::BUILTIN_PLACES => new FilterDefinition(IFilter::BUILTIN_PLACES, FilterDefinition::TYPE_STRINGS, false),
+			IFilter::BUILTIN_PROVIDER => new FilterDefinition(IFilter::BUILTIN_PROVIDER, FilterDefinition::TYPE_STRING, false),
 		];
 	}
 
@@ -189,7 +189,7 @@ class SearchComposer {
 					$triggers += $provider->getAlternateIds();
 					$filters = $provider->getSupportedFilters();
 				} else {
-					$filters = ['term'];
+					$filters = [IFilter::BUILTIN_TERM];
 				}
 
 				return [
@@ -310,7 +310,7 @@ class SearchComposer {
 		$provider = $this->providers[$providerId]['provider'];
 		$supportedFilters = $provider instanceof IFilteringProvider
 			? $provider->getSupportedFilters()
-			: ['term'];
+			: [IFilter::BUILTIN_TERM];
 
 		return in_array($filterDefinition->name(), $supportedFilters, true);
 	}

--- a/lib/public/Search/IFilter.php
+++ b/lib/public/Search/IFilter.php
@@ -31,6 +31,21 @@ namespace OCP\Search;
  * @since 28.0.0
  */
 interface IFilter {
+	/** @since 28.0.0 */
+	public const BUILTIN_TERM = 'term';
+	/** @since 28.0.0 */
+	public const BUILTIN_SINCE = 'since';
+	/** @since 28.0.0 */
+	public const BUILTIN_UNTIL = 'until';
+	/** @since 28.0.0 */
+	public const BUILTIN_PERSON = 'person';
+	/** @since 28.0.0 */
+	public const BUILTIN_TITLE_ONLY = 'title-only';
+	/** @since 28.0.0 */
+	public const BUILTIN_PLACES = 'places';
+	/** @since 28.0.0 */
+	public const BUILTIN_PROVIDER = 'provider';
+
 	/**
 	 * Get filter value
 	 *

--- a/lib/public/Search/ISearchQuery.php
+++ b/lib/public/Search/ISearchQuery.php
@@ -48,7 +48,6 @@ interface ISearchQuery {
 	 *
 	 * @return string the search term
 	 * @since 20.0.0
-	 * @deprecated 28.0.0
 	 */
 	public function getTerm(): string;
 


### PR DESCRIPTION
- `/` isn't allowed in UID, it will avoid conflicts
- undeprecate `getTerm` on SearchQuery
- introduce constants for builtin filters