### PR TITLE
Improve freeprompt task type description

### DIFF
--- a/lib/public/TextProcessing/FreePromptTaskType.php
+++ b/lib/public/TextProcessing/FreePromptTaskType.php
@@ -61,6 +61,6 @@ class FreePromptTaskType implements ITaskType {
 	 * @since 27.1.0
 	 */
 	public function getDescription(): string {
-		return $this->l->t('Runs an arbitrary prompt through the language model.');
+		return $this->l->t('Send a request to the Assistant, for example: write a first draft of a presentation, give me suggestions for a presentation, write a draft reply to my colleague.');
 	}
 }


### PR DESCRIPTION
Any other idea for this description?

This could be backported to 27 and 28.

Extra question: Should we directly rename this task type here? For now, the assistant renames "Free prompt" to "Generate text" but it's a hack.