### PR TITLE
enh(metadata): Introduce a memory limit for metadata generation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1374,6 +1374,15 @@ $CONFIG = [
 ],
 
 /**
+ * Maximum file size for metadata generation.
+ * If a file exceeds this size, metadata generation will be skipped.
+ * Note: memory equivalent to this size will be used for metadata generation.
+ *
+ * Default: 256 megabytes.
+ */
+'metadata_max_filesize' => 256,
+
+/**
  * LDAP
  *
  * Global settings used by LDAP User and Group Backend


### PR DESCRIPTION
## Summary

Fix https://github.com/nextcloud/server/issues/42793

By introducing a (configurable) memory limit, one should not reach OOM on very big files that the server can't support.

## TODO

- [x] Once approved, document `metadata_max_filesize` param

Similar to:

https://github.com/nextcloud/server/blob/265e9060f87b4865485e0852724b0a2b398e0b6d/config/config.sample.php#L1241-L1249

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
