### PR TITLE
Added option to disable Edit Locally menu option

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -280,7 +280,8 @@ class ViewController extends Controller {
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 
 		$params = [
-			'fileNotFound' => $fileNotFound ? 1 : 0
+			'fileNotFound' => $fileNotFound ? 1 : 0,
+			'disableEditLocally' => $this->config->getSystemValueBool('disable_edit_locally') ? 1 : 0,
 		];
 
 		$response = new TemplateResponse(

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -278,10 +278,10 @@ class ViewController extends Controller {
 
 		$this->initialState->provideInitialState('templates_path', $this->templateManager->hasTemplateDirectory() ? $this->templateManager->getTemplatePath() : false);
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
+		$this->initialState->provideInitialState('disable_edit_locally', $this->config->getSystemValueBool('disable_edit_locally'));
 
 		$params = [
 			'fileNotFound' => $fileNotFound ? 1 : 0,
-			'disableEditLocally' => $this->config->getSystemValueBool('disable_edit_locally') ? 1 : 0,
 		];
 
 		$response = new TemplateResponse(

--- a/apps/files/src/actions/editLocallyAction.ts
+++ b/apps/files/src/actions/editLocallyAction.ts
@@ -51,6 +51,10 @@ export const action = new FileAction({
 
 	// Only works on single files
 	enabled(nodes: Node[]) {
+		if ($('#disableEditLocally').val() === "1") {
+			return false
+		}
+
 		// Only works on single node
 		if (nodes.length !== 1) {
 			return false

--- a/apps/files/src/actions/editLocallyAction.ts
+++ b/apps/files/src/actions/editLocallyAction.ts
@@ -23,11 +23,14 @@ import { encodePath } from '@nextcloud/paths'
 import { generateOcsUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
 import { FileAction, Permission, type Node } from '@nextcloud/files'
+import { loadState } from '@nextcloud/initial-state'
 import { showError } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
 
 import LaptopSvg from '@mdi/svg/svg/laptop.svg?raw'
+
+let disableEditLocally = loadState('files', 'disable_edit_locally', false)
 
 const openLocalClient = async function(path: string) {
 	const link = generateOcsUrl('apps/files/api/v1') + '/openlocaleditor?format=json'
@@ -51,7 +54,7 @@ export const action = new FileAction({
 
 	// Only works on single files
 	enabled(nodes: Node[]) {
-		if ($('#disableEditLocally').val() === "1") {
+		if (disableEditLocally) {
 			return false
 		}
 

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -7,3 +7,4 @@
 <!-- config hints for javascript -->
 <input type="hidden" name="filesApp" id="filesApp" value="1" />
 <input type="hidden" name="fileNotFound" id="fileNotFound" value="<?php p($_['fileNotFound']); ?>" />
+<input type="hidden" name="disableEditLocally" id="disableEditLocally" value="<?php p($_['disableEditLocally']); ?>" />

--- a/apps/files/templates/index.php
+++ b/apps/files/templates/index.php
@@ -7,4 +7,3 @@
 <!-- config hints for javascript -->
 <input type="hidden" name="filesApp" id="filesApp" value="1" />
 <input type="hidden" name="fileNotFound" id="fileNotFound" value="<?php p($_['fileNotFound']); ?>" />
-<input type="hidden" name="disableEditLocally" id="disableEditLocally" value="<?php p($_['disableEditLocally']); ?>" />

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -168,7 +168,7 @@ class ViewControllerTest extends TestCase {
 				[$this->user->getUID(), 'files', 'crop_image_previews', true, true],
 				[$this->user->getUID(), 'files', 'show_grid', true],
 			]);
-		
+
 		$baseFolderFiles = $this->getMockBuilder(Folder::class)->getMock();
 
 		$this->rootFolder->expects($this->any())
@@ -186,6 +186,7 @@ class ViewControllerTest extends TestCase {
 			'index',
 			[
 				'fileNotFound' => 0,
+				'disableEditLocally' => 0,
 			]
 		);
 		$policy = new Http\ContentSecurityPolicy();

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -186,7 +186,6 @@ class ViewControllerTest extends TestCase {
 			'index',
 			[
 				'fileNotFound' => 0,
-				'disableEditLocally' => 0,
 			]
 		);
 		$policy = new Http\ContentSecurityPolicy();

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2412,4 +2412,11 @@ $CONFIG = [
  * Defaults to ``true``
  */
 'enable_non-accessible_features' => true,
+
+/**
+ * Disable "Edit locally" menu item in file viewer
+ *
+ * Defaults to ``false``
+ */
+'disable_edit_locally' => false,
 ];


### PR DESCRIPTION
## Summary
Many of our users has no installed software for edit file locally. This leads to struggling with mentioned menu option. For me this option also does nothing for any file format. So as an option - we can add a way to disable it completely.

by default:
![image](https://github.com/nextcloud/server/assets/191082/730d00ea-1aa4-4c6f-9d2b-72d0381853e0)

with option
```php
# config/config.php

<?php
$CONFIG = array (
  // ...
  'disable_edit_locally' => true,
);
```
![image](https://github.com/nextcloud/server/assets/191082/edccb934-cc11-4170-9c52-ab937700a4f1)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
