### PR TITLE
fix(TextProcessing): Add task type template param to IManager and registerTPProvider

### DIFF
--- a/lib/public/TextProcessing/IProvider.php
+++ b/lib/public/TextProcessing/IProvider.php
@@ -31,7 +31,7 @@ use RuntimeException;
 /**
  * This is the interface that is implemented by apps that
  * implement a text processing provider
- * @template T of ITaskType
+ * @psalm-template-covariant  T of ITaskType
  * @since 27.1.0
  */
 interface IProvider {

--- a/lib/public/TextProcessing/Task.php
+++ b/lib/public/TextProcessing/Task.php
@@ -28,9 +28,7 @@ namespace OCP\TextProcessing;
 /**
  * This is a text processing task
  * @since 27.1.0
- * @psalm-template T of ITaskType
- * @psalm-template S as class-string<T>
- * @psalm-template P as IProvider<T>
+ * @psalm-template-covariant T of ITaskType
  */
 final class Task implements \JsonSerializable {
 	protected ?int $id = null;
@@ -74,7 +72,7 @@ final class Task implements \JsonSerializable {
 	protected int $status = self::STATUS_UNKNOWN;
 
 	/**
-	 * @psalm-param S $type
+	 * @psalm-param class-string<T> $type
 	 * @param string $type
 	 * @param string $input
 	 * @param string $appId
@@ -92,7 +90,7 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-param P $provider
+	 * @psalm-param IProvider<T> $provider
 	 * @param IProvider $provider
 	 * @return string
 	 * @since 27.1.0
@@ -109,7 +107,7 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-param P $provider
+	 * @psalm-param IProvider<T> $provider
 	 * @param IProvider $provider
 	 * @return bool
 	 * @since 27.1.0
@@ -119,7 +117,7 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-return S
+	 * @psalm-return class-string<T>
 	 * @since 27.1.0
 	 */
 	final public function getType(): string {
@@ -207,7 +205,7 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-return array{id: ?int, type: S, status: 0|1|2|3|4, userId: ?string, appId: string, input: string, output: ?string, identifier: string, completionExpectedAt: ?int}
+	 * @psalm-return array{id: ?int, type: class-string<T>, status: 0|1|2|3|4, userId: ?string, appId: string, input: string, output: ?string, identifier: string, completionExpectedAt: ?int}
 	 * @since 27.1.0
 	 */
 	public function jsonSerialize(): array {


### PR DESCRIPTION
otherwise we cannot use them reasonably

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
