### PR TITLE
perf: Add partial index on configvalue of preferences table

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -44,6 +44,7 @@ use OC\Authentication\Listeners\UserDeletedWebAuthnCleanupListener;
 use OC\Authentication\Notifications\Notifier as AuthenticationNotifier;
 use OC\Core\Listener\BeforeTemplateRenderedListener;
 use OC\Core\Notification\CoreNotifier;
+use OC\SystemConfig;
 use OC\TagManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
@@ -81,6 +82,7 @@ class Application extends App {
 		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(AddMissingIndicesEvent::class, function (AddMissingIndicesEvent $event) {
+			$dbType = $this->getContainer()->get(SystemConfig::class)->getSystemValue('dbtype', 'sqlite');
 			$event->addMissingIndex(
 				'share',
 				'share_with_index',
@@ -236,6 +238,15 @@ class Application extends App {
 				'preferences_app_key',
 				['appid', 'configkey']
 			);
+
+			if ($dbType !== 'oci') {
+				$event->addMissingIndex(
+					'preferences',
+					'preferences_configvalue',
+					['configvalue'],
+					['lengths' => [80]]
+				);
+			}
 
 			$event->addMissingIndex(
 				'mounts',

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -31,6 +31,7 @@
  */
 namespace OC\Core\Migrations;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
@@ -332,6 +333,9 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['userid', 'appid', 'configkey']);
 			$table->addIndex(['appid', 'configkey'], 'preferences_app_key');
+			if (!$this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+				$table->addIndex(['configvalue'], 'preferences_configvalue', [], ['lengths' => [80]]);
+			}
 		}
 
 		if (!$schema->hasTable('properties')) {


### PR DESCRIPTION
To be reconsidered, there are some instances using such an index, but having diverging schema between different db backends is probably something to avoid.

Other ideas:
- Add a hash column to access by value with an index (might also need a hash for lower cased form)