### PR TITLE
Correct spelling of Brute Force and other fixes

### DIFF
--- a/apps/settings/lib/SetupChecks/BruteForceThrottler.php
+++ b/apps/settings/lib/SetupChecks/BruteForceThrottler.php
@@ -47,7 +47,7 @@ class BruteForceThrottler implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Bruteforce Throttle');
+		return $this->l10n->t('Brute Force Throttle');
 	}
 
 	public function run(): SetupResult {
@@ -62,12 +62,12 @@ class BruteForceThrottler implements ISetupCheck {
 			}
 		} elseif ($this->throttler->showBruteforceWarning($address)) {
 			return SetupResult::error(
-				$this->l10n->t('Your remote address was identified as "%s" and is bruteforce throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
+				$this->l10n->t('Your remote address was identified as "%s" and is brute force throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
 				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
 			);
 		} else {
 			return SetupResult::success(
-				$this->l10n->t('Your remote address "%s" is not bruteforce throttled.', [$address])
+				$this->l10n->t('Your remote address "%s" is not brute force throttled.', [$address])
 			);
 		}
 	}

--- a/apps/settings/lib/SetupChecks/BruteForceThrottler.php
+++ b/apps/settings/lib/SetupChecks/BruteForceThrottler.php
@@ -47,7 +47,7 @@ class BruteForceThrottler implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('Brute Force Throttle');
+		return $this->l10n->t('Brute-force Throttle');
 	}
 
 	public function run(): SetupResult {
@@ -62,12 +62,12 @@ class BruteForceThrottler implements ISetupCheck {
 			}
 		} elseif ($this->throttler->showBruteforceWarning($address)) {
 			return SetupResult::error(
-				$this->l10n->t('Your remote address was identified as "%s" and is brute force throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
+				$this->l10n->t('Your remote address was identified as "%s" and is brute-force throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
 				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
 			);
 		} else {
 			return SetupResult::success(
-				$this->l10n->t('Your remote address "%s" is not brute force throttled.', [$address])
+				$this->l10n->t('Your remote address "%s" is not brute-force throttled.', [$address])
 			);
 		}
 	}

--- a/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
+++ b/apps/settings/lib/SetupChecks/PhpDefaultCharset.php
@@ -47,7 +47,7 @@ class PhpDefaultCharset implements ISetupCheck {
 		if (strtoupper(trim(ini_get('default_charset'))) === 'UTF-8') {
 			return SetupResult::success('UTF-8');
 		} else {
-			return SetupResult::warning($this->l10n->t('PHP configuration option default_charset should be UTF-8'));
+			return SetupResult::warning($this->l10n->t('PHP configuration option "default_charset" should be UTF-8'));
 		}
 	}
 }

--- a/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
+++ b/apps/settings/lib/SetupChecks/PhpOutputBuffering.php
@@ -40,7 +40,7 @@ class PhpOutputBuffering implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('PHP output_buffering option');
+		return $this->l10n->t('PHP "output_buffering" option');
 	}
 
 	public function run(): SetupResult {
@@ -48,7 +48,7 @@ class PhpOutputBuffering implements ISetupCheck {
 		if ($value === '' || $value === '0') {
 			return SetupResult::success($this->l10n->t('Disabled'));
 		} else {
-			return SetupResult::error($this->l10n->t('PHP configuration option output_buffering must be disabled'));
+			return SetupResult::error($this->l10n->t('PHP configuration option "output_buffering" must be disabled'));
 		}
 	}
 }

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -83,7 +83,7 @@ class SupportedDatabase implements ISetupCheck {
 		} elseif ($databasePlatform instanceof SqlitePlatform) {
 			$version = 'Sqlite';
 		} else {
-			return SetupResult::error($this->l10n->t('Unknown database plaform'));
+			return SetupResult::error($this->l10n->t('Unknown database platform'));
 		}
 		return SetupResult::success($version);
 	}


### PR DESCRIPTION
1. Correcting the spelling of "Bruteforce" to "Brute Force".
2. Adding quotation marks.
3. Fixed a typo.