### PR TITLE
fix: Fix linkToOCSRouteAbsolute() without index.php and with subfolder

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -116,16 +116,25 @@ class URLGenerator implements IURLGenerator {
 	}
 
 	public function linkToOCSRouteAbsolute(string $routeName, array $arguments = []): string {
+		// Returns `/subfolder/index.php/ocsapp/…` with `'htaccess.IgnoreFrontController' => false` in config.php
+		// And `/subfolder/ocsapp/…` with `'htaccess.IgnoreFrontController' => true` in config.php
 		$route = $this->router->generate('ocs.'.$routeName, $arguments, false);
 
-		$indexPhpPos = strpos($route, '/index.php/');
-		if ($indexPhpPos !== false) {
-			$route = substr($route, $indexPhpPos + 10);
+		// Cut off `/subfolder`
+		if (\OC::$WEBROOT !== '' && str_starts_with($route, \OC::$WEBROOT)) {
+			$route = substr($route, \strlen(\OC::$WEBROOT));
 		}
 
+		if (str_starts_with($route, '/index.php/')) {
+			$route = substr($route, 10);
+		}
+
+		// Remove `ocsapp/` bit
 		$route = substr($route, 7);
+		// Prefix with ocs/v2.php endpoint
 		$route = '/ocs/v2.php' . $route;
 
+		// Turn into an absolute URL
 		return $this->getAbsoluteURL($route);
 	}
 

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -192,26 +192,34 @@ class UrlGeneratorTest extends \Test\TestCase {
 	/**
 	 * @dataProvider provideOCSRoutes
 	 */
-	public function testLinkToOCSRouteAbsolute(string $route, string $expected) {
+	public function testLinkToOCSRouteAbsolute(string $route, bool $ignoreFrontController, string $expected): void {
 		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/nextcloud';
 		$this->router->expects($this->once())
 			->method('generate')
-			->willReturnCallback(function ($routeName, $parameters) {
+			->willReturnCallback(function (string $routeName, array $parameters) use ($ignoreFrontController) {
 				if ($routeName === 'ocs.core.OCS.getCapabilities') {
-					return '/index.php/ocsapp/cloud/capabilities';
+					if (!$ignoreFrontController) {
+						return '/nextcloud/index.php/ocsapp/cloud/capabilities';
+					}
+					return '/nextcloud/ocsapp/cloud/capabilities';
 				} elseif ($routeName === 'ocs.core.WhatsNew.dismiss') {
-					return '/index.php/ocsapp/core/whatsnew';
+					if (!$ignoreFrontController) {
+						return '/nextcloud/index.php/ocsapp/core/whatsnew';
+					}
+					return '/nextcloud/ocsapp/core/whatsnew';
 				}
 			});
 		$result = $this->urlGenerator->linkToOCSRouteAbsolute($route);
 		$this->assertEquals($expected, $result);
 	}
 
-	public function provideOCSRoutes() {
+	public function provideOCSRoutes(): array {
 		return [
-			['core.OCS.getCapabilities', 'http://localhost/nextcloud/ocs/v2.php/cloud/capabilities'],
-			['core.WhatsNew.dismiss', 'http://localhost/nextcloud/ocs/v2.php/core/whatsnew'],
+			['core.OCS.getCapabilities', false, 'http://localhost/nextcloud/ocs/v2.php/cloud/capabilities'],
+			['core.OCS.getCapabilities', true, 'http://localhost/nextcloud/ocs/v2.php/cloud/capabilities'],
+			['core.WhatsNew.dismiss', false, 'http://localhost/nextcloud/ocs/v2.php/core/whatsnew'],
+			['core.WhatsNew.dismiss', true, 'http://localhost/nextcloud/ocs/v2.php/core/whatsnew'],
 		];
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/twofactor_nextcloud_notification/issues/773

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
