### PR TITLE
make failure to load app commands non-fatal

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -121,7 +121,14 @@ class Application {
 						// load commands using info.xml
 						$info = $appManager->getAppInfo($app);
 						if (isset($info['commands'])) {
-							$this->loadCommandsFromInfoXml($info['commands']);
+							try {
+								$this->loadCommandsFromInfoXml($info['commands']);
+							} catch (\Throwable $e) {
+								$output->writeln("<error>" . $e->getMessage() . "</error>");
+								$this->logger->error($e->getMessage(), [
+									'exception' => $e,
+								]);
+							}
 						}
 						// load from register_command.php
 						\OC_App::registerAutoloading($app, $appPath);


### PR DESCRIPTION
Currently if a command fails to load the occ commands fails with a fatal error. This also prevents using `occ app:disable` to disable the offending command.

This instead catches the error, logs it and continues loading the commands from other apps.