### PR TITLE
fix: always add user to group cache

### DIFF
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -184,9 +184,7 @@ class Group implements IGroup {
 		foreach ($this->backends as $backend) {
 			if ($backend->implementsActions(\OC\Group\Backend::ADD_TO_GROUP)) {
 				$backend->addToGroup($user->getUID(), $this->gid);
-				if ($this->users) {
-					$this->users[$user->getUID()] = $user;
-				}
+				$this->users[$user->getUID()] = $user;
 
 				$this->dispatcher->dispatchTyped(new UserAddedEvent($this, $user));
 


### PR DESCRIPTION
## Summary
When there is no user in a group, and we add one, it's not added to the group cache. So consecutive call of `addUser()` and `getUsers()` is inconsistent. Furthermore, the user cache is never null, so this check is unesserary.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
