### PR TITLE
fix(theming): Adjust high contrast theme to fulfill WCAG AAA text contrast

### DIFF
--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -59,17 +59,25 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 		$colorMainBackground = '#ffffff';
 		$colorMainBackgroundRGB = join(',', $this->util->hexToRGB($colorMainBackground));
 
+		$colorError = '#D10000';
+		$colorWarning = '#995900';
+		$colorSuccess = '#207830';
+		$colorInfo = '#006DA8';
+
+		$primaryVariables = $this->generatePrimaryVariables($colorMainBackground, $colorMainText, true);
 		return array_merge(
 			$defaultVariables,
-			$this->generatePrimaryVariables($colorMainBackground, $colorMainText),
+			$primaryVariables,
 			[
+				'--color-primary-element-text-dark' => $primaryVariables['--color-primary-element-text'],
+
 				'--color-main-background' => $colorMainBackground,
 				'--color-main-background-rgb' => $colorMainBackgroundRGB,
 				'--color-main-background-translucent' => 'rgba(var(--color-main-background-rgb), 1)',
 				'--color-main-text' => $colorMainText,
 
-				'--color-background-dark' => $this->util->darken($colorMainBackground, 30),
-				'--color-background-darker' => $this->util->darken($colorMainBackground, 30),
+				'--color-background-dark' => $this->util->darken($colorMainBackground, 20),
+				'--color-background-darker' => $this->util->darken($colorMainBackground, 20),
 
 				'--color-main-background-blur' => $colorMainBackground,
 				'--filter-background-blur' => 'none',
@@ -81,6 +89,26 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 				'--color-text-maxcontrast-background-blur' => $colorMainText,
 				'--color-text-light' => $colorMainText,
 				'--color-text-lighter' => $colorMainText,
+
+				'--color-error' => $colorError,
+				'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),
+				'--color-error-hover' => $this->util->darken($colorError, 8),
+				'--color-error-text' => $this->util->darken($colorError, 17),
+
+				'--color-warning' => $colorWarning,
+				'--color-warning-rgb' => join(',', $this->util->hexToRGB($colorWarning)),
+				'--color-warning-hover' => $this->util->darken($colorWarning, 7),
+				'--color-warning-text' => $this->util->darken($colorWarning, 13),
+
+				'--color-info' => $colorInfo,
+				'--color-info-rgb' => join(',', $this->util->hexToRGB($colorInfo)),
+				'--color-info-hover' => $this->util->darken($colorInfo, 7),
+				'--color-info-text' => $this->util->darken($colorInfo, 15),
+
+				'--color-success' => $colorSuccess,
+				'--color-success-rgb' => join(',', $this->util->hexToRGB($colorSuccess)),
+				'--color-success-hover' => $this->util->darken($colorSuccess, 7),
+				'--color-success-text' => $this->util->darken($colorSuccess, 14),
 
 				'--color-scrollbar' => $this->util->darken($colorMainBackground, 25),
 

--- a/apps/theming/tests/Themes/HighContrastThemeTest.php
+++ b/apps/theming/tests/Themes/HighContrastThemeTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Theming\Tests\Themes;
+
+use OCA\Theming\AppInfo\Application;
+use OCA\Theming\ImageManager;
+use OCA\Theming\ITheme;
+use OCA\Theming\Service\BackgroundService;
+use OCA\Theming\Themes\HighContrastTheme;
+use OCA\Theming\ThemingDefaults;
+use OCA\Theming\Util;
+use OCP\App\IAppManager;
+use OCP\Files\IAppData;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class HighContrastThemeTest extends AccessibleThemeTestCase {
+	/** @var ThemingDefaults|MockObject */
+	private $themingDefaults;
+	/** @var IUserSession|MockObject */
+	private $userSession;
+	/** @var IURLGenerator|MockObject */
+	private $urlGenerator;
+	/** @var ImageManager|MockObject */
+	private $imageManager;
+	/** @var IConfig|MockObject */
+	private $config;
+	/** @var IL10N|MockObject */
+	private $l10n;
+	/** @var IAppManager|MockObject */
+	private $appManager;
+
+	// !! important: Enable WCAG AAA tests
+	protected bool $WCAGaaa = true;
+
+	protected function setUp(): void {
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->imageManager = $this->createMock(ImageManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+
+		$this->util = new Util(
+			$this->config,
+			$this->appManager,
+			$this->createMock(IAppData::class),
+			$this->imageManager
+		);
+
+		$this->themingDefaults
+			->expects($this->any())
+			->method('getColorPrimary')
+			->willReturn('#0082c9');
+
+		$this->themingDefaults
+			->expects($this->any())
+			->method('getDefaultColorPrimary')
+			->willReturn('#0082c9');
+
+		$this->themingDefaults
+			->expects($this->any())
+			->method('getBackground')
+			->willReturn('/apps/' . Application::APP_ID . '/img/background/' . BackgroundService::DEFAULT_BACKGROUND_IMAGE);
+
+		$this->l10n
+			->expects($this->any())
+			->method('t')
+			->willReturnCallback(function ($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			});
+
+		$this->urlGenerator
+			->expects($this->any())
+			->method('imagePath')
+			->willReturnCallback(function ($app = 'core', $filename = '') {
+				return "/$app/img/$filename";
+			});
+
+		$this->theme = new HighContrastTheme(
+			$this->util,
+			$this->themingDefaults,
+			$this->userSession,
+			$this->urlGenerator,
+			$this->imageManager,
+			$this->config,
+			$this->l10n,
+			$this->appManager,
+		);
+
+		parent::setUp();
+	}
+
+
+	public function testGetId() {
+		$this->assertEquals('light-highcontrast', $this->theme->getId());
+	}
+
+	public function testGetType() {
+		$this->assertEquals(ITheme::TYPE_THEME, $this->theme->getType());
+	}
+
+	public function testGetTitle() {
+		$this->assertEquals('High contrast mode', $this->theme->getTitle());
+	}
+
+	public function testGetEnableLabel() {
+		$this->assertEquals('Enable high contrast mode', $this->theme->getEnableLabel());
+	}
+
+	public function testGetDescription() {
+		$this->assertEquals('A high contrast mode to ease your navigation. Visual quality will be reduced but clarity will be increased.', $this->theme->getDescription());
+	}
+
+	public function testGetMediaQuery() {
+		$this->assertEquals('(prefers-contrast: more)', $this->theme->getMediaQuery());
+	}
+}


### PR DESCRIPTION
## Summary
The last one of the themes to adjust. This adjusts the light high contrast theme to fulfill WCAG AAA text contrast criteria.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
