### PR TITLE
fix(webdav): multiple headers check

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -73,7 +73,8 @@ $linkCheckPlugin = new \OCA\DAV\Files\Sharing\PublicLinkCheckPlugin();
 $filesDropPlugin = new \OCA\DAV\Files\Sharing\FilesDropPlugin();
 
 $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, function (\Sabre\DAV\Server $server) use ($authBackend, $linkCheckPlugin, $filesDropPlugin) {
-	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest');
+	$request = \OC::$server->getRequest();
+	$isAjax = (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && in_array('XMLHttpRequest', explode(',', $request->getHeader('X-Requested-With'))));
 	/** @var \OCA\FederatedFileSharing\FederatedShareProvider $shareProvider */
 	$federatedShareProvider = \OC::$server->query(\OCA\FederatedFileSharing\FederatedShareProvider::class);
 	if ($federatedShareProvider->isOutgoingServer2serverShareEnabled() === false && !$isAjax) {


### PR DESCRIPTION
<!-- related github issue -->

## Summary
Some customers had the issue that public shares can't be opened. They result in a reload loop. This is caused by an unauthenticated dav request. I turns out that the `XMLHttpRequest` could be set twice and the logic checks for exact one match.

We provided this patch as a quick fix and maybe it's a good idea to bring this to the server to make it more robust besides fixing the main cause.

Customers were on nextcloud 24.0.12.9.

## TODO

- [ ] check if useful
- [ ] add backports

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
