### PR TITLE
Fix log rotation notification level (warning->info)

### DIFF
--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -43,7 +43,7 @@ class Rotate extends \OCP\BackgroundJob\Job {
 		if ($this->shouldRotateBySize()) {
 			$rotatedFile = $this->rotate();
 			$msg = 'Log file "'.$this->filePath.'" was over '.$this->maxSize.' bytes, moved to "'.$rotatedFile.'"';
-			\OC::$server->getLogger()->warning($msg, ['app' => Rotate::class]);
+			\OC::$server->getLogger()->info($msg, ['app' => Rotate::class]);
 		}
 	}
 }


### PR DESCRIPTION
* Resolves: #42537  <!-- related github issue -->

## Summary

The notification that the log has been rotated is just informational. It should not be logged as a warning.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
