### PR TITLE
[stable28] Return providers as indexed array

### DIFF
--- a/lib/private/TextToImage/Manager.php
+++ b/lib/private/TextToImage/Manager.php
@@ -66,7 +66,7 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @inerhitDocs
+	 * @inheritDoc
 	 */
 	public function getProviders(): array {
 		$context = $this->coordinator->getRegistrationContext();
@@ -313,7 +313,7 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * @return IProvider[]
+	 * @return list<IProvider>
 	 */
 	private function getPreferredProviders() {
 		$providers = $this->getProviders();

--- a/lib/private/TextToImage/Manager.php
+++ b/lib/private/TextToImage/Manager.php
@@ -49,7 +49,7 @@ use RuntimeException;
 use Throwable;
 
 class Manager implements IManager {
-	/** @var ?IProvider[] */
+	/** @var ?list<IProvider> */
 	private ?array $providers = null;
 	private IAppData $appData;
 
@@ -83,7 +83,9 @@ class Manager implements IManager {
 		foreach ($context->getTextToImageProviders() as $providerServiceRegistration) {
 			$class = $providerServiceRegistration->getService();
 			try {
-				$this->providers[] = $this->serverContainer->get($class);
+				/** @var IProvider $provider */
+				$provider = $this->serverContainer->get($class);
+				$this->providers[] = $provider;
 			} catch (Throwable $e) {
 				$this->logger->error('Failed to load Text to image provider ' . $class, [
 					'exception' => $e,

--- a/lib/private/TextToImage/Manager.php
+++ b/lib/private/TextToImage/Manager.php
@@ -83,7 +83,7 @@ class Manager implements IManager {
 		foreach ($context->getTextToImageProviders() as $providerServiceRegistration) {
 			$class = $providerServiceRegistration->getService();
 			try {
-				$this->providers[$class] = $this->serverContainer->get($class);
+				$this->providers[] = $this->serverContainer->get($class);
 			} catch (Throwable $e) {
 				$this->logger->error('Failed to load Text to image provider ' . $class, [
 					'exception' => $e,

--- a/lib/public/TextToImage/IManager.php
+++ b/lib/public/TextToImage/IManager.php
@@ -45,7 +45,7 @@ interface IManager {
 
 	/**
 	 * @since 28.0.0
-	 * @return IProvider[]
+	 * @return list<IProvider>
 	 */
 	public function getProviders(): array;
 


### PR DESCRIPTION
Backport of https://github.com/nextcloud/server/pull/42377

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
