### PR TITLE
enh(OCP\Translation): Add missing ITranslationProviderWithId check

### DIFF
--- a/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
+++ b/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
@@ -66,7 +66,7 @@ class ArtificialIntelligence implements IDelegatedSettings {
 				'class' => $provider instanceof ITranslationProviderWithId ? $provider->getId() : $provider::class,
 				'name' => $provider->getName(),
 			];
-			$translationPreferences[] = $provider::class;
+			$translationPreferences[] = $provider instanceof ITranslationProviderWithId ? $provider->getId() : $provider::class;
 		}
 
 		$sttProviders = [];


### PR DESCRIPTION
## Summary

Add missing `ITranslationProviderWithId` check. In original PR (#42649) we missed that :(

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
