### PR TITLE
Migrate available temp space check to new SetupCheck API

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -110,6 +110,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',
     'OCA\\Settings\\SetupChecks\\SupportedDatabase' => $baseDir . '/../lib/SetupChecks/SupportedDatabase.php',
     'OCA\\Settings\\SetupChecks\\SystemIs64bit' => $baseDir . '/../lib/SetupChecks/SystemIs64bit.php',
+    'OCA\\Settings\\SetupChecks\\TempSpaceAvailableIfS3PrimaryStorage' => $baseDir . '/../lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php',
     'OCA\\Settings\\SetupChecks\\TransactionIsolation' => $baseDir . '/../lib/SetupChecks/TransactionIsolation.php',
     'OCA\\Settings\\UserMigration\\AccountMigrator' => $baseDir . '/../lib/UserMigration/AccountMigrator.php',
     'OCA\\Settings\\UserMigration\\AccountMigratorException' => $baseDir . '/../lib/UserMigration/AccountMigratorException.php',

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -110,7 +110,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',
     'OCA\\Settings\\SetupChecks\\SupportedDatabase' => $baseDir . '/../lib/SetupChecks/SupportedDatabase.php',
     'OCA\\Settings\\SetupChecks\\SystemIs64bit' => $baseDir . '/../lib/SetupChecks/SystemIs64bit.php',
-    'OCA\\Settings\\SetupChecks\\TempSpaceAvailableIfS3PrimaryStorage' => $baseDir . '/../lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php',
+    'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => $baseDir . '/../lib/SetupChecks/TempSpaceAvailable.php',
     'OCA\\Settings\\SetupChecks\\TransactionIsolation' => $baseDir . '/../lib/SetupChecks/TransactionIsolation.php',
     'OCA\\Settings\\UserMigration\\AccountMigrator' => $baseDir . '/../lib/UserMigration/AccountMigrator.php',
     'OCA\\Settings\\UserMigration\\AccountMigratorException' => $baseDir . '/../lib/UserMigration/AccountMigratorException.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -125,7 +125,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',
         'OCA\\Settings\\SetupChecks\\SupportedDatabase' => __DIR__ . '/..' . '/../lib/SetupChecks/SupportedDatabase.php',
         'OCA\\Settings\\SetupChecks\\SystemIs64bit' => __DIR__ . '/..' . '/../lib/SetupChecks/SystemIs64bit.php',
-        'OCA\\Settings\\SetupChecks\\TempSpaceAvailableIfS3PrimaryStorage' => __DIR__ . '/..' . '/../lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php',
+        'OCA\\Settings\\SetupChecks\\TempSpaceAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/TempSpaceAvailable.php',
         'OCA\\Settings\\SetupChecks\\TransactionIsolation' => __DIR__ . '/..' . '/../lib/SetupChecks/TransactionIsolation.php',
         'OCA\\Settings\\UserMigration\\AccountMigrator' => __DIR__ . '/..' . '/../lib/UserMigration/AccountMigrator.php',
         'OCA\\Settings\\UserMigration\\AccountMigratorException' => __DIR__ . '/..' . '/../lib/UserMigration/AccountMigratorException.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -125,6 +125,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',
         'OCA\\Settings\\SetupChecks\\SupportedDatabase' => __DIR__ . '/..' . '/../lib/SetupChecks/SupportedDatabase.php',
         'OCA\\Settings\\SetupChecks\\SystemIs64bit' => __DIR__ . '/..' . '/../lib/SetupChecks/SystemIs64bit.php',
+        'OCA\\Settings\\SetupChecks\\TempSpaceAvailableIfS3PrimaryStorage' => __DIR__ . '/..' . '/../lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php',
         'OCA\\Settings\\SetupChecks\\TransactionIsolation' => __DIR__ . '/..' . '/../lib/SetupChecks/TransactionIsolation.php',
         'OCA\\Settings\\UserMigration\\AccountMigrator' => __DIR__ . '/..' . '/../lib/UserMigration/AccountMigrator.php',
         'OCA\\Settings\\UserMigration\\AccountMigratorException' => __DIR__ . '/..' . '/../lib/UserMigration/AccountMigratorException.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -82,7 +82,7 @@ use OCA\Settings\SetupChecks\RandomnessSecure;
 use OCA\Settings\SetupChecks\ReadOnlyConfig;
 use OCA\Settings\SetupChecks\SupportedDatabase;
 use OCA\Settings\SetupChecks\SystemIs64bit;
-use OCA\Settings\SetupChecks\TempSpaceAvailableIfS3PrimaryStorage;
+use OCA\Settings\SetupChecks\TempSpaceAvailable;
 use OCA\Settings\SetupChecks\TransactionIsolation;
 use OCA\Settings\UserMigration\AccountMigrator;
 use OCA\Settings\WellKnown\ChangePasswordHandler;
@@ -207,7 +207,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(ReadOnlyConfig::class);
 		$context->registerSetupCheck(SupportedDatabase::class);
 		$context->registerSetupCheck(SystemIs64bit::class);
-		$context->registerSetupCheck(TempSpaceAvailableIfS3PrimaryStorage::class);
+		$context->registerSetupCheck(TempSpaceAvailable::class);
 		$context->registerSetupCheck(TransactionIsolation::class);
 
 		$context->registerUserMigrator(AccountMigrator::class);

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -82,6 +82,7 @@ use OCA\Settings\SetupChecks\RandomnessSecure;
 use OCA\Settings\SetupChecks\ReadOnlyConfig;
 use OCA\Settings\SetupChecks\SupportedDatabase;
 use OCA\Settings\SetupChecks\SystemIs64bit;
+use OCA\Settings\SetupChecks\TempSpaceAvailableIfS3PrimaryStorage;
 use OCA\Settings\SetupChecks\TransactionIsolation;
 use OCA\Settings\UserMigration\AccountMigrator;
 use OCA\Settings\WellKnown\ChangePasswordHandler;
@@ -206,6 +207,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(ReadOnlyConfig::class);
 		$context->registerSetupCheck(SupportedDatabase::class);
 		$context->registerSetupCheck(SystemIs64bit::class);
+		$context->registerSetupCheck(TempSpaceAvailableIfS3PrimaryStorage::class);
 		$context->registerSetupCheck(TransactionIsolation::class);
 
 		$context->registerUserMigrator(AccountMigrator::class);

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -55,7 +55,6 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
 use OCP\SetupCheck\ISetupCheckManager;
@@ -73,8 +72,6 @@ class CheckSetupController extends Controller {
 	private $checker;
 	/** @var LoggerInterface */
 	private $logger;
-	/** @var ITempManager */
-	private $tempManager;
 	/** @var IManager */
 	private $manager;
 	private ISetupCheckManager $setupCheckManager;
@@ -86,7 +83,6 @@ class CheckSetupController extends Controller {
 		IL10N $l10n,
 		Checker $checker,
 		LoggerInterface $logger,
-		ITempManager $tempManager,
 		IManager $manager,
 		ISetupCheckManager $setupCheckManager,
 	) {
@@ -96,7 +92,6 @@ class CheckSetupController extends Controller {
 		$this->l10n = $l10n;
 		$this->checker = $checker;
 		$this->logger = $logger;
-		$this->tempManager = $tempManager;
 		$this->manager = $manager;
 		$this->setupCheckManager = $setupCheckManager;
 	}
@@ -192,16 +187,6 @@ Raw output
 		);
 	}
 
-	private function isTemporaryDirectoryWritable(): bool {
-		try {
-			if (!empty($this->tempManager->getTempBaseDir())) {
-				return true;
-			}
-		} catch (\Exception $e) {
-		}
-		return false;
-	}
-
 	/**
 	 * @return DataResponse
 	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
@@ -212,7 +197,6 @@ Raw output
 				'isFairUseOfFreePushService' => $this->isFairUseOfFreePushService(),
 				'reverseProxyDocs' => $this->urlGenerator->linkToDocs('admin-reverse-proxy'),
 				'reverseProxyGeneratedURL' => $this->urlGenerator->getAbsoluteURL('index.php'),
-				'temporaryDirectoryWritable' => $this->isTemporaryDirectoryWritable(),
 				'generic' => $this->setupCheckManager->runAll(),
 			]
 		);

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -202,42 +202,6 @@ Raw output
 		return false;
 	}
 
-	protected function isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed(): bool {
-		$objectStore = $this->config->getSystemValue('objectstore', null);
-		$objectStoreMultibucket = $this->config->getSystemValue('objectstore_multibucket', null);
-
-		if (!isset($objectStoreMultibucket) && !isset($objectStore)) {
-			return true;
-		}
-
-		if (isset($objectStoreMultibucket['class']) && $objectStoreMultibucket['class'] !== 'OC\\Files\\ObjectStore\\S3') {
-			return true;
-		}
-
-		if (isset($objectStore['class']) && $objectStore['class'] !== 'OC\\Files\\ObjectStore\\S3') {
-			return true;
-		}
-
-		$tempPath = sys_get_temp_dir();
-		if (!is_dir($tempPath)) {
-			$this->logger->error('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: ' . $tempPath);
-			return false;
-		}
-		$freeSpaceInTemp = function_exists('disk_free_space') ? disk_free_space($tempPath) : false;
-		if ($freeSpaceInTemp === false) {
-			$this->logger->error('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: ' . $tempPath);
-			return false;
-		}
-
-		$freeSpaceInTempInGB = $freeSpaceInTemp / 1024 / 1024 / 1024;
-		if ($freeSpaceInTempInGB > 50) {
-			return true;
-		}
-
-		$this->logger->warning('Checking the available space in the temporary path resulted in ' . round($freeSpaceInTempInGB, 1) . ' GB instead of the recommended 50GB. Path: ' . $tempPath);
-		return false;
-	}
-
 	/**
 	 * @return DataResponse
 	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
@@ -247,7 +211,6 @@ Raw output
 			[
 				'isFairUseOfFreePushService' => $this->isFairUseOfFreePushService(),
 				'reverseProxyDocs' => $this->urlGenerator->linkToDocs('admin-reverse-proxy'),
-				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed' => $this->isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed(),
 				'reverseProxyGeneratedURL' => $this->urlGenerator->getAbsoluteURL('index.php'),
 				'temporaryDirectoryWritable' => $this->isTemporaryDirectoryWritable(),
 				'generic' => $this->setupCheckManager->runAll(),

--- a/apps/settings/lib/SetupChecks/TempSpaceAvailable.php
+++ b/apps/settings/lib/SetupChecks/TempSpaceAvailable.php
@@ -27,15 +27,17 @@ namespace OCA\Settings\SetupChecks;
 
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
-class TempSpaceAvailableIfS3PrimaryStorage implements ISetupCheck {
+class TempSpaceAvailable implements ISetupCheck {
 	public function __construct(
 		private IL10N $l10n,
 		private IConfig $config,
 		private IURLGenerator $urlGenerator,
+		private ITempManager $tempManager,
 	) {
 	}
 
@@ -47,38 +49,69 @@ class TempSpaceAvailableIfS3PrimaryStorage implements ISetupCheck {
 		return 'system';
 	}
 
-	public function run(): SetupResult {
+	private function isPrimaryStorageS3(): bool {
 		$objectStore = $this->config->getSystemValue('objectstore', null);
 		$objectStoreMultibucket = $this->config->getSystemValue('objectstore_multibucket', null);
 
-		// TODO we should check and display temp space available even if not s3
 		if (!isset($objectStoreMultibucket) && !isset($objectStore)) {
-			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+			return false;
 		}
 
 		if (isset($objectStoreMultibucket['class']) && $objectStoreMultibucket['class'] !== 'OC\\Files\\ObjectStore\\S3') {
-			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+			return false;
 		}
 
 		if (isset($objectStore['class']) && $objectStore['class'] !== 'OC\\Files\\ObjectStore\\S3') {
-			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+			return false;
 		}
 
-		$tempPath = sys_get_temp_dir();
-		if (!is_dir($tempPath)) {
-			return SetupResult::error($this->l10n->t('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: %s', [$tempPath]));
+		return true;
+	}
+
+	public function run(): SetupResult {
+		$phpTempPath = sys_get_temp_dir();
+		$nextcloudTempPath = '';
+		try {
+			$nextcloudTempPath = $this->tempManager->getTempBaseDir();
+		} catch (\Exception $e) {
 		}
-		$freeSpaceInTemp = function_exists('disk_free_space') ? disk_free_space($tempPath) : false;
+
+		if (empty($nextcloudTempPath)) {
+			return SetupResult::error('The temporary directory of this instance points to an either non-existing or non-writable directory.');
+		}
+
+		if (!is_dir($phpTempPath)) {
+			return SetupResult::error($this->l10n->t('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: %s', [$phpTempPath]));
+		}
+
+		$freeSpaceInTemp = function_exists('disk_free_space') ? disk_free_space($phpTempPath) : false;
 		if ($freeSpaceInTemp === false) {
-			return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$tempPath]));
+			return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$phpTempPath]));
 		}
 
+		/** Build details data about temporary directory, either one or two of them */
 		$freeSpaceInTempInGB = $freeSpaceInTemp / 1024 / 1024 / 1024;
+		$spaceDetail = $this->l10n->t('- %.1f GiB available in %s (PHP temporary directory)', [round($freeSpaceInTempInGB, 1),$phpTempPath]);
+		if ($nextcloudTempPath !== $phpTempPath) {
+			$freeSpaceInNextcloudTemp = function_exists('disk_free_space') ? disk_free_space($nextcloudTempPath) : false;
+			if ($freeSpaceInNextcloudTemp === false) {
+				return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$nextcloudTempPath]));
+			}
+			$freeSpaceInNextcloudTempInGB = $freeSpaceInNextcloudTemp / 1024 / 1024 / 1024;
+			$spaceDetail .= "\n".$this->l10n->t('- %.1f GiB available in %s (Nextcloud temporary directory)', [round($freeSpaceInNextcloudTempInGB, 1),$nextcloudTempPath]);
+		}
+
+		if (!$this->isPrimaryStorageS3()) {
+			return SetupResult::success(
+				$this->l10n->t("Temporary directory is correctly configured:\n%s", [$spaceDetail])
+			);
+		}
+
 		if ($freeSpaceInTempInGB > 50) {
 			return SetupResult::success(
 				$this->l10n->t(
-					"This instance uses an S3 based object store as primary storage, and has enough space in the temporary directory.\nAvailable: %.1f GiB\nPath: %s",
-					[round($freeSpaceInTempInGB, 1),$tempPath]
+					"This instance uses an S3 based object store as primary storage, and has enough space in the temporary directory.\n%s",
+					[$spaceDetail]
 				)
 			);
 		}
@@ -86,7 +119,7 @@ class TempSpaceAvailableIfS3PrimaryStorage implements ISetupCheck {
 		return SetupResult::warning(
 			$this->l10n->t(
 				"This instance uses an S3 based object store as primary storage. The uploaded files are stored temporarily on the server and thus it is recommended to have 50 GiB of free space available in the temp directory of PHP. To improve this please change the temporary directory in the php.ini or make more space available in that path. \nChecking the available space in the temporary path resulted in %.1f GiB instead of the recommended 50 GiB. Path: %s",
-				[round($freeSpaceInTempInGB, 1),$tempPath]
+				[round($freeSpaceInTempInGB, 1),$phpTempPath]
 			)
 		);
 	}

--- a/apps/settings/lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php
+++ b/apps/settings/lib/SetupChecks/TempSpaceAvailableIfS3PrimaryStorage.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class TempSpaceAvailableIfS3PrimaryStorage implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Temporary space available');
+	}
+
+	public function getCategory(): string {
+		return 'system';
+	}
+
+	public function run(): SetupResult {
+		$objectStore = $this->config->getSystemValue('objectstore', null);
+		$objectStoreMultibucket = $this->config->getSystemValue('objectstore_multibucket', null);
+
+		// TODO we should check and display temp space available even if not s3
+		if (!isset($objectStoreMultibucket) && !isset($objectStore)) {
+			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+		}
+
+		if (isset($objectStoreMultibucket['class']) && $objectStoreMultibucket['class'] !== 'OC\\Files\\ObjectStore\\S3') {
+			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+		}
+
+		if (isset($objectStore['class']) && $objectStore['class'] !== 'OC\\Files\\ObjectStore\\S3') {
+			return SetupResult::success($this->l10n->t('This instance does not use an S3 based object store as primary storage'));
+		}
+
+		$tempPath = sys_get_temp_dir();
+		if (!is_dir($tempPath)) {
+			return SetupResult::error($this->l10n->t('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: %s', [$tempPath]));
+		}
+		$freeSpaceInTemp = function_exists('disk_free_space') ? disk_free_space($tempPath) : false;
+		if ($freeSpaceInTemp === false) {
+			return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$tempPath]));
+		}
+
+		$freeSpaceInTempInGB = $freeSpaceInTemp / 1024 / 1024 / 1024;
+		if ($freeSpaceInTempInGB > 50) {
+			return SetupResult::success(
+				$this->l10n->t(
+					"This instance uses an S3 based object store as primary storage, and has enough space in the temporary directory.\nAvailable: %.1f GiB\nPath: %s",
+					[round($freeSpaceInTempInGB, 1),$tempPath]
+				)
+			);
+		}
+
+		return SetupResult::warning(
+			$this->l10n->t(
+				"This instance uses an S3 based object store as primary storage. The uploaded files are stored temporarily on the server and thus it is recommended to have 50 GiB of free space available in the temp directory of PHP. To improve this please change the temporary directory in the php.ini or make more space available in that path. \nChecking the available space in the temporary path resulted in %.1f GiB instead of the recommended 50 GiB. Path: %s",
+				[round($freeSpaceInTempInGB, 1),$tempPath]
+			)
+		);
+	}
+}

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -118,7 +118,6 @@ class CheckSetupControllerTest extends TestCase {
 				'getCurlVersion',
 				'isPhpOutdated',
 				'isPHPMailerUsed',
-				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed',
 			])->getMock();
 	}
 
@@ -140,11 +139,6 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->request->expects($this->never())
 			->method('getHeader');
-
-		$this->checkSetupController
-			->expects($this->once())
-			->method('isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed')
-			->willReturn(true);
 
 		$this->urlGenerator->method('linkToDocs')
 			->willReturnCallback(function (string $key): string {
@@ -180,7 +174,6 @@ class CheckSetupControllerTest extends TestCase {
 		$expected = new DataResponse(
 			[
 				'reverseProxyDocs' => 'reverse-proxy-doc-link',
-				'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed' => true,
 				'reverseProxyGeneratedURL' => 'https://server/index.php',
 				'isFairUseOfFreePushService' => false,
 				'temporaryDirectoryWritable' => false,
@@ -644,49 +637,5 @@ Array
 			]
 		);
 		$this->assertEquals($expected, $this->checkSetupController->getFailedIntegrityCheckFiles());
-	}
-
-	public function dataForIsEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed() {
-		return [
-			['singlebucket', 'OC\\Files\\ObjectStore\\Swift', true],
-			['multibucket', 'OC\\Files\\ObjectStore\\Swift', true],
-			['singlebucket', 'OC\\Files\\ObjectStore\\Custom', true],
-			['multibucket', 'OC\Files\\ObjectStore\\Custom', true],
-			['singlebucket', 'OC\Files\ObjectStore\Swift', true],
-			['multibucket', 'OC\Files\ObjectStore\Swift', true],
-			['singlebucket', 'OC\Files\ObjectStore\Custom', true],
-			['multibucket', 'OC\Files\ObjectStore\Custom', true],
-		];
-	}
-
-	/**
-	 * @dataProvider dataForIsEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed
-	 */
-	public function testIsEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed(string $mode, string $className, bool $expected) {
-		$this->config->method('getSystemValue')
-			->willReturnCallback(function ($key, $default) use ($mode, $className) {
-				if ($key === 'objectstore' && $mode === 'singlebucket') {
-					return ['class' => $className];
-				}
-				if ($key === 'objectstore_multibucket' && $mode === 'multibucket') {
-					return ['class' => $className];
-				}
-				return $default;
-			});
-
-		$checkSetupController = new CheckSetupController(
-			'settings',
-			$this->request,
-			$this->config,
-			$this->urlGenerator,
-			$this->l10n,
-			$this->checker,
-			$this->logger,
-			$this->tempManager,
-			$this->notificationManager,
-			$this->setupCheckManager,
-		);
-
-		$this->assertSame($expected, $this->invokePrivate($checkSetupController, 'isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed'));
 	}
 }

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -43,7 +43,6 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\Notification\IManager;
 use OCP\SetupCheck\ISetupCheckManager;
@@ -72,8 +71,6 @@ class CheckSetupControllerTest extends TestCase {
 	private $logger;
 	/** @var Checker|\PHPUnit\Framework\MockObject\MockObject */
 	private $checker;
-	/** @var ITempManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $tempManager;
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $notificationManager;
 	/** @var ISetupCheckManager|MockObject */
@@ -98,7 +95,6 @@ class CheckSetupControllerTest extends TestCase {
 		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
 				->disableOriginalConstructor()->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-		$this->tempManager = $this->getMockBuilder(ITempManager::class)->getMock();
 		$this->notificationManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->setupCheckManager = $this->createMock(ISetupCheckManager::class);
 		$this->checkSetupController = $this->getMockBuilder(CheckSetupController::class)
@@ -110,7 +106,6 @@ class CheckSetupControllerTest extends TestCase {
 				$this->l10n,
 				$this->checker,
 				$this->logger,
-				$this->tempManager,
 				$this->notificationManager,
 				$this->setupCheckManager,
 			])
@@ -176,7 +171,6 @@ class CheckSetupControllerTest extends TestCase {
 				'reverseProxyDocs' => 'reverse-proxy-doc-link',
 				'reverseProxyGeneratedURL' => 'https://server/index.php',
 				'isFairUseOfFreePushService' => false,
-				'temporaryDirectoryWritable' => false,
 				'generic' => [],
 			]
 		);

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -189,12 +189,6 @@
 						});
 					}
 
-					if (!data.isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed) {
-						messages.push({
-							msg: t('core', 'This instance uses an S3 based object store as primary storage. The uploaded files are stored temporarily on the server and thus it is recommended to have 50 GB of free space available in the temp directory of PHP. Check the logs for full details about the path and the available space. To improve this please change the temporary directory in the php.ini or make more space available in that path.'),
-							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-						})
-					}
 					if (!data.temporaryDirectoryWritable) {
 						messages.push({
 							msg: t('core', 'The temporary directory of this instance points to an either non-existing or non-writable directory.'),

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -189,12 +189,6 @@
 						});
 					}
 
-					if (!data.temporaryDirectoryWritable) {
-						messages.push({
-							msg: t('core', 'The temporary directory of this instance points to an either non-existing or non-writable directory.'),
-							type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-						})
-					}
 					if (window.location.protocol === 'https:' && data.reverseProxyGeneratedURL.split('/')[0] !== 'https:') {
 						messages.push({
 							msg: t('core', 'You are accessing your instance over a secure connection, however your instance is generating insecure URLs. This most likely means that you are behind a reverse proxy and the overwrite config variables are not set correctly. Please read {linkstart}the documentation page about this ↗{linkend}.')

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -225,7 +225,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -260,7 +259,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -295,7 +293,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -331,7 +328,6 @@ describe('OC.SetupChecks tests', function() {
 					isFairUseOfFreePushService: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -396,7 +392,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -441,7 +436,6 @@ describe('OC.SetupChecks tests', function() {
 					isFairUseOfFreePushService: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -475,7 +469,6 @@ describe('OC.SetupChecks tests', function() {
 					isFairUseOfFreePushService: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -505,7 +498,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
 					generic: {
 						network: {
 							"Internet connectivity": {
@@ -529,39 +521,6 @@ describe('OC.SetupChecks tests', function() {
 				expect(data).toEqual([{
 					msg: 'Your installation has no default phone region set. This is required to validate phone numbers in the profile settings without a country code. To allow numbers without a country code, please add &quot;default_phone_region&quot; with the respective ISO 3166-1 code of the region to your config file. For more details see the <a target="_blank" rel="noreferrer noopener" class="external" href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements">documentation ↗</a>.',
 					type: OC.SetupChecks.MESSAGE_TYPE_INFO
-				}]);
-				done();
-			});
-		});
-
-		it('should return an info if the temporary directory is either non-existent or non-writable', function(done) {
-			var async = OC.SetupChecks.checkSetup();
-
-			suite.server.requests[0].respond(
-				200,
-				{
-					'Content-Type': 'application/json',
-				},
-				JSON.stringify({
-					isFairUseOfFreePushService: true,
-					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: false,
-					generic: {
-						network: {
-							"Internet connectivity": {
-								severity: "success",
-								description: null,
-								linkToDoc: null
-							}
-						},
-					},
-				})
-			);
-
-			async.done(function( data, s, x ){
-				expect(data).toEqual([{
-					msg: 'The temporary directory of this instance points to an either non-existing or non-writable directory.',
-					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}]);
 				done();
 			});

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -224,7 +224,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -260,7 +259,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -296,7 +294,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -333,7 +330,6 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -399,7 +395,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -444,7 +439,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
 					temporaryDirectoryWritable: true,
@@ -479,7 +473,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyDocs: 'https://docs.nextcloud.com/foo/bar.html',
 					reverseProxyGeneratedURL: 'http://server',
 					temporaryDirectoryWritable: true,
@@ -501,40 +494,6 @@ describe('OC.SetupChecks tests', function() {
 			});
 		});
 
-		it('should return an error if there is not enough free space in the temp directory', function(done) {
-			var async = OC.SetupChecks.checkSetup();
-
-			suite.server.requests[0].respond(
-				200,
-				{
-					'Content-Type': 'application/json',
-				},
-				JSON.stringify({
-					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: false,
-					reverseProxyGeneratedURL: 'https://server',
-					temporaryDirectoryWritable: true,
-					generic: {
-						network: {
-							"Internet connectivity": {
-								severity: "success",
-								description: null,
-								linkToDoc: null
-							}
-						},
-					},
-				})
-			);
-
-			async.done(function( data, s, x ){
-				expect(data).toEqual([{
-					msg: 'This instance uses an S3 based object store as primary storage. The uploaded files are stored temporarily on the server and thus it is recommended to have 50 GB of free space available in the temp directory of PHP. Check the logs for full details about the path and the available space. To improve this please change the temporary directory in the php.ini or make more space available in that path.',
-					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-				}]);
-				done();
-			});
-		});
-
 		it('should return an info if there is no default phone region', function(done) {
 			var async = OC.SetupChecks.checkSetup();
 
@@ -545,7 +504,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: true,
 					generic: {
@@ -586,7 +544,6 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isFairUseOfFreePushService: true,
-					isEnoughTempSpaceAvailableIfS3PrimaryStorageIsUsed: true,
 					reverseProxyGeneratedURL: 'https://server',
 					temporaryDirectoryWritable: false,
 					generic: {


### PR DESCRIPTION
See #41364 

## Summary

Migrate available temp space check to new SetupCheck API.
Also put info in the check and not in the log file.

- [x] See whether is makes sense to display available temp space even if not s3 based?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
