### PR TITLE
fix: Let git ignore composer dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ tests/acceptance/vendor/
 
 composer.phar
 /lib/composer/bin
+/lib/composer/bamarni
 /vendor-bin/**/vendor
 
 ./.htaccess

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"autoload": {
+		"exclude-from-classmap": ["**/bamarni/composer-bin-plugin/**"],
 		"files": [
 			"lib/public/Log/functions.php"
 		],
@@ -48,11 +49,11 @@
 	"scripts": {
 		"post-install-cmd": [
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || composer bin all install",
-			"composer dump-autoload"
+			"composer dump-autoload --no-dev"
 		],
 		"post-update-cmd": [
 			"[ $COMPOSER_DEV_MODE -eq 0 ] || composer bin all update --ansi",
-			"composer dump-autoload"
+			"composer dump-autoload --no-dev"
 		],
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",


### PR DESCRIPTION
## Summary

Do not trash the state when running composer install with dev dependencies.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
