### PR TITLE
fix(weather_status): Fix forecast format in OpenAPI

### DIFF
--- a/apps/weather_status/lib/ResponseDefinitions.php
+++ b/apps/weather_status/lib/ResponseDefinitions.php
@@ -27,25 +27,18 @@ declare(strict_types=1);
 namespace OCA\WeatherStatus;
 
 /**
- * https://api.met.no/doc/ForecastJSON
+ * https://api.met.no/doc/ForecastJSON compact format according to https://docs.api.met.no/doc/locationforecast/datamodel
  * @psalm-type WeatherStatusForecast = array{
  *     time: string,
  *     data: array{
  *         instant: array{
  *             details: array{
- *                 air_pressure_at_sea_level: float,
- *                 air_temperature: float,
- *                 cloud_area_fraction: float,
- *                 cloud_area_fraction_high: float,
- *                 cloud_area_fraction_low: float,
- *                 cloud_area_fraction_medium: float,
- *                 dew_point_temperature: float,
- *                 fog_area_fraction: float,
- *                 relative_humidity: float,
- *                 ultraviolet_index_clear_sky: float,
- *                 wind_from_direction: float,
- *                 wind_speed: float,
- *                 wind_speed_of_gust: float,
+ *                 air_pressure_at_sea_level: numeric,
+ *                 air_temperature: numeric,
+ *                 cloud_area_fraction: numeric,
+ *                 relative_humidity: numeric,
+ *                 wind_from_direction: numeric,
+ *                 wind_speed: numeric,
  *             },
  *         },
  *         next_12_hours: array{
@@ -53,7 +46,7 @@ namespace OCA\WeatherStatus;
  *                 symbol_code: string,
  *             },
  *             details: array{
- *                 probability_of_precipitation: float,
+ *                 precipitation_amount?: numeric,
  *             },
  *         },
  *         next_1_hours: array{
@@ -61,11 +54,7 @@ namespace OCA\WeatherStatus;
  *                 symbol_code: string,
  *             },
  *             details: array{
- *                 precipitation_amount: float,
- *                 precipitation_amount_max: float,
- *                 precipitation_amount_min: float,
- *                 probability_of_precipitation: float,
- *                 probability_of_thunder: float,
+ *                 precipitation_amount?: numeric,
  *             },
  *         },
  *         next_6_hours: array{
@@ -73,12 +62,7 @@ namespace OCA\WeatherStatus;
  *                 symbol_code: string,
  *             },
  *             details: array{
- *                 air_temperature_max: float,
- *                 air_temperature_min: float,
- *                 precipitation_amount: float,
- *                 precipitation_amount_max: float,
- *                 precipitation_amount_min: float,
- *                 probability_of_precipitation: float,
+ *                 precipitation_amount?: numeric,
  *             },
  *         },
  *     },

--- a/apps/weather_status/openapi.json
+++ b/apps/weather_status/openapi.json
@@ -70,69 +70,28 @@
                                             "air_pressure_at_sea_level",
                                             "air_temperature",
                                             "cloud_area_fraction",
-                                            "cloud_area_fraction_high",
-                                            "cloud_area_fraction_low",
-                                            "cloud_area_fraction_medium",
-                                            "dew_point_temperature",
-                                            "fog_area_fraction",
                                             "relative_humidity",
-                                            "ultraviolet_index_clear_sky",
                                             "wind_from_direction",
-                                            "wind_speed",
-                                            "wind_speed_of_gust"
+                                            "wind_speed"
                                         ],
                                         "properties": {
                                             "air_pressure_at_sea_level": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             },
                                             "air_temperature": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             },
                                             "cloud_area_fraction": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "cloud_area_fraction_high": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "cloud_area_fraction_low": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "cloud_area_fraction_medium": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "dew_point_temperature": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "fog_area_fraction": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             },
                                             "relative_humidity": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "ultraviolet_index_clear_sky": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             },
                                             "wind_from_direction": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             },
                                             "wind_speed": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "wind_speed_of_gust": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             }
                                         }
                                     }
@@ -158,13 +117,9 @@
                                     },
                                     "details": {
                                         "type": "object",
-                                        "required": [
-                                            "probability_of_precipitation"
-                                        ],
                                         "properties": {
-                                            "probability_of_precipitation": {
-                                                "type": "number",
-                                                "format": "float"
+                                            "precipitation_amount": {
+                                                "type": "number"
                                             }
                                         }
                                     }
@@ -190,33 +145,9 @@
                                     },
                                     "details": {
                                         "type": "object",
-                                        "required": [
-                                            "precipitation_amount",
-                                            "precipitation_amount_max",
-                                            "precipitation_amount_min",
-                                            "probability_of_precipitation",
-                                            "probability_of_thunder"
-                                        ],
                                         "properties": {
                                             "precipitation_amount": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "precipitation_amount_max": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "precipitation_amount_min": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "probability_of_precipitation": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "probability_of_thunder": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             }
                                         }
                                     }
@@ -242,38 +173,9 @@
                                     },
                                     "details": {
                                         "type": "object",
-                                        "required": [
-                                            "air_temperature_max",
-                                            "air_temperature_min",
-                                            "precipitation_amount",
-                                            "precipitation_amount_max",
-                                            "precipitation_amount_min",
-                                            "probability_of_precipitation"
-                                        ],
                                         "properties": {
-                                            "air_temperature_max": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "air_temperature_min": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
                                             "precipitation_amount": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "precipitation_amount_max": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "precipitation_amount_min": {
-                                                "type": "number",
-                                                "format": "float"
-                                            },
-                                            "probability_of_precipitation": {
-                                                "type": "number",
-                                                "format": "float"
+                                                "type": "number"
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Summary

The format was wrong because I looked at the complete format and not the compact format. Took some time to dig up the page where they explain which format contains which data...

Requires https://github.com/nextcloud/openapi-extractor/pull/64 and an updated openapi-extractor.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
