### PR TITLE
Fix AppDirsWithDifferentOwnerTest

### DIFF
--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -86,13 +86,6 @@ class CheckSetupControllerTest extends TestCase {
 	/** @var ISetupCheckManager|MockObject */
 	private $setupCheckManager;
 
-	/**
-	 * Holds a list of directories created during tests.
-	 *
-	 * @var array
-	 */
-	private $dirsToRemove = [];
-
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -143,19 +136,6 @@ class CheckSetupControllerTest extends TestCase {
 				'isMysqlUsedWithoutUTF8MB4',
 				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed',
 			])->getMock();
-	}
-
-	/**
-	 * Removes directories created during tests.
-	 *
-	 * @after
-	 * @return void
-	 */
-	public function removeTestDirectories() {
-		foreach ($this->dirsToRemove as $dirToRemove) {
-			rmdir($dirToRemove);
-		}
-		$this->dirsToRemove = [];
 	}
 
 	public function testCheck() {

--- a/apps/settings/tests/SetupChecks/AppDirsWithDifferentOwnerTest.php
+++ b/apps/settings/tests/SetupChecks/AppDirsWithDifferentOwnerTest.php
@@ -33,6 +33,13 @@ class AppDirsWithDifferentOwnerTest extends TestCase {
 	private IL10N $l10n;
 	private AppDirsWithDifferentOwner $check;
 
+	/**
+	 * Holds a list of directories created during tests.
+	 *
+	 * @var array
+	 */
+	private $dirsToRemove = [];
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -96,5 +103,18 @@ class AppDirsWithDifferentOwnerTest extends TestCase {
 			[],
 			$this->invokePrivate($this->check, 'getAppDirsWithDifferentOwner', [posix_getuid()])
 		);
+	}
+
+	/**
+	 * Removes directories created during tests.
+	 *
+	 * @after
+	 * @return void
+	 */
+	public function removeTestDirectories() {
+		foreach ($this->dirsToRemove as $dirToRemove) {
+			rmdir($dirToRemove);
+		}
+		$this->dirsToRemove = [];
 	}
 }


### PR DESCRIPTION
Follow up of #42176 

## Summary

Fix tests by avoiding:
```
There was 1 error:

1) OCA\Settings\Tests\AppDirsWithDifferentOwnerTest::testAppDirectoryOwnersOk
Creation of dynamic property OCA\Settings\Tests\AppDirsWithDifferentOwnerTest::$dirsToRemove is deprecated

/__w/server/server/apps/settings/tests/SetupChecks/AppDirsWithDifferentOwnerTest.php:64
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
