### PR TITLE
chore(dav): Remove dead \OCA\DAV\Server::getSabreServer

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -386,7 +386,4 @@ class Server {
 		return false;
 	}
 
-	public function getSabreServer(): Connector\Sabre\Server {
-		return $this->server;
-	}
 }


### PR DESCRIPTION
* Ref: https://github.com/nextcloud/server/commit/5b7a5474b9fe9bc08f65f48c115ea08ecac5a73c#r134689595

## Summary

This method was added in https://github.com/nextcloud/server/pull/41340 but never used. It can go.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
