### PR TITLE
fix(dav): Prioritize timezone from core/login

### DIFF
--- a/apps/dav/lib/CalDAV/TimezoneService.php
+++ b/apps/dav/lib/CalDAV/TimezoneService.php
@@ -42,6 +42,15 @@ class TimezoneService {
 	}
 
 	public function getUserTimezone(string $userId): ?string {
+		$fromConfig = $this->config->getUserValue(
+			$userId,
+			'core',
+			'timezone',
+		);
+		if ($fromConfig !== '') {
+			return $fromConfig;
+		}
+
 		$availabilityPropPath = 'calendars/' . $userId . '/inbox';
 		$availabilityProp = '{' . Plugin::NS_CALDAV . '}calendar-availability';
 		$availabilities = $this->propertyMapper->findPropertyByPathAndName($userId, $availabilityPropPath, $availabilityProp);

--- a/apps/dav/tests/unit/CalDAV/TimezoneServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/TimezoneServiceTest.php
@@ -78,7 +78,22 @@ class TimezoneServiceTest extends TestCase {
 		);
 	}
 
+	public function testGetUserTimezoneFromSettings(): void {
+		$this->config->expects(self::once())
+			->method('getUserValue')
+			->with('test123', 'core', 'timezone', '')
+			->willReturn('Europe/Warsaw');
+
+		$timezone = $this->service->getUserTimezone('test123');
+
+		self::assertSame('Europe/Warsaw', $timezone);
+	}
+
 	public function testGetUserTimezoneFromAvailability(): void {
+		$this->config->expects(self::once())
+			->method('getUserValue')
+			->with('test123', 'core', 'timezone', '')
+			->willReturn('');
 		$property = new Property();
 		$property->setPropertyvalue('BEGIN:VCALENDAR
 PRODID:Nextcloud DAV app
@@ -99,10 +114,12 @@ END:VCALENDAR');
 	}
 
 	public function testGetUserTimezoneFromPersonalCalendar(): void {
-		$this->config->expects(self::once())
+		$this->config->expects(self::exactly(2))
 			->method('getUserValue')
-			->with('test123', 'dav', 'defaultCalendar')
-			->willReturn('personal-1');
+			->willReturnMap([
+				['test123', 'core', 'timezone', '', ''],
+				['test123', 'dav', 'defaultCalendar', '', 'personal-1'],
+			]);
 		$other = $this->createMock(ICalendar::class);
 		$other->method('getUri')->willReturn('other');
 		$personal = $this->createMock(CalendarImpl::class);
@@ -126,10 +143,12 @@ END:VCALENDAR');
 	}
 
 	public function testGetUserTimezoneFromAny(): void {
-		$this->config->expects(self::once())
+		$this->config->expects(self::exactly(2))
 			->method('getUserValue')
-			->with('test123', 'dav', 'defaultCalendar')
-			->willReturn('personal-1');
+			->willReturnMap([
+				['test123', 'core', 'timezone', '', ''],
+				['test123', 'dav', 'defaultCalendar', '', 'personal-1'],
+			]);
 		$other = $this->createMock(ICalendar::class);
 		$other->method('getUri')->willReturn('other');
 		$personal = $this->createMock(CalendarImpl::class);


### PR DESCRIPTION
## Summary

The DAV app tries to guess a user's timezone from the calendar timezones and the availability settings. It turns out Nextcloud already tracks a timezone, set when a user logs in. Let's use that as primary source, then fall back to calendar timezones and availability timezone.

## How to test

1) Set your calendar timezones to your home timezone
2) Travel to a different timezone
3) Log in
4) Use code that accesses the timezone server

Master: calendar timezone is used
Here: login timezone is used

In the long run we should probably only *set*, not *update* the timezone at login, and make the timezone configurable via the personal settings.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
