### PR TITLE
Ignore shared Collective mounts when scanning files

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -239,7 +239,7 @@ class Scanner extends PublicEmitter {
 				}
 			}
 
-			// don't scan received local shares, these can be scanned when scanning the owner's storage
+			// don't scan received local shares or collectives, these can be scanned when scanning the owner's storage
 			if ($storage->instanceOfStorage(SharedStorage::class) || $storage->instanceOfStorage(CollectiveStorage::class)) {
 				continue;
 			}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -240,7 +240,7 @@ class Scanner extends PublicEmitter {
 			}
 
 			// don't scan received local shares or collectives, these can be scanned when scanning the owner's storage
-			if ($storage->instanceOfStorage(SharedStorage::class) || $storage->instanceOfStorage(CollectiveStorage::class)) {
+			if (substr($storage->getId(), 0, 6) !== 'home::') {
 				continue;
 			}
 

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -37,6 +37,7 @@ use OC\Files\Storage\Home;
 use OC\ForbiddenException;
 use OC\Hooks\PublicEmitter;
 use OC\Lock\DBLockingProvider;
+use OCA\Collectives\Mount\CollectiveStorage;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\BeforeFileScannedEvent;
@@ -239,9 +240,10 @@ class Scanner extends PublicEmitter {
 			}
 
 			// don't scan received local shares, these can be scanned when scanning the owner's storage
-			if ($storage->instanceOfStorage(SharedStorage::class)) {
+			if ($storage->instanceOfStorage(SharedStorage::class) || $storage->instanceOfStorage(CollectiveStorage::class)) {
 				continue;
 			}
+
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);


### PR DESCRIPTION
* Resolves: #42496

## Summary

When scanning files using `occ files:scan`, shared Collective mounts trigger "Path not found" error messages. This change will make sure that that Collective mounts will be ignored.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
