### PR TITLE
fix(userstatus): Only track message timestamp for values

### DIFF
--- a/apps/user_status/lib/Db/UserStatus.php
+++ b/apps/user_status/lib/Db/UserStatus.php
@@ -50,7 +50,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setCustomMessage(string|null $customMessage)
  * @method int|null getClearAt()
  * @method void setClearAt(int|null $clearAt)
- * @method setIsBackup(bool $true): void
+ * @method setIsBackup(bool $isBackup): void
  * @method getIsBackup(): bool
  * @method int getStatusMessageTimestamp()
  * @method void setStatusMessageTimestamp(int $statusTimestamp)

--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -314,7 +314,13 @@ class StatusService {
 		$userStatus->setCustomIcon(null);
 		$userStatus->setCustomMessage($customMessage);
 		$userStatus->setClearAt(null);
-		$userStatus->setStatusMessageTimestamp($this->timeFactory->now()->getTimestamp());
+		if ($this->predefinedStatusService->getTranslatedStatusForId($messageId) !== null
+			|| ($customMessage !== null && $customMessage !== '')) {
+			// Only track status message ID if there is one
+			$userStatus->setStatusMessageTimestamp($this->timeFactory->now()->getTimestamp());
+		} else {
+			$userStatus->setStatusMessageTimestamp(0);
+		}
 
 		if ($userStatus->getId() !== null) {
 			return $this->mapper->update($userStatus);

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -1130,4 +1130,34 @@ EOF;
 
 		$this->assertEquals($status, $this->service->findByUserId('admin'));
 	}
+
+	public function testSetStatusWithoutMessage(): void {
+		$this->predefinedStatusService->expects(self::once())
+			->method('isValidId')
+			->with(IUserStatus::MESSAGE_AVAILABILITY)
+			->willReturn(true);
+		$this->timeFactory
+			->method('getTime')
+			->willReturn(1234);
+		$status = new UserStatus();
+		$status->setUserId('admin');
+		$status->setStatusTimestamp(1234);
+		$status->setIsUserDefined(true);
+		$status->setStatus(IUserStatus::DND);
+		$status->setIsBackup(false);
+		$status->setMessageId(IUserStatus::MESSAGE_AVAILABILITY);
+		$this->mapper->expects(self::once())
+			->method('insert')
+			->with($this->equalTo($status))
+			->willReturnArgument(0);
+
+		$result = $this->service->setUserStatus(
+			'admin',
+			IUserStatus::DND,
+			IUserStatus::MESSAGE_AVAILABILITY,
+			true,
+		);
+
+		self::assertNotNull($result);
+	}
 }


### PR DESCRIPTION



* Resolves: # <!-- related github issue -->

## Summary

Do not track status messages that are empty, e.g. DND outside of availability.

## How to test

1) Set availability and DND automation, make sure current time is *outside* working hours
2) Run background jobs in case the status isn't propagated right away
3) Open the dashboard with another user

master: ", seconds ago" shows for the main user
here: no status update is shown on the dashboard because the user didn't change their status.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
