### PR TITLE
[IAppConfig] returns non lazy value while searching for lazy one

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -462,11 +462,14 @@ class AppConfig implements IAppConfig {
 			throw new AppConfigTypeConflictException('conflict with value type from database');
 		}
 
-		if ($lazy) {
-			return $this->lazyCache[$app][$key] ?? $default;
-		}
-
-		return $this->fastCache[$app][$key] ?? $default;
+		/**
+		 * - the pair $app/$key cannot exist in both array,
+		 * - we should still returns an existing non-lazy value even if current method
+		 *   is called with $lazy is true
+		 *
+		 * This way, lazyCache will be empty until the load for lazy config value is requested.
+		 */
+		return $this->lazyCache[$app][$key] ?? $this->fastCache[$app][$key] ?? $default;
 	}
 
 	/**


### PR DESCRIPTION
There is this possible situation where your part of code is using already existing config value. This config value needs to be switched to _lazy_ to improve performance, but the only way to store a value as `lazy` is:

- set a value using function like `setValueString()` with the argument `lazy: true` and the config value itself.
- using `updateLazy()` on the app/key pair without the need of the content of  the config value.

the `updateLazy()` could be run at one point of the migration, or later on, but there is room for a use case where an app is requesting a _lazy_ config value still stored as _non lazy_ in the database