### PR TITLE
movie preview bug fix, in some case stream reading functions may block indefinitely

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -307,6 +307,8 @@ class Movie extends ProviderV2 {
 		$returnCode = -1;
 		$output = '';
 		if (is_resource($proc)) {
+			stream_set_blocking($pipes[1], false);
+			stream_set_blocking($pipes[2], false);
 			$stderr = trim(stream_get_contents($pipes[2]));
 			$stdout = trim(stream_get_contents($pipes[1]));
 			$returnCode = proc_close($proc);

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -343,6 +343,8 @@ class Movie extends ProviderV2 {
 		$returnCode = -1;
 		$output = '';
 		if (is_resource($proc)) {
+			stream_set_blocking($pipes[1], false);
+			stream_set_blocking($pipes[2], false);
 			// Read stderr before stdout: ffmpeg's stderr can exceed 64KB (OS pipe buffer) for certain
 			// files, causing a deadlock if stdout is read first. stdout is always empty.
 			$stderr = trim(stream_get_contents($pipes[2]));


### PR DESCRIPTION
## Summary
For some reason, I need to run nextcloud as root, and in this case ffmpeg will block the process when it generates preview.

## refencese:
https://www.php.net/manual/en/function.proc-open.php#97012
https://www.php.net/manual/en/function.stream-get-contents.php#106905
