### PR TITLE
fix(settings): fix l10n->t signature call in PhpMemoryLimit setup check

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpMemoryLimit.php
+++ b/apps/settings/lib/SetupChecks/PhpMemoryLimit.php
@@ -51,7 +51,7 @@ class PhpMemoryLimit implements ISetupCheck {
 		if ($this->memoryInfo->isMemoryLimitSufficient()) {
 			return SetupResult::success(Util::humanFileSize($this->memoryInfo->getMemoryLimit()));
 		} else {
-			return SetupResult::error($this->l10n->t('The PHP memory limit is below the recommended value of %s.'), Util::humanFileSize(MemoryInfo::RECOMMENDED_MEMORY_LIMIT));
+			return SetupResult::error($this->l10n->t('The PHP memory limit is below the recommended value of %s.', Util::humanFileSize(MemoryInfo::RECOMMENDED_MEMORY_LIMIT)));
 		}
 	}
 }


### PR DESCRIPTION
Parenthesis in the wrong place

Fixes:
```
{                                                                                                                                                                                                                                                                                                                             
  "reqId": "cy78x3iX3qaxB33cjH9Y",                                                                                                                                                                                                                                                                                            
  "level": 3,                                                                                                                                                                                                                                                                                                                 
  "time": "2023-11-26T15:30:49+00:00",                                                                                                                                                                                                                                                                                        
  "remoteAddr": "",                                                                                                                                                                                                                                                                                  
  "user": "tcit",                                                                                                                                                                                                                                                                                                             
  "app": "index",                                                                                                                                                                                                                                                                                                             
  "method": "GET",                                                                                                                                                                                                                                                                                                            
  "url": "/settings/ajax/checksetup",                                                                                                                                                                                                                                                                                         
  "message": "The arguments array must contain 1 items, 0 given in file '/var/www/nextcloud/lib/private/L10N/L10NString.php' line 88",                                                                                                                                                                                        
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",                                                                                                                                                                                                                                      
  "version": "28.0.0.7",                                                                                                                                                                                                                                                                                                      
  "exception": {                                                                                                                                                                                                                                                                                                              
    "Exception": "Exception",                                   
    "Message": "The arguments array must contain 1 items, 0 given in file '/var/www/nextcloud/lib/private/L10N/L10NString.php' line 88",
    "Code": 0,
    "Trace": [
      {                                                                                                                                                        
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 184,           
        "function": "dispatch",                        
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->"
      }, 
      {                                                                                                                                                        
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 315,          
        "function": "main",                                          
        "class": "OC\\AppFramework\\App",
        "type": "::"
      }, 
      {                                                                                                                                                        
        "file": "/var/www/nextcloud/lib/base.php",
        "line": 1069,                     
        "function": "match",                            
        "class": "OC\\Route\\Router",
        "type": "->"
      }, 
      {                                                                 
        "file": "/var/www/nextcloud/index.php",
        "line": 37,              
        "function": "handleRequest",                    
        "class": "OC",
        "type": "::"
      }  
    ],                                                              
    "File": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
    "Line": 169,             
    "Previous": {                          
      "Exception": "ValueError",
      "Message": "The arguments array must contain 1 items, 0 given",
      "Code": 0,
      "Trace": [                                    
        {              
          "file": "/var/www/nextcloud/lib/private/L10N/L10NString.php",
          "line": 88,                  
          "function": "vsprintf"
        },
        {
          "file": "/var/www/nextcloud/lib/private/L10N/L10N.php",
          "line": 105,
          "function": "__toString",   
          "class": "OC\\L10N\\L10NString",
          "type": "->"
        },
        {                                                                                                                                                                                                                                                                                                                     
          "file": "/var/www/nextcloud/lib/private/L10N/LazyL10N.php",                                                                                                                                                                                                                                                         
          "line": 51,                                                                                                                                                                                                                                                                                                         
          "function": "t",                                                                                                                                                                                                                                                                                                    
          "class": "OC\\L10N\\L10N",                                                                                                                                                                                                                                                                                          
          "type": "->"                                                                                                                                                                                                                                                                                                        
        },                                                                                                                                                                                                                                                                                                                    
        {                                                                                                                                                                                                                                                                                                                     
          "file": "/var/www/nextcloud/apps/settings/lib/SetupChecks/PhpMemoryLimit.php",                                                                                                                                                                                                                                      
          "line": 54,                                                                                                                                                                                                                                                                                                         
          "function": "t",                                                                                                                                                                                                                                                                                                    
          "class": "OC\\L10N\\LazyL10N",                                                                                                                                                                                                                                                                                      
          "type": "->"                                                                                                                                                                                                                                                                                                        
        },   
        {
          "file": "/var/www/nextcloud/lib/private/SetupCheck/SetupCheckManager.php",
          "line": 49,
          "function": "run",
          "class": "OCA\\Settings\\SetupChecks\\PhpMemoryLimit",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/apps/settings/lib/Controller/CheckSetupController.php",
          "line": 719,
          "function": "runAll",
          "class": "OC\\SetupCheck\\SetupCheckManager",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 230,
          "function": "check",
          "class": "OCA\\Settings\\Controller\\CheckSetupController",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 137,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
          "line": 184,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/lib/private/Route/Router.php",
          "line": 315,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::"
        },
        {
          "file": "/var/www/nextcloud/lib/base.php",
          "line": 1069,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->"
        },
        {
          "file": "/var/www/nextcloud/index.php",
          "line": 37,
          "function": "handleRequest",
          "class": "OC",
          "type": "::"
        }
      ],
      "File": "/var/www/nextcloud/lib/private/L10N/L10NString.php",
      "Line": 88
    },
    "message": "The arguments array must contain 1 items, 0 given in file '/var/www/nextcloud/lib/private/L10N/L10NString.php' line 88",
    "exception": {},
    "CustomMessage": "The arguments array must contain 1 items, 0 given in file '/var/www/nextcloud/lib/private/L10N/L10NString.php' line 88"
  }
}
