### PR TITLE
fix(ViewController): Properly handle non-existent fileIds (regression lead to 500 errors)

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -237,12 +237,16 @@ class ViewController extends Controller {
 		if ($fileid && $dir !== '') {
 			$baseFolder = $this->rootFolder->getUserFolder($userId);
 			$nodes = $baseFolder->getById((int) $fileid);
-			$nodePath = $baseFolder->getRelativePath($nodes[0]->getPath());
-			$relativePath = $nodePath ? dirname($nodePath) : '';
-			// If the requested path does not contain the file id
-			// or if the requested path is not the file id itself
-			if (count($nodes) === 1 && $relativePath !== $dir && $nodePath !== $dir) {
-				return $this->redirectToFile((int) $fileid);
+			if (!empty($nodes)) {
+				$nodePath = $baseFolder->getRelativePath($nodes[0]->getPath());
+				$relativePath = $nodePath ? dirname($nodePath) : '';
+				// If the requested path does not contain the file id
+				// or if the requested path is not the file id itself
+				if (count($nodes) === 1 && $relativePath !== $dir && $nodePath !== $dir) {
+					return $this->redirectToFile((int) $fileid);
+				}
+			} else { // fileid does not exist anywhere
+				$fileNotFound = true;
 			}
 		}
 


### PR DESCRIPTION
* Resolves: #42418 <!-- related github issue -->

## Summary

The handling added in #40515 broke the handling for `fileIds` that don't exist anywhere.

## Notes

- One difference in behavior remains  (versus <NC28) and that is that when we redirect to the `index`, the URL in the browser used to drop the bogus fileId (but now it stays). I'd personally would prefer to drop it. I haven't deciphered all the changes to the newer `files` to know where that's coming from. I tried using the old RedirectResponse approach taken in NC27 (see [here](https://github.com/nextcloud/server/blob/e454bf49c3ddc28d8566beabd673bbae89dbccef/apps/files/lib/Controller/ViewController.php#L181-L187)) and the bogus fileId still sticks around now. Open to suggestions and/or ignoring it since it may be outside the scope of this PR.

- Backport only to v28
