### PR TITLE
Add RichObject support for SetupCheck descriptions

### DIFF
--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -59,13 +59,11 @@ class SetupChecks extends Base {
 					throw new \InvalidArgumentException("Invalid rich object, {$requiredField} field is missing");
 				}
 			}
-			if ($parameter['type'] === 'user') {
-				$replacements[] = '@' . $parameter['name'];
-			} elseif ($parameter['type'] === 'file') {
-				$replacements[] = $parameter['path'] ?? $parameter['name'];
-			} else {
-				$replacements[] = $parameter['name'];
-			}
+			$replacements[] = match($parameter['type']) {
+				'user' => '@' . $parameter['name'],
+				'file' => $parameter['path'] ?? $parameter['name'],
+				default => $parameter['name'],
+			};
 		}
 		return str_replace($placeholders, $replacements, $message);
 	}

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -95,7 +95,7 @@ class SetupChecks extends Base {
 						$verbosity = ($check->getSeverity() === 'error' ? OutputInterface::VERBOSITY_QUIET : OutputInterface::VERBOSITY_NORMAL);
 						$description = $check->getDescription();
 						$descriptionParameters = $check->getDescriptionParameters();
-						if ($descriptionParameters !== null) {
+						if ($description !== null && $descriptionParameters !== null) {
 							$description = $this->richToParsed($description, $descriptionParameters);
 						}
 						$output->writeln(

--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -46,6 +46,7 @@ class SetupChecks extends Base {
 	}
 
 	/**
+	 * @TODO move this method to a common service used by notifications, activity and this command
 	 * @throws \InvalidArgumentException if a parameter has no name or no type
 	 */
 	private function richToParsed(string $message, array $parameters): string {

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -332,6 +332,28 @@
 			return deferred.promise();
 		},
 
+		/**
+		* @param message      The message string containing placeholders.
+		* @param parameters   An object with keys as placeholders and values as their replacements.
+		*
+		* @return The message with placeholders replaced by values.
+		*/
+		richToParsed: function (message, parameters) {
+			for (var [placeholder, parameter] of Object.entries(parameters)) {
+				var replacement;
+				if (parameter.type === 'user') {
+					replacement = '@' + parameter.name;
+				} else if (parameter.type === 'file') {
+					replacement = parameter.path || parameter.name;
+				} else {
+					replacement = parameter.name;
+				}
+				message = message.replace('{' + placeholder + '}', replacement);
+			}
+
+			return message;
+		},
+
 		addGenericSetupCheck: function(data, check, messages) {
 			var setupCheck = data[check] || { pass: true, description: '', severity: 'info', linkToDoc: null}
 
@@ -343,6 +365,9 @@
 			}
 
 			var message = setupCheck.description;
+			if (setupCheck.descriptionParameters) {
+				message = this.richToParsed(message, setupCheck.descriptionParameters);
+			}
 			if (setupCheck.linkToDoc) {
 				message += ' ' + t('core', 'For more details see the {linkstart}documentation ↗{linkend}.')
 					.replace('{linkstart}', '<a target="_blank" rel="noreferrer noopener" class="external" href="' + setupCheck.linkToDoc + '">')

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -46,10 +46,12 @@ class SetupResult implements \JsonSerializable {
 	 * @brief Private constructor, use success()/info()/warning()/error() instead
 	 * @param self::SUCCESS|self::INFO|self::WARNING|self::ERROR $severity
 	 * @since 28.0.0
+	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 */
 	private function __construct(
 		private string $severity,
 		private ?string $description = null,
+		private ?array $descriptionParameters = null,
 		private ?string $linkToDoc = null,
 	) {
 	}
@@ -59,9 +61,10 @@ class SetupResult implements \JsonSerializable {
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
+	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 */
-	public static function success(?string $description = null, ?string $linkToDoc = null): self {
-		return new self(self::SUCCESS, $description, $linkToDoc);
+	public static function success(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
+		return new self(self::SUCCESS, $description, $descriptionParameters, $linkToDoc);
 	}
 
 	/**
@@ -69,9 +72,10 @@ class SetupResult implements \JsonSerializable {
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
+	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 */
-	public static function info(?string $description = null, ?string $linkToDoc = null): self {
-		return new self(self::INFO, $description, $linkToDoc);
+	public static function info(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
+		return new self(self::INFO, $description, $descriptionParameters, $linkToDoc);
 	}
 
 	/**
@@ -79,9 +83,10 @@ class SetupResult implements \JsonSerializable {
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
+	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 */
-	public static function warning(?string $description = null, ?string $linkToDoc = null): self {
-		return new self(self::WARNING, $description, $linkToDoc);
+	public static function warning(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
+		return new self(self::WARNING, $description, $descriptionParameters, $linkToDoc);
 	}
 
 	/**
@@ -89,9 +94,10 @@ class SetupResult implements \JsonSerializable {
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
 	 * @since 28.0.0
+	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 */
-	public static function error(?string $description = null, ?string $linkToDoc = null): self {
-		return new self(self::ERROR, $description, $linkToDoc);
+	public static function error(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
+		return new self(self::ERROR, $description, $descriptionParameters, $linkToDoc);
 	}
 
 	/**
@@ -111,6 +117,17 @@ class SetupResult implements \JsonSerializable {
 	 */
 	public function getDescription(): ?string {
 		return $this->description;
+	}
+
+	/**
+	 * @brief Get the description parameters for the setup check result
+	 *
+	 * If this returns null, description must not be treated as rich text
+	 *
+	 * @since 28.0.2
+	 */
+	public function getDescriptionParameters(): ?array {
+		return $this->descriptionParameters;
 	}
 
 	/**
@@ -150,6 +167,7 @@ class SetupResult implements \JsonSerializable {
 			'name' => $this->name,
 			'severity' => $this->severity,
 			'description' => $this->description,
+			'descriptionParameters' => $this->descriptionParameters,
 			'linkToDoc' => $this->linkToDoc,
 		];
 	}

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 
 namespace OCP\SetupCheck;
 
+use OCP\RichObjectStrings\IValidator;
+
 /**
  * @brief This class is used for storing the result of a setup check
  *
@@ -54,6 +56,9 @@ class SetupResult implements \JsonSerializable {
 		private ?array $descriptionParameters = null,
 		private ?string $linkToDoc = null,
 	) {
+		if ($description !== null && $descriptionParameters !== null) {
+			\OCP\Server::get(IValidator::class)->validate($description, $descriptionParameters);
+		}
 	}
 
 	/**

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -49,6 +49,7 @@ class SetupResult implements \JsonSerializable {
 	 * @param self::SUCCESS|self::INFO|self::WARNING|self::ERROR $severity
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
+	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 */
 	private function __construct(
 		private string $severity,


### PR DESCRIPTION
## Summary

Allow SetupCheck to pass rich parameters for description in SetupResult. Then UI can use that to render properly users and other elements.

## TODO

- [x] Validate parameters using `OCP\RichObjectStrings\IValidator`
- [x] Fix UI in settings admin in case of rich description
- [x] Avoid duplication of `richToParsed` method from notifications

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
