### PR TITLE
feat(user_status): Add online status type for OpenAPI

### DIFF
--- a/apps/user_status/lib/Controller/StatusesController.php
+++ b/apps/user_status/lib/Controller/StatusesController.php
@@ -39,6 +39,7 @@ use OCP\IRequest;
 use OCP\UserStatus\IUserStatus;
 
 /**
+ * @psalm-import-type UserStatusType from ResponseDefinitions
  * @psalm-import-type UserStatusPublic from ResponseDefinitions
  */
 class StatusesController extends OCSController {
@@ -105,6 +106,7 @@ class StatusesController extends OCSController {
 	 * @return UserStatusPublic
 	 */
 	private function formatStatus(UserStatus $status): array {
+		/** @var UserStatusType $visibleStatus */
 		$visibleStatus = $status->getStatus();
 		if ($visibleStatus === IUserStatus::INVISIBLE) {
 			$visibleStatus = IUserStatus::OFFLINE;

--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -47,6 +47,7 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 /**
+ * @psalm-import-type UserStatusType from ResponseDefinitions
  * @psalm-import-type UserStatusPrivate from ResponseDefinitions
  */
 class UserStatusController extends OCSController {
@@ -207,6 +208,8 @@ class UserStatusController extends OCSController {
 	 * @return UserStatusPrivate
 	 */
 	private function formatStatus(UserStatus $status): array {
+		/** @var UserStatusType $visibleStatus */
+		$visibleStatus = $status->getStatus();
 		return [
 			'userId' => $status->getUserId(),
 			'message' => $status->getCustomMessage(),
@@ -214,7 +217,7 @@ class UserStatusController extends OCSController {
 			'messageIsPredefined' => $status->getMessageId() !== null,
 			'icon' => $status->getCustomIcon(),
 			'clearAt' => $status->getClearAt(),
-			'status' => $status->getStatus(),
+			'status' => $visibleStatus,
 			'statusIsUserDefined' => $status->getIsUserDefined(),
 		];
 	}

--- a/apps/user_status/lib/ResponseDefinitions.php
+++ b/apps/user_status/lib/ResponseDefinitions.php
@@ -42,12 +42,14 @@ namespace OCA\UserStatus;
  *     visible: ?bool,
  * }
  *
+ * @psalm-type UserStatusType = "online"|"away"|"dnd"|"busy"|"offline"|"invisible"
+ *
  * @psalm-type UserStatusPublic = array{
  *     userId: string,
  *     message: ?string,
  *     icon: ?string,
  *     clearAt: ?int,
- *     status: string,
+ *     status: UserStatusType,
  * }
  *
  * @psalm-type UserStatusPrivate = UserStatusPublic&array{

--- a/apps/user_status/openapi.json
+++ b/apps/user_status/openapi.json
@@ -188,9 +188,20 @@
                         "nullable": true
                     },
                     "status": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/Type"
                     }
                 }
+            },
+            "Type": {
+                "type": "string",
+                "enum": [
+                    "online",
+                    "away",
+                    "dnd",
+                    "busy",
+                    "offline",
+                    "invisible"
+                ]
             }
         }
     },


### PR DESCRIPTION
## Summary

Adds proper typing for the status type. I tried a few ways but sadly there is no way to ensure it conforms with the values from IUserStatus.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
