### PR TITLE
fix(appstore): Only send subscription keys to valid appstores

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -109,10 +109,13 @@ abstract class Fetcher {
 			];
 		}
 
-		// If we have a valid subscription key, send it to the appstore
-		$subscriptionKey = $this->config->getAppValue('support', 'subscription_key');
-		if ($this->registry->delegateHasValidSubscription() && $subscriptionKey) {
-			$options['headers']['X-NC-Subscription-Key'] = $subscriptionKey;
+		if ($this->config->getSystemValueString('appstoreurl', 'https://apps.nextcloud.com/api/v1') === 'https://apps.nextcloud.com/api/v1') {
+			// If we have a valid subscription key, send it to the appstore
+			$subscriptionKey = $this->config->getAppValue('support', 'subscription_key');
+			if ($this->registry->delegateHasValidSubscription() && $subscriptionKey) {
+				$options['headers'] ??= [];
+				$options['headers']['X-NC-Subscription-Key'] = $subscriptionKey;
+			}
 		}
 
 		$client = $this->clientService->newClient();

--- a/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppFetcherTest.php
@@ -2098,6 +2098,95 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->willReturnCallback(function ($key, $default) {
 				if ($key === 'version') {
 					return '11.0.0.2';
+				} else {
+					return $default;
+				}
+			});
+		$this->config->method('getSystemValue')
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'appsallowlist') {
+					return ['contacts'];
+				}
+				return $default;
+			});
+		$this->config->method('getAppValue')
+			->willReturnCallback(function ($app, $key, $default) {
+				if ($app === 'support' && $key === 'subscription_key') {
+					return 'subscription-key';
+				}
+				return $default;
+			});
+		$this->config
+			->method('getSystemValueBool')
+			->willReturnArgument(1);
+
+		$file = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder
+			->expects($this->once())
+			->method('getFile')
+			->with('apps.json')
+			->willThrowException(new NotFoundException());
+		$folder
+			->expects($this->once())
+			->method('newFile')
+			->with('apps.json')
+			->willReturn($file);
+		$this->appData
+			->expects($this->once())
+			->method('getFolder')
+			->with('/')
+			->willReturn($folder);
+		$client = $this->createMock(IClient::class);
+		$this->clientService
+			->expects($this->once())
+			->method('newClient')
+			->willReturn($client);
+		$response = $this->createMock(IResponse::class);
+		$client
+			->expects($this->once())
+			->method('get')
+			->with('https://apps.nextcloud.com/api/v1/apps.json', [
+				'timeout' => 60,
+				'headers' => [
+					'X-NC-Subscription-Key' => 'subscription-key',
+				],
+			])
+			->willReturn($response);
+		$response
+			->expects($this->once())
+			->method('getBody')
+			->willReturn(self::$responseJson);
+		$response->method('getHeader')
+			->with($this->equalTo('ETag'))
+			->willReturn('"myETag"');
+		$this->timeFactory
+			->expects($this->once())
+			->method('getTime')
+			->willReturn(1234);
+
+		$this->registry
+			->expects($this->exactly(2))
+			->method('delegateHasValidSubscription')
+			->willReturn(true);
+
+		$file
+			->expects($this->once())
+			->method('putContent');
+		$file
+			->method('getContent')
+			->willReturn(json_encode(self::$expectedResponse));
+
+		$apps = array_values($this->fetcher->get());
+		$this->assertEquals(count($apps), 1);
+		$this->assertEquals($apps[0]['id'], 'contacts');
+	}
+
+	public function testGetAppsAllowlistCustomAppstore(): void {
+		$this->config->method('getSystemValueString')
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'version') {
+					return '11.0.0.2';
 				} elseif ($key === 'appstoreurl' && $default === 'https://apps.nextcloud.com/api/v1') {
 					return 'https://custom.appsstore.endpoint/api/v1';
 				} else {
@@ -2142,7 +2231,9 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 		$client
 			->expects($this->once())
 			->method('get')
-			->with('https://custom.appsstore.endpoint/api/v1/apps.json')
+			->with('https://custom.appsstore.endpoint/api/v1/apps.json', [
+				'timeout' => 60,
+			])
 			->willReturn($response);
 		$response
 			->expects($this->once())
@@ -2157,7 +2248,7 @@ EJL3BaQAQaASSsvFrcozYxrQG4VzEg==
 			->willReturn(1234);
 
 		$this->registry
-			->expects($this->exactly(2))
+			->expects($this->exactly(1))
 			->method('delegateHasValidSubscription')
 			->willReturn(true);
 


### PR DESCRIPTION
## Summary

Ref https://github.com/nextcloud/server/pull/29235

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
