### PR TITLE
fix(files): Adjust ID for skip content buttons

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -280,7 +280,9 @@ class ViewController extends Controller {
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 
 		$params = [
-			'fileNotFound' => $fileNotFound ? 1 : 0
+			'fileNotFound' => $fileNotFound ? 1 : 0,
+			'id-app-content' => '#app-content-vue',
+			'id-app-navigation' => '#app-navigation-vue',
 		];
 
 		$response = new TemplateResponse(

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -186,6 +186,8 @@ class ViewControllerTest extends TestCase {
 			'index',
 			[
 				'fileNotFound' => 0,
+				'id-app-content' => '#app-content-vue',
+				'id-app-navigation' => '#app-navigation-vue',
 			]
 		);
 		$policy = new Http\ContentSecurityPolicy();


### PR DESCRIPTION
* Resolves: #41696 for the files app

## Summary
As we now use Vue the ID needs to be adjusted.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
