### PR TITLE
add named metadata event

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -96,8 +96,9 @@ class Scan extends Base {
 			->addOption(
 				'generate-metadata',
 				null,
-				InputOption::VALUE_NONE,
-				'Generate metadata for all scanned files'
+				InputOption::VALUE_OPTIONAL,
+				'Generate metadata for all scanned files; if specified only generate for named value',
+				''
 			)
 			->addOption(
 				'all',
@@ -122,7 +123,7 @@ class Scan extends Base {
 			);
 	}
 
-	protected function scanFiles(string $user, string $path, bool $scanMetadata, OutputInterface $output, bool $backgroundScan = false, bool $recursive = true, bool $homeOnly = false): void {
+	protected function scanFiles(string $user, string $path, ?string $scanMetadata, OutputInterface $output, bool $backgroundScan = false, bool $recursive = true, bool $homeOnly = false): void {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner(
 			$user,
@@ -136,11 +137,12 @@ class Scan extends Base {
 			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->filesCounter;
 			$this->abortIfInterrupted();
-			if ($scanMetadata) {
+			if ($scanMetadata !== null) {
 				$node = $this->rootFolder->get($path);
 				$this->filesMetadataManager->refreshMetadata(
 					$node,
-					IFilesMetadataManager::PROCESS_LIVE | IFilesMetadataManager::PROCESS_BACKGROUND
+					($scanMetadata !== '') ? IFilesMetadataManager::PROCESS_NAMED : IFilesMetadataManager::PROCESS_LIVE | IFilesMetadataManager::PROCESS_BACKGROUND,
+					$scanMetadata
 				);
 			}
 		});
@@ -221,6 +223,12 @@ class Scan extends Base {
 
 		$this->initTools($output);
 
+		// getOption() logic on VALUE_OPTIONAL
+		$metadata = null; // null if --generate-metadata is not set, empty if option have no value, value if set
+		if ($input->getOption('generate-metadata') !== '') {
+			$metadata = $input->getOption('generate-metadata') ?? '';
+		}
+
 		$user_count = 0;
 		foreach ($users as $user) {
 			if (is_object($user)) {
@@ -230,7 +238,7 @@ class Scan extends Base {
 			++$user_count;
 			if ($this->userManager->userExists($user)) {
 				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
-				$this->scanFiles($user, $path, $input->getOption('generate-metadata'), $output, $input->getOption('unscanned'), !$input->getOption('shallow'), $input->getOption('home-only'));
+				$this->scanFiles($user, $path, $metadata, $output, $input->getOption('unscanned'), !$input->getOption('shallow'), $input->getOption('home-only'));
 				$output->writeln('', OutputInterface::VERBOSITY_VERBOSE);
 			} else {
 				$output->writeln("<error>Unknown user $user_count $user</error>");

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -290,6 +290,7 @@ return array(
     'OCP\\FilesMetadata\\AMetadataEvent' => $baseDir . '/lib/public/FilesMetadata/AMetadataEvent.php',
     'OCP\\FilesMetadata\\Event\\MetadataBackgroundEvent' => $baseDir . '/lib/public/FilesMetadata/Event/MetadataBackgroundEvent.php',
     'OCP\\FilesMetadata\\Event\\MetadataLiveEvent' => $baseDir . '/lib/public/FilesMetadata/Event/MetadataLiveEvent.php',
+    'OCP\\FilesMetadata\\Event\\MetadataNamedEvent' => $baseDir . '/lib/public/FilesMetadata/Event/MetadataNamedEvent.php',
     'OCP\\FilesMetadata\\Exceptions\\FilesMetadataException' => $baseDir . '/lib/public/FilesMetadata/Exceptions/FilesMetadataException.php',
     'OCP\\FilesMetadata\\Exceptions\\FilesMetadataKeyFormatException' => $baseDir . '/lib/public/FilesMetadata/Exceptions/FilesMetadataKeyFormatException.php',
     'OCP\\FilesMetadata\\Exceptions\\FilesMetadataNotFoundException' => $baseDir . '/lib/public/FilesMetadata/Exceptions/FilesMetadataNotFoundException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -323,6 +323,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\FilesMetadata\\AMetadataEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/AMetadataEvent.php',
         'OCP\\FilesMetadata\\Event\\MetadataBackgroundEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Event/MetadataBackgroundEvent.php',
         'OCP\\FilesMetadata\\Event\\MetadataLiveEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Event/MetadataLiveEvent.php',
+        'OCP\\FilesMetadata\\Event\\MetadataNamedEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Event/MetadataNamedEvent.php',
         'OCP\\FilesMetadata\\Exceptions\\FilesMetadataException' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Exceptions/FilesMetadataException.php',
         'OCP\\FilesMetadata\\Exceptions\\FilesMetadataKeyFormatException' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Exceptions/FilesMetadataKeyFormatException.php',
         'OCP\\FilesMetadata\\Exceptions\\FilesMetadataNotFoundException' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Exceptions/FilesMetadataNotFoundException.php',

--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -44,6 +44,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\FilesMetadata\Event\MetadataBackgroundEvent;
 use OCP\FilesMetadata\Event\MetadataLiveEvent;
+use OCP\FilesMetadata\Event\MetadataNamedEvent;
 use OCP\FilesMetadata\Exceptions\FilesMetadataException;
 use OCP\FilesMetadata\Exceptions\FilesMetadataNotFoundException;
 use OCP\FilesMetadata\IFilesMetadataManager;
@@ -89,7 +90,8 @@ class FilesMetadataManager implements IFilesMetadataManager {
 	 */
 	public function refreshMetadata(
 		Node $node,
-		int $process = self::PROCESS_LIVE
+		int $process = self::PROCESS_LIVE,
+		string $namedEvent = ''
 	): IFilesMetadata {
 		try {
 			$metadata = $this->metadataRequestService->getMetadataFromFileId($node->getId());
@@ -98,8 +100,12 @@ class FilesMetadataManager implements IFilesMetadataManager {
 		}
 
 		// if $process is LIVE, we enforce LIVE
+		// if $process is NAMED, we go NAMED
+		// else BACKGROUND
 		if ((self::PROCESS_LIVE & $process) !== 0) {
 			$event = new MetadataLiveEvent($node, $metadata);
+		} elseif ((self::PROCESS_NAMED & $process) !== 0) {
+			$event = new MetadataNamedEvent($node, $metadata, $namedEvent);
 		} else {
 			$event = new MetadataBackgroundEvent($node, $metadata);
 		}

--- a/lib/public/FilesMetadata/Event/MetadataNamedEvent.php
+++ b/lib/public/FilesMetadata/Event/MetadataNamedEvent.php
@@ -23,46 +23,52 @@ declare(strict_types=1);
  *
  */
 
-namespace OCP\FilesMetadata;
+namespace OCP\FilesMetadata\Event;
 
-use OCP\EventDispatcher\Event;
 use OCP\Files\Node;
+use OCP\FilesMetadata\AMetadataEvent;
 use OCP\FilesMetadata\Model\IFilesMetadata;
 
 /**
+ * MetadataNamedEvent is an event similar to MetadataBackgroundEvent completed with a target name,
+ * used to limit the refresh of metadata only listeners capable of filtering themselves out.
+ *
+ * Meaning that when using this event, your app must implement a filter on the event's registered
+ * name returned by getName()
+ *
+ * This event is mostly triggered when a registered name is added to the files scan
+ *    i.e. ./occ files:scan --generate-metadata [name]
+ *
+ * @see AMetadataEvent::getMetadata()
+ * @see AMetadataEvent::getNode()
+ * @see MetadataNamedEvent::getName()
  * @since 28.0.0
  */
-abstract class AMetadataEvent extends Event {
+class MetadataNamedEvent extends AMetadataEvent {
 	/**
 	 * @param Node $node
 	 * @param IFilesMetadata $metadata
+	 * @param string $name name assigned to the event
+	 *
 	 * @since 28.0.0
 	 */
 	public function __construct(
-		protected Node $node,
-		protected IFilesMetadata $metadata
+		Node $node,
+		IFilesMetadata $metadata,
+		private string $name = ''
 	) {
-		parent::__construct();
+		parent::__construct($node, $metadata);
 	}
 
 	/**
-	 * returns related node
+	 * get the assigned name for the event.
+	 * This is used to know if your app is the called one when running the
+	 *    ./occ files:scan --generate-metadata [name]
 	 *
-	 * @return Node
+	 * @return string
 	 * @since 28.0.0
 	 */
-	public function getNode(): Node {
-		return $this->node;
-	}
-
-	/**
-	 * returns metadata. if known, it already contains data from the database.
-	 * If the object is modified using its setters, changes are stored in database at the end of the event.
-	 *
-	 * @return IFilesMetadata
-	 * @since 28.0.0
-	 */
-	public function getMetadata(): IFilesMetadata {
-		return $this->metadata;
+	public function getName(): string {
+		return $this->name;
 	}
 }

--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -42,6 +42,8 @@ interface IFilesMetadataManager {
 	public const PROCESS_LIVE = 1;
 	/** @since 28.0.0 */
 	public const PROCESS_BACKGROUND = 2;
+	/** @since 28.0.0 */
+	public const PROCESS_NAMED = 4;
 
 	/**
 	 * initiate the process of refreshing the metadata in relation to a node
@@ -54,15 +56,18 @@ interface IFilesMetadataManager {
 	 *
 	 * @param Node $node related node
 	 * @param int $process type of process
+	 * @param string $namedEvent limit process to a named event
 	 *
 	 * @return IFilesMetadata
 	 * @see self::PROCESS_BACKGROUND
 	 * @see self::PROCESS_LIVE
+	 * @see self::PROCESS_NAMED
 	 * @since 28.0.0
 	 */
 	public function refreshMetadata(
 		Node $node,
-		int $process = self::PROCESS_LIVE
+		int $process = self::PROCESS_LIVE,
+		string $namedEvent = ''
 	): IFilesMetadata;
 
 	/**


### PR DESCRIPTION
This adds:

- a new event `MetadataNamedEvent`,
- an optional parameter to the existing `occ files:scan --generate-metadata [name]` command.

The idea is to provide a last param to the `IFilesMetadataManager::refreshMetadata()` that assign a name to the event.
Any app listening to the `MetadataNameEvent` will use `getName()` to confirm the event is related to itself and manage the refresh of metadata the same way it would manage the `Live` and/or `Background` Event.

This way, we can ask a refresh of the metadata from all files' from the cloud without loosing time refreshing all metadata provided by all apps.
