### PR TITLE
add a debug option to force a full filesystem setup

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -80,6 +80,7 @@ class SetupManager {
 	private bool $listeningForProviders;
 	private array $fullSetupRequired = [];
 	private bool $setupBuiltinWrappersDone = false;
+	private bool $forceFullSetup = false;
 
 	public function __construct(
 		private IEventLogger $eventLogger,
@@ -97,6 +98,7 @@ class SetupManager {
 	) {
 		$this->cache = $cacheFactory->createDistributed('setupmanager::');
 		$this->listeningForProviders = false;
+		$this->forceFullSetup = $this->config->getSystemValueBool('debug.force-full-fs-setup');
 
 		$this->setupListeners();
 	}
@@ -470,6 +472,10 @@ class SetupManager {
 	}
 
 	private function fullSetupRequired(IUser $user): bool {
+		if ($this->forceFullSetup) {
+			return true;
+		}
+
 		// we perform a "cached" setup only after having done the full setup recently
 		// this is also used to trigger a full setup after handling events that are likely
 		// to change the available mounts


### PR DESCRIPTION
Make it easier to debug whether filesystem related issues are caused by the "minimal filesystem setup" optimization.