### PR TITLE
fix: added german translation to the word 'home'

### DIFF
--- a/apps/files/l10n/de.js
+++ b/apps/files/l10n/de.js
@@ -8,7 +8,7 @@ OC.L10N.register(
     "Tags" : "Schlagworte",
     "Show list view" : "Listenansicht anzeigen",
     "Show grid view" : "Rasteransicht anzeigen",
-    "Home" : "Home",
+    "Home" : "Startverzeichnis",
     "Close" : "Schließen",
     "Could not create folder \"{dir}\"" : "Der Ordner konnte nicht erstellt werden \"{dir}\"",
     "This will stop your current uploads." : "Hiermit werden die aktuellen Uploads angehalten.",

--- a/apps/files/l10n/de.json
+++ b/apps/files/l10n/de.json
@@ -6,7 +6,7 @@
     "Tags" : "Schlagworte",
     "Show list view" : "Listenansicht anzeigen",
     "Show grid view" : "Rasteransicht anzeigen",
-    "Home" : "Home",
+    "Home" : "Startverzeichnis",
     "Close" : "Schließen",
     "Could not create folder \"{dir}\"" : "Der Ordner konnte nicht erstellt werden \"{dir}\"",
     "This will stop your current uploads." : "Hiermit werden die aktuellen Uploads angehalten.",

--- a/apps/files/l10n/de_DE.js
+++ b/apps/files/l10n/de_DE.js
@@ -8,7 +8,7 @@ OC.L10N.register(
     "Tags" : "Schlagworte",
     "Show list view" : "Listenansicht anzeigen",
     "Show grid view" : "Rasteransicht anzeigen",
-    "Home" : "Home",
+    "Home" : "Startverzeichnis",
     "Close" : "Schließen",
     "Could not create folder \"{dir}\"" : "Der Ordner konnte nicht erstellt werden \"{dir}\"",
     "This will stop your current uploads." : "Hiermit werden die aktuellen Uploads angehalten.",

--- a/apps/files/l10n/de_DE.json
+++ b/apps/files/l10n/de_DE.json
@@ -6,7 +6,7 @@
     "Tags" : "Schlagworte",
     "Show list view" : "Listenansicht anzeigen",
     "Show grid view" : "Rasteransicht anzeigen",
-    "Home" : "Home",
+    "Home" : "Startverzeichnis",
     "Close" : "Schließen",
     "Could not create folder \"{dir}\"" : "Der Ordner konnte nicht erstellt werden \"{dir}\"",
     "This will stop your current uploads." : "Hiermit werden die aktuellen Uploads angehalten.",


### PR DESCRIPTION
* Resolves: #41895

## Summary
The german translation for 'Home' in our transfix seems to just be 'Home'. For the moment, that's okay, as it seems as everywhere else is translated / this is fine, but just for safebet, I added those translations in 👍 If this is not how the translations are added, let me know and I can either close this PR and do it the proper way, or this is the proper way and I just forget one step 😊

## TODO

- [x] Add german translations to the word 'Home'

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
