### PR TITLE
28.0.2 RC4

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [28, 0, 2, 2];
+$OC_Version = [28, 0, 2, 3];
 
 // The human-readable string
-$OC_VersionString = '28.0.2 RC3';
+$OC_VersionString = '28.0.2 RC4';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
No version detected - the output will not contain any pending PRs. Use a git tag starting with "v" like "v13.0.5".

* #43070
* #43091
* #43107
* #43119
* nextcloud/3rdparty#1685
* nextcloud/bruteforcesettings#533
* nextcloud/photos#2283
* nextcloud/updater#522
* nextcloud/updater#527
