### PR TITLE
fix(files_versions): Check for user and owner before call getUserFolder

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -59,11 +59,10 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class FileEventsListener implements IEventListener {
-	private IRootFolder $rootFolder;
-	private IVersionManager $versionManager;
 	/**
 	 * @var array<int, array>
 	 */
@@ -76,19 +75,14 @@ class FileEventsListener implements IEventListener {
 	 * @var array<string, Node>
 	 */
 	private array $versionsDeleted = [];
-	private IMimeTypeLoader $mimeTypeLoader;
-	private LoggerInterface $logger;
 
 	public function __construct(
-		IRootFolder $rootFolder,
-		IVersionManager $versionManager,
-		IMimeTypeLoader $mimeTypeLoader,
-		LoggerInterface $logger,
+		private IRootFolder $rootFolder,
+		private IVersionManager $versionManager,
+		private IMimeTypeLoader $mimeTypeLoader,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
 	) {
-		$this->rootFolder = $rootFolder;
-		$this->versionManager = $versionManager;
-		$this->mimeTypeLoader = $mimeTypeLoader;
-		$this->logger = $logger;
 	}
 
 	public function handle(Event $event): void {
@@ -354,18 +348,20 @@ class FileEventsListener implements IEventListener {
 	 * If no user is connected, try to use the node's owner.
 	 */
 	private function getPathForNode(Node $node): ?string {
-		try {
+		$user = $this->userSession->getUser()?->getUID();
+		if ($user) {
 			return $this->rootFolder
-				->getUserFolder(\OC_User::getUser())
-				->getRelativePath($node->getPath());
-		} catch (\Throwable $ex) {
-			$owner = $node->getOwner();
-			if ($owner === null) {
-				return null;
-			}
-			return $this->rootFolder
-				->getUserFolder($owner->getUid())
+				->getUserFolder($user)
 				->getRelativePath($node->getPath());
 		}
+
+		$owner = $node->getOwner()?->getUid();
+		if ($owner) {
+			return $this->rootFolder
+				->getUserFolder($owner)
+				->getRelativePath($node->getPath());
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
Explicitly check both values to avoid `false` or `null` values being passed to `getUserFolder()` calls.

```
[files] Error: OC\User\NoUserException: Backends provided no user object at <<closure>>

 0. <<closure>>
    OC\Files\Node\Root->getUserFolder(false)
 1. /var/www/nextcloud/lib/private/Files/Node/LazyFolder.php line 73
    call_user_func_array([["OC\\Files\\No ... "], [false])
 2. /var/www/nextcloud/lib/private/Files/Node/LazyRoot.php line 40
    OC\Files\Node\LazyFolder->__call("getUserFolder", [false])
 3. /var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php line 357
    OC\Files\Node\LazyRoot->getUserFolder(false)
...
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
