### PR TITLE
enh: Implement PrimaryReadReplicaConnection

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -152,6 +152,14 @@ $CONFIG = [
 'dbpersistent' => '',
 
 /**
+ * Specify read only replicas to be used by Nextcloud when querying the database
+ */
+'dbreplica' => [
+	['user' => 'replica1', 'password', 'host' => '', 'dbname' => ''],
+	['user' => 'replica1', 'password', 'host' => '', 'dbname' => ''],
+],
+
+/**
  * Indicates whether the Nextcloud instance was installed successfully; ``true``
  * indicates a successful installation, and ``false`` indicates an unsuccessful
  * installation.

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -32,7 +32,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
-use Doctrine\DBAL\Event\Listeners\SQLSessionInit;
 use OC\SystemConfig;
 
 /**
@@ -127,11 +126,8 @@ class ConnectionFactory {
 		$normalizedType = $this->normalizeType($type);
 		$eventManager = new EventManager();
 		$eventManager->addEventSubscriber(new SetTransactionIsolationLevel());
+		$additionalConnectionParams = array_merge($this->createConnectionParams(), $additionalConnectionParams);
 		switch ($normalizedType) {
-			case 'mysql':
-				$eventManager->addEventSubscriber(
-					new SQLSessionInit("SET SESSION AUTOCOMMIT=1"));
-				break;
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);
 				// the driverOptions are unused in dbal and need to be mapped to the parameters
@@ -159,7 +155,7 @@ class ConnectionFactory {
 		}
 		/** @var Connection $connection */
 		$connection = DriverManager::getConnection(
-			array_merge($this->getDefaultConnectionParams($type), $additionalConnectionParams),
+			$additionalConnectionParams,
 			new Configuration(),
 			$eventManager
 		);
@@ -195,10 +191,10 @@ class ConnectionFactory {
 	public function createConnectionParams(string $configPrefix = '') {
 		$type = $this->config->getValue('dbtype', 'sqlite');
 
-		$connectionParams = [
+		$connectionParams = array_merge($this->getDefaultConnectionParams($type), [
 			'user' => $this->config->getValue($configPrefix . 'dbuser', $this->config->getValue('dbuser', '')),
 			'password' => $this->config->getValue($configPrefix . 'dbpassword', $this->config->getValue('dbpassword', '')),
-		];
+		]);
 		$name = $this->config->getValue($configPrefix . 'dbname', $this->config->getValue('dbname', self::DEFAULT_DBNAME));
 
 		if ($this->normalizeType($type) === 'sqlite3') {
@@ -237,7 +233,11 @@ class ConnectionFactory {
 			$connectionParams['persistent'] = true;
 		}
 
-		return $connectionParams;
+		$replica = $this->config->getValue('dbreplica', []) ?: [$connectionParams];
+		return array_merge($connectionParams, [
+			'primary' => $connectionParams,
+			'replica' => $replica,
+		]);
 	}
 
 	/**

--- a/lib/private/DB/SetTransactionIsolationLevel.php
+++ b/lib/private/DB/SetTransactionIsolationLevel.php
@@ -26,8 +26,10 @@ declare(strict_types=1);
 namespace OC\DB;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\TransactionIsolationLevel;
 
 class SetTransactionIsolationLevel implements EventSubscriber {
@@ -36,7 +38,13 @@ class SetTransactionIsolationLevel implements EventSubscriber {
 	 * @return void
 	 */
 	public function postConnect(ConnectionEventArgs $args) {
-		$args->getConnection()->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
+		$connection = $args->getConnection();
+		if ($connection instanceof PrimaryReadReplicaConnection && $connection->isConnectedToPrimary()) {
+			$connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
+			if ($connection->getDatabasePlatform() instanceof MySQLPlatform) {
+				$connection->executeStatement('SET SESSION AUTOCOMMIT=1');
+			}
+		}
 	}
 
 	public function getSubscribedEvents() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -842,8 +842,7 @@ class Server extends ServerContainer implements IServerContainer {
 			if (!$factory->isValidType($type)) {
 				throw new \OC\DatabaseException('Invalid database type');
 			}
-			$connectionParams = $factory->createConnectionParams();
-			$connection = $factory->getConnection($type, $connectionParams);
+			$connection = $factory->getConnection($type, []);
 			return $connection;
 		});
 		/** @deprecated 19.0.0 */

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -141,7 +141,7 @@ abstract class AbstractDatabase {
 			$connectionParams['host'] = $host;
 		}
 
-		$connectionParams = array_merge($connectionParams, $configOverwrite);
+		$connectionParams = array_merge($connectionParams, ['primary' => $connectionParams, 'replica' => [$connectionParams]], $configOverwrite);
 		$cf = new ConnectionFactory($this->config);
 		return $cf->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
 	}


### PR DESCRIPTION
First approach for https://github.com/nextcloud/server/issues/33542 split to only have the read replica support in this PR. Follow up prepared in #42345 

Fixes https://github.com/nextcloud/server/issues/40334

## Summary

Make use of the PrimaryReadReplicaConnection class that Doctrine offers to be able to configure read replicas for Nextcloud databases.

Library docs: https://github.com/doctrine/dbal/blob/3.7.x/src/Connections/PrimaryReadReplicaConnection.php#L28C1-L76

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [ ] https://github.com/nextcloud/documentation/pull/11446
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
