### PR TITLE
feat(LDAP): implement IIsAdmin interface

### DIFF
--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -51,6 +51,7 @@ A user logs into Nextcloud with their LDAP or AD credentials, and is granted acc
 		<command>OCA\User_LDAP\Command\CheckGroup</command>
 		<command>OCA\User_LDAP\Command\CreateEmptyConfig</command>
 		<command>OCA\User_LDAP\Command\DeleteConfig</command>
+		<command>OCA\User_LDAP\Command\PromoteGroup</command>
 		<command>OCA\User_LDAP\Command\ResetGroup</command>
 		<command>OCA\User_LDAP\Command\ResetUser</command>
 		<command>OCA\User_LDAP\Command\Search</command>

--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -15,6 +15,7 @@ return array(
     'OCA\\User_LDAP\\Command\\CheckUser' => $baseDir . '/../lib/Command/CheckUser.php',
     'OCA\\User_LDAP\\Command\\CreateEmptyConfig' => $baseDir . '/../lib/Command/CreateEmptyConfig.php',
     'OCA\\User_LDAP\\Command\\DeleteConfig' => $baseDir . '/../lib/Command/DeleteConfig.php',
+    'OCA\\User_LDAP\\Command\\PromoteGroup' => $baseDir . '/../lib/Command/PromoteGroup.php',
     'OCA\\User_LDAP\\Command\\ResetGroup' => $baseDir . '/../lib/Command/ResetGroup.php',
     'OCA\\User_LDAP\\Command\\ResetUser' => $baseDir . '/../lib/Command/ResetUser.php',
     'OCA\\User_LDAP\\Command\\Search' => $baseDir . '/../lib/Command/Search.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -30,6 +30,7 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\Command\\CheckUser' => __DIR__ . '/..' . '/../lib/Command/CheckUser.php',
         'OCA\\User_LDAP\\Command\\CreateEmptyConfig' => __DIR__ . '/..' . '/../lib/Command/CreateEmptyConfig.php',
         'OCA\\User_LDAP\\Command\\DeleteConfig' => __DIR__ . '/..' . '/../lib/Command/DeleteConfig.php',
+        'OCA\\User_LDAP\\Command\\PromoteGroup' => __DIR__ . '/..' . '/../lib/Command/PromoteGroup.php',
         'OCA\\User_LDAP\\Command\\ResetGroup' => __DIR__ . '/..' . '/../lib/Command/ResetGroup.php',
         'OCA\\User_LDAP\\Command\\ResetUser' => __DIR__ . '/..' . '/../lib/Command/ResetUser.php',
         'OCA\\User_LDAP\\Command\\Search' => __DIR__ . '/..' . '/../lib/Command/Search.php',

--- a/apps/user_ldap/lib/Command/PromoteGroup.php
+++ b/apps/user_ldap/lib/Command/PromoteGroup.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\User_LDAP\Command;
+
+use OCA\User_LDAP\Group_Proxy;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class PromoteGroup extends Command {
+
+	public function __construct(
+		private IGroupManager $groupManager,
+		private Group_Proxy $backend
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('ldap:promote-group')
+			->setDescription('declares the specified group as admin group (only one is possible per LDAP configuration)')
+			->addArgument(
+				'group',
+				InputArgument::REQUIRED,
+				'the group ID in Nextcloud or a group name'
+			)
+			->addOption(
+				'yes',
+				'y',
+				InputOption::VALUE_NONE,
+				'do not ask for confirmation'
+			);
+	}
+
+	protected function promoteGroup(IGroup $group, InputInterface $input, OutputInterface $output): void {
+		if ($input->getOption('yes') === false) {
+			/** @var QuestionHelper $helper */
+			$helper = $this->getHelper('question');
+
+			$idLabel = '';
+			if ($group->getGID() !== $group->getDisplayName()) {
+				$idLabel = sprintf(' (Group ID: %s)', $group->getGID());
+			}
+
+			$q = new Question(sprintf('Promote %s%s to the admin group (y|N)? ', $group->getDisplayName(), $idLabel));
+			$input->setOption('yes', $helper->ask($input, $output, $q) === 'y');
+		}
+		if ($input->getOption('yes') === true) {
+			$access = $this->backend->getLDAPAccess($group->getGID());
+			$access->connection->setConfiguration(['ldapAdminGroup' => $group->getGID()]);
+			$access->connection->saveConfiguration();
+			$output->writeln(sprintf('<info>Group %s was promoted</info>', $group->getDisplayName()));
+		} else {
+			$output->writeln('<comment>Group promotion cancelled</comment>');
+		}
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$groupInput = (string)$input->getArgument('group');
+		$group = $this->groupManager->get($groupInput);
+
+		if ($group instanceof IGroup && $this->backend->groupExists($group->getGID())) {
+			$this->promoteGroup($group, $input, $output);
+			return 0;
+		}
+
+		$groupCandidates = $this->backend->getGroups($groupInput, 20);
+		foreach ($groupCandidates as $gidCandidate) {
+			$group = $this->groupManager->get($gidCandidate);
+			if ($group !== null
+				&& $this->backend->groupExists($group->getGID()) // ensure it is an LDAP group
+				&& ($group->getGID() === $groupInput
+					|| $group->getDisplayName() === $groupInput)
+			) {
+				$this->promoteGroup($group, $input, $output);
+				return 0;
+			}
+		}
+
+		$output->writeln('<error>No matching group found</error>');
+		return 1;
+	}
+
+}

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -134,6 +134,7 @@ class Configuration {
 		'ldapAttributeRole' => null,
 		'ldapAttributeHeadline' => null,
 		'ldapAttributeBiography' => null,
+		'ldapAdminGroup' => '',
 	];
 
 	public function __construct(string $configPrefix, bool $autoRead = true) {
@@ -490,6 +491,7 @@ class Configuration {
 			'ldap_attr_role' => '',
 			'ldap_attr_headline' => '',
 			'ldap_attr_biography' => '',
+			'ldap_admin_group' => '',
 		];
 	}
 
@@ -566,6 +568,7 @@ class Configuration {
 			'ldap_attr_role' => 'ldapAttributeRole',
 			'ldap_attr_headline' => 'ldapAttributeHeadline',
 			'ldap_attr_biography' => 'ldapAttributeBiography',
+			'ldap_admin_group' => 'ldapAdminGroup',
 		];
 		return $array;
 	}

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -83,6 +83,7 @@ use Psr\Log\LoggerInterface;
  * @property string ldapAttributeRole
  * @property string ldapAttributeHeadline
  * @property string ldapAttributeBiography
+ * @property string ldapAdminGroup
  */
 class Connection extends LDAPUtility {
 	/**

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -51,6 +51,7 @@ use OCP\Cache\CappedMemoryCache;
 use OCP\Group\Backend\ABackend;
 use OCP\Group\Backend\IDeleteGroupBackend;
 use OCP\Group\Backend\IGetDisplayNameBackend;
+use OCP\Group\Backend\IIsAdminBackend;
 use OCP\GroupInterface;
 use OCP\IConfig;
 use OCP\IUserManager;
@@ -58,7 +59,7 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 use function json_decode;
 
-class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, IDeleteGroupBackend {
+class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, IDeleteGroupBackend, IIsAdminBackend {
 	protected bool $enabled = false;
 
 	/** @var CappedMemoryCache<string[]> $cachedGroupMembers array of user DN with gid as key */
@@ -1241,6 +1242,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 	public function implementsActions($actions): bool {
 		return (bool)((GroupInterface::COUNT_USERS |
 				GroupInterface::DELETE_GROUP |
+				GroupInterface::IS_ADMIN |
 				$this->groupPluginManager->getImplementedActions()) & $actions);
 	}
 
@@ -1443,5 +1445,19 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 		// $cacheKey = 'usersInGroup-' . $gid . '-' . $search . '-' . $limit . '-' . $offset;
 		// $cacheKey = 'usersInGroup-' . $gid . '-' . $search;
 		// $cacheKey = 'countUsersInGroup-' . $gid . '-' . $search;
+	}
+
+	/**
+	 * @throws ServerNotAvailableException
+	 */
+	public function isAdmin(string $uid): bool {
+		if (!$this->enabled) {
+			return false;
+		}
+		$ldapAdminGroup = $this->access->connection->ldapAdminGroup;
+		if ($ldapAdminGroup === '') {
+			return false;
+		}
+		return $this->inGroup($uid, $ldapAdminGroup);
 	}
 }

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -33,12 +33,13 @@ use OCP\Group\Backend\IBatchMethodsBackend;
 use OCP\Group\Backend\IDeleteGroupBackend;
 use OCP\Group\Backend\IGetDisplayNameBackend;
 use OCP\Group\Backend\IGroupDetailsBackend;
+use OCP\Group\Backend\IIsAdminBackend;
 use OCP\Group\Backend\INamedBackend;
 use OCP\GroupInterface;
 use OCP\IConfig;
 use OCP\IUserManager;
 
-class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend {
+class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend, IIsAdminBackend {
 	private $backends = [];
 	private ?Group_LDAP $refBackend = null;
 	private Helper $helper;
@@ -395,5 +396,9 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGet
 
 	public function addRelationshipToCaches(string $uid, ?string $dnUser, string $gid): void {
 		$this->handleRequest($gid, 'addRelationshipToCaches', [$uid, $dnUser, $gid]);
+	}
+
+	public function isAdmin(string $uid): bool {
+		return $this->handleRequest($uid, 'isAdmin', [$uid]);
 	}
 }

--- a/build/integration/ldap_features/openldap-numerical-id.feature
+++ b/build/integration/ldap_features/openldap-numerical-id.feature
@@ -66,3 +66,31 @@ Scenario: Test LDAP group membership with intermediate groups not matching filte
     | 50194 | 1 |
     | 59376 | 1 |
     | 59463 | 1 |
+
+Scenario: Test LDAP admin group mapping, empowered user
+  Given modify LDAP configuration
+    | ldapBaseGroups                | ou=NumericGroups,dc=nextcloud,dc=ci |
+    | ldapGroupFilter               | (objectclass=groupOfNames) |
+    | ldapGroupMemberAssocAttr      | member |
+    | ldapAdminGroup                | 3001   |
+    | useMemberOfToDetectMembership | 1 |
+  And cookies are reset
+  # alice, part of the promoted group
+  And Logging in using web as "92379"
+  And sending "GET" to "/cloud/groups"
+  And sending "GET" to "/cloud/groups/2000/users"
+  And Sending a "GET" to "/index.php/settings/admin/overview" with requesttoken
+  Then the HTTP status code should be "200"
+
+Scenario: Test LDAP admin group mapping, regular user (no access)
+    Given modify LDAP configuration
+      | ldapBaseGroups                | ou=NumericGroups,dc=nextcloud,dc=ci |
+      | ldapGroupFilter               | (objectclass=groupOfNames) |
+      | ldapGroupMemberAssocAttr      | member |
+      | ldapAdminGroup                | 3001   |
+      | useMemberOfToDetectMembership | 1 |
+    And cookies are reset
+    # gustaf, not part of the promoted group
+    And Logging in using web as "59376"
+    And Sending a "GET" to "/index.php/settings/admin/overview" with requesttoken
+    Then the HTTP status code should be "403"


### PR DESCRIPTION
* Resolves: #6428 

## Summary

Promotes an LDAP group (per LDAP configuration) to an admin group.

A group can either be promoted via a dedicates occ call whres the group parameter can be a nextcloud group ID or a group name that will be search against – an exact match is required in that case.:

```
$ php occ ldap:promote-group  --help 2>/dev/null
Description:
  declares the specified group as admin group (only one is possible per LDAP configuration)

Usage:
  ldap:promote-group [options] [--] <group>

Arguments:
  group                 the group ID in Nextcloud or a group name

Options:
  -y, --yes             do not ask for confirmation
…

# Example
$ php occ ldap:promote-group  "Nextcloud Admins"
Promote Nextcloud Admins to the admin group (y|N)? y
Group Nextcloud Admins was promoted

$ php occ ldap:promote-group  "Paramount Court"
Promote Nextcloud Admins to the admin group and demote Nextcloud Admins (Group ID: nextcloud_admins) (y|N)? y
Group Paramount Court was promoted

$ php occ ldap:promote-group  "Paramount Court"
The specified group is already promoted
```

It is also possible to set the admin group mapping using `occ ldap:set-config $configId ldapAdminGroup $groupId` but as the Nextcloud group ID might not be known (yet) it is especially recommnded for automatized setups to use this command, that would also pull in the group and determine the group ID.

In order to demote or reset a promotion, an empty string should be set against to the targeted config's ldapAdminGroup:

```
# Reset an admin group mapping via set-config
occ ldap:set-config $configId ldapAdminGroup ""
# Example
occ ldap:set-config s01 ldapAdminGroup ""
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
