### PR TITLE
Update IRC URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 -->
 ## Submitting issues
 
-If you have questions about how to install or use Nextcloud, please direct these to our [forum][forum]. We are also available on [IRC][irc].
+If you have questions about how to install or use Nextcloud, please direct these to our [forum][forum]. We are also available on [IRC][irc] (unofficial).
 
 ### Short version
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Help us to maximize the effort we can spend fixing issues and adding new feature
 
 [templates]: ./ISSUE_TEMPLATE
 [forum]: https://help.nextcloud.com/
-[irc]: https://webchat.freenode.net/?channels=nextcloud
+[irc]: https://web.libera.chat/#nextcloud
 
 ## Contributing to Source Code
 


### PR DESCRIPTION
* Resolves: N/A

## Summary

Update IRC URL to use libera instead of freenode

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits