### PR TITLE
use correct mode constant of files:scan's --path option

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -90,7 +90,7 @@ class Scan extends Base {
 			->addOption(
 				'path',
 				'p',
-				InputArgument::OPTIONAL,
+				InputOption::VALUE_REQUIRED,
 				'limit rescan to this path, eg. --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored'
 			)
 			->addOption(


### PR DESCRIPTION
`InputArgument::OPTIONAL` happens to be the same value as `InputOption::VALUE_REQUIRED` by chance, so the previous code works as expected by accident. But it's confusing for people reading the code.