### PR TITLE
fix(dav): undeclared `$cache` property

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php
@@ -49,6 +49,7 @@ class StatusServiceTest extends TestCase {
 	private IAvailabilityCoordinator|MockObject $availabilityCoordinator;
 	private ICacheFactory|MockObject $cacheFactory;
 	private LoggerInterface|MockObject $logger;
+	private ICache|MockObject $cache;
 	private StatusService $service;
 
 	protected function setUp(): void {


### PR DESCRIPTION
After https://github.com/nextcloud/server/pull/42380

Fails on 8.3 https://github.com/nextcloud/server/actions/runs/7286709234/job/19858533093
Manual run for this PR: https://github.com/nextcloud/server/actions/runs/7288786922


```
1) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testNoUser
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

2) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testOOOInEffect
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

3) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testNoCalendars
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

4) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testNoCalendarEvents
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

5) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testCalendarEvent
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

6) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testCallStatus
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

7) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testInvisibleStatus
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64

8) OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::testDNDStatus
Creation of dynamic property OCA\DAV\Tests\unit\CalDAV\Status\StatusServiceTest::$cache is deprecated

/__w/server/server/apps/dav/tests/unit/CalDAV/Status/StatusServiceTest.php:64
```