### PR TITLE
[stable23] fix: Only throttle on invalid requests for public share links

### DIFF
--- a/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
+++ b/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
@@ -77,6 +77,8 @@ class PublicShareMiddleware extends Middleware {
 		$controller->setToken($token);
 
 		if (!$controller->isValidToken()) {
+			$this->throttle($bruteforceProtectionAction, $token);
+
 			$controller->shareNotFound();
 			throw new NotFoundException();
 		}
@@ -88,7 +90,6 @@ class PublicShareMiddleware extends Middleware {
 
 		// If authentication succeeds just continue
 		if ($controller->isAuthenticated()) {
-			$this->throttle($bruteforceProtectionAction, $token);
 			return;
 		}
 


### PR DESCRIPTION
Fix a false backport from https://github.com/nextcloud/server/pull/35652 where the throttle happened on the success case instead of when the token is invalid

On stable24 and later this is correct 

https://github.com/nextcloud/server/blob/5b08f8481c7520b509f9d51d9adfda6caad44171/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php#L80C1-L95