### PR TITLE
chore(ci): Force github CI for tests failing on self-hosted runners

### DIFF
--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -36,7 +36,7 @@ jobs:
               - '**.php'
 
   s3-primary-tests-minio:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: changes
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}

--- a/.github/workflows/smb-kerberos.yml
+++ b/.github/workflows/smb-kerberos.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   smb-kerberos-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
 


### PR DESCRIPTION
## Summary

2 jobs are always failing on self hosted runners, so for now force them on github CI to avoid false-negative.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
