### PR TITLE
fix: Properly fetch version from shared files by accessing the owner storage version

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Files_Versions\Versions;
 
 use OC\Files\View;
+use OCA\Files_Sharing\ISharedStorage;
 use OCA\Files_Sharing\SharedStorage;
 use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
@@ -196,6 +197,21 @@ class LegacyVersionsBackend implements IVersionBackend, INameableVersionBackend,
 
 	public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): File {
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$owner = $sourceFile->getOwner();
+		$storage = $sourceFile->getStorage();
+
+		// Shared files have their versions in the owners root folder so we need to obtain them from there
+		if ($storage->instanceOfStorage(ISharedStorage::class) && $owner) {
+			/** @var SharedStorage $storage */
+			$userFolder = $this->rootFolder->getUserFolder($owner->getUID());
+			$user = $owner;
+			$ownerPathInStorage = $sourceFile->getInternalPath();
+			$sourceFile = $storage->getShare()->getNode();
+			if ($sourceFile instanceof Folder) {
+				$sourceFile = $sourceFile->get($ownerPathInStorage);
+			}
+		}
+
 		$versionFolder = $this->getVersionFolder($user);
 		/** @var File $file */
 		$file = $versionFolder->get($userFolder->getRelativePath($sourceFile->getPath()) . '.v' . $revision);


### PR DESCRIPTION
File versions of shared files are located in the owners root, so we need special handling to obtain the version file.

This fixes version previews for shared files and in combination with https://github.com/nextcloud/richdocuments/pull/3330 version browsing of shared office files