### PR TITLE
fix(theming): Adjust config listener to validate `apporder` config also for closure navigation

### DIFF
--- a/apps/theming/lib/Listener/BeforePreferenceListener.php
+++ b/apps/theming/lib/Listener/BeforePreferenceListener.php
@@ -79,12 +79,16 @@ class BeforePreferenceListener implements IEventListener {
 		}
 
 		$value = json_decode($event->getConfigValue(), true, flags:JSON_THROW_ON_ERROR);
-		if (is_array(($value))) {
-			foreach ($value as $id => $info) {
-				if (!is_array($info) || empty($info) || !isset($info['app']) || !$this->appManager->isEnabledForUser($info['app']) || !is_numeric($info['order'] ?? '')) {
-					// Invalid config value, refuse the change
-					return;
-				}
+		if (!is_array(($value))) {
+			// Must be an array
+			return;
+		}
+
+		foreach ($value as $id => $info) {
+			// required format: [ navigation_id: string => [ order: int, app?: string ] ]
+			if (!is_string($id) || !is_array($info) || empty($info) || !isset($info['order']) || !is_numeric($info['order']) || (isset($info['app']) && !$this->appManager->isEnabledForUser($info['app']))) {
+				// Invalid config value, refuse the change
+				return;
 			}
 		}
 		$event->setValid(true);


### PR DESCRIPTION
## Summary

The `app` key is optional in the settings, so we only need to check it if set.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
