### PR TITLE
fix(dav): fallback realm for HTTP authentication

### DIFF
--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -63,7 +63,7 @@ class LegacyPublicAuth extends AbstractBasic {
 
 		// setup realm
 		$defaults = new \OCP\Defaults();
-		$this->realm = $defaults->getName();
+		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -75,7 +75,7 @@ class Auth extends AbstractBasic {
 
 		// setup realm
 		$defaults = new \OCP\Defaults();
-		$this->realm = $defaults->getName();
+		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/BearerAuth.php
+++ b/apps/dav/lib/Connector/Sabre/BearerAuth.php
@@ -47,7 +47,7 @@ class BearerAuth extends AbstractBearer {
 
 		// setup realm
 		$defaults = new \OCP\Defaults();
-		$this->realm = $defaults->getName();
+		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 
 	private function setupUserFs($userId) {


### PR DESCRIPTION
* Resolves: https://help.nextcloud.com/t/thunderbird-dont-save-caldav-password-because-of-missing-httprealm-or-formsubmiturl/93233

## Summary
By default, the name of the Nextcloud instance is an empty string, until changed by the admin. This leads to an empty realm sent with the `WWW-Authenticate` header, while the realm is mandatory for Basic HTTP authentication. Some clients have issues with an empty realm, e.g. Thunderbird cannot store passwords in this case.

This commit applies "Nextcloud" as fallback for the realm, in case the name of the Nextcloud instance is not set.

To solve the particular linked issue, only `apps/dav/lib/Connector/Sabre/Auth.php` is relevant, but I decided to align this across all DAV authentication APIs and not allow an empty realm in general.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
