### PR TITLE
enh(OCP\TextToImage): Introduce IProviderWithUserId

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -706,6 +706,7 @@ return array(
     'OCP\\TextToImage\\Exception\\TextToImageException' => $baseDir . '/lib/public/TextToImage/Exception/TextToImageException.php',
     'OCP\\TextToImage\\IManager' => $baseDir . '/lib/public/TextToImage/IManager.php',
     'OCP\\TextToImage\\IProvider' => $baseDir . '/lib/public/TextToImage/IProvider.php',
+    'OCP\\TextToImage\\IProviderWithUserId' => $baseDir . '/lib/public/TextToImage/IProviderWithUserId.php',
     'OCP\\TextToImage\\Task' => $baseDir . '/lib/public/TextToImage/Task.php',
     'OCP\\Translation\\CouldNotTranslateException' => $baseDir . '/lib/public/Translation/CouldNotTranslateException.php',
     'OCP\\Translation\\IDetectLanguageProvider' => $baseDir . '/lib/public/Translation/IDetectLanguageProvider.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -739,6 +739,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TextToImage\\Exception\\TextToImageException' => __DIR__ . '/../../..' . '/lib/public/TextToImage/Exception/TextToImageException.php',
         'OCP\\TextToImage\\IManager' => __DIR__ . '/../../..' . '/lib/public/TextToImage/IManager.php',
         'OCP\\TextToImage\\IProvider' => __DIR__ . '/../../..' . '/lib/public/TextToImage/IProvider.php',
+        'OCP\\TextToImage\\IProviderWithUserId' => __DIR__ . '/../../..' . '/lib/public/TextToImage/IProviderWithUserId.php',
         'OCP\\TextToImage\\Task' => __DIR__ . '/../../..' . '/lib/public/TextToImage/Task.php',
         'OCP\\Translation\\CouldNotTranslateException' => __DIR__ . '/../../..' . '/lib/public/Translation/CouldNotTranslateException.php',
         'OCP\\Translation\\IDetectLanguageProvider' => __DIR__ . '/../../..' . '/lib/public/Translation/IDetectLanguageProvider.php',

--- a/lib/private/TextToImage/Manager.php
+++ b/lib/private/TextToImage/Manager.php
@@ -43,6 +43,7 @@ use OCP\TextToImage\Exception\TaskFailureException;
 use OCP\TextToImage\Exception\TaskNotFoundException;
 use OCP\TextToImage\IManager;
 use OCP\TextToImage\IProvider;
+use OCP\TextToImage\IProviderWithUserId;
 use OCP\TextToImage\Task;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -158,6 +159,9 @@ class Manager implements IManager {
 					}
 				}
 				$this->logger->debug('Calling Text2Image provider\'s generate method');
+				if ($provider instanceof IProviderWithUserId) {
+					$provider->setUserId($task->getUserId());
+				}
 				$provider->generate($task->getInput(), $resources);
 				for ($i = 0; $i < $task->getNumberOfImages(); $i++) {
 					if (is_resource($resources[$i])) {

--- a/lib/public/TextToImage/IProviderWithUserId.php
+++ b/lib/public/TextToImage/IProviderWithUserId.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCP\TextToImage;
+
+/**
+ * @since 29.0.0
+ */
+interface IProviderWithUserId extends IProvider {
+	/**
+	 * @since 29.0.0
+	 */
+	public function setUserId(?string $userId): void;
+}


### PR DESCRIPTION
## Summary

To keep consistency between SpeechToText, TextProcessing, Translation and TextToImage providers introduce IProviderWithUserId.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
