### PR TITLE
[stable28] fix(theming): Apply same logic on capabilities for primary color as done on themes

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -94,7 +94,11 @@ class Capabilities implements IPublicCapability {
 	 */
 	public function getCapabilities() {
 		$color = $this->theming->getDefaultColorPrimary();
-		$colorText = $this->theming->getDefaultTextColorPrimary();
+		// Same as in DefaultTheme
+		if ($color === BackgroundService::DEFAULT_COLOR) {
+			$color = BackgroundService::DEFAULT_ACCESSIBLE_COLOR;
+		}
+		$colorText = $this->util->invertTextColor($color) ? '#000000' : '#ffffff';
 
 		$backgroundLogo = $this->config->getAppValue('theming', 'backgroundMime', '');
 		$backgroundPlain = $backgroundLogo === 'backgroundColor' || ($backgroundLogo === '' && $color !== '#0082c9');
@@ -108,7 +112,10 @@ class Capabilities implements IPublicCapability {
 			 * @see \OCA\Theming\Themes\CommonThemeTrait::generateUserBackgroundVariables()
 			 */
 			$color = $this->theming->getColorPrimary();
-			$colorText = $this->theming->getTextColorPrimary();
+			if ($color === BackgroundService::DEFAULT_COLOR) {
+				$color = BackgroundService::DEFAULT_ACCESSIBLE_COLOR;
+			}
+			$colorText = $this->util->invertTextColor($color) ? '#000000' : '#ffffff';
 
 			$backgroundImage = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background_image', BackgroundService::BACKGROUND_DEFAULT);
 			if ($backgroundImage === BackgroundService::BACKGROUND_CUSTOM) {

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -174,9 +174,6 @@ class CapabilitiesTest extends TestCase {
 		$this->theming->expects($this->exactly(3))
 			->method('getLogo')
 			->willReturn($logo);
-		$this->theming->expects($this->once())
-			->method('getDefaultTextColorPrimary')
-			->willReturn($textColor);
 
 		$util = new Util($this->config, $this->createMock(IAppManager::class), $this->createMock(IAppData::class), $this->createMock(ImageManager::class));
 		$this->util->expects($this->exactly(3))
@@ -186,6 +183,9 @@ class CapabilitiesTest extends TestCase {
 				return $util->elementColor($color, $brightBackground);
 			});
 
+		$this->util->expects($this->any())
+			->method('invertTextColor')
+			->willReturnCallback(fn () => $textColor === '#000000');
 		$this->util->expects($this->once())
 			->method('isBackgroundThemed')
 			->willReturn($backgroundThemed);


### PR DESCRIPTION
* Backport of https://github.com/nextcloud/server/pull/43033

## Summary
On themes we replace the default color with the accessible color, so we also need to do this on the capabilities.
This worked previously but as we now enforce contrasts of the text color clients that use the capabilities changes to black text on that color.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
