### PR TITLE
Fix data type in FilesMetadata::setIntList()

### DIFF
--- a/lib/private/FilesMetadata/Model/FilesMetadata.php
+++ b/lib/private/FilesMetadata/Model/FilesMetadata.php
@@ -480,7 +480,7 @@ class FilesMetadata implements IFilesMetadata {
 			// if value does not exist, or type has changed, we keep on the writing
 		}
 
-		$valueWrapper = new MetadataValueWrapper(IMetadataValueWrapper::TYPE_STRING_LIST);
+		$valueWrapper = new MetadataValueWrapper(IMetadataValueWrapper::TYPE_INT_LIST);
 		$this->metadata[$key] = $valueWrapper->setValueIntList($value)->setIndexed($index);
 		$this->updated = true;
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

FilesMetadata::setIntList() throws an exception because it uses the incorrect type IMetadataValueWrapper::TYPE_STRING_LIST instead of IMetadataValueWrapper::TYPE_INT_LIST.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
