### PR TITLE
fix(dav): Hide less than minute diff in calendar notification title

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/Notifier.php
+++ b/apps/dav/lib/CalDAV/Reminder/Notifier.php
@@ -170,7 +170,7 @@ class Notifier implements INotifier {
 			$components[] = $this->l10n->n('%n minute', '%n minutes', $diff->i);
 		}
 
-		if (!$this->hasPhpDatetimeDiffBug()) {
+		if (count($components) > 0 && !$this->hasPhpDatetimeDiffBug()) {
 			// Limiting to the first three components to prevent
 			// the string from getting too long
 			$firstThreeComponents = array_slice($components, 0, 2);


### PR DESCRIPTION
## Summary

This has been bugging me for a long time, now I'll fix it as a christmas gift for myself :D

If you check the notifications at the moment when the event starts the diff is less than a minute. In that case the notification title will be `... (in )` or `... ( ago)`. Please let me know if there is a better way to detect if the diff is less than a minute.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
