### PR TITLE
fix: lower threshold for system address book sync

### DIFF
--- a/apps/dav/lib/Migration/Version1027Date20230504122946.php
+++ b/apps/dav/lib/Migration/Version1027Date20230504122946.php
@@ -49,7 +49,7 @@ class Version1027Date20230504122946 extends SimpleMigrationStep {
 	 * @param array $options
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		if($this->userManager->countSeenUsers() > 1000) {
+		if($this->userManager->countSeenUsers() > 100 || array_sum($this->userManager->countUsers()) > 100) {
 			$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'yes');
 			$output->info('Could not sync system address books during update - too many user records have been found. Please call occ dav:sync-system-addressbook manually.');
 			return;


### PR DESCRIPTION
## Summary

- Switch back to countUsers to have the actual value. countSeenUsers is bad if Nextcloud is connected to a larger directory, but only a part is using Nextcloud and therefore the seen count is much lower because the sync is done for all users.
- Lower the threshold to 100



## TODO

- [ ] CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
