### PR TITLE
Improve path resolution in files_version hooks

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -350,16 +350,24 @@ class FileEventsListener implements IEventListener {
 	private function getPathForNode(Node $node): ?string {
 		$user = $this->userSession->getUser()?->getUID();
 		if ($user) {
-			return $this->rootFolder
+			$path = $this->rootFolder
 				->getUserFolder($user)
 				->getRelativePath($node->getPath());
+
+			if ($path !== null) {
+				return $path;
+			}
 		}
 
 		$owner = $node->getOwner()?->getUid();
 		if ($owner) {
-			return $this->rootFolder
+			$path = $this->rootFolder
 				->getUserFolder($owner)
 				->getRelativePath($node->getPath());
+
+			if ($path !== null) {
+				return $path;
+			}
 		}
 
 		return null;


### PR DESCRIPTION
When the user is logged in and is accessing the file through a public share, the fileinfo will be relative to the public share owner. So we need to resolve the path relative to the owner's root folder.

This PR ensure that we fall back to the owner root folder if the file cannot be found from the current user perspective.

Fix https://github.com/nextcloud/server/issues/40090