### PR TITLE
fix(core): add translations on the login page

### DIFF
--- a/core/Listener/BeforeTemplateRenderedListener.php
+++ b/core/Listener/BeforeTemplateRenderedListener.php
@@ -53,6 +53,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			// todo: make login work without these
 			Util::addScript('core', 'common');
 			Util::addScript('core', 'main');
+			Util::addTranslations('core');
 		}
 
 		if ($event instanceof BeforeTemplateRenderedEvent) {


### PR DESCRIPTION
* Resolves: #41881
  * Includes: #41874

## Summary

- Not sure, but it seems to be a regression from: https://github.com/nextcloud/server/pull/39867/

Login form has translations from `core` app.

`script('core')` on the login template doesn't load translations because `addScript` ignores translations for the `core` app. Translations should be loaded implicitly.

Before `Util::addTranslations('core');` was always a part of `initTemplateEngine`, but it was changed on the mentioned PR.

## Screenshots

Before | After
---|---
![image](https://github.com/nextcloud/server/assets/25978914/2f3b47b5-4cf2-4389-8f29-4d56d12f9438) | ![image](https://github.com/nextcloud/server/assets/25978914/7d8669d5-d643-4496-8339-3661f2117826)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
