### PR TITLE
Revert "Improve shared status button"

### DIFF
--- a/apps/files/src/components/FileEntry/FileEntryActions.vue
+++ b/apps/files/src/components/FileEntry/FileEntryActions.vue
@@ -37,7 +37,6 @@
 			:container="getBoundariesElement"
 			:disabled="isLoading || loading !== ''"
 			:force-name="true"
-			type="tertiary"
 			:force-menu="enabledInlineActions.length === 0 /* forceMenu only if no inline actions */"
 			:inline="enabledInlineActions.length"
 			:open.sync="openedMenu"
@@ -95,7 +94,7 @@
 <script lang="ts">
 import { DefaultType, FileAction, Node, NodeStatus, View, getFileActions } from '@nextcloud/files'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import { translate as t } from '@nextcloud/l10n'
+import { translate as t } from '@nextcloud/l10n';
 import Vue, { PropType } from 'vue'
 
 import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
@@ -326,15 +325,3 @@ export default Vue.extend({
 	},
 })
 </script>
-
-<style lang="scss" scoped>
-
-:deep(.button-vue--icon-and-text, .files-list__row-action-sharing-status) {
-	.button-vue__text {
-		color: var(--color-primary-element);
-	}
-	.button-vue__icon {
-		color: var(--color-primary-element);
-	}
-}
-</style>


### PR DESCRIPTION
This reverts commit c2c5994d7069464b9e69a54ce2c660a1a340c711.

Sorry @marcoambrosini, I cannot approve the previous PR:
1. using deep selectors is not acceptable to me
2. you're changing this for all actions, while only the sharing got request
3. a comment was written by a lead with another lead reaction and got completely ignored


I'll have a look with the design team to make sure we keep the previous issue fixed too

