### PR TITLE
fix(CI): Add codeowners as reviewers for improved backport experience

### DIFF
--- a/.github/workflows/update-cacert-bundle.yml
+++ b/.github/workflows/update-cacert-bundle.yml
@@ -40,3 +40,4 @@ jobs:
           labels: |
             dependencies
             3. to review
+          reviewers: ChristophWurst, miaulalala, nickvergessen

--- a/.github/workflows/update-code-signing-crl.yml
+++ b/.github/workflows/update-code-signing-crl.yml
@@ -43,3 +43,4 @@ jobs:
           labels: |
             dependencies
             3. to review
+          reviewers: mgallien, miaulalala, nickvergessen


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
