### PR TITLE
fix(cron): Respect config_is_read_only config in in cron and console commands

### DIFF
--- a/console.php
+++ b/console.php
@@ -63,15 +63,17 @@ try {
 		echo "The posix extensions are required - see https://www.php.net/manual/en/book.posix.php" . PHP_EOL;
 		exit(1);
 	}
-	$user = posix_getuid();
-	$configUser = fileowner(OC::$configDir . 'config.php');
-	if ($user !== $configUser) {
-		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-		echo "Current user id: " . $user . PHP_EOL;
-		echo "Owner id of config.php: " . $configUser . PHP_EOL;
-		echo "Try adding 'sudo -u #" . $configUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
-		echo "If running with 'docker exec' try adding the option '-u " . $configUser . "' to the docker command (without the single quotes)" . PHP_EOL;
-		exit(1);
+	if (!\OC::$server->getConfig()->getSystemValue('config_is_read_only', false)) {
+		$user = posix_getuid();
+		$configUser = fileowner(OC::$configDir . 'config.php');
+		if ($user !== $configUser) {
+			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+			echo "Current user id: " . $user . PHP_EOL;
+			echo "Owner id of config.php: " . $configUser . PHP_EOL;
+			echo "Try adding 'sudo -u #" . $configUser . "' to the beginning of the command (without the single quotes)" . PHP_EOL;
+			echo "If running with 'docker exec' try adding the option '-u " . $configUser . "' to the docker command (without the single quotes)" . PHP_EOL;
+			exit(1);
+		}
 	}
 
 	$oldWorkingDir = getcwd();

--- a/cron.php
+++ b/cron.php
@@ -96,13 +96,15 @@ try {
 			exit(1);
 		}
 
-		$user = posix_getuid();
-		$configUser = fileowner(OC::$configDir . 'config.php');
-		if ($user !== $configUser) {
-			echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-			echo "Current user id: " . $user . PHP_EOL;
-			echo "Owner id of config.php: " . $configUser . PHP_EOL;
-			exit(1);
+		if (!$config->getSystemValue('config_is_read_only', false)) {
+			$user = posix_getuid();
+			$configUser = fileowner(OC::$configDir . 'config.php');
+			if ($user !== $configUser) {
+				echo "Cron has to be executed with the user that owns the file config/config.php" . PHP_EOL;
+				echo "Current user id: " . $user . PHP_EOL;
+				echo "Owner id of config.php: " . $configUser . PHP_EOL;
+				exit(1);
+			}
 		}
 
 


### PR DESCRIPTION
* Resolves: https://help.nextcloud.com/t/running-cron-with-read-only-config/177221

## Summary

I’d like to keep the config and application code read-only for the webserver as an extra security measure.
We have the `config_is_read_only` config boolean for that, but still occ and cron complain about not being the config file owner.

Even if they do have write access, which I think atleast cron should be able to do without.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
