### PR TITLE
[stable24] fix(dav): Name properties table columns explicitly

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -234,7 +234,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		}
 
 		$qb = $this->connection->getQueryBuilder();
-		$qb->select('*')
+		$qb->select('id', 'userid', 'propertypath', 'propertyname', 'propertyvalue')
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('propertypath', $qb->createNamedParameter($path)));
 		$result = $qb->executeQuery();
@@ -263,7 +263,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		}
 
 		// TODO: chunking if more than 1000 properties
-		$sql = 'SELECT * FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ?';
+		$sql = 'SELECT id, userid, propertypath, propertyname, propertyvalue FROM `*PREFIX*properties` WHERE `userid` = ? AND `propertypath` = ?';
 
 		$whereValues = [$this->user->getUID(), $this->formatPath($path)];
 		$whereTypes = [null, null];


### PR DESCRIPTION
* Ref https://github.com/nextcloud/server/pull/30368#issuecomment-1152462916

## Summary

And ignore any optional columns. This allows instances to run the expensive query for the new column in 25 in the background, while keeping the 24 installation live.

## TODO

- [x] Make changes
- [ ] Test changes

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
