### PR TITLE
fix(metadata): Fix copy-paste doc block throws

### DIFF
--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -89,7 +89,6 @@ interface IFilesMetadataManager {
 	 *
 	 * @return array File ID is the array key, files without metadata are not returned in the array
 	 * @psalm-return array<int, IFilesMetadata>
-	 * @throws FilesMetadataNotFoundException if not found
 	 * @since 28.0.0
 	 */
 	public function getMetadataForFiles(array $fileIds): array;


### PR DESCRIPTION
Small 🍝  from #42008 