### PR TITLE
[Fix] Abort Streamer-processing when user-connection aborted

### DIFF
--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -28,7 +28,7 @@
  */
 namespace OC;
 
-use Icewind\Streams\CallBackWrapper;
+use Icewind\Streams\CallbackWrapper;
 use OC\Files\Filesystem;
 use OCP\Files\File;
 use OCP\Files\Folder;

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -28,6 +28,7 @@
  */
 namespace OC;
 
+use Icewind\Streams\CallBackWrapper;
 use OC\Files\Filesystem;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -126,6 +127,7 @@ class Streamer {
 		/** @var LoggerInterface $logger */
 		$logger = \OC::$server->query(LoggerInterface::class);
 		foreach ($files as $file) {
+			if(connection_status() !== CONNECTION_NORMAL) return;
 			if ($file instanceof File) {
 				try {
 					$fh = $file->fopen('r');
@@ -161,6 +163,15 @@ class Streamer {
 	 * @return bool $success
 	 */
 	public function addFileFromStream($stream, string $internalName, int|float $size, $time): bool {
+		if(connection_status() !== CONNECTION_NORMAL) return false;
+		// Close file-stream when user-connection closed
+		$stream = CallbackWrapper::wrap($stream,
+			function ($count) use ($stream) {
+				if (connection_status() !== CONNECTION_NORMAL) {
+					fclose($stream);
+				}
+			});
+
 		$options = [];
 		if ($time) {
 			$options = [


### PR DESCRIPTION
* Resolves: #8161

## Summary
Streamer, which builds compressed archives to stream to the browser (e.g. for downloading folders), didnt have checks when the browser aborts the connection (e.g. download cancelled).

This PR adds checks at certain positions:
- before file or folder is processed in `addDirRecursive` to avoid opening files or further traversing directories, even though writing is impossible
- before file is given to streamer in `addFileFromStream`
- FileStream is wrapped to close file-Stream when connection aborted while reading
  - This happens after 1-3 stream-read-calls as PHP `connection_status()` only updates when data is attempted to be send to the browser (e.g. with `flush()`)

## Todo
- How the abort is handled while another system is processing streams could maybe be a bit more elegant or moved somewhere else?