### PR TITLE
fix(files_external): add back js config files

### DIFF
--- a/apps/files_external/js/oauth1.js
+++ b/apps/files_external/js/oauth1.js
@@ -1,0 +1,82 @@
+window.addEventListener('DOMContentLoaded', function() {
+
+	function displayGranted($tr) {
+		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+	}
+
+	OCA.Files_External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
+		if (authMechanism === 'oauth1::oauth1') {
+			var config = $tr.find('.configuration');
+			config.append($(document.createElement('input'))
+				.addClass('button auth-param')
+				.attr('type', 'button')
+				.attr('value', t('files_external', 'Grant access'))
+				.attr('name', 'oauth1_grant')
+			);
+
+			onCompletion.then(function() {
+				var configured = $tr.find('[data-parameter="configured"]');
+				if ($(configured).val() == 'true') {
+					displayGranted($tr);
+				} else {
+					var app_key = $tr.find('.configuration [data-parameter="app_key"]').val();
+					var app_secret = $tr.find('.configuration [data-parameter="app_secret"]').val();
+					if (app_key != '' && app_secret != '') {
+						var pos = window.location.search.indexOf('oauth_token') + 12;
+						var token = $tr.find('.configuration [data-parameter="token"]');
+						if (pos != -1 && window.location.search.substr(pos, $(token).val().length) == $(token).val()) {
+							var token_secret = $tr.find('.configuration [data-parameter="token_secret"]');
+							var statusSpan = $tr.find('.status span');
+							statusSpan.removeClass();
+							statusSpan.addClass('waiting');
+							$.post(OC.filePath('files_external', 'ajax', 'oauth1.php'), { step: 2, app_key: app_key, app_secret: app_secret, request_token: $(token).val(), request_token_secret: $(token_secret).val() }, function(result) {
+								if (result && result.status == 'success') {
+									$(token).val(result.access_token);
+									$(token_secret).val(result.access_token_secret);
+									$(configured).val('true');
+									OCA.Files_External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
+										if (status) {
+											displayGranted($tr);
+										}
+									});
+								} else {
+									OC.dialogs.alert(result.data.message, t('files_external', 'Error configuring OAuth1'));
+								}
+							});
+						}
+					}
+				}
+			});
+		}
+	});
+
+	$('#externalStorage').on('click', '[name="oauth1_grant"]', function(event) {
+		event.preventDefault();
+		var tr = $(this).parent().parent();
+		var app_key = $(this).parent().find('[data-parameter="app_key"]').val();
+		var app_secret = $(this).parent().find('[data-parameter="app_secret"]').val();
+		if (app_key != '' && app_secret != '') {
+			var configured = $(this).parent().find('[data-parameter="configured"]');
+			var token = $(this).parent().find('[data-parameter="token"]');
+			var token_secret = $(this).parent().find('[data-parameter="token_secret"]');
+			$.post(OC.filePath('files_external', 'ajax', 'oauth1.php'), { step: 1, app_key: app_key, app_secret: app_secret, callback: location.protocol + '//' + location.host + location.pathname }, function(result) {
+				if (result && result.status == 'success') {
+					$(configured).val('false');
+					$(token).val(result.data.request_token);
+					$(token_secret).val(result.data.request_token_secret);
+					OCA.Files_External.Settings.mountConfig.saveStorageConfig(tr, function() {
+						window.location = result.data.url;
+					});
+				} else {
+					OC.dialogs.alert(result.data.message, t('files_external', 'Error configuring OAuth1'));
+				}
+			});
+		} else {
+			OC.dialogs.alert(
+				t('files_external', 'Please provide a valid app key and secret.'),
+				t('files_external', 'Error configuring OAuth1')
+			);
+		}
+	});
+
+});

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -1,0 +1,96 @@
+window.addEventListener('DOMContentLoaded', function() {
+
+	function displayGranted($tr) {
+		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+	}
+
+	OCA.Files_External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
+		if (authMechanism === 'oauth2::oauth2') {
+			var config = $tr.find('.configuration');
+			config.append($(document.createElement('input'))
+				.addClass('button auth-param')
+				.attr('type', 'button')
+				.attr('value', t('files_external', 'Grant access'))
+				.attr('name', 'oauth2_grant')
+			);
+
+			onCompletion.then(function() {
+				var configured = $tr.find('[data-parameter="configured"]');
+				if ($(configured).val() == 'true') {
+					displayGranted($tr);
+				} else {
+					var client_id = $tr.find('.configuration [data-parameter="client_id"]').val();
+					var client_secret = $tr.find('.configuration [data-parameter="client_secret"]')
+						.val();
+					if (client_id != '' && client_secret != '') {
+						var params = {};
+						window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
+							params[key] = value;
+						});
+						if (params['code'] !== undefined) {
+							var token = $tr.find('.configuration [data-parameter="token"]');
+							var statusSpan = $tr.find('.status span');
+							statusSpan.removeClass();
+							statusSpan.addClass('waiting');
+							$.post(OC.filePath('files_external', 'ajax', 'oauth2.php'),
+									{
+										step: 2,
+										client_id: client_id,
+										client_secret: client_secret,
+										redirect: location.protocol + '//' + location.host + location.pathname,
+										code: params['code'],
+									}, function(result) {
+										if (result && result.status == 'success') {
+											$(token).val(result.data.token);
+											$(configured).val('true');
+											OCA.Files_External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
+												if (status) {
+													displayGranted($tr);
+												}
+											});
+										} else {
+											OC.dialogs.alert(result.data.message,
+													t('files_external', 'Error configuring OAuth2')
+													);
+										}
+									}
+							);
+						}
+					}
+				}
+			});
+		}
+	});
+
+	$('#externalStorage').on('click', '[name="oauth2_grant"]', function(event) {
+		event.preventDefault();
+		var tr = $(this).parent().parent();
+		var configured = $(this).parent().find('[data-parameter="configured"]');
+		var client_id = $(this).parent().find('[data-parameter="client_id"]').val();
+		var client_secret = $(this).parent().find('[data-parameter="client_secret"]').val();
+		if (client_id != '' && client_secret != '') {
+			var token = $(this).parent().find('[data-parameter="token"]');
+			$.post(OC.filePath('files_external', 'ajax', 'oauth2.php'),
+				{
+					step: 1,
+					client_id: client_id,
+					client_secret: client_secret,
+					redirect: location.protocol + '//' + location.host + location.pathname,
+				}, function(result) {
+					if (result && result.status == 'success') {
+						$(configured).val('false');
+						$(token).val('false');
+						OCA.Files_External.Settings.mountConfig.saveStorageConfig(tr, function(status) {
+							window.location = result.data.url;
+						});
+					} else {
+						OC.dialogs.alert(result.data.message,
+							t('files_external', 'Error configuring OAuth2')
+						);
+					}
+				}
+			);
+		}
+	});
+
+});

--- a/apps/files_external/js/public_key.js
+++ b/apps/files_external/js/public_key.js
@@ -1,0 +1,64 @@
+window.addEventListener('DOMContentLoaded', function() {
+
+	OCA.Files_External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
+		if (scheme === 'publickey' && authMechanism === 'publickey::rsa') {
+			var config = $tr.find('.configuration');
+			if ($(config).find('[name="public_key_generate"]').length === 0) {
+				setupTableRow($tr, config);
+				onCompletion.then(function() {
+					// If there's no private key, build one
+					if (0 === $(config).find('[data-parameter="private_key"]').val().length) {
+						generateKeys($tr);
+					}
+				});
+			}
+		}
+	});
+
+	$('#externalStorage').on('click', '[name="public_key_generate"]', function(event) {
+		event.preventDefault();
+		var tr = $(this).parent().parent();
+		generateKeys(tr);
+	});
+
+	function setupTableRow(tr, config) {
+		var selectList = document.createElement('select');
+		selectList.id = 'keyLength';
+
+		var options = [1024, 2048, 4096];
+		for (var i = 0; i < options.length; i++) {
+			var option = document.createElement('option');
+			option.value = options[i];
+			option.text = options[i];
+			selectList.appendChild(option);
+		}
+
+		$(config).append(selectList);
+
+		$(config).append($(document.createElement('input'))
+			.addClass('button auth-param')
+			.attr('type', 'button')
+			.attr('value', t('files_external', 'Generate keys'))
+			.attr('name', 'public_key_generate')
+		);
+	}
+
+	function generateKeys(tr) {
+		var config = $(tr).find('.configuration');
+		var keyLength = config.find('#keyLength').val();
+
+		$.post(OC.filePath('files_external', 'ajax', 'public_key.php'), {
+			keyLength: keyLength
+		}, function(result) {
+			if (result && result.status === 'success') {
+				$(config).find('[data-parameter="public_key"]').val(result.data.public_key).keyup();
+				$(config).find('[data-parameter="private_key"]').val(result.data.private_key);
+				OCA.Files_External.Settings.mountConfig.saveStorageConfig(tr, function() {
+					// Nothing to do
+				});
+			} else {
+				OC.dialogs.alert(result.data.message, t('files_external', 'Error generating key pair') );
+			}
+		});
+	}
+});


### PR DESCRIPTION
Seems I cleaned up too much in https://github.com/nextcloud/server/commit/38480fda3cd1f10652bc1e854207b074921e66b8
The settings still have their own legacy handlings

https://github.com/nextcloud/server/blob/9319bbb00ce98bbb6da8f8772199356872f1873b/apps/files_external/lib/Lib/FrontendDefinitionTrait.php#L75-L89

https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/apps/files_external/lib/Lib/Auth/OAuth1/OAuth1.php#L50
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/apps/files_external/lib/Lib/Auth/OAuth2/OAuth2.php#L48
https://github.com/nextcloud/server/blob/5e31ed4f526e943e695d994a6434ed71d1a45c1c/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php#L55

Fix https://github.com/nextcloud/server/issues/42158