### PR TITLE
[stable26] fix(files_versions): Check for user and owner before call getUserFolder

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -58,11 +58,10 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class FileEventsListener implements IEventListener {
-	private IRootFolder $rootFolder;
-	private VersionsMapper $versionsMapper;
 	/**
 	 * @var array<int, array>
 	 */
@@ -75,19 +74,14 @@ class FileEventsListener implements IEventListener {
 	 * @var array<string, Node>
 	 */
 	private array $versionsDeleted = [];
-	private IMimeTypeLoader $mimeTypeLoader;
-	private LoggerInterface $logger;
 
 	public function __construct(
-		IRootFolder $rootFolder,
-		VersionsMapper $versionsMapper,
-		IMimeTypeLoader $mimeTypeLoader,
-		LoggerInterface $logger,
+		private IRootFolder $rootFolder,
+		private IVersionManager $versionManager,
+		private IMimeTypeLoader $mimeTypeLoader,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
 	) {
-		$this->rootFolder = $rootFolder;
-		$this->versionsMapper = $versionsMapper;
-		$this->mimeTypeLoader = $mimeTypeLoader;
-		$this->logger = $logger;
 	}
 
 	public function handle(Event $event): void {
@@ -349,17 +343,23 @@ class FileEventsListener implements IEventListener {
 
 	/**
 	 * Retrieve the path relative to the current user root folder.
-	 * If no user is connected, use the node's owner.
+	 * If no user is connected, try to use the node's owner.
 	 */
 	private function getPathForNode(Node $node): ?string {
-		try {
+		$user = $this->userSession->getUser()?->getUID();
+		if ($user) {
 			return $this->rootFolder
-				->getUserFolder(\OC_User::getUser())
-				->getRelativePath($node->getPath());
-		} catch (\Throwable $ex) {
-			return $this->rootFolder
-				->getUserFolder($node->getOwner()->getUid())
+				->getUserFolder($user)
 				->getRelativePath($node->getPath());
 		}
+
+		$owner = $node->getOwner()?->getUid();
+		if ($owner) {
+			return $this->rootFolder
+				->getUserFolder($owner)
+				->getRelativePath($node->getPath());
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary
Backport of https://github.com/nextcloud/server/pull/41749

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
