### PR TITLE
fix(files): Fix type issues of mixing string and number

### DIFF
--- a/apps/files/src/components/FileEntry/FileEntryCheckbox.vue
+++ b/apps/files/src/components/FileEntry/FileEntryCheckbox.vue
@@ -30,9 +30,11 @@
 </template>
 
 <script lang="ts">
-import { Node } from '@nextcloud/files'
+import type { Node } from '@nextcloud/files'
+import type { PropType } from 'vue'
+
 import { translate as t } from '@nextcloud/l10n'
-import Vue, { PropType } from 'vue'
+import { defineComponent } from 'vue'
 
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
@@ -41,7 +43,7 @@ import { useKeyboardStore } from '../../store/keyboard.ts'
 import { useSelectionStore } from '../../store/selection.ts'
 import logger from '../../logger.js'
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'FileEntryCheckbox',
 
 	components: {
@@ -55,7 +57,7 @@ export default Vue.extend({
 			required: true,
 		},
 		fileid: {
-			type: String,
+			type: Number,
 			required: true,
 		},
 		isLoading: {
@@ -85,12 +87,17 @@ export default Vue.extend({
 			return this.selectedFiles.includes(this.fileid)
 		},
 		index() {
-			return this.nodes.findIndex((node: Node) => node.fileid === parseInt(this.fileid))
+			return this.nodes.findIndex((node: Node) => node.fileid === this.fileid)
 		},
 	},
 
 	methods: {
 		onSelectionChange(selected: boolean) {
+			// eslint-disable-next-line jsdoc/require-jsdoc
+			function isNumber(value: unknown): value is number {
+				return typeof value === 'number'
+			}
+
 			const newSelectedIndex = this.index
 			const lastSelectedIndex = this.selectionStore.lastSelectedIndex
 
@@ -103,8 +110,9 @@ export default Vue.extend({
 
 				const lastSelection = this.selectionStore.lastSelection
 				const filesToSelect = this.nodes
-					.map(file => file.fileid?.toString?.())
+					.map(file => file.fileid)
 					.slice(start, end + 1)
+					.filter(isNumber)
 
 				// If already selected, update the new selection _without_ the current file
 				const selection = [...lastSelection, ...filesToSelect]

--- a/apps/files/src/components/FilesListTableHeader.vue
+++ b/apps/files/src/components/FilesListTableHeader.vue
@@ -76,9 +76,13 @@
 </template>
 
 <script lang="ts">
+import type { Navigation, Node } from '@nextcloud/files'
+import type { PropType } from 'vue'
+
 import { translate } from '@nextcloud/l10n'
+import { defineComponent } from 'vue'
+
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
-import Vue from 'vue'
 
 import { useFilesStore } from '../store/files.ts'
 import { useSelectionStore } from '../store/selection.ts'
@@ -87,7 +91,7 @@ import FilesListTableHeaderButton from './FilesListTableHeaderButton.vue'
 import filesSortingMixin from '../mixins/filesSorting.ts'
 import logger from '../logger.js'
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'FilesListTableHeader',
 
 	components: {
@@ -110,7 +114,7 @@ export default Vue.extend({
 			default: false,
 		},
 		nodes: {
-			type: Array,
+			type: Array as PropType<Node[]>,
 			required: true,
 		},
 		filesListWidth: {
@@ -130,7 +134,7 @@ export default Vue.extend({
 
 	computed: {
 		currentView() {
-			return this.$navigation.active
+			return (this.$navigation as Navigation).active
 		},
 
 		columns() {
@@ -143,7 +147,7 @@ export default Vue.extend({
 
 		dir() {
 			// Remove any trailing slash but leave root slash
-			return (this.$route?.query?.dir || '/').replace(/^(.+)\/$/, '$1')
+			return (this.$route?.query?.dir || '/').replace(/^(.+)\/$/, '$1') as string
 		},
 
 		selectAllBind() {
@@ -188,13 +192,13 @@ export default Vue.extend({
 				'files-list__column': true,
 				'files-list__column--sortable': !!column.sort,
 				'files-list__row-column-custom': true,
-				[`files-list__row-${this.currentView.id}-${column.id}`]: true,
+				[`files-list__row-${this.currentView?.id}-${column.id}`]: true,
 			}
 		},
 
 		onToggleAll(selected) {
 			if (selected) {
-				const selection = this.nodes.map(node => node.fileid.toString())
+				const selection = this.nodes.map(node => node.fileid).filter((id) => id !== undefined) as number[]
 				logger.debug('Added all nodes to selection', { selection })
 				this.selectionStore.setLastIndex(null)
 				this.selectionStore.set(selection)

--- a/apps/files/src/components/FilesListTableHeaderActions.vue
+++ b/apps/files/src/components/FilesListTableHeaderActions.vue
@@ -42,14 +42,18 @@
 </template>
 
 <script lang="ts">
+import type { Node as NcNode, View } from '@nextcloud/files'
+import type { PropType } from 'vue'
+
 import { NodeStatus, getFileActions } from '@nextcloud/files'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { translate } from '@nextcloud/l10n'
+import { defineComponent } from 'vue'
+
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
-import Vue from 'vue'
 
 import { useActionsMenuStore } from '../store/actionsmenu.ts'
 import { useFilesStore } from '../store/files.ts'
@@ -60,7 +64,7 @@ import logger from '../logger.js'
 // The registered actions list
 const actions = getFileActions()
 
-export default Vue.extend({
+export default defineComponent({
 	name: 'FilesListTableHeaderActions',
 
 	components: {
@@ -76,11 +80,11 @@ export default Vue.extend({
 
 	props: {
 		currentView: {
-			type: Object,
+			type: Object as PropType<View>,
 			required: true,
 		},
 		selectedNodes: {
-			type: Array,
+			type: Array as PropType<number[]>,
 			default: () => ([]),
 		},
 	},
@@ -115,13 +119,17 @@ export default Vue.extend({
 		},
 
 		nodes() {
+			// eslint-disable-next-line jsdoc/require-jsdoc
+			function isNode(node: unknown): node is NcNode {
+				return node !== undefined
+			}
 			return this.selectedNodes
-				.map(fileid => this.getNode(fileid))
-				.filter(node => node)
+				.map((fileid) => this.filesStore.getNode(fileid))
+				.filter(isNode)
 		},
 
 		areSomeNodesLoading() {
-			return this.nodes.some(node => node.status === NodeStatus.LOADING)
+			return this.nodes.some((node) => node.status === NodeStatus.LOADING)
 		},
 
 		openedMenu: {
@@ -148,16 +156,6 @@ export default Vue.extend({
 	},
 
 	methods: {
-		/**
-		 * Get a cached note from the store
-		 *
-		 * @param {number} fileId the file id to get
-		 * @return {Folder|File}
-		 */
-		getNode(fileId) {
-			return this.filesStore.getNode(fileId)
-		},
-
 		async onActionClick(action) {
 			const displayName = action.displayName(this.nodes, this.currentView)
 			const selectionIds = this.selectedNodes
@@ -165,7 +163,7 @@ export default Vue.extend({
 				// Set loading markers
 				this.loading = action.id
 				this.nodes.forEach(node => {
-					Vue.set(node, 'status', NodeStatus.LOADING)
+					this.$set(node, 'status', NodeStatus.LOADING)
 				})
 
 				// Dispatch action execution
@@ -199,7 +197,7 @@ export default Vue.extend({
 				// Remove loading markers
 				this.loading = null
 				this.nodes.forEach(node => {
-					Vue.set(node, 'status', undefined)
+					this.$set(node, 'status', undefined)
 				})
 			}
 		},

--- a/apps/files/src/store/files.ts
+++ b/apps/files/src/store/files.ts
@@ -29,7 +29,8 @@ import Vue from 'vue'
 
 export const useFilesStore = function(...args) {
 	const store = defineStore('files', {
-		state: (): FilesState => ({
+		state: (): FilesState & { _initialized: boolean } => ({
+			_initialized: false,
 			files: {} as FilesStore,
 			roots: {} as RootsStore,
 		}),
@@ -37,18 +38,21 @@ export const useFilesStore = function(...args) {
 		getters: {
 			/**
 			 * Get a file or folder by id
+			 * @param state the stores state
 			 */
 			getNode: (state) => (id: FileId): Node|undefined => state.files[id],
 
 			/**
 			 * Get a list of files or folders by their IDs
 			 * Does not return undefined values
+			 * @param state the stores state
 			 */
 			getNodes: (state) => (ids: FileId[]): Node[] => ids
 				.map(id => state.files[id])
 				.filter(Boolean),
 			/**
 			 * Get a file or folder by id
+			 * @param state the stores state
 			 */
 			getRoot: (state) => (service: Service): Folder|undefined => state.roots[service],
 		},
@@ -58,7 +62,7 @@ export const useFilesStore = function(...args) {
 				// Update the store all at once
 				const files = nodes.reduce((acc, node) => {
 					if (!node.fileid) {
-						logger.error('Trying to update/set a node without fileid', node)
+						logger.error('Trying to update/set a node without fileid', { node })
 						return acc
 					}
 					acc[node.fileid] = node

--- a/apps/files/src/types.ts
+++ b/apps/files/src/types.ts
@@ -82,7 +82,7 @@ export interface SelectionStore {
 // Actions menu store
 export type GlobalActions = 'global'
 export interface ActionsMenuStore {
-	opened: GlobalActions|string|null
+	opened: GlobalActions|string|number|null
 }
 
 // View config store


### PR DESCRIPTION
## Summary

Fix some type issues in the files list where numbers were mixed with strings for fileids and thus the strict compare will fail (`===`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
