### PR TITLE
Lower failed movie preview generation logs to level info

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -163,7 +163,7 @@ class Movie extends ProviderV2 {
 
 		if ($second === 0) {
 			$logger = \OC::$server->get(LoggerInterface::class);
-			$logger->error('Movie preview generation failed Output: {output}', ['app' => 'core', 'output' => $output]);
+			$logger->info('Movie preview generation failed Output: {output}', ['app' => 'core', 'output' => $output]);
 		}
 
 		unlink($tmpPath);


### PR DESCRIPTION
## Summary

Just like other external providers (ex. Imaginary) as there is not much we can do about it.

https://github.com/nextcloud/server/blob/9695c021c2da7a497a248aba969396f16dea5d49/lib/private/Preview/Imaginary.php#L172

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
