### PR TITLE
fix: Also cleanup orphaned shares user cannot be found anymore

### DIFF
--- a/apps/files_sharing/lib/OrphanHelper.php
+++ b/apps/files_sharing/lib/OrphanHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing;
 
+use OC\User\NoUserException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
@@ -40,7 +41,11 @@ class OrphanHelper {
 	}
 
 	public function isShareValid(string $owner, int $fileId): bool {
-		$userFolder = $this->rootFolder->getUserFolder($owner);
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($owner);
+		} catch (NoUserException $e) {
+			return false;
+		}
 		$nodes = $userFolder->getById($fileId);
 		return count($nodes) > 0;
 	}


### PR DESCRIPTION
Make sure that orphaned shares are also cleaned up if the user cannot be found anymore. Otherwise the occ command for cleanup would just throw at this point.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
