### PR TITLE
Revert "perf: Add partial index on configvalue of preferences table"

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -44,7 +44,6 @@ use OC\Authentication\Listeners\UserDeletedWebAuthnCleanupListener;
 use OC\Authentication\Notifications\Notifier as AuthenticationNotifier;
 use OC\Core\Listener\BeforeTemplateRenderedListener;
 use OC\Core\Notification\CoreNotifier;
-use OC\SystemConfig;
 use OC\TagManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
@@ -82,7 +81,6 @@ class Application extends App {
 		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(AddMissingIndicesEvent::class, function (AddMissingIndicesEvent $event) {
-			$dbType = $this->getContainer()->get(SystemConfig::class)->getSystemValue('dbtype', 'sqlite');
 			$event->addMissingIndex(
 				'share',
 				'share_with_index',
@@ -238,15 +236,6 @@ class Application extends App {
 				'preferences_app_key',
 				['appid', 'configkey']
 			);
-
-			if ($dbType !== 'oci') {
-				$event->addMissingIndex(
-					'preferences',
-					'preferences_configvalue',
-					['configvalue'],
-					['lengths' => [80]]
-				);
-			}
 
 			$event->addMissingIndex(
 				'mounts',

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -31,7 +31,6 @@
  */
 namespace OC\Core\Migrations;
 
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
@@ -333,9 +332,6 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['userid', 'appid', 'configkey']);
 			$table->addIndex(['appid', 'configkey'], 'preferences_app_key');
-			if (!$this->connection->getDatabasePlatform() instanceof OraclePlatform) {
-				$table->addIndex(['configvalue'], 'preferences_configvalue', [], ['lengths' => [80]]);
-			}
 		}
 
 		if (!$schema->hasTable('properties')) {


### PR DESCRIPTION
This reverts commit 0ccf84bb3174a0dba47938888d104db96dcacb1b from https://github.com/nextcloud/server/pull/41927

The index was not supposed to be merged, I probably failed to push the right updated version, but was sure that there used to be just the two commits on the pr 🤷 