### PR TITLE
fix(dashboard): Fix case of null userId

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardApiController.php
+++ b/apps/dashboard/lib/Controller/DashboardApiController.php
@@ -58,7 +58,7 @@ class DashboardApiController extends OCSController {
 	private $dashboardManager;
 	/** @var IConfig */
 	private $config;
-	/** @var string|null */
+	/** @var string */
 	private $userId;
 
 	public function __construct(
@@ -66,7 +66,7 @@ class DashboardApiController extends OCSController {
 		IRequest $request,
 		IManager $dashboardManager,
 		IConfig $config,
-		?string $userId
+		string $userId
 	) {
 		parent::__construct($appName, $request);
 


### PR DESCRIPTION
## Summary

In some rare instances I see this error when using the dashboard API:
```log
{"Exception":"Exception","Message":"OCA\\Activity\\Dashboard\\ActivityWidget::getWidgetButtons(): Argument #1 ($userId) must be of type string, null given, called in \/usr\/src\/nextcloud\/apps\/dashboard\/lib\/Controller\/DashboardApiController.php on line 184 in file '\/usr\/src\/nextcloud\/apps\/activity\/lib\/Dashboard\/ActivityWidget.php' line 192","Code":0,"Trace":[{"file":"\/usr\/src\/nextcloud\/lib\/private\/AppFramework\/App.php","line":184,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Dashboard\\Controller\\DashboardApiController"],"getWidgets"]},{"file":"\/usr\/src\/nextcloud\/lib\/private\/Route\/Router.php","line":315,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Dashboard\\Controller\\DashboardApiController","getWidgets",["OC\\AppFramework\\DependencyInjection\\DIContainer"],["ocs.dashboard.dashboardApi.getWidgets"]]},{"file":"\/usr\/src\/nextcloud\/ocs\/v1.php","line":65,"function":"match","class":"OC\\Route\\Router","type":"->","args":["\/ocsapp\/apps\/dashboard\/api\/v1\/widgets"]},{"file":"\/usr\/src\/nextcloud\/ocs\/v2.php","line":23,"args":["\/usr\/src\/nextcloud\/ocs\/v1.php"],"function":"require_once"}],"File":"\/usr\/src\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","Line":169,"Previous":{"Exception":"TypeError","Message":"OCA\\Activity\\Dashboard\\ActivityWidget::getWidgetButtons(): Argument #1 ($userId) must be of type string, null given, called in \/usr\/src\/nextcloud\/apps\/dashboard\/lib\/Controller\/DashboardApiController.php on line 184","Code":0,"Trace":[{"file":"\/usr\/src\/nextcloud\/apps\/dashboard\/lib\/Controller\/DashboardApiController.php","line":184,"function":"getWidgetButtons","class":"OCA\\Activity\\Dashboard\\ActivityWidget","type":"->","args":[null]},{"function":"OCA\\Dashboard\\Controller\\{closure}","class":"OCA\\Dashboard\\Controller\\DashboardApiController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"\/usr\/src\/nextcloud\/apps\/dashboard\/lib\/Controller\/DashboardApiController.php","line":163,"function":"array_map","args":[["Closure"],["*** sensitive parameters replaced ***",["OCA\\Notes\\AppInfo\\DashboardWidget"],["OCA\\Recommendations\\Dashboard\\RecommendationWidget"],["OCA\\Talk\\Dashboard\\TalkWidget"],["OCA\\UserStatus\\Dashboard\\UserStatusWidget"]]]},{"file":"\/usr\/src\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":230,"function":"getWidgets","class":"OCA\\Dashboard\\Controller\\DashboardApiController","type":"->","args":[]},{"file":"\/usr\/src\/nextcloud\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":137,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Dashboard\\Controller\\DashboardApiController"],"getWidgets"]},{"file":"\/usr\/src\/nextcloud\/lib\/private\/AppFramework\/App.php","line":184,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Dashboard\\Controller\\DashboardApiController"],"getWidgets"]},{"file":"\/usr\/src\/nextcloud\/lib\/private\/Route\/Router.php","line":315,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Dashboard\\Controller\\DashboardApiController","getWidgets",["OC\\AppFramework\\DependencyInjection\\DIContainer"],["ocs.dashboard.dashboardApi.getWidgets"]]},{"file":"\/usr\/src\/nextcloud\/ocs\/v1.php","line":65,"function":"match","class":"OC\\Route\\Router","type":"->","args":["\/ocsapp\/apps\/dashboard\/api\/v1\/widgets"]},{"file":"\/usr\/src\/nextcloud\/ocs\/v2.php","line":23,"args":["\/usr\/src\/nextcloud\/ocs\/v1.php"],"function":"require_once"}],"File":"\/usr\/src\/nextcloud\/apps\/activity\/lib\/Dashboard\/ActivityWidget.php","Line":192},"CustomMessage":"Exception thrown: Exception"}
```
the important part being `getWidgetButtons(): Argument #1 ($userId) must be of type string, null given`.

I don't know if this patch actually fixes it since it is not possible to reproduce it reliably, but it seems wrong to me that it can be null here as all usages in this controller expect it to be non-null.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
