### PR TITLE
fix(tests): Make PostgreSQL unit tests less flacky by ordering

### DIFF
--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -326,7 +326,7 @@ class QueryBuilderTest extends \Test\TestCase {
 				'appid',
 				$this->queryBuilder->expr()->literal('testFirstResult1')
 			))
-			->orderBy('appid', 'DESC');
+			->orderBy('configkey', 'ASC');
 
 		$query = $this->queryBuilder->execute();
 		$rows = $query->fetchAll();


### PR DESCRIPTION
* Fixes e.g. https://drone.nextcloud.com/nextcloud/server/48020/17/5

## Summary

Postgres uses a journal file, so if you select a list from DB without ordering it, the order does not have to be FIFO.
Since the test is not about ordering but selecting distinct, it's okay to change the order to configkey (there was only 1 appid selected anyway so sorting by that doesn't do anything).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
