### PR TITLE
Improve view only error message

### DIFF
--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -97,7 +97,7 @@ class ViewOnlyPlugin extends ServerPlugin {
 			// Check if read-only and on whether permission can download is both set and disabled.
 			$canDownload = $attributes->getAttribute('permissions', 'download');
 			if ($canDownload !== null && !$canDownload) {
-				throw new Forbidden('Access to this resource has been denied because it is in view-only mode.');
+				throw new Forbidden('Access to this shared resource has been denied because its download permission is disabled.');
 			}
 		} catch (NotFound $e) {
 			// File not found


### PR DESCRIPTION
When a user tries to download a shared file that do not have the download permissions, this plugin will throw an error, but the message is misleading.

Here it is adjusted.