### PR TITLE
fix(auth): Fix logging in with email and app password

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -460,7 +460,8 @@ class Session implements IUserSession, Emitter {
 			if ($isTokenPassword) {
 				$dbToken = $this->tokenProvider->getToken($password);
 				$userFromToken = $this->manager->get($dbToken->getUID());
-				$isValidEmailLogin = $userFromToken->getEMailAddress() === $user;
+				$isValidEmailLogin = $userFromToken->getEMailAddress() === $user
+					&& $this->validateTokenLoginName($userFromToken->getEMailAddress(), $dbToken);
 			} else {
 				$users = $this->manager->getByEmail($user);
 				$isValidEmailLogin = (\count($users) === 1 && $this->login($users[0]->getUID(), $password));
@@ -800,18 +801,7 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
-		// Check if login names match
-		if (!is_null($user) && $dbToken->getLoginName() !== $user) {
-			// TODO: this makes it impossible to use different login names on browser and client
-			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
-			//      allow to use the client token with the login name 'user'.
-			$this->logger->error('App token login name does not match', [
-				'tokenLoginName' => $dbToken->getLoginName(),
-				'sessionLoginName' => $user,
-				'app' => 'core',
-				'user' => $dbToken->getUID(),
-			]);
-
+		if (!is_null($user) && !$this->validateTokenLoginName($user, $dbToken)) {
 			return false;
 		}
 
@@ -827,6 +817,27 @@ class Session implements IUserSession, Emitter {
 		$this->lockdownManager->setToken($dbToken);
 
 		$this->tokenProvider->updateTokenActivity($dbToken);
+
+		return true;
+	}
+
+	/**
+	 * Check if login names match
+	 */
+	private function validateTokenLoginName(?string $loginName, IToken $token): bool {
+		if ($token->getLoginName() !== $loginName) {
+			// TODO: this makes it impossible to use different login names on browser and client
+			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
+			//      allow to use the client token with the login name 'user'.
+			$this->logger->error('App token login name does not match', [
+				'tokenLoginName' => $token->getLoginName(),
+				'sessionLoginName' => $loginName,
+				'app' => 'core',
+				'user' => $token->getUID(),
+			]);
+
+			return false;
+		}
 
 		return true;
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/42961

## Summary

Logging in with email and app password is only allowed if the token was created in a web session authenticated with the email. That's because Nextcloud enforces the login name to match when logging in with an app password.

``\OCA\DAV\Connector\Sabre\Auth::validateUserPass`` calls ``\OC\User\Session::logClientIn``, which tries to log in with `\OC\User\Session::login`, which validates the token. Because of the login name mismatch login "fails". Yet `\OC\User\Session::logClientIn` continues the email login fallback. Since https://github.com/nextcloud/server/pull/42651 there is a shortcut to not do a second login. But the return value indicates a successful login that never happened.

### Tested

* [x] Log in with username and password -> works as expected
* [x] Log in with username and app password generated with username login -> works as expected
* [x] Log in with email and password -> works as expected
* [x] Log in with email and app password generated with username login -> fails gracefully as expected
* [x] Log in with email and app password generated with email login -> fails gracefully as expected

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
