### PR TITLE
fix(userstatus): catch unique constraint violation

### DIFF
--- a/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
@@ -38,6 +38,7 @@ use OCP\EventDispatcher\GenericEvent;
 use OCP\IUser;
 use OCP\User\Events\UserLiveStatusEvent;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class UserLiveStatusListenerTest extends TestCase {
@@ -54,6 +55,8 @@ class UserLiveStatusListenerTest extends TestCase {
 
 	private CalendarStatusService|MockObject $calendarStatusService;
 
+	private LoggerInterface|MockObject $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -61,12 +64,14 @@ class UserLiveStatusListenerTest extends TestCase {
 		$this->statusService = $this->createMock(StatusService::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->calendarStatusService = $this->createMock(CalendarStatusService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new UserLiveStatusListener(
 			$this->mapper,
 			$this->statusService,
 			$this->timeFactory,
 			$this->calendarStatusService,
+			$this->logger,
 		);
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/42625

## Summary
Due to how we have our read/write commit set up, sometimes a different process writes to the DB but we don't read it when running a SELECT. We can therefore ignore the Unique Constraint Violation and drop the insert completely.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
