### PR TITLE
fix(db): Do not log transacted reads as dirty read

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -265,13 +265,16 @@ class Connection extends PrimaryReadReplicaConnection {
 	 */
 	public function executeQuery(string $sql, array $params = [], $types = [], QueryCacheProfile $qcp = null): Result {
 		$tables = $this->getQueriedTables($sql);
-		if (count(array_intersect($this->tableDirtyWrites, $tables)) === 0 && !$this->isTransactionActive()) {
+		if ($this->isTransactionActive()) {
+			// Transacted queries go to the primary. The consistency of the primary guarantees that we can not run
+			// into a dirty read.
+		} elseif (count(array_intersect($this->tableDirtyWrites, $tables)) === 0) {
 			// No tables read that could have been written already in the same request and no transaction active
 			// so we can switch back to the replica for reading as long as no writes happen that switch back to the primary
 			// We cannot log here as this would log too early in the server boot process
 			$this->ensureConnectedToReplica();
 		} else {
-			// Read to a table that was previously written to
+			// Read to a table that has been written to previously
 			// While this might not necessarily mean that we did a read after write it is an indication for a code path to check
 			$this->logger->debug('dirty table reads: ' . $sql, ['tables' => $this->tableDirtyWrites, 'reads' => $tables, 'exception' => new \Exception()]);
 		}


### PR DESCRIPTION
* Follow-up to https://github.com/nextcloud/server/pull/42345

## Summary

Starting a transaction makes `\Doctrine\DBAL\Connections\PrimaryReadReplicaConnection::beginTransaction` switch over to the primary. That means reading implicitly becomes safe because we are not connected to an outdated replica.

Reads are only dirty if data has been written to the primary within the same request and we are now reading from a replica.

## How to test

tail -f nextcloud.log

master: *lots* of logs for dirty reads. On closer inspection the majority is written as dirty not because there was a preceding write but  because there is an ongoing transaction.
here: only a few logs when we indeed write+read without a transaction within the same request.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
