### PR TITLE
disable the internal s3sdk multi part copy logic

### DIFF
--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -212,7 +212,8 @@ trait S3ObjectTrait {
 			$copy->copy();
 		} else {
 			$this->getConnection()->copy($this->getBucket(), $from, $this->getBucket(), $to, 'private', array_merge([
-				'params' => $this->getSSECParameters() + $this->getSSECParameters(true)
+				'params' => $this->getSSECParameters() + $this->getSSECParameters(true),
+				'mup_threshold' => PHP_INT_MAX,
 			], $options));
 		}
 	}


### PR DESCRIPTION
We have our own logic so just set the threshold in the library to 2^64-1