### PR TITLE
Don't write back .htaccess file on a RO filesystem

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -522,6 +522,10 @@ class Setup {
 			\OCP\Server::get(Installer::class)
 		);
 
+		if (!is_writable($setupHelper->pathToHtaccess())) {
+			return false;
+		}
+
 		$htaccessContent = file_get_contents($setupHelper->pathToHtaccess());
 		$content = "#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####\n";
 		$htaccessContent = explode($content, $htaccessContent, 2)[0];


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/42286

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
