### PR TITLE
feat(occ): add possibility to edit indices

### DIFF
--- a/lib/public/DB/Events/AddMissingIndicesEvent.php
+++ b/lib/public/DB/Events/AddMissingIndicesEvent.php
@@ -39,6 +39,9 @@ class AddMissingIndicesEvent extends \OCP\EventDispatcher\Event {
 	/** @var array<array-key, array{tableName: string, indexName: string, columns: string[], options: array{}, dropUnnamedIndex: bool, uniqueIndex: bool}> */
 	private array $missingIndices = [];
 
+	/** @var array<array-key, array{tableName: string, oldIndexNames: array, newIndexName: string, columns: string[], uniqueIndex: bool, options: array{}}> */
+	private array $toReplaceIndices = [];
+
 	/**
 	 * @param string[] $columns
 	 * @since 28.0.0
@@ -74,5 +77,43 @@ class AddMissingIndicesEvent extends \OCP\EventDispatcher\Event {
 	 */
 	public function getMissingIndices(): array {
 		return $this->missingIndices;
+	}
+
+	/**
+	 * Replace one or more existing indices with a new one. Can be used to make an index unique afterwards or merge two indices into a multicolumn index.
+	 *
+	 * Note: Make sure to not use the same index name for the new index as for old indices.
+	 *
+	 * Example:
+	 *
+	 * <code>
+	 *     $event->replaceIndex(
+	 *         'my_table',
+	 *         ['old_index_col_a', 'old_index_col_b'],
+	 *         'new_index_col_a_b',
+	 *         ['column_a', 'column_b'],
+	 *         false
+	 *     );
+	 * </code>
+	 *
+	 * @since 29.0.0
+	 */
+	public function replaceIndex(string $tableName, array $oldIndexNames, string $newIndexName, array $columns, bool $unique, array $options = []): void {
+		$this->toReplaceIndices[] = [
+			'tableName' => $tableName,
+			'oldIndexNames' => $oldIndexNames,
+			'newIndexName' => $newIndexName,
+			'columns' => $columns,
+			'uniqueIndex' => $unique,
+			'options' => $options,
+		];
+	}
+
+	/**
+	 * @since 29.0.0
+	 * @return array<array-key, array{tableName: string, oldIndexNames: array, newIndexName: string, columns: string[], uniqueIndex: bool, options: array{}}>
+	 */
+	public function getIndicesToReplace(): array {
+		return $this->toReplaceIndices;
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

To be able to edit indices, this pr extend the `occ db:add-missing-indices` by the this possibility.
This is important if there is an index that need to be edited (deleting and right after that adding indices).

Use cases:
* Extend index with new column(s)
* Make index unique / not unique
* Change index name

Contributes to: https://github.com/nextcloud/mail/issues/9162

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - https://github.com/nextcloud/documentation/pull/11586
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
