### PR TITLE
fix(Update): Handle upstream exception scenario cleanly

### DIFF
--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -108,6 +108,7 @@ class Update extends Command {
 							'exception' => $e,
 						]);
 						$output->writeln('Error: ' . $e->getMessage());
+						$result = false;
 						$return = 1;
 					}
 


### PR DESCRIPTION
* Resolves: #42476  <!-- related github issue -->

## Summary

The exception from `checkAppDependencies()` trickles through `updateApp()` then through to `updateAppstoreApp()`. We want the exception (because it has the explanation), but the catch in `Update::execute()` (that triggers this change of events) wasn't accounting for `$result` being left unset when an exception is triggered. The outcome wasn't fatal, but generated `Undefined variable` errors. An "easy as :pie:" fix in the end (which probably means someone will point out something obvious I overlooked).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~
- [x] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
