### PR TITLE
fix(files_versions): don't call getUid() on null

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -351,7 +351,7 @@ class FileEventsListener implements IEventListener {
 
 	/**
 	 * Retrieve the path relative to the current user root folder.
-	 * If no user is connected, use the node's owner.
+	 * If no user is connected, try to use the node's owner.
 	 */
 	private function getPathForNode(Node $node): ?string {
 		try {
@@ -359,8 +359,12 @@ class FileEventsListener implements IEventListener {
 				->getUserFolder(\OC_User::getUser())
 				->getRelativePath($node->getPath());
 		} catch (\Throwable $ex) {
+			$owner = $node->getOwner();
+			if ($owner === null) {
+				return null;
+			}
 			return $this->rootFolder
-				->getUserFolder($node->getOwner()->getUid())
+				->getUserFolder($owner->getUid())
 				->getRelativePath($node->getPath());
 		}
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/backup/issues/559

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
