### PR TITLE
fix(theming): Invert filter should be based on primary-element

### DIFF
--- a/apps/theming/lib/Themes/CommonThemeTrait.php
+++ b/apps/theming/lib/Themes/CommonThemeTrait.php
@@ -54,8 +54,8 @@ trait CommonThemeTrait {
 			// ⚠️ Using 'no' as a value to make sure we specify an
 			// invalid one with no fallback. 'unset' could here fallback to some
 			// other theme with media queries
-			'--primary-invert-if-bright' => $this->util->invertTextColor($this->primaryColor) ? 'invert(100%)' : 'no',
-			'--primary-invert-if-dark' => $this->util->invertTextColor($this->primaryColor) ? 'no' : 'invert(100%)',
+			'--primary-invert-if-bright' => $this->util->invertTextColor($colorPrimaryElement) ? 'invert(100%)' : 'no',
+			'--primary-invert-if-dark' => $this->util->invertTextColor($colorPrimaryElement) ? 'no' : 'invert(100%)',
 
 			'--color-primary' => $this->primaryColor,
 			'--color-primary-default' => $this->defaultPrimaryColor,


### PR DESCRIPTION
## Summary
The invert filter should be based on the primary-element color as that is the color used for elements, see screenshots.

### Screenshots
before|after
---|---
![Screenshot_20231222_013128](https://github.com/nextcloud/server/assets/1855448/724e1558-203d-4d5d-82e0-293d265dec8e)|![Screenshot_20231222_013117](https://github.com/nextcloud/server/assets/1855448/c3aa2e99-67d1-45e9-88c2-32e63e9a080e)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
