### PR TITLE
feat(CI): Automatically update the root.crl from the appstore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /apps/workflowengine/appinfo/info.xml         @blizzz @juliushaertl
 
 # Security team
+/resources/codesigning              @mgallien @miaulalala @nickvergessen
 /resources/config/ca-bundle.crt     @ChristophWurst @miaulalala @nickvergessen
 /.drone.yml                         @nickvergessen
 

--- a/.github/workflows/update-code-signing-crl.yml
+++ b/.github/workflows/update-code-signing-crl.yml
@@ -1,0 +1,45 @@
+name: Update code signing revocation list
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 2 * * *"
+
+jobs:
+  update-code-signing-crl:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branches: ["master", "stable28",  "stable27", "stable26", "stable25", "stable24", "stable23", "stable22"]
+
+    name: update-code-signing-crl-${{ matrix.branches }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          ref: ${{ matrix.branches }}
+          submodules: true
+
+      - name: Download CRL file from Appstore repository
+        run: curl --output resources/codesigning/root.crl https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/certificate/nextcloud.crl
+
+      - name: Verify CRL is from CRT
+        run: openssl crl -verify -in resources/codesigning/root.crl -CAfile resources/codesigning/root.crt -noout
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          commit-message: "fix(security): Update code signing revocation list"
+          committer: GitHub <noreply@github.com>
+          author: nextcloud-command <nextcloud-command@users.noreply.github.com>
+          signoff: true
+          branch: automated/noid/${{ matrix.branches }}-update-code-signing-crl
+          title: "[${{ matrix.branches }}] fix(security): Update code signing revocation list"
+          body: |
+            Auto-generated update of code signing revocation list from [Appstore](https://github.com/nextcloud/appstore/commits/master/nextcloudappstore/certificate/nextcloud.crl)
+          labels: |
+            dependencies
+            3. to review


### PR DESCRIPTION
Helps to avoid manual PR mess https://github.com/nextcloud/server/pulls?q=is%3Apr+update+CRL+is%3Aclosed

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
