### PR TITLE
Fix sharing icon

### DIFF
--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -34,8 +34,8 @@
 						type="tertiary"
 						@click="openSharingSidebar">
 						<template #icon>
-							<LinkIcon v-if="shareButtonType === Type.SHARE_TYPE_LINK" />
-							<ShareVariantIcon v-else :size="20" />
+							<FolderAccountIcon v-if="shareButtonType !== null" />
+							<AccountPlusIcon v-else :size="20" />
 						</template>
 					</NcButton>
 
@@ -135,7 +135,7 @@ import { UploadPicker } from '@nextcloud/upload'
 import { loadState } from '@nextcloud/initial-state'
 import { defineComponent } from 'vue'
 
-import LinkIcon from 'vue-material-design-icons/Link.vue'
+import FolderAccountIcon from 'vue-material-design-icons/FolderAccount.vue'
 import ListViewIcon from 'vue-material-design-icons/FormatListBulletedSquare.vue'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -143,7 +143,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
-import ShareVariantIcon from 'vue-material-design-icons/ShareVariant.vue'
+import AccountPlusIcon from 'vue-material-design-icons/AccountPlus.vue'
 import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
 
 import { action as sidebarAction } from '../actions/sidebarAction.ts'
@@ -169,7 +169,6 @@ export default defineComponent({
 		BreadCrumbs,
 		DragAndDropNotice,
 		FilesListVirtual,
-		LinkIcon,
 		ListViewIcon,
 		NcAppContent,
 		NcButton,
@@ -177,9 +176,10 @@ export default defineComponent({
 		NcIconSvgWrapper,
 		NcLoadingIcon,
 		PlusIcon,
-		ShareVariantIcon,
+		AccountPlusIcon,
 		UploadPicker,
 		ViewGridIcon,
+		FolderAccountIcon,
 	},
 
 	mixins: [


### PR DESCRIPTION
* Resolves: #40202

## Summary

## shared state
![Screenshot from 2023-12-28 14-13-36](https://github.com/nextcloud/server/assets/26852655/5f4478a9-b2e5-46d0-aec8-3bec49593c25)

## unshared state
![Screenshot from 2023-12-28 14-13-59](https://github.com/nextcloud/server/assets/26852655/35dc8bf3-09b4-41d5-bcf5-f545ddb64c87)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
