### PR TITLE
feat(db): Make dirty query logging available in production

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -995,6 +995,15 @@ $CONFIG = [
 'loglevel_frontend' => 2,
 
 /**
+ * Loglevel used by the dirty database query detection. Useful to identify
+ * potential database bugs in production. Set this to loglevel or higher to
+ * see dirty queries in the logs.
+ *
+ * Defaults to ``0`` (debug)
+ */
+'loglevel_dirty_database_queries' => 0,
+
+/**
  * If you maintain different instances and aggregate the logs, you may want
  * to distinguish between them. ``syslog_tag`` can be set per instance
  * with a unique id. Only available if ``log_type`` is set to ``syslog`` or

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -276,7 +276,15 @@ class Connection extends PrimaryReadReplicaConnection {
 		} else {
 			// Read to a table that has been written to previously
 			// While this might not necessarily mean that we did a read after write it is an indication for a code path to check
-			$this->logger->debug('dirty table reads: ' . $sql, ['tables' => $this->tableDirtyWrites, 'reads' => $tables, 'exception' => new \Exception()]);
+			$this->logger->log(
+				(int) ($this->systemConfig->getValue('loglevel_dirty_database_queries', null) ?? 0),
+				'dirty table reads: ' . $sql,
+				[
+					'tables' => $this->tableDirtyWrites,
+					'reads' => $tables,
+					'exception' => new \Exception(),
+				],
+			);
 		}
 
 		$sql = $this->replaceTablePrefix($sql);


### PR DESCRIPTION
* Resolves: none

## Summary

Makes https://github.com/nextcloud/server/pull/42345 usable in production environments.

:warning: depending on the number of dirty queries detected, this may log very often :warning: 

## How to test

1) Set loglevel to 3
2) Set loglevel_dirty_database_queries to 3
3) Log into Nextcloud with user_status enabled
4) Look into nextcloud.log

master: nothing related to dirty queries
here: https://github.com/nextcloud/server/issues/43109 logged with level 3

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
