### PR TITLE
27.1.5

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [27, 1, 5, 0];
+$OC_Version = [27, 1, 5, 1];
 
 // The human-readable string
-$OC_VersionString = '27.1.5 RC1';
+$OC_VersionString = '27.1.5';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
No version detected - the output will not contain any pending PRs. Use a git tag starting with "v" like "v13.0.5".

* #42188
* nextcloud/activity#1459
* nextcloud/nextcloud_announcements#272
* nextcloud/text#5117
