### PR TITLE
fix wrong icon color in app store

### DIFF
--- a/apps/settings/src/views/Apps.vue
+++ b/apps/settings/src/views/Apps.vue
@@ -396,6 +396,28 @@ export default {
 	right: -8px;
 }
 
+// Fix wrong color for active icons
+@media (prefers-color-scheme: dark) { body {
+	.app-navigation-entry.active .app-navigation-entry-icon {
+		filter: var(--primary-invert-if-bright);
+	}
+}}
+@media (prefers-color-scheme: light) { body {
+	.app-navigation-entry.active .app-navigation-entry-icon {
+		filter: var(--primary-invert-if-dark);
+	}
+}}
+[data-themes*=dark] {
+	.app-navigation-entry.active .app-navigation-entry-icon {
+		filter: var(--primary-invert-if-bright);
+	}
+}
+[data-themes*=light] {
+	.app-navigation-entry.active .app-navigation-entry-icon {
+		filter: var(--primary-invert-if-dark);
+	}
+}
+
 .app-sidebar-tabs__release {
 	h2 {
 		border-bottom: 1px solid var(--color-border);

--- a/apps/settings/src/views/Apps.vue
+++ b/apps/settings/src/views/Apps.vue
@@ -398,22 +398,22 @@ export default {
 
 // Fix wrong color for active icons
 @media (prefers-color-scheme: dark) { body {
-	.app-navigation-entry.active .app-navigation-entry-icon {
+	:deep(.app-navigation-entry.active .app-navigation-entry-icon) {
 		filter: var(--primary-invert-if-bright);
 	}
 }}
 @media (prefers-color-scheme: light) { body {
-	.app-navigation-entry.active .app-navigation-entry-icon {
+	:deep(.app-navigation-entry.active .app-navigation-entry-icon) {
 		filter: var(--primary-invert-if-dark);
 	}
 }}
 [data-themes*=dark] {
-	.app-navigation-entry.active .app-navigation-entry-icon {
+	:deep(.app-navigation-entry.active .app-navigation-entry-icon) {
 		filter: var(--primary-invert-if-bright);
 	}
 }
 [data-themes*=light] {
-	.app-navigation-entry.active .app-navigation-entry-icon {
+	:deep(.app-navigation-entry.active .app-navigation-entry-icon) {
 		filter: var(--primary-invert-if-dark);
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/42998

<details>
<summary>For my own testing</summary>

```
docker run -it --rm ^
--name nextcloud-easy-test1 ^
-p 8444:443 ^
-e SERVER_BRANCH=enh/42998/fix-icon-color ^
-e COMPILE_SERVER=1 ^
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" ^
ghcr.io/szaimen/nextcloud-easy-test:latest

```

</details>