### PR TITLE
fix(contacts): mouse now is pointer

### DIFF
--- a/core/src/views/ContactsMenu.vue
+++ b/core/src/views/ContactsMenu.vue
@@ -30,15 +30,15 @@
 		</template>
 		<div class="contactsmenu__menu">
 			<div class="contactsmenu__menu__input-wrapper">
-				<NcTextField :value.sync="searchTerm"
-					trailing-button-icon="close"
+				<NcTextField id="contactsmenu__menu__search"
 					ref="contactsMenuInput"
+					trailing-button-icon="close"
+					class="contactsmenu__menu__search"
+					:value.sync="searchTerm"
 					:label="t('core', 'Search contacts')"
 					:trailing-button-label="t('core','Reset search')"
 					:show-trailing-button="searchTerm !== ''"
 					:placeholder="t('core', 'Search contacts …')"
-					id="contactsmenu__menu__search"
-					class="contactsmenu__menu__search"
 					@input="onInputDebounced"
 					@trailing-button-click="onReset" />
 			</div>
@@ -230,6 +230,12 @@ export default {
 				box-shadow: inset 0 0 0 2px var(--color-main-text) !important; // override rule in core/css/headers.scss #header a:focus-visible
 			}
 		}
+	}
+
+	// NOTE when migrating to Vue3, while not deprecated, a better solution would be to style the child slotted element
+	// LINK https://stackoverflow.com/a/55368933
+	:deep span {
+		cursor: pointer !important;
 	}
 }
 </style>


### PR DESCRIPTION
* Resolves: #42959

## Summary
Contacts menu is now hoverable on all sections! The icon was not hoverable beforehand.

## TODO
- made icon hoverable

## BEFORE AND AFTER
🏚️ Before | 🏡 After
---|---
![firefox_N5dzbiLu1o](https://github.com/nextcloud/server/assets/110193237/5ca97364-4fd3-4d62-b433-1579d9dcbbca)|![firefox_ywyd4fUx9v](https://github.com/nextcloud/server/assets/110193237/933a43e8-1403-4544-8c29-a50d0c56e186)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
