### PR TITLE
fix(metadata): Allow to load metadata of multiple files at once

### DIFF
--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -148,6 +148,19 @@ class FilesMetadataManager implements IFilesMetadataManager {
 	}
 
 	/**
+	 * returns metadata of multiple file ids
+	 *
+	 * @param int[] $fileIds file ids
+	 *
+	 * @return array File ID is the array key, files without metadata are not returned in the array
+	 * @psalm-return array<int, IFilesMetadata>
+	 * @since 28.0.0
+	 */
+	public function getMetadataForFiles(array $fileIds): array {
+		return $this->metadataRequestService->getMetadataFromFileIds($fileIds);
+	}
+
+	/**
 	 * @param IFilesMetadata $filesMetadata metadata
 	 *
 	 * @inheritDoc

--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -71,7 +71,7 @@ interface IFilesMetadataManager {
 	): IFilesMetadata;
 
 	/**
-	 * returns metadata from a file id
+	 * returns metadata of a file id
 	 *
 	 * @param int $fileId file id
 	 * @param boolean $generate Generate if metadata does not exist
@@ -81,6 +81,18 @@ interface IFilesMetadataManager {
 	 * @since 28.0.0
 	 */
 	public function getMetadata(int $fileId, bool $generate = false): IFilesMetadata;
+
+	/**
+	 * returns metadata of multiple file ids
+	 *
+	 * @param int[] $fileIds file ids
+	 *
+	 * @return array File ID is the array key, files without metadata are not returned in the array
+	 * @psalm-return array<int, IFilesMetadata>
+	 * @throws FilesMetadataNotFoundException if not found
+	 * @since 28.0.0
+	 */
+	public function getMetadataForFiles(array $fileIds): array;
 
 	/**
 	 * save metadata to database and refresh indexes.


### PR DESCRIPTION
* Would be helpful for Talk to avoid a query per file: https://github.com/nextcloud/spreed/pull/11093
* Similarly other apps like photos could benefit from it, but instead it currently uses exposure/manipulation via the query builder: https://github.com/nextcloud/photos/blob/aa82646be1493e74a00513757153e1759a8e3a69/lib/DB/Place/PlaceMapper.php#L59-L67

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
