### PR TITLE
perf: Use more performant way to obtain and check the email as a login name with token login

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -44,6 +44,7 @@ use OC\Authentication\Listeners\UserDeletedWebAuthnCleanupListener;
 use OC\Authentication\Notifications\Notifier as AuthenticationNotifier;
 use OC\Core\Listener\BeforeTemplateRenderedListener;
 use OC\Core\Notification\CoreNotifier;
+use OC\SystemConfig;
 use OC\TagManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
@@ -81,6 +82,7 @@ class Application extends App {
 		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(AddMissingIndicesEvent::class, function (AddMissingIndicesEvent $event) {
+			$dbType = $this->getContainer()->get(SystemConfig::class)->getSystemValue('dbtype', 'sqlite');
 			$event->addMissingIndex(
 				'share',
 				'share_with_index',
@@ -236,6 +238,15 @@ class Application extends App {
 				'preferences_app_key',
 				['appid', 'configkey']
 			);
+
+			if ($dbType !== 'oci') {
+				$event->addMissingIndex(
+					'preferences',
+					'preferences_configvalue',
+					['configvalue'],
+					['lengths' => [80]]
+				);
+			}
 
 			$event->addMissingIndex(
 				'mounts',

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Core\Migrations;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
@@ -332,6 +333,9 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['userid', 'appid', 'configkey']);
 			$table->addIndex(['appid', 'configkey'], 'preferences_app_key');
+			if (!$this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+				$table->addIndex(['configvalue'], 'preferences_configvalue', [], ['lengths' => [80]]);
+			}
 		}
 
 		if (!$schema->hasTable('properties')) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -456,8 +456,17 @@ class Session implements IUserSession, Emitter {
 				$this->handleLoginFailed($throttler, $currentDelay, $remoteAddress, $user, $password);
 				return false;
 			}
-			$users = $this->manager->getByEmail($user);
-			if (!(\count($users) === 1 && $this->login($users[0]->getUID(), $password))) {
+
+			if ($isTokenPassword) {
+				$dbToken = $this->tokenProvider->getToken($password);
+				$userFromToken = $this->manager->get($dbToken->getUID());
+				$isValidEmailLogin = $userFromToken->getEMailAddress() === $user;
+			} else {
+				$users = $this->manager->getByEmail($user);
+				$isValidEmailLogin = (\count($users) === 1 && $this->login($users[0]->getUID(), $password));
+			}
+
+			if (!$isValidEmailLogin) {
 				$this->handleLoginFailed($throttler, $currentDelay, $remoteAddress, $user, $password);
 				return false;
 			}

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1110,7 +1110,7 @@ class SessionTest extends \Test\TestCase {
 
 		$userSession->expects($this->once())
 			->method('isTokenPassword')
-			->willReturn(true);
+			->willReturn(false);
 		$userSession->expects($this->once())
 			->method('login')
 			->with('john@foo.bar', 'I-AM-AN-PASSWORD')


### PR DESCRIPTION
[UserManager::getByEmail](https://github.com/nextcloud/server/blob/bcc1d57a038e8431b63eb9e1e5f76d0616a474eb/lib/private/User/Manager.php#L712-L723) is slow on large userbases so we should avoid it where possible.

- [x] When logging in with a token we first try to verify against the login name passed but then do a second attempt using the email address. As we already know the user id that we need to look up the email for we can use the stored uid from the token and compare the email instead of searching by mail
- [x] Revert change to always use an sql cast that was a behavioral change from https://github.com/nextcloud/server/commit/8bbdd9ea0ce9678720459037e30239dc176b9ed8 between 24 and 25
- [x] ~Add a partial index to the configvalue to ensure that most email checks can use an indexed query~ -> Moved to https://github.com/nextcloud/server/pull/42022
  ```  KEY `tmp_configvalue_index` (`configvalue`(80)),```
  - [x] OCI doesn't like that index `cannot create index on expression with datatype LOB`


TODO:

- [ ] Come up with a good approach for adding a test case to avoid future regressions in performance

