### PR TITLE
Remove disputed bz2 check

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpModules.php
+++ b/apps/settings/lib/SetupChecks/PhpModules.php
@@ -49,11 +49,10 @@ class PhpModules implements ISetupCheck {
 		'zlib',
 	];
 	protected const RECOMMENDED_MODULES = [
-		'intl',
-		'sysvsem',
 		'exif',
+		'intl',
 		'sodium',
-		'bz2',
+		'sysvsem',
 	];
 
 	public function __construct(


### PR DESCRIPTION
* Resolves: #42342

## Summary
This is fixing kind of a regression of https://github.com/nextcloud/server/pull/40889 by restoring the previous behavior. The regression and reason is described in https://github.com/nextcloud/server/issues/42342.

## TODO

- [x] merge https://github.com/nextcloud/documentation/pull/11444

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated: https://github.com/nextcloud/documentation/pull/11444
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
