### PR TITLE
fix(loginflow): Log state token mismatch errors

### DIFF
--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -38,6 +38,8 @@ use OCP\IUserSession;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
+use function hash_equals;
+use function OCP\Log\logger;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ClientFlowLoginController extends Controller {
@@ -71,9 +73,20 @@ class ClientFlowLoginController extends Controller {
 	private function isValidToken(string $stateToken): bool {
 		$currentToken = $this->session->get(self::STATE_NAME);
 		if (!is_string($currentToken)) {
+			logger('core')->error('Client login flow state token is not set', [
+				'sessionToken' => $currentToken,
+				'requestToken' => $stateToken,
+			]);
 			return false;
 		}
-		return hash_equals($currentToken, $stateToken);
+		$hashEquals = hash_equals($currentToken, $stateToken);
+		if (!$hashEquals) {
+			logger('core')->error('Client login flow state token does not match', [
+				'sessionToken' => $currentToken,
+				'requestToken' => $stateToken,
+			]);
+		}
+		return $hashEquals;
 	}
 
 	private function stateTokenForbiddenResponse(): StandaloneTemplateResponse {
@@ -125,6 +138,9 @@ class ClientFlowLoginController extends Controller {
 			ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS
 		);
 		$this->session->set(self::STATE_NAME, $stateToken);
+		logger('core')->error('Client login flow state token set', [
+			'token' => $stateToken,
+		]);
 
 		$csp = new ContentSecurityPolicy();
 		if ($client) {

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -35,6 +35,8 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
+use Psr\Log\LoggerInterface;
+use function OCP\Log\logger;
 
 /**
  * @psalm-import-type CoreLoginFlowV2Credentials from ResponseDefinitions
@@ -95,6 +97,11 @@ class ClientFlowLoginV2Controller extends Controller {
 		}
 
 		$this->session->set(self::TOKEN_NAME, $token);
+		logger('core')->debug('Client login flow state token set on landing page', [
+			'sessionId' => $this->session->getId(),
+			'sessionToken' => $token,
+			'user' => $user,
+		]);
 
 		return new RedirectResponse(
 			$this->urlGenerator->linkToRouteAbsolute('core.ClientFlowLoginV2.showAuthPickerPage', ['user' => $user, 'direct' => $direct])
@@ -120,6 +127,11 @@ class ClientFlowLoginV2Controller extends Controller {
 			ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS
 		);
 		$this->session->set(self::STATE_NAME, $stateToken);
+		logger('core')->debug('Client login flow state token set on auth picker page', [
+			'sessionId' => $this->session->getId(),
+			'sessionToken' => $stateToken,
+			'user' => $user,
+		]);
 
 		return new StandaloneTemplateResponse(
 			$this->appName,
@@ -309,9 +321,22 @@ class ClientFlowLoginV2Controller extends Controller {
 	private function isValidStateToken(string $stateToken): bool {
 		$currentToken = $this->session->get(self::STATE_NAME);
 		if (!is_string($stateToken) || !is_string($currentToken)) {
+			logger('core')->error('Client login flow state token is not set', [
+				'sessionId' => $this->session->getId(),
+				'sessionToken' => $currentToken,
+				'requestToken' => $stateToken,
+			]);
 			return false;
 		}
-		return hash_equals($currentToken, $stateToken);
+		$hashEquals = hash_equals($currentToken, $stateToken);
+		if (!$hashEquals) {
+			logger('core')->error('Client login flow state token does not match', [
+				'sessionId' => $this->session->getId(),
+				'sessionToken' => $currentToken,
+				'requestToken' => $stateToken,
+			]);
+		}
+		return $hashEquals;
 	}
 
 	private function stateTokenMissingResponse(): StandaloneTemplateResponse {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
