### PR TITLE
use deletion time instead of mtime in trashbin handling

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashFile.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFile.php
@@ -30,10 +30,10 @@ use OCA\Files_Trashbin\Trashbin;
 
 class TrashFile extends AbstractTrashFile {
 	public function get() {
-		return $this->data->getStorage()->fopen(Trashbin::getTrashFilename($this->data->getInternalPath(), $this->getLastModified()), 'rb');
+		return $this->data->getStorage()->fopen(Trashbin::getTrashFilename($this->data->getInternalPath(), $this->getDeletionTime()), 'rb');
 	}
 
 	public function getName(): string {
-		return Trashbin::getTrashFilename($this->data->getName(), $this->getLastModified());
+		return Trashbin::getTrashFilename($this->data->getName(), $this->getDeletionTime());
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolder.php
@@ -30,6 +30,6 @@ use OCA\Files_Trashbin\Trashbin;
 
 class TrashFolder extends AbstractTrashFolder {
 	public function getName(): string {
-		return Trashbin::getTrashFilename($this->data->getName(), $this->getLastModified());
+		return Trashbin::getTrashFilename($this->data->getName(), $this->getDeletionTime());
 	}
 }


### PR DESCRIPTION
The mtime of the deleted file and the deletion time are the same with the standard trashbin backend, but this isn't necessarily the case for other backends.