### PR TITLE
fix(settings): Allow to connect to local address when checking for `.mjs` support

### DIFF
--- a/apps/settings/lib/SetupChecks/JavaScriptModules.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptModules.php
@@ -64,12 +64,18 @@ class JavaScriptModules implements ISetupCheck {
 		foreach ($testURLs as $testURL) {
 			try {
 				$client = $this->clientService->newClient();
-				$response = $client->head($testURL, ['connect_timeout' => 10]);
+				$response = $client->head($testURL, [
+					'connect_timeout' => 10,
+					'nextcloud' => [
+						'allow_local_address' => true,
+					],
+				]);
 				if (preg_match('/(text|application)\/javascript/i', $response->getHeader('Content-Type'))) {
 					return SetupResult::success();
 				}
 			} catch (\Throwable $e) {
 				$this->logger->debug('Can not connect to local server for checking JavaScript modules support', ['exception' => $e, 'url' => $testURL]);
+				return SetupResult::warning($this->l10n->t('Could not check for JavaScript support. Please check manually if your webserver serves `.mjs` files using the JavaScript MIME type.'));
 			}
 		}
 		return SetupResult::error($this->l10n->t('Your webserver does not serve `.mjs` files using the JavaScript MIME type. This will break some apps by preventing browsers from executing the JavaScript files. You should configure your webserver to serve `.mjs` files with either the `text/javascript` or `application/javascript` MIME type.'));


### PR DESCRIPTION
* Resolves: #42989

## Summary
Allow local address when checking for module javascript support, as the server will connect to itself.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
