### PR TITLE
fix(OCP\TextProcessing): add missing return statement, inline return

### DIFF
--- a/lib/private/TextProcessing/Manager.php
+++ b/lib/private/TextProcessing/Manager.php
@@ -287,7 +287,7 @@ class Manager implements IManager {
 					if ($provider instanceof IProviderWithId) {
 						return $provider->getId() === $preferences[$task->getType()];
 					}
-					$provider::class === $preferences[$task->getType()];
+					return $provider::class === $preferences[$task->getType()];
 				})));
 				if ($provider !== false) {
 					$providers = array_filter($providers, fn ($p) => $p !== $provider);
@@ -295,7 +295,6 @@ class Manager implements IManager {
 				}
 			}
 		}
-		$providers = array_values(array_filter($providers, fn (IProvider $provider) => $task->canUseProvider($provider)));
-		return $providers;
+		return array_values(array_filter($providers, fn (IProvider $provider) => $task->canUseProvider($provider)));
 	}
 }


### PR DESCRIPTION
## Summary

Add missing return statement, inline last return in function.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
