### PR TITLE
AppConfig: returns default on exception 

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -292,11 +292,17 @@ class AppConfig implements IAppConfig {
 		string $default = '',
 		?bool $lazy = false
 	): string {
+		try {
+			$lazy = ($lazy === null) ? $this->isLazy($app, $key) : $lazy;
+		} catch (AppConfigUnknownKeyException $e) {
+			return $default;
+		}
+
 		return $this->getTypedValue(
 			$app,
 			$key,
 			$default,
-			($lazy === null) ? $this->isLazy($app, $key) : $lazy,
+			$lazy,
 			self::VALUE_MIXED
 		);
 	}


### PR DESCRIPTION
catching exception from isLazy() and returns default.

should fix #42846