### PR TITLE
enh(NavigationManager): Use ID as fallback for `app` property of entries

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -95,7 +95,10 @@ class NavigationManager implements INavigationManager {
 			return;
 		}
 
+		$id = $entry['id'];
+
 		$entry['active'] = false;
+		$entry['unread'] = $this->unreadCounters[$id] ?? 0;
 		if (!isset($entry['icon'])) {
 			$entry['icon'] = '';
 		}
@@ -106,9 +109,12 @@ class NavigationManager implements INavigationManager {
 			$entry['type'] = 'link';
 		}
 
-		$id = $entry['id'];
-		$entry['unread'] = $this->unreadCounters[$id] ?? 0;
 		if ($entry['type'] === 'link') {
+			// app might not be set when using closures, in this case try to fallback to ID
+			if (!isset($entry['app']) && $this->appManager->isEnabledForUser($id)) {
+				$entry['app'] = $id;
+			}
+
 			// This is the default app that will always be shown first
 			$entry['default'] = ($entry['app'] ?? false) === $this->defaultApp;
 			// Set order from user defined app order


### PR DESCRIPTION
## Summary
Some apps like Talk do not use the appinfo for registering the navigation entries but using the NavigationManager directly. Those apps do not always set the app property of the navigation entry, in this cases it is currently not possible to use that entry for the default app.

To fix 99% of the cases the ID is now checked to be a valid and enabled app and if yes then use it as fallback.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
