### PR TITLE
fix(files): Don't attempt to format a partial cache entry

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -91,7 +91,7 @@ class CacheWrapper extends Cache {
 	 */
 	public function get($file) {
 		$result = $this->getCache()->get($file);
-		if ($result) {
+		if ($result instanceof ICacheEntry) {
 			$result = $this->formatCacheEntry($result);
 		}
 		return $result;


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/files_accesscontrol/issues/464

## Summary

``\OC\Files\Cache\Wrapper\CacheWrapper::get`` should return ``\OCP\Files\Cache\ICacheEntry`` but home cache sometimes returns partial cache entries that are plain arrays. If they are processed in ``\OC\Files\Cache\Wrapper\CacheWrapper::formatCacheEntry`` and overrides, information might be missing. This happens in ``\OCA\Files_Sharing\Cache::formatCacheEntry`` when there is no path and ``\OC\Files\Cache\Wrapper\CacheJail::getJailedPath`` returns null. Using null for the path passed to ``\OCA\Files_Sharing\SharedStorage::getPermissions`` eventually leads to https://github.com/nextcloud/files_accesscontrol/issues/464.

So the theory and the tale. This is my first time touching cache wrappers. Double and tripple check what I'm doing :pray: 

## TODO

- [x] Do

## How to test

1. Enable server side encryption
2. Enable terms of service
3. Create user1
4. Create user2
5. Create directory "S1" as user1, share with user2 r+w
6. Log in as user2
7.) Copy a file into S1 (due to https://github.com/nextcloud/server/issues/42469 you might need cadaver)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
