### PR TITLE
npm audit fix - remove stable24 and stable25 as they are EOL

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ["main", "master", "stable28", "stable27", "stable26", "stable25", "stable24"]
+        branches: ["main", "master", "stable28", "stable27", "stable26"]
 
     name: npm-audit-fix-${{ matrix.branches }}
 


### PR DESCRIPTION
Synced from https://github.com/nextcloud/.github/blob/master/workflow-templates/npm-audit-fix.yml