### PR TITLE
fix(db): Remove very verbose dirty query logs

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -321,7 +321,6 @@ class Connection extends PrimaryReadReplicaConnection {
 	public function executeStatement($sql, array $params = [], array $types = []): int {
 		$tables = $this->getQueriedTables($sql);
 		$this->tableDirtyWrites = array_unique(array_merge($this->tableDirtyWrites, $tables));
-		$this->logger->debug('dirty table writes: ' . $sql, ['tables' => $this->tableDirtyWrites]);
 		$sql = $this->replaceTablePrefix($sql);
 		$sql = $this->adapter->fixupStatement($sql);
 		$this->queriesExecuted++;
@@ -642,16 +641,6 @@ class Connection extends PrimaryReadReplicaConnection {
 		} else {
 			return new Migrator($this, $config, $dispatcher);
 		}
-	}
-
-	protected function performConnect(?string $connectionName = null): bool {
-		$before = $this->isConnectedToPrimary();
-		$result = parent::performConnect($connectionName);
-		$after = $this->isConnectedToPrimary();
-		if (!$before && $after) {
-			$this->logger->debug('Switched to primary database', ['exception' => new \Exception()]);
-		}
-		return $result;
 	}
 
 	public function beginTransaction() {


### PR DESCRIPTION
## Summary

* Primary/secondary switching happens in almost every request. Logging this is too much. If one is interested in this mechanism they can turn on query logging. Query logs are prefixed with primary/replica.
* Logging dirty tables for each statement (write) is *a lot*. This doesn't have a real benefit. Removing.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
