### PR TITLE
Comment legacy file_metadata table migrations

### DIFF
--- a/core/Migrations/Version24000Date20220404230027.php
+++ b/core/Migrations/Version24000Date20220404230027.php
@@ -40,26 +40,26 @@ class Version24000Date20220404230027 extends SimpleMigrationStep {
 	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
+		// /** @var ISchemaWrapper $schema */
+		// $schema = $schemaClosure();
 
-		if (!$schema->hasTable('file_metadata')) {
-			$table = $schema->createTable('file_metadata');
-			$table->addColumn('id', Types::BIGINT, [
-				'notnull' => true,
-			]);
-			$table->addColumn('group_name', Types::STRING, [
-				'notnull' => true,
-				'length' => 50,
-			]);
-			$table->addColumn('value', Types::TEXT, [
-				'notnull' => false,
-				'default' => '',
-			]);
-			$table->setPrimaryKey(['id', 'group_name'], 'file_metadata_idx');
+		// if (!$schema->hasTable('file_metadata')) {
+		// 	$table = $schema->createTable('file_metadata');
+		// 	$table->addColumn('id', Types::BIGINT, [
+		// 		'notnull' => true,
+		// 	]);
+		// 	$table->addColumn('group_name', Types::STRING, [
+		// 		'notnull' => true,
+		// 		'length' => 50,
+		// 	]);
+		// 	$table->addColumn('value', Types::TEXT, [
+		// 		'notnull' => false,
+		// 		'default' => '',
+		// 	]);
+		// 	$table->setPrimaryKey(['id', 'group_name'], 'file_metadata_idx');
 
-			return $schema;
-		}
+		// 	return $schema;
+		// }
 
 		return null;
 	}

--- a/core/Migrations/Version27000Date20230309104325.php
+++ b/core/Migrations/Version27000Date20230309104325.php
@@ -50,19 +50,20 @@ class Version27000Date20230309104325 extends SimpleMigrationStep {
 	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
-		$metadataTable = $schema->getTable('file_metadata');
+		// /** @var ISchemaWrapper $schema */
+		// $schema = $schemaClosure();
+		// $metadataTable = $schema->getTable('file_metadata');
 
-		if ($metadataTable->hasColumn('value')) {
-			return null;
-		}
+		// if ($metadataTable->hasColumn('value')) {
+		// 	return null;
+		// }
 
-		$metadataTable->addColumn('value', Types::TEXT, [
-			'notnull' => false,
-			'default' => '',
-		]);
-		return $schema;
+		// $metadataTable->addColumn('value', Types::TEXT, [
+		// 	'notnull' => false,
+		// 	'default' => '',
+		// ]);
+		// return $schema;
+		return null;
 	}
 
 
@@ -74,17 +75,17 @@ class Version27000Date20230309104325 extends SimpleMigrationStep {
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
-		$metadataTable = $schema->getTable('file_metadata');
+		// $schema = $schemaClosure();
+		// $metadataTable = $schema->getTable('file_metadata');
 
-		if (!$metadataTable->hasColumn('metadata')) {
-			return;
-		}
+		// if (!$metadataTable->hasColumn('metadata')) {
+		// 	return;
+		// }
 
-		$this->connection
-			->getQueryBuilder()
-			->update('file_metadata')
-			->set('value', 'metadata')
-			->executeStatement();
+		// $this->connection
+		// 	->getQueryBuilder()
+		// 	->update('file_metadata')
+		// 	->set('value', 'metadata')
+		// 	->executeStatement();
 	}
 }

--- a/core/Migrations/Version27000Date20230309104802.php
+++ b/core/Migrations/Version27000Date20230309104802.php
@@ -43,14 +43,14 @@ class Version27000Date20230309104802 extends SimpleMigrationStep {
 	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
-		$schema = $schemaClosure();
-		$metadataTable = $schema->getTable('file_metadata');
+		// /** @var ISchemaWrapper $schema */
+		// $schema = $schemaClosure();
+		// $metadataTable = $schema->getTable('file_metadata');
 
-		if ($metadataTable->hasColumn('metadata')) {
-			$metadataTable->dropColumn('metadata');
-			return $schema;
-		}
+		// if ($metadataTable->hasColumn('metadata')) {
+		// 	$metadataTable->dropColumn('metadata');
+		// 	return $schema;
+		// }
 
 		return null;
 	}


### PR DESCRIPTION
This prevents creating the table for nothing on new instances.
On old instances, the table is already removed during the upgrade to 28.