### PR TITLE
feat(UserMenu): add target property to usermenu component

### DIFF
--- a/core/src/components/UserMenu/UserMenuEntry.vue
+++ b/core/src/components/UserMenu/UserMenuEntry.vue
@@ -25,6 +25,7 @@
 		class="menu-entry">
 		<a v-if="href"
 			:href="href"
+			:target="target"
 			:class="{ active }"
 			@click.exact="handleClick">
 			<NcLoadingIcon v-if="loading"
@@ -70,6 +71,10 @@ export default {
 		active: {
 			type: Boolean,
 			required: true,
+		},
+		target: {
+			type: String,
+			required: false,
 		},
 		icon: {
 			type: String,

--- a/core/src/views/UserMenu.vue
+++ b/core/src/views/UserMenu.vue
@@ -44,6 +44,7 @@
 				:key="entry.id"
 				:name="entry.name"
 				:href="entry.href"
+				:target="entry.target"
 				:active="entry.active"
 				:icon="entry.icon" />
 		</ul>

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -294,6 +294,7 @@ class NavigationManager implements INavigationManager {
 					'id' => 'admin_settings',
 					'order' => 4,
 					'href' => $this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'overview']),
+					'target' => '_blank',
 					'name' => $l->t('Administration settings'),
 					'icon' => $this->urlGenerator->imagePath('settings', 'admin.svg'),
 				]);

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -343,7 +343,8 @@ class NavigationManagerTest extends TestCase {
 				'active' => false,
 				'type' => 'settings',
 				'classes' => '',
-				'unread' => 0
+				'unread' => 0,
+				'target' => '_blank',
 			]
 		];
 


### PR DESCRIPTION
* Resolves: #41050

## Summary
Add target property to UserMenu and UserMenuEntry components and add target "_blank" to Administration settings

## TODO

- [x] Add target property to UserMenu and UserMenuEntry components
- [x] Add target "_blank" to admin_settings

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
