### PR TITLE
fix(db): Fix replica password example config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -155,8 +155,8 @@ $CONFIG = [
  * Specify read only replicas to be used by Nextcloud when querying the database
  */
 'dbreplica' => [
-	['user' => 'replica1', 'password', 'host' => '', 'dbname' => ''],
-	['user' => 'replica1', 'password', 'host' => '', 'dbname' => ''],
+	['user' => 'nextcloud', 'password' => 'password1', 'host' => 'replica1', 'dbname' => ''],
+	['user' => 'nextcloud', 'password' => 'password2', 'host' => 'replica2', 'dbname' => ''],
 ],
 
 /**


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Replica config is an associative array with password=>password.

Ref https://github.com/nextcloud/server/pull/41998

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
