### PR TITLE
fix(dav): Avoid date diffing if PHP is buggy

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/Notifier.php
+++ b/apps/dav/lib/CalDAV/Reminder/Notifier.php
@@ -170,18 +170,32 @@ class Notifier implements INotifier {
 			$components[] = $this->l10n->n('%n minute', '%n minutes', $diff->i);
 		}
 
-		// Limiting to the first three components to prevent
-		// the string from getting too long
-		$firstThreeComponents = array_slice($components, 0, 2);
-		$diffLabel = implode(', ', $firstThreeComponents);
+		if (!$this->hasPhpDatetimeDiffBug()) {
+			// Limiting to the first three components to prevent
+			// the string from getting too long
+			$firstThreeComponents = array_slice($components, 0, 2);
+			$diffLabel = implode(', ', $firstThreeComponents);
 
-		if ($diff->invert) {
-			$title = $this->l10n->t('%s (in %s)', [$title, $diffLabel]);
-		} else {
-			$title = $this->l10n->t('%s (%s ago)', [$title, $diffLabel]);
+			if ($diff->invert) {
+				$title = $this->l10n->t('%s (in %s)', [$title, $diffLabel]);
+			} else {
+				$title = $this->l10n->t('%s (%s ago)', [$title, $diffLabel]);
+			}
 		}
 
 		$notification->setParsedSubject($title);
+	}
+
+	/**
+	 * @see https://github.com/nextcloud/server/issues/41615
+	 * @see https://github.com/php/php-src/issues/9699
+	 */
+	private function hasPhpDatetimeDiffBug(): bool {
+		$d1 = DateTime::createFromFormat(\DateTimeInterface::ATOM, '2023-11-22T11:52:00+01:00');
+		$d2 = new DateTime('2023-11-22T10:52:03', new \DateTimeZone('UTC'));
+
+		// The difference is 3 seconds, not -1year+11months+…
+		return $d1->diff($d2)->y < 0;
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/41615

## Summary

PHP<8.1.10 had a bug where the diff of two datetime objects results in garbage. Doing our own date diffing is hard, so we are just hiding the relative date in this specific case.

This is only an issue for Nextcloud because the PHP version shipped with current ubuntu LTS is affected by this.

## Screenshots

| Before | After | Unaffected installations before+after |
|--------|--------|--------|
| ![Bildschirmfoto vom 2023-11-24 09-42-34](https://github.com/nextcloud/server/assets/1374172/2ac9695b-9fb4-4fbd-b63d-7130ae169cc3) | ![Bildschirmfoto vom 2023-11-24 09-41-33](https://github.com/nextcloud/server/assets/1374172/73e63ee4-95b2-41c5-96da-c1715ee7074a) | ![image](https://github.com/nextcloud/server/assets/1374172/e17760be-00e1-415f-8723-594fa74109dc) |

Before is faked because I don't have the bug locally thanks to a maintained PHP version on Arch.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
