### PR TITLE
feat: Track dirty table writes and long transactions

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -81,6 +81,8 @@ class Connection extends PrimaryReadReplicaConnection {
 
 	protected ?float $transactionActiveSince = null;
 
+	protected $tableDirtyWrites = [];
+
 	/**
 	 * Initializes a new instance of the Connection class.
 	 *
@@ -257,11 +259,33 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws \Doctrine\DBAL\Exception
 	 */
 	public function executeQuery(string $sql, array $params = [], $types = [], QueryCacheProfile $qcp = null): Result {
+		$tables = $this->getQueriedTables($sql);
+		if (count(array_intersect($this->tableDirtyWrites, $tables)) === 0 && !$this->isTransactionActive()) {
+			// No tables read that could have been written already in the same request and no transaction active
+			// so we can switch back to the replica for reading as long as no writes happen that switch back to the primary
+			// We cannot log here as this would log too early in the server boot process
+			$this->ensureConnectedToReplica();
+		} else {
+			// Read to a table that was previously written to
+			// While this might not necessarily mean that we did a read after write it is an indication for a code path to check
+			$this->logger->debug('dirty table reads: ' . $sql, ['tables' => $this->tableDirtyWrites, 'reads' => $tables, 'exception' => new \Exception()]);
+		}
+
 		$sql = $this->replaceTablePrefix($sql);
 		$sql = $this->adapter->fixupStatement($sql);
 		$this->queriesExecuted++;
 		$this->logQueryToFile($sql);
 		return parent::executeQuery($sql, $params, $types, $qcp);
+	}
+
+	/**
+	 * Helper function to get the list of tables affected by a given query
+	 * used to track dirty tables that received a write with the current request
+	 */
+	private function getQueriedTables(string $sql): array {
+		$re = '/(\*PREFIX\*\w+)/mi';
+		preg_match_all($re, $sql, $matches);
+		return array_map([$this, 'replaceTablePrefix'], $matches[0] ?? []);
 	}
 
 	/**
@@ -290,6 +314,9 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws \Doctrine\DBAL\Exception
 	 */
 	public function executeStatement($sql, array $params = [], array $types = []): int {
+		$tables = $this->getQueriedTables($sql);
+		$this->tableDirtyWrites = array_unique(array_merge($this->tableDirtyWrites, $tables));
+		$this->logger->debug('dirty table writes: ' . $sql, ['tables' => $this->tableDirtyWrites]);
 		$sql = $this->replaceTablePrefix($sql);
 		$sql = $this->adapter->fixupStatement($sql);
 		$this->queriesExecuted++;


### PR DESCRIPTION
- feat: First attempt to track dirty tables after writes and switch back to replicas if reads go to other tables
- feat: Add logging for transaction time

* Based on: #41998 

## Summary

The main benefit of this approach is that we can switch back to read replicas for queries that are not towards dirty tables (that were written before), which makes #41998 more performant as less reads go to the primary. In addition the logging can be used to more easily track down read after write by using the debug log.

In addition logging long transactions can be a good indicator for code paths that might need rework to avoid long locks or could cause potential deadlock scenarios.

- [x] Pending documentation as we should cover this in the developer docs https://github.com/nextcloud/documentation/pull/11492
  - [x] Mention log messages to look out for https://github.com/nextcloud/documentation/pull/11492