### PR TITLE
[stable27] fix(files): Set download property and encode source

### DIFF
--- a/apps/files/src/components/FileEntry.vue
+++ b/apps/files/src/components/FileEntry.vue
@@ -120,6 +120,7 @@
 <script lang='ts'>
 import { debounce } from 'debounce'
 import { formatFileSize } from '@nextcloud/files'
+import { encodePath } from '@nextcloud/paths'
 import { Fragment } from 'vue-frag'
 import { join, extname } from 'path'
 import { showError, showSuccess } from '@nextcloud/dialogs'
@@ -301,8 +302,10 @@ export default Vue.extend({
 				}
 			}
 
+			const encodedSource = origin + encodePath(this.source.source.slice(origin.length))
 			return {
-				href: this.source.source,
+				download: '',
+				href: encodedSource,
 				// TODO: Use first action title ?
 				title: this.t('files', 'Download file {name}', { name: this.displayName }),
 			}


### PR DESCRIPTION
- Fix part of https://github.com/nextcloud/groupfolders/issues/2680

## Summary

- Fix download on trashbin files originally in a groupfolder

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)