### PR TITLE
fix(LDAP): ensure stored groups are formatted as simple list

### DIFF
--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -685,7 +685,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 
 	protected function getCachedGroupsForUserId(string $uid): array {
 		$groupStr = $this->config->getUserValue($uid, 'user_ldap', 'cached-group-memberships-' . $this->access->connection->getConfigPrefix(), '[]');
-		return json_decode($groupStr) ?? [];
+		return json_decode($groupStr, true) ?? [];
 	}
 
 	/**
@@ -838,7 +838,7 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 			return $groups;
 		}
 
-		$groups = array_unique($groups, SORT_LOCALE_STRING);
+		$groups = array_values(array_unique($groups, SORT_LOCALE_STRING));
 		$this->access->connection->writeToCache($cacheKey, $groups);
 
 		$groupStr = \json_encode($groups);

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -901,6 +901,33 @@ class Group_LDAPTest extends TestCase {
 		$this->assertTrue(in_array('groupF', $returnedGroups));
 	}
 
+	/**
+	 * regression tests against a case where a json object was stored instead of expected list
+	 * @see https://github.com/nextcloud/server/issues/42374
+	 */
+	public function testGetUserGroupsOfflineUserUnexpectedJson() {
+		$this->enableGroups();
+
+		$offlineUser = $this->createMock(OfflineUser::class);
+
+		$this->config->expects($this->any())
+			->method('getUserValue')
+			->with('userX', 'user_ldap', 'cached-group-memberships-', $this->anything())
+			// results in a json object: {"0":"groupB","2":"groupF"}
+			->willReturn(\json_encode([0 => 'groupB', 2 => 'groupF']));
+
+		$this->access->userManager->expects($this->any())
+			->method('get')
+			->with('userX')
+			->willReturn($offlineUser);
+
+		$this->initBackend();
+		$returnedGroups = $this->groupBackend->getUserGroups('userX');
+		$this->assertCount(2, $returnedGroups);
+		$this->assertTrue(in_array('groupB', $returnedGroups));
+		$this->assertTrue(in_array('groupF', $returnedGroups));
+	}
+
 	public function testGetUserGroupsUnrecognizedOfflineUser() {
 		$this->enableGroups();
 		$dn = 'cn=userX,dc=foobar';


### PR DESCRIPTION
* Resolves: #42374 

## Summary

With array_unique it is possible that the keys are not in sequential order but have gaps. json_encode then would store them as associative array, which later on json_decode would result in a stdClass by default. This is unexpected and would also contradict the return type hint.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
