### PR TITLE
[stable28] fix(cypress): Adjust user columns tests

### DIFF
--- a/cypress/e2e/settings/users_columns.cy.ts
+++ b/cypress/e2e/settings/users_columns.cy.ts
@@ -38,7 +38,7 @@ describe('Settings: Show and hide columns', function() {
 		// reset all visibility toggles
 		cy.get('.modal-container #settings-section_visibility-settings input[type="checkbox"]').uncheck({ force: true })
 
-		cy.get('.modal-container').within(() => {
+		cy.contains('.modal-container', 'User management settings').within(() => {
 			// enable the last login toggle
 			cy.get('[data-test="showLastLogin"] input[type="checkbox"]').check({ force: true })
 			// close the settings dialog
@@ -59,7 +59,7 @@ describe('Settings: Show and hide columns', function() {
 		// open the settings dialog
 		cy.get('.app-navigation-entry__settings').contains('User management settings').click()
 
-		cy.get('.modal-container').within(() => {
+		cy.contains('.modal-container', 'User management settings').within(() => {
 			// enable the language toggle
 			cy.get('[data-test="showLanguages"] input[type="checkbox"]').should('not.be.checked')
 			cy.get('[data-test="showLanguages"] input[type="checkbox"]').check({ force: true })
@@ -90,7 +90,7 @@ describe('Settings: Show and hide columns', function() {
 		// open the settings dialog
 		cy.get('.app-navigation-entry__settings').contains('User management settings').click()
 
-		cy.get('.modal-container').within(() => {
+		cy.contains('.modal-container', 'User management settings').within(() => {
 			// disable the last login toggle
 			cy.get('[data-test="showLastLogin"] input[type="checkbox"]').should('be.checked')
 			cy.get('[data-test="showLastLogin"] input[type="checkbox"]').uncheck({ force: true })
@@ -98,7 +98,7 @@ describe('Settings: Show and hide columns', function() {
 			// close the settings dialog
 			cy.get('button.modal-container__close').click()
 		})
-		cy.waitUntil(() => cy.get('.modal-container').should(el => assertNotExistOrNotVisible(el)))
+		cy.waitUntil(() => cy.contains('.modal-container', 'User management settings').should(el => assertNotExistOrNotVisible(el)))
 
 		// see that the last login column is not in the header
 		cy.get('[data-cy-user-list-header-last-login]').should('not.exist')


### PR DESCRIPTION
## Summary

When selecting the modal we should make sure to select the user settings modal and not any other (in this case global search).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
