### PR TITLE
perf: Avoid updating the folder size if we know the size difference

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -119,7 +119,7 @@ class Updater implements IUpdater {
 	 * @param string $path
 	 * @param int $time
 	 */
-	public function update($path, $time = null) {
+	public function update($path, $time = null, ?int $sizeDifference = null) {
 		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
@@ -128,20 +128,22 @@ class Updater implements IUpdater {
 		}
 
 		$data = $this->scanner->scan($path, Scanner::SCAN_SHALLOW, -1, false);
-		if (
-			isset($data['oldSize']) && isset($data['size']) &&
-			!$data['encrypted'] // encryption is a pita and touches the cache itself
-		) {
+
+		if (isset($data['oldSize']) && isset($data['size'])) {
 			$sizeDifference = $data['size'] - $data['oldSize'];
-		} else {
-			// scanner didn't provide size info, fallback to full size calculation
-			$sizeDifference = 0;
-			if ($this->cache instanceof Cache) {
-				$this->cache->correctFolderSize($path, $data);
-			}
+		}
+
+		// encryption is a pita and touches the cache itself
+		if (isset($data['encrypted']) && !!$data['encrypted']) {
+			$sizeDifference = null;
+		}
+
+		// scanner didn't provide size info, fallback to full size calculation
+		if ($this->cache instanceof Cache && $sizeDifference === null) {
+			$this->cache->correctFolderSize($path, $data);
 		}
 		$this->correctParentStorageMtime($path);
-		$this->propagator->propagateChange($path, $time, $sizeDifference);
+		$this->propagator->propagateChange($path, $time, $sizeDifference ?? 0);
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -287,12 +287,12 @@ class View {
 		$this->updaterEnabled = true;
 	}
 
-	protected function writeUpdate(Storage $storage, string $internalPath, ?int $time = null): void {
+	protected function writeUpdate(Storage $storage, string $internalPath, ?int $time = null, ?int $sizeDifference = null): void {
 		if ($this->updaterEnabled) {
 			if (is_null($time)) {
 				$time = time();
 			}
-			$storage->getUpdater()->update($internalPath, $time);
+			$storage->getUpdater()->update($internalPath, $time, $sizeDifference);
 		}
 	}
 
@@ -1173,7 +1173,9 @@ class View {
 					$this->removeUpdate($storage, $internalPath);
 				}
 				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
-					$this->writeUpdate($storage, $internalPath);
+					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && in_array('create', $hooks, true));
+					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
+					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
 				if ($result !== false && in_array('touch', $hooks)) {
 					$this->writeUpdate($storage, $internalPath, $extraParam);

--- a/lib/public/Files/Cache/IUpdater.php
+++ b/lib/public/Files/Cache/IUpdater.php
@@ -53,7 +53,7 @@ interface IUpdater {
 	 * @param int $time
 	 * @since 9.0.0
 	 */
-	public function update($path, $time = null);
+	public function update($path, $time = null, ?int $sizeDifference = null);
 
 	/**
 	 * Remove $path from the cache and update the size, etag and mtime of the parent folders


### PR DESCRIPTION
When using object storage the scanner does not return any results so `correctFolderSize` was always called even for operations where we don't need to update the parent sizes like `mkdir`.

This PR introduces a shortcut to skip this update if we know the size difference for sure so it can be propagated through https://github.com/nextcloud/server/blob/7db5bcc40920f45337056b86b24207a94a7c6e61/lib/private/Files/Cache/Updater.php#L144
