### PR TITLE
fix(files_external): Fix "Could not find resource main.js to load"

### DIFF
--- a/apps/files_external/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_external/lib/Listener/LoadAdditionalListener.php
@@ -53,6 +53,5 @@ class LoadAdditionalListener implements IEventListener {
 		$this->initialState->provideInitialState('allowUserMounting', $allowUserMounting);
 
 		Util::addInitScript(Application::APP_ID, 'init');
-		Util::addScript(Application::APP_ID, 'main', 'files');
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Seems to be the init script which is imported directly before:
https://github.com/nextcloud/server/commits/a5a8655bebb8652206ea5aa886699f706739e1fe/apps/files_external/src/init.ts

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
