### PR TITLE
fix(user_status): Allow setting custom message with icon only

### DIFF
--- a/apps/user_status/lib/Controller/UserStatusController.php
+++ b/apps/user_status/lib/Controller/UserStatusController.php
@@ -149,7 +149,7 @@ class UserStatusController extends OCSController {
 		?string $message,
 		?int $clearAt): DataResponse {
 		try {
-			if (($message !== null && $message !== '') || ($clearAt !== null && $clearAt !== 0)) {
+			if (($statusIcon !== null && $statusIcon !== '') || ($message !== null && $message !== '') || ($clearAt !== null && $clearAt !== 0)) {
 				$status = $this->service->setCustomMessage($this->userId, $statusIcon, $message, $clearAt);
 			} else {
 				$this->service->clearMessage($this->userId);

--- a/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
+++ b/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
@@ -330,7 +330,7 @@ class UserStatusControllerTest extends TestCase {
 		return [
 			['👨🏽‍💻', 'Busy developing the status feature', 500, true, false, null, false, null],
 			['👨🏽‍💻', '', 500, true, false, null, false, null, false],
-			['👨🏽‍💻', '', 0, true, false, null, false, null, true],
+			['👨🏽‍💻', '', 0, true, false, null, false, null, false],
 			['👨🏽‍💻', 'Busy developing the status feature', 500, false, true, new InvalidClearAtException('Original exception message'), true,
 				'New user-status for "john.doe" was rejected due to an invalid clearAt value "500"'],
 			['👨🏽‍💻', 'Busy developing the status feature', 500, false, true, new InvalidStatusIconException('Original exception message'), true,


### PR DESCRIPTION
## Summary

Allows setting a custom message with icon only.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
