### PR TITLE
refactor(core): remove `sudo-login-form` layout

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -75,16 +75,6 @@ p($theme->getTitle());
 			</div>
 		</header>
 
-		<div id="sudo-login-background" class="hidden"></div>
-		<form id="sudo-login-form" class="hidden" method="POST">
-			<label>
-				<?php p($l->t('This action requires you to confirm your password')); ?><br/>
-				<input type="password" class="question" autocomplete="new-password" name="question" value=" <?php /* Hack against browsers ignoring autocomplete="off" */ ?>"
-				placeholder="<?php p($l->t('Confirm your password')); ?>" />
-			</label>
-			<input class="confirm" value="<?php p($l->t('Confirm')); ?>" type="submit">
-		</form>
-
 		<main id="content" class="app-<?php p($_['appid']) ?>">
 			<h1 class="hidden-visually" id="page-heading-level-1">
 				<?php p(!empty($_['pageTitle'])?$_['pageTitle']:$theme->getName()); ?>


### PR DESCRIPTION
## Summary

This layout was never used.

When the password confirmation was introduced in Nextcloud 12 in https://github.com/nextcloud/server/pull/1447/ , it first was created using this form and then migrated to the existing prompt `OC.dialogs` in https://github.com/nextcloud/server/pull/1447/commits/8d33d76ce8f8102f64d6b615dfc178b31e397e62 during the same PR.

No visual changes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
