### PR TITLE
Inherit private Exception from OCP to fix class hierarchy

### DIFF
--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -28,8 +28,6 @@ declare(strict_types=1);
  */
 namespace OCA\OAuth2\Controller;
 
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\ClientMapper;
@@ -39,6 +37,8 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\DB\Exception;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
  */
 namespace OCA\OAuth2\Migration;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCA\OAuth2\Db\AccessToken;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;

--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -32,10 +32,8 @@
 namespace OCA\Settings\Controller;
 
 use BadMethodCallException;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
 use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -45,6 +43,9 @@ use OCP\Activity\IManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
@@ -292,7 +293,8 @@ class AuthSettingsController extends Controller {
 			$token = $e->getToken();
 		}
 		if ($token->getUID() !== $this->uid) {
-			throw new InvalidTokenException('This token does not belong to you!');
+			/* We have to throw the OC version so both OC and OCP catches catch it */
+			throw new OcInvalidTokenException('This token does not belong to you!');
 		}
 		return $token;
 	}
@@ -305,7 +307,7 @@ class AuthSettingsController extends Controller {
 	 * @param int $id
 	 * @return JSONResponse
 	 * @throws InvalidTokenException
-	 * @throws \OC\Authentication\Exceptions\ExpiredTokenException
+	 * @throws ExpiredTokenException
 	 */
 	public function wipe(int $id): JSONResponse {
 		if ($this->checkAppToken()) {

--- a/apps/settings/lib/Settings/Personal/Security/Authtokens.php
+++ b/apps/settings/lib/Settings/Personal/Security/Authtokens.php
@@ -25,12 +25,12 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\Settings\Personal\Security;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;

--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -29,13 +29,13 @@ declare(strict_types=1);
 namespace OC\Core\Controller;
 
 use OC\Authentication\Events\AppPasswordCreatedEvent;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\PasswordUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\EventDispatcher\IEventDispatcher;

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -33,7 +33,7 @@
 namespace OC\Core\Controller;
 
 use OC\Authentication\Events\AppPasswordCreatedEvent;
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -47,6 +47,7 @@ use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
@@ -331,7 +332,7 @@ class ClientFlowLoginController extends Controller {
 		try {
 			$token = $this->tokenProvider->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new InvalidTokenException('login name does not match');
+				throw new OcInvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Core\Db\LoginFlowV2;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OC\Core\Service\LoginFlowV2Service;
@@ -40,6 +40,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Defaults;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -211,7 +212,7 @@ class ClientFlowLoginV2Controller extends Controller {
 		try {
 			$token = \OC::$server->get(\OC\Authentication\Token\IProvider::class)->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new InvalidTokenException('login name does not match');
+				throw new OcInvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -26,11 +26,11 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\RemoteWipe;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IRequest;
 
 class WipeController extends Controller {

--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
  */
 namespace OC\Core\Service;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -37,6 +36,7 @@ use OC\Core\Db\LoginFlowV2Mapper;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\LoginCredentials;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\LoginCredentials\ICredentials;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\ISession;

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -28,10 +28,11 @@ declare(strict_types=1);
 namespace OC\Authentication\Token;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Exceptions\PasswordlessTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\PasswordlessTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
 
 class Manager implements IProvider, OCPIProvider {
@@ -221,7 +222,7 @@ class Manager implements IProvider, OCPIProvider {
 			return $this->publicKeyTokenProvider->rotate($token, $oldTokenId, $newTokenId);
 		}
 
-		throw new InvalidTokenException();
+		throw new OcInvalidTokenException();
 	}
 
 	/**
@@ -233,7 +234,7 @@ class Manager implements IProvider, OCPIProvider {
 		if ($token instanceof PublicKeyToken) {
 			return $this->publicKeyTokenProvider;
 		}
-		throw new InvalidTokenException();
+		throw new OcInvalidTokenException();
 	}
 
 

--- a/lib/private/Authentication/Token/RemoteWipe.php
+++ b/lib/private/Authentication/Token/RemoteWipe.php
@@ -29,8 +29,8 @@ namespace OC\Authentication\Token;
 
 use OC\Authentication\Events\RemoteWipeFinished;
 use OC\Authentication\Events\RemoteWipeStarted;
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -29,10 +29,10 @@ namespace OC\Authentication\TwoFactorAuth;
 
 use BadMethodCallException;
 use Exception;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -33,8 +33,8 @@ declare(strict_types=1);
  */
 namespace OC\Session;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
 /**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -39,8 +39,6 @@
 namespace OC\User;
 
 use OC;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\Token\IProvider;
@@ -51,6 +49,8 @@ use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\NotPermittedException;

--- a/lib/public/Authentication/Exceptions/ExpiredTokenException.php
+++ b/lib/public/Authentication/Exceptions/ExpiredTokenException.php
@@ -30,7 +30,7 @@ use OCP\Authentication\Token\IToken;
 /**
  * @since 28.0.0
  */
-class ExpiredTokenException extends InvalidTokenException {
+class ExpiredTokenException extends \OC\Authentication\Exceptions\InvalidTokenException {
 	/**
 	 * @since 28.0.0
 	 */

--- a/lib/public/Authentication/Exceptions/WipeTokenException.php
+++ b/lib/public/Authentication/Exceptions/WipeTokenException.php
@@ -30,7 +30,7 @@ use OCP\Authentication\Token\IToken;
 /**
  * @since 28.0.0
  */
-class WipeTokenException extends InvalidTokenException {
+class WipeTokenException extends \OC\Authentication\Exceptions\InvalidTokenException {
 	/**
 	 * @since 28.0.0
 	 */


### PR DESCRIPTION
Fix regression of authentication workflow because class hierarchy changed when moving Exception to OCP

* Resolves: #42394

## Summary

27:

```mermaid
graph BT;
     \OC\ExpiredTokenException --> \OC\InvalidTokenException
     \OC\WipeTokenException --> \OC\InvalidTokenException
     \OC\InvalidTokenException --> \Exception
```

28:

```mermaid
graph BT;
     \OC\ExpiredTokenException --> \OCP\ExpiredTokenException
     \OC\WipeTokenException --> \OCP\WipeTokenException
     \OC\InvalidTokenException --> \OCP\InvalidTokenException
     \OCP\ExpiredTokenException --> \OCP\InvalidTokenException
     \OCP\WipeTokenException --> \OCP\InvalidTokenException
     \OCP\InvalidTokenException --> \Exception
```

This PR:

```mermaid
graph BT;
     \OC\ExpiredTokenException --> \OCP\ExpiredTokenException
     \OC\WipeTokenException --> \OCP\WipeTokenException
     \OC\InvalidTokenException --> \OCP\InvalidTokenException
     \OCP\ExpiredTokenException --> \OC\InvalidTokenException
     \OCP\WipeTokenException --> \OC\InvalidTokenException
     \OCP\InvalidTokenException --> \Exception
```

It is a bit sad to reference `OC` from `OCP` but I am not sure we have a better solution here to restore backward compatibility of the API. We should still move all code to using the `OCP` namespaced exceptions and remove the `OC` ones when possible.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
