### PR TITLE
fix(2fa-backupcodes): Don't remember disabled and deleted users over …

### DIFF
--- a/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
@@ -58,6 +58,10 @@ class CheckBackupCodes extends QueuedJob {
 
 	protected function run($argument) {
 		$this->userManager->callForSeenUsers(function (IUser $user) {
+			if (!$user->isEnabled()) {
+				return;
+			}
+
 			$providers = $this->registry->getProviderStates($user);
 			$isTwoFactorAuthenticated = $this->twofactorManager->isTwoFactorAuthenticated($user);
 

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
@@ -70,6 +70,7 @@ class RememberBackupCodesJob extends TimedJob {
 
 		if ($user === null) {
 			// We can't run with an invalid user
+			$this->jobList->remove(self::class, $argument);
 			return;
 		}
 
@@ -98,6 +99,11 @@ class RememberBackupCodesJob extends TimedJob {
 			->setSubject('create_backupcodes');
 		$this->notificationManager->markProcessed($notification);
 
+		if (!$user->isEnabled()) {
+			// Don't recreate a notification for a user that can not read it
+			$this->jobList->remove(self::class, $argument);
+			return;
+		}
 		$notification->setDateTime($date);
 		$this->notificationManager->notify($notification);
 	}

--- a/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
@@ -82,6 +82,9 @@ class CheckBackupCodeTest extends TestCase {
 	}
 
 	public function testRunAlreadyGenerated() {
+		$this->user->method('isEnabled')
+			->willReturn(true);
+
 		$this->registry->method('getProviderStates')
 			->with($this->user)
 			->willReturn(['backup_codes' => true]);
@@ -97,6 +100,8 @@ class CheckBackupCodeTest extends TestCase {
 	public function testRun() {
 		$this->user->method('getUID')
 			->willReturn('myUID');
+		$this->user->method('isEnabled')
+			->willReturn(true);
 
 		$this->registry->expects($this->once())
 			->method('getProviderStates')
@@ -117,7 +122,26 @@ class CheckBackupCodeTest extends TestCase {
 		$this->invokePrivate($this->checkBackupCodes, 'run', [[]]);
 	}
 
+	public function testRunDisabledUser() {
+		$this->user->method('getUID')
+			->willReturn('myUID');
+		$this->user->method('isEnabled')
+			->willReturn(false);
+
+		$this->registry->expects($this->never())
+			->method('getProviderStates')
+			->with($this->user);
+
+		$this->jobList->expects($this->never())
+			->method('add');
+
+		$this->invokePrivate($this->checkBackupCodes, 'run', [[]]);
+	}
+
 	public function testRunNoProviders() {
+		$this->user->method('isEnabled')
+			->willReturn(true);
+
 		$this->registry->expects($this->once())
 			->method('getProviderStates')
 			->with($this->user)


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

* https://github.com/nextcloud/server/pull/41447 already improved the situation on our server, but a lot of permanently disabled and deleted users still have a background job and (for disabled users) receive a new notification every second week.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
