### PR TITLE
fix(dav): Fix user status "Undefined array key 0 at StatusService.php…

### DIFF
--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -94,12 +94,15 @@ class StatusService {
 		}
 
 		// Filter events to see if we have any that apply to the calendar status
-		$applicableEvents = array_filter($calendarEvents, function (array $calendarEvent) use ($userStatusTimestamp) {
-			$component = $calendarEvent['objects'][0];
-			if(isset($component['X-NEXTCLOUD-OUT-OF-OFFICE'])) {
+		$applicableEvents = array_filter($calendarEvents, static function (array $calendarEvent) use ($userStatusTimestamp): bool {
+			if (empty($calendarEvent['objects'])) {
 				return false;
 			}
-			if(isset($component['DTSTART']) && $userStatusTimestamp !== null) {
+			$component = $calendarEvent['objects'][0];
+			if (isset($component['X-NEXTCLOUD-OUT-OF-OFFICE'])) {
+				return false;
+			}
+			if (isset($component['DTSTART']) && $userStatusTimestamp !== null) {
 				/** @var DateTimeImmutable $dateTime */
 				$dateTime = $component['DTSTART'][0];
 				$timestamp = $dateTime->getTimestamp();
@@ -108,7 +111,7 @@ class StatusService {
 				}
 			}
 			// Ignore events that are transparent
-			if(isset($component['TRANSP']) && strcasecmp($component['TRANSP'][0], 'TRANSPARENT') === 0) {
+			if (isset($component['TRANSP']) && strcasecmp($component['TRANSP'][0], 'TRANSPARENT') === 0) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
…#98"


* Resolves hundred of issues we have in our log:

```
│[error] 2024-01-05T10:43:23.000 PHP              Undefined array key 0 at …/apps/dav/lib/CalDAV/Status/StatusService.php#98           │
 Received Time: 2024-01-05T10:43:23.000 -- 3 days ago                                                                                                                       │
 Known message fields for table nextcloud_log:                                                                                                                              │
 ├ reqId         = UJgUkgYIMW4vZQHZSA7X                                                                                                                                     │
 ├ level         = 3                                                                                                                                                        │
 ├ time          = 2024-01-05T10:43:23.000                                                                                                                                  │
 ├ remoteAddr    = 2a…                                                                                                                  │
 ├ user          = f…n                                                                                                                                                   │
 ├ app           = PHP                                                                                                                                                      │
 ├ method        = PUT                                                                                                                                                      │
 ├ url           = /ocs/v2.php/apps/user_status/api/v1/heartbeat?format=json                                                                                                │
 ├ body          = Undefined array key 0 at …/apps/dav/lib/CalDAV/Status/StatusService.php#98                                          │
 ├ message       = Undefined array key 0 at …/apps/dav/lib/CalDAV/Status/StatusService.php#98                                          │
 ├ userAgent     = Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0                                                                     │
 ├ version       = 28.0.1.1                                                                                                                                                 │
 ├ data          = {"app":"PHP"}                                                                                                                                            │
 JSON fields:                                                                                                                                                               │
 ├ jget(data,'/app') = "PHP"                                                                                                                                                │
 Discovered fields for logline table from message format: Undefined array key # at #                                                                                        │
 ├ col_0 = 0                                                                                                                                                                │
 └ col_1 = …/apps/dav/lib/CalDAV/Status/StatusService.php#98  
 ```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
