### PR TITLE
fix(userstatus): Fix setting and reverting status for busy calendar

### DIFF
--- a/apps/dav/lib/CalDAV/Status/Status.php
+++ b/apps/dav/lib/CalDAV/Status/Status.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /*
  * *
  *  * Dav App
@@ -27,7 +30,7 @@ namespace OCA\DAV\CalDAV\Status;
 
 class Status {
 
-	public function __construct(private string $status = '', private ?string $message = null, private ?string $customMessage = null) {
+	public function __construct(private string $status, private ?string $messageId, private ?string $customMessage = null) {
 	}
 
 	public function getStatus(): string {
@@ -38,12 +41,12 @@ class Status {
 		$this->status = $status;
 	}
 
-	public function getMessage(): ?string {
-		return $this->message;
+	public function getMessageId(): string {
+		return $this->messageId;
 	}
 
-	public function setMessage(?string $message): void {
-		$this->message = $message;
+	public function setMessageId(string $messageId): void {
+		$this->messageId = $messageId;
 	}
 
 	public function getCustomMessage(): ?string {

--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -200,9 +200,8 @@ class StatusService {
 		$freeBusyComponent = $result->VFREEBUSY;
 		$freeBusyProperties = $freeBusyComponent->select('FREEBUSY');
 		// If there is no FreeBusy property, the time-range is empty and available
-		// so set the status to online as otherwise we will never recover from a BUSY status
 		if (count($freeBusyProperties) === 0) {
-			return new Status(IUserStatus::ONLINE);
+			return null;
 		}
 
 		/** @var Property $freeBusyProperty */
@@ -222,10 +221,6 @@ class StatusService {
 		switch ($fbType) {
 			case 'BUSY':
 				return new Status(IUserStatus::BUSY, IUserStatus::MESSAGE_CALENDAR_BUSY, $this->l10n->t('In a meeting'));
-			case 'BUSY-UNAVAILABLE':
-				return new Status(IUserStatus::AWAY, IUserStatus::MESSAGE_AVAILABILITY);
-			case 'BUSY-TENTATIVE':
-				return new Status(IUserStatus::AWAY, IUserStatus::MESSAGE_CALENDAR_BUSY_TENTATIVE);
 			default:
 				return null;
 		}

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -1091,7 +1091,7 @@ EOF;
 			->willReturn($calDavStatus);
 		$this->predefinedStatusService->expects(self::once())
 			->method('isValidId')
-			->with($calDavStatus->getMessage())
+			->with($calDavStatus->getMessageId())
 			->willReturn(true);
 		$this->mapper->expects(self::once())
 			->method('insert')


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/41548

## Summary

* Remove calendar busy state from being a persistent.
* Stop setting a status for BUSY-TENTATIVE and BUSY-UNAVAILABLE. These should not have any meaning for the status.
* Revert calendar status as soon as the calendar no longer reports business.

## How to test

1.    Ensure the test user has calendars but opening the Calendar app once
2.    Ensure the user has an email address set
3.    Have no ongoing events
4.    Set personal availability so you are current out of office
5.    Clear oc_user_status
6.    Reload the page twice

Master: user online status is *Away*
Here: user online status is *Online*


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
