### PR TITLE
optionally hide hidden files if accessed via public share

### DIFF
--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -83,6 +83,17 @@ interface ICache {
 	public function getFolderContentsById($fileId);
 
 	/**
+	 * get the metadata of all files stored in $folder except hidden files
+	 *
+	 * Only returns files one level deep, no recursion
+	 *
+	 * @param int $fileId the file id of the folder
+	 * @return ICacheEntry[]
+	 * @since 9.0.0
+	 */
+	public function getFolderContentsByIdExceptHidden($fileId);
+
+	/**
 	 * store meta data for a file or folder
 	 * This will automatically call either insert or update depending on if the file exists
 	 *


### PR DESCRIPTION

* Resolves: # n/a

## Summary
optionally hide hidden files if accessed via public share
config.php setting: hide_hidden_files_via_public_share_access true|false (default = false)

Nextcloud users are able to show/hide hidden files (starting with dot "."). However if a folder containing hidden files is accessed via a public share hidden files are shown. As far as I can see there is currently no option available to hide hidden files for public share access.

I'm not sure if this is a valid or the best way to implement this. It's just a way I figured out to implement it. By default this change should not have any impact. Only if enabled via config.php setting 'hide_hidden_files_via_public_share_access' => true hidden files are excluded from file list if a folder is accessed via a public share link.

Before (example using a nextcloud maps share)
![before](https://github.com/nextcloud/server/assets/3709024/6cfcbcdf-3baf-42d2-9db4-f9bd7994ba4f)

After and enabled via config.php
![after_and_enabled](https://github.com/nextcloud/server/assets/3709024/7c897cb1-e6bc-48a3-9526-9028e53d4ea9)

## TODO

- [ ] 


## Checklist

- Code is [properly formatted] (https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
