### PR TITLE
fix: Avoid using replicas during setup

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -140,10 +140,12 @@ abstract class AbstractDatabase {
 			}
 			$connectionParams['host'] = $host;
 		}
-
-		$connectionParams = array_merge($connectionParams, ['primary' => $connectionParams, 'replica' => [$connectionParams]], $configOverwrite);
+		$connectionParams = array_merge($connectionParams, $configOverwrite);
+		$connectionParams = array_merge($connectionParams, ['primary' => $connectionParams, 'replica' => [$connectionParams]]);
 		$cf = new ConnectionFactory($this->config);
-		return $cf->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
+		$connection = $cf->getConnection($this->config->getValue('dbtype', 'sqlite'), $connectionParams);
+		$connection->ensureConnectedToPrimary();
+		return $connection;
 	}
 
 	/**


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/41998

It turned out that installation through occ fails if the database that is used has not been created already on the instance as the setup passes over `database => null` to the connection for the installation checks. We need to merge this to the connection params first so that it is part of both the primary and replica configuration.

Caused CI failure in tables
- before https://github.com/nextcloud/tables/actions/runs/7346289021/job/20000795573?pr=756
- with this pr https://github.com/nextcloud/tables/actions/runs/7346908190/job/20002445192?pr=756