### PR TITLE
AppAPI: allow to bypass Two-Factor

### DIFF
--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -100,7 +100,10 @@ class TwoFactorMiddleware extends Middleware {
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();
 
-			if ($this->session->exists('app_password') || $this->twoFactorManager->isTwoFactorAuthenticated($user)) {
+			if ($this->session->exists('app_password')  // authenticated using an app password
+				|| $this->session->exists('app_api')  // authenticated using an AppAPI Auth
+				|| $this->twoFactorManager->isTwoFactorAuthenticated($user)) {
+
 				$this->checkTwoFactor($controller, $methodName, $user);
 			} elseif ($controller instanceof TwoFactorChallengeController) {
 				// Allow access to the two-factor controllers only if two-factor authentication

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -318,8 +318,8 @@ class Manager {
 			return false;
 		}
 
-		// If we are authenticated using an app password skip all this
-		if ($this->session->exists('app_password')) {
+		// If we are authenticated using an app password or AppAPI Auth, skip all this
+		if ($this->session->exists('app_password') || $this->session->get('app_api') === true) {
 			return false;
 		}
 

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -629,13 +629,26 @@ class ManagerTest extends TestCase {
 					return false;
 				} elseif ($var === 'app_password') {
 					return false;
+				} elseif ($var === 'app_api') {
+					return false;
 				}
 				return true;
 			});
+		$this->session->method('get')
+			->willReturnCallback(function ($var) {
+				if ($var === Manager::SESSION_UID_KEY) {
+					return 'user';
+				} elseif ($var === 'app_api') {
+					return true;
+				}
+				return null;
+			});
 		$this->session->expects($this->once())
 			->method('get')
-			->with(Manager::SESSION_UID_DONE)
-			->willReturn('user');
+			->willReturnMap([
+				[Manager::SESSION_UID_DONE, 'user'],
+				['app_api', true]
+			]);
 
 		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}
@@ -695,8 +708,10 @@ class ManagerTest extends TestCase {
 	public function testNeedsSecondFactorAppPassword() {
 		$user = $this->createMock(IUser::class);
 		$this->session->method('exists')
-			->with('app_password')
-			->willReturn(true);
+			->willReturnMap([
+				['app_password', true],
+				['app_api', true]
+			]);
 
 		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}


### PR DESCRIPTION
* Resolves: _**AppAPI with TwoFactor Auth enabled**_

## Summary

[AppAPI](https://github.com/cloud-py-api/app_api) must support passing two-factor authentication so that ExApps can work in such systems.
By design they should do so.

Original issue where it was discovered(we just completely forgot about two-factor auth):
https://github.com/cloud-py-api/app_api/issues/181

Since the [context_chat](https://apps.nextcloud.com/apps/context_chat) was already released we should provide a fix for this situation.
Also the backport to **stable28** branch is required, as this is a bug that blocks all Apps developed for AppAPI to work in most production systems.
_If possible, also a backport to **stable27** branch will be nice._

Ref:
 * Previous PR allowing CORS skip for AppAPI: #40737
 * Rename AppEcosystem to AppAPI: https://github.com/nextcloud/server/pull/40295
 * Initial PR with AppEcosystem auth: #39655

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
