### PR TITLE
VerificationToken - Expiration time added in argument

### DIFF
--- a/lib/private/Security/VerificationToken/VerificationToken.php
+++ b/lib/private/Security/VerificationToken/VerificationToken.php
@@ -101,6 +101,7 @@ class VerificationToken implements IVerificationToken {
 		IUser $user,
 		string $subject,
 		string $passwordPrefix = '',
+		, int $expirationTime = self::TOKEN_LIFETIME * 2
 	): string {
 		$token = $this->secureRandom->generate(
 			21,
@@ -115,7 +116,7 @@ class VerificationToken implements IVerificationToken {
 			'userId' => $user->getUID(),
 			'subject' => $subject,
 			'pp' => $passwordPrefix,
-			'notBefore' => $this->timeFactory->getTime() + self::TOKEN_LIFETIME * 2, // multiply to provide a grace period
+			'notBefore' => $this->timeFactory->getTime() + $expirationTime, // multiply to provide a grace period
 		]);
 		$this->jobList->add(CleanUpJob::class, $jobArgs);
 

--- a/lib/private/Security/VerificationToken/VerificationToken.php
+++ b/lib/private/Security/VerificationToken/VerificationToken.php
@@ -101,7 +101,7 @@ class VerificationToken implements IVerificationToken {
 		IUser $user,
 		string $subject,
 		string $passwordPrefix = '',
-		, int $expirationTime = self::TOKEN_LIFETIME * 2
+		int $expirationTime = self::TOKEN_LIFETIME * 2
 	): string {
 		$token = $this->secureRandom->generate(
 			21,


### PR DESCRIPTION
* Resolves: #42107

## Summary
We have a requirement to set token expiration at specific intervals, like 15 minutes or 1 day. To address this, I am suggesting an enhancement.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
