### PR TITLE
fix(share): use user timezone to parse share expiration date

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -70,6 +70,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IPreview;
@@ -124,20 +125,6 @@ class ShareAPIController extends OCSController {
 
 	/**
 	 * Share20OCS constructor.
-	 *
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param IManager $shareManager
-	 * @param IGroupManager $groupManager
-	 * @param IUserManager $userManager
-	 * @param IRootFolder $rootFolder
-	 * @param IURLGenerator $urlGenerator
-	 * @param string $userId
-	 * @param IL10N $l10n
-	 * @param IConfig $config
-	 * @param IAppManager $appManager
-	 * @param IServerContainer $serverContainer
-	 * @param IUserStatusManager $userStatusManager
 	 */
 	public function __construct(
 		string $appName,
@@ -153,7 +140,8 @@ class ShareAPIController extends OCSController {
 		IAppManager $appManager,
 		IServerContainer $serverContainer,
 		IUserStatusManager $userStatusManager,
-		IPreview $previewManager
+		IPreview $previewManager,
+		private IDateTimeZone $dateTimeZone,
 	) {
 		parent::__construct($appName, $request);
 
@@ -597,7 +585,7 @@ class ShareAPIController extends OCSController {
 	 * @param string $publicUpload If public uploading is allowed
 	 * @param string $password Password for the share
 	 * @param string|null $sendPasswordByTalk Send the password for the share over Talk
-	 * @param string $expireDate Expiry date of the share
+	 * @param string $expireDate Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used.
 	 * @param string $note Note for the share
 	 * @param string $label Label for the share (only used in link and email)
 	 * @param string|null $attributes Additional attributes for the share
@@ -1706,11 +1694,12 @@ class ShareAPIController extends OCSController {
 	 */
 	private function parseDate(string $expireDate): \DateTime {
 		try {
-			$date = new \DateTime(trim($expireDate, "\""));
+			$date = new \DateTime(trim($expireDate, "\""), $this->dateTimeZone->getTimeZone());
 		} catch (\Exception $e) {
 			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
 		}
 
+		$date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 		$date->setTime(0, 0, 0);
 
 		return $date;

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -1899,7 +1899,7 @@
                     {
                         "name": "expireDate",
                         "in": "query",
-                        "description": "Expiry date of the share",
+                        "description": "Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used.",
                         "schema": {
                             "type": "string",
                             "default": ""

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -44,6 +44,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IL10N;
 use OCP\IPreview;
 use OCP\IRequest;
@@ -122,6 +123,7 @@ class ApiTest extends TestCase {
 		$serverContainer = $this->createMock(IServerContainer::class);
 		$userStatusManager = $this->createMock(IUserStatusManager::class);
 		$previewManager = $this->createMock(IPreview::class);
+		$dateTimeZone = $this->createMock(IDateTimeZone::class);
 
 		return new ShareAPIController(
 			self::APP_NAME,
@@ -137,7 +139,8 @@ class ApiTest extends TestCase {
 			$appManager,
 			$serverContainer,
 			$userStatusManager,
-			$previewManager
+			$previewManager,
+			$dateTimeZone,
 		);
 	}
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -47,6 +47,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -117,6 +118,9 @@ class ShareAPIControllerTest extends TestCase {
 	/** @var IPreview|\PHPUnit\Framework\MockObject\MockObject */
 	private $previewManager;
 
+	/** @var IDateTimeZone|\PHPUnit\Framework\MockObject\MockObject */
+	private $dateTimeZone;
+
 	protected function setUp(): void {
 		$this->shareManager = $this->createMock(IManager::class);
 		$this->shareManager
@@ -147,6 +151,7 @@ class ShareAPIControllerTest extends TestCase {
 			->willReturnCallback(function ($fileInfo) {
 				return $fileInfo->getMimeType() === 'mimeWithPreview';
 			});
+		$this->dateTimeZone = $this->createMock(IDateTimeZone::class);
 
 		$this->ocs = new ShareAPIController(
 			$this->appName,
@@ -162,7 +167,8 @@ class ShareAPIControllerTest extends TestCase {
 			$this->appManager,
 			$this->serverContainer,
 			$this->userStatusManager,
-			$this->previewManager
+			$this->previewManager,
+			$this->dateTimeZone,
 		);
 	}
 
@@ -186,6 +192,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 	}
@@ -783,6 +790,7 @@ class ShareAPIControllerTest extends TestCase {
 					$this->serverContainer,
 					$this->userStatusManager,
 					$this->previewManager,
+					$this->dateTimeZone,
 				])->setMethods(['canAccessShare'])
 				->getMock();
 
@@ -1407,6 +1415,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1746,6 +1755,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1840,6 +1850,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -2249,6 +2260,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -2315,6 +2327,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -2554,6 +2567,7 @@ class ShareAPIControllerTest extends TestCase {
 				$this->serverContainer,
 				$this->userStatusManager,
 				$this->previewManager,
+				$this->dateTimeZone,
 			])->setMethods(['formatShare'])
 			->getMock();
 


### PR DESCRIPTION
* Resolves: #38405
* Resolves: #42453

## Summary
If an user in UTC+1 try to create a share at 00:00, it's day D for him, but D-1 for the server (UTC).
This fix aims to apply the correct offset.

Later, it will be better to also handle hours for share expiration.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
