### PR TITLE
enh(dashboard): changed h1 to say Dashboard instead of Nextcloud

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -43,8 +43,8 @@ use OCP\Dashboard\IWidget;
 use OCP\Dashboard\RegisterWidgetEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
-use OCP\IRequest;
 use OCP\IL10N;
+use OCP\IRequest;
 
 #[IgnoreOpenAPI]
 class DashboardController extends Controller {

--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
  * @author Kate Döen <kate.doeen@nextcloud.com>
+ * @author Eduardo Morales <eduardo.morales@nextcloud.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -43,6 +44,7 @@ use OCP\Dashboard\RegisterWidgetEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IL10N;
 
 #[IgnoreOpenAPI]
 class DashboardController extends Controller {
@@ -55,6 +57,8 @@ class DashboardController extends Controller {
 	private $dashboardManager;
 	/** @var IConfig */
 	private $config;
+	/** @var IL10N */
+	private $l10n;
 	/** @var string */
 	private $userId;
 
@@ -65,6 +69,7 @@ class DashboardController extends Controller {
 		IEventDispatcher $eventDispatcher,
 		IManager $dashboardManager,
 		IConfig $config,
+		IL10N $l10n,
 		$userId
 	) {
 		parent::__construct($appName, $request);
@@ -73,6 +78,7 @@ class DashboardController extends Controller {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->dashboardManager = $dashboardManager;
 		$this->config = $config;
+		$this->l10n = $l10n;
 		$this->userId = $userId;
 	}
 
@@ -117,6 +123,7 @@ class DashboardController extends Controller {
 		$response = new TemplateResponse('dashboard', 'index', [
 			'id-app-content' => '#app-dashboard',
 			'id-app-navigation' => null,
+			'pageTitle' => $this->l10n->t('Dashboard'),
 		]);
 
 		// For the weather widget we should allow the geolocation


### PR DESCRIPTION
☑️ Resolves #42267

🖼️ Screenshots

🏚️ Before
![image](https://github.com/nextcloud/server/assets/110193237/a0ec6b6f-7e93-4ea0-aed9-108236416a10) 
🏡 After
![image](https://github.com/nextcloud/server/assets/110193237/a6779ab8-5cce-4619-8bc0-f04e5ac1aabc)


🚧 Summary
In order to make the dashboard / main page more accessible, the heading will be changed to something more descriptive, such as 'Dashboard'. I checked out the rest of the dashboard controller, and there seemed to be no usage of the translator, but if there is, it is preferable to use it here in this change for the header.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
