### PR TITLE
Allow application to pass external links in navigation

### DIFF
--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -115,10 +115,10 @@ class NavigationController extends OCSController {
 	 */
 	private function rewriteToAbsoluteUrls(array $navigation): array {
 		foreach ($navigation as &$entry) {
-			if (!str_starts_with($entry['href'], $this->urlGenerator->getBaseUrl())) {
+			if (!str_starts_with($entry['href'], 'https://') && !str_starts_with($entry['href'], 'http://')) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
-			if (!str_starts_with($entry['icon'], $this->urlGenerator->getBaseUrl())) {
+			if (!str_starts_with($entry['icon'], 'https://') && !str_starts_with($entry['icon'], 'http://')) {
 				$entry['icon'] = $this->urlGenerator->getAbsoluteURL($entry['icon']);
 			}
 		}

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -115,7 +115,8 @@ class NavigationController extends OCSController {
 	 */
 	private function rewriteToAbsoluteUrls(array $navigation): array {
 		foreach ($navigation as &$entry) {
-			if (!str_starts_with($entry['href'], 'https://') && !str_starts_with($entry['href'], 'http://')) {
+			/* If parse_url finds no host it means the URL is not absolute */
+			if (!isset(\parse_url($entry['href'])['host'])) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
 			if (!str_starts_with($entry['icon'], $this->urlGenerator->getBaseUrl())) {

--- a/core/Controller/NavigationController.php
+++ b/core/Controller/NavigationController.php
@@ -118,7 +118,7 @@ class NavigationController extends OCSController {
 			if (!str_starts_with($entry['href'], 'https://') && !str_starts_with($entry['href'], 'http://')) {
 				$entry['href'] = $this->urlGenerator->getAbsoluteURL($entry['href']);
 			}
-			if (!str_starts_with($entry['icon'], 'https://') && !str_starts_with($entry['icon'], 'http://')) {
+			if (!str_starts_with($entry['icon'], $this->urlGenerator->getBaseUrl())) {
 				$entry['icon'] = $this->urlGenerator->getAbsoluteURL($entry['icon']);
 			}
 		}


### PR DESCRIPTION
* Resolves: #43204 

## Summary

[External application](https://github.com/nextcloud/external) returns external links for Nextcloud navigation.
But the NavigationController was attempting to turn those into local link, resulting in craziness like `http://stable26.local/https://duckduckgo.com` - See related issue.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
