### PR TITLE
fix(dav): allow any throwable in logException

### DIFF
--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -70,9 +70,9 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 	}
 
 	/**
-	 * @param \Exception $ex
+	 * @param \Throwable $ex
 	 */
-	public function logException(\Exception $ex) {
+	public function logException(\Throwable $ex): void {
 		if ($ex instanceof Exception) {
 			$httpCode = $ex->getHTTPCode();
 			$headers = $ex->getHTTPHeaders($this->server);


### PR DESCRIPTION
If a TypeError is passed here, it in turn causes a TypeError which kills the rendering of the error page.