### PR TITLE
fix(cypress): Adjust cypress tests that relied on version to be 28

### DIFF
--- a/cypress/e2e/theming/navigation-bar-settings.cy.ts
+++ b/cypress/e2e/theming/navigation-bar-settings.cy.ts
@@ -89,6 +89,7 @@ describe('Admin theming set default apps', () => {
 	})
 
 	it('See the default app is changed back to default', () => {
+		cy.reload()
 		cy.get('#nextcloud').click()
 		cy.url().should('match', /apps\/dashboard/)
 	})

--- a/cypress/support/commonUtils.ts
+++ b/cypress/support/commonUtils.ts
@@ -45,7 +45,7 @@ export function installTestApp() {
 		const version = output.stdout.match(/(\d\d+)\.\d+\.\d+/)?.[1]
 		cy.wrap(version).should('not.be.undefined')
 		cy.exec(`docker cp '${testAppPath}' nextcloud-cypress-tests-server:/var/www/html/apps`, { log: true })
-		cy.exec(`docker exec nextcloud-cypress-tests-server sed -i 's|version="[0-9]+|version="${version}|' apps/testapp/appinfo/info.xml`)
+		cy.exec(`docker exec nextcloud-cypress-tests-server sed -i -e 's|-version="[0-9]\\+|-version="${version}|g' apps/testapp/appinfo/info.xml`)
 		cy.runOccCommand('app:enable testapp')
 	})
 }


### PR DESCRIPTION
## Summary

Make cypress green again.
The sed syntax for adjusting the test app version was wrong, casing the tests to fail because of "not supported app".

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
