### PR TITLE
Disable code coverage upload on pull request

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - php-versions: '8.3'
             mariadb-versions: '10.6'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -55,7 +55,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: Memcached (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -57,7 +57,7 @@ jobs:
         include:
           - mysql-versions: '8.1'
             php-versions: '8.3'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MySQL ${{ matrix.mysql-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -56,7 +56,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: No DB unit tests (PHP ${{ matrix.php-versions }})
 

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -50,7 +50,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: Oracle ${{ matrix.oracle-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - php-versions: '8.3'
             postgres-versions: '15'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: PostgreSQL ${{ matrix.postgres-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: PHPUnit database tests
         run: composer run test:db ${{ matrix.coverage && ' -- --coverage-clover ./clover.db.xml' || '' }}
-  
+
       - name: Upload db code coverage
         if: ${{ !cancelled() && matrix.coverage }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -55,7 +55,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         include:
           - php-versions: '8.1'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
     name: SQLite (PHP ${{ matrix.php-versions }})
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ comment: false
 coverage:
   status:
     project: off
+    patch: off


### PR DESCRIPTION
## Summary

Only run code coverage on master, as before migration from drone to github actions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
