### PR TITLE
fix(userstatus): CALL status should overwrite MEETING status

### DIFF
--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -77,12 +77,13 @@ class StatusService {
 			return;
 		}
 
-		$userStatusTimestamp = null;
-		$currentStatus = null;
 		try {
 			$currentStatus = $this->userStatusService->findByUserId($userId);
-			$userStatusTimestamp = $currentStatus->getIsUserDefined() ? $currentStatus->getStatusTimestamp() : null;
+			// Was the status set by anything other than the calendar automation?
+			$userStatusTimestamp = $currentStatus->getIsUserDefined() && $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY ? $currentStatus->getStatusTimestamp() : null;
 		} catch (DoesNotExistException) {
+			$userStatusTimestamp = null;
+			$currentStatus = null;
 		}
 
 		if($currentStatus !== null && $currentStatus->getMessageId() === IUserStatus::MESSAGE_CALL
@@ -123,19 +124,21 @@ class StatusService {
 			return;
 		}
 
-		// One event that fulfills all status conditions is enough
-		// 1. Not an OOO event
-		// 2. Current user status was not set after the start of this event
-		// 3. Event is not set to be transparent
-		$count = count($applicableEvents);
-		$this->logger->debug("Found $count applicable event(s), changing user status", ['user' => $userId]);
-		$this->userStatusService->setUserStatus(
-			$userId,
-			IUserStatus::AWAY,
-			IUserStatus::MESSAGE_CALENDAR_BUSY,
-			true
-		);
-
+		// Only update the status if it's neccesary otherwise we mess up the timestamp
+		if($currentStatus !== null && $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY) {
+			// One event that fulfills all status conditions is enough
+			// 1. Not an OOO event
+			// 2. Current user status (that is not a calendar status) was not set after the start of this event
+			// 3. Event is not set to be transparent
+			$count = count($applicableEvents);
+			$this->logger->debug("Found $count applicable event(s), changing user status", ['user' => $userId]);
+			$this->userStatusService->setUserStatus(
+				$userId,
+				IUserStatus::AWAY,
+				IUserStatus::MESSAGE_CALENDAR_BUSY,
+				true
+			);
+		}
 	}
 
 	private function getCalendarEvents(User $user): array {

--- a/apps/dav/lib/CalDAV/Status/StatusService.php
+++ b/apps/dav/lib/CalDAV/Status/StatusService.php
@@ -125,7 +125,7 @@ class StatusService {
 		}
 
 		// Only update the status if it's neccesary otherwise we mess up the timestamp
-		if($currentStatus !== null && $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY) {
+		if($currentStatus === null || $currentStatus->getMessageId() !== IUserStatus::MESSAGE_CALENDAR_BUSY) {
 			// One event that fulfills all status conditions is enough
 			// 1. Not an OOO event
 			// 2. Current user status (that is not a calendar status) was not set after the start of this event

--- a/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
+++ b/apps/user_status/tests/Integration/Service/StatusServiceIntegrationTest.php
@@ -126,6 +126,73 @@ class StatusServiceIntegrationTest extends TestCase {
 		);
 	}
 
+	public function testCallOverwritesMeetingStatus(): void {
+		$this->service->setStatus(
+			'test123',
+			IUserStatus::ONLINE,
+			null,
+			false,
+		);
+		$this->service->setUserStatus(
+			'test123',
+			IUserStatus::AWAY,
+			IUserStatus::MESSAGE_CALENDAR_BUSY,
+			true,
+		);
+		self::assertSame(
+			'meeting',
+			$this->service->findByUserId('test123')->getMessageId(),
+		);
+
+		$this->service->setUserStatus(
+			'test123',
+			IUserStatus::AWAY,
+			IUserStatus::MESSAGE_CALL,
+			true,
+		);
+		self::assertSame(
+			IUserStatus::AWAY,
+			$this->service->findByUserId('test123')->getStatus(),
+		);
+
+		self::assertSame(
+			IUserStatus::MESSAGE_CALL,
+			$this->service->findByUserId('test123')->getMessageId(),
+		);
+	}
+
+	public function testOtherAutomationsDoNotOverwriteEachOther(): void {
+		$this->service->setStatus(
+			'test123',
+			IUserStatus::ONLINE,
+			null,
+			false,
+		);
+		$this->service->setUserStatus(
+			'test123',
+			IUserStatus::AWAY,
+			IUserStatus::MESSAGE_CALENDAR_BUSY,
+			true,
+		);
+		self::assertSame(
+			'meeting',
+			$this->service->findByUserId('test123')->getMessageId(),
+		);
+
+		$nostatus = $this->service->setUserStatus(
+			'test123',
+			IUserStatus::AWAY,
+			IUserStatus::MESSAGE_AVAILABILITY,
+			true,
+		);
+
+		self::assertNull($nostatus);
+		self::assertSame(
+			IUserStatus::MESSAGE_CALENDAR_BUSY,
+			$this->service->findByUserId('test123')->getMessageId(),
+		);
+	}
+
 	public function testCi(): void {
 		// TODO: remove if CI turns red
 		self::assertTrue(false);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/42451

## Summary

When a meeting status is set, the call status will not be written if a backup exists. The code now shortcuts this single scenario and overwrites the existing status "In a meeting" with the "In a call" status irregardless of a backup status, since both are automated status and will revert to the backup after their respective automation has run.

This also fixes the issue of having a call while "in a meeting" is set, leaving the call, and the meeting status not coming back after.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
