### PR TITLE
chore: Fix missing template parameter for IEventListener

### DIFF
--- a/apps/admin_audit/lib/Listener/CriticalActionPerformedEventListener.php
+++ b/apps/admin_audit/lib/Listener/CriticalActionPerformedEventListener.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Log\Audit\CriticalActionPerformedEvent;
 
+/** @template-implements IEventListener<CriticalActionPerformedEvent> */
 class CriticalActionPerformedEventListener extends Action implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof CriticalActionPerformedEvent)) {

--- a/apps/comments/lib/Listener/CommentsEntityEventListener.php
+++ b/apps/comments/lib/Listener/CommentsEntityEventListener.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\IRootFolder;
 
+/** @template-implements IEventListener<CommentsEntityEvent> */
 class CommentsEntityEventListener implements IEventListener {
 	public function __construct(
 		private IRootFolder $rootFolder,

--- a/apps/comments/lib/Listener/LoadAdditionalScripts.php
+++ b/apps/comments/lib/Listener/LoadAdditionalScripts.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScripts implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {

--- a/apps/comments/lib/Listener/LoadSidebarScripts.php
+++ b/apps/comments/lib/Listener/LoadSidebarScripts.php
@@ -35,6 +35,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadSidebar> */
 class LoadSidebarScripts implements IEventListener {
 	public function __construct(
 		private ICommentsManager $commentsManager,

--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -40,6 +40,7 @@ use Psr\Log\LoggerInterface;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\UUIDUtil;
 
+/** @template-implements IEventListener<ContactInteractedWithEvent> */
 class ContactInteractionListener implements IEventListener {
 
 	use TTransactional;
@@ -74,7 +75,7 @@ class ContactInteractionListener implements IEventListener {
 			$uid = $event->getUid();
 			$email = $event->getEmail();
 			$federatedCloudId = $event->getFederatedCloudId();
-		
+
 			$existingContact = $this->cardSearchDao->findExisting(
 				$event->getActor(),
 				$uid,

--- a/apps/dav/lib/Listener/ActivityUpdaterListener.php
+++ b/apps/dav/lib/Listener/ActivityUpdaterListener.php
@@ -44,6 +44,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use function sprintf;
 
+/** @template-implements IEventListener<CalendarCreatedEvent|CalendarUpdatedEvent|CalendarMovedToTrashEvent|CalendarRestoredEvent|CalendarDeletedEvent|CalendarObjectCreatedEvent|CalendarObjectUpdatedEvent|CalendarObjectMovedEvent|CalendarObjectMovedToTrashEvent|CalendarObjectRestoredEvent|CalendarObjectDeletedEvent> */
 class ActivityUpdaterListener implements IEventListener {
 
 	/** @var ActivityBackend */

--- a/apps/dav/lib/Listener/AddressbookListener.php
+++ b/apps/dav/lib/Listener/AddressbookListener.php
@@ -36,6 +36,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use function sprintf;
 
+/** @template-implements IEventListener<AddressBookCreatedEvent|AddressBookUpdatedEvent|AddressBookDeletedEvent|AddressBookShareUpdatedEvent> */
 class AddressbookListener implements IEventListener {
 	/** @var ActivityBackend */
 	private $activityBackend;

--- a/apps/dav/lib/Listener/BirthdayListener.php
+++ b/apps/dav/lib/Listener/BirthdayListener.php
@@ -32,6 +32,7 @@ use OCA\DAV\Events\CardUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<CardCreatedEvent|CardUpdatedEvent|CardDeletedEvent> */
 class BirthdayListener implements IEventListener {
 	private BirthdayService $birthdayService;
 

--- a/apps/dav/lib/Listener/CalendarContactInteractionListener.php
+++ b/apps/dav/lib/Listener/CalendarContactInteractionListener.php
@@ -45,6 +45,7 @@ use Throwable;
 use function strlen;
 use function substr;
 
+/** @template-implements IEventListener<CalendarObjectCreatedEvent|CalendarObjectUpdatedEvent|CalendarShareUpdatedEvent> */
 class CalendarContactInteractionListener implements IEventListener {
 	private const URI_USERS = 'principals/users/';
 

--- a/apps/dav/lib/Listener/CalendarDeletionDefaultUpdaterListener.php
+++ b/apps/dav/lib/Listener/CalendarDeletionDefaultUpdaterListener.php
@@ -33,7 +33,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 /**
- * @template-implements IEventListener<\OCA\DAV\Events\CalendarDeletedEvent>
+ * @template-implements IEventListener<CalendarDeletedEvent>
  */
 class CalendarDeletionDefaultUpdaterListener implements IEventListener {
 

--- a/apps/dav/lib/Listener/CalendarObjectReminderUpdaterListener.php
+++ b/apps/dav/lib/Listener/CalendarObjectReminderUpdaterListener.php
@@ -42,6 +42,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use function sprintf;
 
+/** @template-implements IEventListener<CalendarMovedToTrashEvent|CalendarDeletedEvent|CalendarRestoredEvent|CalendarObjectCreatedEvent|CalendarObjectUpdatedEvent|CalendarObjectMovedToTrashEvent|CalendarObjectRestoredEvent|CalendarObjectDeletedEvent> */
 class CalendarObjectReminderUpdaterListener implements IEventListener {
 
 	/** @var ReminderBackend */

--- a/apps/dav/lib/Listener/CalendarPublicationListener.php
+++ b/apps/dav/lib/Listener/CalendarPublicationListener.php
@@ -32,6 +32,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/** @template-implements IEventListener<CalendarPublishedEvent|CalendarUnpublishedEvent> */
 class CalendarPublicationListener implements IEventListener {
 	private Backend $activityBackend;
 	private LoggerInterface $logger;

--- a/apps/dav/lib/Listener/CalendarShareUpdateListener.php
+++ b/apps/dav/lib/Listener/CalendarShareUpdateListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/** @template-implements IEventListener<CalendarShareUpdatedEvent> */
 class CalendarShareUpdateListener implements IEventListener {
 	private Backend $activityBackend;
 	private LoggerInterface $logger;

--- a/apps/dav/lib/Listener/CardListener.php
+++ b/apps/dav/lib/Listener/CardListener.php
@@ -36,6 +36,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use function sprintf;
 
+/** @template-implements IEventListener<CardCreatedEvent|CardUpdatedEvent|CardDeletedEvent> */
 class CardListener implements IEventListener {
 	/** @var ActivityBackend */
 	private $activityBackend;

--- a/apps/dav/lib/Listener/ClearPhotoCacheListener.php
+++ b/apps/dav/lib/Listener/ClearPhotoCacheListener.php
@@ -31,6 +31,7 @@ use OCA\DAV\Events\CardUpdatedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<CardUpdatedEvent|CardDeletedEvent> */
 class ClearPhotoCacheListener implements IEventListener {
 	private PhotoCache $photoCache;
 

--- a/apps/dav/lib/Listener/SubscriptionListener.php
+++ b/apps/dav/lib/Listener/SubscriptionListener.php
@@ -35,6 +35,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/** @template-implements IEventListener<SubscriptionCreatedEvent|SubscriptionDeletedEvent> */
 class SubscriptionListener implements IEventListener {
 	private IJobList $jobList;
 	private RefreshWebcalService $refreshWebcalService;

--- a/apps/dav/lib/Listener/TrustedServerRemovedListener.php
+++ b/apps/dav/lib/Listener/TrustedServerRemovedListener.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 
+/** @template-implements IEventListener<TrustedServerRemovedEvent> */
 class TrustedServerRemovedListener implements IEventListener {
 	private CardDavBackend $cardDavBackend;
 

--- a/apps/dav/lib/Listener/UserPreferenceListener.php
+++ b/apps/dav/lib/Listener/UserPreferenceListener.php
@@ -31,6 +31,7 @@ use OCP\Config\BeforePreferenceSetEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<BeforePreferenceSetEvent|BeforePreferenceDeletedEvent> */
 class UserPreferenceListener implements IEventListener {
 
 	protected IJobList $jobList;

--- a/apps/federatedfilesharing/lib/Listeners/LoadAdditionalScriptsListener.php
+++ b/apps/federatedfilesharing/lib/Listeners/LoadAdditionalScriptsListener.php
@@ -30,6 +30,7 @@ use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScriptsListener implements IEventListener {
 	/** @var FederatedShareProvider */
 	protected $federatedShareProvider;

--- a/apps/federation/lib/Listener/SabrePluginAuthInitListener.php
+++ b/apps/federation/lib/Listener/SabrePluginAuthInitListener.php
@@ -33,6 +33,7 @@ use Sabre\DAV\Auth\Plugin;
 
 /**
  * @since 20.0.0
+ * @template-implements IEventListener<SabrePluginAuthInitEvent>
  */
 class SabrePluginAuthInitListener implements IEventListener {
 	private FedAuth $fedAuth;

--- a/apps/files/lib/Listener/LoadSidebarListener.php
+++ b/apps/files/lib/Listener/LoadSidebarListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadSidebar> */
 class LoadSidebarListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadSidebar)) {

--- a/apps/files/lib/Listener/RenderReferenceEventListener.php
+++ b/apps/files/lib/Listener/RenderReferenceEventListener.php
@@ -28,6 +28,7 @@ use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<RenderReferenceEvent> */
 class RenderReferenceEventListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!$event instanceof RenderReferenceEvent) {

--- a/apps/files_external/lib/Listener/GroupDeletedListener.php
+++ b/apps/files_external/lib/Listener/GroupDeletedListener.php
@@ -28,6 +28,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Events\GroupDeletedEvent;
 
+/** @template-implements IEventListener<GroupDeletedEvent> */
 class GroupDeletedListener implements IEventListener {
 	/** @var DBConfigService */
 	private $config;

--- a/apps/files_external/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_external/lib/Listener/LoadAdditionalListener.php
@@ -34,7 +34,7 @@ use OCP\IConfig;
 use OCP\Util;
 
 /**
- * @template-implements IEventListener<Event|LoadAdditionalScriptsEvent>
+ * @template-implements IEventListener<LoadAdditionalScriptsEvent>
  */
 class LoadAdditionalListener implements IEventListener {
 

--- a/apps/files_external/lib/Listener/StorePasswordListener.php
+++ b/apps/files_external/lib/Listener/StorePasswordListener.php
@@ -33,6 +33,7 @@ use OCP\Security\ICredentialsManager;
 use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserLoggedInEvent;
 
+/** @template-implements IEventListener<PasswordUpdatedEvent|UserLoggedInEvent> */
 class StorePasswordListener implements IEventListener {
 	/** @var ICredentialsManager */
 	private $credentialsManager;

--- a/apps/files_external/lib/Listener/UserDeletedListener.php
+++ b/apps/files_external/lib/Listener/UserDeletedListener.php
@@ -28,6 +28,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<UserDeletedEvent> */
 class UserDeletedListener implements IEventListener {
 	/** @var DBConfigService */
 	private $config;

--- a/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScriptsListener implements IEventListener {
 	public function __construct(
 		private IAppManager $appManager,

--- a/apps/files_reminders/lib/Listener/NodeDeletedListener.php
+++ b/apps/files_reminders/lib/Listener/NodeDeletedListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 
+/** @template-implements IEventListener<NodeDeletedEvent> */
 class NodeDeletedListener implements IEventListener {
 	public function __construct(
 		private ReminderService $reminderService,

--- a/apps/files_reminders/lib/Listener/UserDeletedListener.php
+++ b/apps/files_reminders/lib/Listener/UserDeletedListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<UserDeletedEvent> */
 class UserDeletedListener implements IEventListener {
 	public function __construct(
 		private ReminderService $reminderService,

--- a/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
@@ -32,6 +32,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Share\IManager;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {

--- a/apps/files_sharing/lib/Listener/LoadSidebarListener.php
+++ b/apps/files_sharing/lib/Listener/LoadSidebarListener.php
@@ -35,7 +35,7 @@ use OCP\Share\IManager;
 use OCP\Util;
 
 /**
- * @template-implements IEventListener<Event>
+ * @template-implements IEventListener<LoadSidebar>
  */
 class LoadSidebarListener implements IEventListener {
 

--- a/apps/files_sharing/lib/Listener/ShareInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/ShareInteractionListener.php
@@ -36,7 +36,7 @@ use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use function in_array;
 
-/** @template-implements IEventListener<ContactInteractedWithEvent> */
+/** @template-implements IEventListener<ShareCreatedEvent> */
 class ShareInteractionListener implements IEventListener {
 	private const SUPPORTED_SHARE_TYPES = [
 		IShare::TYPE_USER,

--- a/apps/files_sharing/lib/Listener/ShareInteractionListener.php
+++ b/apps/files_sharing/lib/Listener/ShareInteractionListener.php
@@ -36,6 +36,7 @@ use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use function in_array;
 
+/** @template-implements IEventListener<ContactInteractedWithEvent> */
 class ShareInteractionListener implements IEventListener {
 	private const SUPPORTED_SHARE_TYPES = [
 		IShare::TYPE_USER,

--- a/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
+++ b/apps/files_sharing/lib/Listener/UserAddedToGroupListener.php
@@ -33,6 +33,7 @@ use OCP\IConfig;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
+/** @template-implements IEventListener<UserAddedEvent> */
 class UserAddedToGroupListener implements IEventListener {
 
 	/** @var IManager */

--- a/apps/files_sharing/lib/Listener/UserShareAcceptanceListener.php
+++ b/apps/files_sharing/lib/Listener/UserShareAcceptanceListener.php
@@ -36,6 +36,7 @@ use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
+/** @template-implements IEventListener<ShareCreatedEvent> */
 class UserShareAcceptanceListener implements IEventListener {
 
 	/** @var IConfig */

--- a/apps/files_trashbin/lib/Listeners/LoadAdditionalScripts.php
+++ b/apps/files_trashbin/lib/Listeners/LoadAdditionalScripts.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScripts implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {

--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -62,6 +62,7 @@ use OCP\Files\Node;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
+/** @template-implements IEventListener<BeforeNodeCopiedEvent|BeforeNodeDeletedEvent|BeforeNodeRenamedEvent|BeforeNodeTouchedEvent|BeforeNodeWrittenEvent|NodeCopiedEvent|NodeCreatedEvent|NodeDeletedEvent|NodeRenamedEvent|NodeTouchedEvent|NodeWrittenEvent> */
 class FileEventsListener implements IEventListener {
 	/**
 	 * @var array<int, array>

--- a/apps/files_versions/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_versions/lib/Listener/LoadAdditionalListener.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {

--- a/apps/files_versions/lib/Listener/LoadSidebarListener.php
+++ b/apps/files_versions/lib/Listener/LoadSidebarListener.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
 
+/** @template-implements IEventListener<LoadSidebar> */
 class LoadSidebarListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadSidebar)) {

--- a/apps/provisioning_api/lib/Listener/UserDeletedListener.php
+++ b/apps/provisioning_api/lib/Listener/UserDeletedListener.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<UserDeletedEvent> */
 class UserDeletedListener implements IEventListener {
 
 	/** @var KnownUserService */

--- a/apps/settings/lib/Listener/GroupRemovedListener.php
+++ b/apps/settings/lib/Listener/GroupRemovedListener.php
@@ -28,6 +28,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Group\Events\GroupDeletedEvent;
 
+/** @template-implements IEventListener<GroupDeletedEvent> */
 class GroupRemovedListener implements IEventListener {
 
 	/** @var AuthorizedGroupService $authorizedGroupService */

--- a/apps/settings/lib/Listener/UserAddedToGroupActivityListener.php
+++ b/apps/settings/lib/Listener/UserAddedToGroupActivityListener.php
@@ -34,6 +34,7 @@ use OCP\Group\Events\UserAddedEvent;
 use OCP\IUser;
 use OCP\IUserSession;
 
+/** @template-implements IEventListener<UserAddedEvent> */
 class UserAddedToGroupActivityListener implements IEventListener {
 
 	/** @var Manager */

--- a/apps/settings/lib/Listener/UserRemovedFromGroupActivityListener.php
+++ b/apps/settings/lib/Listener/UserRemovedFromGroupActivityListener.php
@@ -34,6 +34,7 @@ use OCP\Group\Events\UserRemovedEvent;
 use OCP\IUser;
 use OCP\IUserSession;
 
+/** @template-implements IEventListener<UserRemovedEvent> */
 class UserRemovedFromGroupActivityListener implements IEventListener {
 
 	/** @var Manager */

--- a/apps/theming/lib/Listener/BeforePreferenceListener.php
+++ b/apps/theming/lib/Listener/BeforePreferenceListener.php
@@ -32,6 +32,7 @@ use OCP\Config\BeforePreferenceSetEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<BeforePreferenceDeletedEvent|BeforePreferenceSetEvent> */
 class BeforePreferenceListener implements IEventListener {
 	public function __construct(
 		private IAppManager $appManager,

--- a/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
@@ -29,6 +29,7 @@ use OCA\Theming\AppInfo\Application;
 use OCA\Theming\Service\BackgroundService;
 use OCA\Theming\Service\JSDataService;
 use OCA\Theming\Service\ThemeInjectionService;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -38,7 +39,7 @@ use OCP\IConfig;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 
-/** @template-implements IEventListener<BeforeTemplateRenderedEvent> */
+/** @template-implements IEventListener<BeforeTemplateRenderedEvent|BeforeLoginTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
 
 	private IInitialState $initialState;
@@ -67,7 +68,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			fn () => $this->container->get(JSDataService::class),
 		);
 
-		/** @var BeforeTemplateRenderedEvent $event */
+		/** @var BeforeTemplateRenderedEvent|BeforeLoginTemplateRenderedEvent $event */
 		if ($event->getResponse()->getRenderAs() === TemplateResponse::RENDER_AS_USER) {
 			$this->initialState->provideLazyInitialState('shortcutsDisabled', function () {
 				if ($this->userSession->getUser()) {

--- a/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
@@ -38,6 +38,7 @@ use OCP\IConfig;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 
+/** @template-implements IEventListener<BeforeTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
 
 	private IInitialState $initialState;

--- a/apps/twofactor_backupcodes/lib/AppInfo/Application.php
+++ b/apps/twofactor_backupcodes/lib/AppInfo/Application.php
@@ -40,7 +40,8 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserRegistered;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserUnregistered;
 use OCP\User\Events\UserDeletedEvent;
 
 class Application extends App implements IBootstrap {
@@ -56,8 +57,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CodesGenerated::class, ActivityPublisher::class);
 		$context->registerEventListener(CodesGenerated::class, RegistryUpdater::class);
 		$context->registerEventListener(CodesGenerated::class, ClearNotifications::class);
-		$context->registerEventListener(IRegistry::EVENT_PROVIDER_ENABLED, ProviderEnabled::class);
-		$context->registerEventListener(IRegistry::EVENT_PROVIDER_DISABLED, ProviderDisabled::class);
+		$context->registerEventListener(TwoFactorProviderForUserRegistered::class, ProviderEnabled::class);
+		$context->registerEventListener(TwoFactorProviderForUserUnregistered::class, ProviderDisabled::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeleted::class);
 
 

--- a/apps/twofactor_backupcodes/lib/Listener/ActivityPublisher.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ActivityPublisher.php
@@ -32,6 +32,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
+/** @template-implements IEventListener<CodesGenerated> */
 class ActivityPublisher implements IEventListener {
 	public function __construct(
 		private IManager $activityManager,

--- a/apps/twofactor_backupcodes/lib/Listener/ClearNotifications.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ClearNotifications.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Notification\IManager;
 
+/** @template-implements IEventListener<CodesGenerated> */
 class ClearNotifications implements IEventListener {
 
 	/** @var IManager */

--- a/apps/twofactor_backupcodes/lib/Listener/ProviderDisabled.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ProviderDisabled.php
@@ -28,12 +28,12 @@ namespace OCA\TwoFactorBackupCodes\Listener;
 
 use OCA\TwoFactorBackupCodes\BackgroundJob\RememberBackupCodesJob;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserUnregistered;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
-/** @template-implements IEventListener<RegistryEvent> */
+/** @template-implements IEventListener<TwoFactorProviderForUserUnregistered> */
 class ProviderDisabled implements IEventListener {
 
 	/** @var IRegistry */
@@ -49,7 +49,7 @@ class ProviderDisabled implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof RegistryEvent)) {
+		if (!($event instanceof TwoFactorProviderForUserUnregistered)) {
 			return;
 		}
 

--- a/apps/twofactor_backupcodes/lib/Listener/ProviderDisabled.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ProviderDisabled.php
@@ -33,6 +33,7 @@ use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<RegistryEvent> */
 class ProviderDisabled implements IEventListener {
 
 	/** @var IRegistry */

--- a/apps/twofactor_backupcodes/lib/Listener/ProviderEnabled.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ProviderEnabled.php
@@ -28,12 +28,12 @@ namespace OCA\TwoFactorBackupCodes\Listener;
 
 use OCA\TwoFactorBackupCodes\BackgroundJob\RememberBackupCodesJob;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserRegistered;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
-/** @template-implements IEventListener<RegistryEvent> */
+/** @template-implements IEventListener<TwoFactorProviderForUserRegistered> */
 class ProviderEnabled implements IEventListener {
 
 	/** @var IRegistry */
@@ -49,7 +49,7 @@ class ProviderEnabled implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof RegistryEvent)) {
+		if (!($event instanceof TwoFactorProviderForUserRegistered)) {
 			return;
 		}
 

--- a/apps/twofactor_backupcodes/lib/Listener/ProviderEnabled.php
+++ b/apps/twofactor_backupcodes/lib/Listener/ProviderEnabled.php
@@ -33,6 +33,7 @@ use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<RegistryEvent> */
 class ProviderEnabled implements IEventListener {
 
 	/** @var IRegistry */

--- a/apps/twofactor_backupcodes/lib/Listener/RegistryUpdater.php
+++ b/apps/twofactor_backupcodes/lib/Listener/RegistryUpdater.php
@@ -31,6 +31,7 @@ use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/** @template-implements IEventListener<CodesGenerated> */
 class RegistryUpdater implements IEventListener {
 
 	/** @var IRegistry */

--- a/apps/twofactor_backupcodes/lib/Listener/UserDeleted.php
+++ b/apps/twofactor_backupcodes/lib/Listener/UserDeleted.php
@@ -30,6 +30,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<UserDeletedEvent> */
 class UserDeleted implements IEventListener {
 
 	/** @var BackupCodeMapper */

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderDisabledTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderDisabledTest.php
@@ -29,22 +29,16 @@ namespace OCA\TwoFactorBackupCodes\Tests\Unit\Listener;
 use OCA\TwoFactorBackupCodes\BackgroundJob\RememberBackupCodesJob;
 use OCA\TwoFactorBackupCodes\Listener\ProviderDisabled;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserUnregistered;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use Test\TestCase;
 
 class ProviderDisabledTest extends TestCase {
-
-	/** @var IRegistry|\PHPUnit\Framework\MockObject\MockObject */
-	private $registy;
-
-	/** @var IJobList|\PHPUnit\Framework\MockObject\MockObject */
-	private $jobList;
-
-	/** @var ProviderDisabled */
-	private $listener;
+	private IRegistry $registy;
+	private IJobList $jobList;
+	private ProviderDisabled $listener;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -67,7 +61,7 @@ class ProviderDisabledTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('myUID');
-		$event = $this->createMock(RegistryEvent::class);
+		$event = $this->createMock(TwoFactorProviderForUserUnregistered::class);
 		$event->method('getUser')
 			->willReturn($user);
 
@@ -88,7 +82,7 @@ class ProviderDisabledTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('myUID');
-		$event = $this->createMock(RegistryEvent::class);
+		$event = $this->createMock(TwoFactorProviderForUserUnregistered::class);
 		$event->method('getUser')
 			->willReturn($user);
 

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderEnabledTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ProviderEnabledTest.php
@@ -29,22 +29,16 @@ namespace OCA\TwoFactorBackupCodes\Tests\Unit\Listener;
 use OCA\TwoFactorBackupCodes\BackgroundJob\RememberBackupCodesJob;
 use OCA\TwoFactorBackupCodes\Listener\ProviderEnabled;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\Authentication\TwoFactorAuth\RegistryEvent;
+use OCP\Authentication\TwoFactorAuth\TwoFactorProviderForUserRegistered;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use Test\TestCase;
 
 class ProviderEnabledTest extends TestCase {
-
-	/** @var IRegistry|\PHPUnit\Framework\MockObject\MockObject */
-	private $registy;
-
-	/** @var IJobList|\PHPUnit\Framework\MockObject\MockObject */
-	private $jobList;
-
-	/** @var ProviderEnabled */
-	private $listener;
+	private IRegistry $registy;
+	private IJobList $jobList;
+	private ProviderEnabled $listener;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -67,7 +61,7 @@ class ProviderEnabledTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('myUID');
-		$event = $this->createMock(RegistryEvent::class);
+		$event = $this->createMock(TwoFactorProviderForUserRegistered::class);
 		$event->method('getUser')
 			->willReturn($user);
 
@@ -87,7 +81,7 @@ class ProviderEnabledTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('myUID');
-		$event = $this->createMock(RegistryEvent::class);
+		$event = $this->createMock(TwoFactorProviderForUserRegistered::class);
 		$event->method('getUser')
 			->willReturn($user);
 

--- a/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
@@ -37,6 +37,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IInitialStateService;
 use OCP\IUserSession;
 
+/** @template-implements IEventListener<BeforeTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
 
 	/** @var ProfileManager */

--- a/apps/user_status/lib/Listener/UserDeletedListener.php
+++ b/apps/user_status/lib/Listener/UserDeletedListener.php
@@ -34,6 +34,7 @@ use OCP\User\Events\UserDeletedEvent;
  * Class UserDeletedListener
  *
  * @package OCA\UserStatus\Listener
+ * @template-implements IEventListener<UserDeletedEvent>
  */
 class UserDeletedListener implements IEventListener {
 

--- a/apps/user_status/lib/Listener/UserLiveStatusListener.php
+++ b/apps/user_status/lib/Listener/UserLiveStatusListener.php
@@ -43,6 +43,7 @@ use Psr\Log\LoggerInterface;
  * Class UserDeletedListener
  *
  * @package OCA\UserStatus\Listener
+ * @template-implements IEventListener<UserLiveStatusEvent>
  */
 class UserLiveStatusListener implements IEventListener {
 	private UserStatusMapper $mapper;

--- a/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
+++ b/apps/workflowengine/lib/Listener/LoadAdditionalSettingsScriptsListener.php
@@ -31,9 +31,11 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Template;
 use OCP\Util;
+use OCP\WorkflowEngine\Events\LoadSettingsScriptsEvent;
 use function class_exists;
 use function function_exists;
 
+/** @template-implements IEventListener<LoadSettingsScriptsEvent> */
 class LoadAdditionalSettingsScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
 		if (!function_exists('style')) {

--- a/core/Listener/BeforeTemplateRenderedListener.php
+++ b/core/Listener/BeforeTemplateRenderedListener.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\Util;
 
+/** @template-implements IEventListener<BeforeLoginTemplateRenderedEvent|BeforeTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
 	public function __construct(private IConfig $config) {
 	}

--- a/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php
@@ -34,6 +34,7 @@ use OCP\Files\Storage\IStorage;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<BeforeUserDeletedEvent|UserDeletedEvent> */
 class UserDeletedFilesCleanupListener implements IEventListener {
 	/** @var array<string,IStorage> */
 	private $homeStorageCache = [];

--- a/lib/private/Authentication/Listeners/UserDeletedWebAuthnCleanupListener.php
+++ b/lib/private/Authentication/Listeners/UserDeletedWebAuthnCleanupListener.php
@@ -31,6 +31,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
 
+/** @template-implements IEventListener<UserDeletedEvent> */
 class UserDeletedWebAuthnCleanupListener implements IEventListener {
 	/** @var PublicKeyCredentialMapper */
 	private $credentialMapper;

--- a/lib/private/Group/DisplayNameCache.php
+++ b/lib/private/Group/DisplayNameCache.php
@@ -38,6 +38,7 @@ use OCP\IGroupManager;
  * Class that cache the relation Group ID -> Display name
  *
  * This saves fetching the group from the backend for "just" the display name
+ * @template-implements IEventListener<GroupChangedEvent|GroupDeletedEvent>
  */
 class DisplayNameCache implements IEventListener {
 	private CappedMemoryCache $cache;

--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -37,6 +37,7 @@ use OCP\User\Events\UserDeletedEvent;
  * This saves fetching the user from a user backend and later on fetching
  * their preferences. It's generally not an issue if this data is slightly
  * outdated.
+ * @template-implements IEventListener<UserChangedEvent|UserDeletedEvent>
  */
 class DisplayNameCache implements IEventListener {
 	private array $cache = [];


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Hopefully fixes all `MissingTemplateParam` psalm errors from baseline.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
