### PR TITLE
fix(security): Handle idn_to_utf8 returning false

### DIFF
--- a/lib/private/Security/RemoteHostValidator.php
+++ b/lib/private/Security/RemoteHostValidator.php
@@ -52,6 +52,10 @@ final class RemoteHostValidator implements IRemoteHostValidator {
 		}
 
 		$host = idn_to_utf8(strtolower(urldecode($host)));
+		if ($host === false) {
+			return false;
+		}
+
 		// Remove brackets from IPv6 addresses
 		if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
 			$host = substr($host, 1, -1);

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -149,6 +149,7 @@ class ClientTest extends \Test\TestCase {
 			['https://service.localhost'],
 			['!@#$', true], // test invalid url
 			['https://normal.host.com'],
+			['https://com.one-.nextcloud-one.com'],
 		];
 	}
 

--- a/tests/lib/Security/RemoteHostValidatorTest.php
+++ b/tests/lib/Security/RemoteHostValidatorTest.php
@@ -60,8 +60,17 @@ class RemoteHostValidatorTest extends TestCase {
 		);
 	}
 
-	public function testValid(): void {
-		$host = 'nextcloud.com';
+	public function dataValid(): array {
+		return [
+			['nextcloud.com', true],
+			['com.one-.nextcloud-one.com', false],
+		];
+	}
+
+	/**
+	 * @dataProvider dataValid
+	 */
+	public function testValid(string $host, bool $expected): void {
 		$this->hostnameClassifier
 			->method('isLocalHostname')
 			->with($host)
@@ -73,7 +82,7 @@ class RemoteHostValidatorTest extends TestCase {
 
 		$valid = $this->validator->isValid($host);
 
-		self::assertTrue($valid);
+		self::assertSame($expected, $valid);
 	}
 
 	public function testLocalHostname(): void {


### PR DESCRIPTION
* Resolves: `TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, bool given` From our instance

Test failed before:

```
.E..                                                                4 / 4 (100%)

Time: 00:00.017, Memory: 28.00 MB

There was 1 error:

1) lib\Security\RemoteHostValidatorTest::testValid with data set #1 ('com.one-.nextcloud-one.com', false)
TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, bool given

/home/nickv/Nextcloud/29/server/lib/private/Security/RemoteHostValidator.php:56
/home/nickv/Nextcloud/29/server/tests/lib/Security/RemoteHostValidatorTest.php:83


ERRORS!
Tests: 4, Assertions: 3, Errors: 1.
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
