### PR TITLE
fix: Allow to disable multipart copy on external s3 storage

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -56,6 +56,9 @@ class AmazonS3 extends Backend {
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
 				(new DefinitionParameter('legacy_auth', $l->t('Legacy (v2) authentication')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN),
+				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(true),
 			])
 			->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
 			->addAuthScheme(AuthMechanism::SCHEME_NULL)


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/server/pull/41914 (https://github.com/nextcloud/server/pull/41914/commits/e4054370b1e3fff36f532f5543d89d31faec1380)

As we cannot detect if multipart copy is supported there is a config flag added in the earlier pull request. However for external storages we need to expose this flag so the admin can disable it if needed.