### PR TITLE
[stable27] fix(files): service worker

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -400,6 +400,7 @@ class ApiController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @PublicPage
 	 */
 	public function serviceWorker(): StreamResponse {
 		$response = new StreamResponse(__DIR__ . '/../../../../dist/preview-service-worker.js');

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -320,6 +320,8 @@ class ViewController extends Controller {
 		);
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedFrameDomain('\'self\'');
+		// Allow preview service worker
+		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$response->setContentSecurityPolicy($policy);
 
 		$this->provideInitialState($dir, $openfile);

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -402,6 +402,7 @@ class ViewControllerTest extends TestCase {
 		);
 		$policy = new Http\ContentSecurityPolicy();
 		$policy->addAllowedFrameDomain('\'self\'');
+		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$expected->setContentSecurityPolicy($policy);
 
 		$this->activityHelper->method('getFavoriteFilePaths')


### PR DESCRIPTION
This is a partial backport of 3344f0f121865e03d4bc076fe79e7d88f32836da

* Resolves: #39849 for stable 27

## Summary

Backports a fix which allows the service worker of the files app to be reigstered

```
Refused to create a worker from 'https://nextcloud.mydomain.de/index.php/apps/files/preview-service-worker.js' because it violates the following Content Security Policy directive: "script-src 'nonce-aFNJRWFwcklWUlMvTVM5WDZxdnBtOEtyeWh4OVpzbHBGckh3NkpGeHk4OD06L0c1OEJOU0RiRk9IYVg1OGpzN2NycnZoa2xrZU51WWhmY216M3ZNMHVKaz0='". Note that 'worker-src' was not explicitly set, so 'script-src' is used as a fallback.
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
