### PR TITLE
fix(theming): Make sure `color-border-maxcontrast` fulfills 3:1 contrast

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -43,7 +43,7 @@
   --color-box-shadow: rgba(var(--color-box-shadow-rgb), 0.5);
   --color-border: #ededed;
   --color-border-dark: #dbdbdb;
-  --color-border-maxcontrast: #949494;
+  --color-border-maxcontrast: #7d7d7d;
   --font-face: system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --default-font-size: 15px;
   --animation-quick: 100ms;

--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -118,6 +118,7 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 
 				'--color-border' => $this->util->lighten($colorMainBackground, 50),
 				'--color-border-dark' => $this->util->lighten($colorMainBackground, 50),
+				'--color-border-maxcontrast' => $this->util->lighten($colorMainBackground, 55),
 			]
 		);
 	}

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -115,7 +115,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 
 				'--color-border' => $this->util->lighten($colorMainBackground, 7),
 				'--color-border-dark' => $this->util->lighten($colorMainBackground, 14),
-				'--color-border-maxcontrast' => $this->util->lighten($colorMainBackground, 30),
+				'--color-border-maxcontrast' => $this->util->lighten($colorMainBackground, 40),
 
 				'--background-invert-if-dark' => 'invert(100%)',
 				'--background-invert-if-bright' => 'no',

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -171,7 +171,7 @@ class DefaultTheme implements ITheme {
 
 			'--color-border' => $this->util->darken($colorMainBackground, 7),
 			'--color-border-dark' => $this->util->darken($colorMainBackground, 14),
-			'--color-border-maxcontrast' => $this->util->darken($colorMainBackground, 42),
+			'--color-border-maxcontrast' => $this->util->darken($colorMainBackground, 51),
 
 			'--font-face' => "system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
 			'--default-font-size' => '15px',

--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -121,6 +121,7 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 
 				'--color-border' => $this->util->darken($colorMainBackground, 50),
 				'--color-border-dark' => $this->util->darken($colorMainBackground, 50),
+				'--color-border-maxcontrast' => $this->util->darken($colorMainBackground, 56),
 			]
 		);
 	}

--- a/apps/theming/tests/Themes/AccessibleThemeTestCase.php
+++ b/apps/theming/tests/Themes/AccessibleThemeTestCase.php
@@ -74,6 +74,18 @@ class AccessibleThemeTestCase extends TestCase {
 				],
 				$elementContrast,
 			],
+			'border-colors' => [
+				[
+					'--color-border-maxcontrast',
+				],
+				[
+					'--color-main-background',
+					'--color-background-hover',
+					'--color-background-dark',
+					'--color-main-background-blur',
+				],
+				$elementContrast,
+			],
 			// Those two colors are used for borders which will be `color-main-text` on focussed state, thus need 3:1 contrast to it
 			'success-error-border-colors' => [
 				[


### PR DESCRIPTION
* Resolves: #42785

## Summary
We need a 3:1 contrast for input fields, that is why `--color-border-maxcontrast` was introduced. But that variable was not guaranteed to have 3:1 contrast.
So this adds tests and adjusts the color a bit.

### Screenshots

before|after
---|---
![Screenshot 2024-01-17 at 15-29-23 Nextcloud](https://github.com/nextcloud/server/assets/1855448/5868c655-ee71-43bf-b4b0-ce3bbc8df027)|![Screenshot 2024-01-17 at 15-29-54 Nextcloud](https://github.com/nextcloud/server/assets/1855448/c81d01f5-1ce3-49b7-8ac7-f9c329848e3f)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
