### PR TITLE
Clean-up and standardization of "App password"

### DIFF
--- a/core/templates/loginflow/authpicker.php
+++ b/core/templates/loginflow/authpicker.php
@@ -57,7 +57,7 @@ $urlGenerator = $_['urlGenerator'];
 			<label for="user" class="infield"><?php p($l->t('Username')) ?></label>
 		</p>
 		<p class="groupbottom">
-			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App token')) ?>">
+			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App password')) ?>">
 			<label for="password" class="infield"><?php p($l->t('Password')) ?></label>
 		</p>
 		<input type="hidden" name="stateToken" value="<?php p($_['stateToken']) ?>" />
@@ -69,6 +69,6 @@ $urlGenerator = $_['urlGenerator'];
 	</form>
 
 	<?php if (empty($_['oauthState'])): ?>
-		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
+		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app password')) ?></a>
 	<?php endif; ?>
 </div>

--- a/core/templates/loginflowv2/authpicker.php
+++ b/core/templates/loginflowv2/authpicker.php
@@ -57,7 +57,7 @@ $urlGenerator = $_['urlGenerator'];
 			<label for="user" class="infield"><?php p($l->t('Username')) ?></label>
 		</p>
 		<p class="groupbottom">
-			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App token')) ?>">
+			<input type="password" name="password" id="password" placeholder="<?php p($l->t('App password')) ?>">
 			<label for="password" class="infield"><?php p($l->t('Password')) ?></label>
 		</p>
 		<input type="hidden" name="stateToken" value="<?php p($_['stateToken']) ?>" />
@@ -66,6 +66,6 @@ $urlGenerator = $_['urlGenerator'];
 	</form>
 
 	<?php if (empty($_['oauthState'])): ?>
-		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app token')) ?></a>
+		<a id="app-token-login" class="apptoken-link" href="#"><?php p($l->t('Alternative log in using app password')) ?></a>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
Reported at Transifex.

We have only two occurences at Transifex matching "App token".
We have 21 matching "App password".

After looking at the UI, code and discussion at community chat I propose to align the wording.