### PR TITLE
feat: Print early exceptions in debug mode instead of plain error pages

### DIFF
--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -275,8 +275,10 @@ class OC_Template extends \OC\Template\Base {
 	 * @suppress PhanAccessMethodInternal
 	 */
 	public static function printExceptionErrorPage($exception, $statusCode = 503) {
+		$debug = false;
 		http_response_code($statusCode);
 		try {
+			$debug = \OC::$server->getSystemConfig()->getValue('debug', false);
 			$request = \OC::$server->getRequest();
 			$content = new \OC_Template('', 'exception', 'error', false);
 			$content->assign('errorClass', get_class($exception));
@@ -285,7 +287,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('file', $exception->getFile());
 			$content->assign('line', $exception->getLine());
 			$content->assign('exception', $exception);
-			$content->assign('debugMode', \OC::$server->getSystemConfig()->getValue('debug', false));
+			$content->assign('debugMode', $debug);
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());
 			$content->printPage();
@@ -296,22 +298,28 @@ class OC_Template extends \OC\Template\Base {
 				$logger->logException($e, ['app' => 'core']);
 			} catch (Throwable $e) {
 				// no way to log it properly - but to avoid a white page of death we send some output
-				header('Content-Type: text/plain; charset=utf-8');
-				print("Internal Server Error\n\n");
-				print("The server encountered an internal error and was unable to complete your request.\n");
-				print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
-				print("More details can be found in the server log.\n");
+				self::printPlainErrorPage($e, $debug);
 
 				// and then throw it again to log it at least to the web server error log
 				throw $e;
 			}
 
-			header('Content-Type: text/plain; charset=utf-8');
-			print("Internal Server Error\n\n");
-			print("The server encountered an internal error and was unable to complete your request.\n");
-			print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
-			print("More details can be found in the server log.\n");
+			self::printPlainErrorPage($e, $debug);
 		}
 		die();
+	}
+
+	private static function printPlainErrorPage(\Throwable $exception, bool $debug = false) {
+		header('Content-Type: text/plain; charset=utf-8');
+		print("Internal Server Error\n\n");
+		print("The server encountered an internal error and was unable to complete your request.\n");
+		print("Please contact the server administrator if this error reappears multiple times, please include the technical details below in your report.\n");
+		print("More details can be found in the server log.\n");
+
+		if ($debug) {
+			print("\n");
+			print($exception->getMessage() . ' ' . $exception->getFile() . ' at ' . $exception->getLine() . "\n");
+			print($exception->getTraceAsString());
+		}
 	}
 }


### PR DESCRIPTION
This enhances error pages of early thrown exceptions where we cannot render a template to display the actual exception details. Only applied in debug mode as with the regular exception rendering.

| Before | After |
| --- | --- |
| <img width="962" alt="Screenshot 2023-12-05 at 21 46 31" src="https://github.com/nextcloud/server/assets/3404133/f1b8b7d2-44f0-41df-9e84-1909fd223e76"> | <img width="940" alt="Screenshot 2023-12-05 at 21 46 17" src="https://github.com/nextcloud/server/assets/3404133/e905acb4-435e-46da-9e0d-398ff4f5d0b4"> |


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
