### PR TITLE
fix(setupcheck): Fix memory limit setup check

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpMemoryLimit.php
+++ b/apps/settings/lib/SetupChecks/PhpMemoryLimit.php
@@ -51,7 +51,7 @@ class PhpMemoryLimit implements ISetupCheck {
 		if ($this->memoryInfo->isMemoryLimitSufficient()) {
 			return SetupResult::success(Util::humanFileSize($this->memoryInfo->getMemoryLimit()));
 		} else {
-			return SetupResult::error($this->l10n->t('The PHP memory limit is below the recommended value of %s.'), Util::humanFileSize(MemoryInfo::RECOMMENDED_MEMORY_LIMIT));
+			return SetupResult::error($this->l10n->t('The PHP memory limit is below the recommended value of %s.', Util::humanFileSize(MemoryInfo::RECOMMENDED_MEMORY_LIMIT)));
 		}
 	}
 }


### PR DESCRIPTION
* Resolves: `The arguments array must contain 1 items, 0 given in file …/L10NString.php' line 88`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
