### PR TITLE
fix(session): Set last-password-confirm for token logins

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -883,6 +883,8 @@ class Session implements IUserSession, Emitter {
 		if ($dbToken->getRemember() === IToken::DO_NOT_REMEMBER) {
 			// Set the session variable so we know this is an app password
 			$this->session->set('app_password', $token);
+			// Set the last-password-confirm session to make the sudo mode work
+			$this->session->set('last-password-confirm', $this->timeFactory->getTime());
 		}
 
 		return true;


### PR DESCRIPTION
## Summary

This allows using app passwords for endpoints which require password confirmation. Unlike previous investigations suggested this fixes it regardless of the cookies.

For history: https://github.com/nextcloud/server/pull/43000

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
