### PR TITLE
[stable27] fix: Avoid triggering a defered sidebar open if openFile is already handling that

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -410,7 +410,7 @@
 
 			if (options.scrollTo) {
 				this.$fileList.one('updated', function() {
-					self.scrollTo(options.scrollTo);
+					self.scrollTo(options.scrollTo, !options.openFile);
 				});
 			}
 
@@ -3351,11 +3351,14 @@
 			this.$el.find('.mask').remove();
 			this.$table.removeClass('hidden');
 		},
-		scrollTo:function(file) {
+		scrollTo:function(file, showDetails) {
+			if (showDetails === undefined) {
+				showDetails = true
+			}
 			if (!_.isArray(file)) {
 				file = [file];
 			}
-			if (file.length === 1) {
+			if (file.length === 1 && showDetails) {
 				_.defer(function() {
 					if (document.documentElement.clientWidth > 1024) {
 						this.showDetailsView(file[0]);


### PR DESCRIPTION
In the office integration we don't want to show the sidebar after opening a file through a direct link as it takes away too much space. We just call a sidebar close within richdocuments but the deferred call to show the details view on the scrollTo action will trigger later. In this case we can actually avoid trigger the details view that way as it is already called when the file action is triggered a few lines below https://github.com/nextcloud/server/blob/18034204e6dbb8bbecafbf2bb750832c004b21a0/apps/files/js/filelist.js#L440

This fix is targeting 27 only as master might have changed behaviour due to the files2vue migration (needs https://github.com/nextcloud/server/issues/41467 to be re-evaluated)

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
