### PR TITLE
Enable new global search by default

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -108,11 +108,8 @@ class TemplateLayout extends \OC_Template {
 
 			$this->initialState->provideInitialState('core', 'active-app', $this->navigationManager->getActiveEntry());
 			$this->initialState->provideInitialState('core', 'apps', $this->navigationManager->getAll());
-			/*
-			 * NB : Unified search enabled, defaults to true since new advanced search is
-			 * unstable. Once we think otherwise, the default should be false.
-			 */
-			if ($this->config->getSystemValueBool('unified_search.enabled', true)) {
+			
+			if ($this->config->getSystemValueBool('unified_search.enabled', false)) {
 				$this->initialState->provideInitialState('unified-search', 'limit-default', (int)$this->config->getAppValue('core', 'unified-search.limit-default', (string)SearchQuery::LIMIT_DEFAULT));
 				$this->initialState->provideInitialState('unified-search', 'min-search-length', (int)$this->config->getAppValue('core', 'unified-search.min-search-length', (string)1));
 				$this->initialState->provideInitialState('unified-search', 'live-search', $this->config->getAppValue('core', 'unified-search.live-search', 'yes') === 'yes');


### PR DESCRIPTION
The new global search would now be activated by default and users, have the option to revert to the old unified search by setting `unified_search.enabled` to true in the NC `config.php` file.