### PR TITLE
feat(search): hide search provider from list

### DIFF
--- a/apps/settings/lib/Search/UserSearch.php
+++ b/apps/settings/lib/Search/UserSearch.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2023 Stephan Orbaugh <stephan.orbaugh@nextcloud.com>
  *
  * @author Stephan Orbaugh <stephan.orbaugh@nextcloud.com>
- *
+ * @author Benjamin Gaussorgues <benjamin.gaussorgues@nextcloud.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -33,45 +33,26 @@ use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 
 class UserSearch implements IProvider {
-
-
-	/** @var IL10N */
-	protected $l;
-
 	public function __construct(
-								IL10N $l) {
-		$this->l = $l;
+		private IL10N $l,
+	) {
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function getId(): string {
 		return 'users';
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function getName(): string {
 		return $this->l->t('Users');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function getOrder(string $route, array $routeParameters): int {
-		return 300;
+	public function getOrder(string $route, array $routeParameters): ?int {
+		return $route === 'settings.Users.usersList'
+			? 300
+			: null;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
-
-		return SearchResult::complete(
-			$this->l->t('Users'),
-			[]
-		);
+		return SearchResult::complete($this->l->t('Users'), []);
 	}
 }

--- a/lib/private/Search/SearchComposer.php
+++ b/lib/private/Search/SearchComposer.php
@@ -184,6 +184,10 @@ class SearchComposer {
 			function (array $providerData) use ($route, $routeParameters) {
 				$appId = $providerData['appId'];
 				$provider = $providerData['provider'];
+				$order = $provider->getOrder($route, $routeParameters);
+				if ($order === null) {
+					return;
+				}
 				$triggers = [$provider->getId()];
 				if ($provider instanceof IFilteringProvider) {
 					$triggers += $provider->getAlternateIds();
@@ -197,7 +201,7 @@ class SearchComposer {
 					'appId' => $appId,
 					'name' => $provider->getName(),
 					'icon' => $this->fetchIcon($appId, $provider->getId()),
-					'order' => $provider->getOrder($route, $routeParameters),
+					'order' => $order,
 					'triggers' => $triggers,
 					'filters' => $this->getFiltersType($filters, $provider->getId()),
 					'inAppSearch' => $provider instanceof IInAppSearch,
@@ -205,6 +209,7 @@ class SearchComposer {
 			},
 			$this->providers,
 		);
+		$providers = array_filter($providers);
 
 		// Sort providers by order and strip associative keys
 		usort($providers, function ($provider1, $provider2) {

--- a/lib/public/Search/IProvider.php
+++ b/lib/public/Search/IProvider.php
@@ -68,15 +68,17 @@ interface IProvider {
 	/**
 	 * Get the search provider order
 	 * The lower the int, the higher it will be sorted (0 will be before 10)
+	 * If null, the search provider will be hidden in the UI and the API not called
 	 *
 	 * @param string $route the route the user is currently at, e.g. files.view.index
 	 * @param array $routeParameters the parameters of the route the user is currently at, e.g. [fileId = 982, dir = "/"]
 	 *
-	 * @return int
+	 * @return int|null
 	 *
 	 * @since 20.0.0
+	 * @since 28.0.0 Can return null
 	 */
-	public function getOrder(string $route, array $routeParameters): int;
+	public function getOrder(string $route, array $routeParameters): ?int;
 
 	/**
 	 * Find matching search entries in an app


### PR DESCRIPTION
 - Some search providers can be hidden if they send `null` in `getOrder`
 - Hide user search provider if not on user list (#41484)