### PR TITLE
Document throwing behavior of SetupResult upon invalid rich object

### DIFF
--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -47,6 +47,7 @@ class SetupResult implements \JsonSerializable {
 	/**
 	 * @brief Private constructor, use success()/info()/warning()/error() instead
 	 * @param self::SUCCESS|self::INFO|self::WARNING|self::ERROR $severity
+	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
 	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
@@ -66,8 +67,10 @@ class SetupResult implements \JsonSerializable {
 	 * @brief Create a success result object
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
+	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
+	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 */
 	public static function success(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
 		return new self(self::SUCCESS, $description, $descriptionParameters, $linkToDoc);
@@ -77,8 +80,10 @@ class SetupResult implements \JsonSerializable {
 	 * @brief Create an info result object
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
+	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
+	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 */
 	public static function info(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
 		return new self(self::INFO, $description, $descriptionParameters, $linkToDoc);
@@ -88,8 +93,10 @@ class SetupResult implements \JsonSerializable {
 	 * @brief Create a warning result object
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
+	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
+	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 */
 	public static function warning(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
 		return new self(self::WARNING, $description, $descriptionParameters, $linkToDoc);
@@ -99,8 +106,10 @@ class SetupResult implements \JsonSerializable {
 	 * @brief Create an error result object
 	 * @param ?string $description Translated detailed description to display to the user
 	 * @param ?string $linkToDoc URI of related relevent documentation, be it from Nextcloud or another project
+	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters
+	 * @since 28.0.2 throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 */
 	public static function error(?string $description = null, ?string $linkToDoc = null, ?array $descriptionParameters = null): self {
 		return new self(self::ERROR, $description, $descriptionParameters, $linkToDoc);


### PR DESCRIPTION
## Summary

Complete phpdoc for SetupResult which was not clear about which methods may throw if passed invalid rich objects.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
