### PR TITLE
fix(build): Fix OpenAPI diff on non-default specs

### DIFF
--- a/build/openapi-checker.sh
+++ b/build/openapi-checker.sh
@@ -9,7 +9,7 @@ done
 files="$(git diff --name-only)"
 changed=false
 for file in $files; do
-    if [[ $file == *"openapi.json" ]]; then
+    if [[ $file == *"openapi"*".json" ]]; then
         changed=true
         break
     fi


### PR DESCRIPTION
## Summary

Required to also fail on diffs for specs that are not the default one.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
