### PR TITLE
Make a scrollbar visible for sharing tab

### DIFF
--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="sharingTabDetailsView">
-		<div class="sharingTabDetailsView__header">
+		<div class="sharingTabDetailsView__wrapper">
+			<div class="sharingTabDetailsView__header">
 			<span>
 				<NcAvatar v-if="isUserShare"
 					class="sharing-entry__avatar"
@@ -14,8 +15,7 @@
 			<span>
 				<h1>{{ title }}</h1>
 			</span>
-		</div>
-		<div class="sharingTabDetailsView__wrapper">
+			</div>
 			<div class="sharingTabDetailsView__quick-permissions">
 				<div>
 					<NcCheckboxRadioSwitch :button-variant="true"
@@ -933,9 +933,15 @@ export default {
 	flex-direction: column;
 	width: 100%;
 	margin: 0 auto;
-	position: relative;
+	max-height: 100%;
 	height: 100%;
-	overflow: hidden;
+
+	&__wrapper {
+		flex: 1 0;
+		overflow-y: auto;
+		padding: 4px;
+		padding-right: 12px;
+	}
 
 	&__header {
 		display: flex;
@@ -953,13 +959,6 @@ export default {
 			}
 
 		}
-	}
-
-	&__wrapper {
-		overflow: scroll;
-		flex-shrink: 1;
-		padding: 4px;
-		padding-right: 12px;
 	}
 
 	&__quick-permissions {
@@ -1053,7 +1052,6 @@ export default {
 	&__footer {
 		width: 100%;
 		display: flex;
-		position: sticky;
 		bottom: 0;
 		flex-direction: column;
 		justify-content: space-between;


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/41572

## Summary

State for now:

![Peek 2023-11-17 11-40](https://github.com/nextcloud/server/assets/6078378/a9337c24-f60a-4c33-9e46-5a1bcef676c7)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
