### PR TITLE
fix(weather_status): Fix location format for OpenAPI

### DIFF
--- a/apps/weather_status/lib/Controller/WeatherStatusController.php
+++ b/apps/weather_status/lib/Controller/WeatherStatusController.php
@@ -34,6 +34,10 @@ use OCP\IRequest;
 
 /**
  * @psalm-import-type WeatherStatusForecast from ResponseDefinitions
+ * @psalm-import-type WeatherStatusSuccess from ResponseDefinitions
+ * @psalm-import-type WeatherStatusLocation from ResponseDefinitions
+ * @psalm-import-type WeatherStatusLocationWithSuccess from ResponseDefinitions
+ * @psalm-import-type WeatherStatusLocationWithMode from ResponseDefinitions
  */
 class WeatherStatusController extends OCSController {
 	public function __construct(
@@ -50,7 +54,7 @@ class WeatherStatusController extends OCSController {
 	 *
 	 * Try to use the address set in user personal settings as weather location
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool, lat: ?float, lon: ?float, address: ?string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusLocationWithSuccess, array{}>
 	 *
 	 * 200: Address updated
 	 */
@@ -66,7 +70,7 @@ class WeatherStatusController extends OCSController {
 	 * - use the user defined address
 	 *
 	 * @param int $mode New mode
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusSuccess, array{}>
 	 *
 	 * 200: Weather status mode updated
 	 */
@@ -83,7 +87,7 @@ class WeatherStatusController extends OCSController {
 	 * @param string|null $address Any approximative or exact address
 	 * @param float|null $lat Latitude in decimal degree format
 	 * @param float|null $lon Longitude in decimal degree format
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool, lat: ?float, lon: ?float, address: ?string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusLocationWithSuccess, array{}>
 	 *
 	 * 200: Location updated
 	 */
@@ -97,7 +101,7 @@ class WeatherStatusController extends OCSController {
 	 *
 	 * Get stored user location
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{lat: float, lon: float, address: string, mode: int}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusLocationWithMode, array{}>
 	 *
 	 * 200: Location returned
 	 */
@@ -111,7 +115,7 @@ class WeatherStatusController extends OCSController {
 	 *
 	 * Get forecast for current location
 	 *
-	 * @return DataResponse<Http::STATUS_OK, WeatherStatusForecast[], array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{success: bool}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusForecast[]|array{error: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, WeatherStatusSuccess, array{}>
 	 *
 	 * 200: Forecast returned
 	 * 404: Forecast not found
@@ -144,7 +148,7 @@ class WeatherStatusController extends OCSController {
 	 * Set favorites list
 	 *
 	 * @param string[] $favorites Favorite addresses
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, WeatherStatusSuccess, array{}>
 	 *
 	 * 200: Favorites updated
 	 */

--- a/apps/weather_status/lib/ResponseDefinitions.php
+++ b/apps/weather_status/lib/ResponseDefinitions.php
@@ -67,6 +67,23 @@ namespace OCA\WeatherStatus;
  *         },
  *     },
  * }
+ *
+ * @psalm-type WeatherStatusSuccess = array{
+ *     success: bool,
+ * }
+ *
+ * @psalm-type WeatherStatusMode = array{
+ *     mode: int,
+ * }
+ * @psalm-type WeatherStatusLocation = array{
+ *     lat?: string,
+ *     lon?: string,
+ *     address?: ?string,
+ * }
+ *
+ * @psalm-type WeatherStatusLocationWithSuccess = WeatherStatusLocation&WeatherStatusSuccess
+ *
+ * @psalm-type WeatherStatusLocationWithMode = WeatherStatusLocation&WeatherStatusMode
  */
 class ResponseDefinitions {
 }

--- a/apps/weather_status/openapi.json
+++ b/apps/weather_status/openapi.json
@@ -185,6 +185,53 @@
                     }
                 }
             },
+            "Location": {
+                "type": "object",
+                "properties": {
+                    "lat": {
+                        "type": "string"
+                    },
+                    "lon": {
+                        "type": "string"
+                    },
+                    "address": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
+            "LocationWithMode": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Location"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Mode"
+                    }
+                ]
+            },
+            "LocationWithSuccess": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Location"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Success"
+                    }
+                ]
+            },
+            "Mode": {
+                "type": "object",
+                "required": [
+                    "mode"
+                ],
+                "properties": {
+                    "mode": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
             "OCSMeta": {
                 "type": "object",
                 "required": [
@@ -206,6 +253,17 @@
                     },
                     "itemsperpage": {
                         "type": "string"
+                    }
+                }
+            },
+            "Success": {
+                "type": "object",
+                "required": [
+                    "success"
+                ],
+                "properties": {
+                    "success": {
+                        "type": "boolean"
                     }
                 }
             }
@@ -271,15 +329,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "success"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/Success"
                                                 }
                                             }
                                         }
@@ -340,32 +390,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "success",
-                                                        "lat",
-                                                        "lon",
-                                                        "address"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "lat": {
-                                                            "type": "number",
-                                                            "format": "float",
-                                                            "nullable": true
-                                                        },
-                                                        "lon": {
-                                                            "type": "number",
-                                                            "format": "float",
-                                                            "nullable": true
-                                                        },
-                                                        "address": {
-                                                            "type": "string",
-                                                            "nullable": true
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/LocationWithSuccess"
                                                 }
                                             }
                                         }
@@ -426,30 +451,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "lat",
-                                                        "lon",
-                                                        "address",
-                                                        "mode"
-                                                    ],
-                                                    "properties": {
-                                                        "lat": {
-                                                            "type": "number",
-                                                            "format": "float"
-                                                        },
-                                                        "lon": {
-                                                            "type": "number",
-                                                            "format": "float"
-                                                        },
-                                                        "address": {
-                                                            "type": "string"
-                                                        },
-                                                        "mode": {
-                                                            "type": "integer",
-                                                            "format": "int64"
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/LocationWithMode"
                                                 }
                                             }
                                         }
@@ -537,32 +539,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "success",
-                                                        "lat",
-                                                        "lon",
-                                                        "address"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "lat": {
-                                                            "type": "number",
-                                                            "format": "float",
-                                                            "nullable": true
-                                                        },
-                                                        "lon": {
-                                                            "type": "number",
-                                                            "format": "float",
-                                                            "nullable": true
-                                                        },
-                                                        "address": {
-                                                            "type": "string",
-                                                            "nullable": true
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/LocationWithSuccess"
                                                 }
                                             }
                                         }
@@ -623,10 +600,25 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Forecast"
-                                                    }
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/Forecast"
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "error"
+                                                            ],
+                                                            "properties": {
+                                                                "error": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
                                                 }
                                             }
                                         }
@@ -656,15 +648,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "success"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/Success"
                                                 }
                                             }
                                         }
@@ -799,15 +783,7 @@
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
                                                 "data": {
-                                                    "type": "object",
-                                                    "required": [
-                                                        "success"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
+                                                    "$ref": "#/components/schemas/Success"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Summary

Previously lat and lon were typed as float but they are always string. I fixed that and also fixed the type hierarchy so now all the endpoints use the same base type for locations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
