### PR TITLE
debug logs on huge metadata

### DIFF
--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -176,7 +176,8 @@ class FilesMetadataManager implements IFilesMetadataManager {
 
 		$json = json_encode($filesMetadata->jsonSerialize());
 		if (strlen($json) > self::JSON_MAXSIZE) {
-			throw new FilesMetadataException('json cannot exceed ' . self::JSON_MAXSIZE . ' characters long');
+			$this->logger->debug('huge metadata content detected: ' . $json);
+			throw new FilesMetadataException('json cannot exceed ' . self::JSON_MAXSIZE . ' characters long; fileId: ' . $filesMetadata->getFileId() . '; size: ' . strlen($json));
 		}
 
 		try {


### PR DESCRIPTION
related to #42308

adding debug logs for details on huge metadata that fails to be stored