### PR TITLE
Use Dependency Injection in register_commands.php

### DIFF
--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -26,16 +26,20 @@ use OC\Core\Command\Base;
 use OCP\ICertificate;
 use OCP\ICertificateManager;
 use OCP\IL10N;
+use OCP\L10N\IFactory as IL10NFactory;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCertificates extends Base {
+	protected IL10N $l;
+
 	public function __construct(
 		protected ICertificateManager $certificateManager,
-		protected IL10N $l,
+		IL10NFactory $l10nFactory,
 	) {
 		parent::__construct();
+		$this->l = $l10nFactory->get('core');
 	}
 
 	protected function configure() {

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -49,175 +49,142 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
+use OC\Core\Command;
+use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 $application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
-$application->add(new OC\Core\Command\Status(\OC::$server->get(\OCP\IConfig::class), \OC::$server->get(\OCP\Defaults::class)));
-$application->add(new OC\Core\Command\Check(\OC::$server->getSystemConfig()));
-$application->add(new OC\Core\Command\L10n\CreateJs());
-$application->add(new \OC\Core\Command\Integrity\SignApp(
-	\OC::$server->getIntegrityCodeChecker(),
-	new \OC\IntegrityCheck\Helpers\FileAccessHelper(),
-	\OC::$server->getURLGenerator()
-));
-$application->add(new \OC\Core\Command\Integrity\SignCore(
-	\OC::$server->getIntegrityCodeChecker(),
-	new \OC\IntegrityCheck\Helpers\FileAccessHelper()
-));
-$application->add(new \OC\Core\Command\Integrity\CheckApp(
-	\OC::$server->getIntegrityCodeChecker()
-));
-$application->add(new \OC\Core\Command\Integrity\CheckCore(
-	\OC::$server->getIntegrityCodeChecker()
-));
+$application->add(Server::get(Command\Status::class));
+$application->add(Server::get(Command\Check::class));
+$application->add(Server::get(Command\L10n\CreateJs::class));
+$application->add(Server::get(Command\Integrity\SignApp::class));
+$application->add(Server::get(Command\Integrity\SignCore::class));
+$application->add(Server::get(Command\Integrity\CheckApp::class));
+$application->add(Server::get(Command\Integrity\CheckCore::class));
 
+$config = Server::get(IConfig::class);
 
-if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
-	$application->add(new OC\Core\Command\App\Disable(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\App\Install());
-	$application->add(new OC\Core\Command\App\GetPath());
-	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\App\Remove(\OC::$server->getAppManager(), \OC::$server->query(\OC\Installer::class), \OC::$server->get(LoggerInterface::class)));
-	$application->add(\OC::$server->query(\OC\Core\Command\App\Update::class));
+if ($config->getSystemValueBool('installed', false)) {
+	$application->add(Server::get(Command\App\Disable::class));
+	$application->add(Server::get(Command\App\Enable::class));
+	$application->add(Server::get(Command\App\Install::class));
+	$application->add(Server::get(Command\App\GetPath::class));
+	$application->add(Server::get(Command\App\ListApps::class));
+	$application->add(Server::get(Command\App\Remove::class));
+	$application->add(Server::get(Command\App\Update::class));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Cleanup::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enforce::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Enable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\Disable::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\TwoFactorAuth\State::class));
+	$application->add(Server::get(Command\TwoFactorAuth\Cleanup::class));
+	$application->add(Server::get(Command\TwoFactorAuth\Enforce::class));
+	$application->add(Server::get(Command\TwoFactorAuth\Enable::class));
+	$application->add(Server::get(Command\TwoFactorAuth\Disable::class));
+	$application->add(Server::get(Command\TwoFactorAuth\State::class));
 
-	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Background\Job(\OC::$server->getJobList(), \OC::$server->getLogger()));
-	$application->add(new OC\Core\Command\Background\ListCommand(\OC::$server->getJobList()));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Background\Delete::class));
+	$application->add(Server::get(Command\Background\Cron::class));
+	$application->add(Server::get(Command\Background\WebCron::class));
+	$application->add(Server::get(Command\Background\Ajax::class));
+	$application->add(Server::get(Command\Background\Job::class));
+	$application->add(Server::get(Command\Background\ListCommand::class));
+	$application->add(Server::get(Command\Background\Delete::class));
 
-	$application->add(\OC::$server->query(\OC\Core\Command\Broadcast\Test::class));
+	$application->add(Server::get(Command\Broadcast\Test::class));
 
-	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Config\App\GetConfig::class));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Config\App\SetConfig::class));
-	$application->add(new OC\Core\Command\Config\Import(\OC::$server->getConfig()));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Config\ListConfigs::class));
-	$application->add(new OC\Core\Command\Config\System\DeleteConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\GetConfig(\OC::$server->getSystemConfig()));
-	$application->add(new OC\Core\Command\Config\System\SetConfig(\OC::$server->getSystemConfig()));
+	$application->add(Server::get(Command\Config\App\DeleteConfig::class));
+	$application->add(Server::get(Command\Config\App\GetConfig::class));
+	$application->add(Server::get(Command\Config\App\SetConfig::class));
+	$application->add(Server::get(Command\Config\Import::class));
+	$application->add(Server::get(Command\Config\ListConfigs::class));
+	$application->add(Server::get(Command\Config\System\DeleteConfig::class));
+	$application->add(Server::get(Command\Config\System\GetConfig::class));
+	$application->add(Server::get(Command\Config\System\SetConfig::class));
 
-	$application->add(\OC::$server->get(OC\Core\Command\Info\File::class));
-	$application->add(\OC::$server->get(OC\Core\Command\Info\Space::class));
+	$application->add(Server::get(Command\Info\File::class));
+	$application->add(Server::get(Command\Info\Space::class));
 
-	$application->add(new OC\Core\Command\Db\ConvertType(\OC::$server->getConfig(), new \OC\DB\ConnectionFactory(\OC::$server->getSystemConfig())));
-	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator(), \OC::$server->get(LoggerInterface::class)));
-	$application->add(new OC\Core\Command\Db\ConvertFilecacheBigInt(\OC::$server->get(\OC\DB\Connection::class)));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingColumns::class));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingIndices::class));
-	$application->add(\OCP\Server::get(\OC\Core\Command\Db\AddMissingPrimaryKeys::class));
+	$application->add(Server::get(Command\Db\ConvertType::class));
+	$application->add(Server::get(Command\Db\ConvertMysqlToMB4::class));
+	$application->add(Server::get(Command\Db\ConvertFilecacheBigInt::class));
+	$application->add(Server::get(Command\Db\AddMissingColumns::class));
+	$application->add(Server::get(Command\Db\AddMissingIndices::class));
+	$application->add(Server::get(Command\Db\AddMissingPrimaryKeys::class));
 
-	if (\OC::$server->getConfig()->getSystemValueBool('debug', false)) {
-		$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->get(\OC\DB\Connection::class)));
-		$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->get(\OC\DB\Connection::class)));
-		$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getAppManager()));
-		$application->add(new OC\Core\Command\Db\Migrations\ExecuteCommand(\OC::$server->get(\OC\DB\Connection::class), \OC::$server->getConfig()));
+	if ($config->getSystemValueBool('debug', false)) {
+		$application->add(Server::get(Command\Db\Migrations\StatusCommand::class));
+		$application->add(Server::get(Command\Db\Migrations\MigrateCommand::class));
+		$application->add(Server::get(Command\Db\Migrations\GenerateCommand::class));
+		$application->add(Server::get(Command\Db\Migrations\ExecuteCommand::class));
 	}
 
-	$application->add(new OC\Core\Command\Encryption\Disable(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Enable(\OC::$server->getConfig(), \OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\ListModules(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\SetDefaultModule(\OC::$server->getEncryptionManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Encryption\Status(\OC::$server->getEncryptionManager()));
-	$application->add(new OC\Core\Command\Encryption\EncryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getAppManager(), \OC::$server->getConfig(), new \Symfony\Component\Console\Helper\QuestionHelper()));
-	$application->add(new OC\Core\Command\Encryption\DecryptAll(
-		\OC::$server->getEncryptionManager(),
-		\OC::$server->getAppManager(),
-		\OC::$server->getConfig(),
-		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
-		new \Symfony\Component\Console\Helper\QuestionHelper())
-	);
+	$application->add(Server::get(Command\Encryption\Disable::class));
+	$application->add(Server::get(Command\Encryption\Enable::class));
+	$application->add(Server::get(Command\Encryption\ListModules::class));
+	$application->add(Server::get(Command\Encryption\SetDefaultModule::class));
+	$application->add(Server::get(Command\Encryption\Status::class));
+	$application->add(Server::get(Command\Encryption\EncryptAll::class));
+	$application->add(Server::get(Command\Encryption\DecryptAll::class));
 
-	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Log\File(\OC::$server->getConfig()));
+	$application->add(Server::get(Command\Log\Manage::class));
+	$application->add(Server::get(Command\Log\File::class));
 
-	$view = new \OC\Files\View();
-	$util = new \OC\Encryption\Util(
-		$view,
-		\OC::$server->getUserManager(),
-		\OC::$server->getGroupManager(),
-		\OC::$server->getConfig()
-	);
-	$application->add(new OC\Core\Command\Encryption\ChangeKeyStorageRoot(
-		$view,
-		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
-		$util,
-		new \Symfony\Component\Console\Helper\QuestionHelper()
-	)
-	);
-	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
-	$application->add(new OC\Core\Command\Encryption\MigrateKeyStorage(
-		$view,
-		\OC::$server->getUserManager(),
-		\OC::$server->getConfig(),
-		$util,
-		\OC::$server->getCrypto()
-	)
-	);
+	$application->add(Server::get(Command\Encryption\ChangeKeyStorageRoot::class));
+	$application->add(Server::get(Command\Encryption\ShowKeyStorageRoot::class));
+	$application->add(Server::get(Command\Encryption\MigrateKeyStorage::class));
 
-	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
-	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
-	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
-	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
-	$application->add(new OC\Core\Command\Maintenance\UpdateTheme(\OC::$server->getMimeTypeDetector(), \OC::$server->getMemCacheFactory()));
+	$application->add(Server::get(Command\Maintenance\DataFingerprint::class));
+	$application->add(Server::get(Command\Maintenance\Mimetype\UpdateDB::class));
+	$application->add(Server::get(Command\Maintenance\Mimetype\UpdateJS::class));
+	$application->add(Server::get(Command\Maintenance\Mode::class));
+	$application->add(Server::get(Command\Maintenance\UpdateHtaccess::class));
+	$application->add(Server::get(Command\Maintenance\UpdateTheme::class));
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\Maintenance\Repair(
-		new \OC\Repair([], \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class)),
+	$application->add(Server::get(Command\Upgrade::class));
+	$application->add(new Command\Maintenance\Repair(
+		new \OC\Repair([], Server::get(\OCP\EventDispatcher\IEventDispatcher::class), Server::get(LoggerInterface::class)),
 		\OC::$server->getConfig(),
-		\OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class),
+		Server::get(\OCP\EventDispatcher\IEventDispatcher::class),
 		\OC::$server->getAppManager()
 	));
-	$application->add(\OC::$server->query(OC\Core\Command\Maintenance\RepairShareOwnership::class));
+	$application->add(Server::get(Command\Maintenance\RepairShareOwnership::class));
 
-	$application->add(\OC::$server->get(\OC\Core\Command\Preview\Generate::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\Repair::class));
-	$application->add(\OC::$server->query(\OC\Core\Command\Preview\ResetRenderedTexts::class));
+	$application->add(Server::get(Command\Preview\Generate::class));
+	$application->add(Server::get(Command\Preview\Repair::class));
+	$application->add(Server::get(Command\Preview\ResetRenderedTexts::class));
 
-	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
-	$application->add(\OC::$server->get(\OC\Core\Command\User\Report::class));
-	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getAppManager()));
-	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig()));
-	$application->add(new OC\Core\Command\User\ListCommand(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\Info(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\User\SyncAccountDataCommand(\OC::$server->getUserManager(), \OC::$server->get(\OCP\Accounts\IAccountManager::class)));
-	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Add::class));
-	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\ListCommand::class));
-	$application->add(\OC::$server->get(\OC\Core\Command\User\AuthTokens\Delete::class));
+	$application->add(Server::get(Command\User\Add::class));
+	$application->add(Server::get(Command\User\Delete::class));
+	$application->add(Server::get(Command\User\Disable::class));
+	$application->add(Server::get(Command\User\Enable::class));
+	$application->add(Server::get(Command\User\LastSeen::class));
+	$application->add(Server::get(Command\User\Report::class));
+	$application->add(Server::get(Command\User\ResetPassword::class));
+	$application->add(Server::get(Command\User\Setting::class));
+	$application->add(Server::get(Command\User\ListCommand::class));
+	$application->add(Server::get(Command\User\Info::class));
+	$application->add(Server::get(Command\User\SyncAccountDataCommand::class));
+	$application->add(Server::get(Command\User\AuthTokens\Add::class));
+	$application->add(Server::get(Command\User\AuthTokens\ListCommand::class));
+	$application->add(Server::get(Command\User\AuthTokens\Delete::class));
 
-	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\ListCommand(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\AddUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\Info(\OC::$server->get(\OCP\IGroupManager::class)));
+	$application->add(Server::get(Command\Group\Add::class));
+	$application->add(Server::get(Command\Group\Delete::class));
+	$application->add(Server::get(Command\Group\ListCommand::class));
+	$application->add(Server::get(Command\Group\AddUser::class));
+	$application->add(Server::get(Command\Group\RemoveUser::class));
+	$application->add(Server::get(Command\Group\Info::class));
 
-	$application->add(new OC\Core\Command\SystemTag\ListCommand(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
-	$application->add(new OC\Core\Command\SystemTag\Delete(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
-	$application->add(new OC\Core\Command\SystemTag\Add(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
-	$application->add(new OC\Core\Command\SystemTag\Edit(\OC::$server->get(\OCP\SystemTag\ISystemTagManager::class)));
+	$application->add(Server::get(Command\SystemTag\ListCommand::class));
+	$application->add(Server::get(Command\SystemTag\Delete::class));
+	$application->add(Server::get(Command\SystemTag\Add::class));
+	$application->add(Server::get(Command\SystemTag\Edit::class));
 
-	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(), \OC::$server->getL10N('core')));
-	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager()));
-	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager()));
-	$application->add(\OC::$server->get(\OC\Core\Command\Security\BruteforceAttempts::class));
-	$application->add(\OC::$server->get(\OC\Core\Command\Security\BruteforceResetAttempts::class));
-	$application->add(\OC::$server->get(\OC\Core\Command\SetupChecks::class));
-	$application->add(\OCP\Server::get(\OC\Core\Command\FilesMetadata\Get::class));
+	$application->add(new Command\Security\ListCertificates(\OC::$server->getCertificateManager(), \OC::$server->getL10N('core')));
+	$application->add(Server::get(Command\Security\ImportCertificate::class));
+	$application->add(Server::get(Command\Security\RemoveCertificate::class));
+	$application->add(Server::get(Command\Security\BruteforceAttempts::class));
+	$application->add(Server::get(Command\Security\BruteforceResetAttempts::class));
+	$application->add(Server::get(Command\SetupChecks::class));
+	$application->add(Server::get(Command\FilesMetadata\Get::class));
 } else {
-	$application->add(\OC::$server->get(\OC\Core\Command\Maintenance\Install::class));
+	$application->add(Server::get(Command\Maintenance\Install::class));
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -53,6 +53,7 @@ declare(strict_types=1);
 
 use OC\Core\Command;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
@@ -61,10 +62,17 @@ $application->add(new CompletionCommand());
 $application->add(Server::get(Command\Status::class));
 $application->add(Server::get(Command\Check::class));
 $application->add(Server::get(Command\L10n\CreateJs::class));
-$application->add(Server::get(Command\Integrity\SignApp::class));
-$application->add(Server::get(Command\Integrity\SignCore::class));
-$application->add(Server::get(Command\Integrity\CheckApp::class));
-$application->add(Server::get(Command\Integrity\CheckCore::class));
+$application->add(new \OC\Core\Command\Integrity\SignApp(
+	Server::get('IntegrityCodeChecker'),
+	new \OC\IntegrityCheck\Helpers\FileAccessHelper(),
+	Server::get(IURLGenerator::class)
+));
+$application->add(new \OC\Core\Command\Integrity\SignCore(
+	Server::get('IntegrityCodeChecker'),
+	new \OC\IntegrityCheck\Helpers\FileAccessHelper()
+));
+$application->add(new \OC\Core\Command\Integrity\CheckApp(Server::get('IntegrityCodeChecker')));
+$application->add(new \OC\Core\Command\Integrity\CheckCore(Server::get('IntegrityCodeChecker')));
 
 $config = Server::get(IConfig::class);
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -53,7 +53,6 @@ declare(strict_types=1);
 
 use OC\Core\Command;
 use OCP\IConfig;
-use OCP\IURLGenerator;
 use OCP\Server;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 
@@ -61,17 +60,10 @@ $application->add(new CompletionCommand());
 $application->add(Server::get(Command\Status::class));
 $application->add(Server::get(Command\Check::class));
 $application->add(Server::get(Command\L10n\CreateJs::class));
-$application->add(new \OC\Core\Command\Integrity\SignApp(
-	Server::get('IntegrityCodeChecker'),
-	new \OC\IntegrityCheck\Helpers\FileAccessHelper(),
-	Server::get(IURLGenerator::class)
-));
-$application->add(new \OC\Core\Command\Integrity\SignCore(
-	Server::get('IntegrityCodeChecker'),
-	new \OC\IntegrityCheck\Helpers\FileAccessHelper()
-));
-$application->add(new \OC\Core\Command\Integrity\CheckApp(Server::get('IntegrityCodeChecker')));
-$application->add(new \OC\Core\Command\Integrity\CheckCore(Server::get('IntegrityCodeChecker')));
+$application->add(Server::get(Command\Integrity\SignApp::class));
+$application->add(Server::get(Command\Integrity\SignCore::class));
+$application->add(Server::get(Command\Integrity\CheckApp::class));
+$application->add(Server::get(Command\Integrity\CheckCore::class));
 
 $config = Server::get(IConfig::class);
 

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -55,8 +55,9 @@ use OC\Core\Command;
 use OCP\IConfig;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 
-$application->add(new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand());
+$application->add(new CompletionCommand());
 $application->add(Server::get(Command\Status::class));
 $application->add(Server::get(Command\Check::class));
 $application->add(Server::get(Command\L10n\CreateJs::class));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -55,7 +55,6 @@ use OC\Core\Command;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\Server;
-use Psr\Log\LoggerInterface;
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 
 $application->add(new CompletionCommand());
@@ -149,12 +148,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\Maintenance\UpdateTheme::class));
 
 	$application->add(Server::get(Command\Upgrade::class));
-	$application->add(new Command\Maintenance\Repair(
-		new \OC\Repair([], Server::get(\OCP\EventDispatcher\IEventDispatcher::class), Server::get(LoggerInterface::class)),
-		\OC::$server->getConfig(),
-		Server::get(\OCP\EventDispatcher\IEventDispatcher::class),
-		\OC::$server->getAppManager()
-	));
+	$application->add(Server::get(Command\Maintenance\Repair::class));
 	$application->add(Server::get(Command\Maintenance\RepairShareOwnership::class));
 
 	$application->add(Server::get(Command\Preview\Generate::class));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Christian Kampka <christian@kampka.net>
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
  * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
  * @author Daniel Kesselberg <mail@danielkesselberg.de>
  * @author Denis Mosolov <denismosolov@gmail.com>

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -180,7 +180,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\SystemTag\Add::class));
 	$application->add(Server::get(Command\SystemTag\Edit::class));
 
-	$application->add(new Command\Security\ListCertificates(\OC::$server->getCertificateManager(), \OC::$server->getL10N('core')));
+	$application->add(Server::get(Command\Security\ListCertificates::class));
 	$application->add(Server::get(Command\Security\ImportCertificate::class));
 	$application->add(Server::get(Command\Security\RemoveCertificate::class));
 	$application->add(Server::get(Command\Security\BruteforceAttempts::class));

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -31,6 +31,7 @@ namespace OC\Encryption;
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\View;
 use OCP\Encryption\IEncryptionModule;
+use OCP\Encryption\IManager;
 use OCP\IUserManager;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,31 +44,14 @@ class DecryptAll {
 	/** @var  InputInterface */
 	protected $input;
 
-	/** @var  Manager */
-	protected $encryptionManager;
-
-	/** @var IUserManager */
-	protected $userManager;
-
-	/** @var View */
-	protected $rootView;
-
 	/** @var  array files which couldn't be decrypted */
 	protected $failed;
 
-	/**
-	 * @param Manager $encryptionManager
-	 * @param IUserManager $userManager
-	 * @param View $rootView
-	 */
 	public function __construct(
-		Manager $encryptionManager,
-		IUserManager $userManager,
-		View $rootView
+		protected IManager $encryptionManager,
+		protected IUserManager $userManager,
+		protected View $rootView
 	) {
-		$this->encryptionManager = $encryptionManager;
-		$this->userManager = $userManager;
-		$this->rootView = $rootView;
 		$this->failed = [];
 	}
 

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -39,34 +39,17 @@ use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 class Manager implements IManager {
-	/** @var array */
-	protected $encryptionModules;
+	protected array $encryptionModules;
 
-	/** @var IConfig */
-	protected $config;
-
-	protected LoggerInterface $logger;
-
-	/** @var Il10n */
-	protected $l;
-
-	/** @var View  */
-	protected $rootView;
-
-	/** @var Util  */
-	protected $util;
-
-	/** @var ArrayCache  */
-	protected $arrayCache;
-
-	public function __construct(IConfig $config, LoggerInterface $logger, IL10N $l10n, View $rootView, Util $util, ArrayCache $arrayCache) {
+	public function __construct(
+		protected IConfig $config,
+		protected LoggerInterface $logger,
+		protected IL10N $l,
+		protected View $rootView,
+		protected Util $util,
+		protected ArrayCache $arrayCache,
+	) {
 		$this->encryptionModules = [];
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->l = $l10n;
-		$this->rootView = $rootView;
-		$this->util = $util;
-		$this->arrayCache = $arrayCache;
 	}
 
 	/**

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -32,7 +32,6 @@ use OC_App;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
-use OCP\EventDispatcher\IEventDispatcher;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -42,7 +41,7 @@ use Psr\Log\LoggerInterface;
  */
 class BackgroundRepair extends TimedJob {
 	public function __construct(
-		private IEventDispatcher $dispatcher,
+		private Repair $repair,
 		ITimeFactory $time,
 		private LoggerInterface $logger,
 		private IJobList $jobList,
@@ -73,9 +72,9 @@ class BackgroundRepair extends TimedJob {
 		}
 
 		$step = $argument['step'];
-		$repair = \OCP\Server::get(Repair::class);
+		$this->repair->setRepairSteps([]);
 		try {
-			$repair->addStep($step);
+			$this->repair->addStep($step);
 		} catch (\Exception $ex) {
 			$this->logger->error($ex->getMessage(), [
 				'app' => 'migration',
@@ -88,7 +87,7 @@ class BackgroundRepair extends TimedJob {
 		}
 
 		// execute the repair step
-		$repair->run();
+		$this->repair->run();
 
 		// remove the job once executed successfully
 		$this->jobList->remove($this, $this->argument);

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -73,7 +73,7 @@ class BackgroundRepair extends TimedJob {
 		}
 
 		$step = $argument['step'];
-		$repair = new Repair([], $this->dispatcher, \OC::$server->get(LoggerInterface::class));
+		$repair = \OCP\Server::get(Repair::class);
 		try {
 			$repair->addStep($step);
 		} catch (\Exception $ex) {

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -91,23 +91,19 @@ use Throwable;
 
 class Repair implements IOutput {
 	/** @var IRepairStep[] */
-	private array $repairSteps;
-
-	private IEventDispatcher $dispatcher;
+	private array $repairSteps = [];
 
 	private string $currentStep;
 
-	private LoggerInterface $logger;
+	public function __construct(
+		private IEventDispatcher $dispatcher,
+		private LoggerInterface $logger
+	) {
+	}
 
-	/**
-	 * Creates a new repair step runner
-	 *
-	 * @param IRepairStep[] $repairSteps array of RepairStep instances
-	 */
-	public function __construct(array $repairSteps, IEventDispatcher $dispatcher, LoggerInterface $logger) {
+	/** @param IRepairStep[] $repairSteps */
+	public function setRepairSteps(array $repairSteps): void {
 		$this->repairSteps = $repairSteps;
-		$this->dispatcher = $dispatcher;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -976,7 +976,8 @@ class Server extends ServerContainer implements IServerContainer {
 			return $backend;
 		});
 
-		$this->registerService('IntegrityCodeChecker', function (ContainerInterface $c) {
+		$this->registerDeprecatedAlias('IntegrityCodeChecker', Checker::class);
+		$this->registerService(Checker::class, function (ContainerInterface $c) {
 			// IConfig and IAppManager requires a working database. This code
 			// might however be called when ownCloud is not yet setup.
 			if (\OC::$server->get(SystemConfig::class)->getValue('installed', false)) {

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -255,7 +255,8 @@ class Updater extends BasicEmitter {
 		file_put_contents($this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data') . '/.ocdata', '');
 
 		// pre-upgrade repairs
-		$repair = new Repair(Repair::getBeforeUpgradeRepairSteps(), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$repair = \OCP\Server::get(Repair::class);
+		$repair->setRepairSteps(Repair::getBeforeUpgradeRepairSteps());
 		$repair->run();
 
 		$this->doCoreUpgrade();
@@ -296,7 +297,8 @@ class Updater extends BasicEmitter {
 		}
 
 		// post-upgrade repairs
-		$repair = new Repair(Repair::getRepairSteps(), \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class), \OC::$server->get(LoggerInterface::class));
+		$repair = \OCP\Server::get(Repair::class);
+		$repair->setRepairSteps(Repair::getRepairSteps());
 		$repair->run();
 
 		//Invalidate update feed

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -823,7 +823,7 @@ class OC_App {
 		$dispatcher = \OC::$server->get(IEventDispatcher::class);
 
 		// load the steps
-		$r = new Repair([], $dispatcher, \OC::$server->get(LoggerInterface::class));
+		$r = \OCP\Server::get(Repair::class);
 		foreach ($steps as $step) {
 			try {
 				$r->addStep($step);

--- a/tests/lib/Migration/BackgroundRepairTest.php
+++ b/tests/lib/Migration/BackgroundRepairTest.php
@@ -24,12 +24,12 @@ namespace Test\Migration;
 use OC\BackgroundJob\JobList;
 use OC\Migration\BackgroundRepair;
 use OC\NeedsUpdateException;
+use OC\Repair;
 use OC\Repair\Events\RepairStepEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
@@ -57,20 +57,12 @@ class TestRepairStep implements IRepairStep {
 }
 
 class BackgroundRepairTest extends TestCase {
-	/** @var JobList|MockObject */
-	private $jobList;
-
-	/** @var BackgroundRepair|MockObject */
-	private $job;
-
-	/** @var LoggerInterface|MockObject */
-	private $logger;
-
-	/** @var IEventDispatcher|MockObject $dispatcher  */
-	private $dispatcher;
-
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject $dispatcher  */
-	private $time;
+	private JobList $jobList;
+	private BackgroundRepair $job;
+	private LoggerInterface $logger;
+	private IEventDispatcher $dispatcher;
+	private ITimeFactory $time;
+	private Repair $repair;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -85,8 +77,9 @@ class BackgroundRepairTest extends TestCase {
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')
 			->willReturn(999999);
+		$this->repair = new Repair($this->dispatcher, $this->logger);
 		$this->job = $this->getMockBuilder(BackgroundRepair::class)
-			->setConstructorArgs([$this->dispatcher, $this->time, $this->logger, $this->jobList])
+			->setConstructorArgs([$this->repair, $this->time, $this->logger, $this->jobList])
 			->setMethods(['loadApp'])
 			->getMock();
 	}

--- a/tests/lib/RepairTest.php
+++ b/tests/lib/RepairTest.php
@@ -46,7 +46,7 @@ class RepairTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$dispatcher = \OC::$server->get(IEventDispatcher::class);
-		$this->repair = new \OC\Repair([], $dispatcher, $this->createMock(LoggerInterface::class));
+		$this->repair = new Repair($dispatcher, $this->createMock(LoggerInterface::class));
 
 		$dispatcher->addListener(RepairWarningEvent::class, function (RepairWarningEvent $event) {
 			$this->outputArray[] = 'warning: ' . $event->getMessage();


### PR DESCRIPTION
## Summary

Use DI for all commands from Core to stop relying on deprecated methods.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
