### PR TITLE
fix(CI): MySQL unit tests, use LTS for code coverage and drop EOL

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -53,9 +53,9 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0']
-        mysql-versions: ['8.0', '8.1']
+        mysql-versions: ['8.0', '8.3']
         include:
-          - mysql-versions: '8.1'
+          - mysql-versions: '8.0'
             php-versions: '8.3'
             coverage: true
 


### PR DESCRIPTION
## Summary
1. Use the LTS version of MySQL for the code coverage instead of an EOL version
2. Test LTS (8.0) and the latest version (8.3) (lower + upper bound) and drop EOL version 8.1

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
