### PR TITLE
gs.federation.auto_accept_shares

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -301,6 +301,10 @@ class Manager {
 		$updateResult->closeCursor();
 	}
 
+	public function initUserId(string $userId): void {
+		$this->uid = $userId;
+	}
+
 	/**
 	 * accept server-to-server share
 	 *


### PR DESCRIPTION
This add the system config parameter `gs.federation.auto_accept_shares` (bool, default to `false`) that bypass the recipient's confirmation request.

Usefull in globalscale setup, however it does not filters shares from federated instance from outside the globalscale network.