### PR TITLE
fix(ooo): add new ooo status with new emoji

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -89,7 +89,7 @@ class UserStatusAutomation extends TimedJob {
 			$this->logger->info('Removing ' . self::class . ' background job for user "' . $userId . '" because the user has no valid availability rules and no OOO data set');
 			$this->jobList->remove(self::class, $argument);
 			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_AVAILABILITY, IUserStatus::DND);
-			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_VACATION, IUserStatus::DND);
+			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND);
 			return;
 		}
 
@@ -227,7 +227,7 @@ class UserStatusAutomation extends TimedJob {
 		if(empty($ooo)) {
 			// Reset the user status if the absence doesn't exist
 			$this->logger->debug('User has no OOO period in effect, reverting DND status if applicable');
-			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_VACATION, IUserStatus::DND);
+			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND);
 			// We need to also run the availability automation
 			return true;
 		}
@@ -235,7 +235,7 @@ class UserStatusAutomation extends TimedJob {
 		if(!$this->coordinator->isInEffect($ooo)) {
 			// Reset the user status if the absence is (no longer) in effect
 			$this->logger->debug('User has no OOO period in effect, reverting DND status if applicable');
-			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_VACATION, IUserStatus::DND);
+			$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND);
 
 			if($ooo->getStartDate() > $this->time->getTime()) {
 				// Set the next run to take place at the start of the ooo period if it is in the future
@@ -250,7 +250,7 @@ class UserStatusAutomation extends TimedJob {
 		// Revert both a possible 'CALL - away' and 'office hours - DND' status
 		$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_CALL, IUserStatus::DND);
 		$this->manager->revertUserStatus($user->getUID(), IUserStatus::MESSAGE_AVAILABILITY, IUserStatus::DND);
-		$this->manager->setUserStatus($user->getUID(), IUserStatus::MESSAGE_VACATION, IUserStatus::DND, true, $ooo->getShortMessage());
+		$this->manager->setUserStatus($user->getUID(), IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND, true, $ooo->getShortMessage());
 		// Run at the end of an ooo period to return to availability / regular user status
 		// If it's overwritten by a custom status in the meantime, there's nothing we can do about it
 		$this->setLastRunToNextToggleTime($user->getUID(), $ooo->getEndDate());

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -228,7 +228,7 @@ END:VCALENDAR');
 			->method('revertUserStatus');
 		$this->statusManager->expects(self::once())
 			->method('setUserStatus')
-			->with('user', IUserStatus::MESSAGE_VACATION, IUserStatus::DND, true, $ooo->getShortMessage());
+			->with('user', IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND, true, $ooo->getShortMessage());
 		$this->config->expects(self::never())
 			->method('getUserValue');
 		$this->time->method('getDateTime')

--- a/apps/user_status/lib/Listener/OutOfOfficeStatusListener.php
+++ b/apps/user_status/lib/Listener/OutOfOfficeStatusListener.php
@@ -53,7 +53,7 @@ class OutOfOfficeStatusListener implements IEventListener {
 	 */
 	public function handle(Event $event): void {
 		if($event instanceof OutOfOfficeClearedEvent) {
-			$this->manager->revertUserStatus($event->getData()->getUser()->getUID(), IUserStatus::MESSAGE_VACATION, IUserStatus::DND);
+			$this->manager->revertUserStatus($event->getData()->getUser()->getUID(), IUserStatus::MESSAGE_OUT_OF_OFFICE, IUserStatus::DND);
 			$this->jobsList->scheduleAfter(UserStatusAutomation::class, $this->time->getTime(), ['userId' => $event->getData()->getUser()->getUID()]);
 			return;
 		}

--- a/apps/user_status/lib/Service/PredefinedStatusService.php
+++ b/apps/user_status/lib/Service/PredefinedStatusService.php
@@ -46,6 +46,7 @@ class PredefinedStatusService {
 	 * @deprecated See \OCP\UserStatus\IUserStatus::MESSAGE_CALL
 	 */
 	public const CALL = 'call';
+	public const OUT_OF_OFFICE = 'out-of-office';
 
 	/** @var IL10N */
 	private $l10n;
@@ -113,6 +114,13 @@ class PredefinedStatusService {
 				'clearAt' => null,
 				'visible' => false,
 			],
+			[
+				'id' => self::OUT_OF_OFFICE,
+				'icon' => '🛑',
+				'message' => $this->getTranslatedStatusForId(self::OUT_OF_OFFICE),
+				'clearAt' => null,
+				'visible' => false,
+			],
 		];
 	}
 
@@ -148,6 +156,9 @@ class PredefinedStatusService {
 			case self::VACATIONING:
 				return '🌴';
 
+			case self::OUT_OF_OFFICE:
+				return '🛑';
+
 			case self::REMOTE_WORK:
 				return '🏡';
 
@@ -178,6 +189,9 @@ class PredefinedStatusService {
 			case self::VACATIONING:
 				return $this->l10n->t('Vacationing');
 
+			case self::OUT_OF_OFFICE:
+				return $this->l10n->t('Out of office');
+
 			case self::REMOTE_WORK:
 				return $this->l10n->t('Working remotely');
 
@@ -199,6 +213,7 @@ class PredefinedStatusService {
 			self::COMMUTING,
 			self::SICK_LEAVE,
 			self::VACATIONING,
+			self::OUT_OF_OFFICE,
 			self::REMOTE_WORK,
 			IUserStatus::MESSAGE_CALL,
 			IUserStatus::MESSAGE_AVAILABILITY,

--- a/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
@@ -47,7 +47,7 @@ class PredefinedStatusServiceTest extends TestCase {
 	}
 
 	public function testGetDefaultStatuses(): void {
-		$this->l10n->expects($this->exactly(6))
+		$this->l10n->expects($this->exactly(7))
 			->method('t')
 			->withConsecutive(
 				['In a meeting'],
@@ -107,6 +107,13 @@ class PredefinedStatusServiceTest extends TestCase {
 				'id' => 'call',
 				'icon' => '💬',
 				'message' => 'In a call',
+				'clearAt' => null,
+				'visible' => false,
+			],
+			[
+				'id' => 'out-of-office',
+				'icon' => '🛑',
+				'message' => 'Out of office',
 				'clearAt' => null,
 				'visible' => false,
 			],
@@ -195,7 +202,7 @@ class PredefinedStatusServiceTest extends TestCase {
 	}
 
 	public function testGetDefaultStatusById(): void {
-		$this->l10n->expects($this->exactly(6))
+		$this->l10n->expects($this->exactly(7))
 			->method('t')
 			->withConsecutive(
 				['In a meeting'],

--- a/lib/public/UserStatus/IUserStatus.php
+++ b/lib/public/UserStatus/IUserStatus.php
@@ -83,6 +83,12 @@ interface IUserStatus {
 
 	/**
 	 * @var string
+	 * @since 28.0.1
+	 */
+	public const MESSAGE_OUT_OF_OFFICE = 'out-of-office';
+
+	/**
+	 * @var string
 	 * @since 28.0.0
 	 */
 	public const MESSAGE_VACATION = 'vacationing';


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/server/issues/42300

## Summary
The OOO status set the predefined vacation status which is awkward when you're out sick :sneezing_face: 

| Before | After |
|--------|--------|
|  ![image](https://github.com/nextcloud/server/assets/7427347/7f9a717d-1cf2-4b6b-98a5-4dc75acf224b) | ![image](https://github.com/nextcloud/server/assets/7427347/ceb63e5b-c1a7-45a0-831e-e0382818fb96) | 

It also solves the issue of an automation not running at all when the `last_run` timestamp is in the future.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
