### PR TITLE
fix: change mime type for msg file

### DIFF
--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -240,7 +240,7 @@ class RepairMimeTypes implements IRepairStep {
 	private function introduceEmlAndMsgFormatType() {
 		$updatedMimetypes = [
 			'eml' => 'message/rfc822',
-			'msg' => 'application/x-ole-storage',
+			'msg' => 'application/vnd.ms-outlook',
 		];
 
 		return $this->updateMimetypes($updatedMimetypes);
@@ -307,7 +307,7 @@ class RepairMimeTypes implements IRepairStep {
 			$out->info('Fixed Enhanced Metafile Format mime types');
 		}
 
-		if (version_compare($ocVersionFromBeforeUpdate, '29.0.0.1', '<') && $this->introduceEmlAndMsgFormatType()) {
+		if (version_compare($ocVersionFromBeforeUpdate, '29.0.0.2', '<') && $this->introduceEmlAndMsgFormatType()) {
 			$out->info('Fixed eml and msg mime type');
 		}
 	}

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -123,7 +123,7 @@
 	"mpeg": ["video/mpeg"],
 	"mpg": ["video/mpeg"],
 	"mpo": ["image/jpeg"],
-	"msg": ["application/x-ole-storage", "text/plain"],
+	"msg": ["application/vnd.ms-outlook"],
 	"msi": ["application/x-msi"],
 	"mt2s": ["video/MP2T"],
 	"mts": ["video/MP2T"],

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [29, 0, 0, 1];
+$OC_Version = [29, 0, 0, 2];
 
 // The human-readable string
 $OC_VersionString = '29.0.0 dev';


### PR DESCRIPTION
For https://github.com/nextcloud/files_emailviewer/issues/1

Follow-up for https://github.com/nextcloud/server/pull/41803

## Summary

Change the mime type to a more specific one. 

## TODO

- [x] CI
- [x] Backport 28

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
