### PR TITLE
Revert "[stable27] fix(files_versions): don't call getUid() on null"

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -351,7 +351,7 @@ class FileEventsListener implements IEventListener {
 
 	/**
 	 * Retrieve the path relative to the current user root folder.
-	 * If no user is connected, try to use the node's owner.
+	 * If no user is connected, use the node's owner.
 	 */
 	private function getPathForNode(Node $node): ?string {
 		try {
@@ -359,12 +359,8 @@ class FileEventsListener implements IEventListener {
 				->getUserFolder(\OC_User::getUser())
 				->getRelativePath($node->getPath());
 		} catch (\Throwable $ex) {
-			$owner = $node->getOwner();
-			if ($owner === null) {
-				return null;
-			}
 			return $this->rootFolder
-				->getUserFolder($owner->getUid())
+				->getUserFolder($node->getOwner()->getUid())
 				->getRelativePath($node->getPath());
 		}
 	}


### PR DESCRIPTION
Reverts nextcloud/server#41553

It was merged too early: did not make it into RC1 of 27.1.4 RC1 and was rescheduled into 27.1.5.