### PR TITLE
fix(reminder): Fix app version and requirement for files_reminder app

### DIFF
--- a/apps/files_reminders/appinfo/info.xml
+++ b/apps/files_reminders/appinfo/info.xml
@@ -8,7 +8,7 @@
 
 Set file reminders.
 	]]></description>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<licence>agpl</licence>
 	<author>Christopher Ng</author>
 	<namespace>FilesReminders</namespace>
@@ -18,7 +18,7 @@ Set file reminders.
 	<bugs>https://github.com/nextcloud/server/issues</bugs>
 
 	<dependencies>
-		<nextcloud min-version="27" max-version="28" />
+		<nextcloud min-version="28" max-version="28" />
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
By accident master and stable27 have the same app version and non-strict requirements on the server version.
For shipped apps the requirement must be 1-1 and the version must be bumped, so potential followup migrations can be executed on different branches

https://github.com/nextcloud/server/blob/master/apps/files_reminders/appinfo/info.xml#L11
https://github.com/nextcloud/server/blob/stable27/apps/files_reminders/appinfo/info.xml#L11


https://github.com/nextcloud/server/blob/master/apps/files_reminders/appinfo/info.xml#L21
https://github.com/nextcloud/server/blob/stable27/apps/files_reminders/appinfo/info.xml#L21