### PR TITLE
(config.php.sample) Clarify the purpose of `session_keepalive` parameter

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -342,7 +342,7 @@ $CONFIG = [
  * keepalive is enabled. This will make sure that an inactive browser will log itself out
  * even if requests to the server might extend the session lifetime. Note: the logout is   
  * handled on the client side. This is not a way to limit the duration of potentially
- * compromized sessions.
+ * compromised sessions.
  *
  * Defaults to ``false``
  */

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -339,8 +339,10 @@ $CONFIG = [
 
 /**
  * Enable or disable the automatic logout after session_lifetime, even if session
- * keepalive is enabled. This will make sure that an inactive browser will be logged out
- * even if requests to the server might extend the session lifetime.
+ * keepalive is enabled. This will make sure that an inactive browser will log itself out
+ * even if requests to the server might extend the session lifetime. Note: the logout is   
+ * handled on the client side. This is not a way to limit the duration of potentially
+ * compromized sessions.
  *
  * Defaults to ``false``
  */


### PR DESCRIPTION
## Summary

Comments to clarify the purpose of session_keepalive. 

Fixes nextcloud/documentation#7244

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
