### PR TITLE
fix(db): Execute dirty reads on the primary node

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -285,6 +285,10 @@ class Connection extends PrimaryReadReplicaConnection {
 					'exception' => new \Exception(),
 				],
 			);
+			// To prevent a dirty read on a replica that is slightly out of sync, we
+			// switch back to the primary. This is detrimental for performance but
+			// safer for consistency.
+			$this->ensureConnectedToPrimary();
 		}
 
 		$sql = $this->replaceTablePrefix($sql);


### PR DESCRIPTION
* Follow-up to https://github.com/nextcloud/server/pull/42345

## Summary

By introducing read replicas in 29+ we open the door for new read after write problems. That is, when we write on the primary and read on the replica and the replica hasn't received the data yet. This condition is logged for developer awareness. Until the dirty read is fixed by the developer, we should force the dirty read to happen on the primary. This guarantees consistency, while hurting performance due to more load on the primary.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
