### PR TITLE
Do not auto-generate metadata for non-local files

### DIFF
--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -53,22 +53,22 @@ class GenerateMetadataJob extends TimedJob {
 
 	protected function run(mixed $argument): void {
 		$users = $this->userManager->search('');
-		$lastMappedUser = $this->config->getAppValue('core', 'metadataGenerationLastHandledUser', '');
+		$lastHandledUser = $this->config->getAppValue('core', 'metadataGenerationLastHandledUser', '');
 
-		if ($lastMappedUser === '') {
+		if ($lastHandledUser === '') {
 			$user = array_key_first($users);
 			if ($user === null) {
 				return;
 			}
 
-			$lastMappedUser = $users[$user]->getUID();
+			$lastHandledUser = $users[$user]->getUID();
 		}
 
 		$startTime = null;
 		foreach ($users as $user) {
 			if ($startTime === null) {
-				// Skip all user before lastMappedUser.
-				if ($lastMappedUser !== $user->getUID()) {
+				// Skip all user before lastHandledUser.
+				if ($lastHandledUser !== $user->getUID()) {
 					continue;
 				}
 

--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -104,6 +104,12 @@ class GenerateMetadataJob extends TimedJob {
 				continue;
 			}
 
+			// Do not scan remote storages. Ex: external storages.
+			$generateMetadataForRemoteStorages = $this->config->getSystemValueBool('generateMetadataForRemoteStorages', false);
+			if (!$folder->getStorage()->isLocal() && !$generateMetadataForRemoteStorages) {
+				return;
+			}
+
 			try {
 				$this->filesMetadataManager->refreshMetadata(
 					$node,


### PR DESCRIPTION
This excludes external storage in the generate metadata background job.
Also adds a system config to disable this filter: `scanMetadataInSystemMountPointsInBackground`

Fix https://github.com/nextcloud/server/issues/42489