### PR TITLE
Fix upgrade of user_ldap when oc_group_members contains duplicated uids

### DIFF
--- a/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
+++ b/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
@@ -99,13 +99,21 @@ class Version1190Date20230706134108 extends SimpleMigrationStep {
 		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$knownUsers = unserialize($row['owncloudusers']);
+			$knownUsers = array_unique($knownUsers);
 			foreach ($knownUsers as $knownUser) {
-				$insert
-					->setParameter('groupid', $row['owncloudname'])
-					->setParameter('userid', $knownUser)
-				;
+				try {
+					$insert
+						->setParameter('groupid', $row['owncloudname'])
+						->setParameter('userid', $knownUser)
+					;
 
-				$insert->executeStatement();
+					$insert->executeStatement();
+				} catch (\OCP\DB\Exception $e) {
+					/*
+					 * If it fails on unique constaint violation it may just be left over value from previous half-migration
+					 * If it fails on something else, ignore as well, data will be filled by background job later anyway
+					 */
+				}
 			}
 		}
 		$result->closeCursor();


### PR DESCRIPTION
* Resolves: #42232

## Summary

When upgrading to 28, if oc_group_members contains duplicated uids, migration was failing on unicity constraint.
Also ignore DB errors for this migration step, as people which failed the upgrade before will have a non-empty table in oc_group_membership, and there is no data loss in this case since membership information is in the LDAP and will be fetched by the background job on the next run if incorrect or incomplete.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
