### PR TITLE
fix(bruteforce-protection): Don't throw a 500 when MaxDelayReached is…

### DIFF
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -41,6 +41,7 @@ if (\OCP\Util::needUpgrade()
 	exit;
 }
 
+use OCP\Security\Bruteforce\MaxDelayReached;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -62,6 +63,9 @@ try {
 	}
 
 	OC::$server->get(\OC\Route\Router::class)->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
+} catch (MaxDelayReached $ex) {
+	$format = \OC::$server->getRequest()->getParam('format', 'xml');
+	OC_API::respond(new \OC\OCS\Result(null, OCP\AppFramework\Http::STATUS_TOO_MANY_REQUESTS, $ex->getMessage()), $format);
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 


### PR DESCRIPTION
… thrown


## Test instructions

```diff
diff --git a/index.php b/index.php
index f9756b7b51a..bbadeb4970c 100644
--- a/index.php
+++ b/index.php
@@ -36,6 +36,7 @@ use Psr\Log\LoggerInterface;
 try {
 	require_once __DIR__ . '/lib/base.php';
 
+	throw new MaxDelayReached('Reached maximum delay');
 	OC::handleRequest();
 } catch (\OC\ServiceUnavailableException $ex) {
 	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
diff --git a/ocs/v1.php b/ocs/v1.php
index 55e9f426aba..cc115d0e352 100644
--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -58,6 +58,7 @@ try {
 	// side effects in existing apps
 	OC_App::loadApps();
 
+	throw new MaxDelayReached('Reached maximum delay');
 	if (!\OC::$server->getUserSession()->isLoggedIn()) {
 		OC::handleLogin(\OC::$server->getRequest());
 	}
```

### Tested with:

- Frontpage: `curl -k https://nextcloud29.local/index.php/cloud/user?format=json -u admin:admin -i -H 'OCS-APIRequest: true' -H 'Accept: text/html'`
- index.php API call: `curl -k https://nextcloud29.local/index.php/cloud/user?format=json -u admin:admin -i -H 'OCS-APIRequest: true'`
- OCS API call: `curl -k https://nextcloud29.local/ocs/v2.php/cloud/user?format=json -u admin:admin -i -H 'OCS-APIRequest: true'`

### Before

```
$ curl -k https://nextcloud29.local/ocs/v2.php/cloud/user?format=json -u admin:admin -i -H 'OCS-APIRequest: true'
HTTP/1.1 500 Internal Server Error
…
{"ocs":{"meta":{"status":"failure","statuscode":500,"message":"Internal Server Error\nReached maximum delay"},"data":[]}}
```

### After
```
$ curl -k https://nextcloud29.local/ocs/v2.php/cloud/user?format=json -u admin:admin -i -H 'OCS-APIRequest: true'
HTTP/1.1 429 Too Many Requests
…
{"ocs":{"meta":{"status":"failure","statuscode":429,"message":"Reached maximum delay"},"data":[]}}
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
