### PR TITLE
Enable AppFramework dispatcher to enforce integer ranges

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -127,7 +127,8 @@ class DashboardApiController extends OCSController {
 	 * Get the items for the widgets
 	 *
 	 * @param array<string, string> $sinceIds Array indexed by widget Ids, contains date/id from which we want the new items
-	 * @param int $limit Limit number of result items per widget
+	 * @param int $limit Limit number of result items per widget, not more than 30 are allowed
+	 * @psalm-param int<1, 30> $limit
 	 * @param string[] $widgets Limit results to specific widgets
 	 * @return DataResponse<Http::STATUS_OK, array<string, DashboardWidgetItems>, array{}>
 	 *

--- a/apps/dashboard/openapi.json
+++ b/apps/dashboard/openapi.json
@@ -360,7 +360,7 @@
                     {
                         "name": "limit",
                         "in": "query",
-                        "description": "Limit number of result items per widget",
+                        "description": "Limit number of result items per widget, not more than 30 are allowed",
                         "schema": {
                             "type": "integer",
                             "format": "int64",

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\Diagnostics\IEventLogger;
 use OCP\IConfig;
 use OCP\IRequest;
+use OutOfRangeException;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -197,7 +198,7 @@ class Dispatcher {
 	private function executeController(Controller $controller, string $methodName): Response {
 		$arguments = [];
 
-		// valid types that will be casted
+		// valid types that will be cast
 		$types = ['int', 'integer', 'bool', 'boolean', 'float', 'double'];
 
 		foreach ($this->reflector->getParameters() as $param => $default) {
@@ -219,6 +220,7 @@ class Dispatcher {
 				$value = false;
 			} elseif ($value !== null && \in_array($type, $types, true)) {
 				settype($value, $type);
+				$this->ensureParameterValueSatisfiesRange($param, $value);
 			} elseif ($value === null && $type !== null && $this->appContainer->has($type)) {
 				$value = $this->appContainer->get($type);
 			}
@@ -249,5 +251,23 @@ class Dispatcher {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * @psalm-param mixed $value
+	 * @throws OutOfRangeException
+	 */
+	private function ensureParameterValueSatisfiesRange(string $param, $value): void {
+		$rangeInfo = $this->reflector->getRange($param);
+		if ($rangeInfo) {
+			if ($value < $rangeInfo['min'] || $value > $rangeInfo['max']) {
+				throw new OutOfRangeException(sprintf(
+					'Parameter %s must be between %d and %d',
+					$param,
+					$rangeInfo['min'],
+					$rangeInfo['max'],
+				));
+			}
+		}
 	}
 }

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -42,6 +42,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 	public $annotations = [];
 	private $types = [];
 	private $parameters = [];
+	private array $ranges = [];
 
 	/**
 	 * @param object $object an object or classname
@@ -54,26 +55,38 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 		if ($docs !== false) {
 			// extract everything prefixed by @ and first letter uppercase
 			preg_match_all('/^\h+\*\h+@(?P<annotation>[A-Z]\w+)((?P<parameter>.*))?$/m', $docs, $matches);
-			foreach ($matches['annotation'] as $key => $annontation) {
-				$annontation = strtolower($annontation);
+			foreach ($matches['annotation'] as $key => $annotation) {
+				$annotation = strtolower($annotation);
 				$annotationValue = $matches['parameter'][$key];
 				if (isset($annotationValue[0]) && $annotationValue[0] === '(' && $annotationValue[\strlen($annotationValue) - 1] === ')') {
 					$cutString = substr($annotationValue, 1, -1);
 					$cutString = str_replace(' ', '', $cutString);
-					$splittedArray = explode(',', $cutString);
-					foreach ($splittedArray as $annotationValues) {
+					$splitArray = explode(',', $cutString);
+					foreach ($splitArray as $annotationValues) {
 						[$key, $value] = explode('=', $annotationValues);
-						$this->annotations[$annontation][$key] = $value;
+						$this->annotations[$annotation][$key] = $value;
 					}
 					continue;
 				}
 
-				$this->annotations[$annontation] = [$annotationValue];
+				$this->annotations[$annotation] = [$annotationValue];
 			}
 
 			// extract type parameter information
 			preg_match_all('/@param\h+(?P<type>\w+)\h+\$(?P<var>\w+)/', $docs, $matches);
 			$this->types = array_combine($matches['var'], $matches['type']);
+			preg_match_all('/@psalm-param\h+(?P<type>\w+)<(?P<rangeMin>(-?\d+|min)),\h*(?P<rangeMax>(-?\d+|max))>\h+\$(?P<var>\w+)/', $docs, $matches);
+			foreach ($matches['var'] as $index => $varName) {
+				if ($matches['type'][$index] !== 'int') {
+					// only int ranges are possible at the moment
+					// @see https://psalm.dev/docs/annotating_code/type_syntax/scalar_types
+					continue;
+				}
+				$this->ranges[$varName] = [
+					'min' => $matches['rangeMin'][$index] === 'min' ? PHP_INT_MIN : (int)$matches['rangeMin'][$index],
+					'max' => $matches['rangeMax'][$index] === 'max' ? PHP_INT_MAX : (int)$matches['rangeMax'][$index],
+				];
+			}
 		}
 
 		foreach ($reflection->getParameters() as $param) {
@@ -101,6 +114,14 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 	public function getType(string $parameter) {
 		if (array_key_exists($parameter, $this->types)) {
 			return $this->types[$parameter];
+		}
+
+		return null;
+	}
+
+	public function getRange(string $parameter): ?array {
+		if (array_key_exists($parameter, $this->ranges)) {
+			return $this->ranges[$parameter];
 		}
 
 		return null;

--- a/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
@@ -54,6 +54,14 @@ class MiddleController extends BaseController {
 
 	public function test3() {
 	}
+
+	/**
+	 * @psalm-param int<-4, 42> $rangedOne
+	 * @psalm-param int<min, max> $rangedTwo
+	 * @return void
+	 */
+	public function test4(int $rangedOne, int $rangedTwo) {
+	}
 }
 
 class EndController extends MiddleController {
@@ -233,5 +241,18 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$reader->reflect('Test\AppFramework\Utility\EndController', 'test3');
 
 		$this->assertFalse($reader->hasAnnotation('Annotation'));
+	}
+
+	public function testRangeDetection() {
+		$reader = new ControllerMethodReflector();
+		$reader->reflect('Test\AppFramework\Utility\EndController', 'test4');
+
+		$rangeInfo1 = $reader->getRange('rangedOne');
+		$this->assertSame(-4, $rangeInfo1['min']);
+		$this->assertSame(42, $rangeInfo1['max']);
+
+		$rangeInfo2 = $reader->getRange('rangedTwo');
+		$this->assertSame(PHP_INT_MIN, $rangeInfo2['min']);
+		$this->assertSame(PHP_INT_MAX, $rangeInfo2['max']);
 	}
 }


### PR DESCRIPTION
## Summary

Psalm allows to specify an int range for integer parameters. We can consider them in the Http Dispatcher so that incoming int values are checked for their range directly in the app framework. Example use case for dashboard added.

Set 28 as milestone, but could go into 29 only. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
