### PR TITLE
Always catch OCP versions of authentication exceptions

### DIFF
--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -28,8 +28,6 @@ declare(strict_types=1);
  */
 namespace OCA\OAuth2\Controller;
 
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Db\ClientMapper;
@@ -39,6 +37,8 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\DB\Exception;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;

--- a/apps/oauth2/lib/Migration/SetTokenExpiration.php
+++ b/apps/oauth2/lib/Migration/SetTokenExpiration.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
  */
 namespace OCA\OAuth2\Migration;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCA\OAuth2\Db\AccessToken;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;

--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -36,7 +36,6 @@ use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenExceptio
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider;
-use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\RemoteWipe;
 use OCA\Settings\Activity\Provider;
 use OCP\Activity\IManager;
@@ -46,6 +45,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
+use OCP\Authentication\Token\IToken;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;

--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -293,7 +293,7 @@ class AuthSettingsController extends Controller {
 			$token = $e->getToken();
 		}
 		if ($token->getUID() !== $this->uid) {
-			/* We have to throw the OC version so both OC and OCP catches catch it */
+			/** @psalm-suppress DeprecatedClass We have to throw the OC version so both OC and OCP catches catch it */
 			throw new OcInvalidTokenException('This token does not belong to you!');
 		}
 		return $token;

--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -32,10 +32,8 @@
 namespace OCA\Settings\Controller;
 
 use BadMethodCallException;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
 use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -45,6 +43,9 @@ use OCP\Activity\IManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
@@ -292,7 +293,8 @@ class AuthSettingsController extends Controller {
 			$token = $e->getToken();
 		}
 		if ($token->getUID() !== $this->uid) {
-			throw new InvalidTokenException('This token does not belong to you!');
+			/* We have to throw the OC version so both OC and OCP catches catch it */
+			throw new OcInvalidTokenException('This token does not belong to you!');
 		}
 		return $token;
 	}
@@ -305,7 +307,7 @@ class AuthSettingsController extends Controller {
 	 * @param int $id
 	 * @return JSONResponse
 	 * @throws InvalidTokenException
-	 * @throws \OC\Authentication\Exceptions\ExpiredTokenException
+	 * @throws ExpiredTokenException
 	 */
 	public function wipe(int $id): JSONResponse {
 		if ($this->checkAppToken()) {

--- a/apps/settings/lib/Settings/Personal/Security/Authtokens.php
+++ b/apps/settings/lib/Settings/Personal/Security/Authtokens.php
@@ -25,12 +25,12 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\Settings\Personal\Security;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\INamedToken;
 use OC\Authentication\Token\IProvider as IAuthTokenProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;

--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -29,13 +29,13 @@ declare(strict_types=1);
 namespace OC\Core\Controller;
 
 use OC\Authentication\Events\AppPasswordCreatedEvent;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\PasswordUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\EventDispatcher\IEventDispatcher;

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -33,7 +33,7 @@
 namespace OC\Core\Controller;
 
 use OC\Authentication\Events\AppPasswordCreatedEvent;
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -47,6 +47,7 @@ use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
@@ -331,7 +332,7 @@ class ClientFlowLoginController extends Controller {
 		try {
 			$token = $this->tokenProvider->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new InvalidTokenException('login name does not match');
+				throw new OcInvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/ClientFlowLoginController.php
+++ b/core/Controller/ClientFlowLoginController.php
@@ -33,7 +33,6 @@
 namespace OC\Core\Controller;
 
 use OC\Authentication\Events\AppPasswordCreatedEvent;
-use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -332,7 +331,7 @@ class ClientFlowLoginController extends Controller {
 		try {
 			$token = $this->tokenProvider->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new OcInvalidTokenException('login name does not match');
+				throw new InvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Core\Db\LoginFlowV2;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OC\Core\Service\LoginFlowV2Service;
@@ -212,7 +211,7 @@ class ClientFlowLoginV2Controller extends Controller {
 		try {
 			$token = \OC::$server->get(\OC\Authentication\Token\IProvider::class)->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new OcInvalidTokenException('login name does not match');
+				throw new InvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
 use OC\Core\Db\LoginFlowV2;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OC\Core\Service\LoginFlowV2Service;
@@ -40,6 +40,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Defaults;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -211,7 +212,7 @@ class ClientFlowLoginV2Controller extends Controller {
 		try {
 			$token = \OC::$server->get(\OC\Authentication\Token\IProvider::class)->getToken($password);
 			if ($token->getLoginName() !== $user) {
-				throw new InvalidTokenException('login name does not match');
+				throw new OcInvalidTokenException('login name does not match');
 			}
 		} catch (InvalidTokenException $e) {
 			$response = new StandaloneTemplateResponse(

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -26,11 +26,11 @@ declare(strict_types=1);
  */
 namespace OC\Core\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\RemoteWipe;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IRequest;
 
 class WipeController extends Controller {

--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
  */
 namespace OC\Core\Service;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
@@ -37,6 +36,7 @@ use OC\Core\Db\LoginFlowV2Mapper;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;

--- a/lib/private/Authentication/Events/AppPasswordCreatedEvent.php
+++ b/lib/private/Authentication/Events/AppPasswordCreatedEvent.php
@@ -25,16 +25,14 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Events;
 
-use OC\Authentication\Token\IToken;
+use OCP\Authentication\Token\IToken;
 use OCP\EventDispatcher\Event;
 
 class AppPasswordCreatedEvent extends Event {
-	/** @var IToken */
-	private $token;
-
-	public function __construct(IToken $token) {
+	public function __construct(
+		private IToken $token,
+	) {
 		parent::__construct();
-		$this->token = $token;
 	}
 
 	public function getToken(): IToken {

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\LoginCredentials;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\LoginCredentials\ICredentials;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\ISession;

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -29,10 +29,10 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Token;
 
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 
 interface IProvider {
 	/**

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -33,6 +33,7 @@ use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
+use OCP\Authentication\Token\IToken;
 
 interface IProvider {
 	/**

--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -33,7 +33,7 @@ use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
-use OCP\Authentication\Token\IToken;
+use OCP\Authentication\Token\IToken as OCPIToken;
 
 interface IProvider {
 	/**
@@ -46,7 +46,7 @@ interface IProvider {
 	 * @param string $name Name will be trimmed to 120 chars when longer
 	 * @param int $type token type
 	 * @param int $remember whether the session token should be used for remember-me
-	 * @return IToken
+	 * @return OCPIToken
 	 * @throws \RuntimeException when OpenSSL reports a problem
 	 */
 	public function generateToken(string $token,
@@ -54,8 +54,8 @@ interface IProvider {
 		string $loginName,
 		?string $password,
 		string $name,
-		int $type = IToken::TEMPORARY_TOKEN,
-		int $remember = IToken::DO_NOT_REMEMBER): IToken;
+		int $type = OCPIToken::TEMPORARY_TOKEN,
+		int $remember = OCPIToken::DO_NOT_REMEMBER): OCPIToken;
 
 	/**
 	 * Get a token by token id
@@ -64,9 +64,9 @@ interface IProvider {
 	 * @throws InvalidTokenException
 	 * @throws ExpiredTokenException
 	 * @throws WipeTokenException
-	 * @return IToken
+	 * @return OCPIToken
 	 */
-	public function getToken(string $tokenId): IToken;
+	public function getToken(string $tokenId): OCPIToken;
 
 	/**
 	 * Get a token by token id
@@ -75,9 +75,9 @@ interface IProvider {
 	 * @throws InvalidTokenException
 	 * @throws ExpiredTokenException
 	 * @throws WipeTokenException
-	 * @return IToken
+	 * @return OCPIToken
 	 */
-	public function getTokenById(int $tokenId): IToken;
+	public function getTokenById(int $tokenId): OCPIToken;
 
 	/**
 	 * Duplicate an existing session token
@@ -86,9 +86,9 @@ interface IProvider {
 	 * @param string $sessionId
 	 * @throws InvalidTokenException
 	 * @throws \RuntimeException when OpenSSL reports a problem
-	 * @return IToken The new token
+	 * @return OCPIToken The new token
 	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken;
+	public function renewSessionToken(string $oldSessionId, string $sessionId): OCPIToken;
 
 	/**
 	 * Invalidate (delete) the given session token
@@ -118,16 +118,16 @@ interface IProvider {
 	/**
 	 * Save the updated token
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 */
-	public function updateToken(IToken $token);
+	public function updateToken(OCPIToken $token);
 
 	/**
 	 * Update token activity timestamp
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 */
-	public function updateTokenActivity(IToken $token);
+	public function updateTokenActivity(OCPIToken $token);
 
 	/**
 	 * Get all tokens of a user
@@ -136,49 +136,49 @@ interface IProvider {
 	 * where a high number of (session) tokens is generated
 	 *
 	 * @param string $uid
-	 * @return IToken[]
+	 * @return OCPIToken[]
 	 */
 	public function getTokenByUser(string $uid): array;
 
 	/**
 	 * Get the (unencrypted) password of the given token
 	 *
-	 * @param IToken $savedToken
+	 * @param OCPIToken $savedToken
 	 * @param string $tokenId
 	 * @throws InvalidTokenException
 	 * @throws PasswordlessTokenException
 	 * @return string
 	 */
-	public function getPassword(IToken $savedToken, string $tokenId): string;
+	public function getPassword(OCPIToken $savedToken, string $tokenId): string;
 
 	/**
 	 * Encrypt and set the password of the given token
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @param string $tokenId
 	 * @param string $password
 	 * @throws InvalidTokenException
 	 */
-	public function setPassword(IToken $token, string $tokenId, string $password);
+	public function setPassword(OCPIToken $token, string $tokenId, string $password);
 
 	/**
 	 * Rotate the token. Useful for for example oauth tokens
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @param string $oldTokenId
 	 * @param string $newTokenId
-	 * @return IToken
+	 * @return OCPIToken
 	 * @throws \RuntimeException when OpenSSL reports a problem
 	 */
-	public function rotate(IToken $token, string $oldTokenId, string $newTokenId): IToken;
+	public function rotate(OCPIToken $token, string $oldTokenId, string $newTokenId): OCPIToken;
 
 	/**
 	 * Marks a token as having an invalid password.
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @param string $tokenId
 	 */
-	public function markPasswordInvalid(IToken $token, string $tokenId);
+	public function markPasswordInvalid(OCPIToken $token, string $tokenId);
 
 	/**
 	 * Update all the passwords of $uid if required

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -29,9 +29,9 @@ namespace OC\Authentication\Token;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
+use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
-use OCP\Authentication\Exceptions\PasswordlessTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
 
@@ -222,6 +222,7 @@ class Manager implements IProvider, OCPIProvider {
 			return $this->publicKeyTokenProvider->rotate($token, $oldTokenId, $newTokenId);
 		}
 
+		/** @psalm-suppress DeprecatedClass We have to throw the OC version so both OC and OCP catches catch it */
 		throw new OcInvalidTokenException();
 	}
 
@@ -234,6 +235,7 @@ class Manager implements IProvider, OCPIProvider {
 		if ($token instanceof PublicKeyToken) {
 			return $this->publicKeyTokenProvider;
 		}
+		/** @psalm-suppress DeprecatedClass We have to throw the OC version so both OC and OCP catches catch it */
 		throw new OcInvalidTokenException();
 	}
 

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -28,10 +28,11 @@ declare(strict_types=1);
 namespace OC\Authentication\Token;
 
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Exceptions\PasswordlessTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
+use OC\Authentication\Exceptions\InvalidTokenException as OcInvalidTokenException;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\PasswordlessTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
 
 class Manager implements IProvider, OCPIProvider {
@@ -221,7 +222,7 @@ class Manager implements IProvider, OCPIProvider {
 			return $this->publicKeyTokenProvider->rotate($token, $oldTokenId, $newTokenId);
 		}
 
-		throw new InvalidTokenException();
+		throw new OcInvalidTokenException();
 	}
 
 	/**
@@ -233,7 +234,7 @@ class Manager implements IProvider, OCPIProvider {
 		if ($token instanceof PublicKeyToken) {
 			return $this->publicKeyTokenProvider;
 		}
-		throw new InvalidTokenException();
+		throw new OcInvalidTokenException();
 	}
 
 

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -34,6 +34,7 @@ use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
+use OCP\Authentication\Token\IToken;
 
 class Manager implements IProvider, OCPIProvider {
 	/** @var PublicKeyTokenProvider */

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -34,7 +34,7 @@ use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
-use OCP\Authentication\Token\IToken;
+use OCP\Authentication\Token\IToken as OCPIToken;
 
 class Manager implements IProvider, OCPIProvider {
 	/** @var PublicKeyTokenProvider */
@@ -54,15 +54,15 @@ class Manager implements IProvider, OCPIProvider {
 	 * @param string $name Name will be trimmed to 120 chars when longer
 	 * @param int $type token type
 	 * @param int $remember whether the session token should be used for remember-me
-	 * @return IToken
+	 * @return OCPIToken
 	 */
 	public function generateToken(string $token,
 		string $uid,
 		string $loginName,
 		$password,
 		string $name,
-		int $type = IToken::TEMPORARY_TOKEN,
-		int $remember = IToken::DO_NOT_REMEMBER): IToken {
+		int $type = OCPIToken::TEMPORARY_TOKEN,
+		int $remember = OCPIToken::DO_NOT_REMEMBER): OCPIToken {
 		if (mb_strlen($name) > 128) {
 			$name = mb_substr($name, 0, 120) . '…';
 		}
@@ -95,10 +95,10 @@ class Manager implements IProvider, OCPIProvider {
 	/**
 	 * Save the updated token
 	 *
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @throws InvalidTokenException
 	 */
-	public function updateToken(IToken $token) {
+	public function updateToken(OCPIToken $token) {
 		$provider = $this->getProvider($token);
 		$provider->updateToken($token);
 	}
@@ -107,16 +107,16 @@ class Manager implements IProvider, OCPIProvider {
 	 * Update token activity timestamp
 	 *
 	 * @throws InvalidTokenException
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 */
-	public function updateTokenActivity(IToken $token) {
+	public function updateTokenActivity(OCPIToken $token) {
 		$provider = $this->getProvider($token);
 		$provider->updateTokenActivity($token);
 	}
 
 	/**
 	 * @param string $uid
-	 * @return IToken[]
+	 * @return OCPIToken[]
 	 */
 	public function getTokenByUser(string $uid): array {
 		return $this->publicKeyTokenProvider->getTokenByUser($uid);
@@ -128,9 +128,9 @@ class Manager implements IProvider, OCPIProvider {
 	 * @param string $tokenId
 	 * @throws InvalidTokenException
 	 * @throws \RuntimeException when OpenSSL reports a problem
-	 * @return IToken
+	 * @return OCPIToken
 	 */
-	public function getToken(string $tokenId): IToken {
+	public function getToken(string $tokenId): OCPIToken {
 		try {
 			return $this->publicKeyTokenProvider->getToken($tokenId);
 		} catch (WipeTokenException $e) {
@@ -147,9 +147,9 @@ class Manager implements IProvider, OCPIProvider {
 	 *
 	 * @param int $tokenId
 	 * @throws InvalidTokenException
-	 * @return IToken
+	 * @return OCPIToken
 	 */
-	public function getTokenById(int $tokenId): IToken {
+	public function getTokenById(int $tokenId): OCPIToken {
 		try {
 			return $this->publicKeyTokenProvider->getTokenById($tokenId);
 		} catch (ExpiredTokenException $e) {
@@ -165,9 +165,9 @@ class Manager implements IProvider, OCPIProvider {
 	 * @param string $oldSessionId
 	 * @param string $sessionId
 	 * @throws InvalidTokenException
-	 * @return IToken
+	 * @return OCPIToken
 	 */
-	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
+	public function renewSessionToken(string $oldSessionId, string $sessionId): OCPIToken {
 		try {
 			return $this->publicKeyTokenProvider->renewSessionToken($oldSessionId, $sessionId);
 		} catch (ExpiredTokenException $e) {
@@ -178,18 +178,18 @@ class Manager implements IProvider, OCPIProvider {
 	}
 
 	/**
-	 * @param IToken $savedToken
+	 * @param OCPIToken $savedToken
 	 * @param string $tokenId session token
 	 * @throws InvalidTokenException
 	 * @throws PasswordlessTokenException
 	 * @return string
 	 */
-	public function getPassword(IToken $savedToken, string $tokenId): string {
+	public function getPassword(OCPIToken $savedToken, string $tokenId): string {
 		$provider = $this->getProvider($savedToken);
 		return $provider->getPassword($savedToken, $tokenId);
 	}
 
-	public function setPassword(IToken $token, string $tokenId, string $password) {
+	public function setPassword(OCPIToken $token, string $tokenId, string $password) {
 		$provider = $this->getProvider($token);
 		$provider->setPassword($token, $tokenId, $password);
 	}
@@ -211,14 +211,14 @@ class Manager implements IProvider, OCPIProvider {
 	}
 
 	/**
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @param string $oldTokenId
 	 * @param string $newTokenId
-	 * @return IToken
+	 * @return OCPIToken
 	 * @throws InvalidTokenException
 	 * @throws \RuntimeException when OpenSSL reports a problem
 	 */
-	public function rotate(IToken $token, string $oldTokenId, string $newTokenId): IToken {
+	public function rotate(OCPIToken $token, string $oldTokenId, string $newTokenId): OCPIToken {
 		if ($token instanceof PublicKeyToken) {
 			return $this->publicKeyTokenProvider->rotate($token, $oldTokenId, $newTokenId);
 		}
@@ -228,11 +228,11 @@ class Manager implements IProvider, OCPIProvider {
 	}
 
 	/**
-	 * @param IToken $token
+	 * @param OCPIToken $token
 	 * @return IProvider
 	 * @throws InvalidTokenException
 	 */
-	private function getProvider(IToken $token): IProvider {
+	private function getProvider(OCPIToken $token): IProvider {
 		if ($token instanceof PublicKeyToken) {
 			return $this->publicKeyTokenProvider;
 		}
@@ -241,7 +241,7 @@ class Manager implements IProvider, OCPIProvider {
 	}
 
 
-	public function markPasswordInvalid(IToken $token, string $tokenId) {
+	public function markPasswordInvalid(OCPIToken $token, string $tokenId) {
 		$this->getProvider($token)->markPasswordInvalid($token, $tokenId);
 	}
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -37,6 +37,7 @@ use OC\Authentication\Exceptions\WipeTokenException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Token\IToken;
 use OCP\Cache\CappedMemoryCache;
 use OCP\IConfig;
 use OCP\IDBConnection;

--- a/lib/private/Authentication/Token/RemoteWipe.php
+++ b/lib/private/Authentication/Token/RemoteWipe.php
@@ -29,8 +29,8 @@ namespace OC\Authentication\Token;
 
 use OC\Authentication\Events\RemoteWipeFinished;
 use OC\Authentication\Events\RemoteWipeStarted;
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Exceptions\WipeTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -29,10 +29,10 @@ namespace OC\Authentication\TwoFactorAuth;
 
 use BadMethodCallException;
 use Exception;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\IProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -33,8 +33,8 @@ declare(strict_types=1);
  */
 namespace OC\Session;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 
 /**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -39,8 +39,6 @@
 namespace OC\User;
 
 use OC;
-use OC\Authentication\Exceptions\ExpiredTokenException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\Token\IProvider;
@@ -51,6 +49,8 @@ use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\ExpiredTokenException;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\NotPermittedException;


### PR DESCRIPTION
* Resolves: #42394

## Summary

Always catch OCP versions of authentication exceptions.
And always throw OC versions for BC.

Alternative to https://github.com/nextcloud/server/pull/42577 and https://github.com/nextcloud/server/pull/42579 which simply fix internal uses instead of trying to fix back OC Exceptions inheritance.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
