### PR TITLE
chore(settings): Cleanup IManager and Manager type annotations

### DIFF
--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -12,6 +12,7 @@
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author sualko <klaus@jsxc.org>
  * @author Carl Schwan <carl@carlschwan.eu>
+ * @author Kate Döen <kate.doeen@nextcloud.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -90,17 +91,14 @@ class Manager implements IManager {
 		$this->subAdmin = $subAdmin;
 	}
 
-	/** @var array */
+	/** @var array<self::SETTINGS_*, list<class-string<IIconSection>>> */
 	protected $sectionClasses = [];
 
-	/** @var array */
+	/** @var array<self::SETTINGS_*, array<string, IIconSection>> */
 	protected $sections = [];
 
 	/**
-	 * @param string $type 'admin' or 'personal'
-	 * @param string $section Class must implement OCP\Settings\IIconSection
-	 *
-	 * @return void
+	 * @inheritdoc
 	 */
 	public function registerSection(string $type, string $section) {
 		if (!isset($this->sectionClasses[$type])) {
@@ -111,7 +109,7 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @param string $type 'admin' or 'personal'
+	 * @psalm-param self::SETTINGS_* $type
 	 *
 	 * @return IIconSection[]
 	 */
@@ -149,6 +147,9 @@ class Manager implements IManager {
 		return $this->sections[$type];
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function getSection(string $type, string $sectionId): ?IIconSection {
 		if (isset($this->sections[$type]) && isset($this->sections[$type][$sectionId])) {
 			return $this->sections[$type][$sectionId];
@@ -163,27 +164,23 @@ class Manager implements IManager {
 		], true);
 	}
 
-	/** @var array */
+	/** @var array<class-string<ISettings>, self::SETTINGS_*> */
 	protected $settingClasses = [];
 
-	/** @var array */
+	/** @var array<self::SETTINGS_*, array<string, list<ISettings>>> */
 	protected $settings = [];
 
 	/**
-	 * @psam-param 'admin'|'personal' $type The type of the setting.
-	 * @param string $setting Class must implement OCP\Settings\ISettings
-	 * @param bool $allowedDelegation
-	 *
-	 * @return void
+	 * @inheritdoc
 	 */
 	public function registerSetting(string $type, string $setting) {
 		$this->settingClasses[$setting] = $type;
 	}
 
 	/**
-	 * @param string $type 'admin' or 'personal'
+	 * @psalm-param self::SETTINGS_* $type The type of the setting.
 	 * @param string $section
-	 * @param Closure $filter optional filter to apply on all loaded ISettings
+	 * @param ?Closure $filter optional filter to apply on all loaded ISettings
 	 *
 	 * @return ISettings[]
 	 */
@@ -258,7 +255,7 @@ class Manager implements IManager {
 	/**
 	 * @inheritdoc
 	 */
-	public function getAdminSettings($section, bool $subAdminOnly = false): array {
+	public function getAdminSettings(string $section, bool $subAdminOnly = false): array {
 		if ($subAdminOnly) {
 			$subAdminSettingsFilter = function (ISettings $settings) {
 				return $settings instanceof ISubAdminSettings;
@@ -329,7 +326,7 @@ class Manager implements IManager {
 	/**
 	 * @inheritdoc
 	 */
-	public function getPersonalSettings($section): array {
+	public function getPersonalSettings(string $section): array {
 		$settings = [];
 		$appSettings = $this->getSettings('personal', $section);
 
@@ -344,6 +341,9 @@ class Manager implements IManager {
 		return $settings;
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function getAllowedAdminSettings(string $section, IUser $user): array {
 		$isAdmin = $this->groupManager->isAdmin($user->getUID());
 		if ($isAdmin) {
@@ -375,6 +375,9 @@ class Manager implements IManager {
 		return $settings;
 	}
 
+	/**
+	 * @inheritdoc
+	 */
 	public function getAllAllowedAdminSettings(IUser $user): array {
 		$this->getSettings('admin', ''); // Make sure all the settings are loaded
 		$settings = [];

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -6,6 +6,7 @@
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Kate Döen <kate.doeen@nextcloud.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -34,34 +35,48 @@ use OCP\IUser;
 interface IManager {
 	/**
 	 * @since 9.1.0
+	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
 	 */
 	public const KEY_ADMIN_SETTINGS = 'admin';
 
 	/**
 	 * @since 9.1.0
+	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
 	 */
 	public const KEY_ADMIN_SECTION = 'admin-section';
 
 	/**
 	 * @since 13.0.0
+	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
 	 */
 	public const KEY_PERSONAL_SETTINGS = 'personal';
 
 	/**
 	 * @since 13.0.0
+	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
 	 */
 	public const KEY_PERSONAL_SECTION = 'personal-section';
 
 	/**
-	 * @param string $type 'admin-section' or 'personal-section'
-	 * @param string $section Class must implement OCP\Settings\ISection
+	 * @since 29.0.0
+	 */
+	public const SETTINGS_ADMIN = 'admin';
+
+	/**
+	 * @since 29.0.0
+	 */
+	public const SETTINGS_PERSONAL = 'personal';
+
+	/**
+	 * @psalm-param self::SETTINGS_* $type
+	 * @param class-string<IIconSection> $section
 	 * @since 14.0.0
 	 */
 	public function registerSection(string $type, string $section);
 
 	/**
-	 * @param string $type 'admin' or 'personal'
-	 * @param string $setting Class must implement OCP\Settings\ISettings
+	 * @psalm-param self::SETTINGS_* $type
+	 * @param class-string<ISettings> $setting
 	 * @since 14.0.0
 	 */
 	public function registerSetting(string $type, string $setting);
@@ -69,7 +84,7 @@ interface IManager {
 	/**
 	 * returns a list of the admin sections
 	 *
-	 * @return array<int, array<int, IIconSection>> array from IConSection[] where key is the priority
+	 * @return array<int, list<IIconSection>> list of sections with priority as key
 	 * @since 9.1.0
 	 */
 	public function getAdminSections(): array;
@@ -77,7 +92,7 @@ interface IManager {
 	/**
 	 * returns a list of the personal sections
 	 *
-	 * @return array array of ISection[] where key is the priority
+	 * @return array<int, list<IIconSection>> list of sections with priority as key
 	 * @since 13.0.0
 	 */
 	public function getPersonalSections(): array;
@@ -87,10 +102,10 @@ interface IManager {
 	 *
 	 * @param string $section the section id for which to load the settings
 	 * @param bool $subAdminOnly only return settings sub admins are supposed to see (since 17.0.0)
-	 * @return array<int, array<int, ISettings>> array of ISettings[] where key is the priority
+	 * @return array<int, list<ISettings>> list of settings with priority as key
 	 * @since 9.1.0
 	 */
-	public function getAdminSettings($section, bool $subAdminOnly = false): array;
+	public function getAdminSettings(string $section, bool $subAdminOnly = false): array;
 
 	/**
 	 * Returns a list of admin settings that the given user can use for the give section
@@ -103,7 +118,7 @@ interface IManager {
 	/**
 	 * Returns a list of admin settings that the given user can use.
 	 *
-	 * @return array<int, list<ISettings>> The array of admin settings there admin delegation is allowed.
+	 * @return list<ISettings> The array of admin settings there admin delegation is allowed.
 	 * @since 23.0.0
 	 */
 	public function getAllAllowedAdminSettings(IUser $user): array;
@@ -112,13 +127,14 @@ interface IManager {
 	 * returns a list of the personal  settings
 	 *
 	 * @param string $section the section id for which to load the settings
-	 * @return array array of ISettings[] where key is the priority
+	 * @return array<int, list<ISettings>> list of settings with priority as key
 	 * @since 13.0.0
 	 */
-	public function getPersonalSettings($section): array;
+	public function getPersonalSettings(string $section): array;
 
 	/**
 	 * Get a specific section by type and id
+	 * @psalm-param self::SETTINGS_* $type
 	 * @since 25.0.0
 	 */
 	public function getSection(string $type, string $sectionId): ?IIconSection;


### PR DESCRIPTION
## Summary

Use correct types everywhere in IManager and Manager of Settings.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
