### PR TITLE
fix(testing): implement getExpectedRuntime on FakeTextProcessingProvider

### DIFF
--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -15,5 +15,6 @@ return array(
     'OCA\\Testing\\Locking\\FakeDBLockingProvider' => $baseDir . '/../lib/Locking/FakeDBLockingProvider.php',
     'OCA\\Testing\\Provider\\FakeText2ImageProvider' => $baseDir . '/../lib/Provider/FakeText2ImageProvider.php',
     'OCA\\Testing\\Provider\\FakeTextProcessingProvider' => $baseDir . '/../lib/Provider/FakeTextProcessingProvider.php',
+    'OCA\\Testing\\Provider\\FakeTextProcessingProviderSync' => $baseDir . '/../lib/Provider/FakeTextProcessingProviderSync.php',
     'OCA\\Testing\\Provider\\FakeTranslationProvider' => $baseDir . '/../lib/Provider/FakeTranslationProvider.php',
 );

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -30,6 +30,7 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\Locking\\FakeDBLockingProvider' => __DIR__ . '/..' . '/../lib/Locking/FakeDBLockingProvider.php',
         'OCA\\Testing\\Provider\\FakeText2ImageProvider' => __DIR__ . '/..' . '/../lib/Provider/FakeText2ImageProvider.php',
         'OCA\\Testing\\Provider\\FakeTextProcessingProvider' => __DIR__ . '/..' . '/../lib/Provider/FakeTextProcessingProvider.php',
+        'OCA\\Testing\\Provider\\FakeTextProcessingProviderSync' => __DIR__ . '/..' . '/../lib/Provider/FakeTextProcessingProviderSync.php',
         'OCA\\Testing\\Provider\\FakeTranslationProvider' => __DIR__ . '/..' . '/../lib/Provider/FakeTranslationProvider.php',
     );
 

--- a/apps/testing/lib/AppInfo/Application.php
+++ b/apps/testing/lib/AppInfo/Application.php
@@ -27,6 +27,7 @@ namespace OCA\Testing\AppInfo;
 use OCA\Testing\AlternativeHomeUserBackend;
 use OCA\Testing\Provider\FakeText2ImageProvider;
 use OCA\Testing\Provider\FakeTextProcessingProvider;
+use OCA\Testing\Provider\FakeTextProcessingProviderSync;
 use OCA\Testing\Provider\FakeTranslationProvider;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -41,6 +42,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		$context->registerTranslationProvider(FakeTranslationProvider::class);
 		$context->registerTextProcessingProvider(FakeTextProcessingProvider::class);
+		$context->registerTextProcessingProvider(FakeTextProcessingProviderSync::class);
 		$context->registerTextToImageProvider(FakeText2ImageProvider::class);
 	}
 

--- a/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
@@ -23,14 +23,16 @@
 namespace OCA\Testing\Provider;
 
 use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\IProvider;
+use OCP\TextProcessing\IProviderWithExpectedRuntime;
 use OCP\TextProcessing\ITaskType;
 
-/** @template-implements IProvider<FreePromptTaskType|ITaskType> */
-class FakeTextProcessingProvider implements IProvider {
+/**
+ * @template-implements IProviderWithExpectedRuntime<FreePromptTaskType|ITaskType>
+ */
+class FakeTextProcessingProviderSync implements IProviderWithExpectedRuntime {
 
 	public function getName(): string {
-		return 'Fake text processing provider (asynchronous)';
+		return 'Fake text processing provider (synchronous)';
 	}
 
 	public function process(string $prompt): string {
@@ -39,5 +41,9 @@ class FakeTextProcessingProvider implements IProvider {
 
 	public function getTaskType(): string {
 		return FreePromptTaskType::class;
+	}
+
+	public function getExpectedRuntime(): int {
+		return 1;
 	}
 }


### PR DESCRIPTION
To be able to test synchronous text processing task handling for https://github.com/nextcloud/text/pull/5269