### PR TITLE
fix(caldav): only call getTimestamp() on actual DateTime data

### DIFF
--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -106,8 +106,7 @@ class StatusService {
 			if (isset($component['DTSTART']) && $userStatusTimestamp !== null) {
 				/** @var DateTimeImmutable $dateTime */
 				$dateTime = $component['DTSTART'][0];
-				$timestamp = $dateTime->getTimestamp();
-				if($userStatusTimestamp > $timestamp) {
+				if($dateTime instanceof DateTimeImmutable && $userStatusTimestamp > $dateTime->getTimestamp()) {
 					return false;
 				}
 			}


### PR DESCRIPTION
For some reason the value of `$component['DTSTART'][0]` may not be a  `DateTimeImmutable`.

In the case of #42464, the property is a `Property\ICalendar\Date`, but that extends `Property\ICalendar\DateTime`, so it *should* still give us a `DateTimeImmutable`, but anyway. :shrug: 

Follow-up to #42619 Closes #42464


