### PR TITLE
fix(session): Log when session_start fails

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -36,6 +36,7 @@ namespace OC\Session;
 use OC\Authentication\Token\IProvider;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Session\Exceptions\SessionNotAvailableException;
+use function OCP\Log\logger;
 
 /**
  * Class Internal
@@ -222,6 +223,8 @@ class Internal extends Session {
 		if (\OC::hasSessionRelaxedExpiry()) {
 			$sessionParams['read_and_close'] = $readAndClose;
 		}
-		$this->invoke('session_start', [$sessionParams], $silence);
+		if ($this->invoke('session_start', [$sessionParams], $silence) === false) {
+			logger('core')->critical('session_start failed');
+		}
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

session_start can fail, e.g. because of https://github.com/phpredis/phpredis/issues/2382. This introduces tricky bugs. I suggest to log when this happens.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
