### PR TITLE
fix(theming): adjust default `--color-background-plain` to new background

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -85,5 +85,5 @@
   --color-primary-element-light-text: #00293f;
   --gradient-primary-background: linear-gradient(40deg, var(--color-primary) 0%, var(--color-primary-hover) 100%);
   --image-background-default: url('/apps/theming/img/background/kamil-porembinski-clouds.jpg');
-  --color-background-plain: #0082c9;
+  --color-background-plain: #00679e;
 }


### PR DESCRIPTION
* Continue of https://github.com/nextcloud/server/pull/42424

Before `--color-background-plain` was the same as the default background image color. Now the image has changed.

It is noticeable on slow connection.

On the image for me color is `#01679d` while we use as primary `#00679e`, but 1/256 is not notable.

Probably there are more places that we need to adjust.

## Screenshots

Before | After
---|---
![bg-before](https://github.com/nextcloud/server/assets/25978914/4b5330ab-9833-4c16-a240-a11b48917f7b) | ![bg-after](https://github.com/nextcloud/server/assets/25978914/53fab95a-1892-4b85-b35e-17f0ef113e2f)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
