### PR TITLE
[stable27] fix: handle exif metadata read errors gracefully

### DIFF
--- a/lib/private/Metadata/Provider/ExifProvider.php
+++ b/lib/private/Metadata/Provider/ExifProvider.php
@@ -71,8 +71,9 @@ class ExifProvider implements IMetadataProvider {
 		$size->setId($file->getId());
 		$size->setArrayAsValue([]);
 
-		if (!$data) {
-			$sizeResult = getimagesizefromstring($file->getContent());
+		$content = $file->getContent();
+		if (!$data && $content) {
+			$sizeResult = getimagesizefromstring($content);
 			if ($sizeResult !== false) {
 				$size->setArrayAsValue([
 					'width' => $sizeResult[0],
@@ -81,7 +82,7 @@ class ExifProvider implements IMetadataProvider {
 
 				$exifData['size'] = $size;
 			}
-		} elseif (array_key_exists('COMPUTED', $data)) {
+		} elseif ($data && array_key_exists('COMPUTED', $data)) {
 			if (array_key_exists('Width', $data['COMPUTED']) && array_key_exists('Height', $data['COMPUTED'])) {
 				$size->setArrayAsValue([
 					'width' => $data['COMPUTED']['Width'],


### PR DESCRIPTION
* Resolves: _none_

## Summary

The `ExifProvider` does not check if the given `$file` can be read before attempting to extract metadata. I improved the code a bit by only calling `getimagesizefromstring` if `$file->getContent()` is not false.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)