### PR TITLE
fix(joblist): also reset last_run timestamp on updating an existing job

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -88,6 +88,7 @@ class JobList implements IJobList {
 			$query->update('jobs')
 				->set('reserved_at', $query->expr()->literal(0, IQueryBuilder::PARAM_INT))
 				->set('last_checked', $query->createNamedParameter($firstCheck, IQueryBuilder::PARAM_INT))
+				->set('last_run', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 				->where($query->expr()->eq('class', $query->createNamedParameter($class)))
 				->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argumentJson))));
 		}


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/server/issues/42138

Scheduling a job check after a certain time does not update the last_run timestamp. That means when want to reschedule a job that has a last_run in the future (as happens for the OOO and Office Hours automation), the job is checked but not run.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
